### PR TITLE
feat(core): support private properties with get/set accessors

### DIFF
--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -1656,6 +1656,7 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
       ...options,
       newEntity: !options.managed,
       merge: options.managed,
+      normalizeAccessors: true,
     });
     options.persist ??= em.config.get('persistOnCreate');
 

--- a/packages/core/src/decorators/Property.ts
+++ b/packages/core/src/decorators/Property.ts
@@ -208,7 +208,7 @@ export interface PropertyOptions<Owner> {
    * Set true to define the properties as setter. (virtual)
    *
    * @example
-   * ```
+   * ```ts
    * @Property({ setter: true })
    * set address(value: string) {
    *     this._address = value.toLocaleLowerCase();
@@ -220,7 +220,7 @@ export interface PropertyOptions<Owner> {
    * Set true to define the properties as getter. (virtual)
    *
    * @example
-   * ```
+   * ```ts
    * @Property({ getter: true })
    * get fullName() {
    *   return this.firstName + this.lastName;
@@ -233,7 +233,7 @@ export interface PropertyOptions<Owner> {
    * to the method name.
    *
    * @example
-   * ```
+   * ```ts
    * @Property({ getter: true })
    * getFullName() {
    *   return this.firstName + this.lastName;
@@ -241,6 +241,53 @@ export interface PropertyOptions<Owner> {
    * ```
    */
   getterName?: keyof Owner;
+  /**
+   * When using a private property backed by a public get/set pair, use the `accessor` option to point to the other side.
+   *
+   * > The `fieldName` will be inferred based on the accessor name unless specified explicitly.
+   *
+   * If the `accessor` option points to something, the ORM will use the backing property directly.
+   *
+   * @example
+   * ```ts
+   * @Entity()
+   * export class User {
+   *   // the ORM will use the backing field directly
+   *   @Property({ accessor: 'email' })
+   *   private _email: string;
+   *
+   *   get email() {
+   *     return this._email;
+   *   }
+   *
+   *   set email() {
+   *     return this._email;
+   *   }
+   * }
+   *```
+   *
+   * If you want to the ORM to use your accessor internally too, use `accessor: true` on the get/set property instead.
+   * This is handy if you want to use a native private property for the backing field.
+   *
+   * @example
+   * ```ts
+   * @Entity({ forceConstructor: true })
+   * export class User {
+   *   #email: string;
+   *
+   *   // the ORM will use the accessor internally
+   *   @Property({ accessor: true })
+   *   get email() {
+   *     return this.#email;
+   *   }
+   *
+   *   set email() {
+   *     return this.#email;
+   *   }
+   * }
+   * ```
+   */
+  accessor?: keyof Owner | boolean;
   /**
    * Set to define serialized primary key for MongoDB. (virtual)
    * Alias for `@SerializedPrimaryKey()` decorator.

--- a/packages/core/src/entity/defineEntity.ts
+++ b/packages/core/src/entity/defineEntity.ts
@@ -188,7 +188,6 @@ export class UniversalPropertyOptionsBuilder<Value, Options, IncludeKeys extends
 
   /**
    * Automatically set the property value when entity gets created, executed during flush operation.
-   * @param entity
    */
   onCreate(onCreate: (entity: any, em: EntityManager) => Value): Pick<UniversalPropertyOptionsBuilder<Value, Options & { onCreate: (...args: any[]) => any }, IncludeKeys>, IncludeKeys> {
     return this.assignOptions({ onCreate }) as any;
@@ -196,7 +195,6 @@ export class UniversalPropertyOptionsBuilder<Value, Options, IncludeKeys extends
 
   /**
    * Automatically update the property value every time entity gets updated, executed during flush operation.
-   * @param entity
    */
   onUpdate(onUpdate: (entity: any, em: EntityManager) => Value): Pick<UniversalPropertyOptionsBuilder<Value, Options, IncludeKeys>, IncludeKeys> {
     return this.assignOptions({ onUpdate }) as any;
@@ -604,6 +602,10 @@ export class UniversalPropertyOptionsBuilder<Value, Options, IncludeKeys extends
   /** Remove the entity when it gets disconnected from the relationship (see {@doclink cascading | Cascading}). */
   orphanRemoval(orphanRemoval = true): Pick<UniversalPropertyOptionsBuilder<Value, Options, IncludeKeys>, IncludeKeys> {
     return this.assignOptions({ orphanRemoval });
+  }
+
+  accessor(accessor: string | boolean = true): Pick<UniversalPropertyOptionsBuilder<Value, Options, IncludeKeys>, IncludeKeys> {
+    return this.assignOptions({ accessor });
   }
 
 }

--- a/packages/core/src/serialization/EntitySerializer.ts
+++ b/packages/core/src/serialization/EntitySerializer.ts
@@ -39,7 +39,7 @@ function isVisible<T extends object>(meta: EntityMetadata<T>, propName: EntityKe
   }
 
   const visible = prop && !(prop.hidden && !options.includeHidden);
-  const prefixed = prop && !prop.primary && propName.startsWith('_'); // ignore prefixed properties, if it's not a PK
+  const prefixed = prop && !prop.primary && !prop.accessor && propName.startsWith('_'); // ignore prefixed properties, if it's not a PK
 
   return visible && !prefixed;
 }

--- a/packages/core/src/serialization/EntityTransformer.ts
+++ b/packages/core/src/serialization/EntityTransformer.ts
@@ -19,7 +19,7 @@ import { SerializationContext } from './SerializationContext';
 function isVisible<Entity extends object>(meta: EntityMetadata<Entity>, propName: EntityKey<Entity>, ignoreFields: string[] = []): boolean {
   const prop = meta.properties[propName];
   const visible = prop && !prop.hidden;
-  const prefixed = prop && !prop.primary && propName.startsWith('_'); // ignore prefixed properties, if it's not a PK
+  const prefixed = prop && !prop.primary && !prop.accessor && propName.startsWith('_'); // ignore prefixed properties, if it's not a PK
 
   return visible && !prefixed && !ignoreFields.includes(propName);
 }

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -546,6 +546,7 @@ export interface EntityProperty<Owner = any, Target = any> {
   setter?: boolean;
   getter?: boolean;
   getterName?: keyof Owner;
+  accessor?: EntityKey<Owner>;
   cascade: Cascade[];
   orphanRemoval?: boolean;
   onCreate?: (entity: Owner, em: EntityManager) => any;
@@ -1306,12 +1307,13 @@ export interface IHydrator {
     convertCustomTypes?: boolean,
     schema?: string,
     parentSchema?: string,
+    normalizeAccessors?: boolean,
   ): void;
 
   /**
    * Hydrates primary keys only
    */
-  hydrateReference<T extends object>(entity: T, meta: EntityMetadata<T>, data: EntityData<T>, factory: EntityFactory, convertCustomTypes?: boolean, schema?: string, parentSchema?: string): void;
+  hydrateReference<T extends object>(entity: T, meta: EntityMetadata<T>, data: EntityData<T>, factory: EntityFactory, convertCustomTypes?: boolean, schema?: string, parentSchema?: string, normalizeAccessors?: boolean): void;
 
   isRunning(): boolean;
 

--- a/tests/EntityHelper.mongo.test.ts
+++ b/tests/EntityHelper.mongo.test.ts
@@ -199,11 +199,11 @@ describe('EntityHelperMongo', () => {
     let actual = inspect(bar);
 
     expect(actual).toBe('FooBar {\n' +
-      '  meta: { onCreateCalled: true, onUpdateCalled: true },\n' +
       "  name: 'bar',\n" +
       "  baz: FooBaz { name: 'baz', bar: Ref<FooBar> { entity: [FooBar] } },\n" +
       '  onCreateTest: true,\n' +
-      '  onUpdateTest: true\n' +
+      '  onUpdateTest: true,\n' +
+      '  meta: { onCreateCalled: true, onUpdateCalled: true }\n' +
       '}');
 
     expect(inspect((bar as AnyEntity).__helper)).toBe('[WrappedEntity<FooBar>]');
@@ -211,11 +211,11 @@ describe('EntityHelperMongo', () => {
     actual = inspect(bar);
 
     expect(actual).toBe('FooBar {\n' +
-      '  meta: { onCreateCalled: true, onUpdateCalled: true },\n' +
       "  name: 'bar',\n" +
       "  baz: (FooBaz) { _id: ObjectId('5b0ff0619fbec620008d2414') },\n" +
       '  onCreateTest: true,\n' +
-      '  onUpdateTest: true\n' +
+      '  onUpdateTest: true,\n' +
+      '  meta: { onCreateCalled: true, onUpdateCalled: true }\n' +
       '}');
 
     process.env.MIKRO_ORM_LOG_EM_ID = '1';
@@ -223,11 +223,11 @@ describe('EntityHelperMongo', () => {
     process.env.MIKRO_ORM_LOG_EM_ID = '0';
 
     expect(actual).toBe('FooBar [not managed] {\n' +
-      '  meta: { onCreateCalled: true, onUpdateCalled: true },\n' +
       "  name: 'bar',\n" +
       "  baz: (FooBaz [managed by 1]) { _id: ObjectId('5b0ff0619fbec620008d2414') },\n" +
       '  onCreateTest: true,\n' +
-      '  onUpdateTest: true\n' +
+      '  onUpdateTest: true,\n' +
+      '  meta: { onCreateCalled: true, onUpdateCalled: true }\n' +
       '}');
 
     const god = orm.em.create(Author, { name: 'God', email: 'hello@heaven.god' });
@@ -240,42 +240,42 @@ describe('EntityHelperMongo', () => {
     actual = inspect(god);
 
     expect(actual).toBe('Author {\n' +
+      "  foo: 'bar',\n" +
+      '  hookTest: false,\n' +
+      "  name: 'God',\n" +
+      "  email: 'hello@heaven.god',\n" +
+      '  termsAccepted: false,\n' +
       '  books: Collection<Book> {\n' +
       "    '0': Book {\n" +
-      '      tags: [Collection<BookTag>],\n' +
       '      createdAt: ISODate(\'2020-07-18T17:31:08.535Z\'),\n' +
       "      title: 'Bible',\n" +
       '      author: [Author],\n' +
-      '      publisher: [Ref<Publisher>]\n' +
+      '      publisher: [Ref<Publisher>],\n' +
+      '      tags: [Collection<BookTag>]\n' +
       '    },\n' +
       '    initialized: true,\n' +
       '    dirty: true\n' +
       '  },\n' +
       '  friends: Collection<Author> { initialized: true, dirty: false },\n' +
-      "  foo: 'bar',\n" +
-      "  name: 'God',\n" +
-      "  email: 'hello@heaven.god',\n" +
-      '  termsAccepted: false,\n' +
       '  favouriteAuthor: Author {\n' +
-      "    books: Collection<Book> { '0': [Book], initialized: true, dirty: true },\n" +
-      '    friends: Collection<Author> { initialized: true, dirty: false },\n' +
       "    foo: 'bar',\n" +
+      '    hookTest: false,\n' +
       "    name: 'God',\n" +
       "    email: 'hello@heaven.god',\n" +
       '    termsAccepted: false,\n' +
+      "    books: Collection<Book> { '0': [Book], initialized: true, dirty: true },\n" +
+      '    friends: Collection<Author> { initialized: true, dirty: false },\n' +
       '    favouriteAuthor: Author {\n' +
-      '      books: [Collection<Book>],\n' +
-      '      friends: [Collection<Author>],\n' +
       "      foo: 'bar',\n" +
+      '      hookTest: false,\n' +
       "      name: 'God',\n" +
       "      email: 'hello@heaven.god',\n" +
       '      termsAccepted: false,\n' +
-      '      favouriteAuthor: [Author],\n' +
-      '      hookTest: false\n' +
-      '    },\n' +
-      '    hookTest: false\n' +
-      '  },\n' +
-      '  hookTest: false\n' +
+      '      books: [Collection<Book>],\n' +
+      '      friends: [Collection<Author>],\n' +
+      '      favouriteAuthor: [Author]\n' +
+      '    }\n' +
+      '  }\n' +
       '}');
   });
 

--- a/tests/EntityManager.mongo.test.ts
+++ b/tests/EntityManager.mongo.test.ts
@@ -1509,7 +1509,7 @@ describe('EntityManagerMongo', () => {
     await expect(author.createdAt).toBeDefined();
     await expect(author.updatedAt).toBeDefined();
     // allow 1 ms difference as updated time is recalculated when persisting
-    await expect(+author.updatedAt - +author.createdAt!).toBeLessThanOrEqual(1);
+    await expect(+author.updatedAt! - +author.createdAt!).toBeLessThanOrEqual(1);
     await orm.em.persistAndFlush(author);
 
     author.name = 'name1';
@@ -1517,14 +1517,14 @@ describe('EntityManagerMongo', () => {
     await expect(author.createdAt).toBeDefined();
     await expect(author.updatedAt).toBeDefined();
     await expect(author.updatedAt).not.toEqual(author.createdAt);
-    await expect(author.updatedAt > author.createdAt!).toBe(true);
+    await expect(author.updatedAt! > author.createdAt!).toBe(true);
 
     orm.em.clear();
     const ent = (await repo.findOne(author.id))!;
     await expect(ent.createdAt).toBeDefined();
     await expect(ent.updatedAt).toBeDefined();
     await expect(ent.updatedAt).not.toEqual(ent.createdAt);
-    await expect(ent.updatedAt > ent.createdAt!).toBe(true);
+    await expect(ent.updatedAt! > ent.createdAt!).toBe(true);
   });
 
   test('EM supports native insert/update/delete/aggregate', async () => {

--- a/tests/entities/BaseEntity.ts
+++ b/tests/entities/BaseEntity.ts
@@ -23,10 +23,10 @@ export abstract class BaseEntity<T extends object, Optional extends keyof T = ne
   id!: string;
 
   @Property()
-  createdAt? = new Date();
+  createdAt?: Date = new Date();
 
   @Property({ onUpdate: () => new Date() })
-  updatedAt = new Date();
+  updatedAt?: Date = new Date();
 
   @Property()
   foo?: string;

--- a/tests/features/accessors.test.ts
+++ b/tests/features/accessors.test.ts
@@ -1,0 +1,283 @@
+import {
+  defineEntity,
+  Dictionary,
+  Entity,
+  MikroORM,
+  Opt,
+  p,
+  PrimaryKey,
+  Property,
+  serialize,
+} from '@mikro-orm/sqlite';
+import { inspect } from 'node:util';
+
+const usageMap = {} as Dictionary<[get: number, set: number]>;
+
+@Entity({ tableName: 'user' })
+class User11 {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ version: true, hidden: true, type: 'integer' })
+  version: number & Opt = 1;
+
+  private _foo!: unknown;
+
+  // `accessor: '_foo'` on the get/set property means the ORM will skip the getter/setter and work with the backing variable directly
+  @Property({ type: 'jsonb', accessor: '_foo' })
+  get foo(): unknown {
+    usageMap.User11 ??= [0, 0];
+    usageMap.User11[0]++;
+    return structuredClone(this._foo);
+  }
+
+  set foo(untrusted: unknown) {
+    usageMap.User11 ??= [0, 0];
+    usageMap.User11[1]++;
+    this._foo = structuredClone(untrusted);
+  }
+
+}
+
+@Entity({ forceConstructor: true, tableName: 'user' })
+class User12 {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ version: true, hidden: true, type: 'integer' })
+  version: number & Opt = 1;
+
+  #foo!: unknown;
+
+  // `accessor: true` on the getter/setter means the ORM will always work with this property through the getter/setter
+  @Property({ type: 'jsonb', accessor: true })
+  get foo(): unknown {
+    // console.log('wat.get', usageMap.User12, usageMap, new Error().stack);
+    usageMap.User12 ??= [0, 0];
+    usageMap.User12[0]++;
+    return structuredClone(this.#foo);
+  }
+
+  set foo(untrusted: unknown) {
+    // console.log('wat.set', usageMap.User12, usageMap, new Error().stack);
+    usageMap.User12 ??= [0, 0];
+    usageMap.User12[1]++;
+    this.#foo = structuredClone(untrusted);
+  }
+
+}
+
+@Entity({ tableName: 'user' })
+class User13 {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ version: true, hidden: true, type: 'integer' })
+  version: number & Opt = 1;
+
+  // `accessor: 'foo'` on the backing property means the ORM will skip the getter/setter and work with the backing variable directly
+  @Property({ type: 'jsonb', accessor: 'foo' })
+  private _foo!: unknown;
+
+  get foo(): unknown {
+    usageMap.User13 ??= [0, 0];
+    usageMap.User13[0]++;
+    return structuredClone(this._foo);
+  }
+
+  set foo(untrusted: unknown) {
+    usageMap.User13 ??= [0, 0];
+    usageMap.User13[1]++;
+    this._foo = structuredClone(untrusted);
+  }
+
+}
+
+class User22 {
+
+  id!: number;
+  version: number & Opt = 1;
+  private _foo!: unknown;
+
+  get foo(): unknown {
+    usageMap.User22 ??= [0, 0];
+    usageMap.User22[0]++;
+    return structuredClone(this._foo);
+  }
+
+  set foo(untrusted: unknown) {
+    usageMap.User22 ??= [0, 0];
+    usageMap.User22[1]++;
+    this._foo = structuredClone(untrusted);
+  }
+
+}
+
+const User22Schema = defineEntity({
+  class: User22,
+  tableName: 'user',
+  properties: {
+    id: p.integer().primary(),
+    version: p.integer().version().hidden(),
+    foo: p.json().accessor('_foo'),
+  },
+});
+
+class User23 {
+
+  id!: number;
+  version: number & Opt = 1;
+  #foo!: unknown;
+
+  get foo(): unknown {
+    usageMap.User23 ??= [0, 0];
+    usageMap.User23[0]++;
+    return structuredClone(this.#foo);
+  }
+
+  set foo(untrusted: unknown) {
+    usageMap.User23 ??= [0, 0];
+    usageMap.User23[1]++;
+    this.#foo = structuredClone(untrusted);
+  }
+
+}
+
+const User23Schema = defineEntity({
+  class: User23,
+  tableName: 'user',
+  forceConstructor: true,
+  properties: {
+    id: p.integer().primary(),
+    version: p.integer().version().hidden(),
+    foo: p.json().accessor(),
+  },
+});
+
+describe.each([User11, User13, User22] as const)('accessors with direct backing property access (%o)', Entity => {
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      dbName: ':memory:',
+      entities: [Entity],
+      discovery: { inferDefaultValues: false }, // otherwise getters would be used during discovery
+    });
+    await orm.schema.createSchema();
+  });
+
+  afterAll(async () => {
+    await orm.close(true);
+  });
+
+  test('schema', async () => {
+    const dump = await orm.schema.getCreateSchemaSQL();
+    expect(dump.trim()).toBe('create table `user` (`id` integer not null primary key autoincrement, `version` integer not null default 1, `foo` json not null);');
+  });
+
+  test('working with accessors', async () => {
+    const entityName = Entity.prototype.constructor.name;
+    expect(usageMap[entityName]).toBeUndefined();
+
+    const e = orm.em.create(Entity, { foo: { name: 'test' } });
+
+    if (['User12', 'User23'].includes(entityName)) {
+      expect(inspect(e)).toEqual(`${entityName} { _foo: { name: 'test' }, version: 1 }`);
+    } else {
+      expect(inspect(e)).toEqual(`${entityName} { version: 1, _foo: { name: 'test' } }`);
+    }
+
+    expect(usageMap[entityName]).toBeUndefined();
+    await orm.em.flush();
+    orm.em.clear();
+
+    await orm.em.transactional(async em => {
+      const users = await em.findAll(Entity);
+      expect(users.length).toBe(1);
+      expect(users[0].version).toBe(1);
+      expect(usageMap[entityName]).toBeUndefined();
+      expect(users[0].foo).toEqual({ name: 'test' });
+      expect(usageMap[entityName]).toEqual([1, 0]);
+    });
+    orm.em.clear();
+
+    const users = await orm.em.findAll(Entity);
+    expect(users.length).toBe(1);
+    expect(users[0].version).toBe(1);
+    expect(usageMap[entityName]).toEqual([1, 0]);
+    expect(users[0].foo).toEqual({ name: 'test' });
+    expect(usageMap[entityName]).toEqual([2, 0]);
+
+    users[0].foo = { name: 'test2' };
+    expect(usageMap[entityName]).toEqual([2, 1]);
+    await orm.em.flush();
+
+    expect(JSON.stringify(users[0])).toBe('{"id":1,"foo":{"name":"test2"}}');
+    expect(serialize(users[0])).toEqual({ id: 1, foo: { name: 'test2' } });
+    expect(usageMap[entityName]).toEqual([2, 1]);
+  });
+});
+
+describe.each([User12, User23] as const)('accessors with opaque backing property (%o)', Entity => {
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      dbName: ':memory:',
+      entities: [Entity],
+      discovery: { inferDefaultValues: false }, // otherwise getters would be used during discovery
+    });
+    await orm.schema.createSchema();
+  });
+
+  afterAll(async () => {
+    await orm.close(true);
+  });
+
+  test('schema', async () => {
+    const dump = await orm.schema.getCreateSchemaSQL();
+    expect(dump.trim()).toBe('create table `user` (`id` integer not null primary key autoincrement, `version` integer not null default 1, `foo` json not null);');
+  });
+
+  test('working with accessors', async () => {
+    const entityName = Entity.prototype.constructor.name;
+    expect(usageMap[entityName]).toBeUndefined();
+
+    const e = orm.em.create(Entity, { foo: { name: 'test' } });
+    expect(usageMap[entityName]).toEqual([0, 1]);
+    expect(inspect(e)).toEqual(`${entityName} { version: 1, foo: { name: 'test' } }`);
+    expect(usageMap[entityName]).toEqual([1, 1]);
+    await orm.em.flush();
+    expect(usageMap[entityName]).toEqual([4, 1]);
+    orm.em.clear();
+
+    await orm.em.transactional(async em => {
+      const users = await em.findAll(Entity);
+      expect(users.length).toBe(1);
+      expect(users[0].version).toBe(1);
+      expect(usageMap[entityName]).toEqual([4, 2]);
+      expect(users[0].foo).toEqual({ name: 'test' });
+      expect(usageMap[entityName]).toEqual([5, 2]);
+    });
+    orm.em.clear();
+
+    const users = await orm.em.findAll(Entity);
+    expect(users.length).toBe(1);
+    expect(users[0].version).toBe(1);
+    expect(usageMap[entityName]).toEqual([7, 3]);
+    expect(users[0].foo).toEqual({ name: 'test' });
+    expect(usageMap[entityName]).toEqual([8, 3]);
+
+    users[0].foo = { name: 'test2' };
+    expect(usageMap[entityName]).toEqual([8, 4]);
+    await orm.em.flush();
+    expect(usageMap[entityName]).toEqual([12, 4]);
+
+    expect(JSON.stringify(users[0])).toBe('{"id":1,"foo":{"name":"test2"}}');
+    expect(serialize(users[0])).toEqual({ id: 1, foo: { name: 'test2' } });
+    expect(usageMap[entityName]).toEqual([18, 4]);
+  });
+});

--- a/tests/features/embeddables/__snapshots__/entities-in-embeddables.mongo.test.ts.snap
+++ b/tests/features/embeddables/__snapshots__/entities-in-embeddables.mongo.test.ts.snap
@@ -218,7 +218,7 @@ exports[`embedded entities in mongo diffing 1`] = `
 `;
 
 exports[`embedded entities in mongo diffing 2`] = `
-"function(entity, data, factory, newEntity, convertCustomTypes, schema) {
+"function(entity, data, factory, newEntity, convertCustomTypes, schema, parentSchema, normalizeAccessors) {
   if (data._id === null) {
     entity._id = null;
   } else if (typeof data._id !== 'undefined') {
@@ -236,7 +236,7 @@ exports[`embedded entities in mongo diffing 2`] = `
       source: data.profile1_source,
     };
     if (entity.profile1 == null) {
-      entity.profile1 = factory.createEmbeddable('Profile', embeddedData, { newEntity, convertCustomTypes });
+      entity.profile1 = factory.createEmbeddable('Profile', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
     }
     if (data.profile1_username === null) {
       entity.profile1.username = null;
@@ -251,7 +251,7 @@ exports[`embedded entities in mongo diffing 2`] = `
         source: data.profile1_identity_source,
       };
       if (entity.profile1.identity == null) {
-        entity.profile1.identity = factory.createEmbeddable('Identity', embeddedData, { newEntity, convertCustomTypes });
+        entity.profile1.identity = factory.createEmbeddable('Identity', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
       }
       if (data.profile1_identity_email === null) {
         entity.profile1.identity.email = null;
@@ -265,7 +265,7 @@ exports[`embedded entities in mongo diffing 2`] = `
           source: data.profile1_identity_meta_source,
         };
         if (entity.profile1.identity.meta == null) {
-          entity.profile1.identity.meta = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes });
+          entity.profile1.identity.meta = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
         }
         if (data.profile1_identity_meta_foo === null) {
           entity.profile1.identity.meta.foo = null;
@@ -281,9 +281,9 @@ exports[`embedded entities in mongo diffing 2`] = `
     entity.profile1.identity.meta.source = null;
         } else if (typeof data.profile1_identity_meta_source !== 'undefined') {
           if (isPrimaryKey(data.profile1_identity_meta_source, true)) {
-            entity.profile1.identity.meta.source = factory.createReference('Source', data.profile1_identity_meta_source, { merge: true, convertCustomTypes, schema });
+            entity.profile1.identity.meta.source = factory.createReference('Source', data.profile1_identity_meta_source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
           } else if (data.profile1_identity_meta_source && typeof data.profile1_identity_meta_source === 'object') {
-            entity.profile1.identity.meta.source = factory.create('Source', data.profile1_identity_meta_source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+            entity.profile1.identity.meta.source = factory.create('Source', data.profile1_identity_meta_source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
           }
         }
       } else if (data.profile1_identity_meta_foo === null && data.profile1_identity_meta_bar === null && data.profile1_identity_meta_source === null) {
@@ -292,7 +292,7 @@ exports[`embedded entities in mongo diffing 2`] = `
       if (data.profile1_identity_meta != null) {
         const embeddedData = data.profile1_identity_meta;
         if (entity.profile1.identity.meta == null) {
-          entity.profile1.identity.meta = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes });
+          entity.profile1.identity.meta = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
         }
         if (data.profile1_identity_meta.foo === null) {
           entity.profile1.identity.meta.foo = null;
@@ -308,9 +308,9 @@ exports[`embedded entities in mongo diffing 2`] = `
     entity.profile1.identity.meta.source = null;
         } else if (typeof data.profile1_identity_meta.source !== 'undefined') {
           if (isPrimaryKey(data.profile1_identity_meta.source, true)) {
-            entity.profile1.identity.meta.source = factory.createReference('Source', data.profile1_identity_meta.source, { merge: true, convertCustomTypes, schema });
+            entity.profile1.identity.meta.source = factory.createReference('Source', data.profile1_identity_meta.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
           } else if (data.profile1_identity_meta.source && typeof data.profile1_identity_meta.source === 'object') {
-            entity.profile1.identity.meta.source = factory.create('Source', data.profile1_identity_meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+            entity.profile1.identity.meta.source = factory.create('Source', data.profile1_identity_meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
           }
         }
       } else if (data.profile1_identity_meta === null) {
@@ -322,7 +322,7 @@ exports[`embedded entities in mongo diffing 2`] = `
           if (data.profile1_identity_links[idx_8] != null) {
             const embeddedData = data.profile1_identity_links[idx_8];
             if (entity.profile1.identity.links[idx_8] == null) {
-              entity.profile1.identity.links[idx_8] = factory.createEmbeddable('IdentityLink', embeddedData, { newEntity, convertCustomTypes });
+              entity.profile1.identity.links[idx_8] = factory.createEmbeddable('IdentityLink', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
             }
             if (data.profile1_identity_links[idx_8].url === null) {
               entity.profile1.identity.links[idx_8].url = null;
@@ -341,7 +341,7 @@ exports[`embedded entities in mongo diffing 2`] = `
             if (data.profile1_identity_links[idx_8].meta != null) {
               const embeddedData = data.profile1_identity_links[idx_8].meta;
               if (entity.profile1.identity.links[idx_8].meta == null) {
-                entity.profile1.identity.links[idx_8].meta = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes });
+                entity.profile1.identity.links[idx_8].meta = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
               }
               if (data.profile1_identity_links[idx_8].meta.foo === null) {
                 entity.profile1.identity.links[idx_8].meta.foo = null;
@@ -357,9 +357,9 @@ exports[`embedded entities in mongo diffing 2`] = `
     entity.profile1.identity.links[idx_8].meta.source = null;
               } else if (typeof data.profile1_identity_links[idx_8].meta.source !== 'undefined') {
                 if (isPrimaryKey(data.profile1_identity_links[idx_8].meta.source, true)) {
-                  entity.profile1.identity.links[idx_8].meta.source = factory.createReference('Source', data.profile1_identity_links[idx_8].meta.source, { merge: true, convertCustomTypes, schema });
+                  entity.profile1.identity.links[idx_8].meta.source = factory.createReference('Source', data.profile1_identity_links[idx_8].meta.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
                 } else if (data.profile1_identity_links[idx_8].meta.source && typeof data.profile1_identity_links[idx_8].meta.source === 'object') {
-                  entity.profile1.identity.links[idx_8].meta.source = factory.create('Source', data.profile1_identity_links[idx_8].meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+                  entity.profile1.identity.links[idx_8].meta.source = factory.create('Source', data.profile1_identity_links[idx_8].meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
                 }
               }
             } else if (data.profile1_identity_links[idx_8].meta === null) {
@@ -371,7 +371,7 @@ exports[`embedded entities in mongo diffing 2`] = `
                 if (data.profile1_identity_links[idx_8].metas[idx_13] != null) {
                   const embeddedData = data.profile1_identity_links[idx_8].metas[idx_13];
                   if (entity.profile1.identity.links[idx_8].metas[idx_13] == null) {
-                    entity.profile1.identity.links[idx_8].metas[idx_13] = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes });
+                    entity.profile1.identity.links[idx_8].metas[idx_13] = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
                   }
                   if (data.profile1_identity_links[idx_8].metas[idx_13].foo === null) {
                     entity.profile1.identity.links[idx_8].metas[idx_13].foo = null;
@@ -387,9 +387,9 @@ exports[`embedded entities in mongo diffing 2`] = `
     entity.profile1.identity.links[idx_8].metas[idx_13].source = null;
                   } else if (typeof data.profile1_identity_links[idx_8].metas[idx_13].source !== 'undefined') {
                     if (isPrimaryKey(data.profile1_identity_links[idx_8].metas[idx_13].source, true)) {
-                      entity.profile1.identity.links[idx_8].metas[idx_13].source = factory.createReference('Source', data.profile1_identity_links[idx_8].metas[idx_13].source, { merge: true, convertCustomTypes, schema });
+                      entity.profile1.identity.links[idx_8].metas[idx_13].source = factory.createReference('Source', data.profile1_identity_links[idx_8].metas[idx_13].source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
                     } else if (data.profile1_identity_links[idx_8].metas[idx_13].source && typeof data.profile1_identity_links[idx_8].metas[idx_13].source === 'object') {
-                      entity.profile1.identity.links[idx_8].metas[idx_13].source = factory.create('Source', data.profile1_identity_links[idx_8].metas[idx_13].source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+                      entity.profile1.identity.links[idx_8].metas[idx_13].source = factory.create('Source', data.profile1_identity_links[idx_8].metas[idx_13].source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
                     }
                   }
                 } else if (data.profile1_identity_links[idx_8].metas[idx_13] === null) {
@@ -401,9 +401,9 @@ exports[`embedded entities in mongo diffing 2`] = `
     entity.profile1.identity.links[idx_8].source = null;
             } else if (typeof data.profile1_identity_links[idx_8].source !== 'undefined') {
               if (isPrimaryKey(data.profile1_identity_links[idx_8].source, true)) {
-                entity.profile1.identity.links[idx_8].source = factory.createReference('Source', data.profile1_identity_links[idx_8].source, { merge: true, convertCustomTypes, schema });
+                entity.profile1.identity.links[idx_8].source = factory.createReference('Source', data.profile1_identity_links[idx_8].source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
               } else if (data.profile1_identity_links[idx_8].source && typeof data.profile1_identity_links[idx_8].source === 'object') {
-                entity.profile1.identity.links[idx_8].source = factory.create('Source', data.profile1_identity_links[idx_8].source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+                entity.profile1.identity.links[idx_8].source = factory.create('Source', data.profile1_identity_links[idx_8].source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
               }
             }
           } else if (data.profile1_identity_links[idx_8] === null) {
@@ -415,9 +415,9 @@ exports[`embedded entities in mongo diffing 2`] = `
     entity.profile1.identity.source = null;
       } else if (typeof data.profile1_identity_source !== 'undefined') {
         if (isPrimaryKey(data.profile1_identity_source, true)) {
-          entity.profile1.identity.source = factory.createReference('Source', data.profile1_identity_source, { merge: true, convertCustomTypes, schema });
+          entity.profile1.identity.source = factory.createReference('Source', data.profile1_identity_source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
         } else if (data.profile1_identity_source && typeof data.profile1_identity_source === 'object') {
-          entity.profile1.identity.source = factory.create('Source', data.profile1_identity_source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+          entity.profile1.identity.source = factory.create('Source', data.profile1_identity_source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
         }
       }
     } else if (data.profile1_identity_email === null && data.profile1_identity_meta_foo === null && data.profile1_identity_meta_bar === null && data.profile1_identity_meta_source === null && data.profile1_identity_links === null && data.profile1_identity_source === null) {
@@ -426,7 +426,7 @@ exports[`embedded entities in mongo diffing 2`] = `
     if (data.profile1_identity != null) {
       const embeddedData = data.profile1_identity;
       if (entity.profile1.identity == null) {
-        entity.profile1.identity = factory.createEmbeddable('Identity', embeddedData, { newEntity, convertCustomTypes });
+        entity.profile1.identity = factory.createEmbeddable('Identity', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
       }
       if (data.profile1_identity.email === null) {
         entity.profile1.identity.email = null;
@@ -440,7 +440,7 @@ exports[`embedded entities in mongo diffing 2`] = `
           source: data.profile1_identity_meta_source,
         };
         if (entity.profile1.identity.meta == null) {
-          entity.profile1.identity.meta = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes });
+          entity.profile1.identity.meta = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
         }
         if (data.profile1_identity_meta_foo === null) {
           entity.profile1.identity.meta.foo = null;
@@ -456,9 +456,9 @@ exports[`embedded entities in mongo diffing 2`] = `
     entity.profile1.identity.meta.source = null;
         } else if (typeof data.profile1_identity_meta_source !== 'undefined') {
           if (isPrimaryKey(data.profile1_identity_meta_source, true)) {
-            entity.profile1.identity.meta.source = factory.createReference('Source', data.profile1_identity_meta_source, { merge: true, convertCustomTypes, schema });
+            entity.profile1.identity.meta.source = factory.createReference('Source', data.profile1_identity_meta_source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
           } else if (data.profile1_identity_meta_source && typeof data.profile1_identity_meta_source === 'object') {
-            entity.profile1.identity.meta.source = factory.create('Source', data.profile1_identity_meta_source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+            entity.profile1.identity.meta.source = factory.create('Source', data.profile1_identity_meta_source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
           }
         }
       } else if (data.profile1_identity_meta_foo === null && data.profile1_identity_meta_bar === null && data.profile1_identity_meta_source === null) {
@@ -467,7 +467,7 @@ exports[`embedded entities in mongo diffing 2`] = `
       if (data.profile1_identity.meta != null) {
         const embeddedData = data.profile1_identity.meta;
         if (entity.profile1.identity.meta == null) {
-          entity.profile1.identity.meta = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes });
+          entity.profile1.identity.meta = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
         }
         if (data.profile1_identity.meta.foo === null) {
           entity.profile1.identity.meta.foo = null;
@@ -483,9 +483,9 @@ exports[`embedded entities in mongo diffing 2`] = `
     entity.profile1.identity.meta.source = null;
         } else if (typeof data.profile1_identity.meta.source !== 'undefined') {
           if (isPrimaryKey(data.profile1_identity.meta.source, true)) {
-            entity.profile1.identity.meta.source = factory.createReference('Source', data.profile1_identity.meta.source, { merge: true, convertCustomTypes, schema });
+            entity.profile1.identity.meta.source = factory.createReference('Source', data.profile1_identity.meta.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
           } else if (data.profile1_identity.meta.source && typeof data.profile1_identity.meta.source === 'object') {
-            entity.profile1.identity.meta.source = factory.create('Source', data.profile1_identity.meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+            entity.profile1.identity.meta.source = factory.create('Source', data.profile1_identity.meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
           }
         }
       } else if (data.profile1_identity.meta === null) {
@@ -497,7 +497,7 @@ exports[`embedded entities in mongo diffing 2`] = `
           if (data.profile1_identity.links[idx_21] != null) {
             const embeddedData = data.profile1_identity.links[idx_21];
             if (entity.profile1.identity.links[idx_21] == null) {
-              entity.profile1.identity.links[idx_21] = factory.createEmbeddable('IdentityLink', embeddedData, { newEntity, convertCustomTypes });
+              entity.profile1.identity.links[idx_21] = factory.createEmbeddable('IdentityLink', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
             }
             if (data.profile1_identity.links[idx_21].url === null) {
               entity.profile1.identity.links[idx_21].url = null;
@@ -516,7 +516,7 @@ exports[`embedded entities in mongo diffing 2`] = `
             if (data.profile1_identity.links[idx_21].meta != null) {
               const embeddedData = data.profile1_identity.links[idx_21].meta;
               if (entity.profile1.identity.links[idx_21].meta == null) {
-                entity.profile1.identity.links[idx_21].meta = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes });
+                entity.profile1.identity.links[idx_21].meta = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
               }
               if (data.profile1_identity.links[idx_21].meta.foo === null) {
                 entity.profile1.identity.links[idx_21].meta.foo = null;
@@ -532,9 +532,9 @@ exports[`embedded entities in mongo diffing 2`] = `
     entity.profile1.identity.links[idx_21].meta.source = null;
               } else if (typeof data.profile1_identity.links[idx_21].meta.source !== 'undefined') {
                 if (isPrimaryKey(data.profile1_identity.links[idx_21].meta.source, true)) {
-                  entity.profile1.identity.links[idx_21].meta.source = factory.createReference('Source', data.profile1_identity.links[idx_21].meta.source, { merge: true, convertCustomTypes, schema });
+                  entity.profile1.identity.links[idx_21].meta.source = factory.createReference('Source', data.profile1_identity.links[idx_21].meta.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
                 } else if (data.profile1_identity.links[idx_21].meta.source && typeof data.profile1_identity.links[idx_21].meta.source === 'object') {
-                  entity.profile1.identity.links[idx_21].meta.source = factory.create('Source', data.profile1_identity.links[idx_21].meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+                  entity.profile1.identity.links[idx_21].meta.source = factory.create('Source', data.profile1_identity.links[idx_21].meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
                 }
               }
             } else if (data.profile1_identity.links[idx_21].meta === null) {
@@ -546,7 +546,7 @@ exports[`embedded entities in mongo diffing 2`] = `
                 if (data.profile1_identity.links[idx_21].metas[idx_26] != null) {
                   const embeddedData = data.profile1_identity.links[idx_21].metas[idx_26];
                   if (entity.profile1.identity.links[idx_21].metas[idx_26] == null) {
-                    entity.profile1.identity.links[idx_21].metas[idx_26] = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes });
+                    entity.profile1.identity.links[idx_21].metas[idx_26] = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
                   }
                   if (data.profile1_identity.links[idx_21].metas[idx_26].foo === null) {
                     entity.profile1.identity.links[idx_21].metas[idx_26].foo = null;
@@ -562,9 +562,9 @@ exports[`embedded entities in mongo diffing 2`] = `
     entity.profile1.identity.links[idx_21].metas[idx_26].source = null;
                   } else if (typeof data.profile1_identity.links[idx_21].metas[idx_26].source !== 'undefined') {
                     if (isPrimaryKey(data.profile1_identity.links[idx_21].metas[idx_26].source, true)) {
-                      entity.profile1.identity.links[idx_21].metas[idx_26].source = factory.createReference('Source', data.profile1_identity.links[idx_21].metas[idx_26].source, { merge: true, convertCustomTypes, schema });
+                      entity.profile1.identity.links[idx_21].metas[idx_26].source = factory.createReference('Source', data.profile1_identity.links[idx_21].metas[idx_26].source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
                     } else if (data.profile1_identity.links[idx_21].metas[idx_26].source && typeof data.profile1_identity.links[idx_21].metas[idx_26].source === 'object') {
-                      entity.profile1.identity.links[idx_21].metas[idx_26].source = factory.create('Source', data.profile1_identity.links[idx_21].metas[idx_26].source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+                      entity.profile1.identity.links[idx_21].metas[idx_26].source = factory.create('Source', data.profile1_identity.links[idx_21].metas[idx_26].source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
                     }
                   }
                 } else if (data.profile1_identity.links[idx_21].metas[idx_26] === null) {
@@ -576,9 +576,9 @@ exports[`embedded entities in mongo diffing 2`] = `
     entity.profile1.identity.links[idx_21].source = null;
             } else if (typeof data.profile1_identity.links[idx_21].source !== 'undefined') {
               if (isPrimaryKey(data.profile1_identity.links[idx_21].source, true)) {
-                entity.profile1.identity.links[idx_21].source = factory.createReference('Source', data.profile1_identity.links[idx_21].source, { merge: true, convertCustomTypes, schema });
+                entity.profile1.identity.links[idx_21].source = factory.createReference('Source', data.profile1_identity.links[idx_21].source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
               } else if (data.profile1_identity.links[idx_21].source && typeof data.profile1_identity.links[idx_21].source === 'object') {
-                entity.profile1.identity.links[idx_21].source = factory.create('Source', data.profile1_identity.links[idx_21].source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+                entity.profile1.identity.links[idx_21].source = factory.create('Source', data.profile1_identity.links[idx_21].source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
               }
             }
           } else if (data.profile1_identity.links[idx_21] === null) {
@@ -590,9 +590,9 @@ exports[`embedded entities in mongo diffing 2`] = `
     entity.profile1.identity.source = null;
       } else if (typeof data.profile1_identity.source !== 'undefined') {
         if (isPrimaryKey(data.profile1_identity.source, true)) {
-          entity.profile1.identity.source = factory.createReference('Source', data.profile1_identity.source, { merge: true, convertCustomTypes, schema });
+          entity.profile1.identity.source = factory.createReference('Source', data.profile1_identity.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
         } else if (data.profile1_identity.source && typeof data.profile1_identity.source === 'object') {
-          entity.profile1.identity.source = factory.create('Source', data.profile1_identity.source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+          entity.profile1.identity.source = factory.create('Source', data.profile1_identity.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
         }
       }
     } else if (data.profile1_identity === null) {
@@ -602,9 +602,9 @@ exports[`embedded entities in mongo diffing 2`] = `
     entity.profile1.source = null;
     } else if (typeof data.profile1_source !== 'undefined') {
       if (isPrimaryKey(data.profile1_source, true)) {
-        entity.profile1.source = factory.createReference('Source', data.profile1_source, { merge: true, convertCustomTypes, schema });
+        entity.profile1.source = factory.createReference('Source', data.profile1_source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
       } else if (data.profile1_source && typeof data.profile1_source === 'object') {
-        entity.profile1.source = factory.create('Source', data.profile1_source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+        entity.profile1.source = factory.create('Source', data.profile1_source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
       }
     }
   } else if (data.profile1_username === null && data.profile1_identity_email === null && data.profile1_identity_meta_foo === null && data.profile1_identity_meta_bar === null && data.profile1_identity_meta_source === null && data.profile1_identity_links === null && data.profile1_identity_source === null && data.profile1_source === null) {
@@ -613,7 +613,7 @@ exports[`embedded entities in mongo diffing 2`] = `
   if (data.profile1 != null) {
     const embeddedData = data.profile1;
     if (entity.profile1 == null) {
-      entity.profile1 = factory.createEmbeddable('Profile', embeddedData, { newEntity, convertCustomTypes });
+      entity.profile1 = factory.createEmbeddable('Profile', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
     }
     if (data.profile1.username === null) {
       entity.profile1.username = null;
@@ -628,7 +628,7 @@ exports[`embedded entities in mongo diffing 2`] = `
         source: data.profile1_identity_source,
       };
       if (entity.profile1.identity == null) {
-        entity.profile1.identity = factory.createEmbeddable('Identity', embeddedData, { newEntity, convertCustomTypes });
+        entity.profile1.identity = factory.createEmbeddable('Identity', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
       }
       if (data.profile1_identity_email === null) {
         entity.profile1.identity.email = null;
@@ -642,7 +642,7 @@ exports[`embedded entities in mongo diffing 2`] = `
           source: data.profile1_identity_meta_source,
         };
         if (entity.profile1.identity.meta == null) {
-          entity.profile1.identity.meta = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes });
+          entity.profile1.identity.meta = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
         }
         if (data.profile1_identity_meta_foo === null) {
           entity.profile1.identity.meta.foo = null;
@@ -658,9 +658,9 @@ exports[`embedded entities in mongo diffing 2`] = `
     entity.profile1.identity.meta.source = null;
         } else if (typeof data.profile1_identity_meta_source !== 'undefined') {
           if (isPrimaryKey(data.profile1_identity_meta_source, true)) {
-            entity.profile1.identity.meta.source = factory.createReference('Source', data.profile1_identity_meta_source, { merge: true, convertCustomTypes, schema });
+            entity.profile1.identity.meta.source = factory.createReference('Source', data.profile1_identity_meta_source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
           } else if (data.profile1_identity_meta_source && typeof data.profile1_identity_meta_source === 'object') {
-            entity.profile1.identity.meta.source = factory.create('Source', data.profile1_identity_meta_source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+            entity.profile1.identity.meta.source = factory.create('Source', data.profile1_identity_meta_source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
           }
         }
       } else if (data.profile1_identity_meta_foo === null && data.profile1_identity_meta_bar === null && data.profile1_identity_meta_source === null) {
@@ -669,7 +669,7 @@ exports[`embedded entities in mongo diffing 2`] = `
       if (data.profile1_identity_meta != null) {
         const embeddedData = data.profile1_identity_meta;
         if (entity.profile1.identity.meta == null) {
-          entity.profile1.identity.meta = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes });
+          entity.profile1.identity.meta = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
         }
         if (data.profile1_identity_meta.foo === null) {
           entity.profile1.identity.meta.foo = null;
@@ -685,9 +685,9 @@ exports[`embedded entities in mongo diffing 2`] = `
     entity.profile1.identity.meta.source = null;
         } else if (typeof data.profile1_identity_meta.source !== 'undefined') {
           if (isPrimaryKey(data.profile1_identity_meta.source, true)) {
-            entity.profile1.identity.meta.source = factory.createReference('Source', data.profile1_identity_meta.source, { merge: true, convertCustomTypes, schema });
+            entity.profile1.identity.meta.source = factory.createReference('Source', data.profile1_identity_meta.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
           } else if (data.profile1_identity_meta.source && typeof data.profile1_identity_meta.source === 'object') {
-            entity.profile1.identity.meta.source = factory.create('Source', data.profile1_identity_meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+            entity.profile1.identity.meta.source = factory.create('Source', data.profile1_identity_meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
           }
         }
       } else if (data.profile1_identity_meta === null) {
@@ -699,7 +699,7 @@ exports[`embedded entities in mongo diffing 2`] = `
           if (data.profile1_identity_links[idx_35] != null) {
             const embeddedData = data.profile1_identity_links[idx_35];
             if (entity.profile1.identity.links[idx_35] == null) {
-              entity.profile1.identity.links[idx_35] = factory.createEmbeddable('IdentityLink', embeddedData, { newEntity, convertCustomTypes });
+              entity.profile1.identity.links[idx_35] = factory.createEmbeddable('IdentityLink', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
             }
             if (data.profile1_identity_links[idx_35].url === null) {
               entity.profile1.identity.links[idx_35].url = null;
@@ -718,7 +718,7 @@ exports[`embedded entities in mongo diffing 2`] = `
             if (data.profile1_identity_links[idx_35].meta != null) {
               const embeddedData = data.profile1_identity_links[idx_35].meta;
               if (entity.profile1.identity.links[idx_35].meta == null) {
-                entity.profile1.identity.links[idx_35].meta = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes });
+                entity.profile1.identity.links[idx_35].meta = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
               }
               if (data.profile1_identity_links[idx_35].meta.foo === null) {
                 entity.profile1.identity.links[idx_35].meta.foo = null;
@@ -734,9 +734,9 @@ exports[`embedded entities in mongo diffing 2`] = `
     entity.profile1.identity.links[idx_35].meta.source = null;
               } else if (typeof data.profile1_identity_links[idx_35].meta.source !== 'undefined') {
                 if (isPrimaryKey(data.profile1_identity_links[idx_35].meta.source, true)) {
-                  entity.profile1.identity.links[idx_35].meta.source = factory.createReference('Source', data.profile1_identity_links[idx_35].meta.source, { merge: true, convertCustomTypes, schema });
+                  entity.profile1.identity.links[idx_35].meta.source = factory.createReference('Source', data.profile1_identity_links[idx_35].meta.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
                 } else if (data.profile1_identity_links[idx_35].meta.source && typeof data.profile1_identity_links[idx_35].meta.source === 'object') {
-                  entity.profile1.identity.links[idx_35].meta.source = factory.create('Source', data.profile1_identity_links[idx_35].meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+                  entity.profile1.identity.links[idx_35].meta.source = factory.create('Source', data.profile1_identity_links[idx_35].meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
                 }
               }
             } else if (data.profile1_identity_links[idx_35].meta === null) {
@@ -748,7 +748,7 @@ exports[`embedded entities in mongo diffing 2`] = `
                 if (data.profile1_identity_links[idx_35].metas[idx_40] != null) {
                   const embeddedData = data.profile1_identity_links[idx_35].metas[idx_40];
                   if (entity.profile1.identity.links[idx_35].metas[idx_40] == null) {
-                    entity.profile1.identity.links[idx_35].metas[idx_40] = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes });
+                    entity.profile1.identity.links[idx_35].metas[idx_40] = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
                   }
                   if (data.profile1_identity_links[idx_35].metas[idx_40].foo === null) {
                     entity.profile1.identity.links[idx_35].metas[idx_40].foo = null;
@@ -764,9 +764,9 @@ exports[`embedded entities in mongo diffing 2`] = `
     entity.profile1.identity.links[idx_35].metas[idx_40].source = null;
                   } else if (typeof data.profile1_identity_links[idx_35].metas[idx_40].source !== 'undefined') {
                     if (isPrimaryKey(data.profile1_identity_links[idx_35].metas[idx_40].source, true)) {
-                      entity.profile1.identity.links[idx_35].metas[idx_40].source = factory.createReference('Source', data.profile1_identity_links[idx_35].metas[idx_40].source, { merge: true, convertCustomTypes, schema });
+                      entity.profile1.identity.links[idx_35].metas[idx_40].source = factory.createReference('Source', data.profile1_identity_links[idx_35].metas[idx_40].source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
                     } else if (data.profile1_identity_links[idx_35].metas[idx_40].source && typeof data.profile1_identity_links[idx_35].metas[idx_40].source === 'object') {
-                      entity.profile1.identity.links[idx_35].metas[idx_40].source = factory.create('Source', data.profile1_identity_links[idx_35].metas[idx_40].source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+                      entity.profile1.identity.links[idx_35].metas[idx_40].source = factory.create('Source', data.profile1_identity_links[idx_35].metas[idx_40].source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
                     }
                   }
                 } else if (data.profile1_identity_links[idx_35].metas[idx_40] === null) {
@@ -778,9 +778,9 @@ exports[`embedded entities in mongo diffing 2`] = `
     entity.profile1.identity.links[idx_35].source = null;
             } else if (typeof data.profile1_identity_links[idx_35].source !== 'undefined') {
               if (isPrimaryKey(data.profile1_identity_links[idx_35].source, true)) {
-                entity.profile1.identity.links[idx_35].source = factory.createReference('Source', data.profile1_identity_links[idx_35].source, { merge: true, convertCustomTypes, schema });
+                entity.profile1.identity.links[idx_35].source = factory.createReference('Source', data.profile1_identity_links[idx_35].source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
               } else if (data.profile1_identity_links[idx_35].source && typeof data.profile1_identity_links[idx_35].source === 'object') {
-                entity.profile1.identity.links[idx_35].source = factory.create('Source', data.profile1_identity_links[idx_35].source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+                entity.profile1.identity.links[idx_35].source = factory.create('Source', data.profile1_identity_links[idx_35].source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
               }
             }
           } else if (data.profile1_identity_links[idx_35] === null) {
@@ -792,9 +792,9 @@ exports[`embedded entities in mongo diffing 2`] = `
     entity.profile1.identity.source = null;
       } else if (typeof data.profile1_identity_source !== 'undefined') {
         if (isPrimaryKey(data.profile1_identity_source, true)) {
-          entity.profile1.identity.source = factory.createReference('Source', data.profile1_identity_source, { merge: true, convertCustomTypes, schema });
+          entity.profile1.identity.source = factory.createReference('Source', data.profile1_identity_source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
         } else if (data.profile1_identity_source && typeof data.profile1_identity_source === 'object') {
-          entity.profile1.identity.source = factory.create('Source', data.profile1_identity_source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+          entity.profile1.identity.source = factory.create('Source', data.profile1_identity_source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
         }
       }
     } else if (data.profile1_identity_email === null && data.profile1_identity_meta_foo === null && data.profile1_identity_meta_bar === null && data.profile1_identity_meta_source === null && data.profile1_identity_links === null && data.profile1_identity_source === null) {
@@ -803,7 +803,7 @@ exports[`embedded entities in mongo diffing 2`] = `
     if (data.profile1.identity != null) {
       const embeddedData = data.profile1.identity;
       if (entity.profile1.identity == null) {
-        entity.profile1.identity = factory.createEmbeddable('Identity', embeddedData, { newEntity, convertCustomTypes });
+        entity.profile1.identity = factory.createEmbeddable('Identity', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
       }
       if (data.profile1.identity.email === null) {
         entity.profile1.identity.email = null;
@@ -817,7 +817,7 @@ exports[`embedded entities in mongo diffing 2`] = `
           source: data.profile1_identity_meta_source,
         };
         if (entity.profile1.identity.meta == null) {
-          entity.profile1.identity.meta = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes });
+          entity.profile1.identity.meta = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
         }
         if (data.profile1_identity_meta_foo === null) {
           entity.profile1.identity.meta.foo = null;
@@ -833,9 +833,9 @@ exports[`embedded entities in mongo diffing 2`] = `
     entity.profile1.identity.meta.source = null;
         } else if (typeof data.profile1_identity_meta_source !== 'undefined') {
           if (isPrimaryKey(data.profile1_identity_meta_source, true)) {
-            entity.profile1.identity.meta.source = factory.createReference('Source', data.profile1_identity_meta_source, { merge: true, convertCustomTypes, schema });
+            entity.profile1.identity.meta.source = factory.createReference('Source', data.profile1_identity_meta_source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
           } else if (data.profile1_identity_meta_source && typeof data.profile1_identity_meta_source === 'object') {
-            entity.profile1.identity.meta.source = factory.create('Source', data.profile1_identity_meta_source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+            entity.profile1.identity.meta.source = factory.create('Source', data.profile1_identity_meta_source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
           }
         }
       } else if (data.profile1_identity_meta_foo === null && data.profile1_identity_meta_bar === null && data.profile1_identity_meta_source === null) {
@@ -844,7 +844,7 @@ exports[`embedded entities in mongo diffing 2`] = `
       if (data.profile1.identity.meta != null) {
         const embeddedData = data.profile1.identity.meta;
         if (entity.profile1.identity.meta == null) {
-          entity.profile1.identity.meta = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes });
+          entity.profile1.identity.meta = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
         }
         if (data.profile1.identity.meta.foo === null) {
           entity.profile1.identity.meta.foo = null;
@@ -860,9 +860,9 @@ exports[`embedded entities in mongo diffing 2`] = `
     entity.profile1.identity.meta.source = null;
         } else if (typeof data.profile1.identity.meta.source !== 'undefined') {
           if (isPrimaryKey(data.profile1.identity.meta.source, true)) {
-            entity.profile1.identity.meta.source = factory.createReference('Source', data.profile1.identity.meta.source, { merge: true, convertCustomTypes, schema });
+            entity.profile1.identity.meta.source = factory.createReference('Source', data.profile1.identity.meta.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
           } else if (data.profile1.identity.meta.source && typeof data.profile1.identity.meta.source === 'object') {
-            entity.profile1.identity.meta.source = factory.create('Source', data.profile1.identity.meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+            entity.profile1.identity.meta.source = factory.create('Source', data.profile1.identity.meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
           }
         }
       } else if (data.profile1.identity.meta === null) {
@@ -874,7 +874,7 @@ exports[`embedded entities in mongo diffing 2`] = `
           if (data.profile1.identity.links[idx_48] != null) {
             const embeddedData = data.profile1.identity.links[idx_48];
             if (entity.profile1.identity.links[idx_48] == null) {
-              entity.profile1.identity.links[idx_48] = factory.createEmbeddable('IdentityLink', embeddedData, { newEntity, convertCustomTypes });
+              entity.profile1.identity.links[idx_48] = factory.createEmbeddable('IdentityLink', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
             }
             if (data.profile1.identity.links[idx_48].url === null) {
               entity.profile1.identity.links[idx_48].url = null;
@@ -893,7 +893,7 @@ exports[`embedded entities in mongo diffing 2`] = `
             if (data.profile1.identity.links[idx_48].meta != null) {
               const embeddedData = data.profile1.identity.links[idx_48].meta;
               if (entity.profile1.identity.links[idx_48].meta == null) {
-                entity.profile1.identity.links[idx_48].meta = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes });
+                entity.profile1.identity.links[idx_48].meta = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
               }
               if (data.profile1.identity.links[idx_48].meta.foo === null) {
                 entity.profile1.identity.links[idx_48].meta.foo = null;
@@ -909,9 +909,9 @@ exports[`embedded entities in mongo diffing 2`] = `
     entity.profile1.identity.links[idx_48].meta.source = null;
               } else if (typeof data.profile1.identity.links[idx_48].meta.source !== 'undefined') {
                 if (isPrimaryKey(data.profile1.identity.links[idx_48].meta.source, true)) {
-                  entity.profile1.identity.links[idx_48].meta.source = factory.createReference('Source', data.profile1.identity.links[idx_48].meta.source, { merge: true, convertCustomTypes, schema });
+                  entity.profile1.identity.links[idx_48].meta.source = factory.createReference('Source', data.profile1.identity.links[idx_48].meta.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
                 } else if (data.profile1.identity.links[idx_48].meta.source && typeof data.profile1.identity.links[idx_48].meta.source === 'object') {
-                  entity.profile1.identity.links[idx_48].meta.source = factory.create('Source', data.profile1.identity.links[idx_48].meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+                  entity.profile1.identity.links[idx_48].meta.source = factory.create('Source', data.profile1.identity.links[idx_48].meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
                 }
               }
             } else if (data.profile1.identity.links[idx_48].meta === null) {
@@ -923,7 +923,7 @@ exports[`embedded entities in mongo diffing 2`] = `
                 if (data.profile1.identity.links[idx_48].metas[idx_53] != null) {
                   const embeddedData = data.profile1.identity.links[idx_48].metas[idx_53];
                   if (entity.profile1.identity.links[idx_48].metas[idx_53] == null) {
-                    entity.profile1.identity.links[idx_48].metas[idx_53] = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes });
+                    entity.profile1.identity.links[idx_48].metas[idx_53] = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
                   }
                   if (data.profile1.identity.links[idx_48].metas[idx_53].foo === null) {
                     entity.profile1.identity.links[idx_48].metas[idx_53].foo = null;
@@ -939,9 +939,9 @@ exports[`embedded entities in mongo diffing 2`] = `
     entity.profile1.identity.links[idx_48].metas[idx_53].source = null;
                   } else if (typeof data.profile1.identity.links[idx_48].metas[idx_53].source !== 'undefined') {
                     if (isPrimaryKey(data.profile1.identity.links[idx_48].metas[idx_53].source, true)) {
-                      entity.profile1.identity.links[idx_48].metas[idx_53].source = factory.createReference('Source', data.profile1.identity.links[idx_48].metas[idx_53].source, { merge: true, convertCustomTypes, schema });
+                      entity.profile1.identity.links[idx_48].metas[idx_53].source = factory.createReference('Source', data.profile1.identity.links[idx_48].metas[idx_53].source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
                     } else if (data.profile1.identity.links[idx_48].metas[idx_53].source && typeof data.profile1.identity.links[idx_48].metas[idx_53].source === 'object') {
-                      entity.profile1.identity.links[idx_48].metas[idx_53].source = factory.create('Source', data.profile1.identity.links[idx_48].metas[idx_53].source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+                      entity.profile1.identity.links[idx_48].metas[idx_53].source = factory.create('Source', data.profile1.identity.links[idx_48].metas[idx_53].source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
                     }
                   }
                 } else if (data.profile1.identity.links[idx_48].metas[idx_53] === null) {
@@ -953,9 +953,9 @@ exports[`embedded entities in mongo diffing 2`] = `
     entity.profile1.identity.links[idx_48].source = null;
             } else if (typeof data.profile1.identity.links[idx_48].source !== 'undefined') {
               if (isPrimaryKey(data.profile1.identity.links[idx_48].source, true)) {
-                entity.profile1.identity.links[idx_48].source = factory.createReference('Source', data.profile1.identity.links[idx_48].source, { merge: true, convertCustomTypes, schema });
+                entity.profile1.identity.links[idx_48].source = factory.createReference('Source', data.profile1.identity.links[idx_48].source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
               } else if (data.profile1.identity.links[idx_48].source && typeof data.profile1.identity.links[idx_48].source === 'object') {
-                entity.profile1.identity.links[idx_48].source = factory.create('Source', data.profile1.identity.links[idx_48].source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+                entity.profile1.identity.links[idx_48].source = factory.create('Source', data.profile1.identity.links[idx_48].source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
               }
             }
           } else if (data.profile1.identity.links[idx_48] === null) {
@@ -967,9 +967,9 @@ exports[`embedded entities in mongo diffing 2`] = `
     entity.profile1.identity.source = null;
       } else if (typeof data.profile1.identity.source !== 'undefined') {
         if (isPrimaryKey(data.profile1.identity.source, true)) {
-          entity.profile1.identity.source = factory.createReference('Source', data.profile1.identity.source, { merge: true, convertCustomTypes, schema });
+          entity.profile1.identity.source = factory.createReference('Source', data.profile1.identity.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
         } else if (data.profile1.identity.source && typeof data.profile1.identity.source === 'object') {
-          entity.profile1.identity.source = factory.create('Source', data.profile1.identity.source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+          entity.profile1.identity.source = factory.create('Source', data.profile1.identity.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
         }
       }
     } else if (data.profile1.identity === null) {
@@ -979,9 +979,9 @@ exports[`embedded entities in mongo diffing 2`] = `
     entity.profile1.source = null;
     } else if (typeof data.profile1.source !== 'undefined') {
       if (isPrimaryKey(data.profile1.source, true)) {
-        entity.profile1.source = factory.createReference('Source', data.profile1.source, { merge: true, convertCustomTypes, schema });
+        entity.profile1.source = factory.createReference('Source', data.profile1.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
       } else if (data.profile1.source && typeof data.profile1.source === 'object') {
-        entity.profile1.source = factory.create('Source', data.profile1.source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+        entity.profile1.source = factory.create('Source', data.profile1.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
       }
     }
   } else if (data.profile1 === null) {
@@ -990,7 +990,7 @@ exports[`embedded entities in mongo diffing 2`] = `
   if (data.profile2 != null) {
     const embeddedData = data.profile2;
     if (entity.profile2 == null) {
-      entity.profile2 = factory.createEmbeddable('Profile', embeddedData, { newEntity, convertCustomTypes });
+      entity.profile2 = factory.createEmbeddable('Profile', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
     }
     if (data.profile2.username === null) {
       entity.profile2.username = null;
@@ -1000,7 +1000,7 @@ exports[`embedded entities in mongo diffing 2`] = `
     if (data.profile2.identity != null) {
       const embeddedData = data.profile2.identity;
       if (entity.profile2.identity == null) {
-        entity.profile2.identity = factory.createEmbeddable('Identity', embeddedData, { newEntity, convertCustomTypes });
+        entity.profile2.identity = factory.createEmbeddable('Identity', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
       }
       if (data.profile2.identity.email === null) {
         entity.profile2.identity.email = null;
@@ -1010,7 +1010,7 @@ exports[`embedded entities in mongo diffing 2`] = `
       if (data.profile2.identity.meta != null) {
         const embeddedData = data.profile2.identity.meta;
         if (entity.profile2.identity.meta == null) {
-          entity.profile2.identity.meta = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes });
+          entity.profile2.identity.meta = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
         }
         if (data.profile2.identity.meta.foo === null) {
           entity.profile2.identity.meta.foo = null;
@@ -1026,9 +1026,9 @@ exports[`embedded entities in mongo diffing 2`] = `
     entity.profile2.identity.meta.source = null;
         } else if (typeof data.profile2.identity.meta.source !== 'undefined') {
           if (isPrimaryKey(data.profile2.identity.meta.source, true)) {
-            entity.profile2.identity.meta.source = factory.createReference('Source', data.profile2.identity.meta.source, { merge: true, convertCustomTypes, schema });
+            entity.profile2.identity.meta.source = factory.createReference('Source', data.profile2.identity.meta.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
           } else if (data.profile2.identity.meta.source && typeof data.profile2.identity.meta.source === 'object') {
-            entity.profile2.identity.meta.source = factory.create('Source', data.profile2.identity.meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+            entity.profile2.identity.meta.source = factory.create('Source', data.profile2.identity.meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
           }
         }
       } else if (data.profile2.identity.meta === null) {
@@ -1040,7 +1040,7 @@ exports[`embedded entities in mongo diffing 2`] = `
           if (data.profile2.identity.links[idx_60] != null) {
             const embeddedData = data.profile2.identity.links[idx_60];
             if (entity.profile2.identity.links[idx_60] == null) {
-              entity.profile2.identity.links[idx_60] = factory.createEmbeddable('IdentityLink', embeddedData, { newEntity, convertCustomTypes });
+              entity.profile2.identity.links[idx_60] = factory.createEmbeddable('IdentityLink', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
             }
             if (data.profile2.identity.links[idx_60].url === null) {
               entity.profile2.identity.links[idx_60].url = null;
@@ -1059,7 +1059,7 @@ exports[`embedded entities in mongo diffing 2`] = `
             if (data.profile2.identity.links[idx_60].meta != null) {
               const embeddedData = data.profile2.identity.links[idx_60].meta;
               if (entity.profile2.identity.links[idx_60].meta == null) {
-                entity.profile2.identity.links[idx_60].meta = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes });
+                entity.profile2.identity.links[idx_60].meta = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
               }
               if (data.profile2.identity.links[idx_60].meta.foo === null) {
                 entity.profile2.identity.links[idx_60].meta.foo = null;
@@ -1075,9 +1075,9 @@ exports[`embedded entities in mongo diffing 2`] = `
     entity.profile2.identity.links[idx_60].meta.source = null;
               } else if (typeof data.profile2.identity.links[idx_60].meta.source !== 'undefined') {
                 if (isPrimaryKey(data.profile2.identity.links[idx_60].meta.source, true)) {
-                  entity.profile2.identity.links[idx_60].meta.source = factory.createReference('Source', data.profile2.identity.links[idx_60].meta.source, { merge: true, convertCustomTypes, schema });
+                  entity.profile2.identity.links[idx_60].meta.source = factory.createReference('Source', data.profile2.identity.links[idx_60].meta.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
                 } else if (data.profile2.identity.links[idx_60].meta.source && typeof data.profile2.identity.links[idx_60].meta.source === 'object') {
-                  entity.profile2.identity.links[idx_60].meta.source = factory.create('Source', data.profile2.identity.links[idx_60].meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+                  entity.profile2.identity.links[idx_60].meta.source = factory.create('Source', data.profile2.identity.links[idx_60].meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
                 }
               }
             } else if (data.profile2.identity.links[idx_60].meta === null) {
@@ -1089,7 +1089,7 @@ exports[`embedded entities in mongo diffing 2`] = `
                 if (data.profile2.identity.links[idx_60].metas[idx_65] != null) {
                   const embeddedData = data.profile2.identity.links[idx_60].metas[idx_65];
                   if (entity.profile2.identity.links[idx_60].metas[idx_65] == null) {
-                    entity.profile2.identity.links[idx_60].metas[idx_65] = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes });
+                    entity.profile2.identity.links[idx_60].metas[idx_65] = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
                   }
                   if (data.profile2.identity.links[idx_60].metas[idx_65].foo === null) {
                     entity.profile2.identity.links[idx_60].metas[idx_65].foo = null;
@@ -1105,9 +1105,9 @@ exports[`embedded entities in mongo diffing 2`] = `
     entity.profile2.identity.links[idx_60].metas[idx_65].source = null;
                   } else if (typeof data.profile2.identity.links[idx_60].metas[idx_65].source !== 'undefined') {
                     if (isPrimaryKey(data.profile2.identity.links[idx_60].metas[idx_65].source, true)) {
-                      entity.profile2.identity.links[idx_60].metas[idx_65].source = factory.createReference('Source', data.profile2.identity.links[idx_60].metas[idx_65].source, { merge: true, convertCustomTypes, schema });
+                      entity.profile2.identity.links[idx_60].metas[idx_65].source = factory.createReference('Source', data.profile2.identity.links[idx_60].metas[idx_65].source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
                     } else if (data.profile2.identity.links[idx_60].metas[idx_65].source && typeof data.profile2.identity.links[idx_60].metas[idx_65].source === 'object') {
-                      entity.profile2.identity.links[idx_60].metas[idx_65].source = factory.create('Source', data.profile2.identity.links[idx_60].metas[idx_65].source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+                      entity.profile2.identity.links[idx_60].metas[idx_65].source = factory.create('Source', data.profile2.identity.links[idx_60].metas[idx_65].source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
                     }
                   }
                 } else if (data.profile2.identity.links[idx_60].metas[idx_65] === null) {
@@ -1119,9 +1119,9 @@ exports[`embedded entities in mongo diffing 2`] = `
     entity.profile2.identity.links[idx_60].source = null;
             } else if (typeof data.profile2.identity.links[idx_60].source !== 'undefined') {
               if (isPrimaryKey(data.profile2.identity.links[idx_60].source, true)) {
-                entity.profile2.identity.links[idx_60].source = factory.createReference('Source', data.profile2.identity.links[idx_60].source, { merge: true, convertCustomTypes, schema });
+                entity.profile2.identity.links[idx_60].source = factory.createReference('Source', data.profile2.identity.links[idx_60].source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
               } else if (data.profile2.identity.links[idx_60].source && typeof data.profile2.identity.links[idx_60].source === 'object') {
-                entity.profile2.identity.links[idx_60].source = factory.create('Source', data.profile2.identity.links[idx_60].source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+                entity.profile2.identity.links[idx_60].source = factory.create('Source', data.profile2.identity.links[idx_60].source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
               }
             }
           } else if (data.profile2.identity.links[idx_60] === null) {
@@ -1133,9 +1133,9 @@ exports[`embedded entities in mongo diffing 2`] = `
     entity.profile2.identity.source = null;
       } else if (typeof data.profile2.identity.source !== 'undefined') {
         if (isPrimaryKey(data.profile2.identity.source, true)) {
-          entity.profile2.identity.source = factory.createReference('Source', data.profile2.identity.source, { merge: true, convertCustomTypes, schema });
+          entity.profile2.identity.source = factory.createReference('Source', data.profile2.identity.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
         } else if (data.profile2.identity.source && typeof data.profile2.identity.source === 'object') {
-          entity.profile2.identity.source = factory.create('Source', data.profile2.identity.source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+          entity.profile2.identity.source = factory.create('Source', data.profile2.identity.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
         }
       }
     } else if (data.profile2.identity === null) {
@@ -1145,9 +1145,9 @@ exports[`embedded entities in mongo diffing 2`] = `
     entity.profile2.source = null;
     } else if (typeof data.profile2.source !== 'undefined') {
       if (isPrimaryKey(data.profile2.source, true)) {
-        entity.profile2.source = factory.createReference('Source', data.profile2.source, { merge: true, convertCustomTypes, schema });
+        entity.profile2.source = factory.createReference('Source', data.profile2.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
       } else if (data.profile2.source && typeof data.profile2.source === 'object') {
-        entity.profile2.source = factory.create('Source', data.profile2.source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+        entity.profile2.source = factory.create('Source', data.profile2.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
       }
     }
   } else if (data.profile2 === null) {

--- a/tests/features/embeddables/__snapshots__/entities-in-embeddables.postgres.test.ts.snap
+++ b/tests/features/embeddables/__snapshots__/entities-in-embeddables.postgres.test.ts.snap
@@ -218,7 +218,7 @@ exports[`embedded entities in postgres diffing 1`] = `
 `;
 
 exports[`embedded entities in postgres diffing 2`] = `
-"function(entity, data, factory, newEntity, convertCustomTypes, schema) {
+"function(entity, data, factory, newEntity, convertCustomTypes, schema, parentSchema, normalizeAccessors) {
   if (data.id === null) {
     entity.id = null;
   } else if (typeof data.id !== 'undefined') {
@@ -236,7 +236,7 @@ exports[`embedded entities in postgres diffing 2`] = `
       source: data.profile1_source,
     };
     if (entity.profile1 == null) {
-      entity.profile1 = factory.createEmbeddable('Profile', embeddedData, { newEntity, convertCustomTypes });
+      entity.profile1 = factory.createEmbeddable('Profile', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
     }
     if (data.profile1_username === null) {
       entity.profile1.username = null;
@@ -251,7 +251,7 @@ exports[`embedded entities in postgres diffing 2`] = `
         source: data.profile1_identity_source,
       };
       if (entity.profile1.identity == null) {
-        entity.profile1.identity = factory.createEmbeddable('Identity', embeddedData, { newEntity, convertCustomTypes });
+        entity.profile1.identity = factory.createEmbeddable('Identity', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
       }
       if (data.profile1_identity_email === null) {
         entity.profile1.identity.email = null;
@@ -265,7 +265,7 @@ exports[`embedded entities in postgres diffing 2`] = `
           source: data.profile1_identity_meta_source,
         };
         if (entity.profile1.identity.meta == null) {
-          entity.profile1.identity.meta = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes });
+          entity.profile1.identity.meta = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
         }
         if (data.profile1_identity_meta_foo === null) {
           entity.profile1.identity.meta.foo = null;
@@ -281,9 +281,9 @@ exports[`embedded entities in postgres diffing 2`] = `
     entity.profile1.identity.meta.source = null;
         } else if (typeof data.profile1_identity_meta_source !== 'undefined') {
           if (isPrimaryKey(data.profile1_identity_meta_source, true)) {
-            entity.profile1.identity.meta.source = factory.createReference('Source', data.profile1_identity_meta_source, { merge: true, convertCustomTypes, schema });
+            entity.profile1.identity.meta.source = factory.createReference('Source', data.profile1_identity_meta_source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
           } else if (data.profile1_identity_meta_source && typeof data.profile1_identity_meta_source === 'object') {
-            entity.profile1.identity.meta.source = factory.create('Source', data.profile1_identity_meta_source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+            entity.profile1.identity.meta.source = factory.create('Source', data.profile1_identity_meta_source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
           }
         }
       } else if (data.profile1_identity_meta_foo === null && data.profile1_identity_meta_bar === null && data.profile1_identity_meta_source === null) {
@@ -292,7 +292,7 @@ exports[`embedded entities in postgres diffing 2`] = `
       if (data.profile1_identity_meta != null) {
         const embeddedData = data.profile1_identity_meta;
         if (entity.profile1.identity.meta == null) {
-          entity.profile1.identity.meta = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes });
+          entity.profile1.identity.meta = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
         }
         if (data.profile1_identity_meta.foo === null) {
           entity.profile1.identity.meta.foo = null;
@@ -308,9 +308,9 @@ exports[`embedded entities in postgres diffing 2`] = `
     entity.profile1.identity.meta.source = null;
         } else if (typeof data.profile1_identity_meta.source !== 'undefined') {
           if (isPrimaryKey(data.profile1_identity_meta.source, true)) {
-            entity.profile1.identity.meta.source = factory.createReference('Source', data.profile1_identity_meta.source, { merge: true, convertCustomTypes, schema });
+            entity.profile1.identity.meta.source = factory.createReference('Source', data.profile1_identity_meta.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
           } else if (data.profile1_identity_meta.source && typeof data.profile1_identity_meta.source === 'object') {
-            entity.profile1.identity.meta.source = factory.create('Source', data.profile1_identity_meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+            entity.profile1.identity.meta.source = factory.create('Source', data.profile1_identity_meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
           }
         }
       } else if (data.profile1_identity_meta === null) {
@@ -322,7 +322,7 @@ exports[`embedded entities in postgres diffing 2`] = `
           if (data.profile1_identity_links[idx_8] != null) {
             const embeddedData = data.profile1_identity_links[idx_8];
             if (entity.profile1.identity.links[idx_8] == null) {
-              entity.profile1.identity.links[idx_8] = factory.createEmbeddable('IdentityLink', embeddedData, { newEntity, convertCustomTypes });
+              entity.profile1.identity.links[idx_8] = factory.createEmbeddable('IdentityLink', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
             }
             if (data.profile1_identity_links[idx_8].url === null) {
               entity.profile1.identity.links[idx_8].url = null;
@@ -343,7 +343,7 @@ exports[`embedded entities in postgres diffing 2`] = `
             if (data.profile1_identity_links[idx_8].meta != null) {
               const embeddedData = data.profile1_identity_links[idx_8].meta;
               if (entity.profile1.identity.links[idx_8].meta == null) {
-                entity.profile1.identity.links[idx_8].meta = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes });
+                entity.profile1.identity.links[idx_8].meta = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
               }
               if (data.profile1_identity_links[idx_8].meta.foo === null) {
                 entity.profile1.identity.links[idx_8].meta.foo = null;
@@ -359,9 +359,9 @@ exports[`embedded entities in postgres diffing 2`] = `
     entity.profile1.identity.links[idx_8].meta.source = null;
               } else if (typeof data.profile1_identity_links[idx_8].meta.source !== 'undefined') {
                 if (isPrimaryKey(data.profile1_identity_links[idx_8].meta.source, true)) {
-                  entity.profile1.identity.links[idx_8].meta.source = factory.createReference('Source', data.profile1_identity_links[idx_8].meta.source, { merge: true, convertCustomTypes, schema });
+                  entity.profile1.identity.links[idx_8].meta.source = factory.createReference('Source', data.profile1_identity_links[idx_8].meta.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
                 } else if (data.profile1_identity_links[idx_8].meta.source && typeof data.profile1_identity_links[idx_8].meta.source === 'object') {
-                  entity.profile1.identity.links[idx_8].meta.source = factory.create('Source', data.profile1_identity_links[idx_8].meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+                  entity.profile1.identity.links[idx_8].meta.source = factory.create('Source', data.profile1_identity_links[idx_8].meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
                 }
               }
             } else if (data.profile1_identity_links[idx_8].meta === null) {
@@ -373,7 +373,7 @@ exports[`embedded entities in postgres diffing 2`] = `
                 if (data.profile1_identity_links[idx_8].metas[idx_13] != null) {
                   const embeddedData = data.profile1_identity_links[idx_8].metas[idx_13];
                   if (entity.profile1.identity.links[idx_8].metas[idx_13] == null) {
-                    entity.profile1.identity.links[idx_8].metas[idx_13] = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes });
+                    entity.profile1.identity.links[idx_8].metas[idx_13] = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
                   }
                   if (data.profile1_identity_links[idx_8].metas[idx_13].foo === null) {
                     entity.profile1.identity.links[idx_8].metas[idx_13].foo = null;
@@ -389,9 +389,9 @@ exports[`embedded entities in postgres diffing 2`] = `
     entity.profile1.identity.links[idx_8].metas[idx_13].source = null;
                   } else if (typeof data.profile1_identity_links[idx_8].metas[idx_13].source !== 'undefined') {
                     if (isPrimaryKey(data.profile1_identity_links[idx_8].metas[idx_13].source, true)) {
-                      entity.profile1.identity.links[idx_8].metas[idx_13].source = factory.createReference('Source', data.profile1_identity_links[idx_8].metas[idx_13].source, { merge: true, convertCustomTypes, schema });
+                      entity.profile1.identity.links[idx_8].metas[idx_13].source = factory.createReference('Source', data.profile1_identity_links[idx_8].metas[idx_13].source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
                     } else if (data.profile1_identity_links[idx_8].metas[idx_13].source && typeof data.profile1_identity_links[idx_8].metas[idx_13].source === 'object') {
-                      entity.profile1.identity.links[idx_8].metas[idx_13].source = factory.create('Source', data.profile1_identity_links[idx_8].metas[idx_13].source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+                      entity.profile1.identity.links[idx_8].metas[idx_13].source = factory.create('Source', data.profile1_identity_links[idx_8].metas[idx_13].source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
                     }
                   }
                 } else if (data.profile1_identity_links[idx_8].metas[idx_13] === null) {
@@ -403,9 +403,9 @@ exports[`embedded entities in postgres diffing 2`] = `
     entity.profile1.identity.links[idx_8].source = null;
             } else if (typeof data.profile1_identity_links[idx_8].source !== 'undefined') {
               if (isPrimaryKey(data.profile1_identity_links[idx_8].source, true)) {
-                entity.profile1.identity.links[idx_8].source = factory.createReference('Source', data.profile1_identity_links[idx_8].source, { merge: true, convertCustomTypes, schema });
+                entity.profile1.identity.links[idx_8].source = factory.createReference('Source', data.profile1_identity_links[idx_8].source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
               } else if (data.profile1_identity_links[idx_8].source && typeof data.profile1_identity_links[idx_8].source === 'object') {
-                entity.profile1.identity.links[idx_8].source = factory.create('Source', data.profile1_identity_links[idx_8].source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+                entity.profile1.identity.links[idx_8].source = factory.create('Source', data.profile1_identity_links[idx_8].source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
               }
             }
           } else if (data.profile1_identity_links[idx_8] === null) {
@@ -417,9 +417,9 @@ exports[`embedded entities in postgres diffing 2`] = `
     entity.profile1.identity.source = null;
       } else if (typeof data.profile1_identity_source !== 'undefined') {
         if (isPrimaryKey(data.profile1_identity_source, true)) {
-          entity.profile1.identity.source = factory.createReference('Source', data.profile1_identity_source, { merge: true, convertCustomTypes, schema });
+          entity.profile1.identity.source = factory.createReference('Source', data.profile1_identity_source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
         } else if (data.profile1_identity_source && typeof data.profile1_identity_source === 'object') {
-          entity.profile1.identity.source = factory.create('Source', data.profile1_identity_source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+          entity.profile1.identity.source = factory.create('Source', data.profile1_identity_source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
         }
       }
     } else if (data.profile1_identity_email === null && data.profile1_identity_meta_foo === null && data.profile1_identity_meta_bar === null && data.profile1_identity_meta_source === null && data.profile1_identity_links === null && data.profile1_identity_source === null) {
@@ -428,7 +428,7 @@ exports[`embedded entities in postgres diffing 2`] = `
     if (data.profile1_identity != null) {
       const embeddedData = data.profile1_identity;
       if (entity.profile1.identity == null) {
-        entity.profile1.identity = factory.createEmbeddable('Identity', embeddedData, { newEntity, convertCustomTypes });
+        entity.profile1.identity = factory.createEmbeddable('Identity', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
       }
       if (data.profile1_identity.email === null) {
         entity.profile1.identity.email = null;
@@ -442,7 +442,7 @@ exports[`embedded entities in postgres diffing 2`] = `
           source: data.profile1_identity_meta_source,
         };
         if (entity.profile1.identity.meta == null) {
-          entity.profile1.identity.meta = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes });
+          entity.profile1.identity.meta = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
         }
         if (data.profile1_identity_meta_foo === null) {
           entity.profile1.identity.meta.foo = null;
@@ -458,9 +458,9 @@ exports[`embedded entities in postgres diffing 2`] = `
     entity.profile1.identity.meta.source = null;
         } else if (typeof data.profile1_identity_meta_source !== 'undefined') {
           if (isPrimaryKey(data.profile1_identity_meta_source, true)) {
-            entity.profile1.identity.meta.source = factory.createReference('Source', data.profile1_identity_meta_source, { merge: true, convertCustomTypes, schema });
+            entity.profile1.identity.meta.source = factory.createReference('Source', data.profile1_identity_meta_source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
           } else if (data.profile1_identity_meta_source && typeof data.profile1_identity_meta_source === 'object') {
-            entity.profile1.identity.meta.source = factory.create('Source', data.profile1_identity_meta_source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+            entity.profile1.identity.meta.source = factory.create('Source', data.profile1_identity_meta_source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
           }
         }
       } else if (data.profile1_identity_meta_foo === null && data.profile1_identity_meta_bar === null && data.profile1_identity_meta_source === null) {
@@ -469,7 +469,7 @@ exports[`embedded entities in postgres diffing 2`] = `
       if (data.profile1_identity.meta != null) {
         const embeddedData = data.profile1_identity.meta;
         if (entity.profile1.identity.meta == null) {
-          entity.profile1.identity.meta = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes });
+          entity.profile1.identity.meta = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
         }
         if (data.profile1_identity.meta.foo === null) {
           entity.profile1.identity.meta.foo = null;
@@ -485,9 +485,9 @@ exports[`embedded entities in postgres diffing 2`] = `
     entity.profile1.identity.meta.source = null;
         } else if (typeof data.profile1_identity.meta.source !== 'undefined') {
           if (isPrimaryKey(data.profile1_identity.meta.source, true)) {
-            entity.profile1.identity.meta.source = factory.createReference('Source', data.profile1_identity.meta.source, { merge: true, convertCustomTypes, schema });
+            entity.profile1.identity.meta.source = factory.createReference('Source', data.profile1_identity.meta.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
           } else if (data.profile1_identity.meta.source && typeof data.profile1_identity.meta.source === 'object') {
-            entity.profile1.identity.meta.source = factory.create('Source', data.profile1_identity.meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+            entity.profile1.identity.meta.source = factory.create('Source', data.profile1_identity.meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
           }
         }
       } else if (data.profile1_identity.meta === null) {
@@ -499,7 +499,7 @@ exports[`embedded entities in postgres diffing 2`] = `
           if (data.profile1_identity.links[idx_21] != null) {
             const embeddedData = data.profile1_identity.links[idx_21];
             if (entity.profile1.identity.links[idx_21] == null) {
-              entity.profile1.identity.links[idx_21] = factory.createEmbeddable('IdentityLink', embeddedData, { newEntity, convertCustomTypes });
+              entity.profile1.identity.links[idx_21] = factory.createEmbeddable('IdentityLink', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
             }
             if (data.profile1_identity.links[idx_21].url === null) {
               entity.profile1.identity.links[idx_21].url = null;
@@ -520,7 +520,7 @@ exports[`embedded entities in postgres diffing 2`] = `
             if (data.profile1_identity.links[idx_21].meta != null) {
               const embeddedData = data.profile1_identity.links[idx_21].meta;
               if (entity.profile1.identity.links[idx_21].meta == null) {
-                entity.profile1.identity.links[idx_21].meta = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes });
+                entity.profile1.identity.links[idx_21].meta = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
               }
               if (data.profile1_identity.links[idx_21].meta.foo === null) {
                 entity.profile1.identity.links[idx_21].meta.foo = null;
@@ -536,9 +536,9 @@ exports[`embedded entities in postgres diffing 2`] = `
     entity.profile1.identity.links[idx_21].meta.source = null;
               } else if (typeof data.profile1_identity.links[idx_21].meta.source !== 'undefined') {
                 if (isPrimaryKey(data.profile1_identity.links[idx_21].meta.source, true)) {
-                  entity.profile1.identity.links[idx_21].meta.source = factory.createReference('Source', data.profile1_identity.links[idx_21].meta.source, { merge: true, convertCustomTypes, schema });
+                  entity.profile1.identity.links[idx_21].meta.source = factory.createReference('Source', data.profile1_identity.links[idx_21].meta.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
                 } else if (data.profile1_identity.links[idx_21].meta.source && typeof data.profile1_identity.links[idx_21].meta.source === 'object') {
-                  entity.profile1.identity.links[idx_21].meta.source = factory.create('Source', data.profile1_identity.links[idx_21].meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+                  entity.profile1.identity.links[idx_21].meta.source = factory.create('Source', data.profile1_identity.links[idx_21].meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
                 }
               }
             } else if (data.profile1_identity.links[idx_21].meta === null) {
@@ -550,7 +550,7 @@ exports[`embedded entities in postgres diffing 2`] = `
                 if (data.profile1_identity.links[idx_21].metas[idx_26] != null) {
                   const embeddedData = data.profile1_identity.links[idx_21].metas[idx_26];
                   if (entity.profile1.identity.links[idx_21].metas[idx_26] == null) {
-                    entity.profile1.identity.links[idx_21].metas[idx_26] = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes });
+                    entity.profile1.identity.links[idx_21].metas[idx_26] = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
                   }
                   if (data.profile1_identity.links[idx_21].metas[idx_26].foo === null) {
                     entity.profile1.identity.links[idx_21].metas[idx_26].foo = null;
@@ -566,9 +566,9 @@ exports[`embedded entities in postgres diffing 2`] = `
     entity.profile1.identity.links[idx_21].metas[idx_26].source = null;
                   } else if (typeof data.profile1_identity.links[idx_21].metas[idx_26].source !== 'undefined') {
                     if (isPrimaryKey(data.profile1_identity.links[idx_21].metas[idx_26].source, true)) {
-                      entity.profile1.identity.links[idx_21].metas[idx_26].source = factory.createReference('Source', data.profile1_identity.links[idx_21].metas[idx_26].source, { merge: true, convertCustomTypes, schema });
+                      entity.profile1.identity.links[idx_21].metas[idx_26].source = factory.createReference('Source', data.profile1_identity.links[idx_21].metas[idx_26].source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
                     } else if (data.profile1_identity.links[idx_21].metas[idx_26].source && typeof data.profile1_identity.links[idx_21].metas[idx_26].source === 'object') {
-                      entity.profile1.identity.links[idx_21].metas[idx_26].source = factory.create('Source', data.profile1_identity.links[idx_21].metas[idx_26].source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+                      entity.profile1.identity.links[idx_21].metas[idx_26].source = factory.create('Source', data.profile1_identity.links[idx_21].metas[idx_26].source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
                     }
                   }
                 } else if (data.profile1_identity.links[idx_21].metas[idx_26] === null) {
@@ -580,9 +580,9 @@ exports[`embedded entities in postgres diffing 2`] = `
     entity.profile1.identity.links[idx_21].source = null;
             } else if (typeof data.profile1_identity.links[idx_21].source !== 'undefined') {
               if (isPrimaryKey(data.profile1_identity.links[idx_21].source, true)) {
-                entity.profile1.identity.links[idx_21].source = factory.createReference('Source', data.profile1_identity.links[idx_21].source, { merge: true, convertCustomTypes, schema });
+                entity.profile1.identity.links[idx_21].source = factory.createReference('Source', data.profile1_identity.links[idx_21].source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
               } else if (data.profile1_identity.links[idx_21].source && typeof data.profile1_identity.links[idx_21].source === 'object') {
-                entity.profile1.identity.links[idx_21].source = factory.create('Source', data.profile1_identity.links[idx_21].source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+                entity.profile1.identity.links[idx_21].source = factory.create('Source', data.profile1_identity.links[idx_21].source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
               }
             }
           } else if (data.profile1_identity.links[idx_21] === null) {
@@ -594,9 +594,9 @@ exports[`embedded entities in postgres diffing 2`] = `
     entity.profile1.identity.source = null;
       } else if (typeof data.profile1_identity.source !== 'undefined') {
         if (isPrimaryKey(data.profile1_identity.source, true)) {
-          entity.profile1.identity.source = factory.createReference('Source', data.profile1_identity.source, { merge: true, convertCustomTypes, schema });
+          entity.profile1.identity.source = factory.createReference('Source', data.profile1_identity.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
         } else if (data.profile1_identity.source && typeof data.profile1_identity.source === 'object') {
-          entity.profile1.identity.source = factory.create('Source', data.profile1_identity.source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+          entity.profile1.identity.source = factory.create('Source', data.profile1_identity.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
         }
       }
     } else if (data.profile1_identity === null) {
@@ -606,9 +606,9 @@ exports[`embedded entities in postgres diffing 2`] = `
     entity.profile1.source = null;
     } else if (typeof data.profile1_source !== 'undefined') {
       if (isPrimaryKey(data.profile1_source, true)) {
-        entity.profile1.source = factory.createReference('Source', data.profile1_source, { merge: true, convertCustomTypes, schema });
+        entity.profile1.source = factory.createReference('Source', data.profile1_source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
       } else if (data.profile1_source && typeof data.profile1_source === 'object') {
-        entity.profile1.source = factory.create('Source', data.profile1_source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+        entity.profile1.source = factory.create('Source', data.profile1_source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
       }
     }
   } else if (data.profile1_username === null && data.profile1_identity_email === null && data.profile1_identity_meta_foo === null && data.profile1_identity_meta_bar === null && data.profile1_identity_meta_source === null && data.profile1_identity_links === null && data.profile1_identity_source === null && data.profile1_source === null) {
@@ -617,7 +617,7 @@ exports[`embedded entities in postgres diffing 2`] = `
   if (data.profile1 != null) {
     const embeddedData = data.profile1;
     if (entity.profile1 == null) {
-      entity.profile1 = factory.createEmbeddable('Profile', embeddedData, { newEntity, convertCustomTypes });
+      entity.profile1 = factory.createEmbeddable('Profile', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
     }
     if (data.profile1.username === null) {
       entity.profile1.username = null;
@@ -632,7 +632,7 @@ exports[`embedded entities in postgres diffing 2`] = `
         source: data.profile1_identity_source,
       };
       if (entity.profile1.identity == null) {
-        entity.profile1.identity = factory.createEmbeddable('Identity', embeddedData, { newEntity, convertCustomTypes });
+        entity.profile1.identity = factory.createEmbeddable('Identity', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
       }
       if (data.profile1_identity_email === null) {
         entity.profile1.identity.email = null;
@@ -646,7 +646,7 @@ exports[`embedded entities in postgres diffing 2`] = `
           source: data.profile1_identity_meta_source,
         };
         if (entity.profile1.identity.meta == null) {
-          entity.profile1.identity.meta = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes });
+          entity.profile1.identity.meta = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
         }
         if (data.profile1_identity_meta_foo === null) {
           entity.profile1.identity.meta.foo = null;
@@ -662,9 +662,9 @@ exports[`embedded entities in postgres diffing 2`] = `
     entity.profile1.identity.meta.source = null;
         } else if (typeof data.profile1_identity_meta_source !== 'undefined') {
           if (isPrimaryKey(data.profile1_identity_meta_source, true)) {
-            entity.profile1.identity.meta.source = factory.createReference('Source', data.profile1_identity_meta_source, { merge: true, convertCustomTypes, schema });
+            entity.profile1.identity.meta.source = factory.createReference('Source', data.profile1_identity_meta_source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
           } else if (data.profile1_identity_meta_source && typeof data.profile1_identity_meta_source === 'object') {
-            entity.profile1.identity.meta.source = factory.create('Source', data.profile1_identity_meta_source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+            entity.profile1.identity.meta.source = factory.create('Source', data.profile1_identity_meta_source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
           }
         }
       } else if (data.profile1_identity_meta_foo === null && data.profile1_identity_meta_bar === null && data.profile1_identity_meta_source === null) {
@@ -673,7 +673,7 @@ exports[`embedded entities in postgres diffing 2`] = `
       if (data.profile1_identity_meta != null) {
         const embeddedData = data.profile1_identity_meta;
         if (entity.profile1.identity.meta == null) {
-          entity.profile1.identity.meta = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes });
+          entity.profile1.identity.meta = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
         }
         if (data.profile1_identity_meta.foo === null) {
           entity.profile1.identity.meta.foo = null;
@@ -689,9 +689,9 @@ exports[`embedded entities in postgres diffing 2`] = `
     entity.profile1.identity.meta.source = null;
         } else if (typeof data.profile1_identity_meta.source !== 'undefined') {
           if (isPrimaryKey(data.profile1_identity_meta.source, true)) {
-            entity.profile1.identity.meta.source = factory.createReference('Source', data.profile1_identity_meta.source, { merge: true, convertCustomTypes, schema });
+            entity.profile1.identity.meta.source = factory.createReference('Source', data.profile1_identity_meta.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
           } else if (data.profile1_identity_meta.source && typeof data.profile1_identity_meta.source === 'object') {
-            entity.profile1.identity.meta.source = factory.create('Source', data.profile1_identity_meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+            entity.profile1.identity.meta.source = factory.create('Source', data.profile1_identity_meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
           }
         }
       } else if (data.profile1_identity_meta === null) {
@@ -703,7 +703,7 @@ exports[`embedded entities in postgres diffing 2`] = `
           if (data.profile1_identity_links[idx_35] != null) {
             const embeddedData = data.profile1_identity_links[idx_35];
             if (entity.profile1.identity.links[idx_35] == null) {
-              entity.profile1.identity.links[idx_35] = factory.createEmbeddable('IdentityLink', embeddedData, { newEntity, convertCustomTypes });
+              entity.profile1.identity.links[idx_35] = factory.createEmbeddable('IdentityLink', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
             }
             if (data.profile1_identity_links[idx_35].url === null) {
               entity.profile1.identity.links[idx_35].url = null;
@@ -724,7 +724,7 @@ exports[`embedded entities in postgres diffing 2`] = `
             if (data.profile1_identity_links[idx_35].meta != null) {
               const embeddedData = data.profile1_identity_links[idx_35].meta;
               if (entity.profile1.identity.links[idx_35].meta == null) {
-                entity.profile1.identity.links[idx_35].meta = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes });
+                entity.profile1.identity.links[idx_35].meta = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
               }
               if (data.profile1_identity_links[idx_35].meta.foo === null) {
                 entity.profile1.identity.links[idx_35].meta.foo = null;
@@ -740,9 +740,9 @@ exports[`embedded entities in postgres diffing 2`] = `
     entity.profile1.identity.links[idx_35].meta.source = null;
               } else if (typeof data.profile1_identity_links[idx_35].meta.source !== 'undefined') {
                 if (isPrimaryKey(data.profile1_identity_links[idx_35].meta.source, true)) {
-                  entity.profile1.identity.links[idx_35].meta.source = factory.createReference('Source', data.profile1_identity_links[idx_35].meta.source, { merge: true, convertCustomTypes, schema });
+                  entity.profile1.identity.links[idx_35].meta.source = factory.createReference('Source', data.profile1_identity_links[idx_35].meta.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
                 } else if (data.profile1_identity_links[idx_35].meta.source && typeof data.profile1_identity_links[idx_35].meta.source === 'object') {
-                  entity.profile1.identity.links[idx_35].meta.source = factory.create('Source', data.profile1_identity_links[idx_35].meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+                  entity.profile1.identity.links[idx_35].meta.source = factory.create('Source', data.profile1_identity_links[idx_35].meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
                 }
               }
             } else if (data.profile1_identity_links[idx_35].meta === null) {
@@ -754,7 +754,7 @@ exports[`embedded entities in postgres diffing 2`] = `
                 if (data.profile1_identity_links[idx_35].metas[idx_40] != null) {
                   const embeddedData = data.profile1_identity_links[idx_35].metas[idx_40];
                   if (entity.profile1.identity.links[idx_35].metas[idx_40] == null) {
-                    entity.profile1.identity.links[idx_35].metas[idx_40] = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes });
+                    entity.profile1.identity.links[idx_35].metas[idx_40] = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
                   }
                   if (data.profile1_identity_links[idx_35].metas[idx_40].foo === null) {
                     entity.profile1.identity.links[idx_35].metas[idx_40].foo = null;
@@ -770,9 +770,9 @@ exports[`embedded entities in postgres diffing 2`] = `
     entity.profile1.identity.links[idx_35].metas[idx_40].source = null;
                   } else if (typeof data.profile1_identity_links[idx_35].metas[idx_40].source !== 'undefined') {
                     if (isPrimaryKey(data.profile1_identity_links[idx_35].metas[idx_40].source, true)) {
-                      entity.profile1.identity.links[idx_35].metas[idx_40].source = factory.createReference('Source', data.profile1_identity_links[idx_35].metas[idx_40].source, { merge: true, convertCustomTypes, schema });
+                      entity.profile1.identity.links[idx_35].metas[idx_40].source = factory.createReference('Source', data.profile1_identity_links[idx_35].metas[idx_40].source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
                     } else if (data.profile1_identity_links[idx_35].metas[idx_40].source && typeof data.profile1_identity_links[idx_35].metas[idx_40].source === 'object') {
-                      entity.profile1.identity.links[idx_35].metas[idx_40].source = factory.create('Source', data.profile1_identity_links[idx_35].metas[idx_40].source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+                      entity.profile1.identity.links[idx_35].metas[idx_40].source = factory.create('Source', data.profile1_identity_links[idx_35].metas[idx_40].source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
                     }
                   }
                 } else if (data.profile1_identity_links[idx_35].metas[idx_40] === null) {
@@ -784,9 +784,9 @@ exports[`embedded entities in postgres diffing 2`] = `
     entity.profile1.identity.links[idx_35].source = null;
             } else if (typeof data.profile1_identity_links[idx_35].source !== 'undefined') {
               if (isPrimaryKey(data.profile1_identity_links[idx_35].source, true)) {
-                entity.profile1.identity.links[idx_35].source = factory.createReference('Source', data.profile1_identity_links[idx_35].source, { merge: true, convertCustomTypes, schema });
+                entity.profile1.identity.links[idx_35].source = factory.createReference('Source', data.profile1_identity_links[idx_35].source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
               } else if (data.profile1_identity_links[idx_35].source && typeof data.profile1_identity_links[idx_35].source === 'object') {
-                entity.profile1.identity.links[idx_35].source = factory.create('Source', data.profile1_identity_links[idx_35].source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+                entity.profile1.identity.links[idx_35].source = factory.create('Source', data.profile1_identity_links[idx_35].source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
               }
             }
           } else if (data.profile1_identity_links[idx_35] === null) {
@@ -798,9 +798,9 @@ exports[`embedded entities in postgres diffing 2`] = `
     entity.profile1.identity.source = null;
       } else if (typeof data.profile1_identity_source !== 'undefined') {
         if (isPrimaryKey(data.profile1_identity_source, true)) {
-          entity.profile1.identity.source = factory.createReference('Source', data.profile1_identity_source, { merge: true, convertCustomTypes, schema });
+          entity.profile1.identity.source = factory.createReference('Source', data.profile1_identity_source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
         } else if (data.profile1_identity_source && typeof data.profile1_identity_source === 'object') {
-          entity.profile1.identity.source = factory.create('Source', data.profile1_identity_source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+          entity.profile1.identity.source = factory.create('Source', data.profile1_identity_source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
         }
       }
     } else if (data.profile1_identity_email === null && data.profile1_identity_meta_foo === null && data.profile1_identity_meta_bar === null && data.profile1_identity_meta_source === null && data.profile1_identity_links === null && data.profile1_identity_source === null) {
@@ -809,7 +809,7 @@ exports[`embedded entities in postgres diffing 2`] = `
     if (data.profile1.identity != null) {
       const embeddedData = data.profile1.identity;
       if (entity.profile1.identity == null) {
-        entity.profile1.identity = factory.createEmbeddable('Identity', embeddedData, { newEntity, convertCustomTypes });
+        entity.profile1.identity = factory.createEmbeddable('Identity', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
       }
       if (data.profile1.identity.email === null) {
         entity.profile1.identity.email = null;
@@ -823,7 +823,7 @@ exports[`embedded entities in postgres diffing 2`] = `
           source: data.profile1_identity_meta_source,
         };
         if (entity.profile1.identity.meta == null) {
-          entity.profile1.identity.meta = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes });
+          entity.profile1.identity.meta = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
         }
         if (data.profile1_identity_meta_foo === null) {
           entity.profile1.identity.meta.foo = null;
@@ -839,9 +839,9 @@ exports[`embedded entities in postgres diffing 2`] = `
     entity.profile1.identity.meta.source = null;
         } else if (typeof data.profile1_identity_meta_source !== 'undefined') {
           if (isPrimaryKey(data.profile1_identity_meta_source, true)) {
-            entity.profile1.identity.meta.source = factory.createReference('Source', data.profile1_identity_meta_source, { merge: true, convertCustomTypes, schema });
+            entity.profile1.identity.meta.source = factory.createReference('Source', data.profile1_identity_meta_source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
           } else if (data.profile1_identity_meta_source && typeof data.profile1_identity_meta_source === 'object') {
-            entity.profile1.identity.meta.source = factory.create('Source', data.profile1_identity_meta_source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+            entity.profile1.identity.meta.source = factory.create('Source', data.profile1_identity_meta_source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
           }
         }
       } else if (data.profile1_identity_meta_foo === null && data.profile1_identity_meta_bar === null && data.profile1_identity_meta_source === null) {
@@ -850,7 +850,7 @@ exports[`embedded entities in postgres diffing 2`] = `
       if (data.profile1.identity.meta != null) {
         const embeddedData = data.profile1.identity.meta;
         if (entity.profile1.identity.meta == null) {
-          entity.profile1.identity.meta = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes });
+          entity.profile1.identity.meta = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
         }
         if (data.profile1.identity.meta.foo === null) {
           entity.profile1.identity.meta.foo = null;
@@ -866,9 +866,9 @@ exports[`embedded entities in postgres diffing 2`] = `
     entity.profile1.identity.meta.source = null;
         } else if (typeof data.profile1.identity.meta.source !== 'undefined') {
           if (isPrimaryKey(data.profile1.identity.meta.source, true)) {
-            entity.profile1.identity.meta.source = factory.createReference('Source', data.profile1.identity.meta.source, { merge: true, convertCustomTypes, schema });
+            entity.profile1.identity.meta.source = factory.createReference('Source', data.profile1.identity.meta.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
           } else if (data.profile1.identity.meta.source && typeof data.profile1.identity.meta.source === 'object') {
-            entity.profile1.identity.meta.source = factory.create('Source', data.profile1.identity.meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+            entity.profile1.identity.meta.source = factory.create('Source', data.profile1.identity.meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
           }
         }
       } else if (data.profile1.identity.meta === null) {
@@ -880,7 +880,7 @@ exports[`embedded entities in postgres diffing 2`] = `
           if (data.profile1.identity.links[idx_48] != null) {
             const embeddedData = data.profile1.identity.links[idx_48];
             if (entity.profile1.identity.links[idx_48] == null) {
-              entity.profile1.identity.links[idx_48] = factory.createEmbeddable('IdentityLink', embeddedData, { newEntity, convertCustomTypes });
+              entity.profile1.identity.links[idx_48] = factory.createEmbeddable('IdentityLink', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
             }
             if (data.profile1.identity.links[idx_48].url === null) {
               entity.profile1.identity.links[idx_48].url = null;
@@ -901,7 +901,7 @@ exports[`embedded entities in postgres diffing 2`] = `
             if (data.profile1.identity.links[idx_48].meta != null) {
               const embeddedData = data.profile1.identity.links[idx_48].meta;
               if (entity.profile1.identity.links[idx_48].meta == null) {
-                entity.profile1.identity.links[idx_48].meta = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes });
+                entity.profile1.identity.links[idx_48].meta = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
               }
               if (data.profile1.identity.links[idx_48].meta.foo === null) {
                 entity.profile1.identity.links[idx_48].meta.foo = null;
@@ -917,9 +917,9 @@ exports[`embedded entities in postgres diffing 2`] = `
     entity.profile1.identity.links[idx_48].meta.source = null;
               } else if (typeof data.profile1.identity.links[idx_48].meta.source !== 'undefined') {
                 if (isPrimaryKey(data.profile1.identity.links[idx_48].meta.source, true)) {
-                  entity.profile1.identity.links[idx_48].meta.source = factory.createReference('Source', data.profile1.identity.links[idx_48].meta.source, { merge: true, convertCustomTypes, schema });
+                  entity.profile1.identity.links[idx_48].meta.source = factory.createReference('Source', data.profile1.identity.links[idx_48].meta.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
                 } else if (data.profile1.identity.links[idx_48].meta.source && typeof data.profile1.identity.links[idx_48].meta.source === 'object') {
-                  entity.profile1.identity.links[idx_48].meta.source = factory.create('Source', data.profile1.identity.links[idx_48].meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+                  entity.profile1.identity.links[idx_48].meta.source = factory.create('Source', data.profile1.identity.links[idx_48].meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
                 }
               }
             } else if (data.profile1.identity.links[idx_48].meta === null) {
@@ -931,7 +931,7 @@ exports[`embedded entities in postgres diffing 2`] = `
                 if (data.profile1.identity.links[idx_48].metas[idx_53] != null) {
                   const embeddedData = data.profile1.identity.links[idx_48].metas[idx_53];
                   if (entity.profile1.identity.links[idx_48].metas[idx_53] == null) {
-                    entity.profile1.identity.links[idx_48].metas[idx_53] = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes });
+                    entity.profile1.identity.links[idx_48].metas[idx_53] = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
                   }
                   if (data.profile1.identity.links[idx_48].metas[idx_53].foo === null) {
                     entity.profile1.identity.links[idx_48].metas[idx_53].foo = null;
@@ -947,9 +947,9 @@ exports[`embedded entities in postgres diffing 2`] = `
     entity.profile1.identity.links[idx_48].metas[idx_53].source = null;
                   } else if (typeof data.profile1.identity.links[idx_48].metas[idx_53].source !== 'undefined') {
                     if (isPrimaryKey(data.profile1.identity.links[idx_48].metas[idx_53].source, true)) {
-                      entity.profile1.identity.links[idx_48].metas[idx_53].source = factory.createReference('Source', data.profile1.identity.links[idx_48].metas[idx_53].source, { merge: true, convertCustomTypes, schema });
+                      entity.profile1.identity.links[idx_48].metas[idx_53].source = factory.createReference('Source', data.profile1.identity.links[idx_48].metas[idx_53].source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
                     } else if (data.profile1.identity.links[idx_48].metas[idx_53].source && typeof data.profile1.identity.links[idx_48].metas[idx_53].source === 'object') {
-                      entity.profile1.identity.links[idx_48].metas[idx_53].source = factory.create('Source', data.profile1.identity.links[idx_48].metas[idx_53].source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+                      entity.profile1.identity.links[idx_48].metas[idx_53].source = factory.create('Source', data.profile1.identity.links[idx_48].metas[idx_53].source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
                     }
                   }
                 } else if (data.profile1.identity.links[idx_48].metas[idx_53] === null) {
@@ -961,9 +961,9 @@ exports[`embedded entities in postgres diffing 2`] = `
     entity.profile1.identity.links[idx_48].source = null;
             } else if (typeof data.profile1.identity.links[idx_48].source !== 'undefined') {
               if (isPrimaryKey(data.profile1.identity.links[idx_48].source, true)) {
-                entity.profile1.identity.links[idx_48].source = factory.createReference('Source', data.profile1.identity.links[idx_48].source, { merge: true, convertCustomTypes, schema });
+                entity.profile1.identity.links[idx_48].source = factory.createReference('Source', data.profile1.identity.links[idx_48].source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
               } else if (data.profile1.identity.links[idx_48].source && typeof data.profile1.identity.links[idx_48].source === 'object') {
-                entity.profile1.identity.links[idx_48].source = factory.create('Source', data.profile1.identity.links[idx_48].source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+                entity.profile1.identity.links[idx_48].source = factory.create('Source', data.profile1.identity.links[idx_48].source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
               }
             }
           } else if (data.profile1.identity.links[idx_48] === null) {
@@ -975,9 +975,9 @@ exports[`embedded entities in postgres diffing 2`] = `
     entity.profile1.identity.source = null;
       } else if (typeof data.profile1.identity.source !== 'undefined') {
         if (isPrimaryKey(data.profile1.identity.source, true)) {
-          entity.profile1.identity.source = factory.createReference('Source', data.profile1.identity.source, { merge: true, convertCustomTypes, schema });
+          entity.profile1.identity.source = factory.createReference('Source', data.profile1.identity.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
         } else if (data.profile1.identity.source && typeof data.profile1.identity.source === 'object') {
-          entity.profile1.identity.source = factory.create('Source', data.profile1.identity.source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+          entity.profile1.identity.source = factory.create('Source', data.profile1.identity.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
         }
       }
     } else if (data.profile1.identity === null) {
@@ -987,9 +987,9 @@ exports[`embedded entities in postgres diffing 2`] = `
     entity.profile1.source = null;
     } else if (typeof data.profile1.source !== 'undefined') {
       if (isPrimaryKey(data.profile1.source, true)) {
-        entity.profile1.source = factory.createReference('Source', data.profile1.source, { merge: true, convertCustomTypes, schema });
+        entity.profile1.source = factory.createReference('Source', data.profile1.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
       } else if (data.profile1.source && typeof data.profile1.source === 'object') {
-        entity.profile1.source = factory.create('Source', data.profile1.source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+        entity.profile1.source = factory.create('Source', data.profile1.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
       }
     }
   } else if (data.profile1 === null) {
@@ -998,7 +998,7 @@ exports[`embedded entities in postgres diffing 2`] = `
   if (data.profile2 != null) {
     const embeddedData = data.profile2;
     if (entity.profile2 == null) {
-      entity.profile2 = factory.createEmbeddable('Profile', embeddedData, { newEntity, convertCustomTypes });
+      entity.profile2 = factory.createEmbeddable('Profile', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
     }
     if (data.profile2.username === null) {
       entity.profile2.username = null;
@@ -1008,7 +1008,7 @@ exports[`embedded entities in postgres diffing 2`] = `
     if (data.profile2.identity != null) {
       const embeddedData = data.profile2.identity;
       if (entity.profile2.identity == null) {
-        entity.profile2.identity = factory.createEmbeddable('Identity', embeddedData, { newEntity, convertCustomTypes });
+        entity.profile2.identity = factory.createEmbeddable('Identity', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
       }
       if (data.profile2.identity.email === null) {
         entity.profile2.identity.email = null;
@@ -1018,7 +1018,7 @@ exports[`embedded entities in postgres diffing 2`] = `
       if (data.profile2.identity.meta != null) {
         const embeddedData = data.profile2.identity.meta;
         if (entity.profile2.identity.meta == null) {
-          entity.profile2.identity.meta = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes });
+          entity.profile2.identity.meta = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
         }
         if (data.profile2.identity.meta.foo === null) {
           entity.profile2.identity.meta.foo = null;
@@ -1034,9 +1034,9 @@ exports[`embedded entities in postgres diffing 2`] = `
     entity.profile2.identity.meta.source = null;
         } else if (typeof data.profile2.identity.meta.source !== 'undefined') {
           if (isPrimaryKey(data.profile2.identity.meta.source, true)) {
-            entity.profile2.identity.meta.source = factory.createReference('Source', data.profile2.identity.meta.source, { merge: true, convertCustomTypes, schema });
+            entity.profile2.identity.meta.source = factory.createReference('Source', data.profile2.identity.meta.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
           } else if (data.profile2.identity.meta.source && typeof data.profile2.identity.meta.source === 'object') {
-            entity.profile2.identity.meta.source = factory.create('Source', data.profile2.identity.meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+            entity.profile2.identity.meta.source = factory.create('Source', data.profile2.identity.meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
           }
         }
       } else if (data.profile2.identity.meta === null) {
@@ -1048,7 +1048,7 @@ exports[`embedded entities in postgres diffing 2`] = `
           if (data.profile2.identity.links[idx_60] != null) {
             const embeddedData = data.profile2.identity.links[idx_60];
             if (entity.profile2.identity.links[idx_60] == null) {
-              entity.profile2.identity.links[idx_60] = factory.createEmbeddable('IdentityLink', embeddedData, { newEntity, convertCustomTypes });
+              entity.profile2.identity.links[idx_60] = factory.createEmbeddable('IdentityLink', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
             }
             if (data.profile2.identity.links[idx_60].url === null) {
               entity.profile2.identity.links[idx_60].url = null;
@@ -1069,7 +1069,7 @@ exports[`embedded entities in postgres diffing 2`] = `
             if (data.profile2.identity.links[idx_60].meta != null) {
               const embeddedData = data.profile2.identity.links[idx_60].meta;
               if (entity.profile2.identity.links[idx_60].meta == null) {
-                entity.profile2.identity.links[idx_60].meta = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes });
+                entity.profile2.identity.links[idx_60].meta = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
               }
               if (data.profile2.identity.links[idx_60].meta.foo === null) {
                 entity.profile2.identity.links[idx_60].meta.foo = null;
@@ -1085,9 +1085,9 @@ exports[`embedded entities in postgres diffing 2`] = `
     entity.profile2.identity.links[idx_60].meta.source = null;
               } else if (typeof data.profile2.identity.links[idx_60].meta.source !== 'undefined') {
                 if (isPrimaryKey(data.profile2.identity.links[idx_60].meta.source, true)) {
-                  entity.profile2.identity.links[idx_60].meta.source = factory.createReference('Source', data.profile2.identity.links[idx_60].meta.source, { merge: true, convertCustomTypes, schema });
+                  entity.profile2.identity.links[idx_60].meta.source = factory.createReference('Source', data.profile2.identity.links[idx_60].meta.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
                 } else if (data.profile2.identity.links[idx_60].meta.source && typeof data.profile2.identity.links[idx_60].meta.source === 'object') {
-                  entity.profile2.identity.links[idx_60].meta.source = factory.create('Source', data.profile2.identity.links[idx_60].meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+                  entity.profile2.identity.links[idx_60].meta.source = factory.create('Source', data.profile2.identity.links[idx_60].meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
                 }
               }
             } else if (data.profile2.identity.links[idx_60].meta === null) {
@@ -1099,7 +1099,7 @@ exports[`embedded entities in postgres diffing 2`] = `
                 if (data.profile2.identity.links[idx_60].metas[idx_65] != null) {
                   const embeddedData = data.profile2.identity.links[idx_60].metas[idx_65];
                   if (entity.profile2.identity.links[idx_60].metas[idx_65] == null) {
-                    entity.profile2.identity.links[idx_60].metas[idx_65] = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes });
+                    entity.profile2.identity.links[idx_60].metas[idx_65] = factory.createEmbeddable('IdentityMeta', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
                   }
                   if (data.profile2.identity.links[idx_60].metas[idx_65].foo === null) {
                     entity.profile2.identity.links[idx_60].metas[idx_65].foo = null;
@@ -1115,9 +1115,9 @@ exports[`embedded entities in postgres diffing 2`] = `
     entity.profile2.identity.links[idx_60].metas[idx_65].source = null;
                   } else if (typeof data.profile2.identity.links[idx_60].metas[idx_65].source !== 'undefined') {
                     if (isPrimaryKey(data.profile2.identity.links[idx_60].metas[idx_65].source, true)) {
-                      entity.profile2.identity.links[idx_60].metas[idx_65].source = factory.createReference('Source', data.profile2.identity.links[idx_60].metas[idx_65].source, { merge: true, convertCustomTypes, schema });
+                      entity.profile2.identity.links[idx_60].metas[idx_65].source = factory.createReference('Source', data.profile2.identity.links[idx_60].metas[idx_65].source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
                     } else if (data.profile2.identity.links[idx_60].metas[idx_65].source && typeof data.profile2.identity.links[idx_60].metas[idx_65].source === 'object') {
-                      entity.profile2.identity.links[idx_60].metas[idx_65].source = factory.create('Source', data.profile2.identity.links[idx_60].metas[idx_65].source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+                      entity.profile2.identity.links[idx_60].metas[idx_65].source = factory.create('Source', data.profile2.identity.links[idx_60].metas[idx_65].source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
                     }
                   }
                 } else if (data.profile2.identity.links[idx_60].metas[idx_65] === null) {
@@ -1129,9 +1129,9 @@ exports[`embedded entities in postgres diffing 2`] = `
     entity.profile2.identity.links[idx_60].source = null;
             } else if (typeof data.profile2.identity.links[idx_60].source !== 'undefined') {
               if (isPrimaryKey(data.profile2.identity.links[idx_60].source, true)) {
-                entity.profile2.identity.links[idx_60].source = factory.createReference('Source', data.profile2.identity.links[idx_60].source, { merge: true, convertCustomTypes, schema });
+                entity.profile2.identity.links[idx_60].source = factory.createReference('Source', data.profile2.identity.links[idx_60].source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
               } else if (data.profile2.identity.links[idx_60].source && typeof data.profile2.identity.links[idx_60].source === 'object') {
-                entity.profile2.identity.links[idx_60].source = factory.create('Source', data.profile2.identity.links[idx_60].source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+                entity.profile2.identity.links[idx_60].source = factory.create('Source', data.profile2.identity.links[idx_60].source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
               }
             }
           } else if (data.profile2.identity.links[idx_60] === null) {
@@ -1143,9 +1143,9 @@ exports[`embedded entities in postgres diffing 2`] = `
     entity.profile2.identity.source = null;
       } else if (typeof data.profile2.identity.source !== 'undefined') {
         if (isPrimaryKey(data.profile2.identity.source, true)) {
-          entity.profile2.identity.source = factory.createReference('Source', data.profile2.identity.source, { merge: true, convertCustomTypes, schema });
+          entity.profile2.identity.source = factory.createReference('Source', data.profile2.identity.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
         } else if (data.profile2.identity.source && typeof data.profile2.identity.source === 'object') {
-          entity.profile2.identity.source = factory.create('Source', data.profile2.identity.source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+          entity.profile2.identity.source = factory.create('Source', data.profile2.identity.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
         }
       }
     } else if (data.profile2.identity === null) {
@@ -1155,9 +1155,9 @@ exports[`embedded entities in postgres diffing 2`] = `
     entity.profile2.source = null;
     } else if (typeof data.profile2.source !== 'undefined') {
       if (isPrimaryKey(data.profile2.source, true)) {
-        entity.profile2.source = factory.createReference('Source', data.profile2.source, { merge: true, convertCustomTypes, schema });
+        entity.profile2.source = factory.createReference('Source', data.profile2.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
       } else if (data.profile2.source && typeof data.profile2.source === 'object') {
-        entity.profile2.source = factory.create('Source', data.profile2.source, { initialized: true, merge: true, newEntity, convertCustomTypes, schema });
+        entity.profile2.source = factory.create('Source', data.profile2.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
       }
     }
   } else if (data.profile2 === null) {

--- a/tests/features/embeddables/__snapshots__/polymorphic-embedded-entities.sqlite.test.ts.snap
+++ b/tests/features/embeddables/__snapshots__/polymorphic-embedded-entities.sqlite.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`polymorphic embeddables in sqlite diffing 1`] = `
-"function(entity, data, factory, newEntity, convertCustomTypes, schema) {
+"function(entity, data, factory, newEntity, convertCustomTypes, schema, parentSchema, normalizeAccessors) {
   if (data.id === null) {
     entity.id = null;
   } else if (typeof data.id !== 'undefined') {
@@ -22,7 +22,7 @@ exports[`polymorphic embeddables in sqlite diffing 1`] = `
     };
     if (data.pet_type == '1') {
       if (entity.pet == null) {
-        entity.pet = factory.createEmbeddable('Dog', embeddedData, { newEntity, convertCustomTypes });
+        entity.pet = factory.createEmbeddable('Dog', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
       }
       if (data.pet_canBark === null) {
         entity.pet.canBark = null;
@@ -49,7 +49,7 @@ exports[`polymorphic embeddables in sqlite diffing 1`] = `
           mice: data.pet_food_mice,
         };
         if (entity.pet.food == null) {
-          entity.pet.food = factory.createEmbeddable('DogFood', embeddedData, { newEntity, convertCustomTypes });
+          entity.pet.food = factory.createEmbeddable('DogFood', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
         }
         if (data.pet_food_cats === null) {
           entity.pet.food.cats = null;
@@ -70,7 +70,7 @@ exports[`polymorphic embeddables in sqlite diffing 1`] = `
       if (data.pet_food != null) {
         const embeddedData = data.pet_food;
         if (entity.pet.food == null) {
-          entity.pet.food = factory.createEmbeddable('DogFood', embeddedData, { newEntity, convertCustomTypes });
+          entity.pet.food = factory.createEmbeddable('DogFood', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
         }
         if (data.pet_food.cats === null) {
           entity.pet.food.cats = null;
@@ -88,7 +88,7 @@ exports[`polymorphic embeddables in sqlite diffing 1`] = `
     }
     if (data.pet_type == '0') {
       if (entity.pet == null) {
-        entity.pet = factory.createEmbeddable('Cat', embeddedData, { newEntity, convertCustomTypes });
+        entity.pet = factory.createEmbeddable('Cat', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
       }
       if (data.pet_canBark === null) {
         entity.pet.canBark = null;
@@ -115,7 +115,7 @@ exports[`polymorphic embeddables in sqlite diffing 1`] = `
           mice: data.pet_food_mice,
         };
         if (entity.pet.food == null) {
-          entity.pet.food = factory.createEmbeddable('CatFood', embeddedData, { newEntity, convertCustomTypes });
+          entity.pet.food = factory.createEmbeddable('CatFood', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
         }
         if (data.pet_food_cats === null) {
           entity.pet.food.cats = null;
@@ -136,7 +136,7 @@ exports[`polymorphic embeddables in sqlite diffing 1`] = `
       if (data.pet_food != null) {
         const embeddedData = data.pet_food;
         if (entity.pet.food == null) {
-          entity.pet.food = factory.createEmbeddable('CatFood', embeddedData, { newEntity, convertCustomTypes });
+          entity.pet.food = factory.createEmbeddable('CatFood', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
         }
         if (data.pet_food.cats === null) {
           entity.pet.food.cats = null;
@@ -162,7 +162,7 @@ exports[`polymorphic embeddables in sqlite diffing 1`] = `
     const embeddedData = data.pet;
     if (data.pet.type == '1') {
       if (entity.pet == null) {
-        entity.pet = factory.createEmbeddable('Dog', embeddedData, { newEntity, convertCustomTypes });
+        entity.pet = factory.createEmbeddable('Dog', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
       }
       if (data.pet.canBark === null) {
         entity.pet.canBark = null;
@@ -189,7 +189,7 @@ exports[`polymorphic embeddables in sqlite diffing 1`] = `
           mice: data.pet_food_mice,
         };
         if (entity.pet.food == null) {
-          entity.pet.food = factory.createEmbeddable('DogFood', embeddedData, { newEntity, convertCustomTypes });
+          entity.pet.food = factory.createEmbeddable('DogFood', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
         }
         if (data.pet_food_cats === null) {
           entity.pet.food.cats = null;
@@ -210,7 +210,7 @@ exports[`polymorphic embeddables in sqlite diffing 1`] = `
       if (data.pet.food != null) {
         const embeddedData = data.pet.food;
         if (entity.pet.food == null) {
-          entity.pet.food = factory.createEmbeddable('DogFood', embeddedData, { newEntity, convertCustomTypes });
+          entity.pet.food = factory.createEmbeddable('DogFood', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
         }
         if (data.pet.food.cats === null) {
           entity.pet.food.cats = null;
@@ -228,7 +228,7 @@ exports[`polymorphic embeddables in sqlite diffing 1`] = `
     }
     if (data.pet.type == '0') {
       if (entity.pet == null) {
-        entity.pet = factory.createEmbeddable('Cat', embeddedData, { newEntity, convertCustomTypes });
+        entity.pet = factory.createEmbeddable('Cat', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
       }
       if (data.pet.canBark === null) {
         entity.pet.canBark = null;
@@ -255,7 +255,7 @@ exports[`polymorphic embeddables in sqlite diffing 1`] = `
           mice: data.pet_food_mice,
         };
         if (entity.pet.food == null) {
-          entity.pet.food = factory.createEmbeddable('CatFood', embeddedData, { newEntity, convertCustomTypes });
+          entity.pet.food = factory.createEmbeddable('CatFood', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
         }
         if (data.pet_food_cats === null) {
           entity.pet.food.cats = null;
@@ -276,7 +276,7 @@ exports[`polymorphic embeddables in sqlite diffing 1`] = `
       if (data.pet.food != null) {
         const embeddedData = data.pet.food;
         if (entity.pet.food == null) {
-          entity.pet.food = factory.createEmbeddable('CatFood', embeddedData, { newEntity, convertCustomTypes });
+          entity.pet.food = factory.createEmbeddable('CatFood', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
         }
         if (data.pet.food.cats === null) {
           entity.pet.food.cats = null;
@@ -302,7 +302,7 @@ exports[`polymorphic embeddables in sqlite diffing 1`] = `
     const embeddedData = data.pet2;
     if (data.pet2.type == '1') {
       if (entity.pet2 == null) {
-        entity.pet2 = factory.createEmbeddable('Dog', embeddedData, { newEntity, convertCustomTypes });
+        entity.pet2 = factory.createEmbeddable('Dog', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
       }
       if (data.pet2.canBark === null) {
         entity.pet2.canBark = null;
@@ -329,7 +329,7 @@ exports[`polymorphic embeddables in sqlite diffing 1`] = `
           mice: data['pet2~foodmice'],
         };
         if (entity.pet2.food == null) {
-          entity.pet2.food = factory.createEmbeddable('DogFood', embeddedData, { newEntity, convertCustomTypes });
+          entity.pet2.food = factory.createEmbeddable('DogFood', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
         }
         if (data['pet2~foodcats'] === null) {
           entity.pet2.food.cats = null;
@@ -350,7 +350,7 @@ exports[`polymorphic embeddables in sqlite diffing 1`] = `
       if (data.pet2.food != null) {
         const embeddedData = data.pet2.food;
         if (entity.pet2.food == null) {
-          entity.pet2.food = factory.createEmbeddable('DogFood', embeddedData, { newEntity, convertCustomTypes });
+          entity.pet2.food = factory.createEmbeddable('DogFood', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
         }
         if (data.pet2.food.cats === null) {
           entity.pet2.food.cats = null;
@@ -368,7 +368,7 @@ exports[`polymorphic embeddables in sqlite diffing 1`] = `
     }
     if (data.pet2.type == '0') {
       if (entity.pet2 == null) {
-        entity.pet2 = factory.createEmbeddable('Cat', embeddedData, { newEntity, convertCustomTypes });
+        entity.pet2 = factory.createEmbeddable('Cat', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
       }
       if (data.pet2.canBark === null) {
         entity.pet2.canBark = null;
@@ -395,7 +395,7 @@ exports[`polymorphic embeddables in sqlite diffing 1`] = `
           mice: data['pet2~foodmice'],
         };
         if (entity.pet2.food == null) {
-          entity.pet2.food = factory.createEmbeddable('CatFood', embeddedData, { newEntity, convertCustomTypes });
+          entity.pet2.food = factory.createEmbeddable('CatFood', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
         }
         if (data['pet2~foodcats'] === null) {
           entity.pet2.food.cats = null;
@@ -416,7 +416,7 @@ exports[`polymorphic embeddables in sqlite diffing 1`] = `
       if (data.pet2.food != null) {
         const embeddedData = data.pet2.food;
         if (entity.pet2.food == null) {
-          entity.pet2.food = factory.createEmbeddable('CatFood', embeddedData, { newEntity, convertCustomTypes });
+          entity.pet2.food = factory.createEmbeddable('CatFood', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
         }
         if (data.pet2.food.cats === null) {
           entity.pet2.food.cats = null;
@@ -448,7 +448,7 @@ exports[`polymorphic embeddables in sqlite diffing 1`] = `
         const embeddedData = data.pets[idx_50];
         if (data.pets[idx_50].type == '1') {
           if (entity.pets[idx_50] == null) {
-            entity.pets[idx_50] = factory.createEmbeddable('Dog', embeddedData, { newEntity, convertCustomTypes });
+            entity.pets[idx_50] = factory.createEmbeddable('Dog', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
           }
           if (data.pets[idx_50].canBark === null) {
             entity.pets[idx_50].canBark = null;
@@ -475,7 +475,7 @@ exports[`polymorphic embeddables in sqlite diffing 1`] = `
               mice: data['pets~foodmice'],
             };
             if (entity.pets[idx_50].food == null) {
-              entity.pets[idx_50].food = factory.createEmbeddable('DogFood', embeddedData, { newEntity, convertCustomTypes });
+              entity.pets[idx_50].food = factory.createEmbeddable('DogFood', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
             }
             if (data['pets~foodcats'] === null) {
               entity.pets[idx_50].food.cats = null;
@@ -496,7 +496,7 @@ exports[`polymorphic embeddables in sqlite diffing 1`] = `
           if (data.pets[idx_50].food != null) {
             const embeddedData = data.pets[idx_50].food;
             if (entity.pets[idx_50].food == null) {
-              entity.pets[idx_50].food = factory.createEmbeddable('DogFood', embeddedData, { newEntity, convertCustomTypes });
+              entity.pets[idx_50].food = factory.createEmbeddable('DogFood', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
             }
             if (data.pets[idx_50].food.cats === null) {
               entity.pets[idx_50].food.cats = null;
@@ -514,7 +514,7 @@ exports[`polymorphic embeddables in sqlite diffing 1`] = `
         }
         if (data.pets[idx_50].type == '0') {
           if (entity.pets[idx_50] == null) {
-            entity.pets[idx_50] = factory.createEmbeddable('Cat', embeddedData, { newEntity, convertCustomTypes });
+            entity.pets[idx_50] = factory.createEmbeddable('Cat', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
           }
           if (data.pets[idx_50].canBark === null) {
             entity.pets[idx_50].canBark = null;
@@ -541,7 +541,7 @@ exports[`polymorphic embeddables in sqlite diffing 1`] = `
               mice: data['pets~foodmice'],
             };
             if (entity.pets[idx_50].food == null) {
-              entity.pets[idx_50].food = factory.createEmbeddable('CatFood', embeddedData, { newEntity, convertCustomTypes });
+              entity.pets[idx_50].food = factory.createEmbeddable('CatFood', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
             }
             if (data['pets~foodcats'] === null) {
               entity.pets[idx_50].food.cats = null;
@@ -562,7 +562,7 @@ exports[`polymorphic embeddables in sqlite diffing 1`] = `
           if (data.pets[idx_50].food != null) {
             const embeddedData = data.pets[idx_50].food;
             if (entity.pets[idx_50].food == null) {
-              entity.pets[idx_50].food = factory.createEmbeddable('CatFood', embeddedData, { newEntity, convertCustomTypes });
+              entity.pets[idx_50].food = factory.createEmbeddable('CatFood', embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
             }
             if (data.pets[idx_50].food.cats === null) {
               entity.pets[idx_50].food.cats = null;

--- a/tests/issues/GH5525.test.ts
+++ b/tests/issues/GH5525.test.ts
@@ -63,9 +63,9 @@ test('basic CRUD example - no populate - user debuggable in VSCode', async () =>
   const user = await orm.em.fork().findOneOrFail(User, { email: 'foo' });
   const s = (user as any)[Symbol.for('nodejs.util.inspect.custom')]();
   expect(s).toBe(`User {
+  id: 1,
   name: 'Foo',
   email: 'foo',
-  id: 1,
   books: Collection<Book> { initialized: false, dirty: false }
 }`);
   expect(user.name).toBe('Foo');
@@ -79,12 +79,12 @@ test('basic CRUD example - populate books - user should not be debuggable in VSC
   );
   const s = (user as any)[Symbol.for('nodejs.util.inspect.custom')]();
   expect(s).toBe(`User {
+  id: 1,
   name: 'Foo',
   email: 'foo',
-  id: 1,
   books: Collection<Book> {
-    '0': Book { name: 'Book 1', user: [User], id: 1 },
-    '1': Book { name: 'Book 2', user: [User], id: 2 },
+    '0': Book { id: 1, name: 'Book 1', user: [User] },
+    '1': Book { id: 2, name: 'Book 2', user: [User] },
     initialized: true,
     dirty: false
   }


### PR DESCRIPTION
When using a private property backed by a public get/set pair, use the `accessor` option to point to the other side.

> The `fieldName` will be inferred based on the accessor name unless specified explicitly.

If the `accessor` option points to something, the ORM will use the backing property directly:

```ts
@Entity()
class User {
  // the ORM will use the backing field directly
  @Property({ accessor: 'email' })
  private _email: string;

  get email() {
    return this._email;
  }

  set email(email: string) {
    return this._email;
  }
}
```

If you want to the ORM to use your accessor internally too, use `accessor: true` on the get/set property instead. This is handy if you want to use a **native private property** for the backing field. 

```ts
@Entity({ forceConstructor: true })
class User {
  #email: string;

  // the ORM will use the get/set field internally
  @Property({ accessor: true })
  get email() {
    return this.#email;
  }

  set email(email: string) {
    return this.#email;
  }
}
```

Closes #6932