### PR TITLE
feat(entity-generator): support native postgres enums

### DIFF
--- a/packages/core/src/naming-strategy/AbstractNamingStrategy.ts
+++ b/packages/core/src/naming-strategy/AbstractNamingStrategy.ts
@@ -64,14 +64,14 @@ export abstract class AbstractNamingStrategy implements NamingStrategy {
   /**
    * @inheritDoc
    */
-  getEnumClassName(columnName: string, tableName: string, schemaName?: string): string {
-    return this.getEntityName(`${tableName}_${columnName}`, schemaName);
+  getEnumClassName(columnName: string, tableName: string | undefined, schemaName?: string): string {
+    return this.getEntityName(tableName ? `${tableName}_${columnName}` : columnName, schemaName);
   }
 
   /**
    * @inheritDoc
    */
-  getEnumTypeName(columnName: string, tableName: string, schemaName?: string): string {
+  getEnumTypeName(columnName: string, tableName: string | undefined, schemaName?: string): string {
     return 'T' + this.getEnumClassName(columnName, tableName, schemaName);
   }
 

--- a/packages/core/src/naming-strategy/NamingStrategy.ts
+++ b/packages/core/src/naming-strategy/NamingStrategy.ts
@@ -31,7 +31,7 @@ export interface NamingStrategy {
    *
    * @return A new class name that will be used for the enum.
    */
-  getEnumClassName(columnName: string, tableName: string, schemaName?: string): string;
+  getEnumClassName(columnName: string, tableName: string | undefined, schemaName?: string): string;
 
   /**
    * Get an enum type name. Used with `enumType: 'dictionary'` and `enumType: 'union-type'` entity generator option.
@@ -42,7 +42,7 @@ export interface NamingStrategy {
    *
    * @return A new type name that will be used for the enum.
    */
-  getEnumTypeName(columnName: string, tableName: string, schemaName?: string): string;
+  getEnumTypeName(columnName: string, tableName: string | undefined, schemaName?: string): string;
 
   /**
    * Get an enum option name for a given enum value.

--- a/packages/entity-generator/src/DefineEntitySourceFile.ts
+++ b/packages/entity-generator/src/DefineEntitySourceFile.ts
@@ -16,7 +16,11 @@ export class DefineEntitySourceFile extends EntitySchemaSourceFile {
 
     for (const prop of Object.values(this.meta.properties)) {
       if (prop.enum && (typeof prop.kind === 'undefined' || prop.kind === ReferenceKind.SCALAR)) {
-        enumDefinitions.push(this.getEnumClassDefinition(prop, 2));
+        const def = this.getEnumClassDefinition(prop, 2);
+
+        if (def.length) {
+          enumDefinitions.push(def);
+        }
       }
     }
 

--- a/packages/entity-generator/src/EntitySchemaSourceFile.ts
+++ b/packages/entity-generator/src/EntitySchemaSourceFile.ts
@@ -17,7 +17,11 @@ export class EntitySchemaSourceFile extends SourceFile {
 
     for (const prop of Object.values(this.meta.properties)) {
       if (prop.enum && (typeof prop.kind === 'undefined' || prop.kind === ReferenceKind.SCALAR)) {
-        enumDefinitions.push(this.getEnumClassDefinition(prop, 2));
+        const def = this.getEnumClassDefinition(prop, 2);
+
+        if (def.length) {
+          enumDefinitions.push(def);
+        }
       }
     }
 

--- a/packages/entity-generator/src/NativeEnumSourceFile.ts
+++ b/packages/entity-generator/src/NativeEnumSourceFile.ts
@@ -1,0 +1,62 @@
+import type { EntityMetadata, GenerateOptions, NamingStrategy, Platform } from '@mikro-orm/core';
+import { identifierRegex, SourceFile } from './SourceFile';
+
+export class NativeEnumSourceFile extends SourceFile {
+
+  constructor(
+    meta: EntityMetadata,
+    namingStrategy: NamingStrategy,
+    platform: Platform,
+    options: GenerateOptions,
+    protected readonly nativeEnum: { name: string; schema?: string; items: string[] },
+  ) {
+    super(meta, namingStrategy, platform, options);
+  }
+
+  override generate(): string {
+    const enumClassName = this.namingStrategy.getEnumClassName(this.nativeEnum.name, undefined, this.nativeEnum.schema);
+    const enumTypeName = this.namingStrategy.getEnumTypeName(this.nativeEnum.name, undefined, this.nativeEnum.schema);
+    const padding = '  ';
+    const enumMode = this.options.enumMode;
+    const enumValues = this.nativeEnum.items as string[];
+
+    if (enumMode === 'union-type') {
+      return `export type ${enumTypeName} = ${enumValues.map(item => this.quote(item)).join(' | ')};\n`;
+    }
+
+    let ret = '';
+
+    if (enumMode === 'dictionary') {
+      ret += `export const ${enumClassName} = {\n`;
+    } else {
+      ret += `export enum ${enumClassName} {\n`;
+    }
+
+    for (const enumValue of enumValues) {
+      const enumName = this.namingStrategy.enumValueToEnumProperty(enumValue, this.nativeEnum.name, '', this.nativeEnum.schema);
+
+      if (enumMode === 'dictionary') {
+        ret += `${padding}${identifierRegex.test(enumName) ? enumName : this.quote(enumName)}: ${this.quote(enumValue)},\n`;
+      } else {
+        ret += `${padding}${identifierRegex.test(enumName) ? enumName : this.quote(enumName)} = ${this.quote(enumValue)},\n`;
+      }
+    }
+
+    if (enumMode === 'dictionary') {
+      ret += '} as const;\n';
+    } else {
+      ret += '}\n';
+    }
+
+    if (enumMode === 'dictionary') {
+      ret += `\nexport type ${enumTypeName} = (typeof ${enumClassName})[keyof typeof ${enumClassName}];\n`;
+    }
+
+    return ret;
+  }
+
+  override getBaseName(extension = '.ts') {
+    return `${this.options.fileName!(this.nativeEnum.name)}${extension}`;
+  }
+
+}

--- a/tests/features/entity-generator/__snapshots__/EntityGenerator.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/EntityGenerator.test.ts.snap
@@ -90,8 +90,8 @@ export class Book3 {
 }
 ",
   "import { Entity, Index, ManyToOne, PrimaryKey } from '@mikro-orm/core';
-import { Book3 } from './book3';
 import { BookTag3 } from './book-tag3';
+import { Book3 } from './book3';
 
 @Entity({ tableName: 'book3_tags' })
 export class Book3Tags {

--- a/tests/features/entity-generator/__snapshots__/MetadataHooks.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/MetadataHooks.mysql.test.ts.snap
@@ -19,12 +19,12 @@ export class Address2 {
 }
 ",
   "import { Cascade, Collection, EagerProps, Embedded, Entity, Formula, type Hidden, type IType, Index, ManyToMany, ManyToOne, OneToMany, OneToOne, type Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
-import { Address2 } from '../Address2';
-import { Book2 } from '../Book2';
 import '../../runtimeTypes/BrandedTypes';
-import { MyBoolean as CustomBooleanType } from '../../types/MyBoolean';
 import Email from '../../runtimeTypes/Email';
 import * as EmailSerializer from '../../serializers/Email';
+import { MyBoolean as CustomBooleanType } from '../../types/MyBoolean';
+import { Address2 } from '../Address2';
+import { Book2 } from '../Book2';
 import { IdentitiesContainer } from '../IdentitiesContainer';
 import { MyExtendedDataClass } from '../MyExtendedDataClass';
 
@@ -183,12 +183,12 @@ export class BookTag2 {
 }
 ",
   "import { Collection, Embedded, Entity, type IType, Index, ManyToMany, ManyToOne, OneToMany, OneToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
-import { Author2 } from './subfolder/Author2';
 import { Book2Tags } from './Book2Tags';
 import { BookTag2 } from './BookTag2';
 import { MetaType } from './MetaType';
 import { Publisher2 } from './Publisher2';
 import { Test2 } from './Test2';
+import { Author2 } from './subfolder/Author2';
 
 @Entity()
 export class Book2 {
@@ -347,9 +347,9 @@ export class Dummy2 {
 }
 ",
   "import { Collection, Entity, type IType, ManyToMany, OneToMany, OneToOne, type Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+import { JSONObject } from './../runtimeTypes/JSONObject';
 import { FooBaz2 } from './FooBaz2';
 import { FooParam2 } from './FooParam2';
-import { JSONObject } from './../runtimeTypes/JSONObject';
 import { Test2 } from './Test2';
 
 @Entity()
@@ -454,9 +454,9 @@ export class FooParam2 {
 }
 ",
   "import { Collection, Entity, Enum, type IType, OneToMany, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
+import { UrlTypeLike } from './../types/UrlTypeLike';
 import { Book2 } from './Book2';
 import { Publisher2Tests } from './Publisher2Tests';
-import { UrlTypeLike } from './../types/UrlTypeLike';
 
 @Entity()
 export class Publisher2 {
@@ -732,12 +732,12 @@ export const Address2Schema = defineEntity({
 });
 ",
   "import { Cascade, Collection, EagerProps, type Hidden, type IType, type Opt, defineEntity, p } from '@mikro-orm/core';
-import { Address2 } from '../Address2';
-import { Book2 } from '../Book2';
 import '../../runtimeTypes/BrandedTypes';
-import { MyBoolean as CustomBooleanType } from '../../types/MyBoolean';
 import Email from '../../runtimeTypes/Email';
 import * as EmailSerializer from '../../serializers/Email';
+import { MyBoolean as CustomBooleanType } from '../../types/MyBoolean';
+import { Address2 } from '../Address2';
+import { Book2 } from '../Book2';
 import { IdentitiesContainer } from '../IdentitiesContainer';
 import { MyExtendedDataClass } from '../MyExtendedDataClass';
 
@@ -877,12 +877,12 @@ export const BookTag2Schema = defineEntity({
 });
 ",
   "import { Collection, type IType, type Opt, PrimaryKeyProp, defineEntity, p } from '@mikro-orm/core';
-import { Author2 } from './subfolder/Author2';
 import { Book2Tags } from './Book2Tags';
 import { BookTag2 } from './BookTag2';
 import { MetaType } from './MetaType';
 import { Publisher2 } from './Publisher2';
 import { Test2 } from './Test2';
+import { Author2 } from './subfolder/Author2';
 
 export class Book2 {
   [PrimaryKeyProp]?: 'uuidPk';
@@ -1022,9 +1022,9 @@ export const Dummy2Schema = defineEntity({
 });
 ",
   "import { Collection, type IType, type Opt, defineEntity, p } from '@mikro-orm/core';
+import { JSONObject } from './../runtimeTypes/JSONObject';
 import { FooBaz2 } from './FooBaz2';
 import { FooParam2 } from './FooParam2';
-import { JSONObject } from './../runtimeTypes/JSONObject';
 import { Test2 } from './Test2';
 
 export class FooBar2 {
@@ -1112,9 +1112,9 @@ export const FooParam2Schema = defineEntity({
 });
 ",
   "import { Collection, type IType, type Opt, defineEntity, p } from '@mikro-orm/core';
+import { UrlTypeLike } from './../types/UrlTypeLike';
 import { Book2 } from './Book2';
 import { Publisher2Tests } from './Publisher2Tests';
-import { UrlTypeLike } from './../types/UrlTypeLike';
 
 export class Publisher2 {
   id!: number;
@@ -1412,12 +1412,12 @@ export const Address2Schema = new EntitySchema({
 });
 ",
   "import { Cascade, Collection, EagerProps, EntitySchema, type Hidden, type IType, type Opt } from '@mikro-orm/core';
-import { Address2 } from '../Address2';
-import { Book2 } from '../Book2';
 import '../../runtimeTypes/BrandedTypes';
-import { MyBoolean as CustomBooleanType } from '../../types/MyBoolean';
 import Email from '../../runtimeTypes/Email';
 import * as EmailSerializer from '../../serializers/Email';
+import { MyBoolean as CustomBooleanType } from '../../types/MyBoolean';
+import { Address2 } from '../Address2';
+import { Book2 } from '../Book2';
 import { IdentitiesContainer } from '../IdentitiesContainer';
 import { MyExtendedDataClass } from '../MyExtendedDataClass';
 
@@ -1673,12 +1673,12 @@ export const BookTag2Schema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, type IType, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
-import { Author2 } from './subfolder/Author2';
 import { Book2Tags } from './Book2Tags';
 import { BookTag2 } from './BookTag2';
 import { MetaType } from './MetaType';
 import { Publisher2 } from './Publisher2';
 import { Test2 } from './Test2';
+import { Author2 } from './subfolder/Author2';
 
 export class Book2 {
   [PrimaryKeyProp]?: 'uuidPk';
@@ -1870,9 +1870,9 @@ export const Dummy2Schema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, type IType, type Opt } from '@mikro-orm/core';
+import { JSONObject } from './../runtimeTypes/JSONObject';
 import { FooBaz2 } from './FooBaz2';
 import { FooParam2 } from './FooParam2';
-import { JSONObject } from './../runtimeTypes/JSONObject';
 import { Test2 } from './Test2';
 
 export class FooBar2 {
@@ -1986,9 +1986,9 @@ export const FooParam2Schema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, type IType, type Opt } from '@mikro-orm/core';
+import { UrlTypeLike } from './../types/UrlTypeLike';
 import { Book2 } from './Book2';
 import { Publisher2Tests } from './Publisher2Tests';
-import { UrlTypeLike } from './../types/UrlTypeLike';
 
 export class Publisher2 {
   id!: number;
@@ -2369,12 +2369,12 @@ export class Address2 {
 }
 ",
   "import { Cascade, Collection, EagerProps, Embedded, Entity, Formula, type Hidden, type IType, Index, ManyToMany, ManyToOne, OneToMany, OneToOne, type Opt, PrimaryKey, Property, type Ref, Unique, ref } from '@mikro-orm/core';
-import { Address2 } from '../Address2';
-import { Book2 } from '../Book2';
 import '../../runtimeTypes/BrandedTypes';
-import { MyBoolean as CustomBooleanType } from '../../types/MyBoolean';
 import Email from '../../runtimeTypes/Email';
 import * as EmailSerializer from '../../serializers/Email';
+import { MyBoolean as CustomBooleanType } from '../../types/MyBoolean';
+import { Address2 } from '../Address2';
+import { Book2 } from '../Book2';
 import { IdentitiesContainer } from '../IdentitiesContainer';
 import { MyExtendedDataClass } from '../MyExtendedDataClass';
 
@@ -2533,12 +2533,12 @@ export class BookTag2 {
 }
 ",
   "import { Collection, Embedded, Entity, type IType, Index, ManyToMany, ManyToOne, OneToMany, OneToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
-import { Author2 } from './subfolder/Author2';
 import { Book2Tags } from './Book2Tags';
 import { BookTag2 } from './BookTag2';
 import { MetaType } from './MetaType';
 import { Publisher2 } from './Publisher2';
 import { Test2 } from './Test2';
+import { Author2 } from './subfolder/Author2';
 
 @Entity()
 export class Book2 {
@@ -2697,9 +2697,9 @@ export class Dummy2 {
 }
 ",
   "import { Collection, Entity, type IType, ManyToMany, OneToMany, OneToOne, type Opt, PrimaryKey, Property, type Ref, Unique } from '@mikro-orm/core';
+import { JSONObject } from './../runtimeTypes/JSONObject';
 import { FooBaz2 } from './FooBaz2';
 import { FooParam2 } from './FooParam2';
-import { JSONObject } from './../runtimeTypes/JSONObject';
 import { Test2 } from './Test2';
 
 @Entity()
@@ -2804,9 +2804,9 @@ export class FooParam2 {
 }
 ",
   "import { Collection, Entity, Enum, type IType, OneToMany, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
+import { UrlTypeLike } from './../types/UrlTypeLike';
 import { Book2 } from './Book2';
 import { Publisher2Tests } from './Publisher2Tests';
-import { UrlTypeLike } from './../types/UrlTypeLike';
 
 @Entity()
 export class Publisher2 {
@@ -3082,12 +3082,12 @@ export const Address2Schema = defineEntity({
 });
 ",
   "import { Cascade, Collection, EagerProps, type Hidden, type IType, type Opt, type Ref, defineEntity, p, ref } from '@mikro-orm/core';
-import { Address2 } from '../Address2';
-import { Book2 } from '../Book2';
 import '../../runtimeTypes/BrandedTypes';
-import { MyBoolean as CustomBooleanType } from '../../types/MyBoolean';
 import Email from '../../runtimeTypes/Email';
 import * as EmailSerializer from '../../serializers/Email';
+import { MyBoolean as CustomBooleanType } from '../../types/MyBoolean';
+import { Address2 } from '../Address2';
+import { Book2 } from '../Book2';
 import { IdentitiesContainer } from '../IdentitiesContainer';
 import { MyExtendedDataClass } from '../MyExtendedDataClass';
 
@@ -3227,12 +3227,12 @@ export const BookTag2Schema = defineEntity({
 });
 ",
   "import { Collection, type IType, type Opt, PrimaryKeyProp, type Ref, defineEntity, p } from '@mikro-orm/core';
-import { Author2 } from './subfolder/Author2';
 import { Book2Tags } from './Book2Tags';
 import { BookTag2 } from './BookTag2';
 import { MetaType } from './MetaType';
 import { Publisher2 } from './Publisher2';
 import { Test2 } from './Test2';
+import { Author2 } from './subfolder/Author2';
 
 export class Book2 {
   [PrimaryKeyProp]?: 'uuidPk';
@@ -3372,9 +3372,9 @@ export const Dummy2Schema = defineEntity({
 });
 ",
   "import { Collection, type IType, type Opt, type Ref, defineEntity, p } from '@mikro-orm/core';
+import { JSONObject } from './../runtimeTypes/JSONObject';
 import { FooBaz2 } from './FooBaz2';
 import { FooParam2 } from './FooParam2';
-import { JSONObject } from './../runtimeTypes/JSONObject';
 import { Test2 } from './Test2';
 
 export class FooBar2 {
@@ -3462,9 +3462,9 @@ export const FooParam2Schema = defineEntity({
 });
 ",
   "import { Collection, type IType, type Opt, defineEntity, p } from '@mikro-orm/core';
+import { UrlTypeLike } from './../types/UrlTypeLike';
 import { Book2 } from './Book2';
 import { Publisher2Tests } from './Publisher2Tests';
-import { UrlTypeLike } from './../types/UrlTypeLike';
 
 export class Publisher2 {
   id!: number;
@@ -3763,12 +3763,12 @@ export const Address2Schema = new EntitySchema({
 });
 ",
   "import { Cascade, Collection, EagerProps, EntitySchema, type Hidden, type IType, type Opt, type Ref, ref } from '@mikro-orm/core';
-import { Address2 } from '../Address2';
-import { Book2 } from '../Book2';
 import '../../runtimeTypes/BrandedTypes';
-import { MyBoolean as CustomBooleanType } from '../../types/MyBoolean';
 import Email from '../../runtimeTypes/Email';
 import * as EmailSerializer from '../../serializers/Email';
+import { MyBoolean as CustomBooleanType } from '../../types/MyBoolean';
+import { Address2 } from '../Address2';
+import { Book2 } from '../Book2';
 import { IdentitiesContainer } from '../IdentitiesContainer';
 import { MyExtendedDataClass } from '../MyExtendedDataClass';
 
@@ -4035,12 +4035,12 @@ export const BookTag2Schema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, type IType, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
-import { Author2 } from './subfolder/Author2';
 import { Book2Tags } from './Book2Tags';
 import { BookTag2 } from './BookTag2';
 import { MetaType } from './MetaType';
 import { Publisher2 } from './Publisher2';
 import { Test2 } from './Test2';
+import { Author2 } from './subfolder/Author2';
 
 export class Book2 {
   [PrimaryKeyProp]?: 'uuidPk';
@@ -4241,9 +4241,9 @@ export const Dummy2Schema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, type IType, type Opt, type Ref } from '@mikro-orm/core';
+import { JSONObject } from './../runtimeTypes/JSONObject';
 import { FooBaz2 } from './FooBaz2';
 import { FooParam2 } from './FooParam2';
-import { JSONObject } from './../runtimeTypes/JSONObject';
 import { Test2 } from './Test2';
 
 export class FooBar2 {
@@ -4361,9 +4361,9 @@ export const FooParam2Schema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, type IType, type Opt } from '@mikro-orm/core';
+import { UrlTypeLike } from './../types/UrlTypeLike';
 import { Book2 } from './Book2';
 import { Publisher2Tests } from './Publisher2Tests';
-import { UrlTypeLike } from './../types/UrlTypeLike';
 
 export class Publisher2 {
   id!: number;
@@ -4750,12 +4750,12 @@ export class Address2 {
 }
 ",
   "import { Cascade, Collection, EagerProps, Embedded, Entity, Formula, type Hidden, type IType, Index, ManyToMany, ManyToOne, OneToMany, OneToOne, type Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
-import { Address2 } from '../Address2';
-import { Book2 } from '../Book2';
 import '../../runtimeTypes/BrandedTypes';
-import { MyBoolean as CustomBooleanType } from '../../types/MyBoolean';
 import Email from '../../runtimeTypes/Email';
 import * as EmailSerializer from '../../serializers/Email';
+import { MyBoolean as CustomBooleanType } from '../../types/MyBoolean';
+import { Address2 } from '../Address2';
+import { Book2 } from '../Book2';
 import { IdentitiesContainer } from '../IdentitiesContainer';
 import { MyExtendedDataClass } from '../MyExtendedDataClass';
 
@@ -4914,12 +4914,12 @@ export class BookTag2 {
 }
 ",
   "import { Collection, Embedded, Entity, type IType, Index, ManyToMany, ManyToOne, OneToMany, OneToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
-import { Author2 } from './subfolder/Author2';
 import { Book2Tags } from './Book2Tags';
 import { BookTag2 } from './BookTag2';
 import { MetaType } from './MetaType';
 import { Publisher2 } from './Publisher2';
 import { Test2 } from './Test2';
+import { Author2 } from './subfolder/Author2';
 
 @Entity()
 export class Book2 {
@@ -5078,9 +5078,9 @@ export class Dummy2 {
 }
 ",
   "import { Collection, Entity, type IType, ManyToMany, OneToMany, OneToOne, type Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+import { JSONObject } from './../runtimeTypes/JSONObject';
 import { FooBaz2 } from './FooBaz2';
 import { FooParam2 } from './FooParam2';
-import { JSONObject } from './../runtimeTypes/JSONObject';
 import { Test2 } from './Test2';
 
 @Entity()
@@ -5185,9 +5185,9 @@ export class FooParam2 {
 }
 ",
   "import { Collection, Entity, Enum, type IType, OneToMany, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
+import { UrlTypeLike } from './../types/UrlTypeLike';
 import { Book2 } from './Book2';
 import { Publisher2Tests } from './Publisher2Tests';
-import { UrlTypeLike } from './../types/UrlTypeLike';
 
 @Entity()
 export class Publisher2 {
@@ -5463,12 +5463,12 @@ export const Address2Schema = defineEntity({
 });
 ",
   "import { Cascade, Collection, EagerProps, type Hidden, type IType, type Opt, defineEntity, p } from '@mikro-orm/core';
-import { Address2 } from '../Address2';
-import { Book2 } from '../Book2';
 import '../../runtimeTypes/BrandedTypes';
-import { MyBoolean as CustomBooleanType } from '../../types/MyBoolean';
 import Email from '../../runtimeTypes/Email';
 import * as EmailSerializer from '../../serializers/Email';
+import { MyBoolean as CustomBooleanType } from '../../types/MyBoolean';
+import { Address2 } from '../Address2';
+import { Book2 } from '../Book2';
 import { IdentitiesContainer } from '../IdentitiesContainer';
 import { MyExtendedDataClass } from '../MyExtendedDataClass';
 
@@ -5608,12 +5608,12 @@ export const BookTag2Schema = defineEntity({
 });
 ",
   "import { Collection, type IType, type Opt, PrimaryKeyProp, defineEntity, p } from '@mikro-orm/core';
-import { Author2 } from './subfolder/Author2';
 import { Book2Tags } from './Book2Tags';
 import { BookTag2 } from './BookTag2';
 import { MetaType } from './MetaType';
 import { Publisher2 } from './Publisher2';
 import { Test2 } from './Test2';
+import { Author2 } from './subfolder/Author2';
 
 export class Book2 {
   [PrimaryKeyProp]?: 'uuidPk';
@@ -5753,9 +5753,9 @@ export const Dummy2Schema = defineEntity({
 });
 ",
   "import { Collection, type IType, type Opt, defineEntity, p } from '@mikro-orm/core';
+import { JSONObject } from './../runtimeTypes/JSONObject';
 import { FooBaz2 } from './FooBaz2';
 import { FooParam2 } from './FooParam2';
-import { JSONObject } from './../runtimeTypes/JSONObject';
 import { Test2 } from './Test2';
 
 export class FooBar2 {
@@ -5843,9 +5843,9 @@ export const FooParam2Schema = defineEntity({
 });
 ",
   "import { Collection, type IType, type Opt, defineEntity, p } from '@mikro-orm/core';
+import { UrlTypeLike } from './../types/UrlTypeLike';
 import { Book2 } from './Book2';
 import { Publisher2Tests } from './Publisher2Tests';
-import { UrlTypeLike } from './../types/UrlTypeLike';
 
 export class Publisher2 {
   id!: number;
@@ -6143,12 +6143,12 @@ export const Address2Schema = new EntitySchema({
 });
 ",
   "import { Cascade, Collection, EagerProps, EntitySchema, type Hidden, type IType, type Opt } from '@mikro-orm/core';
-import { Address2 } from '../Address2';
-import { Book2 } from '../Book2';
 import '../../runtimeTypes/BrandedTypes';
-import { MyBoolean as CustomBooleanType } from '../../types/MyBoolean';
 import Email from '../../runtimeTypes/Email';
 import * as EmailSerializer from '../../serializers/Email';
+import { MyBoolean as CustomBooleanType } from '../../types/MyBoolean';
+import { Address2 } from '../Address2';
+import { Book2 } from '../Book2';
 import { IdentitiesContainer } from '../IdentitiesContainer';
 import { MyExtendedDataClass } from '../MyExtendedDataClass';
 
@@ -6404,12 +6404,12 @@ export const BookTag2Schema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, type IType, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
-import { Author2 } from './subfolder/Author2';
 import { Book2Tags } from './Book2Tags';
 import { BookTag2 } from './BookTag2';
 import { MetaType } from './MetaType';
 import { Publisher2 } from './Publisher2';
 import { Test2 } from './Test2';
+import { Author2 } from './subfolder/Author2';
 
 export class Book2 {
   [PrimaryKeyProp]?: 'uuidPk';
@@ -6601,9 +6601,9 @@ export const Dummy2Schema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, type IType, type Opt } from '@mikro-orm/core';
+import { JSONObject } from './../runtimeTypes/JSONObject';
 import { FooBaz2 } from './FooBaz2';
 import { FooParam2 } from './FooParam2';
-import { JSONObject } from './../runtimeTypes/JSONObject';
 import { Test2 } from './Test2';
 
 export class FooBar2 {
@@ -6717,9 +6717,9 @@ export const FooParam2Schema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, type IType, type Opt } from '@mikro-orm/core';
+import { UrlTypeLike } from './../types/UrlTypeLike';
 import { Book2 } from './Book2';
 import { Publisher2Tests } from './Publisher2Tests';
-import { UrlTypeLike } from './../types/UrlTypeLike';
 
 export class Publisher2 {
   id!: number;
@@ -7100,12 +7100,12 @@ export class Address2 {
 }
 ",
   "import { Cascade, Collection, EagerProps, Embedded, Entity, Formula, type Hidden, type IType, Index, ManyToMany, ManyToOne, OneToMany, OneToOne, type Opt, PrimaryKey, Property, type Ref, Unique, ref } from '@mikro-orm/core';
-import { Address2 } from '../Address2';
-import { Book2 } from '../Book2';
 import '../../runtimeTypes/BrandedTypes';
-import { MyBoolean as CustomBooleanType } from '../../types/MyBoolean';
 import Email from '../../runtimeTypes/Email';
 import * as EmailSerializer from '../../serializers/Email';
+import { MyBoolean as CustomBooleanType } from '../../types/MyBoolean';
+import { Address2 } from '../Address2';
+import { Book2 } from '../Book2';
 import { IdentitiesContainer } from '../IdentitiesContainer';
 import { MyExtendedDataClass } from '../MyExtendedDataClass';
 
@@ -7264,12 +7264,12 @@ export class BookTag2 {
 }
 ",
   "import { Collection, Embedded, Entity, type IType, Index, ManyToMany, ManyToOne, OneToMany, OneToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
-import { Author2 } from './subfolder/Author2';
 import { Book2Tags } from './Book2Tags';
 import { BookTag2 } from './BookTag2';
 import { MetaType } from './MetaType';
 import { Publisher2 } from './Publisher2';
 import { Test2 } from './Test2';
+import { Author2 } from './subfolder/Author2';
 
 @Entity()
 export class Book2 {
@@ -7428,9 +7428,9 @@ export class Dummy2 {
 }
 ",
   "import { Collection, Entity, type IType, ManyToMany, OneToMany, OneToOne, type Opt, PrimaryKey, Property, type Ref, Unique } from '@mikro-orm/core';
+import { JSONObject } from './../runtimeTypes/JSONObject';
 import { FooBaz2 } from './FooBaz2';
 import { FooParam2 } from './FooParam2';
-import { JSONObject } from './../runtimeTypes/JSONObject';
 import { Test2 } from './Test2';
 
 @Entity()
@@ -7535,9 +7535,9 @@ export class FooParam2 {
 }
 ",
   "import { Collection, Entity, Enum, type IType, OneToMany, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
+import { UrlTypeLike } from './../types/UrlTypeLike';
 import { Book2 } from './Book2';
 import { Publisher2Tests } from './Publisher2Tests';
-import { UrlTypeLike } from './../types/UrlTypeLike';
 
 @Entity()
 export class Publisher2 {
@@ -7813,12 +7813,12 @@ export const Address2Schema = defineEntity({
 });
 ",
   "import { Cascade, Collection, EagerProps, type Hidden, type IType, type Opt, type Ref, defineEntity, p, ref } from '@mikro-orm/core';
-import { Address2 } from '../Address2';
-import { Book2 } from '../Book2';
 import '../../runtimeTypes/BrandedTypes';
-import { MyBoolean as CustomBooleanType } from '../../types/MyBoolean';
 import Email from '../../runtimeTypes/Email';
 import * as EmailSerializer from '../../serializers/Email';
+import { MyBoolean as CustomBooleanType } from '../../types/MyBoolean';
+import { Address2 } from '../Address2';
+import { Book2 } from '../Book2';
 import { IdentitiesContainer } from '../IdentitiesContainer';
 import { MyExtendedDataClass } from '../MyExtendedDataClass';
 
@@ -7958,12 +7958,12 @@ export const BookTag2Schema = defineEntity({
 });
 ",
   "import { Collection, type IType, type Opt, PrimaryKeyProp, type Ref, defineEntity, p } from '@mikro-orm/core';
-import { Author2 } from './subfolder/Author2';
 import { Book2Tags } from './Book2Tags';
 import { BookTag2 } from './BookTag2';
 import { MetaType } from './MetaType';
 import { Publisher2 } from './Publisher2';
 import { Test2 } from './Test2';
+import { Author2 } from './subfolder/Author2';
 
 export class Book2 {
   [PrimaryKeyProp]?: 'uuidPk';
@@ -8103,9 +8103,9 @@ export const Dummy2Schema = defineEntity({
 });
 ",
   "import { Collection, type IType, type Opt, type Ref, defineEntity, p } from '@mikro-orm/core';
+import { JSONObject } from './../runtimeTypes/JSONObject';
 import { FooBaz2 } from './FooBaz2';
 import { FooParam2 } from './FooParam2';
-import { JSONObject } from './../runtimeTypes/JSONObject';
 import { Test2 } from './Test2';
 
 export class FooBar2 {
@@ -8193,9 +8193,9 @@ export const FooParam2Schema = defineEntity({
 });
 ",
   "import { Collection, type IType, type Opt, defineEntity, p } from '@mikro-orm/core';
+import { UrlTypeLike } from './../types/UrlTypeLike';
 import { Book2 } from './Book2';
 import { Publisher2Tests } from './Publisher2Tests';
-import { UrlTypeLike } from './../types/UrlTypeLike';
 
 export class Publisher2 {
   id!: number;
@@ -8494,12 +8494,12 @@ export const Address2Schema = new EntitySchema({
 });
 ",
   "import { Cascade, Collection, EagerProps, EntitySchema, type Hidden, type IType, type Opt, type Ref, ref } from '@mikro-orm/core';
-import { Address2 } from '../Address2';
-import { Book2 } from '../Book2';
 import '../../runtimeTypes/BrandedTypes';
-import { MyBoolean as CustomBooleanType } from '../../types/MyBoolean';
 import Email from '../../runtimeTypes/Email';
 import * as EmailSerializer from '../../serializers/Email';
+import { MyBoolean as CustomBooleanType } from '../../types/MyBoolean';
+import { Address2 } from '../Address2';
+import { Book2 } from '../Book2';
 import { IdentitiesContainer } from '../IdentitiesContainer';
 import { MyExtendedDataClass } from '../MyExtendedDataClass';
 
@@ -8766,12 +8766,12 @@ export const BookTag2Schema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, type IType, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
-import { Author2 } from './subfolder/Author2';
 import { Book2Tags } from './Book2Tags';
 import { BookTag2 } from './BookTag2';
 import { MetaType } from './MetaType';
 import { Publisher2 } from './Publisher2';
 import { Test2 } from './Test2';
+import { Author2 } from './subfolder/Author2';
 
 export class Book2 {
   [PrimaryKeyProp]?: 'uuidPk';
@@ -8972,9 +8972,9 @@ export const Dummy2Schema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, type IType, type Opt, type Ref } from '@mikro-orm/core';
+import { JSONObject } from './../runtimeTypes/JSONObject';
 import { FooBaz2 } from './FooBaz2';
 import { FooParam2 } from './FooParam2';
-import { JSONObject } from './../runtimeTypes/JSONObject';
 import { Test2 } from './Test2';
 
 export class FooBar2 {
@@ -9092,9 +9092,9 @@ export const FooParam2Schema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, type IType, type Opt } from '@mikro-orm/core';
+import { UrlTypeLike } from './../types/UrlTypeLike';
 import { Book2 } from './Book2';
 import { Publisher2Tests } from './Publisher2Tests';
-import { UrlTypeLike } from './../types/UrlTypeLike';
 
 export class Publisher2 {
   id!: number;

--- a/tests/features/entity-generator/__snapshots__/shared-native-enum.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/shared-native-enum.test.ts.snap
@@ -1,0 +1,1524 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`shared native enums [dictionary] [decorators] shared native enum 1`] = `
+[
+  "import { Collection, Entity, Enum, OneToMany, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+import { DbRowStatus, TDbRowStatus } from './DbRowStatus';
+import { UserRoles } from './UserRoles';
+
+@Entity()
+export class Domains {
+
+  [PrimaryKeyProp]?: 'key';
+
+  @PrimaryKey({ length: 64 })
+  key!: string;
+
+  @Property({ length: 256 })
+  name!: string;
+
+  @Property({ type: 'datetime', defaultRaw: \`CURRENT_TIMESTAMP\` })
+  createdAt!: Date & Opt;
+
+  @Property({ type: 'datetime', defaultRaw: \`CURRENT_TIMESTAMP\` })
+  updatedAt!: Date & Opt;
+
+  @Enum({ items: () => DbRowStatus, nativeEnumName: 'db_row_status' })
+  rowStatus: TDbRowStatus & Opt = DbRowStatus.ENABLED;
+
+  @OneToMany({ entity: () => UserRoles, mappedBy: 'domain' })
+  userRolesCollection = new Collection<UserRoles>(this);
+
+}
+",
+  "import { Collection, Entity, Enum, OneToMany, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+import { DbRowStatus, TDbRowStatus } from './DbRowStatus';
+import { UserRoles } from './UserRoles';
+
+@Entity()
+export class Roles {
+
+  [PrimaryKeyProp]?: 'key';
+
+  @PrimaryKey({ length: 64 })
+  key!: string;
+
+  @Property({ length: 256 })
+  name!: string;
+
+  @Property({ type: 'datetime', defaultRaw: \`CURRENT_TIMESTAMP\` })
+  createdAt!: Date & Opt;
+
+  @Property({ type: 'datetime', defaultRaw: \`CURRENT_TIMESTAMP\` })
+  updatedAt!: Date & Opt;
+
+  @Enum({ items: () => DbRowStatus, nativeEnumName: 'db_row_status' })
+  rowStatus: TDbRowStatus & Opt = DbRowStatus.ENABLED;
+
+  @OneToMany({ entity: () => UserRoles, mappedBy: 'role' })
+  userRolesCollection = new Collection<UserRoles>(this);
+
+}
+",
+  "import { Entity, Enum, ManyToOne, type Opt, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
+import { DbRowStatus, TDbRowStatus } from './DbRowStatus';
+import { Domains } from './Domains';
+import { Roles } from './Roles';
+import { Users } from './Users';
+
+@Entity()
+export class UserRoles {
+
+  [PrimaryKeyProp]?: ['domain', 'user'];
+
+  @ManyToOne({ entity: () => Domains, ref: true, deleteRule: 'cascade', primary: true })
+  domain!: Ref<Domains>;
+
+  @Property({ length: 64, persist: false })
+  domainKey!: string;
+
+  @ManyToOne({ entity: () => Users, ref: true, deleteRule: 'cascade', primary: true })
+  user!: Ref<Users>;
+
+  @Property({ type: 'uuid', persist: false })
+  userId!: string;
+
+  @ManyToOne({ entity: () => Roles, ref: true, deleteRule: 'cascade' })
+  role!: Ref<Roles>;
+
+  @Property({ length: 64, persist: false })
+  roleKey!: string;
+
+  @Property({ type: 'datetime', defaultRaw: \`CURRENT_TIMESTAMP\` })
+  createdAt!: Date & Opt;
+
+  @Property({ type: 'datetime', defaultRaw: \`CURRENT_TIMESTAMP\` })
+  updatedAt!: Date & Opt;
+
+  @Enum({ items: () => DbRowStatus, nativeEnumName: 'db_row_status' })
+  rowStatus: TDbRowStatus & Opt = DbRowStatus.ENABLED;
+
+}
+",
+  "import { Collection, Entity, Enum, OneToMany, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
+import { DbRowStatus, TDbRowStatus } from './DbRowStatus';
+import { UserRoles } from './UserRoles';
+
+@Entity()
+export class Users {
+
+  @PrimaryKey({ type: 'uuid' })
+  id!: string;
+
+  @Property({ length: 256 })
+  email!: string;
+
+  @Property({ type: 'datetime', defaultRaw: \`CURRENT_TIMESTAMP\` })
+  createdAt!: Date & Opt;
+
+  @Property({ type: 'datetime', defaultRaw: \`CURRENT_TIMESTAMP\` })
+  updatedAt!: Date & Opt;
+
+  @Enum({ items: () => DbRowStatus, nativeEnumName: 'db_row_status' })
+  rowStatus: TDbRowStatus & Opt = DbRowStatus.ENABLED;
+
+  @OneToMany({ entity: () => UserRoles, mappedBy: 'user' })
+  userRolesCollection = new Collection<UserRoles>(this);
+
+}
+",
+  "export const DbRowStatus = {
+  ENABLED: 'enabled',
+  DISABLED: 'disabled',
+  ARCHIVED: 'archived',
+  DELETED: 'deleted',
+} as const;
+
+export type TDbRowStatus = (typeof DbRowStatus)[keyof typeof DbRowStatus];
+",
+]
+`;
+
+exports[`shared native enums [dictionary] [defineEntity+types] shared native enum 1`] = `
+[
+  "import { InferEntity, defineEntity, p } from '@mikro-orm/core';
+import { DbRowStatus } from './DbRowStatus';
+import { UserRoles } from './UserRoles';
+
+export const Domains = defineEntity({
+  name: 'Domains',
+  properties: {
+    key: p.string().primary().length(64),
+    name: p.string().length(256),
+    createdAt: p.datetime().defaultRaw(\`CURRENT_TIMESTAMP\`),
+    updatedAt: p.datetime().defaultRaw(\`CURRENT_TIMESTAMP\`),
+    rowStatus: p.enum(() => DbRowStatus).nativeEnumName('db_row_status'),
+    userRolesCollection: () => p.oneToMany(UserRoles).mappedBy('domain'),
+  },
+});
+
+export interface IDomains extends InferEntity<typeof Domains> {}
+",
+  "import { InferEntity, defineEntity, p } from '@mikro-orm/core';
+import { DbRowStatus } from './DbRowStatus';
+import { UserRoles } from './UserRoles';
+
+export const Roles = defineEntity({
+  name: 'Roles',
+  properties: {
+    key: p.string().primary().length(64),
+    name: p.string().length(256),
+    createdAt: p.datetime().defaultRaw(\`CURRENT_TIMESTAMP\`),
+    updatedAt: p.datetime().defaultRaw(\`CURRENT_TIMESTAMP\`),
+    rowStatus: p.enum(() => DbRowStatus).nativeEnumName('db_row_status'),
+    userRolesCollection: () => p.oneToMany(UserRoles).mappedBy('role'),
+  },
+});
+
+export interface IRoles extends InferEntity<typeof Roles> {}
+",
+  "import { InferEntity, defineEntity, p } from '@mikro-orm/core';
+import { DbRowStatus } from './DbRowStatus';
+import { Domains } from './Domains';
+import { Roles } from './Roles';
+import { Users } from './Users';
+
+export const UserRoles = defineEntity({
+  name: 'UserRoles',
+  primaryKeys: ['domain', 'user'],
+  properties: {
+    domain: () => p.manyToOne(Domains).primary().ref().deleteRule('cascade'),
+    domainKey: p.string().length(64).persist(false),
+    user: () => p.manyToOne(Users).primary().ref().deleteRule('cascade'),
+    userId: p.uuid().persist(false),
+    role: () => p.manyToOne(Roles).ref().deleteRule('cascade'),
+    roleKey: p.string().length(64).persist(false),
+    createdAt: p.datetime().defaultRaw(\`CURRENT_TIMESTAMP\`),
+    updatedAt: p.datetime().defaultRaw(\`CURRENT_TIMESTAMP\`),
+    rowStatus: p.enum(() => DbRowStatus).nativeEnumName('db_row_status'),
+  },
+});
+
+export interface IUserRoles extends InferEntity<typeof UserRoles> {}
+",
+  "import { InferEntity, defineEntity, p } from '@mikro-orm/core';
+import { DbRowStatus } from './DbRowStatus';
+import { UserRoles } from './UserRoles';
+
+export const Users = defineEntity({
+  name: 'Users',
+  properties: {
+    id: p.uuid().primary(),
+    email: p.string().length(256),
+    createdAt: p.datetime().defaultRaw(\`CURRENT_TIMESTAMP\`),
+    updatedAt: p.datetime().defaultRaw(\`CURRENT_TIMESTAMP\`),
+    rowStatus: p.enum(() => DbRowStatus).nativeEnumName('db_row_status'),
+    userRolesCollection: () => p.oneToMany(UserRoles).mappedBy('user'),
+  },
+});
+
+export interface IUsers extends InferEntity<typeof Users> {}
+",
+  "export const DbRowStatus = {
+  ENABLED: 'enabled',
+  DISABLED: 'disabled',
+  ARCHIVED: 'archived',
+  DELETED: 'deleted',
+} as const;
+
+export type TDbRowStatus = (typeof DbRowStatus)[keyof typeof DbRowStatus];
+",
+]
+`;
+
+exports[`shared native enums [dictionary] [defineEntity] shared native enum 1`] = `
+[
+  "import { Collection, type Opt, PrimaryKeyProp, defineEntity, p } from '@mikro-orm/core';
+import { DbRowStatus, TDbRowStatus } from './DbRowStatus';
+import { UserRoles } from './UserRoles';
+
+export class Domains {
+  [PrimaryKeyProp]?: 'key';
+  key!: string;
+  name!: string;
+  createdAt!: Date & Opt;
+  updatedAt!: Date & Opt;
+  rowStatus: TDbRowStatus & Opt = DbRowStatus.ENABLED;
+  userRolesCollection = new Collection<UserRoles>(this);
+}
+
+export const DomainsSchema = defineEntity({
+  class: Domains,
+  properties: {
+    key: p.string().primary().length(64),
+    name: p.string().length(256),
+    createdAt: p.datetime().defaultRaw(\`CURRENT_TIMESTAMP\`),
+    updatedAt: p.datetime().defaultRaw(\`CURRENT_TIMESTAMP\`),
+    rowStatus: p.enum(() => DbRowStatus).nativeEnumName('db_row_status'),
+    userRolesCollection: () => p.oneToMany(UserRoles).mappedBy('domain'),
+  },
+});
+",
+  "import { Collection, type Opt, PrimaryKeyProp, defineEntity, p } from '@mikro-orm/core';
+import { DbRowStatus, TDbRowStatus } from './DbRowStatus';
+import { UserRoles } from './UserRoles';
+
+export class Roles {
+  [PrimaryKeyProp]?: 'key';
+  key!: string;
+  name!: string;
+  createdAt!: Date & Opt;
+  updatedAt!: Date & Opt;
+  rowStatus: TDbRowStatus & Opt = DbRowStatus.ENABLED;
+  userRolesCollection = new Collection<UserRoles>(this);
+}
+
+export const RolesSchema = defineEntity({
+  class: Roles,
+  properties: {
+    key: p.string().primary().length(64),
+    name: p.string().length(256),
+    createdAt: p.datetime().defaultRaw(\`CURRENT_TIMESTAMP\`),
+    updatedAt: p.datetime().defaultRaw(\`CURRENT_TIMESTAMP\`),
+    rowStatus: p.enum(() => DbRowStatus).nativeEnumName('db_row_status'),
+    userRolesCollection: () => p.oneToMany(UserRoles).mappedBy('role'),
+  },
+});
+",
+  "import { type Opt, PrimaryKeyProp, type Ref, defineEntity, p } from '@mikro-orm/core';
+import { DbRowStatus, TDbRowStatus } from './DbRowStatus';
+import { Domains } from './Domains';
+import { Roles } from './Roles';
+import { Users } from './Users';
+
+export class UserRoles {
+  [PrimaryKeyProp]?: ['domain', 'user'];
+  domain!: Ref<Domains>;
+  domainKey!: string;
+  user!: Ref<Users>;
+  userId!: string;
+  role!: Ref<Roles>;
+  roleKey!: string;
+  createdAt!: Date & Opt;
+  updatedAt!: Date & Opt;
+  rowStatus: TDbRowStatus & Opt = DbRowStatus.ENABLED;
+}
+
+export const UserRolesSchema = defineEntity({
+  class: UserRoles,
+  properties: {
+    domain: () => p.manyToOne(Domains).primary().ref().deleteRule('cascade'),
+    domainKey: p.string().length(64).persist(false),
+    user: () => p.manyToOne(Users).primary().ref().deleteRule('cascade'),
+    userId: p.uuid().persist(false),
+    role: () => p.manyToOne(Roles).ref().deleteRule('cascade'),
+    roleKey: p.string().length(64).persist(false),
+    createdAt: p.datetime().defaultRaw(\`CURRENT_TIMESTAMP\`),
+    updatedAt: p.datetime().defaultRaw(\`CURRENT_TIMESTAMP\`),
+    rowStatus: p.enum(() => DbRowStatus).nativeEnumName('db_row_status'),
+  },
+});
+",
+  "import { Collection, type Opt, defineEntity, p } from '@mikro-orm/core';
+import { DbRowStatus, TDbRowStatus } from './DbRowStatus';
+import { UserRoles } from './UserRoles';
+
+export class Users {
+  id!: string;
+  email!: string;
+  createdAt!: Date & Opt;
+  updatedAt!: Date & Opt;
+  rowStatus: TDbRowStatus & Opt = DbRowStatus.ENABLED;
+  userRolesCollection = new Collection<UserRoles>(this);
+}
+
+export const UsersSchema = defineEntity({
+  class: Users,
+  properties: {
+    id: p.uuid().primary(),
+    email: p.string().length(256),
+    createdAt: p.datetime().defaultRaw(\`CURRENT_TIMESTAMP\`),
+    updatedAt: p.datetime().defaultRaw(\`CURRENT_TIMESTAMP\`),
+    rowStatus: p.enum(() => DbRowStatus).nativeEnumName('db_row_status'),
+    userRolesCollection: () => p.oneToMany(UserRoles).mappedBy('user'),
+  },
+});
+",
+  "export const DbRowStatus = {
+  ENABLED: 'enabled',
+  DISABLED: 'disabled',
+  ARCHIVED: 'archived',
+  DELETED: 'deleted',
+} as const;
+
+export type TDbRowStatus = (typeof DbRowStatus)[keyof typeof DbRowStatus];
+",
+]
+`;
+
+exports[`shared native enums [dictionary] [entitySchema] shared native enum 1`] = `
+[
+  "import { Collection, EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { DbRowStatus, TDbRowStatus } from './DbRowStatus';
+import { UserRoles } from './UserRoles';
+
+export class Domains {
+  [PrimaryKeyProp]?: 'key';
+  key!: string;
+  name!: string;
+  createdAt!: Date & Opt;
+  updatedAt!: Date & Opt;
+  rowStatus: TDbRowStatus & Opt = DbRowStatus.ENABLED;
+  userRolesCollection = new Collection<UserRoles>(this);
+}
+
+export const DomainsSchema = new EntitySchema({
+  class: Domains,
+  properties: {
+    key: { primary: true, type: 'string', length: 64 },
+    name: { type: 'string', length: 256 },
+    createdAt: { type: 'datetime', defaultRaw: \`CURRENT_TIMESTAMP\` },
+    updatedAt: { type: 'datetime', defaultRaw: \`CURRENT_TIMESTAMP\` },
+    rowStatus: {
+      enum: true,
+      items: () => DbRowStatus,
+      nativeEnumName: 'db_row_status',
+    },
+    userRolesCollection: {
+      kind: '1:m',
+      entity: () => UserRoles,
+      mappedBy: 'domain',
+    },
+  },
+});
+",
+  "import { Collection, EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { DbRowStatus, TDbRowStatus } from './DbRowStatus';
+import { UserRoles } from './UserRoles';
+
+export class Roles {
+  [PrimaryKeyProp]?: 'key';
+  key!: string;
+  name!: string;
+  createdAt!: Date & Opt;
+  updatedAt!: Date & Opt;
+  rowStatus: TDbRowStatus & Opt = DbRowStatus.ENABLED;
+  userRolesCollection = new Collection<UserRoles>(this);
+}
+
+export const RolesSchema = new EntitySchema({
+  class: Roles,
+  properties: {
+    key: { primary: true, type: 'string', length: 64 },
+    name: { type: 'string', length: 256 },
+    createdAt: { type: 'datetime', defaultRaw: \`CURRENT_TIMESTAMP\` },
+    updatedAt: { type: 'datetime', defaultRaw: \`CURRENT_TIMESTAMP\` },
+    rowStatus: {
+      enum: true,
+      items: () => DbRowStatus,
+      nativeEnumName: 'db_row_status',
+    },
+    userRolesCollection: {
+      kind: '1:m',
+      entity: () => UserRoles,
+      mappedBy: 'role',
+    },
+  },
+});
+",
+  "import { EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
+import { DbRowStatus, TDbRowStatus } from './DbRowStatus';
+import { Domains } from './Domains';
+import { Roles } from './Roles';
+import { Users } from './Users';
+
+export class UserRoles {
+  [PrimaryKeyProp]?: ['domain', 'user'];
+  domain!: Ref<Domains>;
+  domainKey!: string;
+  user!: Ref<Users>;
+  userId!: string;
+  role!: Ref<Roles>;
+  roleKey!: string;
+  createdAt!: Date & Opt;
+  updatedAt!: Date & Opt;
+  rowStatus: TDbRowStatus & Opt = DbRowStatus.ENABLED;
+}
+
+export const UserRolesSchema = new EntitySchema({
+  class: UserRoles,
+  properties: {
+    domain: {
+      primary: true,
+      kind: 'm:1',
+      entity: () => Domains,
+      ref: true,
+      deleteRule: 'cascade',
+    },
+    domainKey: { type: 'string', length: 64, persist: false },
+    user: {
+      primary: true,
+      kind: 'm:1',
+      entity: () => Users,
+      ref: true,
+      deleteRule: 'cascade',
+    },
+    userId: { type: 'uuid', persist: false },
+    role: { kind: 'm:1', entity: () => Roles, ref: true, deleteRule: 'cascade' },
+    roleKey: { type: 'string', length: 64, persist: false },
+    createdAt: { type: 'datetime', defaultRaw: \`CURRENT_TIMESTAMP\` },
+    updatedAt: { type: 'datetime', defaultRaw: \`CURRENT_TIMESTAMP\` },
+    rowStatus: {
+      enum: true,
+      items: () => DbRowStatus,
+      nativeEnumName: 'db_row_status',
+    },
+  },
+});
+",
+  "import { Collection, EntitySchema, type Opt } from '@mikro-orm/core';
+import { DbRowStatus, TDbRowStatus } from './DbRowStatus';
+import { UserRoles } from './UserRoles';
+
+export class Users {
+  id!: string;
+  email!: string;
+  createdAt!: Date & Opt;
+  updatedAt!: Date & Opt;
+  rowStatus: TDbRowStatus & Opt = DbRowStatus.ENABLED;
+  userRolesCollection = new Collection<UserRoles>(this);
+}
+
+export const UsersSchema = new EntitySchema({
+  class: Users,
+  properties: {
+    id: { primary: true, type: 'uuid' },
+    email: { type: 'string', length: 256 },
+    createdAt: { type: 'datetime', defaultRaw: \`CURRENT_TIMESTAMP\` },
+    updatedAt: { type: 'datetime', defaultRaw: \`CURRENT_TIMESTAMP\` },
+    rowStatus: {
+      enum: true,
+      items: () => DbRowStatus,
+      nativeEnumName: 'db_row_status',
+    },
+    userRolesCollection: {
+      kind: '1:m',
+      entity: () => UserRoles,
+      mappedBy: 'user',
+    },
+  },
+});
+",
+  "export const DbRowStatus = {
+  ENABLED: 'enabled',
+  DISABLED: 'disabled',
+  ARCHIVED: 'archived',
+  DELETED: 'deleted',
+} as const;
+
+export type TDbRowStatus = (typeof DbRowStatus)[keyof typeof DbRowStatus];
+",
+]
+`;
+
+exports[`shared native enums [ts-enum] [decorators] shared native enum 1`] = `
+[
+  "import { Collection, Entity, Enum, OneToMany, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+import { DbRowStatus } from './DbRowStatus';
+import { UserRoles } from './UserRoles';
+
+@Entity()
+export class Domains {
+
+  [PrimaryKeyProp]?: 'key';
+
+  @PrimaryKey({ length: 64 })
+  key!: string;
+
+  @Property({ length: 256 })
+  name!: string;
+
+  @Property({ type: 'datetime', defaultRaw: \`CURRENT_TIMESTAMP\` })
+  createdAt!: Date & Opt;
+
+  @Property({ type: 'datetime', defaultRaw: \`CURRENT_TIMESTAMP\` })
+  updatedAt!: Date & Opt;
+
+  @Enum({ items: () => DbRowStatus, nativeEnumName: 'db_row_status' })
+  rowStatus: DbRowStatus & Opt = DbRowStatus.ENABLED;
+
+  @OneToMany({ entity: () => UserRoles, mappedBy: 'domain' })
+  userRolesCollection = new Collection<UserRoles>(this);
+
+}
+",
+  "import { Collection, Entity, Enum, OneToMany, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+import { DbRowStatus } from './DbRowStatus';
+import { UserRoles } from './UserRoles';
+
+@Entity()
+export class Roles {
+
+  [PrimaryKeyProp]?: 'key';
+
+  @PrimaryKey({ length: 64 })
+  key!: string;
+
+  @Property({ length: 256 })
+  name!: string;
+
+  @Property({ type: 'datetime', defaultRaw: \`CURRENT_TIMESTAMP\` })
+  createdAt!: Date & Opt;
+
+  @Property({ type: 'datetime', defaultRaw: \`CURRENT_TIMESTAMP\` })
+  updatedAt!: Date & Opt;
+
+  @Enum({ items: () => DbRowStatus, nativeEnumName: 'db_row_status' })
+  rowStatus: DbRowStatus & Opt = DbRowStatus.ENABLED;
+
+  @OneToMany({ entity: () => UserRoles, mappedBy: 'role' })
+  userRolesCollection = new Collection<UserRoles>(this);
+
+}
+",
+  "import { Entity, Enum, ManyToOne, type Opt, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
+import { DbRowStatus } from './DbRowStatus';
+import { Domains } from './Domains';
+import { Roles } from './Roles';
+import { Users } from './Users';
+
+@Entity()
+export class UserRoles {
+
+  [PrimaryKeyProp]?: ['domain', 'user'];
+
+  @ManyToOne({ entity: () => Domains, ref: true, deleteRule: 'cascade', primary: true })
+  domain!: Ref<Domains>;
+
+  @Property({ length: 64, persist: false })
+  domainKey!: string;
+
+  @ManyToOne({ entity: () => Users, ref: true, deleteRule: 'cascade', primary: true })
+  user!: Ref<Users>;
+
+  @Property({ type: 'uuid', persist: false })
+  userId!: string;
+
+  @ManyToOne({ entity: () => Roles, ref: true, deleteRule: 'cascade' })
+  role!: Ref<Roles>;
+
+  @Property({ length: 64, persist: false })
+  roleKey!: string;
+
+  @Property({ type: 'datetime', defaultRaw: \`CURRENT_TIMESTAMP\` })
+  createdAt!: Date & Opt;
+
+  @Property({ type: 'datetime', defaultRaw: \`CURRENT_TIMESTAMP\` })
+  updatedAt!: Date & Opt;
+
+  @Enum({ items: () => DbRowStatus, nativeEnumName: 'db_row_status' })
+  rowStatus: DbRowStatus & Opt = DbRowStatus.ENABLED;
+
+}
+",
+  "import { Collection, Entity, Enum, OneToMany, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
+import { DbRowStatus } from './DbRowStatus';
+import { UserRoles } from './UserRoles';
+
+@Entity()
+export class Users {
+
+  @PrimaryKey({ type: 'uuid' })
+  id!: string;
+
+  @Property({ length: 256 })
+  email!: string;
+
+  @Property({ type: 'datetime', defaultRaw: \`CURRENT_TIMESTAMP\` })
+  createdAt!: Date & Opt;
+
+  @Property({ type: 'datetime', defaultRaw: \`CURRENT_TIMESTAMP\` })
+  updatedAt!: Date & Opt;
+
+  @Enum({ items: () => DbRowStatus, nativeEnumName: 'db_row_status' })
+  rowStatus: DbRowStatus & Opt = DbRowStatus.ENABLED;
+
+  @OneToMany({ entity: () => UserRoles, mappedBy: 'user' })
+  userRolesCollection = new Collection<UserRoles>(this);
+
+}
+",
+  "export enum DbRowStatus {
+  ENABLED = 'enabled',
+  DISABLED = 'disabled',
+  ARCHIVED = 'archived',
+  DELETED = 'deleted',
+}
+",
+]
+`;
+
+exports[`shared native enums [ts-enum] [defineEntity+types] shared native enum 1`] = `
+[
+  "import { InferEntity, defineEntity, p } from '@mikro-orm/core';
+import { DbRowStatus } from './DbRowStatus';
+import { UserRoles } from './UserRoles';
+
+export const Domains = defineEntity({
+  name: 'Domains',
+  properties: {
+    key: p.string().primary().length(64),
+    name: p.string().length(256),
+    createdAt: p.datetime().defaultRaw(\`CURRENT_TIMESTAMP\`),
+    updatedAt: p.datetime().defaultRaw(\`CURRENT_TIMESTAMP\`),
+    rowStatus: p.enum(() => DbRowStatus).nativeEnumName('db_row_status'),
+    userRolesCollection: () => p.oneToMany(UserRoles).mappedBy('domain'),
+  },
+});
+
+export interface IDomains extends InferEntity<typeof Domains> {}
+",
+  "import { InferEntity, defineEntity, p } from '@mikro-orm/core';
+import { DbRowStatus } from './DbRowStatus';
+import { UserRoles } from './UserRoles';
+
+export const Roles = defineEntity({
+  name: 'Roles',
+  properties: {
+    key: p.string().primary().length(64),
+    name: p.string().length(256),
+    createdAt: p.datetime().defaultRaw(\`CURRENT_TIMESTAMP\`),
+    updatedAt: p.datetime().defaultRaw(\`CURRENT_TIMESTAMP\`),
+    rowStatus: p.enum(() => DbRowStatus).nativeEnumName('db_row_status'),
+    userRolesCollection: () => p.oneToMany(UserRoles).mappedBy('role'),
+  },
+});
+
+export interface IRoles extends InferEntity<typeof Roles> {}
+",
+  "import { InferEntity, defineEntity, p } from '@mikro-orm/core';
+import { DbRowStatus } from './DbRowStatus';
+import { Domains } from './Domains';
+import { Roles } from './Roles';
+import { Users } from './Users';
+
+export const UserRoles = defineEntity({
+  name: 'UserRoles',
+  primaryKeys: ['domain', 'user'],
+  properties: {
+    domain: () => p.manyToOne(Domains).primary().ref().deleteRule('cascade'),
+    domainKey: p.string().length(64).persist(false),
+    user: () => p.manyToOne(Users).primary().ref().deleteRule('cascade'),
+    userId: p.uuid().persist(false),
+    role: () => p.manyToOne(Roles).ref().deleteRule('cascade'),
+    roleKey: p.string().length(64).persist(false),
+    createdAt: p.datetime().defaultRaw(\`CURRENT_TIMESTAMP\`),
+    updatedAt: p.datetime().defaultRaw(\`CURRENT_TIMESTAMP\`),
+    rowStatus: p.enum(() => DbRowStatus).nativeEnumName('db_row_status'),
+  },
+});
+
+export interface IUserRoles extends InferEntity<typeof UserRoles> {}
+",
+  "import { InferEntity, defineEntity, p } from '@mikro-orm/core';
+import { DbRowStatus } from './DbRowStatus';
+import { UserRoles } from './UserRoles';
+
+export const Users = defineEntity({
+  name: 'Users',
+  properties: {
+    id: p.uuid().primary(),
+    email: p.string().length(256),
+    createdAt: p.datetime().defaultRaw(\`CURRENT_TIMESTAMP\`),
+    updatedAt: p.datetime().defaultRaw(\`CURRENT_TIMESTAMP\`),
+    rowStatus: p.enum(() => DbRowStatus).nativeEnumName('db_row_status'),
+    userRolesCollection: () => p.oneToMany(UserRoles).mappedBy('user'),
+  },
+});
+
+export interface IUsers extends InferEntity<typeof Users> {}
+",
+  "export enum DbRowStatus {
+  ENABLED = 'enabled',
+  DISABLED = 'disabled',
+  ARCHIVED = 'archived',
+  DELETED = 'deleted',
+}
+",
+]
+`;
+
+exports[`shared native enums [ts-enum] [defineEntity] shared native enum 1`] = `
+[
+  "import { Collection, type Opt, PrimaryKeyProp, defineEntity, p } from '@mikro-orm/core';
+import { DbRowStatus } from './DbRowStatus';
+import { UserRoles } from './UserRoles';
+
+export class Domains {
+  [PrimaryKeyProp]?: 'key';
+  key!: string;
+  name!: string;
+  createdAt!: Date & Opt;
+  updatedAt!: Date & Opt;
+  rowStatus: DbRowStatus & Opt = DbRowStatus.ENABLED;
+  userRolesCollection = new Collection<UserRoles>(this);
+}
+
+export const DomainsSchema = defineEntity({
+  class: Domains,
+  properties: {
+    key: p.string().primary().length(64),
+    name: p.string().length(256),
+    createdAt: p.datetime().defaultRaw(\`CURRENT_TIMESTAMP\`),
+    updatedAt: p.datetime().defaultRaw(\`CURRENT_TIMESTAMP\`),
+    rowStatus: p.enum(() => DbRowStatus).nativeEnumName('db_row_status'),
+    userRolesCollection: () => p.oneToMany(UserRoles).mappedBy('domain'),
+  },
+});
+",
+  "import { Collection, type Opt, PrimaryKeyProp, defineEntity, p } from '@mikro-orm/core';
+import { DbRowStatus } from './DbRowStatus';
+import { UserRoles } from './UserRoles';
+
+export class Roles {
+  [PrimaryKeyProp]?: 'key';
+  key!: string;
+  name!: string;
+  createdAt!: Date & Opt;
+  updatedAt!: Date & Opt;
+  rowStatus: DbRowStatus & Opt = DbRowStatus.ENABLED;
+  userRolesCollection = new Collection<UserRoles>(this);
+}
+
+export const RolesSchema = defineEntity({
+  class: Roles,
+  properties: {
+    key: p.string().primary().length(64),
+    name: p.string().length(256),
+    createdAt: p.datetime().defaultRaw(\`CURRENT_TIMESTAMP\`),
+    updatedAt: p.datetime().defaultRaw(\`CURRENT_TIMESTAMP\`),
+    rowStatus: p.enum(() => DbRowStatus).nativeEnumName('db_row_status'),
+    userRolesCollection: () => p.oneToMany(UserRoles).mappedBy('role'),
+  },
+});
+",
+  "import { type Opt, PrimaryKeyProp, type Ref, defineEntity, p } from '@mikro-orm/core';
+import { DbRowStatus } from './DbRowStatus';
+import { Domains } from './Domains';
+import { Roles } from './Roles';
+import { Users } from './Users';
+
+export class UserRoles {
+  [PrimaryKeyProp]?: ['domain', 'user'];
+  domain!: Ref<Domains>;
+  domainKey!: string;
+  user!: Ref<Users>;
+  userId!: string;
+  role!: Ref<Roles>;
+  roleKey!: string;
+  createdAt!: Date & Opt;
+  updatedAt!: Date & Opt;
+  rowStatus: DbRowStatus & Opt = DbRowStatus.ENABLED;
+}
+
+export const UserRolesSchema = defineEntity({
+  class: UserRoles,
+  properties: {
+    domain: () => p.manyToOne(Domains).primary().ref().deleteRule('cascade'),
+    domainKey: p.string().length(64).persist(false),
+    user: () => p.manyToOne(Users).primary().ref().deleteRule('cascade'),
+    userId: p.uuid().persist(false),
+    role: () => p.manyToOne(Roles).ref().deleteRule('cascade'),
+    roleKey: p.string().length(64).persist(false),
+    createdAt: p.datetime().defaultRaw(\`CURRENT_TIMESTAMP\`),
+    updatedAt: p.datetime().defaultRaw(\`CURRENT_TIMESTAMP\`),
+    rowStatus: p.enum(() => DbRowStatus).nativeEnumName('db_row_status'),
+  },
+});
+",
+  "import { Collection, type Opt, defineEntity, p } from '@mikro-orm/core';
+import { DbRowStatus } from './DbRowStatus';
+import { UserRoles } from './UserRoles';
+
+export class Users {
+  id!: string;
+  email!: string;
+  createdAt!: Date & Opt;
+  updatedAt!: Date & Opt;
+  rowStatus: DbRowStatus & Opt = DbRowStatus.ENABLED;
+  userRolesCollection = new Collection<UserRoles>(this);
+}
+
+export const UsersSchema = defineEntity({
+  class: Users,
+  properties: {
+    id: p.uuid().primary(),
+    email: p.string().length(256),
+    createdAt: p.datetime().defaultRaw(\`CURRENT_TIMESTAMP\`),
+    updatedAt: p.datetime().defaultRaw(\`CURRENT_TIMESTAMP\`),
+    rowStatus: p.enum(() => DbRowStatus).nativeEnumName('db_row_status'),
+    userRolesCollection: () => p.oneToMany(UserRoles).mappedBy('user'),
+  },
+});
+",
+  "export enum DbRowStatus {
+  ENABLED = 'enabled',
+  DISABLED = 'disabled',
+  ARCHIVED = 'archived',
+  DELETED = 'deleted',
+}
+",
+]
+`;
+
+exports[`shared native enums [ts-enum] [entitySchema] shared native enum 1`] = `
+[
+  "import { Collection, EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { DbRowStatus } from './DbRowStatus';
+import { UserRoles } from './UserRoles';
+
+export class Domains {
+  [PrimaryKeyProp]?: 'key';
+  key!: string;
+  name!: string;
+  createdAt!: Date & Opt;
+  updatedAt!: Date & Opt;
+  rowStatus: DbRowStatus & Opt = DbRowStatus.ENABLED;
+  userRolesCollection = new Collection<UserRoles>(this);
+}
+
+export const DomainsSchema = new EntitySchema({
+  class: Domains,
+  properties: {
+    key: { primary: true, type: 'string', length: 64 },
+    name: { type: 'string', length: 256 },
+    createdAt: { type: 'datetime', defaultRaw: \`CURRENT_TIMESTAMP\` },
+    updatedAt: { type: 'datetime', defaultRaw: \`CURRENT_TIMESTAMP\` },
+    rowStatus: {
+      enum: true,
+      items: () => DbRowStatus,
+      nativeEnumName: 'db_row_status',
+    },
+    userRolesCollection: {
+      kind: '1:m',
+      entity: () => UserRoles,
+      mappedBy: 'domain',
+    },
+  },
+});
+",
+  "import { Collection, EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { DbRowStatus } from './DbRowStatus';
+import { UserRoles } from './UserRoles';
+
+export class Roles {
+  [PrimaryKeyProp]?: 'key';
+  key!: string;
+  name!: string;
+  createdAt!: Date & Opt;
+  updatedAt!: Date & Opt;
+  rowStatus: DbRowStatus & Opt = DbRowStatus.ENABLED;
+  userRolesCollection = new Collection<UserRoles>(this);
+}
+
+export const RolesSchema = new EntitySchema({
+  class: Roles,
+  properties: {
+    key: { primary: true, type: 'string', length: 64 },
+    name: { type: 'string', length: 256 },
+    createdAt: { type: 'datetime', defaultRaw: \`CURRENT_TIMESTAMP\` },
+    updatedAt: { type: 'datetime', defaultRaw: \`CURRENT_TIMESTAMP\` },
+    rowStatus: {
+      enum: true,
+      items: () => DbRowStatus,
+      nativeEnumName: 'db_row_status',
+    },
+    userRolesCollection: {
+      kind: '1:m',
+      entity: () => UserRoles,
+      mappedBy: 'role',
+    },
+  },
+});
+",
+  "import { EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
+import { DbRowStatus } from './DbRowStatus';
+import { Domains } from './Domains';
+import { Roles } from './Roles';
+import { Users } from './Users';
+
+export class UserRoles {
+  [PrimaryKeyProp]?: ['domain', 'user'];
+  domain!: Ref<Domains>;
+  domainKey!: string;
+  user!: Ref<Users>;
+  userId!: string;
+  role!: Ref<Roles>;
+  roleKey!: string;
+  createdAt!: Date & Opt;
+  updatedAt!: Date & Opt;
+  rowStatus: DbRowStatus & Opt = DbRowStatus.ENABLED;
+}
+
+export const UserRolesSchema = new EntitySchema({
+  class: UserRoles,
+  properties: {
+    domain: {
+      primary: true,
+      kind: 'm:1',
+      entity: () => Domains,
+      ref: true,
+      deleteRule: 'cascade',
+    },
+    domainKey: { type: 'string', length: 64, persist: false },
+    user: {
+      primary: true,
+      kind: 'm:1',
+      entity: () => Users,
+      ref: true,
+      deleteRule: 'cascade',
+    },
+    userId: { type: 'uuid', persist: false },
+    role: { kind: 'm:1', entity: () => Roles, ref: true, deleteRule: 'cascade' },
+    roleKey: { type: 'string', length: 64, persist: false },
+    createdAt: { type: 'datetime', defaultRaw: \`CURRENT_TIMESTAMP\` },
+    updatedAt: { type: 'datetime', defaultRaw: \`CURRENT_TIMESTAMP\` },
+    rowStatus: {
+      enum: true,
+      items: () => DbRowStatus,
+      nativeEnumName: 'db_row_status',
+    },
+  },
+});
+",
+  "import { Collection, EntitySchema, type Opt } from '@mikro-orm/core';
+import { DbRowStatus } from './DbRowStatus';
+import { UserRoles } from './UserRoles';
+
+export class Users {
+  id!: string;
+  email!: string;
+  createdAt!: Date & Opt;
+  updatedAt!: Date & Opt;
+  rowStatus: DbRowStatus & Opt = DbRowStatus.ENABLED;
+  userRolesCollection = new Collection<UserRoles>(this);
+}
+
+export const UsersSchema = new EntitySchema({
+  class: Users,
+  properties: {
+    id: { primary: true, type: 'uuid' },
+    email: { type: 'string', length: 256 },
+    createdAt: { type: 'datetime', defaultRaw: \`CURRENT_TIMESTAMP\` },
+    updatedAt: { type: 'datetime', defaultRaw: \`CURRENT_TIMESTAMP\` },
+    rowStatus: {
+      enum: true,
+      items: () => DbRowStatus,
+      nativeEnumName: 'db_row_status',
+    },
+    userRolesCollection: {
+      kind: '1:m',
+      entity: () => UserRoles,
+      mappedBy: 'user',
+    },
+  },
+});
+",
+  "export enum DbRowStatus {
+  ENABLED = 'enabled',
+  DISABLED = 'disabled',
+  ARCHIVED = 'archived',
+  DELETED = 'deleted',
+}
+",
+]
+`;
+
+exports[`shared native enums [union-type] [decorators] shared native enum 1`] = `
+[
+  "import { Collection, Entity, Enum, OneToMany, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+import { TDbRowStatus } from './DbRowStatus';
+import { UserRoles } from './UserRoles';
+
+@Entity()
+export class Domains {
+
+  [PrimaryKeyProp]?: 'key';
+
+  @PrimaryKey({ length: 64 })
+  key!: string;
+
+  @Property({ length: 256 })
+  name!: string;
+
+  @Property({ type: 'datetime', defaultRaw: \`CURRENT_TIMESTAMP\` })
+  createdAt!: Date & Opt;
+
+  @Property({ type: 'datetime', defaultRaw: \`CURRENT_TIMESTAMP\` })
+  updatedAt!: Date & Opt;
+
+  @Enum({ items: ['enabled', 'disabled', 'archived', 'deleted'] })
+  rowStatus: TDbRowStatus & Opt = 'enabled';
+
+  @OneToMany({ entity: () => UserRoles, mappedBy: 'domain' })
+  userRolesCollection = new Collection<UserRoles>(this);
+
+}
+",
+  "import { Collection, Entity, Enum, OneToMany, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+import { TDbRowStatus } from './DbRowStatus';
+import { UserRoles } from './UserRoles';
+
+@Entity()
+export class Roles {
+
+  [PrimaryKeyProp]?: 'key';
+
+  @PrimaryKey({ length: 64 })
+  key!: string;
+
+  @Property({ length: 256 })
+  name!: string;
+
+  @Property({ type: 'datetime', defaultRaw: \`CURRENT_TIMESTAMP\` })
+  createdAt!: Date & Opt;
+
+  @Property({ type: 'datetime', defaultRaw: \`CURRENT_TIMESTAMP\` })
+  updatedAt!: Date & Opt;
+
+  @Enum({ items: ['enabled', 'disabled', 'archived', 'deleted'] })
+  rowStatus: TDbRowStatus & Opt = 'enabled';
+
+  @OneToMany({ entity: () => UserRoles, mappedBy: 'role' })
+  userRolesCollection = new Collection<UserRoles>(this);
+
+}
+",
+  "import { Entity, Enum, ManyToOne, type Opt, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
+import { TDbRowStatus } from './DbRowStatus';
+import { Domains } from './Domains';
+import { Roles } from './Roles';
+import { Users } from './Users';
+
+@Entity()
+export class UserRoles {
+
+  [PrimaryKeyProp]?: ['domain', 'user'];
+
+  @ManyToOne({ entity: () => Domains, ref: true, deleteRule: 'cascade', primary: true })
+  domain!: Ref<Domains>;
+
+  @Property({ length: 64, persist: false })
+  domainKey!: string;
+
+  @ManyToOne({ entity: () => Users, ref: true, deleteRule: 'cascade', primary: true })
+  user!: Ref<Users>;
+
+  @Property({ type: 'uuid', persist: false })
+  userId!: string;
+
+  @ManyToOne({ entity: () => Roles, ref: true, deleteRule: 'cascade' })
+  role!: Ref<Roles>;
+
+  @Property({ length: 64, persist: false })
+  roleKey!: string;
+
+  @Property({ type: 'datetime', defaultRaw: \`CURRENT_TIMESTAMP\` })
+  createdAt!: Date & Opt;
+
+  @Property({ type: 'datetime', defaultRaw: \`CURRENT_TIMESTAMP\` })
+  updatedAt!: Date & Opt;
+
+  @Enum({ items: ['enabled', 'disabled', 'archived', 'deleted'] })
+  rowStatus: TDbRowStatus & Opt = 'enabled';
+
+}
+",
+  "import { Collection, Entity, Enum, OneToMany, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
+import { TDbRowStatus } from './DbRowStatus';
+import { UserRoles } from './UserRoles';
+
+@Entity()
+export class Users {
+
+  @PrimaryKey({ type: 'uuid' })
+  id!: string;
+
+  @Property({ length: 256 })
+  email!: string;
+
+  @Property({ type: 'datetime', defaultRaw: \`CURRENT_TIMESTAMP\` })
+  createdAt!: Date & Opt;
+
+  @Property({ type: 'datetime', defaultRaw: \`CURRENT_TIMESTAMP\` })
+  updatedAt!: Date & Opt;
+
+  @Enum({ items: ['enabled', 'disabled', 'archived', 'deleted'] })
+  rowStatus: TDbRowStatus & Opt = 'enabled';
+
+  @OneToMany({ entity: () => UserRoles, mappedBy: 'user' })
+  userRolesCollection = new Collection<UserRoles>(this);
+
+}
+",
+  "export type TDbRowStatus = 'enabled' | 'disabled' | 'archived' | 'deleted';
+",
+]
+`;
+
+exports[`shared native enums [union-type] [defineEntity+types] shared native enum 1`] = `
+[
+  "import { InferEntity, defineEntity, p } from '@mikro-orm/core';
+import {  } from './DbRowStatus';
+import { UserRoles } from './UserRoles';
+
+export const Domains = defineEntity({
+  name: 'Domains',
+  properties: {
+    key: p.string().primary().length(64),
+    name: p.string().length(256),
+    createdAt: p.datetime().defaultRaw(\`CURRENT_TIMESTAMP\`),
+    updatedAt: p.datetime().defaultRaw(\`CURRENT_TIMESTAMP\`),
+    rowStatus: p.enum(['enabled', 'disabled', 'archived', 'deleted']),
+    userRolesCollection: () => p.oneToMany(UserRoles).mappedBy('domain'),
+  },
+});
+
+export interface IDomains extends InferEntity<typeof Domains> {}
+",
+  "import { InferEntity, defineEntity, p } from '@mikro-orm/core';
+import {  } from './DbRowStatus';
+import { UserRoles } from './UserRoles';
+
+export const Roles = defineEntity({
+  name: 'Roles',
+  properties: {
+    key: p.string().primary().length(64),
+    name: p.string().length(256),
+    createdAt: p.datetime().defaultRaw(\`CURRENT_TIMESTAMP\`),
+    updatedAt: p.datetime().defaultRaw(\`CURRENT_TIMESTAMP\`),
+    rowStatus: p.enum(['enabled', 'disabled', 'archived', 'deleted']),
+    userRolesCollection: () => p.oneToMany(UserRoles).mappedBy('role'),
+  },
+});
+
+export interface IRoles extends InferEntity<typeof Roles> {}
+",
+  "import { InferEntity, defineEntity, p } from '@mikro-orm/core';
+import {  } from './DbRowStatus';
+import { Domains } from './Domains';
+import { Roles } from './Roles';
+import { Users } from './Users';
+
+export const UserRoles = defineEntity({
+  name: 'UserRoles',
+  primaryKeys: ['domain', 'user'],
+  properties: {
+    domain: () => p.manyToOne(Domains).primary().ref().deleteRule('cascade'),
+    domainKey: p.string().length(64).persist(false),
+    user: () => p.manyToOne(Users).primary().ref().deleteRule('cascade'),
+    userId: p.uuid().persist(false),
+    role: () => p.manyToOne(Roles).ref().deleteRule('cascade'),
+    roleKey: p.string().length(64).persist(false),
+    createdAt: p.datetime().defaultRaw(\`CURRENT_TIMESTAMP\`),
+    updatedAt: p.datetime().defaultRaw(\`CURRENT_TIMESTAMP\`),
+    rowStatus: p.enum(['enabled', 'disabled', 'archived', 'deleted']),
+  },
+});
+
+export interface IUserRoles extends InferEntity<typeof UserRoles> {}
+",
+  "import { InferEntity, defineEntity, p } from '@mikro-orm/core';
+import {  } from './DbRowStatus';
+import { UserRoles } from './UserRoles';
+
+export const Users = defineEntity({
+  name: 'Users',
+  properties: {
+    id: p.uuid().primary(),
+    email: p.string().length(256),
+    createdAt: p.datetime().defaultRaw(\`CURRENT_TIMESTAMP\`),
+    updatedAt: p.datetime().defaultRaw(\`CURRENT_TIMESTAMP\`),
+    rowStatus: p.enum(['enabled', 'disabled', 'archived', 'deleted']),
+    userRolesCollection: () => p.oneToMany(UserRoles).mappedBy('user'),
+  },
+});
+
+export interface IUsers extends InferEntity<typeof Users> {}
+",
+  "export type TDbRowStatus = 'enabled' | 'disabled' | 'archived' | 'deleted';
+",
+]
+`;
+
+exports[`shared native enums [union-type] [defineEntity] shared native enum 1`] = `
+[
+  "import { Collection, type Opt, PrimaryKeyProp, defineEntity, p } from '@mikro-orm/core';
+import { TDbRowStatus } from './DbRowStatus';
+import { UserRoles } from './UserRoles';
+
+export class Domains {
+  [PrimaryKeyProp]?: 'key';
+  key!: string;
+  name!: string;
+  createdAt!: Date & Opt;
+  updatedAt!: Date & Opt;
+  rowStatus: TDbRowStatus & Opt = 'enabled';
+  userRolesCollection = new Collection<UserRoles>(this);
+}
+
+export const DomainsSchema = defineEntity({
+  class: Domains,
+  properties: {
+    key: p.string().primary().length(64),
+    name: p.string().length(256),
+    createdAt: p.datetime().defaultRaw(\`CURRENT_TIMESTAMP\`),
+    updatedAt: p.datetime().defaultRaw(\`CURRENT_TIMESTAMP\`),
+    rowStatus: p.enum(['enabled', 'disabled', 'archived', 'deleted']),
+    userRolesCollection: () => p.oneToMany(UserRoles).mappedBy('domain'),
+  },
+});
+",
+  "import { Collection, type Opt, PrimaryKeyProp, defineEntity, p } from '@mikro-orm/core';
+import { TDbRowStatus } from './DbRowStatus';
+import { UserRoles } from './UserRoles';
+
+export class Roles {
+  [PrimaryKeyProp]?: 'key';
+  key!: string;
+  name!: string;
+  createdAt!: Date & Opt;
+  updatedAt!: Date & Opt;
+  rowStatus: TDbRowStatus & Opt = 'enabled';
+  userRolesCollection = new Collection<UserRoles>(this);
+}
+
+export const RolesSchema = defineEntity({
+  class: Roles,
+  properties: {
+    key: p.string().primary().length(64),
+    name: p.string().length(256),
+    createdAt: p.datetime().defaultRaw(\`CURRENT_TIMESTAMP\`),
+    updatedAt: p.datetime().defaultRaw(\`CURRENT_TIMESTAMP\`),
+    rowStatus: p.enum(['enabled', 'disabled', 'archived', 'deleted']),
+    userRolesCollection: () => p.oneToMany(UserRoles).mappedBy('role'),
+  },
+});
+",
+  "import { type Opt, PrimaryKeyProp, type Ref, defineEntity, p } from '@mikro-orm/core';
+import { TDbRowStatus } from './DbRowStatus';
+import { Domains } from './Domains';
+import { Roles } from './Roles';
+import { Users } from './Users';
+
+export class UserRoles {
+  [PrimaryKeyProp]?: ['domain', 'user'];
+  domain!: Ref<Domains>;
+  domainKey!: string;
+  user!: Ref<Users>;
+  userId!: string;
+  role!: Ref<Roles>;
+  roleKey!: string;
+  createdAt!: Date & Opt;
+  updatedAt!: Date & Opt;
+  rowStatus: TDbRowStatus & Opt = 'enabled';
+}
+
+export const UserRolesSchema = defineEntity({
+  class: UserRoles,
+  properties: {
+    domain: () => p.manyToOne(Domains).primary().ref().deleteRule('cascade'),
+    domainKey: p.string().length(64).persist(false),
+    user: () => p.manyToOne(Users).primary().ref().deleteRule('cascade'),
+    userId: p.uuid().persist(false),
+    role: () => p.manyToOne(Roles).ref().deleteRule('cascade'),
+    roleKey: p.string().length(64).persist(false),
+    createdAt: p.datetime().defaultRaw(\`CURRENT_TIMESTAMP\`),
+    updatedAt: p.datetime().defaultRaw(\`CURRENT_TIMESTAMP\`),
+    rowStatus: p.enum(['enabled', 'disabled', 'archived', 'deleted']),
+  },
+});
+",
+  "import { Collection, type Opt, defineEntity, p } from '@mikro-orm/core';
+import { TDbRowStatus } from './DbRowStatus';
+import { UserRoles } from './UserRoles';
+
+export class Users {
+  id!: string;
+  email!: string;
+  createdAt!: Date & Opt;
+  updatedAt!: Date & Opt;
+  rowStatus: TDbRowStatus & Opt = 'enabled';
+  userRolesCollection = new Collection<UserRoles>(this);
+}
+
+export const UsersSchema = defineEntity({
+  class: Users,
+  properties: {
+    id: p.uuid().primary(),
+    email: p.string().length(256),
+    createdAt: p.datetime().defaultRaw(\`CURRENT_TIMESTAMP\`),
+    updatedAt: p.datetime().defaultRaw(\`CURRENT_TIMESTAMP\`),
+    rowStatus: p.enum(['enabled', 'disabled', 'archived', 'deleted']),
+    userRolesCollection: () => p.oneToMany(UserRoles).mappedBy('user'),
+  },
+});
+",
+  "export type TDbRowStatus = 'enabled' | 'disabled' | 'archived' | 'deleted';
+",
+]
+`;
+
+exports[`shared native enums [union-type] [entitySchema] shared native enum 1`] = `
+[
+  "import { Collection, EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { TDbRowStatus } from './DbRowStatus';
+import { UserRoles } from './UserRoles';
+
+export class Domains {
+  [PrimaryKeyProp]?: 'key';
+  key!: string;
+  name!: string;
+  createdAt!: Date & Opt;
+  updatedAt!: Date & Opt;
+  rowStatus: TDbRowStatus & Opt = 'enabled';
+  userRolesCollection = new Collection<UserRoles>(this);
+}
+
+export const DomainsSchema = new EntitySchema({
+  class: Domains,
+  properties: {
+    key: { primary: true, type: 'string', length: 64 },
+    name: { type: 'string', length: 256 },
+    createdAt: { type: 'datetime', defaultRaw: \`CURRENT_TIMESTAMP\` },
+    updatedAt: { type: 'datetime', defaultRaw: \`CURRENT_TIMESTAMP\` },
+    rowStatus: {
+      enum: true,
+      items: ['enabled', 'disabled', 'archived', 'deleted'],
+    },
+    userRolesCollection: {
+      kind: '1:m',
+      entity: () => UserRoles,
+      mappedBy: 'domain',
+    },
+  },
+});
+",
+  "import { Collection, EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
+import { TDbRowStatus } from './DbRowStatus';
+import { UserRoles } from './UserRoles';
+
+export class Roles {
+  [PrimaryKeyProp]?: 'key';
+  key!: string;
+  name!: string;
+  createdAt!: Date & Opt;
+  updatedAt!: Date & Opt;
+  rowStatus: TDbRowStatus & Opt = 'enabled';
+  userRolesCollection = new Collection<UserRoles>(this);
+}
+
+export const RolesSchema = new EntitySchema({
+  class: Roles,
+  properties: {
+    key: { primary: true, type: 'string', length: 64 },
+    name: { type: 'string', length: 256 },
+    createdAt: { type: 'datetime', defaultRaw: \`CURRENT_TIMESTAMP\` },
+    updatedAt: { type: 'datetime', defaultRaw: \`CURRENT_TIMESTAMP\` },
+    rowStatus: {
+      enum: true,
+      items: ['enabled', 'disabled', 'archived', 'deleted'],
+    },
+    userRolesCollection: {
+      kind: '1:m',
+      entity: () => UserRoles,
+      mappedBy: 'role',
+    },
+  },
+});
+",
+  "import { EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
+import { TDbRowStatus } from './DbRowStatus';
+import { Domains } from './Domains';
+import { Roles } from './Roles';
+import { Users } from './Users';
+
+export class UserRoles {
+  [PrimaryKeyProp]?: ['domain', 'user'];
+  domain!: Ref<Domains>;
+  domainKey!: string;
+  user!: Ref<Users>;
+  userId!: string;
+  role!: Ref<Roles>;
+  roleKey!: string;
+  createdAt!: Date & Opt;
+  updatedAt!: Date & Opt;
+  rowStatus: TDbRowStatus & Opt = 'enabled';
+}
+
+export const UserRolesSchema = new EntitySchema({
+  class: UserRoles,
+  properties: {
+    domain: {
+      primary: true,
+      kind: 'm:1',
+      entity: () => Domains,
+      ref: true,
+      deleteRule: 'cascade',
+    },
+    domainKey: { type: 'string', length: 64, persist: false },
+    user: {
+      primary: true,
+      kind: 'm:1',
+      entity: () => Users,
+      ref: true,
+      deleteRule: 'cascade',
+    },
+    userId: { type: 'uuid', persist: false },
+    role: { kind: 'm:1', entity: () => Roles, ref: true, deleteRule: 'cascade' },
+    roleKey: { type: 'string', length: 64, persist: false },
+    createdAt: { type: 'datetime', defaultRaw: \`CURRENT_TIMESTAMP\` },
+    updatedAt: { type: 'datetime', defaultRaw: \`CURRENT_TIMESTAMP\` },
+    rowStatus: {
+      enum: true,
+      items: ['enabled', 'disabled', 'archived', 'deleted'],
+    },
+  },
+});
+",
+  "import { Collection, EntitySchema, type Opt } from '@mikro-orm/core';
+import { TDbRowStatus } from './DbRowStatus';
+import { UserRoles } from './UserRoles';
+
+export class Users {
+  id!: string;
+  email!: string;
+  createdAt!: Date & Opt;
+  updatedAt!: Date & Opt;
+  rowStatus: TDbRowStatus & Opt = 'enabled';
+  userRolesCollection = new Collection<UserRoles>(this);
+}
+
+export const UsersSchema = new EntitySchema({
+  class: Users,
+  properties: {
+    id: { primary: true, type: 'uuid' },
+    email: { type: 'string', length: 256 },
+    createdAt: { type: 'datetime', defaultRaw: \`CURRENT_TIMESTAMP\` },
+    updatedAt: { type: 'datetime', defaultRaw: \`CURRENT_TIMESTAMP\` },
+    rowStatus: {
+      enum: true,
+      items: ['enabled', 'disabled', 'archived', 'deleted'],
+    },
+    userRolesCollection: {
+      kind: '1:m',
+      entity: () => UserRoles,
+      mappedBy: 'user',
+    },
+  },
+});
+",
+  "export type TDbRowStatus = 'enabled' | 'disabled' | 'archived' | 'deleted';
+",
+]
+`;

--- a/tests/features/entity-generator/shared-native-enum.test.ts
+++ b/tests/features/entity-generator/shared-native-enum.test.ts
@@ -1,0 +1,78 @@
+import { MikroORM } from '@mikro-orm/postgresql';
+
+const schema = `
+CREATE TYPE db_row_status AS ENUM ('enabled', 'disabled', 'archived', 'deleted');
+
+CREATE TABLE domains (
+  key VARCHAR(64) PRIMARY KEY,
+  name VARCHAR(256) NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  row_status db_row_status NOT NULL DEFAULT 'enabled'
+);
+
+CREATE TABLE roles (
+  key VARCHAR(64) PRIMARY KEY,
+  name VARCHAR(256) NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  row_status db_row_status NOT NULL DEFAULT 'enabled'
+);
+
+CREATE TABLE users (
+  id UUID PRIMARY KEY,
+  email VARCHAR(256) NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  row_status db_row_status NOT NULL DEFAULT 'enabled'
+);
+
+CREATE TABLE user_roles (
+  PRIMARY KEY (domain_key, user_id),
+  --
+  domain_key VARCHAR(64) NOT NULL REFERENCES domains (key) ON DELETE CASCADE,
+  user_id UUID NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+  role_key VARCHAR(64) NOT NULL REFERENCES roles (key) ON DELETE CASCADE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  row_status db_row_status NOT NULL DEFAULT 'enabled'
+);
+`;
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    dbName: 'shared-native-enum',
+    discovery: {
+      warnWhenNoEntities: false,
+    },
+    ensureDatabase: false,
+  });
+
+  if (await orm.schema.ensureDatabase({ create: false })) {
+    await orm.schema.execute(schema);
+  }
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+describe.each(['ts-enum', 'union-type', 'dictionary'] as const)('shared native enums [%s]', enumMode => {
+  describe.each(['entitySchema', 'defineEntity', 'defineEntity+types', 'decorators'] as const)('[%s]', entityDefinition => {
+    test('shared native enum', async () => {
+      const dump = await orm.entityGenerator.generate({
+        entityDefinition: entityDefinition === 'defineEntity+types' ? 'defineEntity' : entityDefinition,
+        inferEntityType: entityDefinition === 'defineEntity+types',
+        enumMode,
+        bidirectionalRelations: true,
+        identifiedReferences: true,
+        scalarPropertiesForRelations: 'always',
+        onlyPurePivotTables: false,
+        outputPurePivotTables: true,
+      });
+      expect(dump).toMatchSnapshot();
+    });
+  });
+});

--- a/tests/features/filters/disable-filters-on-relations.postgres.test.ts
+++ b/tests/features/filters/disable-filters-on-relations.postgres.test.ts
@@ -116,14 +116,14 @@ class Membership {
 
 }
 
-describe('filters [postgres]', () => {
+describe('disable filters on relations [postgres]', () => {
 
   let orm: MikroORM<AbstractSqlDriver>;
 
   beforeAll(async () => {
     orm = await MikroORM.init({
       entities: [Employee, Benefit, User, Membership],
-      dbName: `mikro_orm_test_gh_1232`,
+      dbName: `mikro_orm_test_gh_1232_disable`,
       driver: PostgreSqlDriver,
       filtersOnRelations: false,
     });


### PR DESCRIPTION
Native enums in postgres will now emit a separate enum definition it its own file, and reuse it in all the entities that are referring to the type.