### PR TITLE
fix(v7): omit 'extends' from EntityMetadata in defineEntity

### DIFF
--- a/packages/core/src/entity/defineEntity.ts
+++ b/packages/core/src/entity/defineEntity.ts
@@ -714,7 +714,7 @@ export function defineEntity<const TName extends string, const TTableName extend
 ): EntitySchemaWithMeta<TName, TTableName, InferEntityFromProperties<TProperties, TPK>, TBase, TProperties>;
 
 export function defineEntity<const TEntity = any, const TProperties extends Record<string, any> = Record<string, any>, const TClassName extends string = string, const TTableName extends string = string, const TBase = never>(
-  meta: Omit<Partial<EntityMetadata<TEntity>>, 'properties' | 'className' | 'tableName'> & {
+  meta: Omit<Partial<EntityMetadata<TEntity>>, 'properties' | 'extends' | 'className' | 'tableName'> & {
     class: EntityClass<TEntity>;
     className?: TClassName;
     tableName?: TTableName;

--- a/tests/defineEntity.test.ts
+++ b/tests/defineEntity.test.ts
@@ -245,7 +245,7 @@ describe('defineEntity', () => {
 
     const UserSchema = defineEntity({
       class: User,
-      extends: BaseEntity as any,
+      extends: BaseEntity,
       properties: {
         name: p.string(),
       },

--- a/tests/entities-schema/Author4.ts
+++ b/tests/entities-schema/Author4.ts
@@ -95,8 +95,7 @@ function randomHook(args: EventArgs<Author4>) {
 
 export const Author4Schema = defineEntity({
   class: Author4,
-  // FIXME this doesn't work with classes
-  extends: BaseEntity4 as any,
+  extends: BaseEntity4,
   properties: {
     ...BaseProperties,
     name: p.string(),


### PR DESCRIPTION
This fix `extends`'s type error when using `defineEntity`