### PR TITLE
refactor(entity-generator): emit `defineEntity` definitions with `dictionary` enums by default

### DIFF
--- a/docs/docs/upgrading-v6-to-v7.md
+++ b/docs/docs/upgrading-v6-to-v7.md
@@ -132,3 +132,16 @@ When aliasing a raw fragment via `raw(...).as('alias')`, the alias is now automa
 -raw('...').as('"alias"');
 +raw('...').as('alias');
 ```
+
+## Defaults in `EntityGenerator`
+
+The `EntityGenerator` now emits entity definitions with the new `defineEntity` helper by default, and uses JS dictionaries for enums. Also, bidirectional relations are always defined and owning sides use the `Ref` wrapper.
+
+Changed defaults:
+
+- `entityDefinition`: `defineEntity` (used to be `decorators`)
+- `enumMode`: `dictionary` (used to be `ts-enum`)
+- `bidirectionalRelations`: `true` (used to be false)
+- `identifiedReferences`: `true` (used to be false)
+
+The `entitySchema` option is now removed in favor of `entityDefinition: 'entitySchema'`.

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -948,8 +948,6 @@ export interface GenerateOptions {
   coreImportsPrefix?: string;
   onInitialMetadata?: MetadataProcessor;
   onProcessedMetadata?: MetadataProcessor;
-  /** @deprecated use `entityDefinition: 'entitySchema'` instead */
-  entitySchema?: boolean;
 }
 
 export interface IEntityGenerator {

--- a/packages/core/src/utils/Configuration.ts
+++ b/packages/core/src/utils/Configuration.ts
@@ -140,12 +140,12 @@ export class Configuration<D extends IDatabaseDriver = IDatabaseDriver, EM exten
     entityGenerator: {
       forceUndefined: true,
       undefinedDefaults: false,
-      bidirectionalRelations: false,
-      identifiedReferences: false,
       scalarTypeInDecorator: false,
+      bidirectionalRelations: true,
+      identifiedReferences: true,
       scalarPropertiesForRelations: 'never',
-      entityDefinition: 'decorators',
-      enumMode: 'ts-enum',
+      entityDefinition: 'defineEntity',
+      enumMode: 'dictionary',
       fileName: (className: string) => className,
       onlyPurePivotTables: false,
       outputPurePivotTables: false,
@@ -434,12 +434,6 @@ export class Configuration<D extends IDatabaseDriver = IDatabaseDriver, EM exten
 
   private sync(): void {
     process.env.MIKRO_ORM_COLORS = '' + this.options.colors;
-
-    // FIXME remove `entityGenerator.entitySchema` option
-    if (this.options.entityGenerator.entitySchema) {
-      this.options.entityGenerator.entityDefinition = 'entitySchema';
-    }
-
     this.logger.setDebugMode(this.options.debug);
   }
 

--- a/packages/entity-generator/src/EntityGenerator.ts
+++ b/packages/entity-generator/src/EntityGenerator.ts
@@ -56,10 +56,6 @@ export class EntityGenerator {
     const baseDir = Utils.normalizePath(options.path ?? defaultPath);
     this.sources.length = 0;
 
-    if (options.entitySchema) {
-      options.entityDefinition = 'entitySchema';
-    }
-
     const map = {
       defineEntity: DefineEntitySourceFile,
       entitySchema: EntitySchemaSourceFile,

--- a/tests/defineEntity.test.ts
+++ b/tests/defineEntity.test.ts
@@ -73,6 +73,7 @@ describe('defineEntity', () => {
       title: p.string(),
       tags: p.array().$type<string[]>(),
     };
+
     class Book implements InferEntityFromProperties<typeof bookProperties> {
 
       id!: string;
@@ -80,6 +81,7 @@ describe('defineEntity', () => {
       tags!: string[];
 
     }
+
     const BookSchema = defineEntity({
       class: Book,
       className: 'Book',
@@ -319,6 +321,7 @@ describe('defineEntity', () => {
 
   it('should define entity with reference scalar property', () => {
     const p = defineEntity.properties;
+
     interface IProfile {
       email: string;
       address: {
@@ -342,6 +345,7 @@ describe('defineEntity', () => {
         language: string;
       };
     }
+
     const profile = p.json<IProfile>().lazy();
     const Foo = defineEntity({
       name: 'Foo',
@@ -911,7 +915,7 @@ describe('PropertyOptionsBuilder', () => {
       hydrateFalse: string;
       returning: string;
       [PrimaryKeyProp]?: 'id';
-  }>>(true);
+    }>>(true);
 
     const FooSchema = new EntitySchema({
       name: 'Foo',
@@ -962,14 +966,12 @@ describe('PropertyOptionsBuilder', () => {
       email: string;
       createdAt: Date;
       updatedAt: ScalarReference<Date>;
-      settings: ScalarReference<{
-          theme: string;
-      } | null | undefined>;
+      settings: ScalarReference<{ theme: string } | null | undefined>;
       bio: string;
       status: Opt<('active' | 'inactive')[]>;
       type: number;
       [PrimaryKeyProp]?: 'id';
-  }>>(true);
+    }>>(true);
 
     const FooSchema = new EntitySchema({
       name: 'Foo',
@@ -1535,9 +1537,11 @@ describe('ManyToOneOptionsBuilder', () => {
 });
 
 
-type UnwrapRef<T> = T extends ScalarReference<any> ? UnwrapScalarReference<T> :
-  T extends Reference<any> ? UnwrapReference<T> :
-  T;
+type UnwrapRef<T> = T extends ScalarReference<any>
+  ? UnwrapScalarReference<T>
+  : T extends Reference<any>
+    ? UnwrapReference<T>
+    : T;
 
 type UnwrapScalarReference<T extends ScalarReference<any>> = T extends ScalarReference<infer Value> ? Value : T;
 

--- a/tests/features/entity-generator/AmbiguousFks.mysql.test.ts
+++ b/tests/features/entity-generator/AmbiguousFks.mysql.test.ts
@@ -209,8 +209,8 @@ describe(schemaName, () => {
           orm.config.get('entityGenerator').identifiedReferences = identifiedReferences;
         });
 
-        test.each([true, false])('entitySchema=%s', async entitySchema => {
-          orm.config.get('entityGenerator').entitySchema = entitySchema;
+        test.each(['entitySchema', 'decorators'] as const)('entityDefinition=%s', async entityDefinition => {
+          orm.config.get('entityGenerator').entityDefinition = entityDefinition;
 
           const dump = await orm.entityGenerator.generate();
           expect(dump).toMatchSnapshot('dump');

--- a/tests/features/entity-generator/ConflictingEntityNames.mysql.test.ts
+++ b/tests/features/entity-generator/ConflictingEntityNames.mysql.test.ts
@@ -91,9 +91,9 @@ afterEach(async () => {
 
 describe(schemaName, () => {
 
-  test.each([true, false])('entitySchema=%s', async entitySchema => {
+  test.each(['entitySchema', 'decorators'] as const)('entityDefinition=%s', async entityDefinition => {
     const options = orm.config.get('entityGenerator');
-    options.entitySchema = entitySchema;
+    options.entityDefinition = entityDefinition;
     options.bidirectionalRelations = true;
     options.readOnlyPivotTables = true;
     options.coreImportsPrefix = 'MikroORM_';

--- a/tests/features/entity-generator/EntityGenerator.mysql.test.ts
+++ b/tests/features/entity-generator/EntityGenerator.mysql.test.ts
@@ -71,7 +71,7 @@ test('table name with underscore using entitySchema [mysql]', async () => {
       create table if not exists \`123_table_name\` (\`id\` int(10) unsigned not null auto_increment primary key) default character set utf8mb4 engine = InnoDB;
     `);
   const dump = await orm.entityGenerator.generate({
-    entitySchema: true,
+    entityDefinition: 'entitySchema',
     identifiedReferences: true,
     save: false,
     path: './temp/entities-mysql',

--- a/tests/features/entity-generator/FkIndexSelection.mysql.test.ts
+++ b/tests/features/entity-generator/FkIndexSelection.mysql.test.ts
@@ -88,8 +88,8 @@ describe(schemaName, () => {
           orm.config.get('entityGenerator').identifiedReferences = identifiedReferences;
         });
 
-        test.each([true, false])('entitySchema=%s', async entitySchema => {
-          orm.config.get('entityGenerator').entitySchema = entitySchema;
+        test.each(['entitySchema', 'decorators'] as const)('entityDefinition=%s', async entityDefinition => {
+          orm.config.get('entityGenerator').entityDefinition = entityDefinition;
 
           const dump = await orm.entityGenerator.generate();
           expect(dump).toMatchSnapshot('dump');

--- a/tests/features/entity-generator/FkSharedWithColumn.mysql.test.ts
+++ b/tests/features/entity-generator/FkSharedWithColumn.mysql.test.ts
@@ -92,8 +92,8 @@ describe(schemaName, () => {
           orm.config.get('entityGenerator').identifiedReferences = identifiedReferences;
         });
 
-        test.each([true, false])('entitySchema=%s', async entitySchema => {
-          orm.config.get('entityGenerator').entitySchema = entitySchema;
+        test.each(['entitySchema', 'decorators'] as const)('entityDefinition=%s', async entityDefinition => {
+          orm.config.get('entityGenerator').entityDefinition = entityDefinition;
 
           const dump = await orm.entityGenerator.generate();
           expect(dump).toMatchSnapshot('dump');

--- a/tests/features/entity-generator/FksWithDefaults.mysql.test.ts
+++ b/tests/features/entity-generator/FksWithDefaults.mysql.test.ts
@@ -99,8 +99,8 @@ describe(schemaName, () => {
             orm.config.get('entityGenerator').esmImport = esmImport;
           });
 
-          test.each([true, false])('entitySchema=%s', async entitySchema => {
-            orm.config.get('entityGenerator').entitySchema = entitySchema;
+          test.each(['entitySchema', 'decorators'] as const)('entityDefinition=%s', async entityDefinition => {
+            orm.config.get('entityGenerator').entityDefinition = entityDefinition;
 
             const dump = await orm.entityGenerator.generate();
             expect(dump).toMatchSnapshot('dump');

--- a/tests/features/entity-generator/ManyToManyRelations.mysql.test.ts
+++ b/tests/features/entity-generator/ManyToManyRelations.mysql.test.ts
@@ -225,8 +225,8 @@ describe(schemaName, () => {
             orm.config.get('entityGenerator').readOnlyPivotTables = readOnlyPivotTables;
           });
 
-          test.each([true, false])('entitySchema=%s', async entitySchema => {
-            orm.config.get('entityGenerator').entitySchema = entitySchema;
+          test.each(['entitySchema', 'decorators'] as const)('entityDefinition=%s', async entityDefinition => {
+            orm.config.get('entityGenerator').entityDefinition = entityDefinition;
 
             const dump = await orm.entityGenerator.generate();
             expect(dump).toMatchSnapshot('dump');

--- a/tests/features/entity-generator/MetadataHooks.mysql.test.ts
+++ b/tests/features/entity-generator/MetadataHooks.mysql.test.ts
@@ -441,7 +441,7 @@ describe('MetadataHooks [mysql]', () => {
 
       test('metadata hooks with decorators', async () => {
         const dump = await orm.entityGenerator.generate({
-          entitySchema: false,
+          entityDefinition: 'decorators',
           save: true,
           path: './temp/entities-metadata-hooks',
         });
@@ -453,7 +453,7 @@ describe('MetadataHooks [mysql]', () => {
 
       test('metadata hooks with entity schema', async () => {
         const dump = await orm.entityGenerator.generate({
-          entitySchema: true,
+          entityDefinition: 'entitySchema',
         });
         expect(dump).toMatchSnapshot('mysql-EntitySchema-dump');
       });

--- a/tests/features/entity-generator/NonCompositeAmbiguousFks.mysql.test.ts
+++ b/tests/features/entity-generator/NonCompositeAmbiguousFks.mysql.test.ts
@@ -116,8 +116,8 @@ describe(schemaName, () => {
           orm.config.get('entityGenerator').identifiedReferences = identifiedReferences;
         });
 
-        test.each([true, false])('entitySchema=%s', async entitySchema => {
-          orm.config.get('entityGenerator').entitySchema = entitySchema;
+        test.each(['entitySchema', 'decorators'] as const)('entityDefinition=%s', async entityDefinition => {
+          orm.config.get('entityGenerator').entityDefinition = entityDefinition;
 
           const dump = await orm.entityGenerator.generate();
           expect(dump).toMatchSnapshot('dump');

--- a/tests/features/entity-generator/NullableFks.mysql.test.ts
+++ b/tests/features/entity-generator/NullableFks.mysql.test.ts
@@ -136,8 +136,8 @@ describe(schemaName, () => {
           orm.config.get('entityGenerator').identifiedReferences = identifiedReferences;
         });
 
-        test.each([true, false])('entitySchema=%s', async entitySchema => {
-          orm.config.get('entityGenerator').entitySchema = entitySchema;
+        test.each(['entitySchema', 'decorators'] as const)('entityDefinition=%s', async entityDefinition => {
+          orm.config.get('entityGenerator').entityDefinition = entityDefinition;
 
           const dump = await orm.entityGenerator.generate();
           expect(dump).toMatchSnapshot('dump');

--- a/tests/features/entity-generator/OverlapFks.mysql.test.ts
+++ b/tests/features/entity-generator/OverlapFks.mysql.test.ts
@@ -135,8 +135,8 @@ describe(schemaName, () => {
           orm.config.get('entityGenerator').identifiedReferences = identifiedReferences;
         });
 
-        test.each([true, false])('entitySchema=%s', async entitySchema => {
-          orm.config.get('entityGenerator').entitySchema = entitySchema;
+        test.each(['entitySchema', 'decorators'] as const)('entityDefinition=%s', async entityDefinition => {
+          orm.config.get('entityGenerator').entityDefinition = entityDefinition;
 
           const dump = await orm.entityGenerator.generate();
           expect(dump).toMatchSnapshot('dump');

--- a/tests/features/entity-generator/__snapshots__/AmbiguousFks.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/AmbiguousFks.mysql.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`ambiguous_fk_example > scalarPropertiesForRelations=always > bidirectionalRelations=false > identifiedReferences=false > entitySchema=false > dump 1`] = `
+exports[`ambiguous_fk_example > scalarPropertiesForRelations=always > bidirectionalRelations=false > identifiedReferences=false > entityDefinition=decorators > dump 1`] = `
 [
   "import { Collection, Entity, ManyToMany, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { ProductColors } from './ProductColors';
@@ -248,7 +248,7 @@ export class Sellers {
 ]
 `;
 
-exports[`ambiguous_fk_example > scalarPropertiesForRelations=always > bidirectionalRelations=false > identifiedReferences=false > entitySchema=true > dump 1`] = `
+exports[`ambiguous_fk_example > scalarPropertiesForRelations=always > bidirectionalRelations=false > identifiedReferences=false > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { ProductColors } from './ProductColors';
@@ -632,7 +632,7 @@ export const SellersSchema = new EntitySchema({
 ]
 `;
 
-exports[`ambiguous_fk_example > scalarPropertiesForRelations=always > bidirectionalRelations=false > identifiedReferences=true > entitySchema=false > dump 1`] = `
+exports[`ambiguous_fk_example > scalarPropertiesForRelations=always > bidirectionalRelations=false > identifiedReferences=true > entityDefinition=decorators > dump 1`] = `
 [
   "import { Collection, Entity, ManyToMany, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { ProductColors } from './ProductColors';
@@ -880,7 +880,7 @@ export class Sellers {
 ]
 `;
 
-exports[`ambiguous_fk_example > scalarPropertiesForRelations=always > bidirectionalRelations=false > identifiedReferences=true > entitySchema=true > dump 1`] = `
+exports[`ambiguous_fk_example > scalarPropertiesForRelations=always > bidirectionalRelations=false > identifiedReferences=true > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { ProductColors } from './ProductColors';
@@ -1279,7 +1279,7 @@ export const SellersSchema = new EntitySchema({
 ]
 `;
 
-exports[`ambiguous_fk_example > scalarPropertiesForRelations=always > bidirectionalRelations=true > identifiedReferences=false > entitySchema=false > dump 1`] = `
+exports[`ambiguous_fk_example > scalarPropertiesForRelations=always > bidirectionalRelations=true > identifiedReferences=false > entityDefinition=decorators > dump 1`] = `
 [
   "import { Collection, Entity, ManyToMany, OneToMany, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { ProductColors } from './ProductColors';
@@ -1598,7 +1598,7 @@ export class Sellers {
 ]
 `;
 
-exports[`ambiguous_fk_example > scalarPropertiesForRelations=always > bidirectionalRelations=true > identifiedReferences=false > entitySchema=true > dump 1`] = `
+exports[`ambiguous_fk_example > scalarPropertiesForRelations=always > bidirectionalRelations=true > identifiedReferences=false > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { ProductColors } from './ProductColors';
@@ -2098,7 +2098,7 @@ export const SellersSchema = new EntitySchema({
 ]
 `;
 
-exports[`ambiguous_fk_example > scalarPropertiesForRelations=always > bidirectionalRelations=true > identifiedReferences=true > entitySchema=false > dump 1`] = `
+exports[`ambiguous_fk_example > scalarPropertiesForRelations=always > bidirectionalRelations=true > identifiedReferences=true > entityDefinition=decorators > dump 1`] = `
 [
   "import { Collection, Entity, ManyToMany, OneToMany, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { ProductColors } from './ProductColors';
@@ -2417,7 +2417,7 @@ export class Sellers {
 ]
 `;
 
-exports[`ambiguous_fk_example > scalarPropertiesForRelations=always > bidirectionalRelations=true > identifiedReferences=true > entitySchema=true > dump 1`] = `
+exports[`ambiguous_fk_example > scalarPropertiesForRelations=always > bidirectionalRelations=true > identifiedReferences=true > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { ProductColors } from './ProductColors';
@@ -2937,7 +2937,7 @@ export const SellersSchema = new EntitySchema({
 ]
 `;
 
-exports[`ambiguous_fk_example > scalarPropertiesForRelations=never > bidirectionalRelations=false > identifiedReferences=false > entitySchema=false > dump 1`] = `
+exports[`ambiguous_fk_example > scalarPropertiesForRelations=never > bidirectionalRelations=false > identifiedReferences=false > entityDefinition=decorators > dump 1`] = `
 [
   "import { Collection, Entity, ManyToMany, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { ProductColors } from './ProductColors';
@@ -3141,7 +3141,7 @@ export class Sellers {
 ]
 `;
 
-exports[`ambiguous_fk_example > scalarPropertiesForRelations=never > bidirectionalRelations=false > identifiedReferences=false > entitySchema=true > dump 1`] = `
+exports[`ambiguous_fk_example > scalarPropertiesForRelations=never > bidirectionalRelations=false > identifiedReferences=false > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { ProductColors } from './ProductColors';
@@ -3468,7 +3468,7 @@ export const SellersSchema = new EntitySchema({
 ]
 `;
 
-exports[`ambiguous_fk_example > scalarPropertiesForRelations=never > bidirectionalRelations=false > identifiedReferences=true > entitySchema=false > dump 1`] = `
+exports[`ambiguous_fk_example > scalarPropertiesForRelations=never > bidirectionalRelations=false > identifiedReferences=true > entityDefinition=decorators > dump 1`] = `
 [
   "import { Collection, Entity, ManyToMany, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { ProductColors } from './ProductColors';
@@ -3672,7 +3672,7 @@ export class Sellers {
 ]
 `;
 
-exports[`ambiguous_fk_example > scalarPropertiesForRelations=never > bidirectionalRelations=false > identifiedReferences=true > entitySchema=true > dump 1`] = `
+exports[`ambiguous_fk_example > scalarPropertiesForRelations=never > bidirectionalRelations=false > identifiedReferences=true > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { ProductColors } from './ProductColors';
@@ -4014,7 +4014,7 @@ export const SellersSchema = new EntitySchema({
 ]
 `;
 
-exports[`ambiguous_fk_example > scalarPropertiesForRelations=never > bidirectionalRelations=true > identifiedReferences=false > entitySchema=false > dump 1`] = `
+exports[`ambiguous_fk_example > scalarPropertiesForRelations=never > bidirectionalRelations=true > identifiedReferences=false > entityDefinition=decorators > dump 1`] = `
 [
   "import { Collection, Entity, ManyToMany, OneToMany, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { ProductColors } from './ProductColors';
@@ -4289,7 +4289,7 @@ export class Sellers {
 ]
 `;
 
-exports[`ambiguous_fk_example > scalarPropertiesForRelations=never > bidirectionalRelations=true > identifiedReferences=false > entitySchema=true > dump 1`] = `
+exports[`ambiguous_fk_example > scalarPropertiesForRelations=never > bidirectionalRelations=true > identifiedReferences=false > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { ProductColors } from './ProductColors';
@@ -4728,7 +4728,7 @@ export const SellersSchema = new EntitySchema({
 ]
 `;
 
-exports[`ambiguous_fk_example > scalarPropertiesForRelations=never > bidirectionalRelations=true > identifiedReferences=true > entitySchema=false > dump 1`] = `
+exports[`ambiguous_fk_example > scalarPropertiesForRelations=never > bidirectionalRelations=true > identifiedReferences=true > entityDefinition=decorators > dump 1`] = `
 [
   "import { Collection, Entity, ManyToMany, OneToMany, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { ProductColors } from './ProductColors';
@@ -5003,7 +5003,7 @@ export class Sellers {
 ]
 `;
 
-exports[`ambiguous_fk_example > scalarPropertiesForRelations=never > bidirectionalRelations=true > identifiedReferences=true > entitySchema=true > dump 1`] = `
+exports[`ambiguous_fk_example > scalarPropertiesForRelations=never > bidirectionalRelations=true > identifiedReferences=true > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { ProductColors } from './ProductColors';
@@ -5462,7 +5462,7 @@ export const SellersSchema = new EntitySchema({
 ]
 `;
 
-exports[`ambiguous_fk_example > scalarPropertiesForRelations=smart > bidirectionalRelations=false > identifiedReferences=false > entitySchema=false > dump 1`] = `
+exports[`ambiguous_fk_example > scalarPropertiesForRelations=smart > bidirectionalRelations=false > identifiedReferences=false > entityDefinition=decorators > dump 1`] = `
 [
   "import { Collection, Entity, ManyToMany, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { ProductColors } from './ProductColors';
@@ -5666,7 +5666,7 @@ export class Sellers {
 ]
 `;
 
-exports[`ambiguous_fk_example > scalarPropertiesForRelations=smart > bidirectionalRelations=false > identifiedReferences=false > entitySchema=true > dump 1`] = `
+exports[`ambiguous_fk_example > scalarPropertiesForRelations=smart > bidirectionalRelations=false > identifiedReferences=false > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { ProductColors } from './ProductColors';
@@ -5993,7 +5993,7 @@ export const SellersSchema = new EntitySchema({
 ]
 `;
 
-exports[`ambiguous_fk_example > scalarPropertiesForRelations=smart > bidirectionalRelations=false > identifiedReferences=true > entitySchema=false > dump 1`] = `
+exports[`ambiguous_fk_example > scalarPropertiesForRelations=smart > bidirectionalRelations=false > identifiedReferences=true > entityDefinition=decorators > dump 1`] = `
 [
   "import { Collection, Entity, ManyToMany, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { ProductColors } from './ProductColors';
@@ -6197,7 +6197,7 @@ export class Sellers {
 ]
 `;
 
-exports[`ambiguous_fk_example > scalarPropertiesForRelations=smart > bidirectionalRelations=false > identifiedReferences=true > entitySchema=true > dump 1`] = `
+exports[`ambiguous_fk_example > scalarPropertiesForRelations=smart > bidirectionalRelations=false > identifiedReferences=true > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { ProductColors } from './ProductColors';
@@ -6539,7 +6539,7 @@ export const SellersSchema = new EntitySchema({
 ]
 `;
 
-exports[`ambiguous_fk_example > scalarPropertiesForRelations=smart > bidirectionalRelations=true > identifiedReferences=false > entitySchema=false > dump 1`] = `
+exports[`ambiguous_fk_example > scalarPropertiesForRelations=smart > bidirectionalRelations=true > identifiedReferences=false > entityDefinition=decorators > dump 1`] = `
 [
   "import { Collection, Entity, ManyToMany, OneToMany, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { ProductColors } from './ProductColors';
@@ -6814,7 +6814,7 @@ export class Sellers {
 ]
 `;
 
-exports[`ambiguous_fk_example > scalarPropertiesForRelations=smart > bidirectionalRelations=true > identifiedReferences=false > entitySchema=true > dump 1`] = `
+exports[`ambiguous_fk_example > scalarPropertiesForRelations=smart > bidirectionalRelations=true > identifiedReferences=false > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { ProductColors } from './ProductColors';
@@ -7253,7 +7253,7 @@ export const SellersSchema = new EntitySchema({
 ]
 `;
 
-exports[`ambiguous_fk_example > scalarPropertiesForRelations=smart > bidirectionalRelations=true > identifiedReferences=true > entitySchema=false > dump 1`] = `
+exports[`ambiguous_fk_example > scalarPropertiesForRelations=smart > bidirectionalRelations=true > identifiedReferences=true > entityDefinition=decorators > dump 1`] = `
 [
   "import { Collection, Entity, ManyToMany, OneToMany, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { ProductColors } from './ProductColors';
@@ -7528,7 +7528,7 @@ export class Sellers {
 ]
 `;
 
-exports[`ambiguous_fk_example > scalarPropertiesForRelations=smart > bidirectionalRelations=true > identifiedReferences=true > entitySchema=true > dump 1`] = `
+exports[`ambiguous_fk_example > scalarPropertiesForRelations=smart > bidirectionalRelations=true > identifiedReferences=true > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { ProductColors } from './ProductColors';

--- a/tests/features/entity-generator/__snapshots__/BidirectionalSkippedReferencedTable.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/BidirectionalSkippedReferencedTable.test.ts.snap
@@ -2,25 +2,24 @@
 
 exports[`BidirectionalSkippedReferencedTable > generate entities with bidirectional relations and skipped referenced table > entity-bidirectional-skipped-tables-dump 1`] = `
 [
-  "import { Entity, Index, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { defineEntity, p } from '@mikro-orm/core';
 
-@Entity()
 export class Book {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property({ type: 'text' })
   title!: string;
-
-  @Property()
   price!: number;
-
-  @Index({ name: 'book_author_id_index' })
-  @Property({ fieldName: 'author_id' })
   author!: number;
-
 }
+
+export const BookSchema = defineEntity({
+  class: Book,
+  properties: {
+    id: p.integer().primary(),
+    title: p.text(),
+    price: p.integer(),
+    author: p.integer().name('author_id').index('book_author_id_index'),
+  },
+});
 ",
 ]
 `;

--- a/tests/features/entity-generator/__snapshots__/ConflictingEntityNames.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/ConflictingEntityNames.mysql.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`conflicting_entity_names_example > entitySchema=false > dump 1`] = `
+exports[`conflicting_entity_names_example > entityDefinition=decorators > dump 1`] = `
 [
   "import { Embedded as MikroORM_Embedded, Entity as MikroORM_Entity, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
 import { Entity } from './Entity';
@@ -41,7 +41,7 @@ export class Entity {
   id!: number;
 
   @MikroORM_Enum({ items: () => EntityType })
-  type!: EntityType;
+  type!: TEntityType;
 
   @MikroORM_ManyToMany({ entity: () => Property, pivotTable: 'many_to_many', pivotEntity: () => ManyToMany, joinColumn: 'entity_id', inverseJoinColumn: 'property_id', fixedOrder: true, fixedOrderColumn: 'creation_order' })
   manyToMany = new MikroORM_Collection<Property>(this);
@@ -51,10 +51,12 @@ export class Entity {
 
 }
 
-export enum EntityType {
-  LEGAL = 'legal',
-  PHYSICAL = 'physical',
-}
+export const EntityType = {
+  LEGAL: 'legal',
+  PHYSICAL: 'physical',
+} as const;
+
+export type TEntityType = (typeof EntityType)[keyof typeof EntityType];
 ",
   "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, OneToMany as MikroORM_OneToMany, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
 import { Property } from './Property';
@@ -73,7 +75,7 @@ export class Enum {
 
 }
 ",
-  "import { Entity as MikroORM_Entity, ManyToOne as MikroORM_ManyToOne, type Opt as MikroORM_Opt, PrimaryKeyProp as MikroORM_PrimaryKeyProp, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Entity as MikroORM_Entity, ManyToOne as MikroORM_ManyToOne, type Opt as MikroORM_Opt, PrimaryKeyProp as MikroORM_PrimaryKeyProp, Property as MikroORM_Property, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Entity } from './Entity';
 import { Property } from './Property';
 
@@ -82,11 +84,11 @@ export class ManyToMany {
 
   [MikroORM_PrimaryKeyProp]?: ['entity', 'property'];
 
-  @MikroORM_ManyToOne({ entity: () => Entity, primary: true })
-  entity!: Entity;
+  @MikroORM_ManyToOne({ entity: () => Entity, ref: true, primary: true })
+  entity!: MikroORM_Ref<Entity>;
 
-  @MikroORM_ManyToOne({ entity: () => Property, primary: true, index: 'fk_many_to_many_property1_idx' })
-  property!: Property;
+  @MikroORM_ManyToOne({ entity: () => Property, ref: true, primary: true, index: 'fk_many_to_many_property1_idx' })
+  property!: MikroORM_Ref<Property>;
 
   @MikroORM_Property({ unsigned: true, autoincrement: true, unique: 'creation_order_UNIQUE' })
   creationOrder!: number;
@@ -96,7 +98,7 @@ export class ManyToMany {
 
 }
 ",
-  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, ManyToMany as MikroORM_ManyToMany, ManyToOne as MikroORM_ManyToOne, OneToMany as MikroORM_OneToMany, PrimaryKey as MikroORM_PrimaryKey } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, ManyToMany as MikroORM_ManyToMany, ManyToOne as MikroORM_ManyToOne, OneToMany as MikroORM_OneToMany, PrimaryKey as MikroORM_PrimaryKey, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Entity } from './Entity';
 import { Enum } from './Enum';
 import { ManyToMany } from './ManyToMany';
@@ -107,8 +109,8 @@ export class Property {
   @MikroORM_PrimaryKey()
   id!: number;
 
-  @MikroORM_ManyToOne({ entity: () => Enum, fieldName: 'one_to_many', index: 'fk_property_enum_idx' })
-  oneToMany!: Enum;
+  @MikroORM_ManyToOne({ entity: () => Enum, ref: true, fieldName: 'one_to_many', index: 'fk_property_enum_idx' })
+  oneToMany!: MikroORM_Ref<Enum>;
 
   @MikroORM_ManyToMany({ entity: () => Entity, mappedBy: 'manyToMany' })
   manyToManyInverse = new MikroORM_Collection<Entity>(this);
@@ -121,7 +123,7 @@ export class Property {
 ]
 `;
 
-exports[`conflicting_entity_names_example > entitySchema=true > dump 1`] = `
+exports[`conflicting_entity_names_example > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { EntitySchema as MikroORM_EntitySchema } from '@mikro-orm/core';
 import { Entity } from './Entity';
@@ -170,15 +172,17 @@ import { Property } from './Property';
 
 export class Entity {
   id!: number;
-  type!: EntityType;
+  type!: TEntityType;
   manyToMany = new MikroORM_Collection<Property>(this);
   manyToManyCollection = new MikroORM_Collection<ManyToMany>(this);
 }
 
-export enum EntityType {
-  LEGAL = 'legal',
-  PHYSICAL = 'physical',
-}
+export const EntityType = {
+  LEGAL: 'legal',
+  PHYSICAL: 'physical',
+} as const;
+
+export type TEntityType = (typeof EntityType)[keyof typeof EntityType];
 
 export const EntitySchema = new MikroORM_EntitySchema({
   class: Entity,
@@ -225,14 +229,14 @@ export const EnumSchema = new MikroORM_EntitySchema({
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt, PrimaryKeyProp as MikroORM_PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt, PrimaryKeyProp as MikroORM_PrimaryKeyProp, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Entity } from './Entity';
 import { Property } from './Property';
 
 export class ManyToMany {
   [MikroORM_PrimaryKeyProp]?: ['entity', 'property'];
-  entity!: Entity;
-  property!: Property;
+  entity!: MikroORM_Ref<Entity>;
+  property!: MikroORM_Ref<Property>;
   creationOrder!: number;
   ownerSince!: Date & MikroORM_Opt;
 }
@@ -240,11 +244,12 @@ export class ManyToMany {
 export const ManyToManySchema = new MikroORM_EntitySchema({
   class: ManyToMany,
   properties: {
-    entity: { primary: true, kind: 'm:1', entity: () => Entity },
+    entity: { primary: true, kind: 'm:1', entity: () => Entity, ref: true },
     property: {
       primary: true,
       kind: 'm:1',
       entity: () => Property,
+      ref: true,
       index: 'fk_many_to_many_property1_idx',
     },
     creationOrder: {
@@ -257,14 +262,14 @@ export const ManyToManySchema = new MikroORM_EntitySchema({
   },
 });
 ",
-  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Entity } from './Entity';
 import { Enum } from './Enum';
 import { ManyToMany } from './ManyToMany';
 
 export class Property {
   id!: number;
-  oneToMany!: Enum;
+  oneToMany!: MikroORM_Ref<Enum>;
   manyToManyInverse = new MikroORM_Collection<Entity>(this);
   manyToManyCollection = new MikroORM_Collection<ManyToMany>(this);
 }
@@ -276,6 +281,7 @@ export const PropertySchema = new MikroORM_EntitySchema({
     oneToMany: {
       kind: 'm:1',
       entity: () => Enum,
+      ref: true,
       fieldName: 'one_to_many',
       index: 'fk_property_enum_idx',
     },

--- a/tests/features/entity-generator/__snapshots__/CustomBase.sqlite.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/CustomBase.sqlite.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`CustomBase > forceObject=false > useCoreBaseEntity=false > customBaseEntityName= > decorators > dump 1`] = `
 [
-  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, OneToMany as MikroORM_OneToMany, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Book4 } from './Book4';
 
 @MikroORM_Entity()
@@ -39,15 +39,20 @@ export class Author4 {
   bornTime?: string;
 
   @MikroORM_Index({ name: 'author4_favourite_book_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Book4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  favouriteBook?: Book4;
+  @MikroORM_ManyToOne({ entity: () => Book4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  favouriteBook?: MikroORM_Ref<Book4>;
 
   @MikroORM_Property({ type: 'json', nullable: true })
   identity?: any;
 
+  @MikroORM_OneToMany({ entity: () => Book4, mappedBy: 'author' })
+  book4Collection = new MikroORM_Collection<Book4>(this);
+
 }
 ",
-  "import { Entity as MikroORM_Entity, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, ManyToMany as MikroORM_ManyToMany, OneToMany as MikroORM_OneToMany, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+import { Book4 } from './Book4';
+import { TagsOrdered } from './TagsOrdered';
 
 @MikroORM_Entity()
 export class BookTag4 {
@@ -67,12 +72,19 @@ export class BookTag4 {
   @MikroORM_Property({ type: 'datetime', defaultRaw: \`current_timestamp\` })
   version!: Date & MikroORM_Opt;
 
+  @MikroORM_ManyToMany({ entity: () => Book4, mappedBy: 'tagsUnordered' })
+  tagsUnorderedInverse = new MikroORM_Collection<Book4>(this);
+
+  @MikroORM_OneToMany({ entity: () => TagsOrdered, mappedBy: 'bookTag4' })
+  tagsOrderedCollection = new MikroORM_Collection<TagsOrdered>(this);
+
 }
 ",
-  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToMany as MikroORM_ManyToMany, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToMany as MikroORM_ManyToMany, ManyToOne as MikroORM_ManyToOne, OneToMany as MikroORM_OneToMany, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Author4 } from './Author4';
 import { BookTag4 } from './BookTag4';
 import { Publisher4 } from './Publisher4';
+import { TagsOrdered } from './TagsOrdered';
 
 @MikroORM_Entity()
 export class Book4 {
@@ -93,12 +105,12 @@ export class Book4 {
   price?: unknown;
 
   @MikroORM_Index({ name: 'book4_author_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Author4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  author?: Author4;
+  @MikroORM_ManyToOne({ entity: () => Author4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  author?: MikroORM_Ref<Author4>;
 
   @MikroORM_Index({ name: 'book4_publisher_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Publisher4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  publisher?: Publisher4;
+  @MikroORM_ManyToOne({ entity: () => Publisher4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  publisher?: MikroORM_Ref<Publisher4>;
 
   @MikroORM_Property({ type: 'json', nullable: true })
   meta?: any;
@@ -106,9 +118,15 @@ export class Book4 {
   @MikroORM_ManyToMany({ entity: () => BookTag4, pivotTable: 'tags_unordered', joinColumn: 'book4_id', inverseJoinColumn: 'book_tag4_id' })
   tagsUnordered = new MikroORM_Collection<BookTag4>(this);
 
+  @MikroORM_OneToMany({ entity: () => Author4, mappedBy: 'favouriteBook' })
+  author4Collection = new MikroORM_Collection<Author4>(this);
+
+  @MikroORM_OneToMany({ entity: () => TagsOrdered, mappedBy: 'book4' })
+  tagsOrderedCollection = new MikroORM_Collection<TagsOrdered>(this);
+
 }
 ",
-  "import { Entity as MikroORM_Entity, OneToOne as MikroORM_OneToOne, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, Unique as MikroORM_Unique } from '@mikro-orm/core';
+  "import { Entity as MikroORM_Entity, OneToOne as MikroORM_OneToOne, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, type Ref as MikroORM_Ref, Unique as MikroORM_Unique } from '@mikro-orm/core';
 import { FooBaz4 } from './FooBaz4';
 
 @MikroORM_Entity()
@@ -127,12 +145,12 @@ export class FooBar4 {
   name: string & MikroORM_Opt = 'asd';
 
   @MikroORM_Unique({ name: 'foo_bar4_baz_id_unique' })
-  @MikroORM_OneToOne({ entity: () => FooBaz4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  baz?: FooBaz4;
+  @MikroORM_OneToOne({ entity: () => FooBaz4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  baz?: MikroORM_Ref<FooBaz4>;
 
   @MikroORM_Unique({ name: 'foo_bar4_foo_bar_id_unique' })
-  @MikroORM_OneToOne({ entity: () => FooBar4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  fooBar?: FooBar4;
+  @MikroORM_OneToOne({ entity: () => FooBar4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  fooBar?: MikroORM_Ref<FooBar4>;
 
   @MikroORM_Property({ type: 'integer' })
   version: number & MikroORM_Opt = 1;
@@ -149,9 +167,13 @@ export class FooBar4 {
   @MikroORM_Property({ type: 'json', nullable: true })
   object?: any;
 
+  @MikroORM_OneToOne({ entity: () => FooBar4, ref: true, mappedBy: 'fooBar' })
+  fooBar4?: MikroORM_Ref<FooBar4>;
+
 }
 ",
-  "import { Entity as MikroORM_Entity, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Entity as MikroORM_Entity, OneToOne as MikroORM_OneToOne, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, type Ref as MikroORM_Ref } from '@mikro-orm/core';
+import { FooBar4 } from './FooBar4';
 
 @MikroORM_Entity()
 export class FooBaz4 {
@@ -171,9 +193,14 @@ export class FooBaz4 {
   @MikroORM_Property({ type: 'datetime', defaultRaw: \`current_timestamp\` })
   version!: Date & MikroORM_Opt;
 
+  @MikroORM_OneToOne({ entity: () => FooBar4, ref: true, mappedBy: 'baz' })
+  fooBar4?: MikroORM_Ref<FooBar4>;
+
 }
 ",
-  "import { Entity as MikroORM_Entity, Enum as MikroORM_Enum, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, Enum as MikroORM_Enum, OneToMany as MikroORM_OneToMany, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+import { Book4 } from './Book4';
+import { Publisher4Tests } from './Publisher4Tests';
 
 @MikroORM_Entity()
 export class Publisher4 {
@@ -191,19 +218,27 @@ export class Publisher4 {
   name: string & MikroORM_Opt = 'asd';
 
   @MikroORM_Enum({ items: () => Publisher4Type })
-  type: Publisher4Type & MikroORM_Opt = Publisher4Type.LOCAL;
+  type: TPublisher4Type & MikroORM_Opt = Publisher4Type.LOCAL;
 
   @MikroORM_Property({ nullable: true })
   enum3?: number;
 
+  @MikroORM_OneToMany({ entity: () => Book4, mappedBy: 'publisher' })
+  book4Collection = new MikroORM_Collection<Book4>(this);
+
+  @MikroORM_OneToMany({ entity: () => Publisher4Tests, mappedBy: 'publisher4' })
+  publisher4TestsCollection = new MikroORM_Collection<Publisher4Tests>(this);
+
 }
 
-export enum Publisher4Type {
-  LOCAL = 'local',
-  GLOBAL = 'global',
-}
+export const Publisher4Type = {
+  LOCAL: 'local',
+  GLOBAL: 'global',
+} as const;
+
+export type TPublisher4Type = (typeof Publisher4Type)[keyof typeof Publisher4Type];
 ",
-  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey } from '@mikro-orm/core';
+  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Publisher4 } from './Publisher4';
 import { Test4 } from './Test4';
 
@@ -214,16 +249,16 @@ export class Publisher4Tests {
   id!: number;
 
   @MikroORM_Index({ name: 'publisher4_tests_publisher4_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Publisher4, updateRule: 'cascade', deleteRule: 'cascade' })
-  publisher4!: Publisher4;
+  @MikroORM_ManyToOne({ entity: () => Publisher4, ref: true, updateRule: 'cascade', deleteRule: 'cascade' })
+  publisher4!: MikroORM_Ref<Publisher4>;
 
   @MikroORM_Index({ name: 'publisher4_tests_test4_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Test4, updateRule: 'cascade', deleteRule: 'cascade' })
-  test4!: Test4;
+  @MikroORM_ManyToOne({ entity: () => Test4, ref: true, updateRule: 'cascade', deleteRule: 'cascade' })
+  test4!: MikroORM_Ref<Test4>;
 
 }
 ",
-  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey } from '@mikro-orm/core';
+  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Book4 } from './Book4';
 import { BookTag4 } from './BookTag4';
 
@@ -234,16 +269,17 @@ export class TagsOrdered {
   id!: number;
 
   @MikroORM_Index({ name: 'tags_ordered_book4_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Book4, updateRule: 'cascade', deleteRule: 'cascade' })
-  book4!: Book4;
+  @MikroORM_ManyToOne({ entity: () => Book4, ref: true, updateRule: 'cascade', deleteRule: 'cascade' })
+  book4!: MikroORM_Ref<Book4>;
 
   @MikroORM_Index({ name: 'tags_ordered_book_tag4_id_index' })
-  @MikroORM_ManyToOne({ entity: () => BookTag4, updateRule: 'cascade', deleteRule: 'cascade' })
-  bookTag4!: BookTag4;
+  @MikroORM_ManyToOne({ entity: () => BookTag4, ref: true, updateRule: 'cascade', deleteRule: 'cascade' })
+  bookTag4!: MikroORM_Ref<BookTag4>;
 
 }
 ",
-  "import { Entity as MikroORM_Entity, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, OneToMany as MikroORM_OneToMany, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+import { Publisher4Tests } from './Publisher4Tests';
 
 @MikroORM_Entity()
 export class Test4 {
@@ -263,6 +299,9 @@ export class Test4 {
   @MikroORM_Property({ type: 'integer' })
   version: number & MikroORM_Opt = 1;
 
+  @MikroORM_OneToMany({ entity: () => Publisher4Tests, mappedBy: 'test4' })
+  publisher4TestsCollection = new MikroORM_Collection<Publisher4Tests>(this);
+
 }
 ",
   "import { Formula as MikroORM_Formula } from '@mikro-orm/core';
@@ -279,7 +318,7 @@ export abstract class BaseEntity2 {
 
 exports[`CustomBase > forceObject=false > useCoreBaseEntity=false > customBaseEntityName= > entitySchema > dump 1`] = `
 [
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Book4 } from './Book4';
 
 export class Author4 {
@@ -293,8 +332,9 @@ export class Author4 {
   identities?: string;
   born?: string;
   bornTime?: string;
-  favouriteBook?: Book4;
+  favouriteBook?: MikroORM_Ref<Book4>;
   identity?: any;
+  book4Collection = new MikroORM_Collection<Book4>(this);
 }
 
 export const Author4Schema = new MikroORM_EntitySchema({
@@ -313,15 +353,19 @@ export const Author4Schema = new MikroORM_EntitySchema({
     favouriteBook: {
       kind: 'm:1',
       entity: () => Book4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
     },
     identity: { type: 'json', nullable: true },
+    book4Collection: { kind: '1:m', entity: () => Book4, mappedBy: 'author' },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+import { Book4 } from './Book4';
+import { TagsOrdered } from './TagsOrdered';
 
 export class BookTag4 {
   id!: number;
@@ -329,6 +373,8 @@ export class BookTag4 {
   updatedAt?: Date;
   name!: string;
   version!: Date & MikroORM_Opt;
+  tagsUnorderedInverse = new MikroORM_Collection<Book4>(this);
+  tagsOrderedCollection = new MikroORM_Collection<TagsOrdered>(this);
 }
 
 export const BookTag4Schema = new MikroORM_EntitySchema({
@@ -339,13 +385,24 @@ export const BookTag4Schema = new MikroORM_EntitySchema({
     updatedAt: { type: 'datetime', nullable: true },
     name: { type: 'text' },
     version: { type: 'datetime', defaultRaw: \`current_timestamp\` },
+    tagsUnorderedInverse: {
+      kind: 'm:n',
+      entity: () => Book4,
+      mappedBy: 'tagsUnordered',
+    },
+    tagsOrderedCollection: {
+      kind: '1:m',
+      entity: () => TagsOrdered,
+      mappedBy: 'bookTag4',
+    },
   },
 });
 ",
-  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Author4 } from './Author4';
 import { BookTag4 } from './BookTag4';
 import { Publisher4 } from './Publisher4';
+import { TagsOrdered } from './TagsOrdered';
 
 export class Book4 {
   id!: number;
@@ -353,10 +410,12 @@ export class Book4 {
   updatedAt?: Date;
   title!: string;
   price?: unknown;
-  author?: Author4;
-  publisher?: Publisher4;
+  author?: MikroORM_Ref<Author4>;
+  publisher?: MikroORM_Ref<Publisher4>;
   meta?: any;
   tagsUnordered = new MikroORM_Collection<BookTag4>(this);
+  author4Collection = new MikroORM_Collection<Author4>(this);
+  tagsOrderedCollection = new MikroORM_Collection<TagsOrdered>(this);
 }
 
 export const Book4Schema = new MikroORM_EntitySchema({
@@ -370,6 +429,7 @@ export const Book4Schema = new MikroORM_EntitySchema({
     author: {
       kind: 'm:1',
       entity: () => Author4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
@@ -377,6 +437,7 @@ export const Book4Schema = new MikroORM_EntitySchema({
     publisher: {
       kind: 'm:1',
       entity: () => Publisher4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
@@ -389,10 +450,20 @@ export const Book4Schema = new MikroORM_EntitySchema({
       joinColumn: 'book4_id',
       inverseJoinColumn: 'book_tag4_id',
     },
+    author4Collection: {
+      kind: '1:m',
+      entity: () => Author4,
+      mappedBy: 'favouriteBook',
+    },
+    tagsOrderedCollection: {
+      kind: '1:m',
+      entity: () => TagsOrdered,
+      mappedBy: 'book4',
+    },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { FooBaz4 } from './FooBaz4';
 
 export class FooBar4 {
@@ -400,13 +471,14 @@ export class FooBar4 {
   createdAt?: Date;
   updatedAt?: Date;
   name: string & MikroORM_Opt = 'asd';
-  baz?: FooBaz4;
-  fooBar?: FooBar4;
+  baz?: MikroORM_Ref<FooBaz4>;
+  fooBar?: MikroORM_Ref<FooBar4>;
   version: number & MikroORM_Opt = 1;
   blob?: Buffer;
   blob2?: Buffer;
   array?: string;
   object?: any;
+  fooBar4?: MikroORM_Ref<FooBar4>;
 }
 
 export const FooBar4Schema = new MikroORM_EntitySchema({
@@ -419,6 +491,7 @@ export const FooBar4Schema = new MikroORM_EntitySchema({
     baz: {
       kind: '1:1',
       entity: () => FooBaz4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
@@ -426,6 +499,7 @@ export const FooBar4Schema = new MikroORM_EntitySchema({
     fooBar: {
       kind: '1:1',
       entity: () => FooBar4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
@@ -435,10 +509,12 @@ export const FooBar4Schema = new MikroORM_EntitySchema({
     blob2: { type: 'blob', nullable: true },
     array: { type: 'text', nullable: true },
     object: { type: 'json', nullable: true },
+    fooBar4: { kind: '1:1', entity: () => FooBar4, ref: true, mappedBy: 'fooBar' },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt, type Ref as MikroORM_Ref } from '@mikro-orm/core';
+import { FooBar4 } from './FooBar4';
 
 export class FooBaz4 {
   id!: number;
@@ -446,6 +522,7 @@ export class FooBaz4 {
   updatedAt?: Date;
   name!: string;
   version!: Date & MikroORM_Opt;
+  fooBar4?: MikroORM_Ref<FooBar4>;
 }
 
 export const FooBaz4Schema = new MikroORM_EntitySchema({
@@ -456,24 +533,31 @@ export const FooBaz4Schema = new MikroORM_EntitySchema({
     updatedAt: { type: 'datetime', nullable: true },
     name: { type: 'text' },
     version: { type: 'datetime', defaultRaw: \`current_timestamp\` },
+    fooBar4: { kind: '1:1', entity: () => FooBar4, ref: true, mappedBy: 'baz' },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+import { Book4 } from './Book4';
+import { Publisher4Tests } from './Publisher4Tests';
 
 export class Publisher4 {
   id!: number;
   createdAt?: Date;
   updatedAt?: Date;
   name: string & MikroORM_Opt = 'asd';
-  type: Publisher4Type & MikroORM_Opt = Publisher4Type.LOCAL;
+  type: TPublisher4Type & MikroORM_Opt = Publisher4Type.LOCAL;
   enum3?: number;
+  book4Collection = new MikroORM_Collection<Book4>(this);
+  publisher4TestsCollection = new MikroORM_Collection<Publisher4Tests>(this);
 }
 
-export enum Publisher4Type {
-  LOCAL = 'local',
-  GLOBAL = 'global',
-}
+export const Publisher4Type = {
+  LOCAL: 'local',
+  GLOBAL: 'global',
+} as const;
+
+export type TPublisher4Type = (typeof Publisher4Type)[keyof typeof Publisher4Type];
 
 export const Publisher4Schema = new MikroORM_EntitySchema({
   class: Publisher4,
@@ -484,17 +568,23 @@ export const Publisher4Schema = new MikroORM_EntitySchema({
     name: { type: 'text' },
     type: { enum: true, items: () => Publisher4Type },
     enum3: { type: 'integer', nullable: true },
+    book4Collection: { kind: '1:m', entity: () => Book4, mappedBy: 'publisher' },
+    publisher4TestsCollection: {
+      kind: '1:m',
+      entity: () => Publisher4Tests,
+      mappedBy: 'publisher4',
+    },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema } from '@mikro-orm/core';
+  "import { EntitySchema as MikroORM_EntitySchema, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Publisher4 } from './Publisher4';
 import { Test4 } from './Test4';
 
 export class Publisher4Tests {
   id!: number;
-  publisher4!: Publisher4;
-  test4!: Test4;
+  publisher4!: MikroORM_Ref<Publisher4>;
+  test4!: MikroORM_Ref<Test4>;
 }
 
 export const Publisher4TestsSchema = new MikroORM_EntitySchema({
@@ -505,26 +595,28 @@ export const Publisher4TestsSchema = new MikroORM_EntitySchema({
     publisher4: {
       kind: 'm:1',
       entity: () => Publisher4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
     test4: {
       kind: 'm:1',
       entity: () => Test4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema } from '@mikro-orm/core';
+  "import { EntitySchema as MikroORM_EntitySchema, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Book4 } from './Book4';
 import { BookTag4 } from './BookTag4';
 
 export class TagsOrdered {
   id!: number;
-  book4!: Book4;
-  bookTag4!: BookTag4;
+  book4!: MikroORM_Ref<Book4>;
+  bookTag4!: MikroORM_Ref<BookTag4>;
 }
 
 export const TagsOrderedSchema = new MikroORM_EntitySchema({
@@ -534,19 +626,22 @@ export const TagsOrderedSchema = new MikroORM_EntitySchema({
     book4: {
       kind: 'm:1',
       entity: () => Book4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
     bookTag4: {
       kind: 'm:1',
       entity: () => BookTag4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+import { Publisher4Tests } from './Publisher4Tests';
 
 export class Test4 {
   id!: number;
@@ -554,6 +649,7 @@ export class Test4 {
   updatedAt?: Date;
   name?: string;
   version: number & MikroORM_Opt = 1;
+  publisher4TestsCollection = new MikroORM_Collection<Publisher4Tests>(this);
 }
 
 export const Test4Schema = new MikroORM_EntitySchema({
@@ -564,6 +660,11 @@ export const Test4Schema = new MikroORM_EntitySchema({
     updatedAt: { type: 'datetime', nullable: true },
     name: { type: 'text', nullable: true },
     version: { type: 'integer' },
+    publisher4TestsCollection: {
+      kind: '1:m',
+      entity: () => Publisher4Tests,
+      mappedBy: 'test4',
+    },
   },
 });
 ",
@@ -585,7 +686,7 @@ export const BaseEntity2Schema = new MikroORM_EntitySchema({
 
 exports[`CustomBase > forceObject=false > useCoreBaseEntity=false > customBaseEntityName=BaseEntity > decorators > dump 1`] = `
 [
-  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, OneToMany as MikroORM_OneToMany, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 import { Book4 } from './Book4';
 
@@ -623,16 +724,21 @@ export class Author4 extends BaseEntity {
   bornTime?: string;
 
   @MikroORM_Index({ name: 'author4_favourite_book_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Book4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  favouriteBook?: Book4;
+  @MikroORM_ManyToOne({ entity: () => Book4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  favouriteBook?: MikroORM_Ref<Book4>;
 
   @MikroORM_Property({ type: 'json', nullable: true })
   identity?: any;
 
+  @MikroORM_OneToMany({ entity: () => Book4, mappedBy: 'author' })
+  book4Collection = new MikroORM_Collection<Book4>(this);
+
 }
 ",
-  "import { Entity as MikroORM_Entity, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, ManyToMany as MikroORM_ManyToMany, OneToMany as MikroORM_OneToMany, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
+import { Book4 } from './Book4';
+import { TagsOrdered } from './TagsOrdered';
 
 @MikroORM_Entity()
 export class BookTag4 extends BaseEntity {
@@ -652,13 +758,20 @@ export class BookTag4 extends BaseEntity {
   @MikroORM_Property({ type: 'datetime', defaultRaw: \`current_timestamp\` })
   version!: Date & MikroORM_Opt;
 
+  @MikroORM_ManyToMany({ entity: () => Book4, mappedBy: 'tagsUnordered' })
+  tagsUnorderedInverse = new MikroORM_Collection<Book4>(this);
+
+  @MikroORM_OneToMany({ entity: () => TagsOrdered, mappedBy: 'bookTag4' })
+  tagsOrderedCollection = new MikroORM_Collection<TagsOrdered>(this);
+
 }
 ",
-  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToMany as MikroORM_ManyToMany, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToMany as MikroORM_ManyToMany, ManyToOne as MikroORM_ManyToOne, OneToMany as MikroORM_OneToMany, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Author4 } from './Author4';
 import { BaseEntity } from './BaseEntity';
 import { BookTag4 } from './BookTag4';
 import { Publisher4 } from './Publisher4';
+import { TagsOrdered } from './TagsOrdered';
 
 @MikroORM_Entity()
 export class Book4 extends BaseEntity {
@@ -679,12 +792,12 @@ export class Book4 extends BaseEntity {
   price?: unknown;
 
   @MikroORM_Index({ name: 'book4_author_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Author4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  author?: Author4;
+  @MikroORM_ManyToOne({ entity: () => Author4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  author?: MikroORM_Ref<Author4>;
 
   @MikroORM_Index({ name: 'book4_publisher_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Publisher4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  publisher?: Publisher4;
+  @MikroORM_ManyToOne({ entity: () => Publisher4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  publisher?: MikroORM_Ref<Publisher4>;
 
   @MikroORM_Property({ type: 'json', nullable: true })
   meta?: any;
@@ -692,9 +805,15 @@ export class Book4 extends BaseEntity {
   @MikroORM_ManyToMany({ entity: () => BookTag4, pivotTable: 'tags_unordered', joinColumn: 'book4_id', inverseJoinColumn: 'book_tag4_id' })
   tagsUnordered = new MikroORM_Collection<BookTag4>(this);
 
+  @MikroORM_OneToMany({ entity: () => Author4, mappedBy: 'favouriteBook' })
+  author4Collection = new MikroORM_Collection<Author4>(this);
+
+  @MikroORM_OneToMany({ entity: () => TagsOrdered, mappedBy: 'book4' })
+  tagsOrderedCollection = new MikroORM_Collection<TagsOrdered>(this);
+
 }
 ",
-  "import { Entity as MikroORM_Entity, OneToOne as MikroORM_OneToOne, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, Unique as MikroORM_Unique } from '@mikro-orm/core';
+  "import { Entity as MikroORM_Entity, OneToOne as MikroORM_OneToOne, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, type Ref as MikroORM_Ref, Unique as MikroORM_Unique } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 import { FooBaz4 } from './FooBaz4';
 
@@ -714,12 +833,12 @@ export class FooBar4 extends BaseEntity {
   name: string & MikroORM_Opt = 'asd';
 
   @MikroORM_Unique({ name: 'foo_bar4_baz_id_unique' })
-  @MikroORM_OneToOne({ entity: () => FooBaz4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  baz?: FooBaz4;
+  @MikroORM_OneToOne({ entity: () => FooBaz4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  baz?: MikroORM_Ref<FooBaz4>;
 
   @MikroORM_Unique({ name: 'foo_bar4_foo_bar_id_unique' })
-  @MikroORM_OneToOne({ entity: () => FooBar4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  fooBar?: FooBar4;
+  @MikroORM_OneToOne({ entity: () => FooBar4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  fooBar?: MikroORM_Ref<FooBar4>;
 
   @MikroORM_Property({ type: 'integer' })
   version: number & MikroORM_Opt = 1;
@@ -736,10 +855,14 @@ export class FooBar4 extends BaseEntity {
   @MikroORM_Property({ type: 'json', nullable: true })
   object?: any;
 
+  @MikroORM_OneToOne({ entity: () => FooBar4, ref: true, mappedBy: 'fooBar' })
+  fooBar4?: MikroORM_Ref<FooBar4>;
+
 }
 ",
-  "import { Entity as MikroORM_Entity, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Entity as MikroORM_Entity, OneToOne as MikroORM_OneToOne, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
+import { FooBar4 } from './FooBar4';
 
 @MikroORM_Entity()
 export class FooBaz4 extends BaseEntity {
@@ -759,10 +882,15 @@ export class FooBaz4 extends BaseEntity {
   @MikroORM_Property({ type: 'datetime', defaultRaw: \`current_timestamp\` })
   version!: Date & MikroORM_Opt;
 
+  @MikroORM_OneToOne({ entity: () => FooBar4, ref: true, mappedBy: 'baz' })
+  fooBar4?: MikroORM_Ref<FooBar4>;
+
 }
 ",
-  "import { Entity as MikroORM_Entity, Enum as MikroORM_Enum, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, Enum as MikroORM_Enum, OneToMany as MikroORM_OneToMany, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
+import { Book4 } from './Book4';
+import { Publisher4Tests } from './Publisher4Tests';
 
 @MikroORM_Entity()
 export class Publisher4 extends BaseEntity {
@@ -780,19 +908,27 @@ export class Publisher4 extends BaseEntity {
   name: string & MikroORM_Opt = 'asd';
 
   @MikroORM_Enum({ items: () => Publisher4Type })
-  type: Publisher4Type & MikroORM_Opt = Publisher4Type.LOCAL;
+  type: TPublisher4Type & MikroORM_Opt = Publisher4Type.LOCAL;
 
   @MikroORM_Property({ nullable: true })
   enum3?: number;
 
+  @MikroORM_OneToMany({ entity: () => Book4, mappedBy: 'publisher' })
+  book4Collection = new MikroORM_Collection<Book4>(this);
+
+  @MikroORM_OneToMany({ entity: () => Publisher4Tests, mappedBy: 'publisher4' })
+  publisher4TestsCollection = new MikroORM_Collection<Publisher4Tests>(this);
+
 }
 
-export enum Publisher4Type {
-  LOCAL = 'local',
-  GLOBAL = 'global',
-}
+export const Publisher4Type = {
+  LOCAL: 'local',
+  GLOBAL: 'global',
+} as const;
+
+export type TPublisher4Type = (typeof Publisher4Type)[keyof typeof Publisher4Type];
 ",
-  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey } from '@mikro-orm/core';
+  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 import { Publisher4 } from './Publisher4';
 import { Test4 } from './Test4';
@@ -804,16 +940,16 @@ export class Publisher4Tests extends BaseEntity {
   id!: number;
 
   @MikroORM_Index({ name: 'publisher4_tests_publisher4_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Publisher4, updateRule: 'cascade', deleteRule: 'cascade' })
-  publisher4!: Publisher4;
+  @MikroORM_ManyToOne({ entity: () => Publisher4, ref: true, updateRule: 'cascade', deleteRule: 'cascade' })
+  publisher4!: MikroORM_Ref<Publisher4>;
 
   @MikroORM_Index({ name: 'publisher4_tests_test4_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Test4, updateRule: 'cascade', deleteRule: 'cascade' })
-  test4!: Test4;
+  @MikroORM_ManyToOne({ entity: () => Test4, ref: true, updateRule: 'cascade', deleteRule: 'cascade' })
+  test4!: MikroORM_Ref<Test4>;
 
 }
 ",
-  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey } from '@mikro-orm/core';
+  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 import { Book4 } from './Book4';
 import { BookTag4 } from './BookTag4';
@@ -825,17 +961,18 @@ export class TagsOrdered extends BaseEntity {
   id!: number;
 
   @MikroORM_Index({ name: 'tags_ordered_book4_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Book4, updateRule: 'cascade', deleteRule: 'cascade' })
-  book4!: Book4;
+  @MikroORM_ManyToOne({ entity: () => Book4, ref: true, updateRule: 'cascade', deleteRule: 'cascade' })
+  book4!: MikroORM_Ref<Book4>;
 
   @MikroORM_Index({ name: 'tags_ordered_book_tag4_id_index' })
-  @MikroORM_ManyToOne({ entity: () => BookTag4, updateRule: 'cascade', deleteRule: 'cascade' })
-  bookTag4!: BookTag4;
+  @MikroORM_ManyToOne({ entity: () => BookTag4, ref: true, updateRule: 'cascade', deleteRule: 'cascade' })
+  bookTag4!: MikroORM_Ref<BookTag4>;
 
 }
 ",
-  "import { Entity as MikroORM_Entity, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, OneToMany as MikroORM_OneToMany, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
+import { Publisher4Tests } from './Publisher4Tests';
 
 @MikroORM_Entity()
 export class Test4 extends BaseEntity {
@@ -854,6 +991,9 @@ export class Test4 extends BaseEntity {
 
   @MikroORM_Property({ type: 'integer' })
   version: number & MikroORM_Opt = 1;
+
+  @MikroORM_OneToMany({ entity: () => Publisher4Tests, mappedBy: 'test4' })
+  publisher4TestsCollection = new MikroORM_Collection<Publisher4Tests>(this);
 
 }
 ",
@@ -880,7 +1020,7 @@ export abstract class BaseEntity {
 
 exports[`CustomBase > forceObject=false > useCoreBaseEntity=false > customBaseEntityName=BaseEntity > entitySchema > dump 1`] = `
 [
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 import { Book4 } from './Book4';
 
@@ -895,8 +1035,9 @@ export class Author4 extends BaseEntity {
   identities?: string;
   born?: string;
   bornTime?: string;
-  favouriteBook?: Book4;
+  favouriteBook?: MikroORM_Ref<Book4>;
   identity?: any;
+  book4Collection = new MikroORM_Collection<Book4>(this);
 }
 
 export const Author4Schema = new MikroORM_EntitySchema({
@@ -915,16 +1056,20 @@ export const Author4Schema = new MikroORM_EntitySchema({
     favouriteBook: {
       kind: 'm:1',
       entity: () => Book4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
     },
     identity: { type: 'json', nullable: true },
+    book4Collection: { kind: '1:m', entity: () => Book4, mappedBy: 'author' },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
+import { Book4 } from './Book4';
+import { TagsOrdered } from './TagsOrdered';
 
 export class BookTag4 extends BaseEntity {
   id!: number;
@@ -932,6 +1077,8 @@ export class BookTag4 extends BaseEntity {
   updatedAt?: Date;
   name!: string;
   version!: Date & MikroORM_Opt;
+  tagsUnorderedInverse = new MikroORM_Collection<Book4>(this);
+  tagsOrderedCollection = new MikroORM_Collection<TagsOrdered>(this);
 }
 
 export const BookTag4Schema = new MikroORM_EntitySchema({
@@ -942,14 +1089,25 @@ export const BookTag4Schema = new MikroORM_EntitySchema({
     updatedAt: { type: 'datetime', nullable: true },
     name: { type: 'text' },
     version: { type: 'datetime', defaultRaw: \`current_timestamp\` },
+    tagsUnorderedInverse: {
+      kind: 'm:n',
+      entity: () => Book4,
+      mappedBy: 'tagsUnordered',
+    },
+    tagsOrderedCollection: {
+      kind: '1:m',
+      entity: () => TagsOrdered,
+      mappedBy: 'bookTag4',
+    },
   },
 });
 ",
-  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Author4 } from './Author4';
 import { BaseEntity } from './BaseEntity';
 import { BookTag4 } from './BookTag4';
 import { Publisher4 } from './Publisher4';
+import { TagsOrdered } from './TagsOrdered';
 
 export class Book4 extends BaseEntity {
   id!: number;
@@ -957,10 +1115,12 @@ export class Book4 extends BaseEntity {
   updatedAt?: Date;
   title!: string;
   price?: unknown;
-  author?: Author4;
-  publisher?: Publisher4;
+  author?: MikroORM_Ref<Author4>;
+  publisher?: MikroORM_Ref<Publisher4>;
   meta?: any;
   tagsUnordered = new MikroORM_Collection<BookTag4>(this);
+  author4Collection = new MikroORM_Collection<Author4>(this);
+  tagsOrderedCollection = new MikroORM_Collection<TagsOrdered>(this);
 }
 
 export const Book4Schema = new MikroORM_EntitySchema({
@@ -974,6 +1134,7 @@ export const Book4Schema = new MikroORM_EntitySchema({
     author: {
       kind: 'm:1',
       entity: () => Author4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
@@ -981,6 +1142,7 @@ export const Book4Schema = new MikroORM_EntitySchema({
     publisher: {
       kind: 'm:1',
       entity: () => Publisher4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
@@ -993,10 +1155,20 @@ export const Book4Schema = new MikroORM_EntitySchema({
       joinColumn: 'book4_id',
       inverseJoinColumn: 'book_tag4_id',
     },
+    author4Collection: {
+      kind: '1:m',
+      entity: () => Author4,
+      mappedBy: 'favouriteBook',
+    },
+    tagsOrderedCollection: {
+      kind: '1:m',
+      entity: () => TagsOrdered,
+      mappedBy: 'book4',
+    },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 import { FooBaz4 } from './FooBaz4';
 
@@ -1005,13 +1177,14 @@ export class FooBar4 extends BaseEntity {
   createdAt?: Date;
   updatedAt?: Date;
   name: string & MikroORM_Opt = 'asd';
-  baz?: FooBaz4;
-  fooBar?: FooBar4;
+  baz?: MikroORM_Ref<FooBaz4>;
+  fooBar?: MikroORM_Ref<FooBar4>;
   version: number & MikroORM_Opt = 1;
   blob?: Buffer;
   blob2?: Buffer;
   array?: string;
   object?: any;
+  fooBar4?: MikroORM_Ref<FooBar4>;
 }
 
 export const FooBar4Schema = new MikroORM_EntitySchema({
@@ -1024,6 +1197,7 @@ export const FooBar4Schema = new MikroORM_EntitySchema({
     baz: {
       kind: '1:1',
       entity: () => FooBaz4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
@@ -1031,6 +1205,7 @@ export const FooBar4Schema = new MikroORM_EntitySchema({
     fooBar: {
       kind: '1:1',
       entity: () => FooBar4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
@@ -1040,11 +1215,13 @@ export const FooBar4Schema = new MikroORM_EntitySchema({
     blob2: { type: 'blob', nullable: true },
     array: { type: 'text', nullable: true },
     object: { type: 'json', nullable: true },
+    fooBar4: { kind: '1:1', entity: () => FooBar4, ref: true, mappedBy: 'fooBar' },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
+import { FooBar4 } from './FooBar4';
 
 export class FooBaz4 extends BaseEntity {
   id!: number;
@@ -1052,6 +1229,7 @@ export class FooBaz4 extends BaseEntity {
   updatedAt?: Date;
   name!: string;
   version!: Date & MikroORM_Opt;
+  fooBar4?: MikroORM_Ref<FooBar4>;
 }
 
 export const FooBaz4Schema = new MikroORM_EntitySchema({
@@ -1062,25 +1240,32 @@ export const FooBaz4Schema = new MikroORM_EntitySchema({
     updatedAt: { type: 'datetime', nullable: true },
     name: { type: 'text' },
     version: { type: 'datetime', defaultRaw: \`current_timestamp\` },
+    fooBar4: { kind: '1:1', entity: () => FooBar4, ref: true, mappedBy: 'baz' },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
+import { Book4 } from './Book4';
+import { Publisher4Tests } from './Publisher4Tests';
 
 export class Publisher4 extends BaseEntity {
   id!: number;
   createdAt?: Date;
   updatedAt?: Date;
   name: string & MikroORM_Opt = 'asd';
-  type: Publisher4Type & MikroORM_Opt = Publisher4Type.LOCAL;
+  type: TPublisher4Type & MikroORM_Opt = Publisher4Type.LOCAL;
   enum3?: number;
+  book4Collection = new MikroORM_Collection<Book4>(this);
+  publisher4TestsCollection = new MikroORM_Collection<Publisher4Tests>(this);
 }
 
-export enum Publisher4Type {
-  LOCAL = 'local',
-  GLOBAL = 'global',
-}
+export const Publisher4Type = {
+  LOCAL: 'local',
+  GLOBAL: 'global',
+} as const;
+
+export type TPublisher4Type = (typeof Publisher4Type)[keyof typeof Publisher4Type];
 
 export const Publisher4Schema = new MikroORM_EntitySchema({
   class: Publisher4,
@@ -1091,18 +1276,24 @@ export const Publisher4Schema = new MikroORM_EntitySchema({
     name: { type: 'text' },
     type: { enum: true, items: () => Publisher4Type },
     enum3: { type: 'integer', nullable: true },
+    book4Collection: { kind: '1:m', entity: () => Book4, mappedBy: 'publisher' },
+    publisher4TestsCollection: {
+      kind: '1:m',
+      entity: () => Publisher4Tests,
+      mappedBy: 'publisher4',
+    },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema } from '@mikro-orm/core';
+  "import { EntitySchema as MikroORM_EntitySchema, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 import { Publisher4 } from './Publisher4';
 import { Test4 } from './Test4';
 
 export class Publisher4Tests extends BaseEntity {
   id!: number;
-  publisher4!: Publisher4;
-  test4!: Test4;
+  publisher4!: MikroORM_Ref<Publisher4>;
+  test4!: MikroORM_Ref<Test4>;
 }
 
 export const Publisher4TestsSchema = new MikroORM_EntitySchema({
@@ -1113,27 +1304,29 @@ export const Publisher4TestsSchema = new MikroORM_EntitySchema({
     publisher4: {
       kind: 'm:1',
       entity: () => Publisher4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
     test4: {
       kind: 'm:1',
       entity: () => Test4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema } from '@mikro-orm/core';
+  "import { EntitySchema as MikroORM_EntitySchema, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 import { Book4 } from './Book4';
 import { BookTag4 } from './BookTag4';
 
 export class TagsOrdered extends BaseEntity {
   id!: number;
-  book4!: Book4;
-  bookTag4!: BookTag4;
+  book4!: MikroORM_Ref<Book4>;
+  bookTag4!: MikroORM_Ref<BookTag4>;
 }
 
 export const TagsOrderedSchema = new MikroORM_EntitySchema({
@@ -1143,20 +1336,23 @@ export const TagsOrderedSchema = new MikroORM_EntitySchema({
     book4: {
       kind: 'm:1',
       entity: () => Book4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
     bookTag4: {
       kind: 'm:1',
       entity: () => BookTag4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
+import { Publisher4Tests } from './Publisher4Tests';
 
 export class Test4 extends BaseEntity {
   id!: number;
@@ -1164,6 +1360,7 @@ export class Test4 extends BaseEntity {
   updatedAt?: Date;
   name?: string;
   version: number & MikroORM_Opt = 1;
+  publisher4TestsCollection = new MikroORM_Collection<Publisher4Tests>(this);
 }
 
 export const Test4Schema = new MikroORM_EntitySchema({
@@ -1174,6 +1371,11 @@ export const Test4Schema = new MikroORM_EntitySchema({
     updatedAt: { type: 'datetime', nullable: true },
     name: { type: 'text', nullable: true },
     version: { type: 'integer' },
+    publisher4TestsCollection: {
+      kind: '1:m',
+      entity: () => Publisher4Tests,
+      mappedBy: 'test4',
+    },
   },
 });
 ",
@@ -1207,7 +1409,7 @@ export const BaseEntitySchema = new MikroORM_EntitySchema({
 
 exports[`CustomBase > forceObject=false > useCoreBaseEntity=false > customBaseEntityName=BaseEntity2 > decorators > dump 1`] = `
 [
-  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, OneToMany as MikroORM_OneToMany, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity2 } from './BaseEntity2';
 import { Book4 } from './Book4';
 
@@ -1245,16 +1447,21 @@ export class Author4 extends BaseEntity2 {
   bornTime?: string;
 
   @MikroORM_Index({ name: 'author4_favourite_book_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Book4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  favouriteBook?: Book4;
+  @MikroORM_ManyToOne({ entity: () => Book4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  favouriteBook?: MikroORM_Ref<Book4>;
 
   @MikroORM_Property({ type: 'json', nullable: true })
   identity?: any;
 
+  @MikroORM_OneToMany({ entity: () => Book4, mappedBy: 'author' })
+  book4Collection = new MikroORM_Collection<Book4>(this);
+
 }
 ",
-  "import { Entity as MikroORM_Entity, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, ManyToMany as MikroORM_ManyToMany, OneToMany as MikroORM_OneToMany, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
 import { BaseEntity2 } from './BaseEntity2';
+import { Book4 } from './Book4';
+import { TagsOrdered } from './TagsOrdered';
 
 @MikroORM_Entity()
 export class BookTag4 extends BaseEntity2 {
@@ -1274,13 +1481,20 @@ export class BookTag4 extends BaseEntity2 {
   @MikroORM_Property({ type: 'datetime', defaultRaw: \`current_timestamp\` })
   version!: Date & MikroORM_Opt;
 
+  @MikroORM_ManyToMany({ entity: () => Book4, mappedBy: 'tagsUnordered' })
+  tagsUnorderedInverse = new MikroORM_Collection<Book4>(this);
+
+  @MikroORM_OneToMany({ entity: () => TagsOrdered, mappedBy: 'bookTag4' })
+  tagsOrderedCollection = new MikroORM_Collection<TagsOrdered>(this);
+
 }
 ",
-  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToMany as MikroORM_ManyToMany, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToMany as MikroORM_ManyToMany, ManyToOne as MikroORM_ManyToOne, OneToMany as MikroORM_OneToMany, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Author4 } from './Author4';
 import { BaseEntity2 } from './BaseEntity2';
 import { BookTag4 } from './BookTag4';
 import { Publisher4 } from './Publisher4';
+import { TagsOrdered } from './TagsOrdered';
 
 @MikroORM_Entity()
 export class Book4 extends BaseEntity2 {
@@ -1301,12 +1515,12 @@ export class Book4 extends BaseEntity2 {
   price?: unknown;
 
   @MikroORM_Index({ name: 'book4_author_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Author4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  author?: Author4;
+  @MikroORM_ManyToOne({ entity: () => Author4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  author?: MikroORM_Ref<Author4>;
 
   @MikroORM_Index({ name: 'book4_publisher_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Publisher4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  publisher?: Publisher4;
+  @MikroORM_ManyToOne({ entity: () => Publisher4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  publisher?: MikroORM_Ref<Publisher4>;
 
   @MikroORM_Property({ type: 'json', nullable: true })
   meta?: any;
@@ -1314,9 +1528,15 @@ export class Book4 extends BaseEntity2 {
   @MikroORM_ManyToMany({ entity: () => BookTag4, pivotTable: 'tags_unordered', joinColumn: 'book4_id', inverseJoinColumn: 'book_tag4_id' })
   tagsUnordered = new MikroORM_Collection<BookTag4>(this);
 
+  @MikroORM_OneToMany({ entity: () => Author4, mappedBy: 'favouriteBook' })
+  author4Collection = new MikroORM_Collection<Author4>(this);
+
+  @MikroORM_OneToMany({ entity: () => TagsOrdered, mappedBy: 'book4' })
+  tagsOrderedCollection = new MikroORM_Collection<TagsOrdered>(this);
+
 }
 ",
-  "import { Entity as MikroORM_Entity, OneToOne as MikroORM_OneToOne, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, Unique as MikroORM_Unique } from '@mikro-orm/core';
+  "import { Entity as MikroORM_Entity, OneToOne as MikroORM_OneToOne, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, type Ref as MikroORM_Ref, Unique as MikroORM_Unique } from '@mikro-orm/core';
 import { BaseEntity2 } from './BaseEntity2';
 import { FooBaz4 } from './FooBaz4';
 
@@ -1336,12 +1556,12 @@ export class FooBar4 extends BaseEntity2 {
   name: string & MikroORM_Opt = 'asd';
 
   @MikroORM_Unique({ name: 'foo_bar4_baz_id_unique' })
-  @MikroORM_OneToOne({ entity: () => FooBaz4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  baz?: FooBaz4;
+  @MikroORM_OneToOne({ entity: () => FooBaz4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  baz?: MikroORM_Ref<FooBaz4>;
 
   @MikroORM_Unique({ name: 'foo_bar4_foo_bar_id_unique' })
-  @MikroORM_OneToOne({ entity: () => FooBar4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  fooBar?: FooBar4;
+  @MikroORM_OneToOne({ entity: () => FooBar4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  fooBar?: MikroORM_Ref<FooBar4>;
 
   @MikroORM_Property({ type: 'integer' })
   version: number & MikroORM_Opt = 1;
@@ -1358,10 +1578,14 @@ export class FooBar4 extends BaseEntity2 {
   @MikroORM_Property({ type: 'json', nullable: true })
   object?: any;
 
+  @MikroORM_OneToOne({ entity: () => FooBar4, ref: true, mappedBy: 'fooBar' })
+  fooBar4?: MikroORM_Ref<FooBar4>;
+
 }
 ",
-  "import { Entity as MikroORM_Entity, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Entity as MikroORM_Entity, OneToOne as MikroORM_OneToOne, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity2 } from './BaseEntity2';
+import { FooBar4 } from './FooBar4';
 
 @MikroORM_Entity()
 export class FooBaz4 extends BaseEntity2 {
@@ -1381,10 +1605,15 @@ export class FooBaz4 extends BaseEntity2 {
   @MikroORM_Property({ type: 'datetime', defaultRaw: \`current_timestamp\` })
   version!: Date & MikroORM_Opt;
 
+  @MikroORM_OneToOne({ entity: () => FooBar4, ref: true, mappedBy: 'baz' })
+  fooBar4?: MikroORM_Ref<FooBar4>;
+
 }
 ",
-  "import { Entity as MikroORM_Entity, Enum as MikroORM_Enum, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, Enum as MikroORM_Enum, OneToMany as MikroORM_OneToMany, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
 import { BaseEntity2 } from './BaseEntity2';
+import { Book4 } from './Book4';
+import { Publisher4Tests } from './Publisher4Tests';
 
 @MikroORM_Entity()
 export class Publisher4 extends BaseEntity2 {
@@ -1402,19 +1631,27 @@ export class Publisher4 extends BaseEntity2 {
   name: string & MikroORM_Opt = 'asd';
 
   @MikroORM_Enum({ items: () => Publisher4Type })
-  type: Publisher4Type & MikroORM_Opt = Publisher4Type.LOCAL;
+  type: TPublisher4Type & MikroORM_Opt = Publisher4Type.LOCAL;
 
   @MikroORM_Property({ nullable: true })
   enum3?: number;
 
+  @MikroORM_OneToMany({ entity: () => Book4, mappedBy: 'publisher' })
+  book4Collection = new MikroORM_Collection<Book4>(this);
+
+  @MikroORM_OneToMany({ entity: () => Publisher4Tests, mappedBy: 'publisher4' })
+  publisher4TestsCollection = new MikroORM_Collection<Publisher4Tests>(this);
+
 }
 
-export enum Publisher4Type {
-  LOCAL = 'local',
-  GLOBAL = 'global',
-}
+export const Publisher4Type = {
+  LOCAL: 'local',
+  GLOBAL: 'global',
+} as const;
+
+export type TPublisher4Type = (typeof Publisher4Type)[keyof typeof Publisher4Type];
 ",
-  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey } from '@mikro-orm/core';
+  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity2 } from './BaseEntity2';
 import { Publisher4 } from './Publisher4';
 import { Test4 } from './Test4';
@@ -1426,16 +1663,16 @@ export class Publisher4Tests extends BaseEntity2 {
   id!: number;
 
   @MikroORM_Index({ name: 'publisher4_tests_publisher4_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Publisher4, updateRule: 'cascade', deleteRule: 'cascade' })
-  publisher4!: Publisher4;
+  @MikroORM_ManyToOne({ entity: () => Publisher4, ref: true, updateRule: 'cascade', deleteRule: 'cascade' })
+  publisher4!: MikroORM_Ref<Publisher4>;
 
   @MikroORM_Index({ name: 'publisher4_tests_test4_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Test4, updateRule: 'cascade', deleteRule: 'cascade' })
-  test4!: Test4;
+  @MikroORM_ManyToOne({ entity: () => Test4, ref: true, updateRule: 'cascade', deleteRule: 'cascade' })
+  test4!: MikroORM_Ref<Test4>;
 
 }
 ",
-  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey } from '@mikro-orm/core';
+  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity2 } from './BaseEntity2';
 import { Book4 } from './Book4';
 import { BookTag4 } from './BookTag4';
@@ -1447,17 +1684,18 @@ export class TagsOrdered extends BaseEntity2 {
   id!: number;
 
   @MikroORM_Index({ name: 'tags_ordered_book4_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Book4, updateRule: 'cascade', deleteRule: 'cascade' })
-  book4!: Book4;
+  @MikroORM_ManyToOne({ entity: () => Book4, ref: true, updateRule: 'cascade', deleteRule: 'cascade' })
+  book4!: MikroORM_Ref<Book4>;
 
   @MikroORM_Index({ name: 'tags_ordered_book_tag4_id_index' })
-  @MikroORM_ManyToOne({ entity: () => BookTag4, updateRule: 'cascade', deleteRule: 'cascade' })
-  bookTag4!: BookTag4;
+  @MikroORM_ManyToOne({ entity: () => BookTag4, ref: true, updateRule: 'cascade', deleteRule: 'cascade' })
+  bookTag4!: MikroORM_Ref<BookTag4>;
 
 }
 ",
-  "import { Entity as MikroORM_Entity, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, OneToMany as MikroORM_OneToMany, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
 import { BaseEntity2 } from './BaseEntity2';
+import { Publisher4Tests } from './Publisher4Tests';
 
 @MikroORM_Entity()
 export class Test4 extends BaseEntity2 {
@@ -1476,6 +1714,9 @@ export class Test4 extends BaseEntity2 {
 
   @MikroORM_Property({ type: 'integer' })
   version: number & MikroORM_Opt = 1;
+
+  @MikroORM_OneToMany({ entity: () => Publisher4Tests, mappedBy: 'test4' })
+  publisher4TestsCollection = new MikroORM_Collection<Publisher4Tests>(this);
 
 }
 ",
@@ -1496,7 +1737,7 @@ export abstract class BaseEntity2 {
 
 exports[`CustomBase > forceObject=false > useCoreBaseEntity=false > customBaseEntityName=BaseEntity2 > entitySchema > dump 1`] = `
 [
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity2 } from './BaseEntity2';
 import { Book4 } from './Book4';
 
@@ -1511,8 +1752,9 @@ export class Author4 extends BaseEntity2 {
   identities?: string;
   born?: string;
   bornTime?: string;
-  favouriteBook?: Book4;
+  favouriteBook?: MikroORM_Ref<Book4>;
   identity?: any;
+  book4Collection = new MikroORM_Collection<Book4>(this);
 }
 
 export const Author4Schema = new MikroORM_EntitySchema({
@@ -1531,16 +1773,20 @@ export const Author4Schema = new MikroORM_EntitySchema({
     favouriteBook: {
       kind: 'm:1',
       entity: () => Book4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
     },
     identity: { type: 'json', nullable: true },
+    book4Collection: { kind: '1:m', entity: () => Book4, mappedBy: 'author' },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
 import { BaseEntity2 } from './BaseEntity2';
+import { Book4 } from './Book4';
+import { TagsOrdered } from './TagsOrdered';
 
 export class BookTag4 extends BaseEntity2 {
   id!: number;
@@ -1548,6 +1794,8 @@ export class BookTag4 extends BaseEntity2 {
   updatedAt?: Date;
   name!: string;
   version!: Date & MikroORM_Opt;
+  tagsUnorderedInverse = new MikroORM_Collection<Book4>(this);
+  tagsOrderedCollection = new MikroORM_Collection<TagsOrdered>(this);
 }
 
 export const BookTag4Schema = new MikroORM_EntitySchema({
@@ -1558,14 +1806,25 @@ export const BookTag4Schema = new MikroORM_EntitySchema({
     updatedAt: { type: 'datetime', nullable: true },
     name: { type: 'text' },
     version: { type: 'datetime', defaultRaw: \`current_timestamp\` },
+    tagsUnorderedInverse: {
+      kind: 'm:n',
+      entity: () => Book4,
+      mappedBy: 'tagsUnordered',
+    },
+    tagsOrderedCollection: {
+      kind: '1:m',
+      entity: () => TagsOrdered,
+      mappedBy: 'bookTag4',
+    },
   },
 });
 ",
-  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Author4 } from './Author4';
 import { BaseEntity2 } from './BaseEntity2';
 import { BookTag4 } from './BookTag4';
 import { Publisher4 } from './Publisher4';
+import { TagsOrdered } from './TagsOrdered';
 
 export class Book4 extends BaseEntity2 {
   id!: number;
@@ -1573,10 +1832,12 @@ export class Book4 extends BaseEntity2 {
   updatedAt?: Date;
   title!: string;
   price?: unknown;
-  author?: Author4;
-  publisher?: Publisher4;
+  author?: MikroORM_Ref<Author4>;
+  publisher?: MikroORM_Ref<Publisher4>;
   meta?: any;
   tagsUnordered = new MikroORM_Collection<BookTag4>(this);
+  author4Collection = new MikroORM_Collection<Author4>(this);
+  tagsOrderedCollection = new MikroORM_Collection<TagsOrdered>(this);
 }
 
 export const Book4Schema = new MikroORM_EntitySchema({
@@ -1590,6 +1851,7 @@ export const Book4Schema = new MikroORM_EntitySchema({
     author: {
       kind: 'm:1',
       entity: () => Author4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
@@ -1597,6 +1859,7 @@ export const Book4Schema = new MikroORM_EntitySchema({
     publisher: {
       kind: 'm:1',
       entity: () => Publisher4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
@@ -1609,10 +1872,20 @@ export const Book4Schema = new MikroORM_EntitySchema({
       joinColumn: 'book4_id',
       inverseJoinColumn: 'book_tag4_id',
     },
+    author4Collection: {
+      kind: '1:m',
+      entity: () => Author4,
+      mappedBy: 'favouriteBook',
+    },
+    tagsOrderedCollection: {
+      kind: '1:m',
+      entity: () => TagsOrdered,
+      mappedBy: 'book4',
+    },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity2 } from './BaseEntity2';
 import { FooBaz4 } from './FooBaz4';
 
@@ -1621,13 +1894,14 @@ export class FooBar4 extends BaseEntity2 {
   createdAt?: Date;
   updatedAt?: Date;
   name: string & MikroORM_Opt = 'asd';
-  baz?: FooBaz4;
-  fooBar?: FooBar4;
+  baz?: MikroORM_Ref<FooBaz4>;
+  fooBar?: MikroORM_Ref<FooBar4>;
   version: number & MikroORM_Opt = 1;
   blob?: Buffer;
   blob2?: Buffer;
   array?: string;
   object?: any;
+  fooBar4?: MikroORM_Ref<FooBar4>;
 }
 
 export const FooBar4Schema = new MikroORM_EntitySchema({
@@ -1640,6 +1914,7 @@ export const FooBar4Schema = new MikroORM_EntitySchema({
     baz: {
       kind: '1:1',
       entity: () => FooBaz4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
@@ -1647,6 +1922,7 @@ export const FooBar4Schema = new MikroORM_EntitySchema({
     fooBar: {
       kind: '1:1',
       entity: () => FooBar4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
@@ -1656,11 +1932,13 @@ export const FooBar4Schema = new MikroORM_EntitySchema({
     blob2: { type: 'blob', nullable: true },
     array: { type: 'text', nullable: true },
     object: { type: 'json', nullable: true },
+    fooBar4: { kind: '1:1', entity: () => FooBar4, ref: true, mappedBy: 'fooBar' },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity2 } from './BaseEntity2';
+import { FooBar4 } from './FooBar4';
 
 export class FooBaz4 extends BaseEntity2 {
   id!: number;
@@ -1668,6 +1946,7 @@ export class FooBaz4 extends BaseEntity2 {
   updatedAt?: Date;
   name!: string;
   version!: Date & MikroORM_Opt;
+  fooBar4?: MikroORM_Ref<FooBar4>;
 }
 
 export const FooBaz4Schema = new MikroORM_EntitySchema({
@@ -1678,25 +1957,32 @@ export const FooBaz4Schema = new MikroORM_EntitySchema({
     updatedAt: { type: 'datetime', nullable: true },
     name: { type: 'text' },
     version: { type: 'datetime', defaultRaw: \`current_timestamp\` },
+    fooBar4: { kind: '1:1', entity: () => FooBar4, ref: true, mappedBy: 'baz' },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
 import { BaseEntity2 } from './BaseEntity2';
+import { Book4 } from './Book4';
+import { Publisher4Tests } from './Publisher4Tests';
 
 export class Publisher4 extends BaseEntity2 {
   id!: number;
   createdAt?: Date;
   updatedAt?: Date;
   name: string & MikroORM_Opt = 'asd';
-  type: Publisher4Type & MikroORM_Opt = Publisher4Type.LOCAL;
+  type: TPublisher4Type & MikroORM_Opt = Publisher4Type.LOCAL;
   enum3?: number;
+  book4Collection = new MikroORM_Collection<Book4>(this);
+  publisher4TestsCollection = new MikroORM_Collection<Publisher4Tests>(this);
 }
 
-export enum Publisher4Type {
-  LOCAL = 'local',
-  GLOBAL = 'global',
-}
+export const Publisher4Type = {
+  LOCAL: 'local',
+  GLOBAL: 'global',
+} as const;
+
+export type TPublisher4Type = (typeof Publisher4Type)[keyof typeof Publisher4Type];
 
 export const Publisher4Schema = new MikroORM_EntitySchema({
   class: Publisher4,
@@ -1707,18 +1993,24 @@ export const Publisher4Schema = new MikroORM_EntitySchema({
     name: { type: 'text' },
     type: { enum: true, items: () => Publisher4Type },
     enum3: { type: 'integer', nullable: true },
+    book4Collection: { kind: '1:m', entity: () => Book4, mappedBy: 'publisher' },
+    publisher4TestsCollection: {
+      kind: '1:m',
+      entity: () => Publisher4Tests,
+      mappedBy: 'publisher4',
+    },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema } from '@mikro-orm/core';
+  "import { EntitySchema as MikroORM_EntitySchema, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity2 } from './BaseEntity2';
 import { Publisher4 } from './Publisher4';
 import { Test4 } from './Test4';
 
 export class Publisher4Tests extends BaseEntity2 {
   id!: number;
-  publisher4!: Publisher4;
-  test4!: Test4;
+  publisher4!: MikroORM_Ref<Publisher4>;
+  test4!: MikroORM_Ref<Test4>;
 }
 
 export const Publisher4TestsSchema = new MikroORM_EntitySchema({
@@ -1729,27 +2021,29 @@ export const Publisher4TestsSchema = new MikroORM_EntitySchema({
     publisher4: {
       kind: 'm:1',
       entity: () => Publisher4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
     test4: {
       kind: 'm:1',
       entity: () => Test4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema } from '@mikro-orm/core';
+  "import { EntitySchema as MikroORM_EntitySchema, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity2 } from './BaseEntity2';
 import { Book4 } from './Book4';
 import { BookTag4 } from './BookTag4';
 
 export class TagsOrdered extends BaseEntity2 {
   id!: number;
-  book4!: Book4;
-  bookTag4!: BookTag4;
+  book4!: MikroORM_Ref<Book4>;
+  bookTag4!: MikroORM_Ref<BookTag4>;
 }
 
 export const TagsOrderedSchema = new MikroORM_EntitySchema({
@@ -1759,20 +2053,23 @@ export const TagsOrderedSchema = new MikroORM_EntitySchema({
     book4: {
       kind: 'm:1',
       entity: () => Book4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
     bookTag4: {
       kind: 'm:1',
       entity: () => BookTag4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
 import { BaseEntity2 } from './BaseEntity2';
+import { Publisher4Tests } from './Publisher4Tests';
 
 export class Test4 extends BaseEntity2 {
   id!: number;
@@ -1780,6 +2077,7 @@ export class Test4 extends BaseEntity2 {
   updatedAt?: Date;
   name?: string;
   version: number & MikroORM_Opt = 1;
+  publisher4TestsCollection = new MikroORM_Collection<Publisher4Tests>(this);
 }
 
 export const Test4Schema = new MikroORM_EntitySchema({
@@ -1790,6 +2088,11 @@ export const Test4Schema = new MikroORM_EntitySchema({
     updatedAt: { type: 'datetime', nullable: true },
     name: { type: 'text', nullable: true },
     version: { type: 'integer' },
+    publisher4TestsCollection: {
+      kind: '1:m',
+      entity: () => Publisher4Tests,
+      mappedBy: 'test4',
+    },
   },
 });
 ",
@@ -1811,7 +2114,7 @@ export const BaseEntity2Schema = new MikroORM_EntitySchema({
 
 exports[`CustomBase > forceObject=false > useCoreBaseEntity=false > customBaseEntityName=CustomBase > decorators > dump 1`] = `
 [
-  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, OneToMany as MikroORM_OneToMany, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Book4 } from './Book4';
 import { CustomBase } from './CustomBase';
 
@@ -1849,16 +2152,21 @@ export class Author4 extends CustomBase {
   bornTime?: string;
 
   @MikroORM_Index({ name: 'author4_favourite_book_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Book4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  favouriteBook?: Book4;
+  @MikroORM_ManyToOne({ entity: () => Book4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  favouriteBook?: MikroORM_Ref<Book4>;
 
   @MikroORM_Property({ type: 'json', nullable: true })
   identity?: any;
 
+  @MikroORM_OneToMany({ entity: () => Book4, mappedBy: 'author' })
+  book4Collection = new MikroORM_Collection<Book4>(this);
+
 }
 ",
-  "import { Entity as MikroORM_Entity, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, ManyToMany as MikroORM_ManyToMany, OneToMany as MikroORM_OneToMany, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+import { Book4 } from './Book4';
 import { CustomBase } from './CustomBase';
+import { TagsOrdered } from './TagsOrdered';
 
 @MikroORM_Entity()
 export class BookTag4 extends CustomBase {
@@ -1878,13 +2186,20 @@ export class BookTag4 extends CustomBase {
   @MikroORM_Property({ type: 'datetime', defaultRaw: \`current_timestamp\` })
   version!: Date & MikroORM_Opt;
 
+  @MikroORM_ManyToMany({ entity: () => Book4, mappedBy: 'tagsUnordered' })
+  tagsUnorderedInverse = new MikroORM_Collection<Book4>(this);
+
+  @MikroORM_OneToMany({ entity: () => TagsOrdered, mappedBy: 'bookTag4' })
+  tagsOrderedCollection = new MikroORM_Collection<TagsOrdered>(this);
+
 }
 ",
-  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToMany as MikroORM_ManyToMany, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToMany as MikroORM_ManyToMany, ManyToOne as MikroORM_ManyToOne, OneToMany as MikroORM_OneToMany, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Author4 } from './Author4';
 import { BookTag4 } from './BookTag4';
 import { CustomBase } from './CustomBase';
 import { Publisher4 } from './Publisher4';
+import { TagsOrdered } from './TagsOrdered';
 
 @MikroORM_Entity()
 export class Book4 extends CustomBase {
@@ -1905,12 +2220,12 @@ export class Book4 extends CustomBase {
   price?: unknown;
 
   @MikroORM_Index({ name: 'book4_author_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Author4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  author?: Author4;
+  @MikroORM_ManyToOne({ entity: () => Author4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  author?: MikroORM_Ref<Author4>;
 
   @MikroORM_Index({ name: 'book4_publisher_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Publisher4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  publisher?: Publisher4;
+  @MikroORM_ManyToOne({ entity: () => Publisher4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  publisher?: MikroORM_Ref<Publisher4>;
 
   @MikroORM_Property({ type: 'json', nullable: true })
   meta?: any;
@@ -1918,9 +2233,15 @@ export class Book4 extends CustomBase {
   @MikroORM_ManyToMany({ entity: () => BookTag4, pivotTable: 'tags_unordered', joinColumn: 'book4_id', inverseJoinColumn: 'book_tag4_id' })
   tagsUnordered = new MikroORM_Collection<BookTag4>(this);
 
+  @MikroORM_OneToMany({ entity: () => Author4, mappedBy: 'favouriteBook' })
+  author4Collection = new MikroORM_Collection<Author4>(this);
+
+  @MikroORM_OneToMany({ entity: () => TagsOrdered, mappedBy: 'book4' })
+  tagsOrderedCollection = new MikroORM_Collection<TagsOrdered>(this);
+
 }
 ",
-  "import { Entity as MikroORM_Entity, OneToOne as MikroORM_OneToOne, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, Unique as MikroORM_Unique } from '@mikro-orm/core';
+  "import { Entity as MikroORM_Entity, OneToOne as MikroORM_OneToOne, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, type Ref as MikroORM_Ref, Unique as MikroORM_Unique } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
 import { FooBaz4 } from './FooBaz4';
 
@@ -1940,12 +2261,12 @@ export class FooBar4 extends CustomBase {
   name: string & MikroORM_Opt = 'asd';
 
   @MikroORM_Unique({ name: 'foo_bar4_baz_id_unique' })
-  @MikroORM_OneToOne({ entity: () => FooBaz4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  baz?: FooBaz4;
+  @MikroORM_OneToOne({ entity: () => FooBaz4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  baz?: MikroORM_Ref<FooBaz4>;
 
   @MikroORM_Unique({ name: 'foo_bar4_foo_bar_id_unique' })
-  @MikroORM_OneToOne({ entity: () => FooBar4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  fooBar?: FooBar4;
+  @MikroORM_OneToOne({ entity: () => FooBar4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  fooBar?: MikroORM_Ref<FooBar4>;
 
   @MikroORM_Property({ type: 'integer' })
   version: number & MikroORM_Opt = 1;
@@ -1962,10 +2283,14 @@ export class FooBar4 extends CustomBase {
   @MikroORM_Property({ type: 'json', nullable: true })
   object?: any;
 
+  @MikroORM_OneToOne({ entity: () => FooBar4, ref: true, mappedBy: 'fooBar' })
+  fooBar4?: MikroORM_Ref<FooBar4>;
+
 }
 ",
-  "import { Entity as MikroORM_Entity, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Entity as MikroORM_Entity, OneToOne as MikroORM_OneToOne, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
+import { FooBar4 } from './FooBar4';
 
 @MikroORM_Entity()
 export class FooBaz4 extends CustomBase {
@@ -1985,10 +2310,15 @@ export class FooBaz4 extends CustomBase {
   @MikroORM_Property({ type: 'datetime', defaultRaw: \`current_timestamp\` })
   version!: Date & MikroORM_Opt;
 
+  @MikroORM_OneToOne({ entity: () => FooBar4, ref: true, mappedBy: 'baz' })
+  fooBar4?: MikroORM_Ref<FooBar4>;
+
 }
 ",
-  "import { Entity as MikroORM_Entity, Enum as MikroORM_Enum, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, Enum as MikroORM_Enum, OneToMany as MikroORM_OneToMany, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+import { Book4 } from './Book4';
 import { CustomBase } from './CustomBase';
+import { Publisher4Tests } from './Publisher4Tests';
 
 @MikroORM_Entity()
 export class Publisher4 extends CustomBase {
@@ -2006,19 +2336,27 @@ export class Publisher4 extends CustomBase {
   name: string & MikroORM_Opt = 'asd';
 
   @MikroORM_Enum({ items: () => Publisher4Type })
-  type: Publisher4Type & MikroORM_Opt = Publisher4Type.LOCAL;
+  type: TPublisher4Type & MikroORM_Opt = Publisher4Type.LOCAL;
 
   @MikroORM_Property({ nullable: true })
   enum3?: number;
 
+  @MikroORM_OneToMany({ entity: () => Book4, mappedBy: 'publisher' })
+  book4Collection = new MikroORM_Collection<Book4>(this);
+
+  @MikroORM_OneToMany({ entity: () => Publisher4Tests, mappedBy: 'publisher4' })
+  publisher4TestsCollection = new MikroORM_Collection<Publisher4Tests>(this);
+
 }
 
-export enum Publisher4Type {
-  LOCAL = 'local',
-  GLOBAL = 'global',
-}
+export const Publisher4Type = {
+  LOCAL: 'local',
+  GLOBAL: 'global',
+} as const;
+
+export type TPublisher4Type = (typeof Publisher4Type)[keyof typeof Publisher4Type];
 ",
-  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey } from '@mikro-orm/core';
+  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
 import { Publisher4 } from './Publisher4';
 import { Test4 } from './Test4';
@@ -2030,16 +2368,16 @@ export class Publisher4Tests extends CustomBase {
   id!: number;
 
   @MikroORM_Index({ name: 'publisher4_tests_publisher4_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Publisher4, updateRule: 'cascade', deleteRule: 'cascade' })
-  publisher4!: Publisher4;
+  @MikroORM_ManyToOne({ entity: () => Publisher4, ref: true, updateRule: 'cascade', deleteRule: 'cascade' })
+  publisher4!: MikroORM_Ref<Publisher4>;
 
   @MikroORM_Index({ name: 'publisher4_tests_test4_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Test4, updateRule: 'cascade', deleteRule: 'cascade' })
-  test4!: Test4;
+  @MikroORM_ManyToOne({ entity: () => Test4, ref: true, updateRule: 'cascade', deleteRule: 'cascade' })
+  test4!: MikroORM_Ref<Test4>;
 
 }
 ",
-  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey } from '@mikro-orm/core';
+  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Book4 } from './Book4';
 import { BookTag4 } from './BookTag4';
 import { CustomBase } from './CustomBase';
@@ -2051,17 +2389,18 @@ export class TagsOrdered extends CustomBase {
   id!: number;
 
   @MikroORM_Index({ name: 'tags_ordered_book4_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Book4, updateRule: 'cascade', deleteRule: 'cascade' })
-  book4!: Book4;
+  @MikroORM_ManyToOne({ entity: () => Book4, ref: true, updateRule: 'cascade', deleteRule: 'cascade' })
+  book4!: MikroORM_Ref<Book4>;
 
   @MikroORM_Index({ name: 'tags_ordered_book_tag4_id_index' })
-  @MikroORM_ManyToOne({ entity: () => BookTag4, updateRule: 'cascade', deleteRule: 'cascade' })
-  bookTag4!: BookTag4;
+  @MikroORM_ManyToOne({ entity: () => BookTag4, ref: true, updateRule: 'cascade', deleteRule: 'cascade' })
+  bookTag4!: MikroORM_Ref<BookTag4>;
 
 }
 ",
-  "import { Entity as MikroORM_Entity, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, OneToMany as MikroORM_OneToMany, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
+import { Publisher4Tests } from './Publisher4Tests';
 
 @MikroORM_Entity()
 export class Test4 extends CustomBase {
@@ -2080,6 +2419,9 @@ export class Test4 extends CustomBase {
 
   @MikroORM_Property({ type: 'integer' })
   version: number & MikroORM_Opt = 1;
+
+  @MikroORM_OneToMany({ entity: () => Publisher4Tests, mappedBy: 'test4' })
+  publisher4TestsCollection = new MikroORM_Collection<Publisher4Tests>(this);
 
 }
 ",
@@ -2106,7 +2448,7 @@ export abstract class CustomBase {
 
 exports[`CustomBase > forceObject=false > useCoreBaseEntity=false > customBaseEntityName=CustomBase > entitySchema > dump 1`] = `
 [
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Book4 } from './Book4';
 import { CustomBase } from './CustomBase';
 
@@ -2121,8 +2463,9 @@ export class Author4 extends CustomBase {
   identities?: string;
   born?: string;
   bornTime?: string;
-  favouriteBook?: Book4;
+  favouriteBook?: MikroORM_Ref<Book4>;
   identity?: any;
+  book4Collection = new MikroORM_Collection<Book4>(this);
 }
 
 export const Author4Schema = new MikroORM_EntitySchema({
@@ -2141,16 +2484,20 @@ export const Author4Schema = new MikroORM_EntitySchema({
     favouriteBook: {
       kind: 'm:1',
       entity: () => Book4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
     },
     identity: { type: 'json', nullable: true },
+    book4Collection: { kind: '1:m', entity: () => Book4, mappedBy: 'author' },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+import { Book4 } from './Book4';
 import { CustomBase } from './CustomBase';
+import { TagsOrdered } from './TagsOrdered';
 
 export class BookTag4 extends CustomBase {
   id!: number;
@@ -2158,6 +2505,8 @@ export class BookTag4 extends CustomBase {
   updatedAt?: Date;
   name!: string;
   version!: Date & MikroORM_Opt;
+  tagsUnorderedInverse = new MikroORM_Collection<Book4>(this);
+  tagsOrderedCollection = new MikroORM_Collection<TagsOrdered>(this);
 }
 
 export const BookTag4Schema = new MikroORM_EntitySchema({
@@ -2168,14 +2517,25 @@ export const BookTag4Schema = new MikroORM_EntitySchema({
     updatedAt: { type: 'datetime', nullable: true },
     name: { type: 'text' },
     version: { type: 'datetime', defaultRaw: \`current_timestamp\` },
+    tagsUnorderedInverse: {
+      kind: 'm:n',
+      entity: () => Book4,
+      mappedBy: 'tagsUnordered',
+    },
+    tagsOrderedCollection: {
+      kind: '1:m',
+      entity: () => TagsOrdered,
+      mappedBy: 'bookTag4',
+    },
   },
 });
 ",
-  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Author4 } from './Author4';
 import { BookTag4 } from './BookTag4';
 import { CustomBase } from './CustomBase';
 import { Publisher4 } from './Publisher4';
+import { TagsOrdered } from './TagsOrdered';
 
 export class Book4 extends CustomBase {
   id!: number;
@@ -2183,10 +2543,12 @@ export class Book4 extends CustomBase {
   updatedAt?: Date;
   title!: string;
   price?: unknown;
-  author?: Author4;
-  publisher?: Publisher4;
+  author?: MikroORM_Ref<Author4>;
+  publisher?: MikroORM_Ref<Publisher4>;
   meta?: any;
   tagsUnordered = new MikroORM_Collection<BookTag4>(this);
+  author4Collection = new MikroORM_Collection<Author4>(this);
+  tagsOrderedCollection = new MikroORM_Collection<TagsOrdered>(this);
 }
 
 export const Book4Schema = new MikroORM_EntitySchema({
@@ -2200,6 +2562,7 @@ export const Book4Schema = new MikroORM_EntitySchema({
     author: {
       kind: 'm:1',
       entity: () => Author4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
@@ -2207,6 +2570,7 @@ export const Book4Schema = new MikroORM_EntitySchema({
     publisher: {
       kind: 'm:1',
       entity: () => Publisher4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
@@ -2219,10 +2583,20 @@ export const Book4Schema = new MikroORM_EntitySchema({
       joinColumn: 'book4_id',
       inverseJoinColumn: 'book_tag4_id',
     },
+    author4Collection: {
+      kind: '1:m',
+      entity: () => Author4,
+      mappedBy: 'favouriteBook',
+    },
+    tagsOrderedCollection: {
+      kind: '1:m',
+      entity: () => TagsOrdered,
+      mappedBy: 'book4',
+    },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
 import { FooBaz4 } from './FooBaz4';
 
@@ -2231,13 +2605,14 @@ export class FooBar4 extends CustomBase {
   createdAt?: Date;
   updatedAt?: Date;
   name: string & MikroORM_Opt = 'asd';
-  baz?: FooBaz4;
-  fooBar?: FooBar4;
+  baz?: MikroORM_Ref<FooBaz4>;
+  fooBar?: MikroORM_Ref<FooBar4>;
   version: number & MikroORM_Opt = 1;
   blob?: Buffer;
   blob2?: Buffer;
   array?: string;
   object?: any;
+  fooBar4?: MikroORM_Ref<FooBar4>;
 }
 
 export const FooBar4Schema = new MikroORM_EntitySchema({
@@ -2250,6 +2625,7 @@ export const FooBar4Schema = new MikroORM_EntitySchema({
     baz: {
       kind: '1:1',
       entity: () => FooBaz4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
@@ -2257,6 +2633,7 @@ export const FooBar4Schema = new MikroORM_EntitySchema({
     fooBar: {
       kind: '1:1',
       entity: () => FooBar4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
@@ -2266,11 +2643,13 @@ export const FooBar4Schema = new MikroORM_EntitySchema({
     blob2: { type: 'blob', nullable: true },
     array: { type: 'text', nullable: true },
     object: { type: 'json', nullable: true },
+    fooBar4: { kind: '1:1', entity: () => FooBar4, ref: true, mappedBy: 'fooBar' },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
+import { FooBar4 } from './FooBar4';
 
 export class FooBaz4 extends CustomBase {
   id!: number;
@@ -2278,6 +2657,7 @@ export class FooBaz4 extends CustomBase {
   updatedAt?: Date;
   name!: string;
   version!: Date & MikroORM_Opt;
+  fooBar4?: MikroORM_Ref<FooBar4>;
 }
 
 export const FooBaz4Schema = new MikroORM_EntitySchema({
@@ -2288,25 +2668,32 @@ export const FooBaz4Schema = new MikroORM_EntitySchema({
     updatedAt: { type: 'datetime', nullable: true },
     name: { type: 'text' },
     version: { type: 'datetime', defaultRaw: \`current_timestamp\` },
+    fooBar4: { kind: '1:1', entity: () => FooBar4, ref: true, mappedBy: 'baz' },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+import { Book4 } from './Book4';
 import { CustomBase } from './CustomBase';
+import { Publisher4Tests } from './Publisher4Tests';
 
 export class Publisher4 extends CustomBase {
   id!: number;
   createdAt?: Date;
   updatedAt?: Date;
   name: string & MikroORM_Opt = 'asd';
-  type: Publisher4Type & MikroORM_Opt = Publisher4Type.LOCAL;
+  type: TPublisher4Type & MikroORM_Opt = Publisher4Type.LOCAL;
   enum3?: number;
+  book4Collection = new MikroORM_Collection<Book4>(this);
+  publisher4TestsCollection = new MikroORM_Collection<Publisher4Tests>(this);
 }
 
-export enum Publisher4Type {
-  LOCAL = 'local',
-  GLOBAL = 'global',
-}
+export const Publisher4Type = {
+  LOCAL: 'local',
+  GLOBAL: 'global',
+} as const;
+
+export type TPublisher4Type = (typeof Publisher4Type)[keyof typeof Publisher4Type];
 
 export const Publisher4Schema = new MikroORM_EntitySchema({
   class: Publisher4,
@@ -2317,18 +2704,24 @@ export const Publisher4Schema = new MikroORM_EntitySchema({
     name: { type: 'text' },
     type: { enum: true, items: () => Publisher4Type },
     enum3: { type: 'integer', nullable: true },
+    book4Collection: { kind: '1:m', entity: () => Book4, mappedBy: 'publisher' },
+    publisher4TestsCollection: {
+      kind: '1:m',
+      entity: () => Publisher4Tests,
+      mappedBy: 'publisher4',
+    },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema } from '@mikro-orm/core';
+  "import { EntitySchema as MikroORM_EntitySchema, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
 import { Publisher4 } from './Publisher4';
 import { Test4 } from './Test4';
 
 export class Publisher4Tests extends CustomBase {
   id!: number;
-  publisher4!: Publisher4;
-  test4!: Test4;
+  publisher4!: MikroORM_Ref<Publisher4>;
+  test4!: MikroORM_Ref<Test4>;
 }
 
 export const Publisher4TestsSchema = new MikroORM_EntitySchema({
@@ -2339,27 +2732,29 @@ export const Publisher4TestsSchema = new MikroORM_EntitySchema({
     publisher4: {
       kind: 'm:1',
       entity: () => Publisher4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
     test4: {
       kind: 'm:1',
       entity: () => Test4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema } from '@mikro-orm/core';
+  "import { EntitySchema as MikroORM_EntitySchema, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Book4 } from './Book4';
 import { BookTag4 } from './BookTag4';
 import { CustomBase } from './CustomBase';
 
 export class TagsOrdered extends CustomBase {
   id!: number;
-  book4!: Book4;
-  bookTag4!: BookTag4;
+  book4!: MikroORM_Ref<Book4>;
+  bookTag4!: MikroORM_Ref<BookTag4>;
 }
 
 export const TagsOrderedSchema = new MikroORM_EntitySchema({
@@ -2369,20 +2764,23 @@ export const TagsOrderedSchema = new MikroORM_EntitySchema({
     book4: {
       kind: 'm:1',
       entity: () => Book4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
     bookTag4: {
       kind: 'm:1',
       entity: () => BookTag4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
+import { Publisher4Tests } from './Publisher4Tests';
 
 export class Test4 extends CustomBase {
   id!: number;
@@ -2390,6 +2788,7 @@ export class Test4 extends CustomBase {
   updatedAt?: Date;
   name?: string;
   version: number & MikroORM_Opt = 1;
+  publisher4TestsCollection = new MikroORM_Collection<Publisher4Tests>(this);
 }
 
 export const Test4Schema = new MikroORM_EntitySchema({
@@ -2400,6 +2799,11 @@ export const Test4Schema = new MikroORM_EntitySchema({
     updatedAt: { type: 'datetime', nullable: true },
     name: { type: 'text', nullable: true },
     version: { type: 'integer' },
+    publisher4TestsCollection: {
+      kind: '1:m',
+      entity: () => Publisher4Tests,
+      mappedBy: 'test4',
+    },
   },
 });
 ",
@@ -2433,7 +2837,7 @@ export const CustomBaseSchema = new MikroORM_EntitySchema({
 
 exports[`CustomBase > forceObject=false > useCoreBaseEntity=true > customBaseEntityName= > decorators > dump 1`] = `
 [
-  "import { BaseEntity as MikroORM_BaseEntity, Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { BaseEntity as MikroORM_BaseEntity, Collection as MikroORM_Collection, Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, OneToMany as MikroORM_OneToMany, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Book4 } from './Book4';
 
 @MikroORM_Entity()
@@ -2470,15 +2874,20 @@ export class Author4 extends MikroORM_BaseEntity {
   bornTime?: string;
 
   @MikroORM_Index({ name: 'author4_favourite_book_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Book4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  favouriteBook?: Book4;
+  @MikroORM_ManyToOne({ entity: () => Book4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  favouriteBook?: MikroORM_Ref<Book4>;
 
   @MikroORM_Property({ type: 'json', nullable: true })
   identity?: any;
 
+  @MikroORM_OneToMany({ entity: () => Book4, mappedBy: 'author' })
+  book4Collection = new MikroORM_Collection<Book4>(this);
+
 }
 ",
-  "import { BaseEntity as MikroORM_BaseEntity, Entity as MikroORM_Entity, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { BaseEntity as MikroORM_BaseEntity, Collection as MikroORM_Collection, Entity as MikroORM_Entity, ManyToMany as MikroORM_ManyToMany, OneToMany as MikroORM_OneToMany, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+import { Book4 } from './Book4';
+import { TagsOrdered } from './TagsOrdered';
 
 @MikroORM_Entity()
 export class BookTag4 extends MikroORM_BaseEntity {
@@ -2498,12 +2907,19 @@ export class BookTag4 extends MikroORM_BaseEntity {
   @MikroORM_Property({ type: 'datetime', defaultRaw: \`current_timestamp\` })
   version!: Date & MikroORM_Opt;
 
+  @MikroORM_ManyToMany({ entity: () => Book4, mappedBy: 'tagsUnordered' })
+  tagsUnorderedInverse = new MikroORM_Collection<Book4>(this);
+
+  @MikroORM_OneToMany({ entity: () => TagsOrdered, mappedBy: 'bookTag4' })
+  tagsOrderedCollection = new MikroORM_Collection<TagsOrdered>(this);
+
 }
 ",
-  "import { BaseEntity as MikroORM_BaseEntity, Collection as MikroORM_Collection, Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToMany as MikroORM_ManyToMany, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { BaseEntity as MikroORM_BaseEntity, Collection as MikroORM_Collection, Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToMany as MikroORM_ManyToMany, ManyToOne as MikroORM_ManyToOne, OneToMany as MikroORM_OneToMany, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Author4 } from './Author4';
 import { BookTag4 } from './BookTag4';
 import { Publisher4 } from './Publisher4';
+import { TagsOrdered } from './TagsOrdered';
 
 @MikroORM_Entity()
 export class Book4 extends MikroORM_BaseEntity {
@@ -2524,12 +2940,12 @@ export class Book4 extends MikroORM_BaseEntity {
   price?: unknown;
 
   @MikroORM_Index({ name: 'book4_author_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Author4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  author?: Author4;
+  @MikroORM_ManyToOne({ entity: () => Author4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  author?: MikroORM_Ref<Author4>;
 
   @MikroORM_Index({ name: 'book4_publisher_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Publisher4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  publisher?: Publisher4;
+  @MikroORM_ManyToOne({ entity: () => Publisher4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  publisher?: MikroORM_Ref<Publisher4>;
 
   @MikroORM_Property({ type: 'json', nullable: true })
   meta?: any;
@@ -2537,9 +2953,15 @@ export class Book4 extends MikroORM_BaseEntity {
   @MikroORM_ManyToMany({ entity: () => BookTag4, pivotTable: 'tags_unordered', joinColumn: 'book4_id', inverseJoinColumn: 'book_tag4_id' })
   tagsUnordered = new MikroORM_Collection<BookTag4>(this);
 
+  @MikroORM_OneToMany({ entity: () => Author4, mappedBy: 'favouriteBook' })
+  author4Collection = new MikroORM_Collection<Author4>(this);
+
+  @MikroORM_OneToMany({ entity: () => TagsOrdered, mappedBy: 'book4' })
+  tagsOrderedCollection = new MikroORM_Collection<TagsOrdered>(this);
+
 }
 ",
-  "import { BaseEntity as MikroORM_BaseEntity, Entity as MikroORM_Entity, OneToOne as MikroORM_OneToOne, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, Unique as MikroORM_Unique } from '@mikro-orm/core';
+  "import { BaseEntity as MikroORM_BaseEntity, Entity as MikroORM_Entity, OneToOne as MikroORM_OneToOne, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, type Ref as MikroORM_Ref, Unique as MikroORM_Unique } from '@mikro-orm/core';
 import { FooBaz4 } from './FooBaz4';
 
 @MikroORM_Entity()
@@ -2558,12 +2980,12 @@ export class FooBar4 extends MikroORM_BaseEntity {
   name: string & MikroORM_Opt = 'asd';
 
   @MikroORM_Unique({ name: 'foo_bar4_baz_id_unique' })
-  @MikroORM_OneToOne({ entity: () => FooBaz4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  baz?: FooBaz4;
+  @MikroORM_OneToOne({ entity: () => FooBaz4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  baz?: MikroORM_Ref<FooBaz4>;
 
   @MikroORM_Unique({ name: 'foo_bar4_foo_bar_id_unique' })
-  @MikroORM_OneToOne({ entity: () => FooBar4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  fooBar?: FooBar4;
+  @MikroORM_OneToOne({ entity: () => FooBar4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  fooBar?: MikroORM_Ref<FooBar4>;
 
   @MikroORM_Property({ type: 'integer' })
   version: number & MikroORM_Opt = 1;
@@ -2580,9 +3002,13 @@ export class FooBar4 extends MikroORM_BaseEntity {
   @MikroORM_Property({ type: 'json', nullable: true })
   object?: any;
 
+  @MikroORM_OneToOne({ entity: () => FooBar4, ref: true, mappedBy: 'fooBar' })
+  fooBar4?: MikroORM_Ref<FooBar4>;
+
 }
 ",
-  "import { BaseEntity as MikroORM_BaseEntity, Entity as MikroORM_Entity, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { BaseEntity as MikroORM_BaseEntity, Entity as MikroORM_Entity, OneToOne as MikroORM_OneToOne, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, type Ref as MikroORM_Ref } from '@mikro-orm/core';
+import { FooBar4 } from './FooBar4';
 
 @MikroORM_Entity()
 export class FooBaz4 extends MikroORM_BaseEntity {
@@ -2602,9 +3028,14 @@ export class FooBaz4 extends MikroORM_BaseEntity {
   @MikroORM_Property({ type: 'datetime', defaultRaw: \`current_timestamp\` })
   version!: Date & MikroORM_Opt;
 
+  @MikroORM_OneToOne({ entity: () => FooBar4, ref: true, mappedBy: 'baz' })
+  fooBar4?: MikroORM_Ref<FooBar4>;
+
 }
 ",
-  "import { BaseEntity as MikroORM_BaseEntity, Entity as MikroORM_Entity, Enum as MikroORM_Enum, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { BaseEntity as MikroORM_BaseEntity, Collection as MikroORM_Collection, Entity as MikroORM_Entity, Enum as MikroORM_Enum, OneToMany as MikroORM_OneToMany, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+import { Book4 } from './Book4';
+import { Publisher4Tests } from './Publisher4Tests';
 
 @MikroORM_Entity()
 export class Publisher4 extends MikroORM_BaseEntity {
@@ -2622,19 +3053,27 @@ export class Publisher4 extends MikroORM_BaseEntity {
   name: string & MikroORM_Opt = 'asd';
 
   @MikroORM_Enum({ items: () => Publisher4Type })
-  type: Publisher4Type & MikroORM_Opt = Publisher4Type.LOCAL;
+  type: TPublisher4Type & MikroORM_Opt = Publisher4Type.LOCAL;
 
   @MikroORM_Property({ nullable: true })
   enum3?: number;
 
+  @MikroORM_OneToMany({ entity: () => Book4, mappedBy: 'publisher' })
+  book4Collection = new MikroORM_Collection<Book4>(this);
+
+  @MikroORM_OneToMany({ entity: () => Publisher4Tests, mappedBy: 'publisher4' })
+  publisher4TestsCollection = new MikroORM_Collection<Publisher4Tests>(this);
+
 }
 
-export enum Publisher4Type {
-  LOCAL = 'local',
-  GLOBAL = 'global',
-}
+export const Publisher4Type = {
+  LOCAL: 'local',
+  GLOBAL: 'global',
+} as const;
+
+export type TPublisher4Type = (typeof Publisher4Type)[keyof typeof Publisher4Type];
 ",
-  "import { BaseEntity as MikroORM_BaseEntity, Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey } from '@mikro-orm/core';
+  "import { BaseEntity as MikroORM_BaseEntity, Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Publisher4 } from './Publisher4';
 import { Test4 } from './Test4';
 
@@ -2645,16 +3084,16 @@ export class Publisher4Tests extends MikroORM_BaseEntity {
   id!: number;
 
   @MikroORM_Index({ name: 'publisher4_tests_publisher4_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Publisher4, updateRule: 'cascade', deleteRule: 'cascade' })
-  publisher4!: Publisher4;
+  @MikroORM_ManyToOne({ entity: () => Publisher4, ref: true, updateRule: 'cascade', deleteRule: 'cascade' })
+  publisher4!: MikroORM_Ref<Publisher4>;
 
   @MikroORM_Index({ name: 'publisher4_tests_test4_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Test4, updateRule: 'cascade', deleteRule: 'cascade' })
-  test4!: Test4;
+  @MikroORM_ManyToOne({ entity: () => Test4, ref: true, updateRule: 'cascade', deleteRule: 'cascade' })
+  test4!: MikroORM_Ref<Test4>;
 
 }
 ",
-  "import { BaseEntity as MikroORM_BaseEntity, Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey } from '@mikro-orm/core';
+  "import { BaseEntity as MikroORM_BaseEntity, Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Book4 } from './Book4';
 import { BookTag4 } from './BookTag4';
 
@@ -2665,16 +3104,17 @@ export class TagsOrdered extends MikroORM_BaseEntity {
   id!: number;
 
   @MikroORM_Index({ name: 'tags_ordered_book4_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Book4, updateRule: 'cascade', deleteRule: 'cascade' })
-  book4!: Book4;
+  @MikroORM_ManyToOne({ entity: () => Book4, ref: true, updateRule: 'cascade', deleteRule: 'cascade' })
+  book4!: MikroORM_Ref<Book4>;
 
   @MikroORM_Index({ name: 'tags_ordered_book_tag4_id_index' })
-  @MikroORM_ManyToOne({ entity: () => BookTag4, updateRule: 'cascade', deleteRule: 'cascade' })
-  bookTag4!: BookTag4;
+  @MikroORM_ManyToOne({ entity: () => BookTag4, ref: true, updateRule: 'cascade', deleteRule: 'cascade' })
+  bookTag4!: MikroORM_Ref<BookTag4>;
 
 }
 ",
-  "import { BaseEntity as MikroORM_BaseEntity, Entity as MikroORM_Entity, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { BaseEntity as MikroORM_BaseEntity, Collection as MikroORM_Collection, Entity as MikroORM_Entity, OneToMany as MikroORM_OneToMany, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+import { Publisher4Tests } from './Publisher4Tests';
 
 @MikroORM_Entity()
 export class Test4 extends MikroORM_BaseEntity {
@@ -2694,6 +3134,9 @@ export class Test4 extends MikroORM_BaseEntity {
   @MikroORM_Property({ type: 'integer' })
   version: number & MikroORM_Opt = 1;
 
+  @MikroORM_OneToMany({ entity: () => Publisher4Tests, mappedBy: 'test4' })
+  publisher4TestsCollection = new MikroORM_Collection<Publisher4Tests>(this);
+
 }
 ",
   "import { BaseEntity as MikroORM_BaseEntity, Formula as MikroORM_Formula } from '@mikro-orm/core';
@@ -2710,7 +3153,7 @@ export abstract class BaseEntity2 extends MikroORM_BaseEntity {
 
 exports[`CustomBase > forceObject=false > useCoreBaseEntity=true > customBaseEntityName= > entitySchema > dump 1`] = `
 [
-  "import { BaseEntity as MikroORM_BaseEntity, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { BaseEntity as MikroORM_BaseEntity, Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Book4 } from './Book4';
 
 export class Author4 extends MikroORM_BaseEntity {
@@ -2724,8 +3167,9 @@ export class Author4 extends MikroORM_BaseEntity {
   identities?: string;
   born?: string;
   bornTime?: string;
-  favouriteBook?: Book4;
+  favouriteBook?: MikroORM_Ref<Book4>;
   identity?: any;
+  book4Collection = new MikroORM_Collection<Book4>(this);
 }
 
 export const Author4Schema = new MikroORM_EntitySchema({
@@ -2744,15 +3188,19 @@ export const Author4Schema = new MikroORM_EntitySchema({
     favouriteBook: {
       kind: 'm:1',
       entity: () => Book4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
     },
     identity: { type: 'json', nullable: true },
+    book4Collection: { kind: '1:m', entity: () => Book4, mappedBy: 'author' },
   },
 });
 ",
-  "import { BaseEntity as MikroORM_BaseEntity, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { BaseEntity as MikroORM_BaseEntity, Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+import { Book4 } from './Book4';
+import { TagsOrdered } from './TagsOrdered';
 
 export class BookTag4 extends MikroORM_BaseEntity {
   id!: number;
@@ -2760,6 +3208,8 @@ export class BookTag4 extends MikroORM_BaseEntity {
   updatedAt?: Date;
   name!: string;
   version!: Date & MikroORM_Opt;
+  tagsUnorderedInverse = new MikroORM_Collection<Book4>(this);
+  tagsOrderedCollection = new MikroORM_Collection<TagsOrdered>(this);
 }
 
 export const BookTag4Schema = new MikroORM_EntitySchema({
@@ -2770,13 +3220,24 @@ export const BookTag4Schema = new MikroORM_EntitySchema({
     updatedAt: { type: 'datetime', nullable: true },
     name: { type: 'text' },
     version: { type: 'datetime', defaultRaw: \`current_timestamp\` },
+    tagsUnorderedInverse: {
+      kind: 'm:n',
+      entity: () => Book4,
+      mappedBy: 'tagsUnordered',
+    },
+    tagsOrderedCollection: {
+      kind: '1:m',
+      entity: () => TagsOrdered,
+      mappedBy: 'bookTag4',
+    },
   },
 });
 ",
-  "import { BaseEntity as MikroORM_BaseEntity, Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema } from '@mikro-orm/core';
+  "import { BaseEntity as MikroORM_BaseEntity, Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Author4 } from './Author4';
 import { BookTag4 } from './BookTag4';
 import { Publisher4 } from './Publisher4';
+import { TagsOrdered } from './TagsOrdered';
 
 export class Book4 extends MikroORM_BaseEntity {
   id!: number;
@@ -2784,10 +3245,12 @@ export class Book4 extends MikroORM_BaseEntity {
   updatedAt?: Date;
   title!: string;
   price?: unknown;
-  author?: Author4;
-  publisher?: Publisher4;
+  author?: MikroORM_Ref<Author4>;
+  publisher?: MikroORM_Ref<Publisher4>;
   meta?: any;
   tagsUnordered = new MikroORM_Collection<BookTag4>(this);
+  author4Collection = new MikroORM_Collection<Author4>(this);
+  tagsOrderedCollection = new MikroORM_Collection<TagsOrdered>(this);
 }
 
 export const Book4Schema = new MikroORM_EntitySchema({
@@ -2801,6 +3264,7 @@ export const Book4Schema = new MikroORM_EntitySchema({
     author: {
       kind: 'm:1',
       entity: () => Author4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
@@ -2808,6 +3272,7 @@ export const Book4Schema = new MikroORM_EntitySchema({
     publisher: {
       kind: 'm:1',
       entity: () => Publisher4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
@@ -2820,10 +3285,20 @@ export const Book4Schema = new MikroORM_EntitySchema({
       joinColumn: 'book4_id',
       inverseJoinColumn: 'book_tag4_id',
     },
+    author4Collection: {
+      kind: '1:m',
+      entity: () => Author4,
+      mappedBy: 'favouriteBook',
+    },
+    tagsOrderedCollection: {
+      kind: '1:m',
+      entity: () => TagsOrdered,
+      mappedBy: 'book4',
+    },
   },
 });
 ",
-  "import { BaseEntity as MikroORM_BaseEntity, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { BaseEntity as MikroORM_BaseEntity, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { FooBaz4 } from './FooBaz4';
 
 export class FooBar4 extends MikroORM_BaseEntity {
@@ -2831,13 +3306,14 @@ export class FooBar4 extends MikroORM_BaseEntity {
   createdAt?: Date;
   updatedAt?: Date;
   name: string & MikroORM_Opt = 'asd';
-  baz?: FooBaz4;
-  fooBar?: FooBar4;
+  baz?: MikroORM_Ref<FooBaz4>;
+  fooBar?: MikroORM_Ref<FooBar4>;
   version: number & MikroORM_Opt = 1;
   blob?: Buffer;
   blob2?: Buffer;
   array?: string;
   object?: any;
+  fooBar4?: MikroORM_Ref<FooBar4>;
 }
 
 export const FooBar4Schema = new MikroORM_EntitySchema({
@@ -2850,6 +3326,7 @@ export const FooBar4Schema = new MikroORM_EntitySchema({
     baz: {
       kind: '1:1',
       entity: () => FooBaz4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
@@ -2857,6 +3334,7 @@ export const FooBar4Schema = new MikroORM_EntitySchema({
     fooBar: {
       kind: '1:1',
       entity: () => FooBar4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
@@ -2866,10 +3344,12 @@ export const FooBar4Schema = new MikroORM_EntitySchema({
     blob2: { type: 'blob', nullable: true },
     array: { type: 'text', nullable: true },
     object: { type: 'json', nullable: true },
+    fooBar4: { kind: '1:1', entity: () => FooBar4, ref: true, mappedBy: 'fooBar' },
   },
 });
 ",
-  "import { BaseEntity as MikroORM_BaseEntity, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { BaseEntity as MikroORM_BaseEntity, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt, type Ref as MikroORM_Ref } from '@mikro-orm/core';
+import { FooBar4 } from './FooBar4';
 
 export class FooBaz4 extends MikroORM_BaseEntity {
   id!: number;
@@ -2877,6 +3357,7 @@ export class FooBaz4 extends MikroORM_BaseEntity {
   updatedAt?: Date;
   name!: string;
   version!: Date & MikroORM_Opt;
+  fooBar4?: MikroORM_Ref<FooBar4>;
 }
 
 export const FooBaz4Schema = new MikroORM_EntitySchema({
@@ -2887,24 +3368,31 @@ export const FooBaz4Schema = new MikroORM_EntitySchema({
     updatedAt: { type: 'datetime', nullable: true },
     name: { type: 'text' },
     version: { type: 'datetime', defaultRaw: \`current_timestamp\` },
+    fooBar4: { kind: '1:1', entity: () => FooBar4, ref: true, mappedBy: 'baz' },
   },
 });
 ",
-  "import { BaseEntity as MikroORM_BaseEntity, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { BaseEntity as MikroORM_BaseEntity, Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+import { Book4 } from './Book4';
+import { Publisher4Tests } from './Publisher4Tests';
 
 export class Publisher4 extends MikroORM_BaseEntity {
   id!: number;
   createdAt?: Date;
   updatedAt?: Date;
   name: string & MikroORM_Opt = 'asd';
-  type: Publisher4Type & MikroORM_Opt = Publisher4Type.LOCAL;
+  type: TPublisher4Type & MikroORM_Opt = Publisher4Type.LOCAL;
   enum3?: number;
+  book4Collection = new MikroORM_Collection<Book4>(this);
+  publisher4TestsCollection = new MikroORM_Collection<Publisher4Tests>(this);
 }
 
-export enum Publisher4Type {
-  LOCAL = 'local',
-  GLOBAL = 'global',
-}
+export const Publisher4Type = {
+  LOCAL: 'local',
+  GLOBAL: 'global',
+} as const;
+
+export type TPublisher4Type = (typeof Publisher4Type)[keyof typeof Publisher4Type];
 
 export const Publisher4Schema = new MikroORM_EntitySchema({
   class: Publisher4,
@@ -2915,17 +3403,23 @@ export const Publisher4Schema = new MikroORM_EntitySchema({
     name: { type: 'text' },
     type: { enum: true, items: () => Publisher4Type },
     enum3: { type: 'integer', nullable: true },
+    book4Collection: { kind: '1:m', entity: () => Book4, mappedBy: 'publisher' },
+    publisher4TestsCollection: {
+      kind: '1:m',
+      entity: () => Publisher4Tests,
+      mappedBy: 'publisher4',
+    },
   },
 });
 ",
-  "import { BaseEntity as MikroORM_BaseEntity, EntitySchema as MikroORM_EntitySchema } from '@mikro-orm/core';
+  "import { BaseEntity as MikroORM_BaseEntity, EntitySchema as MikroORM_EntitySchema, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Publisher4 } from './Publisher4';
 import { Test4 } from './Test4';
 
 export class Publisher4Tests extends MikroORM_BaseEntity {
   id!: number;
-  publisher4!: Publisher4;
-  test4!: Test4;
+  publisher4!: MikroORM_Ref<Publisher4>;
+  test4!: MikroORM_Ref<Test4>;
 }
 
 export const Publisher4TestsSchema = new MikroORM_EntitySchema({
@@ -2936,26 +3430,28 @@ export const Publisher4TestsSchema = new MikroORM_EntitySchema({
     publisher4: {
       kind: 'm:1',
       entity: () => Publisher4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
     test4: {
       kind: 'm:1',
       entity: () => Test4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
   },
 });
 ",
-  "import { BaseEntity as MikroORM_BaseEntity, EntitySchema as MikroORM_EntitySchema } from '@mikro-orm/core';
+  "import { BaseEntity as MikroORM_BaseEntity, EntitySchema as MikroORM_EntitySchema, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Book4 } from './Book4';
 import { BookTag4 } from './BookTag4';
 
 export class TagsOrdered extends MikroORM_BaseEntity {
   id!: number;
-  book4!: Book4;
-  bookTag4!: BookTag4;
+  book4!: MikroORM_Ref<Book4>;
+  bookTag4!: MikroORM_Ref<BookTag4>;
 }
 
 export const TagsOrderedSchema = new MikroORM_EntitySchema({
@@ -2965,19 +3461,22 @@ export const TagsOrderedSchema = new MikroORM_EntitySchema({
     book4: {
       kind: 'm:1',
       entity: () => Book4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
     bookTag4: {
       kind: 'm:1',
       entity: () => BookTag4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
   },
 });
 ",
-  "import { BaseEntity as MikroORM_BaseEntity, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { BaseEntity as MikroORM_BaseEntity, Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+import { Publisher4Tests } from './Publisher4Tests';
 
 export class Test4 extends MikroORM_BaseEntity {
   id!: number;
@@ -2985,6 +3484,7 @@ export class Test4 extends MikroORM_BaseEntity {
   updatedAt?: Date;
   name?: string;
   version: number & MikroORM_Opt = 1;
+  publisher4TestsCollection = new MikroORM_Collection<Publisher4Tests>(this);
 }
 
 export const Test4Schema = new MikroORM_EntitySchema({
@@ -2995,6 +3495,11 @@ export const Test4Schema = new MikroORM_EntitySchema({
     updatedAt: { type: 'datetime', nullable: true },
     name: { type: 'text', nullable: true },
     version: { type: 'integer' },
+    publisher4TestsCollection: {
+      kind: '1:m',
+      entity: () => Publisher4Tests,
+      mappedBy: 'test4',
+    },
   },
 });
 ",
@@ -3016,7 +3521,7 @@ export const BaseEntity2Schema = new MikroORM_EntitySchema({
 
 exports[`CustomBase > forceObject=false > useCoreBaseEntity=true > customBaseEntityName=BaseEntity > decorators > dump 1`] = `
 [
-  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, OneToMany as MikroORM_OneToMany, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 import { Book4 } from './Book4';
 
@@ -3054,16 +3559,21 @@ export class Author4 extends BaseEntity {
   bornTime?: string;
 
   @MikroORM_Index({ name: 'author4_favourite_book_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Book4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  favouriteBook?: Book4;
+  @MikroORM_ManyToOne({ entity: () => Book4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  favouriteBook?: MikroORM_Ref<Book4>;
 
   @MikroORM_Property({ type: 'json', nullable: true })
   identity?: any;
 
+  @MikroORM_OneToMany({ entity: () => Book4, mappedBy: 'author' })
+  book4Collection = new MikroORM_Collection<Book4>(this);
+
 }
 ",
-  "import { Entity as MikroORM_Entity, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, ManyToMany as MikroORM_ManyToMany, OneToMany as MikroORM_OneToMany, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
+import { Book4 } from './Book4';
+import { TagsOrdered } from './TagsOrdered';
 
 @MikroORM_Entity()
 export class BookTag4 extends BaseEntity {
@@ -3083,13 +3593,20 @@ export class BookTag4 extends BaseEntity {
   @MikroORM_Property({ type: 'datetime', defaultRaw: \`current_timestamp\` })
   version!: Date & MikroORM_Opt;
 
+  @MikroORM_ManyToMany({ entity: () => Book4, mappedBy: 'tagsUnordered' })
+  tagsUnorderedInverse = new MikroORM_Collection<Book4>(this);
+
+  @MikroORM_OneToMany({ entity: () => TagsOrdered, mappedBy: 'bookTag4' })
+  tagsOrderedCollection = new MikroORM_Collection<TagsOrdered>(this);
+
 }
 ",
-  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToMany as MikroORM_ManyToMany, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToMany as MikroORM_ManyToMany, ManyToOne as MikroORM_ManyToOne, OneToMany as MikroORM_OneToMany, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Author4 } from './Author4';
 import { BaseEntity } from './BaseEntity';
 import { BookTag4 } from './BookTag4';
 import { Publisher4 } from './Publisher4';
+import { TagsOrdered } from './TagsOrdered';
 
 @MikroORM_Entity()
 export class Book4 extends BaseEntity {
@@ -3110,12 +3627,12 @@ export class Book4 extends BaseEntity {
   price?: unknown;
 
   @MikroORM_Index({ name: 'book4_author_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Author4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  author?: Author4;
+  @MikroORM_ManyToOne({ entity: () => Author4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  author?: MikroORM_Ref<Author4>;
 
   @MikroORM_Index({ name: 'book4_publisher_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Publisher4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  publisher?: Publisher4;
+  @MikroORM_ManyToOne({ entity: () => Publisher4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  publisher?: MikroORM_Ref<Publisher4>;
 
   @MikroORM_Property({ type: 'json', nullable: true })
   meta?: any;
@@ -3123,9 +3640,15 @@ export class Book4 extends BaseEntity {
   @MikroORM_ManyToMany({ entity: () => BookTag4, pivotTable: 'tags_unordered', joinColumn: 'book4_id', inverseJoinColumn: 'book_tag4_id' })
   tagsUnordered = new MikroORM_Collection<BookTag4>(this);
 
+  @MikroORM_OneToMany({ entity: () => Author4, mappedBy: 'favouriteBook' })
+  author4Collection = new MikroORM_Collection<Author4>(this);
+
+  @MikroORM_OneToMany({ entity: () => TagsOrdered, mappedBy: 'book4' })
+  tagsOrderedCollection = new MikroORM_Collection<TagsOrdered>(this);
+
 }
 ",
-  "import { Entity as MikroORM_Entity, OneToOne as MikroORM_OneToOne, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, Unique as MikroORM_Unique } from '@mikro-orm/core';
+  "import { Entity as MikroORM_Entity, OneToOne as MikroORM_OneToOne, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, type Ref as MikroORM_Ref, Unique as MikroORM_Unique } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 import { FooBaz4 } from './FooBaz4';
 
@@ -3145,12 +3668,12 @@ export class FooBar4 extends BaseEntity {
   name: string & MikroORM_Opt = 'asd';
 
   @MikroORM_Unique({ name: 'foo_bar4_baz_id_unique' })
-  @MikroORM_OneToOne({ entity: () => FooBaz4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  baz?: FooBaz4;
+  @MikroORM_OneToOne({ entity: () => FooBaz4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  baz?: MikroORM_Ref<FooBaz4>;
 
   @MikroORM_Unique({ name: 'foo_bar4_foo_bar_id_unique' })
-  @MikroORM_OneToOne({ entity: () => FooBar4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  fooBar?: FooBar4;
+  @MikroORM_OneToOne({ entity: () => FooBar4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  fooBar?: MikroORM_Ref<FooBar4>;
 
   @MikroORM_Property({ type: 'integer' })
   version: number & MikroORM_Opt = 1;
@@ -3167,10 +3690,14 @@ export class FooBar4 extends BaseEntity {
   @MikroORM_Property({ type: 'json', nullable: true })
   object?: any;
 
+  @MikroORM_OneToOne({ entity: () => FooBar4, ref: true, mappedBy: 'fooBar' })
+  fooBar4?: MikroORM_Ref<FooBar4>;
+
 }
 ",
-  "import { Entity as MikroORM_Entity, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Entity as MikroORM_Entity, OneToOne as MikroORM_OneToOne, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
+import { FooBar4 } from './FooBar4';
 
 @MikroORM_Entity()
 export class FooBaz4 extends BaseEntity {
@@ -3190,10 +3717,15 @@ export class FooBaz4 extends BaseEntity {
   @MikroORM_Property({ type: 'datetime', defaultRaw: \`current_timestamp\` })
   version!: Date & MikroORM_Opt;
 
+  @MikroORM_OneToOne({ entity: () => FooBar4, ref: true, mappedBy: 'baz' })
+  fooBar4?: MikroORM_Ref<FooBar4>;
+
 }
 ",
-  "import { Entity as MikroORM_Entity, Enum as MikroORM_Enum, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, Enum as MikroORM_Enum, OneToMany as MikroORM_OneToMany, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
+import { Book4 } from './Book4';
+import { Publisher4Tests } from './Publisher4Tests';
 
 @MikroORM_Entity()
 export class Publisher4 extends BaseEntity {
@@ -3211,19 +3743,27 @@ export class Publisher4 extends BaseEntity {
   name: string & MikroORM_Opt = 'asd';
 
   @MikroORM_Enum({ items: () => Publisher4Type })
-  type: Publisher4Type & MikroORM_Opt = Publisher4Type.LOCAL;
+  type: TPublisher4Type & MikroORM_Opt = Publisher4Type.LOCAL;
 
   @MikroORM_Property({ nullable: true })
   enum3?: number;
 
+  @MikroORM_OneToMany({ entity: () => Book4, mappedBy: 'publisher' })
+  book4Collection = new MikroORM_Collection<Book4>(this);
+
+  @MikroORM_OneToMany({ entity: () => Publisher4Tests, mappedBy: 'publisher4' })
+  publisher4TestsCollection = new MikroORM_Collection<Publisher4Tests>(this);
+
 }
 
-export enum Publisher4Type {
-  LOCAL = 'local',
-  GLOBAL = 'global',
-}
+export const Publisher4Type = {
+  LOCAL: 'local',
+  GLOBAL: 'global',
+} as const;
+
+export type TPublisher4Type = (typeof Publisher4Type)[keyof typeof Publisher4Type];
 ",
-  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey } from '@mikro-orm/core';
+  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 import { Publisher4 } from './Publisher4';
 import { Test4 } from './Test4';
@@ -3235,16 +3775,16 @@ export class Publisher4Tests extends BaseEntity {
   id!: number;
 
   @MikroORM_Index({ name: 'publisher4_tests_publisher4_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Publisher4, updateRule: 'cascade', deleteRule: 'cascade' })
-  publisher4!: Publisher4;
+  @MikroORM_ManyToOne({ entity: () => Publisher4, ref: true, updateRule: 'cascade', deleteRule: 'cascade' })
+  publisher4!: MikroORM_Ref<Publisher4>;
 
   @MikroORM_Index({ name: 'publisher4_tests_test4_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Test4, updateRule: 'cascade', deleteRule: 'cascade' })
-  test4!: Test4;
+  @MikroORM_ManyToOne({ entity: () => Test4, ref: true, updateRule: 'cascade', deleteRule: 'cascade' })
+  test4!: MikroORM_Ref<Test4>;
 
 }
 ",
-  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey } from '@mikro-orm/core';
+  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 import { Book4 } from './Book4';
 import { BookTag4 } from './BookTag4';
@@ -3256,17 +3796,18 @@ export class TagsOrdered extends BaseEntity {
   id!: number;
 
   @MikroORM_Index({ name: 'tags_ordered_book4_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Book4, updateRule: 'cascade', deleteRule: 'cascade' })
-  book4!: Book4;
+  @MikroORM_ManyToOne({ entity: () => Book4, ref: true, updateRule: 'cascade', deleteRule: 'cascade' })
+  book4!: MikroORM_Ref<Book4>;
 
   @MikroORM_Index({ name: 'tags_ordered_book_tag4_id_index' })
-  @MikroORM_ManyToOne({ entity: () => BookTag4, updateRule: 'cascade', deleteRule: 'cascade' })
-  bookTag4!: BookTag4;
+  @MikroORM_ManyToOne({ entity: () => BookTag4, ref: true, updateRule: 'cascade', deleteRule: 'cascade' })
+  bookTag4!: MikroORM_Ref<BookTag4>;
 
 }
 ",
-  "import { Entity as MikroORM_Entity, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, OneToMany as MikroORM_OneToMany, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
+import { Publisher4Tests } from './Publisher4Tests';
 
 @MikroORM_Entity()
 export class Test4 extends BaseEntity {
@@ -3285,6 +3826,9 @@ export class Test4 extends BaseEntity {
 
   @MikroORM_Property({ type: 'integer' })
   version: number & MikroORM_Opt = 1;
+
+  @MikroORM_OneToMany({ entity: () => Publisher4Tests, mappedBy: 'test4' })
+  publisher4TestsCollection = new MikroORM_Collection<Publisher4Tests>(this);
 
 }
 ",
@@ -3311,7 +3855,7 @@ export abstract class BaseEntity extends MikroORM_BaseEntity {
 
 exports[`CustomBase > forceObject=false > useCoreBaseEntity=true > customBaseEntityName=BaseEntity > entitySchema > dump 1`] = `
 [
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 import { Book4 } from './Book4';
 
@@ -3326,8 +3870,9 @@ export class Author4 extends BaseEntity {
   identities?: string;
   born?: string;
   bornTime?: string;
-  favouriteBook?: Book4;
+  favouriteBook?: MikroORM_Ref<Book4>;
   identity?: any;
+  book4Collection = new MikroORM_Collection<Book4>(this);
 }
 
 export const Author4Schema = new MikroORM_EntitySchema({
@@ -3346,16 +3891,20 @@ export const Author4Schema = new MikroORM_EntitySchema({
     favouriteBook: {
       kind: 'm:1',
       entity: () => Book4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
     },
     identity: { type: 'json', nullable: true },
+    book4Collection: { kind: '1:m', entity: () => Book4, mappedBy: 'author' },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
+import { Book4 } from './Book4';
+import { TagsOrdered } from './TagsOrdered';
 
 export class BookTag4 extends BaseEntity {
   id!: number;
@@ -3363,6 +3912,8 @@ export class BookTag4 extends BaseEntity {
   updatedAt?: Date;
   name!: string;
   version!: Date & MikroORM_Opt;
+  tagsUnorderedInverse = new MikroORM_Collection<Book4>(this);
+  tagsOrderedCollection = new MikroORM_Collection<TagsOrdered>(this);
 }
 
 export const BookTag4Schema = new MikroORM_EntitySchema({
@@ -3373,14 +3924,25 @@ export const BookTag4Schema = new MikroORM_EntitySchema({
     updatedAt: { type: 'datetime', nullable: true },
     name: { type: 'text' },
     version: { type: 'datetime', defaultRaw: \`current_timestamp\` },
+    tagsUnorderedInverse: {
+      kind: 'm:n',
+      entity: () => Book4,
+      mappedBy: 'tagsUnordered',
+    },
+    tagsOrderedCollection: {
+      kind: '1:m',
+      entity: () => TagsOrdered,
+      mappedBy: 'bookTag4',
+    },
   },
 });
 ",
-  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Author4 } from './Author4';
 import { BaseEntity } from './BaseEntity';
 import { BookTag4 } from './BookTag4';
 import { Publisher4 } from './Publisher4';
+import { TagsOrdered } from './TagsOrdered';
 
 export class Book4 extends BaseEntity {
   id!: number;
@@ -3388,10 +3950,12 @@ export class Book4 extends BaseEntity {
   updatedAt?: Date;
   title!: string;
   price?: unknown;
-  author?: Author4;
-  publisher?: Publisher4;
+  author?: MikroORM_Ref<Author4>;
+  publisher?: MikroORM_Ref<Publisher4>;
   meta?: any;
   tagsUnordered = new MikroORM_Collection<BookTag4>(this);
+  author4Collection = new MikroORM_Collection<Author4>(this);
+  tagsOrderedCollection = new MikroORM_Collection<TagsOrdered>(this);
 }
 
 export const Book4Schema = new MikroORM_EntitySchema({
@@ -3405,6 +3969,7 @@ export const Book4Schema = new MikroORM_EntitySchema({
     author: {
       kind: 'm:1',
       entity: () => Author4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
@@ -3412,6 +3977,7 @@ export const Book4Schema = new MikroORM_EntitySchema({
     publisher: {
       kind: 'm:1',
       entity: () => Publisher4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
@@ -3424,10 +3990,20 @@ export const Book4Schema = new MikroORM_EntitySchema({
       joinColumn: 'book4_id',
       inverseJoinColumn: 'book_tag4_id',
     },
+    author4Collection: {
+      kind: '1:m',
+      entity: () => Author4,
+      mappedBy: 'favouriteBook',
+    },
+    tagsOrderedCollection: {
+      kind: '1:m',
+      entity: () => TagsOrdered,
+      mappedBy: 'book4',
+    },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 import { FooBaz4 } from './FooBaz4';
 
@@ -3436,13 +4012,14 @@ export class FooBar4 extends BaseEntity {
   createdAt?: Date;
   updatedAt?: Date;
   name: string & MikroORM_Opt = 'asd';
-  baz?: FooBaz4;
-  fooBar?: FooBar4;
+  baz?: MikroORM_Ref<FooBaz4>;
+  fooBar?: MikroORM_Ref<FooBar4>;
   version: number & MikroORM_Opt = 1;
   blob?: Buffer;
   blob2?: Buffer;
   array?: string;
   object?: any;
+  fooBar4?: MikroORM_Ref<FooBar4>;
 }
 
 export const FooBar4Schema = new MikroORM_EntitySchema({
@@ -3455,6 +4032,7 @@ export const FooBar4Schema = new MikroORM_EntitySchema({
     baz: {
       kind: '1:1',
       entity: () => FooBaz4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
@@ -3462,6 +4040,7 @@ export const FooBar4Schema = new MikroORM_EntitySchema({
     fooBar: {
       kind: '1:1',
       entity: () => FooBar4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
@@ -3471,11 +4050,13 @@ export const FooBar4Schema = new MikroORM_EntitySchema({
     blob2: { type: 'blob', nullable: true },
     array: { type: 'text', nullable: true },
     object: { type: 'json', nullable: true },
+    fooBar4: { kind: '1:1', entity: () => FooBar4, ref: true, mappedBy: 'fooBar' },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
+import { FooBar4 } from './FooBar4';
 
 export class FooBaz4 extends BaseEntity {
   id!: number;
@@ -3483,6 +4064,7 @@ export class FooBaz4 extends BaseEntity {
   updatedAt?: Date;
   name!: string;
   version!: Date & MikroORM_Opt;
+  fooBar4?: MikroORM_Ref<FooBar4>;
 }
 
 export const FooBaz4Schema = new MikroORM_EntitySchema({
@@ -3493,25 +4075,32 @@ export const FooBaz4Schema = new MikroORM_EntitySchema({
     updatedAt: { type: 'datetime', nullable: true },
     name: { type: 'text' },
     version: { type: 'datetime', defaultRaw: \`current_timestamp\` },
+    fooBar4: { kind: '1:1', entity: () => FooBar4, ref: true, mappedBy: 'baz' },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
+import { Book4 } from './Book4';
+import { Publisher4Tests } from './Publisher4Tests';
 
 export class Publisher4 extends BaseEntity {
   id!: number;
   createdAt?: Date;
   updatedAt?: Date;
   name: string & MikroORM_Opt = 'asd';
-  type: Publisher4Type & MikroORM_Opt = Publisher4Type.LOCAL;
+  type: TPublisher4Type & MikroORM_Opt = Publisher4Type.LOCAL;
   enum3?: number;
+  book4Collection = new MikroORM_Collection<Book4>(this);
+  publisher4TestsCollection = new MikroORM_Collection<Publisher4Tests>(this);
 }
 
-export enum Publisher4Type {
-  LOCAL = 'local',
-  GLOBAL = 'global',
-}
+export const Publisher4Type = {
+  LOCAL: 'local',
+  GLOBAL: 'global',
+} as const;
+
+export type TPublisher4Type = (typeof Publisher4Type)[keyof typeof Publisher4Type];
 
 export const Publisher4Schema = new MikroORM_EntitySchema({
   class: Publisher4,
@@ -3522,18 +4111,24 @@ export const Publisher4Schema = new MikroORM_EntitySchema({
     name: { type: 'text' },
     type: { enum: true, items: () => Publisher4Type },
     enum3: { type: 'integer', nullable: true },
+    book4Collection: { kind: '1:m', entity: () => Book4, mappedBy: 'publisher' },
+    publisher4TestsCollection: {
+      kind: '1:m',
+      entity: () => Publisher4Tests,
+      mappedBy: 'publisher4',
+    },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema } from '@mikro-orm/core';
+  "import { EntitySchema as MikroORM_EntitySchema, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 import { Publisher4 } from './Publisher4';
 import { Test4 } from './Test4';
 
 export class Publisher4Tests extends BaseEntity {
   id!: number;
-  publisher4!: Publisher4;
-  test4!: Test4;
+  publisher4!: MikroORM_Ref<Publisher4>;
+  test4!: MikroORM_Ref<Test4>;
 }
 
 export const Publisher4TestsSchema = new MikroORM_EntitySchema({
@@ -3544,27 +4139,29 @@ export const Publisher4TestsSchema = new MikroORM_EntitySchema({
     publisher4: {
       kind: 'm:1',
       entity: () => Publisher4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
     test4: {
       kind: 'm:1',
       entity: () => Test4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema } from '@mikro-orm/core';
+  "import { EntitySchema as MikroORM_EntitySchema, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 import { Book4 } from './Book4';
 import { BookTag4 } from './BookTag4';
 
 export class TagsOrdered extends BaseEntity {
   id!: number;
-  book4!: Book4;
-  bookTag4!: BookTag4;
+  book4!: MikroORM_Ref<Book4>;
+  bookTag4!: MikroORM_Ref<BookTag4>;
 }
 
 export const TagsOrderedSchema = new MikroORM_EntitySchema({
@@ -3574,20 +4171,23 @@ export const TagsOrderedSchema = new MikroORM_EntitySchema({
     book4: {
       kind: 'm:1',
       entity: () => Book4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
     bookTag4: {
       kind: 'm:1',
       entity: () => BookTag4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
+import { Publisher4Tests } from './Publisher4Tests';
 
 export class Test4 extends BaseEntity {
   id!: number;
@@ -3595,6 +4195,7 @@ export class Test4 extends BaseEntity {
   updatedAt?: Date;
   name?: string;
   version: number & MikroORM_Opt = 1;
+  publisher4TestsCollection = new MikroORM_Collection<Publisher4Tests>(this);
 }
 
 export const Test4Schema = new MikroORM_EntitySchema({
@@ -3605,6 +4206,11 @@ export const Test4Schema = new MikroORM_EntitySchema({
     updatedAt: { type: 'datetime', nullable: true },
     name: { type: 'text', nullable: true },
     version: { type: 'integer' },
+    publisher4TestsCollection: {
+      kind: '1:m',
+      entity: () => Publisher4Tests,
+      mappedBy: 'test4',
+    },
   },
 });
 ",
@@ -3638,7 +4244,7 @@ export const BaseEntitySchema = new MikroORM_EntitySchema({
 
 exports[`CustomBase > forceObject=false > useCoreBaseEntity=true > customBaseEntityName=BaseEntity2 > decorators > dump 1`] = `
 [
-  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, OneToMany as MikroORM_OneToMany, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity2 } from './BaseEntity2';
 import { Book4 } from './Book4';
 
@@ -3676,16 +4282,21 @@ export class Author4 extends BaseEntity2 {
   bornTime?: string;
 
   @MikroORM_Index({ name: 'author4_favourite_book_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Book4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  favouriteBook?: Book4;
+  @MikroORM_ManyToOne({ entity: () => Book4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  favouriteBook?: MikroORM_Ref<Book4>;
 
   @MikroORM_Property({ type: 'json', nullable: true })
   identity?: any;
 
+  @MikroORM_OneToMany({ entity: () => Book4, mappedBy: 'author' })
+  book4Collection = new MikroORM_Collection<Book4>(this);
+
 }
 ",
-  "import { Entity as MikroORM_Entity, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, ManyToMany as MikroORM_ManyToMany, OneToMany as MikroORM_OneToMany, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
 import { BaseEntity2 } from './BaseEntity2';
+import { Book4 } from './Book4';
+import { TagsOrdered } from './TagsOrdered';
 
 @MikroORM_Entity()
 export class BookTag4 extends BaseEntity2 {
@@ -3705,13 +4316,20 @@ export class BookTag4 extends BaseEntity2 {
   @MikroORM_Property({ type: 'datetime', defaultRaw: \`current_timestamp\` })
   version!: Date & MikroORM_Opt;
 
+  @MikroORM_ManyToMany({ entity: () => Book4, mappedBy: 'tagsUnordered' })
+  tagsUnorderedInverse = new MikroORM_Collection<Book4>(this);
+
+  @MikroORM_OneToMany({ entity: () => TagsOrdered, mappedBy: 'bookTag4' })
+  tagsOrderedCollection = new MikroORM_Collection<TagsOrdered>(this);
+
 }
 ",
-  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToMany as MikroORM_ManyToMany, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToMany as MikroORM_ManyToMany, ManyToOne as MikroORM_ManyToOne, OneToMany as MikroORM_OneToMany, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Author4 } from './Author4';
 import { BaseEntity2 } from './BaseEntity2';
 import { BookTag4 } from './BookTag4';
 import { Publisher4 } from './Publisher4';
+import { TagsOrdered } from './TagsOrdered';
 
 @MikroORM_Entity()
 export class Book4 extends BaseEntity2 {
@@ -3732,12 +4350,12 @@ export class Book4 extends BaseEntity2 {
   price?: unknown;
 
   @MikroORM_Index({ name: 'book4_author_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Author4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  author?: Author4;
+  @MikroORM_ManyToOne({ entity: () => Author4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  author?: MikroORM_Ref<Author4>;
 
   @MikroORM_Index({ name: 'book4_publisher_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Publisher4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  publisher?: Publisher4;
+  @MikroORM_ManyToOne({ entity: () => Publisher4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  publisher?: MikroORM_Ref<Publisher4>;
 
   @MikroORM_Property({ type: 'json', nullable: true })
   meta?: any;
@@ -3745,9 +4363,15 @@ export class Book4 extends BaseEntity2 {
   @MikroORM_ManyToMany({ entity: () => BookTag4, pivotTable: 'tags_unordered', joinColumn: 'book4_id', inverseJoinColumn: 'book_tag4_id' })
   tagsUnordered = new MikroORM_Collection<BookTag4>(this);
 
+  @MikroORM_OneToMany({ entity: () => Author4, mappedBy: 'favouriteBook' })
+  author4Collection = new MikroORM_Collection<Author4>(this);
+
+  @MikroORM_OneToMany({ entity: () => TagsOrdered, mappedBy: 'book4' })
+  tagsOrderedCollection = new MikroORM_Collection<TagsOrdered>(this);
+
 }
 ",
-  "import { Entity as MikroORM_Entity, OneToOne as MikroORM_OneToOne, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, Unique as MikroORM_Unique } from '@mikro-orm/core';
+  "import { Entity as MikroORM_Entity, OneToOne as MikroORM_OneToOne, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, type Ref as MikroORM_Ref, Unique as MikroORM_Unique } from '@mikro-orm/core';
 import { BaseEntity2 } from './BaseEntity2';
 import { FooBaz4 } from './FooBaz4';
 
@@ -3767,12 +4391,12 @@ export class FooBar4 extends BaseEntity2 {
   name: string & MikroORM_Opt = 'asd';
 
   @MikroORM_Unique({ name: 'foo_bar4_baz_id_unique' })
-  @MikroORM_OneToOne({ entity: () => FooBaz4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  baz?: FooBaz4;
+  @MikroORM_OneToOne({ entity: () => FooBaz4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  baz?: MikroORM_Ref<FooBaz4>;
 
   @MikroORM_Unique({ name: 'foo_bar4_foo_bar_id_unique' })
-  @MikroORM_OneToOne({ entity: () => FooBar4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  fooBar?: FooBar4;
+  @MikroORM_OneToOne({ entity: () => FooBar4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  fooBar?: MikroORM_Ref<FooBar4>;
 
   @MikroORM_Property({ type: 'integer' })
   version: number & MikroORM_Opt = 1;
@@ -3789,10 +4413,14 @@ export class FooBar4 extends BaseEntity2 {
   @MikroORM_Property({ type: 'json', nullable: true })
   object?: any;
 
+  @MikroORM_OneToOne({ entity: () => FooBar4, ref: true, mappedBy: 'fooBar' })
+  fooBar4?: MikroORM_Ref<FooBar4>;
+
 }
 ",
-  "import { Entity as MikroORM_Entity, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Entity as MikroORM_Entity, OneToOne as MikroORM_OneToOne, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity2 } from './BaseEntity2';
+import { FooBar4 } from './FooBar4';
 
 @MikroORM_Entity()
 export class FooBaz4 extends BaseEntity2 {
@@ -3812,10 +4440,15 @@ export class FooBaz4 extends BaseEntity2 {
   @MikroORM_Property({ type: 'datetime', defaultRaw: \`current_timestamp\` })
   version!: Date & MikroORM_Opt;
 
+  @MikroORM_OneToOne({ entity: () => FooBar4, ref: true, mappedBy: 'baz' })
+  fooBar4?: MikroORM_Ref<FooBar4>;
+
 }
 ",
-  "import { Entity as MikroORM_Entity, Enum as MikroORM_Enum, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, Enum as MikroORM_Enum, OneToMany as MikroORM_OneToMany, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
 import { BaseEntity2 } from './BaseEntity2';
+import { Book4 } from './Book4';
+import { Publisher4Tests } from './Publisher4Tests';
 
 @MikroORM_Entity()
 export class Publisher4 extends BaseEntity2 {
@@ -3833,19 +4466,27 @@ export class Publisher4 extends BaseEntity2 {
   name: string & MikroORM_Opt = 'asd';
 
   @MikroORM_Enum({ items: () => Publisher4Type })
-  type: Publisher4Type & MikroORM_Opt = Publisher4Type.LOCAL;
+  type: TPublisher4Type & MikroORM_Opt = Publisher4Type.LOCAL;
 
   @MikroORM_Property({ nullable: true })
   enum3?: number;
 
+  @MikroORM_OneToMany({ entity: () => Book4, mappedBy: 'publisher' })
+  book4Collection = new MikroORM_Collection<Book4>(this);
+
+  @MikroORM_OneToMany({ entity: () => Publisher4Tests, mappedBy: 'publisher4' })
+  publisher4TestsCollection = new MikroORM_Collection<Publisher4Tests>(this);
+
 }
 
-export enum Publisher4Type {
-  LOCAL = 'local',
-  GLOBAL = 'global',
-}
+export const Publisher4Type = {
+  LOCAL: 'local',
+  GLOBAL: 'global',
+} as const;
+
+export type TPublisher4Type = (typeof Publisher4Type)[keyof typeof Publisher4Type];
 ",
-  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey } from '@mikro-orm/core';
+  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity2 } from './BaseEntity2';
 import { Publisher4 } from './Publisher4';
 import { Test4 } from './Test4';
@@ -3857,16 +4498,16 @@ export class Publisher4Tests extends BaseEntity2 {
   id!: number;
 
   @MikroORM_Index({ name: 'publisher4_tests_publisher4_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Publisher4, updateRule: 'cascade', deleteRule: 'cascade' })
-  publisher4!: Publisher4;
+  @MikroORM_ManyToOne({ entity: () => Publisher4, ref: true, updateRule: 'cascade', deleteRule: 'cascade' })
+  publisher4!: MikroORM_Ref<Publisher4>;
 
   @MikroORM_Index({ name: 'publisher4_tests_test4_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Test4, updateRule: 'cascade', deleteRule: 'cascade' })
-  test4!: Test4;
+  @MikroORM_ManyToOne({ entity: () => Test4, ref: true, updateRule: 'cascade', deleteRule: 'cascade' })
+  test4!: MikroORM_Ref<Test4>;
 
 }
 ",
-  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey } from '@mikro-orm/core';
+  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity2 } from './BaseEntity2';
 import { Book4 } from './Book4';
 import { BookTag4 } from './BookTag4';
@@ -3878,17 +4519,18 @@ export class TagsOrdered extends BaseEntity2 {
   id!: number;
 
   @MikroORM_Index({ name: 'tags_ordered_book4_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Book4, updateRule: 'cascade', deleteRule: 'cascade' })
-  book4!: Book4;
+  @MikroORM_ManyToOne({ entity: () => Book4, ref: true, updateRule: 'cascade', deleteRule: 'cascade' })
+  book4!: MikroORM_Ref<Book4>;
 
   @MikroORM_Index({ name: 'tags_ordered_book_tag4_id_index' })
-  @MikroORM_ManyToOne({ entity: () => BookTag4, updateRule: 'cascade', deleteRule: 'cascade' })
-  bookTag4!: BookTag4;
+  @MikroORM_ManyToOne({ entity: () => BookTag4, ref: true, updateRule: 'cascade', deleteRule: 'cascade' })
+  bookTag4!: MikroORM_Ref<BookTag4>;
 
 }
 ",
-  "import { Entity as MikroORM_Entity, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, OneToMany as MikroORM_OneToMany, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
 import { BaseEntity2 } from './BaseEntity2';
+import { Publisher4Tests } from './Publisher4Tests';
 
 @MikroORM_Entity()
 export class Test4 extends BaseEntity2 {
@@ -3907,6 +4549,9 @@ export class Test4 extends BaseEntity2 {
 
   @MikroORM_Property({ type: 'integer' })
   version: number & MikroORM_Opt = 1;
+
+  @MikroORM_OneToMany({ entity: () => Publisher4Tests, mappedBy: 'test4' })
+  publisher4TestsCollection = new MikroORM_Collection<Publisher4Tests>(this);
 
 }
 ",
@@ -3927,7 +4572,7 @@ export abstract class BaseEntity2 extends MikroORM_BaseEntity {
 
 exports[`CustomBase > forceObject=false > useCoreBaseEntity=true > customBaseEntityName=BaseEntity2 > entitySchema > dump 1`] = `
 [
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity2 } from './BaseEntity2';
 import { Book4 } from './Book4';
 
@@ -3942,8 +4587,9 @@ export class Author4 extends BaseEntity2 {
   identities?: string;
   born?: string;
   bornTime?: string;
-  favouriteBook?: Book4;
+  favouriteBook?: MikroORM_Ref<Book4>;
   identity?: any;
+  book4Collection = new MikroORM_Collection<Book4>(this);
 }
 
 export const Author4Schema = new MikroORM_EntitySchema({
@@ -3962,16 +4608,20 @@ export const Author4Schema = new MikroORM_EntitySchema({
     favouriteBook: {
       kind: 'm:1',
       entity: () => Book4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
     },
     identity: { type: 'json', nullable: true },
+    book4Collection: { kind: '1:m', entity: () => Book4, mappedBy: 'author' },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
 import { BaseEntity2 } from './BaseEntity2';
+import { Book4 } from './Book4';
+import { TagsOrdered } from './TagsOrdered';
 
 export class BookTag4 extends BaseEntity2 {
   id!: number;
@@ -3979,6 +4629,8 @@ export class BookTag4 extends BaseEntity2 {
   updatedAt?: Date;
   name!: string;
   version!: Date & MikroORM_Opt;
+  tagsUnorderedInverse = new MikroORM_Collection<Book4>(this);
+  tagsOrderedCollection = new MikroORM_Collection<TagsOrdered>(this);
 }
 
 export const BookTag4Schema = new MikroORM_EntitySchema({
@@ -3989,14 +4641,25 @@ export const BookTag4Schema = new MikroORM_EntitySchema({
     updatedAt: { type: 'datetime', nullable: true },
     name: { type: 'text' },
     version: { type: 'datetime', defaultRaw: \`current_timestamp\` },
+    tagsUnorderedInverse: {
+      kind: 'm:n',
+      entity: () => Book4,
+      mappedBy: 'tagsUnordered',
+    },
+    tagsOrderedCollection: {
+      kind: '1:m',
+      entity: () => TagsOrdered,
+      mappedBy: 'bookTag4',
+    },
   },
 });
 ",
-  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Author4 } from './Author4';
 import { BaseEntity2 } from './BaseEntity2';
 import { BookTag4 } from './BookTag4';
 import { Publisher4 } from './Publisher4';
+import { TagsOrdered } from './TagsOrdered';
 
 export class Book4 extends BaseEntity2 {
   id!: number;
@@ -4004,10 +4667,12 @@ export class Book4 extends BaseEntity2 {
   updatedAt?: Date;
   title!: string;
   price?: unknown;
-  author?: Author4;
-  publisher?: Publisher4;
+  author?: MikroORM_Ref<Author4>;
+  publisher?: MikroORM_Ref<Publisher4>;
   meta?: any;
   tagsUnordered = new MikroORM_Collection<BookTag4>(this);
+  author4Collection = new MikroORM_Collection<Author4>(this);
+  tagsOrderedCollection = new MikroORM_Collection<TagsOrdered>(this);
 }
 
 export const Book4Schema = new MikroORM_EntitySchema({
@@ -4021,6 +4686,7 @@ export const Book4Schema = new MikroORM_EntitySchema({
     author: {
       kind: 'm:1',
       entity: () => Author4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
@@ -4028,6 +4694,7 @@ export const Book4Schema = new MikroORM_EntitySchema({
     publisher: {
       kind: 'm:1',
       entity: () => Publisher4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
@@ -4040,10 +4707,20 @@ export const Book4Schema = new MikroORM_EntitySchema({
       joinColumn: 'book4_id',
       inverseJoinColumn: 'book_tag4_id',
     },
+    author4Collection: {
+      kind: '1:m',
+      entity: () => Author4,
+      mappedBy: 'favouriteBook',
+    },
+    tagsOrderedCollection: {
+      kind: '1:m',
+      entity: () => TagsOrdered,
+      mappedBy: 'book4',
+    },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity2 } from './BaseEntity2';
 import { FooBaz4 } from './FooBaz4';
 
@@ -4052,13 +4729,14 @@ export class FooBar4 extends BaseEntity2 {
   createdAt?: Date;
   updatedAt?: Date;
   name: string & MikroORM_Opt = 'asd';
-  baz?: FooBaz4;
-  fooBar?: FooBar4;
+  baz?: MikroORM_Ref<FooBaz4>;
+  fooBar?: MikroORM_Ref<FooBar4>;
   version: number & MikroORM_Opt = 1;
   blob?: Buffer;
   blob2?: Buffer;
   array?: string;
   object?: any;
+  fooBar4?: MikroORM_Ref<FooBar4>;
 }
 
 export const FooBar4Schema = new MikroORM_EntitySchema({
@@ -4071,6 +4749,7 @@ export const FooBar4Schema = new MikroORM_EntitySchema({
     baz: {
       kind: '1:1',
       entity: () => FooBaz4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
@@ -4078,6 +4757,7 @@ export const FooBar4Schema = new MikroORM_EntitySchema({
     fooBar: {
       kind: '1:1',
       entity: () => FooBar4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
@@ -4087,11 +4767,13 @@ export const FooBar4Schema = new MikroORM_EntitySchema({
     blob2: { type: 'blob', nullable: true },
     array: { type: 'text', nullable: true },
     object: { type: 'json', nullable: true },
+    fooBar4: { kind: '1:1', entity: () => FooBar4, ref: true, mappedBy: 'fooBar' },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity2 } from './BaseEntity2';
+import { FooBar4 } from './FooBar4';
 
 export class FooBaz4 extends BaseEntity2 {
   id!: number;
@@ -4099,6 +4781,7 @@ export class FooBaz4 extends BaseEntity2 {
   updatedAt?: Date;
   name!: string;
   version!: Date & MikroORM_Opt;
+  fooBar4?: MikroORM_Ref<FooBar4>;
 }
 
 export const FooBaz4Schema = new MikroORM_EntitySchema({
@@ -4109,25 +4792,32 @@ export const FooBaz4Schema = new MikroORM_EntitySchema({
     updatedAt: { type: 'datetime', nullable: true },
     name: { type: 'text' },
     version: { type: 'datetime', defaultRaw: \`current_timestamp\` },
+    fooBar4: { kind: '1:1', entity: () => FooBar4, ref: true, mappedBy: 'baz' },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
 import { BaseEntity2 } from './BaseEntity2';
+import { Book4 } from './Book4';
+import { Publisher4Tests } from './Publisher4Tests';
 
 export class Publisher4 extends BaseEntity2 {
   id!: number;
   createdAt?: Date;
   updatedAt?: Date;
   name: string & MikroORM_Opt = 'asd';
-  type: Publisher4Type & MikroORM_Opt = Publisher4Type.LOCAL;
+  type: TPublisher4Type & MikroORM_Opt = Publisher4Type.LOCAL;
   enum3?: number;
+  book4Collection = new MikroORM_Collection<Book4>(this);
+  publisher4TestsCollection = new MikroORM_Collection<Publisher4Tests>(this);
 }
 
-export enum Publisher4Type {
-  LOCAL = 'local',
-  GLOBAL = 'global',
-}
+export const Publisher4Type = {
+  LOCAL: 'local',
+  GLOBAL: 'global',
+} as const;
+
+export type TPublisher4Type = (typeof Publisher4Type)[keyof typeof Publisher4Type];
 
 export const Publisher4Schema = new MikroORM_EntitySchema({
   class: Publisher4,
@@ -4138,18 +4828,24 @@ export const Publisher4Schema = new MikroORM_EntitySchema({
     name: { type: 'text' },
     type: { enum: true, items: () => Publisher4Type },
     enum3: { type: 'integer', nullable: true },
+    book4Collection: { kind: '1:m', entity: () => Book4, mappedBy: 'publisher' },
+    publisher4TestsCollection: {
+      kind: '1:m',
+      entity: () => Publisher4Tests,
+      mappedBy: 'publisher4',
+    },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema } from '@mikro-orm/core';
+  "import { EntitySchema as MikroORM_EntitySchema, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity2 } from './BaseEntity2';
 import { Publisher4 } from './Publisher4';
 import { Test4 } from './Test4';
 
 export class Publisher4Tests extends BaseEntity2 {
   id!: number;
-  publisher4!: Publisher4;
-  test4!: Test4;
+  publisher4!: MikroORM_Ref<Publisher4>;
+  test4!: MikroORM_Ref<Test4>;
 }
 
 export const Publisher4TestsSchema = new MikroORM_EntitySchema({
@@ -4160,27 +4856,29 @@ export const Publisher4TestsSchema = new MikroORM_EntitySchema({
     publisher4: {
       kind: 'm:1',
       entity: () => Publisher4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
     test4: {
       kind: 'm:1',
       entity: () => Test4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema } from '@mikro-orm/core';
+  "import { EntitySchema as MikroORM_EntitySchema, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity2 } from './BaseEntity2';
 import { Book4 } from './Book4';
 import { BookTag4 } from './BookTag4';
 
 export class TagsOrdered extends BaseEntity2 {
   id!: number;
-  book4!: Book4;
-  bookTag4!: BookTag4;
+  book4!: MikroORM_Ref<Book4>;
+  bookTag4!: MikroORM_Ref<BookTag4>;
 }
 
 export const TagsOrderedSchema = new MikroORM_EntitySchema({
@@ -4190,20 +4888,23 @@ export const TagsOrderedSchema = new MikroORM_EntitySchema({
     book4: {
       kind: 'm:1',
       entity: () => Book4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
     bookTag4: {
       kind: 'm:1',
       entity: () => BookTag4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
 import { BaseEntity2 } from './BaseEntity2';
+import { Publisher4Tests } from './Publisher4Tests';
 
 export class Test4 extends BaseEntity2 {
   id!: number;
@@ -4211,6 +4912,7 @@ export class Test4 extends BaseEntity2 {
   updatedAt?: Date;
   name?: string;
   version: number & MikroORM_Opt = 1;
+  publisher4TestsCollection = new MikroORM_Collection<Publisher4Tests>(this);
 }
 
 export const Test4Schema = new MikroORM_EntitySchema({
@@ -4221,6 +4923,11 @@ export const Test4Schema = new MikroORM_EntitySchema({
     updatedAt: { type: 'datetime', nullable: true },
     name: { type: 'text', nullable: true },
     version: { type: 'integer' },
+    publisher4TestsCollection: {
+      kind: '1:m',
+      entity: () => Publisher4Tests,
+      mappedBy: 'test4',
+    },
   },
 });
 ",
@@ -4242,7 +4949,7 @@ export const BaseEntity2Schema = new MikroORM_EntitySchema({
 
 exports[`CustomBase > forceObject=false > useCoreBaseEntity=true > customBaseEntityName=CustomBase > decorators > dump 1`] = `
 [
-  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, OneToMany as MikroORM_OneToMany, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Book4 } from './Book4';
 import { CustomBase } from './CustomBase';
 
@@ -4280,16 +4987,21 @@ export class Author4 extends CustomBase {
   bornTime?: string;
 
   @MikroORM_Index({ name: 'author4_favourite_book_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Book4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  favouriteBook?: Book4;
+  @MikroORM_ManyToOne({ entity: () => Book4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  favouriteBook?: MikroORM_Ref<Book4>;
 
   @MikroORM_Property({ type: 'json', nullable: true })
   identity?: any;
 
+  @MikroORM_OneToMany({ entity: () => Book4, mappedBy: 'author' })
+  book4Collection = new MikroORM_Collection<Book4>(this);
+
 }
 ",
-  "import { Entity as MikroORM_Entity, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, ManyToMany as MikroORM_ManyToMany, OneToMany as MikroORM_OneToMany, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+import { Book4 } from './Book4';
 import { CustomBase } from './CustomBase';
+import { TagsOrdered } from './TagsOrdered';
 
 @MikroORM_Entity()
 export class BookTag4 extends CustomBase {
@@ -4309,13 +5021,20 @@ export class BookTag4 extends CustomBase {
   @MikroORM_Property({ type: 'datetime', defaultRaw: \`current_timestamp\` })
   version!: Date & MikroORM_Opt;
 
+  @MikroORM_ManyToMany({ entity: () => Book4, mappedBy: 'tagsUnordered' })
+  tagsUnorderedInverse = new MikroORM_Collection<Book4>(this);
+
+  @MikroORM_OneToMany({ entity: () => TagsOrdered, mappedBy: 'bookTag4' })
+  tagsOrderedCollection = new MikroORM_Collection<TagsOrdered>(this);
+
 }
 ",
-  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToMany as MikroORM_ManyToMany, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToMany as MikroORM_ManyToMany, ManyToOne as MikroORM_ManyToOne, OneToMany as MikroORM_OneToMany, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Author4 } from './Author4';
 import { BookTag4 } from './BookTag4';
 import { CustomBase } from './CustomBase';
 import { Publisher4 } from './Publisher4';
+import { TagsOrdered } from './TagsOrdered';
 
 @MikroORM_Entity()
 export class Book4 extends CustomBase {
@@ -4336,12 +5055,12 @@ export class Book4 extends CustomBase {
   price?: unknown;
 
   @MikroORM_Index({ name: 'book4_author_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Author4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  author?: Author4;
+  @MikroORM_ManyToOne({ entity: () => Author4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  author?: MikroORM_Ref<Author4>;
 
   @MikroORM_Index({ name: 'book4_publisher_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Publisher4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  publisher?: Publisher4;
+  @MikroORM_ManyToOne({ entity: () => Publisher4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  publisher?: MikroORM_Ref<Publisher4>;
 
   @MikroORM_Property({ type: 'json', nullable: true })
   meta?: any;
@@ -4349,9 +5068,15 @@ export class Book4 extends CustomBase {
   @MikroORM_ManyToMany({ entity: () => BookTag4, pivotTable: 'tags_unordered', joinColumn: 'book4_id', inverseJoinColumn: 'book_tag4_id' })
   tagsUnordered = new MikroORM_Collection<BookTag4>(this);
 
+  @MikroORM_OneToMany({ entity: () => Author4, mappedBy: 'favouriteBook' })
+  author4Collection = new MikroORM_Collection<Author4>(this);
+
+  @MikroORM_OneToMany({ entity: () => TagsOrdered, mappedBy: 'book4' })
+  tagsOrderedCollection = new MikroORM_Collection<TagsOrdered>(this);
+
 }
 ",
-  "import { Entity as MikroORM_Entity, OneToOne as MikroORM_OneToOne, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, Unique as MikroORM_Unique } from '@mikro-orm/core';
+  "import { Entity as MikroORM_Entity, OneToOne as MikroORM_OneToOne, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, type Ref as MikroORM_Ref, Unique as MikroORM_Unique } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
 import { FooBaz4 } from './FooBaz4';
 
@@ -4371,12 +5096,12 @@ export class FooBar4 extends CustomBase {
   name: string & MikroORM_Opt = 'asd';
 
   @MikroORM_Unique({ name: 'foo_bar4_baz_id_unique' })
-  @MikroORM_OneToOne({ entity: () => FooBaz4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  baz?: FooBaz4;
+  @MikroORM_OneToOne({ entity: () => FooBaz4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  baz?: MikroORM_Ref<FooBaz4>;
 
   @MikroORM_Unique({ name: 'foo_bar4_foo_bar_id_unique' })
-  @MikroORM_OneToOne({ entity: () => FooBar4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  fooBar?: FooBar4;
+  @MikroORM_OneToOne({ entity: () => FooBar4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  fooBar?: MikroORM_Ref<FooBar4>;
 
   @MikroORM_Property({ type: 'integer' })
   version: number & MikroORM_Opt = 1;
@@ -4393,10 +5118,14 @@ export class FooBar4 extends CustomBase {
   @MikroORM_Property({ type: 'json', nullable: true })
   object?: any;
 
+  @MikroORM_OneToOne({ entity: () => FooBar4, ref: true, mappedBy: 'fooBar' })
+  fooBar4?: MikroORM_Ref<FooBar4>;
+
 }
 ",
-  "import { Entity as MikroORM_Entity, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Entity as MikroORM_Entity, OneToOne as MikroORM_OneToOne, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
+import { FooBar4 } from './FooBar4';
 
 @MikroORM_Entity()
 export class FooBaz4 extends CustomBase {
@@ -4416,10 +5145,15 @@ export class FooBaz4 extends CustomBase {
   @MikroORM_Property({ type: 'datetime', defaultRaw: \`current_timestamp\` })
   version!: Date & MikroORM_Opt;
 
+  @MikroORM_OneToOne({ entity: () => FooBar4, ref: true, mappedBy: 'baz' })
+  fooBar4?: MikroORM_Ref<FooBar4>;
+
 }
 ",
-  "import { Entity as MikroORM_Entity, Enum as MikroORM_Enum, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, Enum as MikroORM_Enum, OneToMany as MikroORM_OneToMany, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+import { Book4 } from './Book4';
 import { CustomBase } from './CustomBase';
+import { Publisher4Tests } from './Publisher4Tests';
 
 @MikroORM_Entity()
 export class Publisher4 extends CustomBase {
@@ -4437,19 +5171,27 @@ export class Publisher4 extends CustomBase {
   name: string & MikroORM_Opt = 'asd';
 
   @MikroORM_Enum({ items: () => Publisher4Type })
-  type: Publisher4Type & MikroORM_Opt = Publisher4Type.LOCAL;
+  type: TPublisher4Type & MikroORM_Opt = Publisher4Type.LOCAL;
 
   @MikroORM_Property({ nullable: true })
   enum3?: number;
 
+  @MikroORM_OneToMany({ entity: () => Book4, mappedBy: 'publisher' })
+  book4Collection = new MikroORM_Collection<Book4>(this);
+
+  @MikroORM_OneToMany({ entity: () => Publisher4Tests, mappedBy: 'publisher4' })
+  publisher4TestsCollection = new MikroORM_Collection<Publisher4Tests>(this);
+
 }
 
-export enum Publisher4Type {
-  LOCAL = 'local',
-  GLOBAL = 'global',
-}
+export const Publisher4Type = {
+  LOCAL: 'local',
+  GLOBAL: 'global',
+} as const;
+
+export type TPublisher4Type = (typeof Publisher4Type)[keyof typeof Publisher4Type];
 ",
-  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey } from '@mikro-orm/core';
+  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
 import { Publisher4 } from './Publisher4';
 import { Test4 } from './Test4';
@@ -4461,16 +5203,16 @@ export class Publisher4Tests extends CustomBase {
   id!: number;
 
   @MikroORM_Index({ name: 'publisher4_tests_publisher4_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Publisher4, updateRule: 'cascade', deleteRule: 'cascade' })
-  publisher4!: Publisher4;
+  @MikroORM_ManyToOne({ entity: () => Publisher4, ref: true, updateRule: 'cascade', deleteRule: 'cascade' })
+  publisher4!: MikroORM_Ref<Publisher4>;
 
   @MikroORM_Index({ name: 'publisher4_tests_test4_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Test4, updateRule: 'cascade', deleteRule: 'cascade' })
-  test4!: Test4;
+  @MikroORM_ManyToOne({ entity: () => Test4, ref: true, updateRule: 'cascade', deleteRule: 'cascade' })
+  test4!: MikroORM_Ref<Test4>;
 
 }
 ",
-  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey } from '@mikro-orm/core';
+  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Book4 } from './Book4';
 import { BookTag4 } from './BookTag4';
 import { CustomBase } from './CustomBase';
@@ -4482,17 +5224,18 @@ export class TagsOrdered extends CustomBase {
   id!: number;
 
   @MikroORM_Index({ name: 'tags_ordered_book4_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Book4, updateRule: 'cascade', deleteRule: 'cascade' })
-  book4!: Book4;
+  @MikroORM_ManyToOne({ entity: () => Book4, ref: true, updateRule: 'cascade', deleteRule: 'cascade' })
+  book4!: MikroORM_Ref<Book4>;
 
   @MikroORM_Index({ name: 'tags_ordered_book_tag4_id_index' })
-  @MikroORM_ManyToOne({ entity: () => BookTag4, updateRule: 'cascade', deleteRule: 'cascade' })
-  bookTag4!: BookTag4;
+  @MikroORM_ManyToOne({ entity: () => BookTag4, ref: true, updateRule: 'cascade', deleteRule: 'cascade' })
+  bookTag4!: MikroORM_Ref<BookTag4>;
 
 }
 ",
-  "import { Entity as MikroORM_Entity, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, OneToMany as MikroORM_OneToMany, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
+import { Publisher4Tests } from './Publisher4Tests';
 
 @MikroORM_Entity()
 export class Test4 extends CustomBase {
@@ -4511,6 +5254,9 @@ export class Test4 extends CustomBase {
 
   @MikroORM_Property({ type: 'integer' })
   version: number & MikroORM_Opt = 1;
+
+  @MikroORM_OneToMany({ entity: () => Publisher4Tests, mappedBy: 'test4' })
+  publisher4TestsCollection = new MikroORM_Collection<Publisher4Tests>(this);
 
 }
 ",
@@ -4537,7 +5283,7 @@ export abstract class CustomBase extends MikroORM_BaseEntity {
 
 exports[`CustomBase > forceObject=false > useCoreBaseEntity=true > customBaseEntityName=CustomBase > entitySchema > dump 1`] = `
 [
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Book4 } from './Book4';
 import { CustomBase } from './CustomBase';
 
@@ -4552,8 +5298,9 @@ export class Author4 extends CustomBase {
   identities?: string;
   born?: string;
   bornTime?: string;
-  favouriteBook?: Book4;
+  favouriteBook?: MikroORM_Ref<Book4>;
   identity?: any;
+  book4Collection = new MikroORM_Collection<Book4>(this);
 }
 
 export const Author4Schema = new MikroORM_EntitySchema({
@@ -4572,16 +5319,20 @@ export const Author4Schema = new MikroORM_EntitySchema({
     favouriteBook: {
       kind: 'm:1',
       entity: () => Book4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
     },
     identity: { type: 'json', nullable: true },
+    book4Collection: { kind: '1:m', entity: () => Book4, mappedBy: 'author' },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+import { Book4 } from './Book4';
 import { CustomBase } from './CustomBase';
+import { TagsOrdered } from './TagsOrdered';
 
 export class BookTag4 extends CustomBase {
   id!: number;
@@ -4589,6 +5340,8 @@ export class BookTag4 extends CustomBase {
   updatedAt?: Date;
   name!: string;
   version!: Date & MikroORM_Opt;
+  tagsUnorderedInverse = new MikroORM_Collection<Book4>(this);
+  tagsOrderedCollection = new MikroORM_Collection<TagsOrdered>(this);
 }
 
 export const BookTag4Schema = new MikroORM_EntitySchema({
@@ -4599,14 +5352,25 @@ export const BookTag4Schema = new MikroORM_EntitySchema({
     updatedAt: { type: 'datetime', nullable: true },
     name: { type: 'text' },
     version: { type: 'datetime', defaultRaw: \`current_timestamp\` },
+    tagsUnorderedInverse: {
+      kind: 'm:n',
+      entity: () => Book4,
+      mappedBy: 'tagsUnordered',
+    },
+    tagsOrderedCollection: {
+      kind: '1:m',
+      entity: () => TagsOrdered,
+      mappedBy: 'bookTag4',
+    },
   },
 });
 ",
-  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Author4 } from './Author4';
 import { BookTag4 } from './BookTag4';
 import { CustomBase } from './CustomBase';
 import { Publisher4 } from './Publisher4';
+import { TagsOrdered } from './TagsOrdered';
 
 export class Book4 extends CustomBase {
   id!: number;
@@ -4614,10 +5378,12 @@ export class Book4 extends CustomBase {
   updatedAt?: Date;
   title!: string;
   price?: unknown;
-  author?: Author4;
-  publisher?: Publisher4;
+  author?: MikroORM_Ref<Author4>;
+  publisher?: MikroORM_Ref<Publisher4>;
   meta?: any;
   tagsUnordered = new MikroORM_Collection<BookTag4>(this);
+  author4Collection = new MikroORM_Collection<Author4>(this);
+  tagsOrderedCollection = new MikroORM_Collection<TagsOrdered>(this);
 }
 
 export const Book4Schema = new MikroORM_EntitySchema({
@@ -4631,6 +5397,7 @@ export const Book4Schema = new MikroORM_EntitySchema({
     author: {
       kind: 'm:1',
       entity: () => Author4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
@@ -4638,6 +5405,7 @@ export const Book4Schema = new MikroORM_EntitySchema({
     publisher: {
       kind: 'm:1',
       entity: () => Publisher4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
@@ -4650,10 +5418,20 @@ export const Book4Schema = new MikroORM_EntitySchema({
       joinColumn: 'book4_id',
       inverseJoinColumn: 'book_tag4_id',
     },
+    author4Collection: {
+      kind: '1:m',
+      entity: () => Author4,
+      mappedBy: 'favouriteBook',
+    },
+    tagsOrderedCollection: {
+      kind: '1:m',
+      entity: () => TagsOrdered,
+      mappedBy: 'book4',
+    },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
 import { FooBaz4 } from './FooBaz4';
 
@@ -4662,13 +5440,14 @@ export class FooBar4 extends CustomBase {
   createdAt?: Date;
   updatedAt?: Date;
   name: string & MikroORM_Opt = 'asd';
-  baz?: FooBaz4;
-  fooBar?: FooBar4;
+  baz?: MikroORM_Ref<FooBaz4>;
+  fooBar?: MikroORM_Ref<FooBar4>;
   version: number & MikroORM_Opt = 1;
   blob?: Buffer;
   blob2?: Buffer;
   array?: string;
   object?: any;
+  fooBar4?: MikroORM_Ref<FooBar4>;
 }
 
 export const FooBar4Schema = new MikroORM_EntitySchema({
@@ -4681,6 +5460,7 @@ export const FooBar4Schema = new MikroORM_EntitySchema({
     baz: {
       kind: '1:1',
       entity: () => FooBaz4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
@@ -4688,6 +5468,7 @@ export const FooBar4Schema = new MikroORM_EntitySchema({
     fooBar: {
       kind: '1:1',
       entity: () => FooBar4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
@@ -4697,11 +5478,13 @@ export const FooBar4Schema = new MikroORM_EntitySchema({
     blob2: { type: 'blob', nullable: true },
     array: { type: 'text', nullable: true },
     object: { type: 'json', nullable: true },
+    fooBar4: { kind: '1:1', entity: () => FooBar4, ref: true, mappedBy: 'fooBar' },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
+import { FooBar4 } from './FooBar4';
 
 export class FooBaz4 extends CustomBase {
   id!: number;
@@ -4709,6 +5492,7 @@ export class FooBaz4 extends CustomBase {
   updatedAt?: Date;
   name!: string;
   version!: Date & MikroORM_Opt;
+  fooBar4?: MikroORM_Ref<FooBar4>;
 }
 
 export const FooBaz4Schema = new MikroORM_EntitySchema({
@@ -4719,25 +5503,32 @@ export const FooBaz4Schema = new MikroORM_EntitySchema({
     updatedAt: { type: 'datetime', nullable: true },
     name: { type: 'text' },
     version: { type: 'datetime', defaultRaw: \`current_timestamp\` },
+    fooBar4: { kind: '1:1', entity: () => FooBar4, ref: true, mappedBy: 'baz' },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+import { Book4 } from './Book4';
 import { CustomBase } from './CustomBase';
+import { Publisher4Tests } from './Publisher4Tests';
 
 export class Publisher4 extends CustomBase {
   id!: number;
   createdAt?: Date;
   updatedAt?: Date;
   name: string & MikroORM_Opt = 'asd';
-  type: Publisher4Type & MikroORM_Opt = Publisher4Type.LOCAL;
+  type: TPublisher4Type & MikroORM_Opt = Publisher4Type.LOCAL;
   enum3?: number;
+  book4Collection = new MikroORM_Collection<Book4>(this);
+  publisher4TestsCollection = new MikroORM_Collection<Publisher4Tests>(this);
 }
 
-export enum Publisher4Type {
-  LOCAL = 'local',
-  GLOBAL = 'global',
-}
+export const Publisher4Type = {
+  LOCAL: 'local',
+  GLOBAL: 'global',
+} as const;
+
+export type TPublisher4Type = (typeof Publisher4Type)[keyof typeof Publisher4Type];
 
 export const Publisher4Schema = new MikroORM_EntitySchema({
   class: Publisher4,
@@ -4748,18 +5539,24 @@ export const Publisher4Schema = new MikroORM_EntitySchema({
     name: { type: 'text' },
     type: { enum: true, items: () => Publisher4Type },
     enum3: { type: 'integer', nullable: true },
+    book4Collection: { kind: '1:m', entity: () => Book4, mappedBy: 'publisher' },
+    publisher4TestsCollection: {
+      kind: '1:m',
+      entity: () => Publisher4Tests,
+      mappedBy: 'publisher4',
+    },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema } from '@mikro-orm/core';
+  "import { EntitySchema as MikroORM_EntitySchema, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
 import { Publisher4 } from './Publisher4';
 import { Test4 } from './Test4';
 
 export class Publisher4Tests extends CustomBase {
   id!: number;
-  publisher4!: Publisher4;
-  test4!: Test4;
+  publisher4!: MikroORM_Ref<Publisher4>;
+  test4!: MikroORM_Ref<Test4>;
 }
 
 export const Publisher4TestsSchema = new MikroORM_EntitySchema({
@@ -4770,27 +5567,29 @@ export const Publisher4TestsSchema = new MikroORM_EntitySchema({
     publisher4: {
       kind: 'm:1',
       entity: () => Publisher4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
     test4: {
       kind: 'm:1',
       entity: () => Test4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema } from '@mikro-orm/core';
+  "import { EntitySchema as MikroORM_EntitySchema, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Book4 } from './Book4';
 import { BookTag4 } from './BookTag4';
 import { CustomBase } from './CustomBase';
 
 export class TagsOrdered extends CustomBase {
   id!: number;
-  book4!: Book4;
-  bookTag4!: BookTag4;
+  book4!: MikroORM_Ref<Book4>;
+  bookTag4!: MikroORM_Ref<BookTag4>;
 }
 
 export const TagsOrderedSchema = new MikroORM_EntitySchema({
@@ -4800,20 +5599,23 @@ export const TagsOrderedSchema = new MikroORM_EntitySchema({
     book4: {
       kind: 'm:1',
       entity: () => Book4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
     bookTag4: {
       kind: 'm:1',
       entity: () => BookTag4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
+import { Publisher4Tests } from './Publisher4Tests';
 
 export class Test4 extends CustomBase {
   id!: number;
@@ -4821,6 +5623,7 @@ export class Test4 extends CustomBase {
   updatedAt?: Date;
   name?: string;
   version: number & MikroORM_Opt = 1;
+  publisher4TestsCollection = new MikroORM_Collection<Publisher4Tests>(this);
 }
 
 export const Test4Schema = new MikroORM_EntitySchema({
@@ -4831,6 +5634,11 @@ export const Test4Schema = new MikroORM_EntitySchema({
     updatedAt: { type: 'datetime', nullable: true },
     name: { type: 'text', nullable: true },
     version: { type: 'integer' },
+    publisher4TestsCollection: {
+      kind: '1:m',
+      entity: () => Publisher4Tests,
+      mappedBy: 'test4',
+    },
   },
 });
 ",
@@ -4864,7 +5672,7 @@ export const CustomBaseSchema = new MikroORM_EntitySchema({
 
 exports[`CustomBase > forceObject=true > useCoreBaseEntity=false > customBaseEntityName= > decorators > dump 1`] = `
 [
-  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, OneToMany as MikroORM_OneToMany, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Book4 } from './Book4';
 
 @MikroORM_Entity()
@@ -4901,15 +5709,20 @@ export class Author4 {
   bornTime?: string;
 
   @MikroORM_Index({ name: 'author4_favourite_book_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Book4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  favouriteBook?: Book4;
+  @MikroORM_ManyToOne({ entity: () => Book4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  favouriteBook?: MikroORM_Ref<Book4>;
 
   @MikroORM_Property({ type: 'json', nullable: true })
   identity?: any;
 
+  @MikroORM_OneToMany({ entity: () => Book4, mappedBy: 'author' })
+  book4Collection = new MikroORM_Collection<Book4>(this);
+
 }
 ",
-  "import { Entity as MikroORM_Entity, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, ManyToMany as MikroORM_ManyToMany, OneToMany as MikroORM_OneToMany, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+import { Book4 } from './Book4';
+import { TagsOrdered } from './TagsOrdered';
 
 @MikroORM_Entity()
 export class BookTag4 {
@@ -4929,12 +5742,19 @@ export class BookTag4 {
   @MikroORM_Property({ type: 'datetime', defaultRaw: \`current_timestamp\` })
   version!: Date & MikroORM_Opt;
 
+  @MikroORM_ManyToMany({ entity: () => Book4, mappedBy: 'tagsUnordered' })
+  tagsUnorderedInverse = new MikroORM_Collection<Book4>(this);
+
+  @MikroORM_OneToMany({ entity: () => TagsOrdered, mappedBy: 'bookTag4' })
+  tagsOrderedCollection = new MikroORM_Collection<TagsOrdered>(this);
+
 }
 ",
-  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToMany as MikroORM_ManyToMany, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToMany as MikroORM_ManyToMany, ManyToOne as MikroORM_ManyToOne, OneToMany as MikroORM_OneToMany, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Author4 } from './Author4';
 import { BookTag4 } from './BookTag4';
 import { Publisher4 } from './Publisher4';
+import { TagsOrdered } from './TagsOrdered';
 
 @MikroORM_Entity()
 export class Book4 {
@@ -4955,12 +5775,12 @@ export class Book4 {
   price?: unknown;
 
   @MikroORM_Index({ name: 'book4_author_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Author4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  author?: Author4;
+  @MikroORM_ManyToOne({ entity: () => Author4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  author?: MikroORM_Ref<Author4>;
 
   @MikroORM_Index({ name: 'book4_publisher_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Publisher4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  publisher?: Publisher4;
+  @MikroORM_ManyToOne({ entity: () => Publisher4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  publisher?: MikroORM_Ref<Publisher4>;
 
   @MikroORM_Property({ type: 'json', nullable: true })
   meta?: any;
@@ -4968,9 +5788,15 @@ export class Book4 {
   @MikroORM_ManyToMany({ entity: () => BookTag4, pivotTable: 'tags_unordered', joinColumn: 'book4_id', inverseJoinColumn: 'book_tag4_id' })
   tagsUnordered = new MikroORM_Collection<BookTag4>(this);
 
+  @MikroORM_OneToMany({ entity: () => Author4, mappedBy: 'favouriteBook' })
+  author4Collection = new MikroORM_Collection<Author4>(this);
+
+  @MikroORM_OneToMany({ entity: () => TagsOrdered, mappedBy: 'book4' })
+  tagsOrderedCollection = new MikroORM_Collection<TagsOrdered>(this);
+
 }
 ",
-  "import { Entity as MikroORM_Entity, OneToOne as MikroORM_OneToOne, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, Unique as MikroORM_Unique } from '@mikro-orm/core';
+  "import { Entity as MikroORM_Entity, OneToOne as MikroORM_OneToOne, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, type Ref as MikroORM_Ref, Unique as MikroORM_Unique } from '@mikro-orm/core';
 import { FooBaz4 } from './FooBaz4';
 
 @MikroORM_Entity()
@@ -4989,12 +5815,12 @@ export class FooBar4 {
   name: string & MikroORM_Opt = 'asd';
 
   @MikroORM_Unique({ name: 'foo_bar4_baz_id_unique' })
-  @MikroORM_OneToOne({ entity: () => FooBaz4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  baz?: FooBaz4;
+  @MikroORM_OneToOne({ entity: () => FooBaz4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  baz?: MikroORM_Ref<FooBaz4>;
 
   @MikroORM_Unique({ name: 'foo_bar4_foo_bar_id_unique' })
-  @MikroORM_OneToOne({ entity: () => FooBar4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  fooBar?: FooBar4;
+  @MikroORM_OneToOne({ entity: () => FooBar4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  fooBar?: MikroORM_Ref<FooBar4>;
 
   @MikroORM_Property({ type: 'integer' })
   version: number & MikroORM_Opt = 1;
@@ -5011,9 +5837,13 @@ export class FooBar4 {
   @MikroORM_Property({ type: 'json', nullable: true })
   object?: any;
 
+  @MikroORM_OneToOne({ entity: () => FooBar4, ref: true, mappedBy: 'fooBar' })
+  fooBar4?: MikroORM_Ref<FooBar4>;
+
 }
 ",
-  "import { Entity as MikroORM_Entity, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Entity as MikroORM_Entity, OneToOne as MikroORM_OneToOne, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, type Ref as MikroORM_Ref } from '@mikro-orm/core';
+import { FooBar4 } from './FooBar4';
 
 @MikroORM_Entity()
 export class FooBaz4 {
@@ -5033,9 +5863,14 @@ export class FooBaz4 {
   @MikroORM_Property({ type: 'datetime', defaultRaw: \`current_timestamp\` })
   version!: Date & MikroORM_Opt;
 
+  @MikroORM_OneToOne({ entity: () => FooBar4, ref: true, mappedBy: 'baz' })
+  fooBar4?: MikroORM_Ref<FooBar4>;
+
 }
 ",
-  "import { Entity as MikroORM_Entity, Enum as MikroORM_Enum, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, Enum as MikroORM_Enum, OneToMany as MikroORM_OneToMany, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+import { Book4 } from './Book4';
+import { Publisher4Tests } from './Publisher4Tests';
 
 @MikroORM_Entity()
 export class Publisher4 {
@@ -5053,19 +5888,27 @@ export class Publisher4 {
   name: string & MikroORM_Opt = 'asd';
 
   @MikroORM_Enum({ items: () => Publisher4Type })
-  type: Publisher4Type & MikroORM_Opt = Publisher4Type.LOCAL;
+  type: TPublisher4Type & MikroORM_Opt = Publisher4Type.LOCAL;
 
   @MikroORM_Property({ nullable: true })
   enum3?: number;
 
+  @MikroORM_OneToMany({ entity: () => Book4, mappedBy: 'publisher' })
+  book4Collection = new MikroORM_Collection<Book4>(this);
+
+  @MikroORM_OneToMany({ entity: () => Publisher4Tests, mappedBy: 'publisher4' })
+  publisher4TestsCollection = new MikroORM_Collection<Publisher4Tests>(this);
+
 }
 
-export enum Publisher4Type {
-  LOCAL = 'local',
-  GLOBAL = 'global',
-}
+export const Publisher4Type = {
+  LOCAL: 'local',
+  GLOBAL: 'global',
+} as const;
+
+export type TPublisher4Type = (typeof Publisher4Type)[keyof typeof Publisher4Type];
 ",
-  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey } from '@mikro-orm/core';
+  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Publisher4 } from './Publisher4';
 import { Test4 } from './Test4';
 
@@ -5076,16 +5919,16 @@ export class Publisher4Tests {
   id!: number;
 
   @MikroORM_Index({ name: 'publisher4_tests_publisher4_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Publisher4, updateRule: 'cascade', deleteRule: 'cascade' })
-  publisher4!: Publisher4;
+  @MikroORM_ManyToOne({ entity: () => Publisher4, ref: true, updateRule: 'cascade', deleteRule: 'cascade' })
+  publisher4!: MikroORM_Ref<Publisher4>;
 
   @MikroORM_Index({ name: 'publisher4_tests_test4_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Test4, updateRule: 'cascade', deleteRule: 'cascade' })
-  test4!: Test4;
+  @MikroORM_ManyToOne({ entity: () => Test4, ref: true, updateRule: 'cascade', deleteRule: 'cascade' })
+  test4!: MikroORM_Ref<Test4>;
 
 }
 ",
-  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey } from '@mikro-orm/core';
+  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Book4 } from './Book4';
 import { BookTag4 } from './BookTag4';
 
@@ -5096,16 +5939,17 @@ export class TagsOrdered {
   id!: number;
 
   @MikroORM_Index({ name: 'tags_ordered_book4_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Book4, updateRule: 'cascade', deleteRule: 'cascade' })
-  book4!: Book4;
+  @MikroORM_ManyToOne({ entity: () => Book4, ref: true, updateRule: 'cascade', deleteRule: 'cascade' })
+  book4!: MikroORM_Ref<Book4>;
 
   @MikroORM_Index({ name: 'tags_ordered_book_tag4_id_index' })
-  @MikroORM_ManyToOne({ entity: () => BookTag4, updateRule: 'cascade', deleteRule: 'cascade' })
-  bookTag4!: BookTag4;
+  @MikroORM_ManyToOne({ entity: () => BookTag4, ref: true, updateRule: 'cascade', deleteRule: 'cascade' })
+  bookTag4!: MikroORM_Ref<BookTag4>;
 
 }
 ",
-  "import { Entity as MikroORM_Entity, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, OneToMany as MikroORM_OneToMany, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+import { Publisher4Tests } from './Publisher4Tests';
 
 @MikroORM_Entity()
 export class Test4 {
@@ -5125,6 +5969,9 @@ export class Test4 {
   @MikroORM_Property({ type: 'integer' })
   version: number & MikroORM_Opt = 1;
 
+  @MikroORM_OneToMany({ entity: () => Publisher4Tests, mappedBy: 'test4' })
+  publisher4TestsCollection = new MikroORM_Collection<Publisher4Tests>(this);
+
 }
 ",
   "import { Formula as MikroORM_Formula } from '@mikro-orm/core';
@@ -5141,7 +5988,7 @@ export abstract class BaseEntity2 {
 
 exports[`CustomBase > forceObject=true > useCoreBaseEntity=false > customBaseEntityName= > entitySchema > dump 1`] = `
 [
-  "import { Config as MikroORM_Config, type DefineConfig as MikroORM_DefineConfig, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Config as MikroORM_Config, type DefineConfig as MikroORM_DefineConfig, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Book4 } from './Book4';
 
 export class Author4 {
@@ -5156,8 +6003,9 @@ export class Author4 {
   identities?: string;
   born?: string;
   bornTime?: string;
-  favouriteBook?: Book4;
+  favouriteBook?: MikroORM_Ref<Book4>;
   identity?: any;
+  book4Collection = new MikroORM_Collection<Book4>(this);
 }
 
 export const Author4Schema = new MikroORM_EntitySchema({
@@ -5176,15 +6024,19 @@ export const Author4Schema = new MikroORM_EntitySchema({
     favouriteBook: {
       kind: 'm:1',
       entity: () => Book4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
     },
     identity: { type: 'json', nullable: true },
+    book4Collection: { kind: '1:m', entity: () => Book4, mappedBy: 'author' },
   },
 });
 ",
-  "import { Config as MikroORM_Config, type DefineConfig as MikroORM_DefineConfig, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Config as MikroORM_Config, type DefineConfig as MikroORM_DefineConfig, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+import { Book4 } from './Book4';
+import { TagsOrdered } from './TagsOrdered';
 
 export class BookTag4 {
   [MikroORM_Config]?: MikroORM_DefineConfig<{ forceObject: true }>;
@@ -5193,6 +6045,8 @@ export class BookTag4 {
   updatedAt?: Date;
   name!: string;
   version!: Date & MikroORM_Opt;
+  tagsUnorderedInverse = new MikroORM_Collection<Book4>(this);
+  tagsOrderedCollection = new MikroORM_Collection<TagsOrdered>(this);
 }
 
 export const BookTag4Schema = new MikroORM_EntitySchema({
@@ -5203,13 +6057,24 @@ export const BookTag4Schema = new MikroORM_EntitySchema({
     updatedAt: { type: 'datetime', nullable: true },
     name: { type: 'text' },
     version: { type: 'datetime', defaultRaw: \`current_timestamp\` },
+    tagsUnorderedInverse: {
+      kind: 'm:n',
+      entity: () => Book4,
+      mappedBy: 'tagsUnordered',
+    },
+    tagsOrderedCollection: {
+      kind: '1:m',
+      entity: () => TagsOrdered,
+      mappedBy: 'bookTag4',
+    },
   },
 });
 ",
-  "import { Collection as MikroORM_Collection, Config as MikroORM_Config, type DefineConfig as MikroORM_DefineConfig, EntitySchema as MikroORM_EntitySchema } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Config as MikroORM_Config, type DefineConfig as MikroORM_DefineConfig, EntitySchema as MikroORM_EntitySchema, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Author4 } from './Author4';
 import { BookTag4 } from './BookTag4';
 import { Publisher4 } from './Publisher4';
+import { TagsOrdered } from './TagsOrdered';
 
 export class Book4 {
   [MikroORM_Config]?: MikroORM_DefineConfig<{ forceObject: true }>;
@@ -5218,10 +6083,12 @@ export class Book4 {
   updatedAt?: Date;
   title!: string;
   price?: unknown;
-  author?: Author4;
-  publisher?: Publisher4;
+  author?: MikroORM_Ref<Author4>;
+  publisher?: MikroORM_Ref<Publisher4>;
   meta?: any;
   tagsUnordered = new MikroORM_Collection<BookTag4>(this);
+  author4Collection = new MikroORM_Collection<Author4>(this);
+  tagsOrderedCollection = new MikroORM_Collection<TagsOrdered>(this);
 }
 
 export const Book4Schema = new MikroORM_EntitySchema({
@@ -5235,6 +6102,7 @@ export const Book4Schema = new MikroORM_EntitySchema({
     author: {
       kind: 'm:1',
       entity: () => Author4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
@@ -5242,6 +6110,7 @@ export const Book4Schema = new MikroORM_EntitySchema({
     publisher: {
       kind: 'm:1',
       entity: () => Publisher4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
@@ -5254,10 +6123,20 @@ export const Book4Schema = new MikroORM_EntitySchema({
       joinColumn: 'book4_id',
       inverseJoinColumn: 'book_tag4_id',
     },
+    author4Collection: {
+      kind: '1:m',
+      entity: () => Author4,
+      mappedBy: 'favouriteBook',
+    },
+    tagsOrderedCollection: {
+      kind: '1:m',
+      entity: () => TagsOrdered,
+      mappedBy: 'book4',
+    },
   },
 });
 ",
-  "import { Config as MikroORM_Config, type DefineConfig as MikroORM_DefineConfig, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { Config as MikroORM_Config, type DefineConfig as MikroORM_DefineConfig, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { FooBaz4 } from './FooBaz4';
 
 export class FooBar4 {
@@ -5266,13 +6145,14 @@ export class FooBar4 {
   createdAt?: Date;
   updatedAt?: Date;
   name: string & MikroORM_Opt = 'asd';
-  baz?: FooBaz4;
-  fooBar?: FooBar4;
+  baz?: MikroORM_Ref<FooBaz4>;
+  fooBar?: MikroORM_Ref<FooBar4>;
   version: number & MikroORM_Opt = 1;
   blob?: Buffer;
   blob2?: Buffer;
   array?: string;
   object?: any;
+  fooBar4?: MikroORM_Ref<FooBar4>;
 }
 
 export const FooBar4Schema = new MikroORM_EntitySchema({
@@ -5285,6 +6165,7 @@ export const FooBar4Schema = new MikroORM_EntitySchema({
     baz: {
       kind: '1:1',
       entity: () => FooBaz4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
@@ -5292,6 +6173,7 @@ export const FooBar4Schema = new MikroORM_EntitySchema({
     fooBar: {
       kind: '1:1',
       entity: () => FooBar4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
@@ -5301,10 +6183,12 @@ export const FooBar4Schema = new MikroORM_EntitySchema({
     blob2: { type: 'blob', nullable: true },
     array: { type: 'text', nullable: true },
     object: { type: 'json', nullable: true },
+    fooBar4: { kind: '1:1', entity: () => FooBar4, ref: true, mappedBy: 'fooBar' },
   },
 });
 ",
-  "import { Config as MikroORM_Config, type DefineConfig as MikroORM_DefineConfig, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { Config as MikroORM_Config, type DefineConfig as MikroORM_DefineConfig, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt, type Ref as MikroORM_Ref } from '@mikro-orm/core';
+import { FooBar4 } from './FooBar4';
 
 export class FooBaz4 {
   [MikroORM_Config]?: MikroORM_DefineConfig<{ forceObject: true }>;
@@ -5313,6 +6197,7 @@ export class FooBaz4 {
   updatedAt?: Date;
   name!: string;
   version!: Date & MikroORM_Opt;
+  fooBar4?: MikroORM_Ref<FooBar4>;
 }
 
 export const FooBaz4Schema = new MikroORM_EntitySchema({
@@ -5323,10 +6208,13 @@ export const FooBaz4Schema = new MikroORM_EntitySchema({
     updatedAt: { type: 'datetime', nullable: true },
     name: { type: 'text' },
     version: { type: 'datetime', defaultRaw: \`current_timestamp\` },
+    fooBar4: { kind: '1:1', entity: () => FooBar4, ref: true, mappedBy: 'baz' },
   },
 });
 ",
-  "import { Config as MikroORM_Config, type DefineConfig as MikroORM_DefineConfig, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Config as MikroORM_Config, type DefineConfig as MikroORM_DefineConfig, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+import { Book4 } from './Book4';
+import { Publisher4Tests } from './Publisher4Tests';
 
 export class Publisher4 {
   [MikroORM_Config]?: MikroORM_DefineConfig<{ forceObject: true }>;
@@ -5334,14 +6222,18 @@ export class Publisher4 {
   createdAt?: Date;
   updatedAt?: Date;
   name: string & MikroORM_Opt = 'asd';
-  type: Publisher4Type & MikroORM_Opt = Publisher4Type.LOCAL;
+  type: TPublisher4Type & MikroORM_Opt = Publisher4Type.LOCAL;
   enum3?: number;
+  book4Collection = new MikroORM_Collection<Book4>(this);
+  publisher4TestsCollection = new MikroORM_Collection<Publisher4Tests>(this);
 }
 
-export enum Publisher4Type {
-  LOCAL = 'local',
-  GLOBAL = 'global',
-}
+export const Publisher4Type = {
+  LOCAL: 'local',
+  GLOBAL: 'global',
+} as const;
+
+export type TPublisher4Type = (typeof Publisher4Type)[keyof typeof Publisher4Type];
 
 export const Publisher4Schema = new MikroORM_EntitySchema({
   class: Publisher4,
@@ -5352,18 +6244,24 @@ export const Publisher4Schema = new MikroORM_EntitySchema({
     name: { type: 'text' },
     type: { enum: true, items: () => Publisher4Type },
     enum3: { type: 'integer', nullable: true },
+    book4Collection: { kind: '1:m', entity: () => Book4, mappedBy: 'publisher' },
+    publisher4TestsCollection: {
+      kind: '1:m',
+      entity: () => Publisher4Tests,
+      mappedBy: 'publisher4',
+    },
   },
 });
 ",
-  "import { Config as MikroORM_Config, type DefineConfig as MikroORM_DefineConfig, EntitySchema as MikroORM_EntitySchema } from '@mikro-orm/core';
+  "import { Config as MikroORM_Config, type DefineConfig as MikroORM_DefineConfig, EntitySchema as MikroORM_EntitySchema, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Publisher4 } from './Publisher4';
 import { Test4 } from './Test4';
 
 export class Publisher4Tests {
   [MikroORM_Config]?: MikroORM_DefineConfig<{ forceObject: true }>;
   id!: number;
-  publisher4!: Publisher4;
-  test4!: Test4;
+  publisher4!: MikroORM_Ref<Publisher4>;
+  test4!: MikroORM_Ref<Test4>;
 }
 
 export const Publisher4TestsSchema = new MikroORM_EntitySchema({
@@ -5374,27 +6272,29 @@ export const Publisher4TestsSchema = new MikroORM_EntitySchema({
     publisher4: {
       kind: 'm:1',
       entity: () => Publisher4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
     test4: {
       kind: 'm:1',
       entity: () => Test4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
   },
 });
 ",
-  "import { Config as MikroORM_Config, type DefineConfig as MikroORM_DefineConfig, EntitySchema as MikroORM_EntitySchema } from '@mikro-orm/core';
+  "import { Config as MikroORM_Config, type DefineConfig as MikroORM_DefineConfig, EntitySchema as MikroORM_EntitySchema, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Book4 } from './Book4';
 import { BookTag4 } from './BookTag4';
 
 export class TagsOrdered {
   [MikroORM_Config]?: MikroORM_DefineConfig<{ forceObject: true }>;
   id!: number;
-  book4!: Book4;
-  bookTag4!: BookTag4;
+  book4!: MikroORM_Ref<Book4>;
+  bookTag4!: MikroORM_Ref<BookTag4>;
 }
 
 export const TagsOrderedSchema = new MikroORM_EntitySchema({
@@ -5404,19 +6304,22 @@ export const TagsOrderedSchema = new MikroORM_EntitySchema({
     book4: {
       kind: 'm:1',
       entity: () => Book4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
     bookTag4: {
       kind: 'm:1',
       entity: () => BookTag4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
   },
 });
 ",
-  "import { Config as MikroORM_Config, type DefineConfig as MikroORM_DefineConfig, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Config as MikroORM_Config, type DefineConfig as MikroORM_DefineConfig, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+import { Publisher4Tests } from './Publisher4Tests';
 
 export class Test4 {
   [MikroORM_Config]?: MikroORM_DefineConfig<{ forceObject: true }>;
@@ -5425,6 +6328,7 @@ export class Test4 {
   updatedAt?: Date;
   name?: string;
   version: number & MikroORM_Opt = 1;
+  publisher4TestsCollection = new MikroORM_Collection<Publisher4Tests>(this);
 }
 
 export const Test4Schema = new MikroORM_EntitySchema({
@@ -5435,6 +6339,11 @@ export const Test4Schema = new MikroORM_EntitySchema({
     updatedAt: { type: 'datetime', nullable: true },
     name: { type: 'text', nullable: true },
     version: { type: 'integer' },
+    publisher4TestsCollection: {
+      kind: '1:m',
+      entity: () => Publisher4Tests,
+      mappedBy: 'test4',
+    },
   },
 });
 ",
@@ -5457,7 +6366,7 @@ export const BaseEntity2Schema = new MikroORM_EntitySchema({
 
 exports[`CustomBase > forceObject=true > useCoreBaseEntity=false > customBaseEntityName=BaseEntity > decorators > dump 1`] = `
 [
-  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, OneToMany as MikroORM_OneToMany, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 import { Book4 } from './Book4';
 
@@ -5495,16 +6404,21 @@ export class Author4 extends BaseEntity {
   bornTime?: string;
 
   @MikroORM_Index({ name: 'author4_favourite_book_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Book4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  favouriteBook?: Book4;
+  @MikroORM_ManyToOne({ entity: () => Book4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  favouriteBook?: MikroORM_Ref<Book4>;
 
   @MikroORM_Property({ type: 'json', nullable: true })
   identity?: any;
 
+  @MikroORM_OneToMany({ entity: () => Book4, mappedBy: 'author' })
+  book4Collection = new MikroORM_Collection<Book4>(this);
+
 }
 ",
-  "import { Entity as MikroORM_Entity, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, ManyToMany as MikroORM_ManyToMany, OneToMany as MikroORM_OneToMany, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
+import { Book4 } from './Book4';
+import { TagsOrdered } from './TagsOrdered';
 
 @MikroORM_Entity()
 export class BookTag4 extends BaseEntity {
@@ -5524,13 +6438,20 @@ export class BookTag4 extends BaseEntity {
   @MikroORM_Property({ type: 'datetime', defaultRaw: \`current_timestamp\` })
   version!: Date & MikroORM_Opt;
 
+  @MikroORM_ManyToMany({ entity: () => Book4, mappedBy: 'tagsUnordered' })
+  tagsUnorderedInverse = new MikroORM_Collection<Book4>(this);
+
+  @MikroORM_OneToMany({ entity: () => TagsOrdered, mappedBy: 'bookTag4' })
+  tagsOrderedCollection = new MikroORM_Collection<TagsOrdered>(this);
+
 }
 ",
-  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToMany as MikroORM_ManyToMany, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToMany as MikroORM_ManyToMany, ManyToOne as MikroORM_ManyToOne, OneToMany as MikroORM_OneToMany, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Author4 } from './Author4';
 import { BaseEntity } from './BaseEntity';
 import { BookTag4 } from './BookTag4';
 import { Publisher4 } from './Publisher4';
+import { TagsOrdered } from './TagsOrdered';
 
 @MikroORM_Entity()
 export class Book4 extends BaseEntity {
@@ -5551,12 +6472,12 @@ export class Book4 extends BaseEntity {
   price?: unknown;
 
   @MikroORM_Index({ name: 'book4_author_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Author4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  author?: Author4;
+  @MikroORM_ManyToOne({ entity: () => Author4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  author?: MikroORM_Ref<Author4>;
 
   @MikroORM_Index({ name: 'book4_publisher_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Publisher4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  publisher?: Publisher4;
+  @MikroORM_ManyToOne({ entity: () => Publisher4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  publisher?: MikroORM_Ref<Publisher4>;
 
   @MikroORM_Property({ type: 'json', nullable: true })
   meta?: any;
@@ -5564,9 +6485,15 @@ export class Book4 extends BaseEntity {
   @MikroORM_ManyToMany({ entity: () => BookTag4, pivotTable: 'tags_unordered', joinColumn: 'book4_id', inverseJoinColumn: 'book_tag4_id' })
   tagsUnordered = new MikroORM_Collection<BookTag4>(this);
 
+  @MikroORM_OneToMany({ entity: () => Author4, mappedBy: 'favouriteBook' })
+  author4Collection = new MikroORM_Collection<Author4>(this);
+
+  @MikroORM_OneToMany({ entity: () => TagsOrdered, mappedBy: 'book4' })
+  tagsOrderedCollection = new MikroORM_Collection<TagsOrdered>(this);
+
 }
 ",
-  "import { Entity as MikroORM_Entity, OneToOne as MikroORM_OneToOne, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, Unique as MikroORM_Unique } from '@mikro-orm/core';
+  "import { Entity as MikroORM_Entity, OneToOne as MikroORM_OneToOne, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, type Ref as MikroORM_Ref, Unique as MikroORM_Unique } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 import { FooBaz4 } from './FooBaz4';
 
@@ -5586,12 +6513,12 @@ export class FooBar4 extends BaseEntity {
   name: string & MikroORM_Opt = 'asd';
 
   @MikroORM_Unique({ name: 'foo_bar4_baz_id_unique' })
-  @MikroORM_OneToOne({ entity: () => FooBaz4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  baz?: FooBaz4;
+  @MikroORM_OneToOne({ entity: () => FooBaz4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  baz?: MikroORM_Ref<FooBaz4>;
 
   @MikroORM_Unique({ name: 'foo_bar4_foo_bar_id_unique' })
-  @MikroORM_OneToOne({ entity: () => FooBar4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  fooBar?: FooBar4;
+  @MikroORM_OneToOne({ entity: () => FooBar4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  fooBar?: MikroORM_Ref<FooBar4>;
 
   @MikroORM_Property({ type: 'integer' })
   version: number & MikroORM_Opt = 1;
@@ -5608,10 +6535,14 @@ export class FooBar4 extends BaseEntity {
   @MikroORM_Property({ type: 'json', nullable: true })
   object?: any;
 
+  @MikroORM_OneToOne({ entity: () => FooBar4, ref: true, mappedBy: 'fooBar' })
+  fooBar4?: MikroORM_Ref<FooBar4>;
+
 }
 ",
-  "import { Entity as MikroORM_Entity, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Entity as MikroORM_Entity, OneToOne as MikroORM_OneToOne, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
+import { FooBar4 } from './FooBar4';
 
 @MikroORM_Entity()
 export class FooBaz4 extends BaseEntity {
@@ -5631,10 +6562,15 @@ export class FooBaz4 extends BaseEntity {
   @MikroORM_Property({ type: 'datetime', defaultRaw: \`current_timestamp\` })
   version!: Date & MikroORM_Opt;
 
+  @MikroORM_OneToOne({ entity: () => FooBar4, ref: true, mappedBy: 'baz' })
+  fooBar4?: MikroORM_Ref<FooBar4>;
+
 }
 ",
-  "import { Entity as MikroORM_Entity, Enum as MikroORM_Enum, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, Enum as MikroORM_Enum, OneToMany as MikroORM_OneToMany, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
+import { Book4 } from './Book4';
+import { Publisher4Tests } from './Publisher4Tests';
 
 @MikroORM_Entity()
 export class Publisher4 extends BaseEntity {
@@ -5652,19 +6588,27 @@ export class Publisher4 extends BaseEntity {
   name: string & MikroORM_Opt = 'asd';
 
   @MikroORM_Enum({ items: () => Publisher4Type })
-  type: Publisher4Type & MikroORM_Opt = Publisher4Type.LOCAL;
+  type: TPublisher4Type & MikroORM_Opt = Publisher4Type.LOCAL;
 
   @MikroORM_Property({ nullable: true })
   enum3?: number;
 
+  @MikroORM_OneToMany({ entity: () => Book4, mappedBy: 'publisher' })
+  book4Collection = new MikroORM_Collection<Book4>(this);
+
+  @MikroORM_OneToMany({ entity: () => Publisher4Tests, mappedBy: 'publisher4' })
+  publisher4TestsCollection = new MikroORM_Collection<Publisher4Tests>(this);
+
 }
 
-export enum Publisher4Type {
-  LOCAL = 'local',
-  GLOBAL = 'global',
-}
+export const Publisher4Type = {
+  LOCAL: 'local',
+  GLOBAL: 'global',
+} as const;
+
+export type TPublisher4Type = (typeof Publisher4Type)[keyof typeof Publisher4Type];
 ",
-  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey } from '@mikro-orm/core';
+  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 import { Publisher4 } from './Publisher4';
 import { Test4 } from './Test4';
@@ -5676,16 +6620,16 @@ export class Publisher4Tests extends BaseEntity {
   id!: number;
 
   @MikroORM_Index({ name: 'publisher4_tests_publisher4_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Publisher4, updateRule: 'cascade', deleteRule: 'cascade' })
-  publisher4!: Publisher4;
+  @MikroORM_ManyToOne({ entity: () => Publisher4, ref: true, updateRule: 'cascade', deleteRule: 'cascade' })
+  publisher4!: MikroORM_Ref<Publisher4>;
 
   @MikroORM_Index({ name: 'publisher4_tests_test4_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Test4, updateRule: 'cascade', deleteRule: 'cascade' })
-  test4!: Test4;
+  @MikroORM_ManyToOne({ entity: () => Test4, ref: true, updateRule: 'cascade', deleteRule: 'cascade' })
+  test4!: MikroORM_Ref<Test4>;
 
 }
 ",
-  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey } from '@mikro-orm/core';
+  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 import { Book4 } from './Book4';
 import { BookTag4 } from './BookTag4';
@@ -5697,17 +6641,18 @@ export class TagsOrdered extends BaseEntity {
   id!: number;
 
   @MikroORM_Index({ name: 'tags_ordered_book4_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Book4, updateRule: 'cascade', deleteRule: 'cascade' })
-  book4!: Book4;
+  @MikroORM_ManyToOne({ entity: () => Book4, ref: true, updateRule: 'cascade', deleteRule: 'cascade' })
+  book4!: MikroORM_Ref<Book4>;
 
   @MikroORM_Index({ name: 'tags_ordered_book_tag4_id_index' })
-  @MikroORM_ManyToOne({ entity: () => BookTag4, updateRule: 'cascade', deleteRule: 'cascade' })
-  bookTag4!: BookTag4;
+  @MikroORM_ManyToOne({ entity: () => BookTag4, ref: true, updateRule: 'cascade', deleteRule: 'cascade' })
+  bookTag4!: MikroORM_Ref<BookTag4>;
 
 }
 ",
-  "import { Entity as MikroORM_Entity, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, OneToMany as MikroORM_OneToMany, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
+import { Publisher4Tests } from './Publisher4Tests';
 
 @MikroORM_Entity()
 export class Test4 extends BaseEntity {
@@ -5726,6 +6671,9 @@ export class Test4 extends BaseEntity {
 
   @MikroORM_Property({ type: 'integer' })
   version: number & MikroORM_Opt = 1;
+
+  @MikroORM_OneToMany({ entity: () => Publisher4Tests, mappedBy: 'test4' })
+  publisher4TestsCollection = new MikroORM_Collection<Publisher4Tests>(this);
 
 }
 ",
@@ -5752,7 +6700,7 @@ export abstract class BaseEntity {
 
 exports[`CustomBase > forceObject=true > useCoreBaseEntity=false > customBaseEntityName=BaseEntity > entitySchema > dump 1`] = `
 [
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 import { Book4 } from './Book4';
 
@@ -5767,8 +6715,9 @@ export class Author4 extends BaseEntity {
   identities?: string;
   born?: string;
   bornTime?: string;
-  favouriteBook?: Book4;
+  favouriteBook?: MikroORM_Ref<Book4>;
   identity?: any;
+  book4Collection = new MikroORM_Collection<Book4>(this);
 }
 
 export const Author4Schema = new MikroORM_EntitySchema({
@@ -5787,16 +6736,20 @@ export const Author4Schema = new MikroORM_EntitySchema({
     favouriteBook: {
       kind: 'm:1',
       entity: () => Book4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
     },
     identity: { type: 'json', nullable: true },
+    book4Collection: { kind: '1:m', entity: () => Book4, mappedBy: 'author' },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
+import { Book4 } from './Book4';
+import { TagsOrdered } from './TagsOrdered';
 
 export class BookTag4 extends BaseEntity {
   id!: number;
@@ -5804,6 +6757,8 @@ export class BookTag4 extends BaseEntity {
   updatedAt?: Date;
   name!: string;
   version!: Date & MikroORM_Opt;
+  tagsUnorderedInverse = new MikroORM_Collection<Book4>(this);
+  tagsOrderedCollection = new MikroORM_Collection<TagsOrdered>(this);
 }
 
 export const BookTag4Schema = new MikroORM_EntitySchema({
@@ -5814,14 +6769,25 @@ export const BookTag4Schema = new MikroORM_EntitySchema({
     updatedAt: { type: 'datetime', nullable: true },
     name: { type: 'text' },
     version: { type: 'datetime', defaultRaw: \`current_timestamp\` },
+    tagsUnorderedInverse: {
+      kind: 'm:n',
+      entity: () => Book4,
+      mappedBy: 'tagsUnordered',
+    },
+    tagsOrderedCollection: {
+      kind: '1:m',
+      entity: () => TagsOrdered,
+      mappedBy: 'bookTag4',
+    },
   },
 });
 ",
-  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Author4 } from './Author4';
 import { BaseEntity } from './BaseEntity';
 import { BookTag4 } from './BookTag4';
 import { Publisher4 } from './Publisher4';
+import { TagsOrdered } from './TagsOrdered';
 
 export class Book4 extends BaseEntity {
   id!: number;
@@ -5829,10 +6795,12 @@ export class Book4 extends BaseEntity {
   updatedAt?: Date;
   title!: string;
   price?: unknown;
-  author?: Author4;
-  publisher?: Publisher4;
+  author?: MikroORM_Ref<Author4>;
+  publisher?: MikroORM_Ref<Publisher4>;
   meta?: any;
   tagsUnordered = new MikroORM_Collection<BookTag4>(this);
+  author4Collection = new MikroORM_Collection<Author4>(this);
+  tagsOrderedCollection = new MikroORM_Collection<TagsOrdered>(this);
 }
 
 export const Book4Schema = new MikroORM_EntitySchema({
@@ -5846,6 +6814,7 @@ export const Book4Schema = new MikroORM_EntitySchema({
     author: {
       kind: 'm:1',
       entity: () => Author4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
@@ -5853,6 +6822,7 @@ export const Book4Schema = new MikroORM_EntitySchema({
     publisher: {
       kind: 'm:1',
       entity: () => Publisher4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
@@ -5865,10 +6835,20 @@ export const Book4Schema = new MikroORM_EntitySchema({
       joinColumn: 'book4_id',
       inverseJoinColumn: 'book_tag4_id',
     },
+    author4Collection: {
+      kind: '1:m',
+      entity: () => Author4,
+      mappedBy: 'favouriteBook',
+    },
+    tagsOrderedCollection: {
+      kind: '1:m',
+      entity: () => TagsOrdered,
+      mappedBy: 'book4',
+    },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 import { FooBaz4 } from './FooBaz4';
 
@@ -5877,13 +6857,14 @@ export class FooBar4 extends BaseEntity {
   createdAt?: Date;
   updatedAt?: Date;
   name: string & MikroORM_Opt = 'asd';
-  baz?: FooBaz4;
-  fooBar?: FooBar4;
+  baz?: MikroORM_Ref<FooBaz4>;
+  fooBar?: MikroORM_Ref<FooBar4>;
   version: number & MikroORM_Opt = 1;
   blob?: Buffer;
   blob2?: Buffer;
   array?: string;
   object?: any;
+  fooBar4?: MikroORM_Ref<FooBar4>;
 }
 
 export const FooBar4Schema = new MikroORM_EntitySchema({
@@ -5896,6 +6877,7 @@ export const FooBar4Schema = new MikroORM_EntitySchema({
     baz: {
       kind: '1:1',
       entity: () => FooBaz4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
@@ -5903,6 +6885,7 @@ export const FooBar4Schema = new MikroORM_EntitySchema({
     fooBar: {
       kind: '1:1',
       entity: () => FooBar4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
@@ -5912,11 +6895,13 @@ export const FooBar4Schema = new MikroORM_EntitySchema({
     blob2: { type: 'blob', nullable: true },
     array: { type: 'text', nullable: true },
     object: { type: 'json', nullable: true },
+    fooBar4: { kind: '1:1', entity: () => FooBar4, ref: true, mappedBy: 'fooBar' },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
+import { FooBar4 } from './FooBar4';
 
 export class FooBaz4 extends BaseEntity {
   id!: number;
@@ -5924,6 +6909,7 @@ export class FooBaz4 extends BaseEntity {
   updatedAt?: Date;
   name!: string;
   version!: Date & MikroORM_Opt;
+  fooBar4?: MikroORM_Ref<FooBar4>;
 }
 
 export const FooBaz4Schema = new MikroORM_EntitySchema({
@@ -5934,25 +6920,32 @@ export const FooBaz4Schema = new MikroORM_EntitySchema({
     updatedAt: { type: 'datetime', nullable: true },
     name: { type: 'text' },
     version: { type: 'datetime', defaultRaw: \`current_timestamp\` },
+    fooBar4: { kind: '1:1', entity: () => FooBar4, ref: true, mappedBy: 'baz' },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
+import { Book4 } from './Book4';
+import { Publisher4Tests } from './Publisher4Tests';
 
 export class Publisher4 extends BaseEntity {
   id!: number;
   createdAt?: Date;
   updatedAt?: Date;
   name: string & MikroORM_Opt = 'asd';
-  type: Publisher4Type & MikroORM_Opt = Publisher4Type.LOCAL;
+  type: TPublisher4Type & MikroORM_Opt = Publisher4Type.LOCAL;
   enum3?: number;
+  book4Collection = new MikroORM_Collection<Book4>(this);
+  publisher4TestsCollection = new MikroORM_Collection<Publisher4Tests>(this);
 }
 
-export enum Publisher4Type {
-  LOCAL = 'local',
-  GLOBAL = 'global',
-}
+export const Publisher4Type = {
+  LOCAL: 'local',
+  GLOBAL: 'global',
+} as const;
+
+export type TPublisher4Type = (typeof Publisher4Type)[keyof typeof Publisher4Type];
 
 export const Publisher4Schema = new MikroORM_EntitySchema({
   class: Publisher4,
@@ -5963,18 +6956,24 @@ export const Publisher4Schema = new MikroORM_EntitySchema({
     name: { type: 'text' },
     type: { enum: true, items: () => Publisher4Type },
     enum3: { type: 'integer', nullable: true },
+    book4Collection: { kind: '1:m', entity: () => Book4, mappedBy: 'publisher' },
+    publisher4TestsCollection: {
+      kind: '1:m',
+      entity: () => Publisher4Tests,
+      mappedBy: 'publisher4',
+    },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema } from '@mikro-orm/core';
+  "import { EntitySchema as MikroORM_EntitySchema, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 import { Publisher4 } from './Publisher4';
 import { Test4 } from './Test4';
 
 export class Publisher4Tests extends BaseEntity {
   id!: number;
-  publisher4!: Publisher4;
-  test4!: Test4;
+  publisher4!: MikroORM_Ref<Publisher4>;
+  test4!: MikroORM_Ref<Test4>;
 }
 
 export const Publisher4TestsSchema = new MikroORM_EntitySchema({
@@ -5985,27 +6984,29 @@ export const Publisher4TestsSchema = new MikroORM_EntitySchema({
     publisher4: {
       kind: 'm:1',
       entity: () => Publisher4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
     test4: {
       kind: 'm:1',
       entity: () => Test4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema } from '@mikro-orm/core';
+  "import { EntitySchema as MikroORM_EntitySchema, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 import { Book4 } from './Book4';
 import { BookTag4 } from './BookTag4';
 
 export class TagsOrdered extends BaseEntity {
   id!: number;
-  book4!: Book4;
-  bookTag4!: BookTag4;
+  book4!: MikroORM_Ref<Book4>;
+  bookTag4!: MikroORM_Ref<BookTag4>;
 }
 
 export const TagsOrderedSchema = new MikroORM_EntitySchema({
@@ -6015,20 +7016,23 @@ export const TagsOrderedSchema = new MikroORM_EntitySchema({
     book4: {
       kind: 'm:1',
       entity: () => Book4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
     bookTag4: {
       kind: 'm:1',
       entity: () => BookTag4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
+import { Publisher4Tests } from './Publisher4Tests';
 
 export class Test4 extends BaseEntity {
   id!: number;
@@ -6036,6 +7040,7 @@ export class Test4 extends BaseEntity {
   updatedAt?: Date;
   name?: string;
   version: number & MikroORM_Opt = 1;
+  publisher4TestsCollection = new MikroORM_Collection<Publisher4Tests>(this);
 }
 
 export const Test4Schema = new MikroORM_EntitySchema({
@@ -6046,6 +7051,11 @@ export const Test4Schema = new MikroORM_EntitySchema({
     updatedAt: { type: 'datetime', nullable: true },
     name: { type: 'text', nullable: true },
     version: { type: 'integer' },
+    publisher4TestsCollection: {
+      kind: '1:m',
+      entity: () => Publisher4Tests,
+      mappedBy: 'test4',
+    },
   },
 });
 ",
@@ -6080,7 +7090,7 @@ export const BaseEntitySchema = new MikroORM_EntitySchema({
 
 exports[`CustomBase > forceObject=true > useCoreBaseEntity=false > customBaseEntityName=BaseEntity2 > decorators > dump 1`] = `
 [
-  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, OneToMany as MikroORM_OneToMany, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity2 } from './BaseEntity2';
 import { Book4 } from './Book4';
 
@@ -6118,16 +7128,21 @@ export class Author4 extends BaseEntity2 {
   bornTime?: string;
 
   @MikroORM_Index({ name: 'author4_favourite_book_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Book4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  favouriteBook?: Book4;
+  @MikroORM_ManyToOne({ entity: () => Book4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  favouriteBook?: MikroORM_Ref<Book4>;
 
   @MikroORM_Property({ type: 'json', nullable: true })
   identity?: any;
 
+  @MikroORM_OneToMany({ entity: () => Book4, mappedBy: 'author' })
+  book4Collection = new MikroORM_Collection<Book4>(this);
+
 }
 ",
-  "import { Entity as MikroORM_Entity, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, ManyToMany as MikroORM_ManyToMany, OneToMany as MikroORM_OneToMany, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
 import { BaseEntity2 } from './BaseEntity2';
+import { Book4 } from './Book4';
+import { TagsOrdered } from './TagsOrdered';
 
 @MikroORM_Entity()
 export class BookTag4 extends BaseEntity2 {
@@ -6147,13 +7162,20 @@ export class BookTag4 extends BaseEntity2 {
   @MikroORM_Property({ type: 'datetime', defaultRaw: \`current_timestamp\` })
   version!: Date & MikroORM_Opt;
 
+  @MikroORM_ManyToMany({ entity: () => Book4, mappedBy: 'tagsUnordered' })
+  tagsUnorderedInverse = new MikroORM_Collection<Book4>(this);
+
+  @MikroORM_OneToMany({ entity: () => TagsOrdered, mappedBy: 'bookTag4' })
+  tagsOrderedCollection = new MikroORM_Collection<TagsOrdered>(this);
+
 }
 ",
-  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToMany as MikroORM_ManyToMany, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToMany as MikroORM_ManyToMany, ManyToOne as MikroORM_ManyToOne, OneToMany as MikroORM_OneToMany, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Author4 } from './Author4';
 import { BaseEntity2 } from './BaseEntity2';
 import { BookTag4 } from './BookTag4';
 import { Publisher4 } from './Publisher4';
+import { TagsOrdered } from './TagsOrdered';
 
 @MikroORM_Entity()
 export class Book4 extends BaseEntity2 {
@@ -6174,12 +7196,12 @@ export class Book4 extends BaseEntity2 {
   price?: unknown;
 
   @MikroORM_Index({ name: 'book4_author_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Author4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  author?: Author4;
+  @MikroORM_ManyToOne({ entity: () => Author4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  author?: MikroORM_Ref<Author4>;
 
   @MikroORM_Index({ name: 'book4_publisher_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Publisher4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  publisher?: Publisher4;
+  @MikroORM_ManyToOne({ entity: () => Publisher4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  publisher?: MikroORM_Ref<Publisher4>;
 
   @MikroORM_Property({ type: 'json', nullable: true })
   meta?: any;
@@ -6187,9 +7209,15 @@ export class Book4 extends BaseEntity2 {
   @MikroORM_ManyToMany({ entity: () => BookTag4, pivotTable: 'tags_unordered', joinColumn: 'book4_id', inverseJoinColumn: 'book_tag4_id' })
   tagsUnordered = new MikroORM_Collection<BookTag4>(this);
 
+  @MikroORM_OneToMany({ entity: () => Author4, mappedBy: 'favouriteBook' })
+  author4Collection = new MikroORM_Collection<Author4>(this);
+
+  @MikroORM_OneToMany({ entity: () => TagsOrdered, mappedBy: 'book4' })
+  tagsOrderedCollection = new MikroORM_Collection<TagsOrdered>(this);
+
 }
 ",
-  "import { Entity as MikroORM_Entity, OneToOne as MikroORM_OneToOne, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, Unique as MikroORM_Unique } from '@mikro-orm/core';
+  "import { Entity as MikroORM_Entity, OneToOne as MikroORM_OneToOne, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, type Ref as MikroORM_Ref, Unique as MikroORM_Unique } from '@mikro-orm/core';
 import { BaseEntity2 } from './BaseEntity2';
 import { FooBaz4 } from './FooBaz4';
 
@@ -6209,12 +7237,12 @@ export class FooBar4 extends BaseEntity2 {
   name: string & MikroORM_Opt = 'asd';
 
   @MikroORM_Unique({ name: 'foo_bar4_baz_id_unique' })
-  @MikroORM_OneToOne({ entity: () => FooBaz4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  baz?: FooBaz4;
+  @MikroORM_OneToOne({ entity: () => FooBaz4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  baz?: MikroORM_Ref<FooBaz4>;
 
   @MikroORM_Unique({ name: 'foo_bar4_foo_bar_id_unique' })
-  @MikroORM_OneToOne({ entity: () => FooBar4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  fooBar?: FooBar4;
+  @MikroORM_OneToOne({ entity: () => FooBar4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  fooBar?: MikroORM_Ref<FooBar4>;
 
   @MikroORM_Property({ type: 'integer' })
   version: number & MikroORM_Opt = 1;
@@ -6231,10 +7259,14 @@ export class FooBar4 extends BaseEntity2 {
   @MikroORM_Property({ type: 'json', nullable: true })
   object?: any;
 
+  @MikroORM_OneToOne({ entity: () => FooBar4, ref: true, mappedBy: 'fooBar' })
+  fooBar4?: MikroORM_Ref<FooBar4>;
+
 }
 ",
-  "import { Entity as MikroORM_Entity, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Entity as MikroORM_Entity, OneToOne as MikroORM_OneToOne, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity2 } from './BaseEntity2';
+import { FooBar4 } from './FooBar4';
 
 @MikroORM_Entity()
 export class FooBaz4 extends BaseEntity2 {
@@ -6254,10 +7286,15 @@ export class FooBaz4 extends BaseEntity2 {
   @MikroORM_Property({ type: 'datetime', defaultRaw: \`current_timestamp\` })
   version!: Date & MikroORM_Opt;
 
+  @MikroORM_OneToOne({ entity: () => FooBar4, ref: true, mappedBy: 'baz' })
+  fooBar4?: MikroORM_Ref<FooBar4>;
+
 }
 ",
-  "import { Entity as MikroORM_Entity, Enum as MikroORM_Enum, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, Enum as MikroORM_Enum, OneToMany as MikroORM_OneToMany, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
 import { BaseEntity2 } from './BaseEntity2';
+import { Book4 } from './Book4';
+import { Publisher4Tests } from './Publisher4Tests';
 
 @MikroORM_Entity()
 export class Publisher4 extends BaseEntity2 {
@@ -6275,19 +7312,27 @@ export class Publisher4 extends BaseEntity2 {
   name: string & MikroORM_Opt = 'asd';
 
   @MikroORM_Enum({ items: () => Publisher4Type })
-  type: Publisher4Type & MikroORM_Opt = Publisher4Type.LOCAL;
+  type: TPublisher4Type & MikroORM_Opt = Publisher4Type.LOCAL;
 
   @MikroORM_Property({ nullable: true })
   enum3?: number;
 
+  @MikroORM_OneToMany({ entity: () => Book4, mappedBy: 'publisher' })
+  book4Collection = new MikroORM_Collection<Book4>(this);
+
+  @MikroORM_OneToMany({ entity: () => Publisher4Tests, mappedBy: 'publisher4' })
+  publisher4TestsCollection = new MikroORM_Collection<Publisher4Tests>(this);
+
 }
 
-export enum Publisher4Type {
-  LOCAL = 'local',
-  GLOBAL = 'global',
-}
+export const Publisher4Type = {
+  LOCAL: 'local',
+  GLOBAL: 'global',
+} as const;
+
+export type TPublisher4Type = (typeof Publisher4Type)[keyof typeof Publisher4Type];
 ",
-  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey } from '@mikro-orm/core';
+  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity2 } from './BaseEntity2';
 import { Publisher4 } from './Publisher4';
 import { Test4 } from './Test4';
@@ -6299,16 +7344,16 @@ export class Publisher4Tests extends BaseEntity2 {
   id!: number;
 
   @MikroORM_Index({ name: 'publisher4_tests_publisher4_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Publisher4, updateRule: 'cascade', deleteRule: 'cascade' })
-  publisher4!: Publisher4;
+  @MikroORM_ManyToOne({ entity: () => Publisher4, ref: true, updateRule: 'cascade', deleteRule: 'cascade' })
+  publisher4!: MikroORM_Ref<Publisher4>;
 
   @MikroORM_Index({ name: 'publisher4_tests_test4_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Test4, updateRule: 'cascade', deleteRule: 'cascade' })
-  test4!: Test4;
+  @MikroORM_ManyToOne({ entity: () => Test4, ref: true, updateRule: 'cascade', deleteRule: 'cascade' })
+  test4!: MikroORM_Ref<Test4>;
 
 }
 ",
-  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey } from '@mikro-orm/core';
+  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity2 } from './BaseEntity2';
 import { Book4 } from './Book4';
 import { BookTag4 } from './BookTag4';
@@ -6320,17 +7365,18 @@ export class TagsOrdered extends BaseEntity2 {
   id!: number;
 
   @MikroORM_Index({ name: 'tags_ordered_book4_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Book4, updateRule: 'cascade', deleteRule: 'cascade' })
-  book4!: Book4;
+  @MikroORM_ManyToOne({ entity: () => Book4, ref: true, updateRule: 'cascade', deleteRule: 'cascade' })
+  book4!: MikroORM_Ref<Book4>;
 
   @MikroORM_Index({ name: 'tags_ordered_book_tag4_id_index' })
-  @MikroORM_ManyToOne({ entity: () => BookTag4, updateRule: 'cascade', deleteRule: 'cascade' })
-  bookTag4!: BookTag4;
+  @MikroORM_ManyToOne({ entity: () => BookTag4, ref: true, updateRule: 'cascade', deleteRule: 'cascade' })
+  bookTag4!: MikroORM_Ref<BookTag4>;
 
 }
 ",
-  "import { Entity as MikroORM_Entity, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, OneToMany as MikroORM_OneToMany, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
 import { BaseEntity2 } from './BaseEntity2';
+import { Publisher4Tests } from './Publisher4Tests';
 
 @MikroORM_Entity()
 export class Test4 extends BaseEntity2 {
@@ -6349,6 +7395,9 @@ export class Test4 extends BaseEntity2 {
 
   @MikroORM_Property({ type: 'integer' })
   version: number & MikroORM_Opt = 1;
+
+  @MikroORM_OneToMany({ entity: () => Publisher4Tests, mappedBy: 'test4' })
+  publisher4TestsCollection = new MikroORM_Collection<Publisher4Tests>(this);
 
 }
 ",
@@ -6369,7 +7418,7 @@ export abstract class BaseEntity2 {
 
 exports[`CustomBase > forceObject=true > useCoreBaseEntity=false > customBaseEntityName=BaseEntity2 > entitySchema > dump 1`] = `
 [
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity2 } from './BaseEntity2';
 import { Book4 } from './Book4';
 
@@ -6384,8 +7433,9 @@ export class Author4 extends BaseEntity2 {
   identities?: string;
   born?: string;
   bornTime?: string;
-  favouriteBook?: Book4;
+  favouriteBook?: MikroORM_Ref<Book4>;
   identity?: any;
+  book4Collection = new MikroORM_Collection<Book4>(this);
 }
 
 export const Author4Schema = new MikroORM_EntitySchema({
@@ -6404,16 +7454,20 @@ export const Author4Schema = new MikroORM_EntitySchema({
     favouriteBook: {
       kind: 'm:1',
       entity: () => Book4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
     },
     identity: { type: 'json', nullable: true },
+    book4Collection: { kind: '1:m', entity: () => Book4, mappedBy: 'author' },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
 import { BaseEntity2 } from './BaseEntity2';
+import { Book4 } from './Book4';
+import { TagsOrdered } from './TagsOrdered';
 
 export class BookTag4 extends BaseEntity2 {
   id!: number;
@@ -6421,6 +7475,8 @@ export class BookTag4 extends BaseEntity2 {
   updatedAt?: Date;
   name!: string;
   version!: Date & MikroORM_Opt;
+  tagsUnorderedInverse = new MikroORM_Collection<Book4>(this);
+  tagsOrderedCollection = new MikroORM_Collection<TagsOrdered>(this);
 }
 
 export const BookTag4Schema = new MikroORM_EntitySchema({
@@ -6431,14 +7487,25 @@ export const BookTag4Schema = new MikroORM_EntitySchema({
     updatedAt: { type: 'datetime', nullable: true },
     name: { type: 'text' },
     version: { type: 'datetime', defaultRaw: \`current_timestamp\` },
+    tagsUnorderedInverse: {
+      kind: 'm:n',
+      entity: () => Book4,
+      mappedBy: 'tagsUnordered',
+    },
+    tagsOrderedCollection: {
+      kind: '1:m',
+      entity: () => TagsOrdered,
+      mappedBy: 'bookTag4',
+    },
   },
 });
 ",
-  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Author4 } from './Author4';
 import { BaseEntity2 } from './BaseEntity2';
 import { BookTag4 } from './BookTag4';
 import { Publisher4 } from './Publisher4';
+import { TagsOrdered } from './TagsOrdered';
 
 export class Book4 extends BaseEntity2 {
   id!: number;
@@ -6446,10 +7513,12 @@ export class Book4 extends BaseEntity2 {
   updatedAt?: Date;
   title!: string;
   price?: unknown;
-  author?: Author4;
-  publisher?: Publisher4;
+  author?: MikroORM_Ref<Author4>;
+  publisher?: MikroORM_Ref<Publisher4>;
   meta?: any;
   tagsUnordered = new MikroORM_Collection<BookTag4>(this);
+  author4Collection = new MikroORM_Collection<Author4>(this);
+  tagsOrderedCollection = new MikroORM_Collection<TagsOrdered>(this);
 }
 
 export const Book4Schema = new MikroORM_EntitySchema({
@@ -6463,6 +7532,7 @@ export const Book4Schema = new MikroORM_EntitySchema({
     author: {
       kind: 'm:1',
       entity: () => Author4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
@@ -6470,6 +7540,7 @@ export const Book4Schema = new MikroORM_EntitySchema({
     publisher: {
       kind: 'm:1',
       entity: () => Publisher4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
@@ -6482,10 +7553,20 @@ export const Book4Schema = new MikroORM_EntitySchema({
       joinColumn: 'book4_id',
       inverseJoinColumn: 'book_tag4_id',
     },
+    author4Collection: {
+      kind: '1:m',
+      entity: () => Author4,
+      mappedBy: 'favouriteBook',
+    },
+    tagsOrderedCollection: {
+      kind: '1:m',
+      entity: () => TagsOrdered,
+      mappedBy: 'book4',
+    },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity2 } from './BaseEntity2';
 import { FooBaz4 } from './FooBaz4';
 
@@ -6494,13 +7575,14 @@ export class FooBar4 extends BaseEntity2 {
   createdAt?: Date;
   updatedAt?: Date;
   name: string & MikroORM_Opt = 'asd';
-  baz?: FooBaz4;
-  fooBar?: FooBar4;
+  baz?: MikroORM_Ref<FooBaz4>;
+  fooBar?: MikroORM_Ref<FooBar4>;
   version: number & MikroORM_Opt = 1;
   blob?: Buffer;
   blob2?: Buffer;
   array?: string;
   object?: any;
+  fooBar4?: MikroORM_Ref<FooBar4>;
 }
 
 export const FooBar4Schema = new MikroORM_EntitySchema({
@@ -6513,6 +7595,7 @@ export const FooBar4Schema = new MikroORM_EntitySchema({
     baz: {
       kind: '1:1',
       entity: () => FooBaz4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
@@ -6520,6 +7603,7 @@ export const FooBar4Schema = new MikroORM_EntitySchema({
     fooBar: {
       kind: '1:1',
       entity: () => FooBar4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
@@ -6529,11 +7613,13 @@ export const FooBar4Schema = new MikroORM_EntitySchema({
     blob2: { type: 'blob', nullable: true },
     array: { type: 'text', nullable: true },
     object: { type: 'json', nullable: true },
+    fooBar4: { kind: '1:1', entity: () => FooBar4, ref: true, mappedBy: 'fooBar' },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity2 } from './BaseEntity2';
+import { FooBar4 } from './FooBar4';
 
 export class FooBaz4 extends BaseEntity2 {
   id!: number;
@@ -6541,6 +7627,7 @@ export class FooBaz4 extends BaseEntity2 {
   updatedAt?: Date;
   name!: string;
   version!: Date & MikroORM_Opt;
+  fooBar4?: MikroORM_Ref<FooBar4>;
 }
 
 export const FooBaz4Schema = new MikroORM_EntitySchema({
@@ -6551,25 +7638,32 @@ export const FooBaz4Schema = new MikroORM_EntitySchema({
     updatedAt: { type: 'datetime', nullable: true },
     name: { type: 'text' },
     version: { type: 'datetime', defaultRaw: \`current_timestamp\` },
+    fooBar4: { kind: '1:1', entity: () => FooBar4, ref: true, mappedBy: 'baz' },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
 import { BaseEntity2 } from './BaseEntity2';
+import { Book4 } from './Book4';
+import { Publisher4Tests } from './Publisher4Tests';
 
 export class Publisher4 extends BaseEntity2 {
   id!: number;
   createdAt?: Date;
   updatedAt?: Date;
   name: string & MikroORM_Opt = 'asd';
-  type: Publisher4Type & MikroORM_Opt = Publisher4Type.LOCAL;
+  type: TPublisher4Type & MikroORM_Opt = Publisher4Type.LOCAL;
   enum3?: number;
+  book4Collection = new MikroORM_Collection<Book4>(this);
+  publisher4TestsCollection = new MikroORM_Collection<Publisher4Tests>(this);
 }
 
-export enum Publisher4Type {
-  LOCAL = 'local',
-  GLOBAL = 'global',
-}
+export const Publisher4Type = {
+  LOCAL: 'local',
+  GLOBAL: 'global',
+} as const;
+
+export type TPublisher4Type = (typeof Publisher4Type)[keyof typeof Publisher4Type];
 
 export const Publisher4Schema = new MikroORM_EntitySchema({
   class: Publisher4,
@@ -6580,18 +7674,24 @@ export const Publisher4Schema = new MikroORM_EntitySchema({
     name: { type: 'text' },
     type: { enum: true, items: () => Publisher4Type },
     enum3: { type: 'integer', nullable: true },
+    book4Collection: { kind: '1:m', entity: () => Book4, mappedBy: 'publisher' },
+    publisher4TestsCollection: {
+      kind: '1:m',
+      entity: () => Publisher4Tests,
+      mappedBy: 'publisher4',
+    },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema } from '@mikro-orm/core';
+  "import { EntitySchema as MikroORM_EntitySchema, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity2 } from './BaseEntity2';
 import { Publisher4 } from './Publisher4';
 import { Test4 } from './Test4';
 
 export class Publisher4Tests extends BaseEntity2 {
   id!: number;
-  publisher4!: Publisher4;
-  test4!: Test4;
+  publisher4!: MikroORM_Ref<Publisher4>;
+  test4!: MikroORM_Ref<Test4>;
 }
 
 export const Publisher4TestsSchema = new MikroORM_EntitySchema({
@@ -6602,27 +7702,29 @@ export const Publisher4TestsSchema = new MikroORM_EntitySchema({
     publisher4: {
       kind: 'm:1',
       entity: () => Publisher4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
     test4: {
       kind: 'm:1',
       entity: () => Test4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema } from '@mikro-orm/core';
+  "import { EntitySchema as MikroORM_EntitySchema, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity2 } from './BaseEntity2';
 import { Book4 } from './Book4';
 import { BookTag4 } from './BookTag4';
 
 export class TagsOrdered extends BaseEntity2 {
   id!: number;
-  book4!: Book4;
-  bookTag4!: BookTag4;
+  book4!: MikroORM_Ref<Book4>;
+  bookTag4!: MikroORM_Ref<BookTag4>;
 }
 
 export const TagsOrderedSchema = new MikroORM_EntitySchema({
@@ -6632,20 +7734,23 @@ export const TagsOrderedSchema = new MikroORM_EntitySchema({
     book4: {
       kind: 'm:1',
       entity: () => Book4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
     bookTag4: {
       kind: 'm:1',
       entity: () => BookTag4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
 import { BaseEntity2 } from './BaseEntity2';
+import { Publisher4Tests } from './Publisher4Tests';
 
 export class Test4 extends BaseEntity2 {
   id!: number;
@@ -6653,6 +7758,7 @@ export class Test4 extends BaseEntity2 {
   updatedAt?: Date;
   name?: string;
   version: number & MikroORM_Opt = 1;
+  publisher4TestsCollection = new MikroORM_Collection<Publisher4Tests>(this);
 }
 
 export const Test4Schema = new MikroORM_EntitySchema({
@@ -6663,6 +7769,11 @@ export const Test4Schema = new MikroORM_EntitySchema({
     updatedAt: { type: 'datetime', nullable: true },
     name: { type: 'text', nullable: true },
     version: { type: 'integer' },
+    publisher4TestsCollection: {
+      kind: '1:m',
+      entity: () => Publisher4Tests,
+      mappedBy: 'test4',
+    },
   },
 });
 ",
@@ -6685,7 +7796,7 @@ export const BaseEntity2Schema = new MikroORM_EntitySchema({
 
 exports[`CustomBase > forceObject=true > useCoreBaseEntity=false > customBaseEntityName=CustomBase > decorators > dump 1`] = `
 [
-  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, OneToMany as MikroORM_OneToMany, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Book4 } from './Book4';
 import { CustomBase } from './CustomBase';
 
@@ -6723,16 +7834,21 @@ export class Author4 extends CustomBase {
   bornTime?: string;
 
   @MikroORM_Index({ name: 'author4_favourite_book_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Book4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  favouriteBook?: Book4;
+  @MikroORM_ManyToOne({ entity: () => Book4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  favouriteBook?: MikroORM_Ref<Book4>;
 
   @MikroORM_Property({ type: 'json', nullable: true })
   identity?: any;
 
+  @MikroORM_OneToMany({ entity: () => Book4, mappedBy: 'author' })
+  book4Collection = new MikroORM_Collection<Book4>(this);
+
 }
 ",
-  "import { Entity as MikroORM_Entity, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, ManyToMany as MikroORM_ManyToMany, OneToMany as MikroORM_OneToMany, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+import { Book4 } from './Book4';
 import { CustomBase } from './CustomBase';
+import { TagsOrdered } from './TagsOrdered';
 
 @MikroORM_Entity()
 export class BookTag4 extends CustomBase {
@@ -6752,13 +7868,20 @@ export class BookTag4 extends CustomBase {
   @MikroORM_Property({ type: 'datetime', defaultRaw: \`current_timestamp\` })
   version!: Date & MikroORM_Opt;
 
+  @MikroORM_ManyToMany({ entity: () => Book4, mappedBy: 'tagsUnordered' })
+  tagsUnorderedInverse = new MikroORM_Collection<Book4>(this);
+
+  @MikroORM_OneToMany({ entity: () => TagsOrdered, mappedBy: 'bookTag4' })
+  tagsOrderedCollection = new MikroORM_Collection<TagsOrdered>(this);
+
 }
 ",
-  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToMany as MikroORM_ManyToMany, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToMany as MikroORM_ManyToMany, ManyToOne as MikroORM_ManyToOne, OneToMany as MikroORM_OneToMany, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Author4 } from './Author4';
 import { BookTag4 } from './BookTag4';
 import { CustomBase } from './CustomBase';
 import { Publisher4 } from './Publisher4';
+import { TagsOrdered } from './TagsOrdered';
 
 @MikroORM_Entity()
 export class Book4 extends CustomBase {
@@ -6779,12 +7902,12 @@ export class Book4 extends CustomBase {
   price?: unknown;
 
   @MikroORM_Index({ name: 'book4_author_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Author4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  author?: Author4;
+  @MikroORM_ManyToOne({ entity: () => Author4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  author?: MikroORM_Ref<Author4>;
 
   @MikroORM_Index({ name: 'book4_publisher_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Publisher4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  publisher?: Publisher4;
+  @MikroORM_ManyToOne({ entity: () => Publisher4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  publisher?: MikroORM_Ref<Publisher4>;
 
   @MikroORM_Property({ type: 'json', nullable: true })
   meta?: any;
@@ -6792,9 +7915,15 @@ export class Book4 extends CustomBase {
   @MikroORM_ManyToMany({ entity: () => BookTag4, pivotTable: 'tags_unordered', joinColumn: 'book4_id', inverseJoinColumn: 'book_tag4_id' })
   tagsUnordered = new MikroORM_Collection<BookTag4>(this);
 
+  @MikroORM_OneToMany({ entity: () => Author4, mappedBy: 'favouriteBook' })
+  author4Collection = new MikroORM_Collection<Author4>(this);
+
+  @MikroORM_OneToMany({ entity: () => TagsOrdered, mappedBy: 'book4' })
+  tagsOrderedCollection = new MikroORM_Collection<TagsOrdered>(this);
+
 }
 ",
-  "import { Entity as MikroORM_Entity, OneToOne as MikroORM_OneToOne, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, Unique as MikroORM_Unique } from '@mikro-orm/core';
+  "import { Entity as MikroORM_Entity, OneToOne as MikroORM_OneToOne, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, type Ref as MikroORM_Ref, Unique as MikroORM_Unique } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
 import { FooBaz4 } from './FooBaz4';
 
@@ -6814,12 +7943,12 @@ export class FooBar4 extends CustomBase {
   name: string & MikroORM_Opt = 'asd';
 
   @MikroORM_Unique({ name: 'foo_bar4_baz_id_unique' })
-  @MikroORM_OneToOne({ entity: () => FooBaz4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  baz?: FooBaz4;
+  @MikroORM_OneToOne({ entity: () => FooBaz4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  baz?: MikroORM_Ref<FooBaz4>;
 
   @MikroORM_Unique({ name: 'foo_bar4_foo_bar_id_unique' })
-  @MikroORM_OneToOne({ entity: () => FooBar4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  fooBar?: FooBar4;
+  @MikroORM_OneToOne({ entity: () => FooBar4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  fooBar?: MikroORM_Ref<FooBar4>;
 
   @MikroORM_Property({ type: 'integer' })
   version: number & MikroORM_Opt = 1;
@@ -6836,10 +7965,14 @@ export class FooBar4 extends CustomBase {
   @MikroORM_Property({ type: 'json', nullable: true })
   object?: any;
 
+  @MikroORM_OneToOne({ entity: () => FooBar4, ref: true, mappedBy: 'fooBar' })
+  fooBar4?: MikroORM_Ref<FooBar4>;
+
 }
 ",
-  "import { Entity as MikroORM_Entity, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Entity as MikroORM_Entity, OneToOne as MikroORM_OneToOne, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
+import { FooBar4 } from './FooBar4';
 
 @MikroORM_Entity()
 export class FooBaz4 extends CustomBase {
@@ -6859,10 +7992,15 @@ export class FooBaz4 extends CustomBase {
   @MikroORM_Property({ type: 'datetime', defaultRaw: \`current_timestamp\` })
   version!: Date & MikroORM_Opt;
 
+  @MikroORM_OneToOne({ entity: () => FooBar4, ref: true, mappedBy: 'baz' })
+  fooBar4?: MikroORM_Ref<FooBar4>;
+
 }
 ",
-  "import { Entity as MikroORM_Entity, Enum as MikroORM_Enum, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, Enum as MikroORM_Enum, OneToMany as MikroORM_OneToMany, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+import { Book4 } from './Book4';
 import { CustomBase } from './CustomBase';
+import { Publisher4Tests } from './Publisher4Tests';
 
 @MikroORM_Entity()
 export class Publisher4 extends CustomBase {
@@ -6880,19 +8018,27 @@ export class Publisher4 extends CustomBase {
   name: string & MikroORM_Opt = 'asd';
 
   @MikroORM_Enum({ items: () => Publisher4Type })
-  type: Publisher4Type & MikroORM_Opt = Publisher4Type.LOCAL;
+  type: TPublisher4Type & MikroORM_Opt = Publisher4Type.LOCAL;
 
   @MikroORM_Property({ nullable: true })
   enum3?: number;
 
+  @MikroORM_OneToMany({ entity: () => Book4, mappedBy: 'publisher' })
+  book4Collection = new MikroORM_Collection<Book4>(this);
+
+  @MikroORM_OneToMany({ entity: () => Publisher4Tests, mappedBy: 'publisher4' })
+  publisher4TestsCollection = new MikroORM_Collection<Publisher4Tests>(this);
+
 }
 
-export enum Publisher4Type {
-  LOCAL = 'local',
-  GLOBAL = 'global',
-}
+export const Publisher4Type = {
+  LOCAL: 'local',
+  GLOBAL: 'global',
+} as const;
+
+export type TPublisher4Type = (typeof Publisher4Type)[keyof typeof Publisher4Type];
 ",
-  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey } from '@mikro-orm/core';
+  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
 import { Publisher4 } from './Publisher4';
 import { Test4 } from './Test4';
@@ -6904,16 +8050,16 @@ export class Publisher4Tests extends CustomBase {
   id!: number;
 
   @MikroORM_Index({ name: 'publisher4_tests_publisher4_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Publisher4, updateRule: 'cascade', deleteRule: 'cascade' })
-  publisher4!: Publisher4;
+  @MikroORM_ManyToOne({ entity: () => Publisher4, ref: true, updateRule: 'cascade', deleteRule: 'cascade' })
+  publisher4!: MikroORM_Ref<Publisher4>;
 
   @MikroORM_Index({ name: 'publisher4_tests_test4_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Test4, updateRule: 'cascade', deleteRule: 'cascade' })
-  test4!: Test4;
+  @MikroORM_ManyToOne({ entity: () => Test4, ref: true, updateRule: 'cascade', deleteRule: 'cascade' })
+  test4!: MikroORM_Ref<Test4>;
 
 }
 ",
-  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey } from '@mikro-orm/core';
+  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Book4 } from './Book4';
 import { BookTag4 } from './BookTag4';
 import { CustomBase } from './CustomBase';
@@ -6925,17 +8071,18 @@ export class TagsOrdered extends CustomBase {
   id!: number;
 
   @MikroORM_Index({ name: 'tags_ordered_book4_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Book4, updateRule: 'cascade', deleteRule: 'cascade' })
-  book4!: Book4;
+  @MikroORM_ManyToOne({ entity: () => Book4, ref: true, updateRule: 'cascade', deleteRule: 'cascade' })
+  book4!: MikroORM_Ref<Book4>;
 
   @MikroORM_Index({ name: 'tags_ordered_book_tag4_id_index' })
-  @MikroORM_ManyToOne({ entity: () => BookTag4, updateRule: 'cascade', deleteRule: 'cascade' })
-  bookTag4!: BookTag4;
+  @MikroORM_ManyToOne({ entity: () => BookTag4, ref: true, updateRule: 'cascade', deleteRule: 'cascade' })
+  bookTag4!: MikroORM_Ref<BookTag4>;
 
 }
 ",
-  "import { Entity as MikroORM_Entity, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, OneToMany as MikroORM_OneToMany, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
+import { Publisher4Tests } from './Publisher4Tests';
 
 @MikroORM_Entity()
 export class Test4 extends CustomBase {
@@ -6954,6 +8101,9 @@ export class Test4 extends CustomBase {
 
   @MikroORM_Property({ type: 'integer' })
   version: number & MikroORM_Opt = 1;
+
+  @MikroORM_OneToMany({ entity: () => Publisher4Tests, mappedBy: 'test4' })
+  publisher4TestsCollection = new MikroORM_Collection<Publisher4Tests>(this);
 
 }
 ",
@@ -6980,7 +8130,7 @@ export abstract class CustomBase {
 
 exports[`CustomBase > forceObject=true > useCoreBaseEntity=false > customBaseEntityName=CustomBase > entitySchema > dump 1`] = `
 [
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Book4 } from './Book4';
 import { CustomBase } from './CustomBase';
 
@@ -6995,8 +8145,9 @@ export class Author4 extends CustomBase {
   identities?: string;
   born?: string;
   bornTime?: string;
-  favouriteBook?: Book4;
+  favouriteBook?: MikroORM_Ref<Book4>;
   identity?: any;
+  book4Collection = new MikroORM_Collection<Book4>(this);
 }
 
 export const Author4Schema = new MikroORM_EntitySchema({
@@ -7015,16 +8166,20 @@ export const Author4Schema = new MikroORM_EntitySchema({
     favouriteBook: {
       kind: 'm:1',
       entity: () => Book4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
     },
     identity: { type: 'json', nullable: true },
+    book4Collection: { kind: '1:m', entity: () => Book4, mappedBy: 'author' },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+import { Book4 } from './Book4';
 import { CustomBase } from './CustomBase';
+import { TagsOrdered } from './TagsOrdered';
 
 export class BookTag4 extends CustomBase {
   id!: number;
@@ -7032,6 +8187,8 @@ export class BookTag4 extends CustomBase {
   updatedAt?: Date;
   name!: string;
   version!: Date & MikroORM_Opt;
+  tagsUnorderedInverse = new MikroORM_Collection<Book4>(this);
+  tagsOrderedCollection = new MikroORM_Collection<TagsOrdered>(this);
 }
 
 export const BookTag4Schema = new MikroORM_EntitySchema({
@@ -7042,14 +8199,25 @@ export const BookTag4Schema = new MikroORM_EntitySchema({
     updatedAt: { type: 'datetime', nullable: true },
     name: { type: 'text' },
     version: { type: 'datetime', defaultRaw: \`current_timestamp\` },
+    tagsUnorderedInverse: {
+      kind: 'm:n',
+      entity: () => Book4,
+      mappedBy: 'tagsUnordered',
+    },
+    tagsOrderedCollection: {
+      kind: '1:m',
+      entity: () => TagsOrdered,
+      mappedBy: 'bookTag4',
+    },
   },
 });
 ",
-  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Author4 } from './Author4';
 import { BookTag4 } from './BookTag4';
 import { CustomBase } from './CustomBase';
 import { Publisher4 } from './Publisher4';
+import { TagsOrdered } from './TagsOrdered';
 
 export class Book4 extends CustomBase {
   id!: number;
@@ -7057,10 +8225,12 @@ export class Book4 extends CustomBase {
   updatedAt?: Date;
   title!: string;
   price?: unknown;
-  author?: Author4;
-  publisher?: Publisher4;
+  author?: MikroORM_Ref<Author4>;
+  publisher?: MikroORM_Ref<Publisher4>;
   meta?: any;
   tagsUnordered = new MikroORM_Collection<BookTag4>(this);
+  author4Collection = new MikroORM_Collection<Author4>(this);
+  tagsOrderedCollection = new MikroORM_Collection<TagsOrdered>(this);
 }
 
 export const Book4Schema = new MikroORM_EntitySchema({
@@ -7074,6 +8244,7 @@ export const Book4Schema = new MikroORM_EntitySchema({
     author: {
       kind: 'm:1',
       entity: () => Author4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
@@ -7081,6 +8252,7 @@ export const Book4Schema = new MikroORM_EntitySchema({
     publisher: {
       kind: 'm:1',
       entity: () => Publisher4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
@@ -7093,10 +8265,20 @@ export const Book4Schema = new MikroORM_EntitySchema({
       joinColumn: 'book4_id',
       inverseJoinColumn: 'book_tag4_id',
     },
+    author4Collection: {
+      kind: '1:m',
+      entity: () => Author4,
+      mappedBy: 'favouriteBook',
+    },
+    tagsOrderedCollection: {
+      kind: '1:m',
+      entity: () => TagsOrdered,
+      mappedBy: 'book4',
+    },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
 import { FooBaz4 } from './FooBaz4';
 
@@ -7105,13 +8287,14 @@ export class FooBar4 extends CustomBase {
   createdAt?: Date;
   updatedAt?: Date;
   name: string & MikroORM_Opt = 'asd';
-  baz?: FooBaz4;
-  fooBar?: FooBar4;
+  baz?: MikroORM_Ref<FooBaz4>;
+  fooBar?: MikroORM_Ref<FooBar4>;
   version: number & MikroORM_Opt = 1;
   blob?: Buffer;
   blob2?: Buffer;
   array?: string;
   object?: any;
+  fooBar4?: MikroORM_Ref<FooBar4>;
 }
 
 export const FooBar4Schema = new MikroORM_EntitySchema({
@@ -7124,6 +8307,7 @@ export const FooBar4Schema = new MikroORM_EntitySchema({
     baz: {
       kind: '1:1',
       entity: () => FooBaz4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
@@ -7131,6 +8315,7 @@ export const FooBar4Schema = new MikroORM_EntitySchema({
     fooBar: {
       kind: '1:1',
       entity: () => FooBar4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
@@ -7140,11 +8325,13 @@ export const FooBar4Schema = new MikroORM_EntitySchema({
     blob2: { type: 'blob', nullable: true },
     array: { type: 'text', nullable: true },
     object: { type: 'json', nullable: true },
+    fooBar4: { kind: '1:1', entity: () => FooBar4, ref: true, mappedBy: 'fooBar' },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
+import { FooBar4 } from './FooBar4';
 
 export class FooBaz4 extends CustomBase {
   id!: number;
@@ -7152,6 +8339,7 @@ export class FooBaz4 extends CustomBase {
   updatedAt?: Date;
   name!: string;
   version!: Date & MikroORM_Opt;
+  fooBar4?: MikroORM_Ref<FooBar4>;
 }
 
 export const FooBaz4Schema = new MikroORM_EntitySchema({
@@ -7162,25 +8350,32 @@ export const FooBaz4Schema = new MikroORM_EntitySchema({
     updatedAt: { type: 'datetime', nullable: true },
     name: { type: 'text' },
     version: { type: 'datetime', defaultRaw: \`current_timestamp\` },
+    fooBar4: { kind: '1:1', entity: () => FooBar4, ref: true, mappedBy: 'baz' },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+import { Book4 } from './Book4';
 import { CustomBase } from './CustomBase';
+import { Publisher4Tests } from './Publisher4Tests';
 
 export class Publisher4 extends CustomBase {
   id!: number;
   createdAt?: Date;
   updatedAt?: Date;
   name: string & MikroORM_Opt = 'asd';
-  type: Publisher4Type & MikroORM_Opt = Publisher4Type.LOCAL;
+  type: TPublisher4Type & MikroORM_Opt = Publisher4Type.LOCAL;
   enum3?: number;
+  book4Collection = new MikroORM_Collection<Book4>(this);
+  publisher4TestsCollection = new MikroORM_Collection<Publisher4Tests>(this);
 }
 
-export enum Publisher4Type {
-  LOCAL = 'local',
-  GLOBAL = 'global',
-}
+export const Publisher4Type = {
+  LOCAL: 'local',
+  GLOBAL: 'global',
+} as const;
+
+export type TPublisher4Type = (typeof Publisher4Type)[keyof typeof Publisher4Type];
 
 export const Publisher4Schema = new MikroORM_EntitySchema({
   class: Publisher4,
@@ -7191,18 +8386,24 @@ export const Publisher4Schema = new MikroORM_EntitySchema({
     name: { type: 'text' },
     type: { enum: true, items: () => Publisher4Type },
     enum3: { type: 'integer', nullable: true },
+    book4Collection: { kind: '1:m', entity: () => Book4, mappedBy: 'publisher' },
+    publisher4TestsCollection: {
+      kind: '1:m',
+      entity: () => Publisher4Tests,
+      mappedBy: 'publisher4',
+    },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema } from '@mikro-orm/core';
+  "import { EntitySchema as MikroORM_EntitySchema, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
 import { Publisher4 } from './Publisher4';
 import { Test4 } from './Test4';
 
 export class Publisher4Tests extends CustomBase {
   id!: number;
-  publisher4!: Publisher4;
-  test4!: Test4;
+  publisher4!: MikroORM_Ref<Publisher4>;
+  test4!: MikroORM_Ref<Test4>;
 }
 
 export const Publisher4TestsSchema = new MikroORM_EntitySchema({
@@ -7213,27 +8414,29 @@ export const Publisher4TestsSchema = new MikroORM_EntitySchema({
     publisher4: {
       kind: 'm:1',
       entity: () => Publisher4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
     test4: {
       kind: 'm:1',
       entity: () => Test4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema } from '@mikro-orm/core';
+  "import { EntitySchema as MikroORM_EntitySchema, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Book4 } from './Book4';
 import { BookTag4 } from './BookTag4';
 import { CustomBase } from './CustomBase';
 
 export class TagsOrdered extends CustomBase {
   id!: number;
-  book4!: Book4;
-  bookTag4!: BookTag4;
+  book4!: MikroORM_Ref<Book4>;
+  bookTag4!: MikroORM_Ref<BookTag4>;
 }
 
 export const TagsOrderedSchema = new MikroORM_EntitySchema({
@@ -7243,20 +8446,23 @@ export const TagsOrderedSchema = new MikroORM_EntitySchema({
     book4: {
       kind: 'm:1',
       entity: () => Book4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
     bookTag4: {
       kind: 'm:1',
       entity: () => BookTag4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
+import { Publisher4Tests } from './Publisher4Tests';
 
 export class Test4 extends CustomBase {
   id!: number;
@@ -7264,6 +8470,7 @@ export class Test4 extends CustomBase {
   updatedAt?: Date;
   name?: string;
   version: number & MikroORM_Opt = 1;
+  publisher4TestsCollection = new MikroORM_Collection<Publisher4Tests>(this);
 }
 
 export const Test4Schema = new MikroORM_EntitySchema({
@@ -7274,6 +8481,11 @@ export const Test4Schema = new MikroORM_EntitySchema({
     updatedAt: { type: 'datetime', nullable: true },
     name: { type: 'text', nullable: true },
     version: { type: 'integer' },
+    publisher4TestsCollection: {
+      kind: '1:m',
+      entity: () => Publisher4Tests,
+      mappedBy: 'test4',
+    },
   },
 });
 ",
@@ -7308,7 +8520,7 @@ export const CustomBaseSchema = new MikroORM_EntitySchema({
 
 exports[`CustomBase > forceObject=true > useCoreBaseEntity=true > customBaseEntityName= > decorators > dump 1`] = `
 [
-  "import { BaseEntity as MikroORM_BaseEntity, Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { BaseEntity as MikroORM_BaseEntity, Collection as MikroORM_Collection, Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, OneToMany as MikroORM_OneToMany, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Book4 } from './Book4';
 
 @MikroORM_Entity()
@@ -7345,15 +8557,20 @@ export class Author4 extends MikroORM_BaseEntity {
   bornTime?: string;
 
   @MikroORM_Index({ name: 'author4_favourite_book_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Book4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  favouriteBook?: Book4;
+  @MikroORM_ManyToOne({ entity: () => Book4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  favouriteBook?: MikroORM_Ref<Book4>;
 
   @MikroORM_Property({ type: 'json', nullable: true })
   identity?: any;
 
+  @MikroORM_OneToMany({ entity: () => Book4, mappedBy: 'author' })
+  book4Collection = new MikroORM_Collection<Book4>(this);
+
 }
 ",
-  "import { BaseEntity as MikroORM_BaseEntity, Entity as MikroORM_Entity, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { BaseEntity as MikroORM_BaseEntity, Collection as MikroORM_Collection, Entity as MikroORM_Entity, ManyToMany as MikroORM_ManyToMany, OneToMany as MikroORM_OneToMany, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+import { Book4 } from './Book4';
+import { TagsOrdered } from './TagsOrdered';
 
 @MikroORM_Entity()
 export class BookTag4 extends MikroORM_BaseEntity {
@@ -7373,12 +8590,19 @@ export class BookTag4 extends MikroORM_BaseEntity {
   @MikroORM_Property({ type: 'datetime', defaultRaw: \`current_timestamp\` })
   version!: Date & MikroORM_Opt;
 
+  @MikroORM_ManyToMany({ entity: () => Book4, mappedBy: 'tagsUnordered' })
+  tagsUnorderedInverse = new MikroORM_Collection<Book4>(this);
+
+  @MikroORM_OneToMany({ entity: () => TagsOrdered, mappedBy: 'bookTag4' })
+  tagsOrderedCollection = new MikroORM_Collection<TagsOrdered>(this);
+
 }
 ",
-  "import { BaseEntity as MikroORM_BaseEntity, Collection as MikroORM_Collection, Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToMany as MikroORM_ManyToMany, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { BaseEntity as MikroORM_BaseEntity, Collection as MikroORM_Collection, Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToMany as MikroORM_ManyToMany, ManyToOne as MikroORM_ManyToOne, OneToMany as MikroORM_OneToMany, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Author4 } from './Author4';
 import { BookTag4 } from './BookTag4';
 import { Publisher4 } from './Publisher4';
+import { TagsOrdered } from './TagsOrdered';
 
 @MikroORM_Entity()
 export class Book4 extends MikroORM_BaseEntity {
@@ -7399,12 +8623,12 @@ export class Book4 extends MikroORM_BaseEntity {
   price?: unknown;
 
   @MikroORM_Index({ name: 'book4_author_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Author4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  author?: Author4;
+  @MikroORM_ManyToOne({ entity: () => Author4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  author?: MikroORM_Ref<Author4>;
 
   @MikroORM_Index({ name: 'book4_publisher_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Publisher4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  publisher?: Publisher4;
+  @MikroORM_ManyToOne({ entity: () => Publisher4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  publisher?: MikroORM_Ref<Publisher4>;
 
   @MikroORM_Property({ type: 'json', nullable: true })
   meta?: any;
@@ -7412,9 +8636,15 @@ export class Book4 extends MikroORM_BaseEntity {
   @MikroORM_ManyToMany({ entity: () => BookTag4, pivotTable: 'tags_unordered', joinColumn: 'book4_id', inverseJoinColumn: 'book_tag4_id' })
   tagsUnordered = new MikroORM_Collection<BookTag4>(this);
 
+  @MikroORM_OneToMany({ entity: () => Author4, mappedBy: 'favouriteBook' })
+  author4Collection = new MikroORM_Collection<Author4>(this);
+
+  @MikroORM_OneToMany({ entity: () => TagsOrdered, mappedBy: 'book4' })
+  tagsOrderedCollection = new MikroORM_Collection<TagsOrdered>(this);
+
 }
 ",
-  "import { BaseEntity as MikroORM_BaseEntity, Entity as MikroORM_Entity, OneToOne as MikroORM_OneToOne, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, Unique as MikroORM_Unique } from '@mikro-orm/core';
+  "import { BaseEntity as MikroORM_BaseEntity, Entity as MikroORM_Entity, OneToOne as MikroORM_OneToOne, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, type Ref as MikroORM_Ref, Unique as MikroORM_Unique } from '@mikro-orm/core';
 import { FooBaz4 } from './FooBaz4';
 
 @MikroORM_Entity()
@@ -7433,12 +8663,12 @@ export class FooBar4 extends MikroORM_BaseEntity {
   name: string & MikroORM_Opt = 'asd';
 
   @MikroORM_Unique({ name: 'foo_bar4_baz_id_unique' })
-  @MikroORM_OneToOne({ entity: () => FooBaz4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  baz?: FooBaz4;
+  @MikroORM_OneToOne({ entity: () => FooBaz4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  baz?: MikroORM_Ref<FooBaz4>;
 
   @MikroORM_Unique({ name: 'foo_bar4_foo_bar_id_unique' })
-  @MikroORM_OneToOne({ entity: () => FooBar4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  fooBar?: FooBar4;
+  @MikroORM_OneToOne({ entity: () => FooBar4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  fooBar?: MikroORM_Ref<FooBar4>;
 
   @MikroORM_Property({ type: 'integer' })
   version: number & MikroORM_Opt = 1;
@@ -7455,9 +8685,13 @@ export class FooBar4 extends MikroORM_BaseEntity {
   @MikroORM_Property({ type: 'json', nullable: true })
   object?: any;
 
+  @MikroORM_OneToOne({ entity: () => FooBar4, ref: true, mappedBy: 'fooBar' })
+  fooBar4?: MikroORM_Ref<FooBar4>;
+
 }
 ",
-  "import { BaseEntity as MikroORM_BaseEntity, Entity as MikroORM_Entity, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { BaseEntity as MikroORM_BaseEntity, Entity as MikroORM_Entity, OneToOne as MikroORM_OneToOne, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, type Ref as MikroORM_Ref } from '@mikro-orm/core';
+import { FooBar4 } from './FooBar4';
 
 @MikroORM_Entity()
 export class FooBaz4 extends MikroORM_BaseEntity {
@@ -7477,9 +8711,14 @@ export class FooBaz4 extends MikroORM_BaseEntity {
   @MikroORM_Property({ type: 'datetime', defaultRaw: \`current_timestamp\` })
   version!: Date & MikroORM_Opt;
 
+  @MikroORM_OneToOne({ entity: () => FooBar4, ref: true, mappedBy: 'baz' })
+  fooBar4?: MikroORM_Ref<FooBar4>;
+
 }
 ",
-  "import { BaseEntity as MikroORM_BaseEntity, Entity as MikroORM_Entity, Enum as MikroORM_Enum, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { BaseEntity as MikroORM_BaseEntity, Collection as MikroORM_Collection, Entity as MikroORM_Entity, Enum as MikroORM_Enum, OneToMany as MikroORM_OneToMany, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+import { Book4 } from './Book4';
+import { Publisher4Tests } from './Publisher4Tests';
 
 @MikroORM_Entity()
 export class Publisher4 extends MikroORM_BaseEntity {
@@ -7497,19 +8736,27 @@ export class Publisher4 extends MikroORM_BaseEntity {
   name: string & MikroORM_Opt = 'asd';
 
   @MikroORM_Enum({ items: () => Publisher4Type })
-  type: Publisher4Type & MikroORM_Opt = Publisher4Type.LOCAL;
+  type: TPublisher4Type & MikroORM_Opt = Publisher4Type.LOCAL;
 
   @MikroORM_Property({ nullable: true })
   enum3?: number;
 
+  @MikroORM_OneToMany({ entity: () => Book4, mappedBy: 'publisher' })
+  book4Collection = new MikroORM_Collection<Book4>(this);
+
+  @MikroORM_OneToMany({ entity: () => Publisher4Tests, mappedBy: 'publisher4' })
+  publisher4TestsCollection = new MikroORM_Collection<Publisher4Tests>(this);
+
 }
 
-export enum Publisher4Type {
-  LOCAL = 'local',
-  GLOBAL = 'global',
-}
+export const Publisher4Type = {
+  LOCAL: 'local',
+  GLOBAL: 'global',
+} as const;
+
+export type TPublisher4Type = (typeof Publisher4Type)[keyof typeof Publisher4Type];
 ",
-  "import { BaseEntity as MikroORM_BaseEntity, Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey } from '@mikro-orm/core';
+  "import { BaseEntity as MikroORM_BaseEntity, Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Publisher4 } from './Publisher4';
 import { Test4 } from './Test4';
 
@@ -7520,16 +8767,16 @@ export class Publisher4Tests extends MikroORM_BaseEntity {
   id!: number;
 
   @MikroORM_Index({ name: 'publisher4_tests_publisher4_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Publisher4, updateRule: 'cascade', deleteRule: 'cascade' })
-  publisher4!: Publisher4;
+  @MikroORM_ManyToOne({ entity: () => Publisher4, ref: true, updateRule: 'cascade', deleteRule: 'cascade' })
+  publisher4!: MikroORM_Ref<Publisher4>;
 
   @MikroORM_Index({ name: 'publisher4_tests_test4_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Test4, updateRule: 'cascade', deleteRule: 'cascade' })
-  test4!: Test4;
+  @MikroORM_ManyToOne({ entity: () => Test4, ref: true, updateRule: 'cascade', deleteRule: 'cascade' })
+  test4!: MikroORM_Ref<Test4>;
 
 }
 ",
-  "import { BaseEntity as MikroORM_BaseEntity, Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey } from '@mikro-orm/core';
+  "import { BaseEntity as MikroORM_BaseEntity, Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Book4 } from './Book4';
 import { BookTag4 } from './BookTag4';
 
@@ -7540,16 +8787,17 @@ export class TagsOrdered extends MikroORM_BaseEntity {
   id!: number;
 
   @MikroORM_Index({ name: 'tags_ordered_book4_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Book4, updateRule: 'cascade', deleteRule: 'cascade' })
-  book4!: Book4;
+  @MikroORM_ManyToOne({ entity: () => Book4, ref: true, updateRule: 'cascade', deleteRule: 'cascade' })
+  book4!: MikroORM_Ref<Book4>;
 
   @MikroORM_Index({ name: 'tags_ordered_book_tag4_id_index' })
-  @MikroORM_ManyToOne({ entity: () => BookTag4, updateRule: 'cascade', deleteRule: 'cascade' })
-  bookTag4!: BookTag4;
+  @MikroORM_ManyToOne({ entity: () => BookTag4, ref: true, updateRule: 'cascade', deleteRule: 'cascade' })
+  bookTag4!: MikroORM_Ref<BookTag4>;
 
 }
 ",
-  "import { BaseEntity as MikroORM_BaseEntity, Entity as MikroORM_Entity, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { BaseEntity as MikroORM_BaseEntity, Collection as MikroORM_Collection, Entity as MikroORM_Entity, OneToMany as MikroORM_OneToMany, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+import { Publisher4Tests } from './Publisher4Tests';
 
 @MikroORM_Entity()
 export class Test4 extends MikroORM_BaseEntity {
@@ -7569,6 +8817,9 @@ export class Test4 extends MikroORM_BaseEntity {
   @MikroORM_Property({ type: 'integer' })
   version: number & MikroORM_Opt = 1;
 
+  @MikroORM_OneToMany({ entity: () => Publisher4Tests, mappedBy: 'test4' })
+  publisher4TestsCollection = new MikroORM_Collection<Publisher4Tests>(this);
+
 }
 ",
   "import { BaseEntity as MikroORM_BaseEntity, Formula as MikroORM_Formula } from '@mikro-orm/core';
@@ -7585,7 +8836,7 @@ export abstract class BaseEntity2 extends MikroORM_BaseEntity {
 
 exports[`CustomBase > forceObject=true > useCoreBaseEntity=true > customBaseEntityName= > entitySchema > dump 1`] = `
 [
-  "import { BaseEntity as MikroORM_BaseEntity, Config as MikroORM_Config, type DefineConfig as MikroORM_DefineConfig, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { BaseEntity as MikroORM_BaseEntity, Collection as MikroORM_Collection, Config as MikroORM_Config, type DefineConfig as MikroORM_DefineConfig, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Book4 } from './Book4';
 
 export class Author4 extends MikroORM_BaseEntity {
@@ -7600,8 +8851,9 @@ export class Author4 extends MikroORM_BaseEntity {
   identities?: string;
   born?: string;
   bornTime?: string;
-  favouriteBook?: Book4;
+  favouriteBook?: MikroORM_Ref<Book4>;
   identity?: any;
+  book4Collection = new MikroORM_Collection<Book4>(this);
 }
 
 export const Author4Schema = new MikroORM_EntitySchema({
@@ -7620,15 +8872,19 @@ export const Author4Schema = new MikroORM_EntitySchema({
     favouriteBook: {
       kind: 'm:1',
       entity: () => Book4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
     },
     identity: { type: 'json', nullable: true },
+    book4Collection: { kind: '1:m', entity: () => Book4, mappedBy: 'author' },
   },
 });
 ",
-  "import { BaseEntity as MikroORM_BaseEntity, Config as MikroORM_Config, type DefineConfig as MikroORM_DefineConfig, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { BaseEntity as MikroORM_BaseEntity, Collection as MikroORM_Collection, Config as MikroORM_Config, type DefineConfig as MikroORM_DefineConfig, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+import { Book4 } from './Book4';
+import { TagsOrdered } from './TagsOrdered';
 
 export class BookTag4 extends MikroORM_BaseEntity {
   [MikroORM_Config]?: MikroORM_DefineConfig<{ forceObject: true }>;
@@ -7637,6 +8893,8 @@ export class BookTag4 extends MikroORM_BaseEntity {
   updatedAt?: Date;
   name!: string;
   version!: Date & MikroORM_Opt;
+  tagsUnorderedInverse = new MikroORM_Collection<Book4>(this);
+  tagsOrderedCollection = new MikroORM_Collection<TagsOrdered>(this);
 }
 
 export const BookTag4Schema = new MikroORM_EntitySchema({
@@ -7647,13 +8905,24 @@ export const BookTag4Schema = new MikroORM_EntitySchema({
     updatedAt: { type: 'datetime', nullable: true },
     name: { type: 'text' },
     version: { type: 'datetime', defaultRaw: \`current_timestamp\` },
+    tagsUnorderedInverse: {
+      kind: 'm:n',
+      entity: () => Book4,
+      mappedBy: 'tagsUnordered',
+    },
+    tagsOrderedCollection: {
+      kind: '1:m',
+      entity: () => TagsOrdered,
+      mappedBy: 'bookTag4',
+    },
   },
 });
 ",
-  "import { BaseEntity as MikroORM_BaseEntity, Collection as MikroORM_Collection, Config as MikroORM_Config, type DefineConfig as MikroORM_DefineConfig, EntitySchema as MikroORM_EntitySchema } from '@mikro-orm/core';
+  "import { BaseEntity as MikroORM_BaseEntity, Collection as MikroORM_Collection, Config as MikroORM_Config, type DefineConfig as MikroORM_DefineConfig, EntitySchema as MikroORM_EntitySchema, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Author4 } from './Author4';
 import { BookTag4 } from './BookTag4';
 import { Publisher4 } from './Publisher4';
+import { TagsOrdered } from './TagsOrdered';
 
 export class Book4 extends MikroORM_BaseEntity {
   [MikroORM_Config]?: MikroORM_DefineConfig<{ forceObject: true }>;
@@ -7662,10 +8931,12 @@ export class Book4 extends MikroORM_BaseEntity {
   updatedAt?: Date;
   title!: string;
   price?: unknown;
-  author?: Author4;
-  publisher?: Publisher4;
+  author?: MikroORM_Ref<Author4>;
+  publisher?: MikroORM_Ref<Publisher4>;
   meta?: any;
   tagsUnordered = new MikroORM_Collection<BookTag4>(this);
+  author4Collection = new MikroORM_Collection<Author4>(this);
+  tagsOrderedCollection = new MikroORM_Collection<TagsOrdered>(this);
 }
 
 export const Book4Schema = new MikroORM_EntitySchema({
@@ -7679,6 +8950,7 @@ export const Book4Schema = new MikroORM_EntitySchema({
     author: {
       kind: 'm:1',
       entity: () => Author4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
@@ -7686,6 +8958,7 @@ export const Book4Schema = new MikroORM_EntitySchema({
     publisher: {
       kind: 'm:1',
       entity: () => Publisher4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
@@ -7698,10 +8971,20 @@ export const Book4Schema = new MikroORM_EntitySchema({
       joinColumn: 'book4_id',
       inverseJoinColumn: 'book_tag4_id',
     },
+    author4Collection: {
+      kind: '1:m',
+      entity: () => Author4,
+      mappedBy: 'favouriteBook',
+    },
+    tagsOrderedCollection: {
+      kind: '1:m',
+      entity: () => TagsOrdered,
+      mappedBy: 'book4',
+    },
   },
 });
 ",
-  "import { BaseEntity as MikroORM_BaseEntity, Config as MikroORM_Config, type DefineConfig as MikroORM_DefineConfig, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { BaseEntity as MikroORM_BaseEntity, Config as MikroORM_Config, type DefineConfig as MikroORM_DefineConfig, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { FooBaz4 } from './FooBaz4';
 
 export class FooBar4 extends MikroORM_BaseEntity {
@@ -7710,13 +8993,14 @@ export class FooBar4 extends MikroORM_BaseEntity {
   createdAt?: Date;
   updatedAt?: Date;
   name: string & MikroORM_Opt = 'asd';
-  baz?: FooBaz4;
-  fooBar?: FooBar4;
+  baz?: MikroORM_Ref<FooBaz4>;
+  fooBar?: MikroORM_Ref<FooBar4>;
   version: number & MikroORM_Opt = 1;
   blob?: Buffer;
   blob2?: Buffer;
   array?: string;
   object?: any;
+  fooBar4?: MikroORM_Ref<FooBar4>;
 }
 
 export const FooBar4Schema = new MikroORM_EntitySchema({
@@ -7729,6 +9013,7 @@ export const FooBar4Schema = new MikroORM_EntitySchema({
     baz: {
       kind: '1:1',
       entity: () => FooBaz4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
@@ -7736,6 +9021,7 @@ export const FooBar4Schema = new MikroORM_EntitySchema({
     fooBar: {
       kind: '1:1',
       entity: () => FooBar4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
@@ -7745,10 +9031,12 @@ export const FooBar4Schema = new MikroORM_EntitySchema({
     blob2: { type: 'blob', nullable: true },
     array: { type: 'text', nullable: true },
     object: { type: 'json', nullable: true },
+    fooBar4: { kind: '1:1', entity: () => FooBar4, ref: true, mappedBy: 'fooBar' },
   },
 });
 ",
-  "import { BaseEntity as MikroORM_BaseEntity, Config as MikroORM_Config, type DefineConfig as MikroORM_DefineConfig, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { BaseEntity as MikroORM_BaseEntity, Config as MikroORM_Config, type DefineConfig as MikroORM_DefineConfig, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt, type Ref as MikroORM_Ref } from '@mikro-orm/core';
+import { FooBar4 } from './FooBar4';
 
 export class FooBaz4 extends MikroORM_BaseEntity {
   [MikroORM_Config]?: MikroORM_DefineConfig<{ forceObject: true }>;
@@ -7757,6 +9045,7 @@ export class FooBaz4 extends MikroORM_BaseEntity {
   updatedAt?: Date;
   name!: string;
   version!: Date & MikroORM_Opt;
+  fooBar4?: MikroORM_Ref<FooBar4>;
 }
 
 export const FooBaz4Schema = new MikroORM_EntitySchema({
@@ -7767,10 +9056,13 @@ export const FooBaz4Schema = new MikroORM_EntitySchema({
     updatedAt: { type: 'datetime', nullable: true },
     name: { type: 'text' },
     version: { type: 'datetime', defaultRaw: \`current_timestamp\` },
+    fooBar4: { kind: '1:1', entity: () => FooBar4, ref: true, mappedBy: 'baz' },
   },
 });
 ",
-  "import { BaseEntity as MikroORM_BaseEntity, Config as MikroORM_Config, type DefineConfig as MikroORM_DefineConfig, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { BaseEntity as MikroORM_BaseEntity, Collection as MikroORM_Collection, Config as MikroORM_Config, type DefineConfig as MikroORM_DefineConfig, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+import { Book4 } from './Book4';
+import { Publisher4Tests } from './Publisher4Tests';
 
 export class Publisher4 extends MikroORM_BaseEntity {
   [MikroORM_Config]?: MikroORM_DefineConfig<{ forceObject: true }>;
@@ -7778,14 +9070,18 @@ export class Publisher4 extends MikroORM_BaseEntity {
   createdAt?: Date;
   updatedAt?: Date;
   name: string & MikroORM_Opt = 'asd';
-  type: Publisher4Type & MikroORM_Opt = Publisher4Type.LOCAL;
+  type: TPublisher4Type & MikroORM_Opt = Publisher4Type.LOCAL;
   enum3?: number;
+  book4Collection = new MikroORM_Collection<Book4>(this);
+  publisher4TestsCollection = new MikroORM_Collection<Publisher4Tests>(this);
 }
 
-export enum Publisher4Type {
-  LOCAL = 'local',
-  GLOBAL = 'global',
-}
+export const Publisher4Type = {
+  LOCAL: 'local',
+  GLOBAL: 'global',
+} as const;
+
+export type TPublisher4Type = (typeof Publisher4Type)[keyof typeof Publisher4Type];
 
 export const Publisher4Schema = new MikroORM_EntitySchema({
   class: Publisher4,
@@ -7796,18 +9092,24 @@ export const Publisher4Schema = new MikroORM_EntitySchema({
     name: { type: 'text' },
     type: { enum: true, items: () => Publisher4Type },
     enum3: { type: 'integer', nullable: true },
+    book4Collection: { kind: '1:m', entity: () => Book4, mappedBy: 'publisher' },
+    publisher4TestsCollection: {
+      kind: '1:m',
+      entity: () => Publisher4Tests,
+      mappedBy: 'publisher4',
+    },
   },
 });
 ",
-  "import { BaseEntity as MikroORM_BaseEntity, Config as MikroORM_Config, type DefineConfig as MikroORM_DefineConfig, EntitySchema as MikroORM_EntitySchema } from '@mikro-orm/core';
+  "import { BaseEntity as MikroORM_BaseEntity, Config as MikroORM_Config, type DefineConfig as MikroORM_DefineConfig, EntitySchema as MikroORM_EntitySchema, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Publisher4 } from './Publisher4';
 import { Test4 } from './Test4';
 
 export class Publisher4Tests extends MikroORM_BaseEntity {
   [MikroORM_Config]?: MikroORM_DefineConfig<{ forceObject: true }>;
   id!: number;
-  publisher4!: Publisher4;
-  test4!: Test4;
+  publisher4!: MikroORM_Ref<Publisher4>;
+  test4!: MikroORM_Ref<Test4>;
 }
 
 export const Publisher4TestsSchema = new MikroORM_EntitySchema({
@@ -7818,27 +9120,29 @@ export const Publisher4TestsSchema = new MikroORM_EntitySchema({
     publisher4: {
       kind: 'm:1',
       entity: () => Publisher4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
     test4: {
       kind: 'm:1',
       entity: () => Test4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
   },
 });
 ",
-  "import { BaseEntity as MikroORM_BaseEntity, Config as MikroORM_Config, type DefineConfig as MikroORM_DefineConfig, EntitySchema as MikroORM_EntitySchema } from '@mikro-orm/core';
+  "import { BaseEntity as MikroORM_BaseEntity, Config as MikroORM_Config, type DefineConfig as MikroORM_DefineConfig, EntitySchema as MikroORM_EntitySchema, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Book4 } from './Book4';
 import { BookTag4 } from './BookTag4';
 
 export class TagsOrdered extends MikroORM_BaseEntity {
   [MikroORM_Config]?: MikroORM_DefineConfig<{ forceObject: true }>;
   id!: number;
-  book4!: Book4;
-  bookTag4!: BookTag4;
+  book4!: MikroORM_Ref<Book4>;
+  bookTag4!: MikroORM_Ref<BookTag4>;
 }
 
 export const TagsOrderedSchema = new MikroORM_EntitySchema({
@@ -7848,19 +9152,22 @@ export const TagsOrderedSchema = new MikroORM_EntitySchema({
     book4: {
       kind: 'm:1',
       entity: () => Book4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
     bookTag4: {
       kind: 'm:1',
       entity: () => BookTag4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
   },
 });
 ",
-  "import { BaseEntity as MikroORM_BaseEntity, Config as MikroORM_Config, type DefineConfig as MikroORM_DefineConfig, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { BaseEntity as MikroORM_BaseEntity, Collection as MikroORM_Collection, Config as MikroORM_Config, type DefineConfig as MikroORM_DefineConfig, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+import { Publisher4Tests } from './Publisher4Tests';
 
 export class Test4 extends MikroORM_BaseEntity {
   [MikroORM_Config]?: MikroORM_DefineConfig<{ forceObject: true }>;
@@ -7869,6 +9176,7 @@ export class Test4 extends MikroORM_BaseEntity {
   updatedAt?: Date;
   name?: string;
   version: number & MikroORM_Opt = 1;
+  publisher4TestsCollection = new MikroORM_Collection<Publisher4Tests>(this);
 }
 
 export const Test4Schema = new MikroORM_EntitySchema({
@@ -7879,6 +9187,11 @@ export const Test4Schema = new MikroORM_EntitySchema({
     updatedAt: { type: 'datetime', nullable: true },
     name: { type: 'text', nullable: true },
     version: { type: 'integer' },
+    publisher4TestsCollection: {
+      kind: '1:m',
+      entity: () => Publisher4Tests,
+      mappedBy: 'test4',
+    },
   },
 });
 ",
@@ -7901,7 +9214,7 @@ export const BaseEntity2Schema = new MikroORM_EntitySchema({
 
 exports[`CustomBase > forceObject=true > useCoreBaseEntity=true > customBaseEntityName=BaseEntity > decorators > dump 1`] = `
 [
-  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, OneToMany as MikroORM_OneToMany, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 import { Book4 } from './Book4';
 
@@ -7939,16 +9252,21 @@ export class Author4 extends BaseEntity {
   bornTime?: string;
 
   @MikroORM_Index({ name: 'author4_favourite_book_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Book4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  favouriteBook?: Book4;
+  @MikroORM_ManyToOne({ entity: () => Book4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  favouriteBook?: MikroORM_Ref<Book4>;
 
   @MikroORM_Property({ type: 'json', nullable: true })
   identity?: any;
 
+  @MikroORM_OneToMany({ entity: () => Book4, mappedBy: 'author' })
+  book4Collection = new MikroORM_Collection<Book4>(this);
+
 }
 ",
-  "import { Entity as MikroORM_Entity, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, ManyToMany as MikroORM_ManyToMany, OneToMany as MikroORM_OneToMany, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
+import { Book4 } from './Book4';
+import { TagsOrdered } from './TagsOrdered';
 
 @MikroORM_Entity()
 export class BookTag4 extends BaseEntity {
@@ -7968,13 +9286,20 @@ export class BookTag4 extends BaseEntity {
   @MikroORM_Property({ type: 'datetime', defaultRaw: \`current_timestamp\` })
   version!: Date & MikroORM_Opt;
 
+  @MikroORM_ManyToMany({ entity: () => Book4, mappedBy: 'tagsUnordered' })
+  tagsUnorderedInverse = new MikroORM_Collection<Book4>(this);
+
+  @MikroORM_OneToMany({ entity: () => TagsOrdered, mappedBy: 'bookTag4' })
+  tagsOrderedCollection = new MikroORM_Collection<TagsOrdered>(this);
+
 }
 ",
-  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToMany as MikroORM_ManyToMany, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToMany as MikroORM_ManyToMany, ManyToOne as MikroORM_ManyToOne, OneToMany as MikroORM_OneToMany, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Author4 } from './Author4';
 import { BaseEntity } from './BaseEntity';
 import { BookTag4 } from './BookTag4';
 import { Publisher4 } from './Publisher4';
+import { TagsOrdered } from './TagsOrdered';
 
 @MikroORM_Entity()
 export class Book4 extends BaseEntity {
@@ -7995,12 +9320,12 @@ export class Book4 extends BaseEntity {
   price?: unknown;
 
   @MikroORM_Index({ name: 'book4_author_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Author4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  author?: Author4;
+  @MikroORM_ManyToOne({ entity: () => Author4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  author?: MikroORM_Ref<Author4>;
 
   @MikroORM_Index({ name: 'book4_publisher_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Publisher4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  publisher?: Publisher4;
+  @MikroORM_ManyToOne({ entity: () => Publisher4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  publisher?: MikroORM_Ref<Publisher4>;
 
   @MikroORM_Property({ type: 'json', nullable: true })
   meta?: any;
@@ -8008,9 +9333,15 @@ export class Book4 extends BaseEntity {
   @MikroORM_ManyToMany({ entity: () => BookTag4, pivotTable: 'tags_unordered', joinColumn: 'book4_id', inverseJoinColumn: 'book_tag4_id' })
   tagsUnordered = new MikroORM_Collection<BookTag4>(this);
 
+  @MikroORM_OneToMany({ entity: () => Author4, mappedBy: 'favouriteBook' })
+  author4Collection = new MikroORM_Collection<Author4>(this);
+
+  @MikroORM_OneToMany({ entity: () => TagsOrdered, mappedBy: 'book4' })
+  tagsOrderedCollection = new MikroORM_Collection<TagsOrdered>(this);
+
 }
 ",
-  "import { Entity as MikroORM_Entity, OneToOne as MikroORM_OneToOne, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, Unique as MikroORM_Unique } from '@mikro-orm/core';
+  "import { Entity as MikroORM_Entity, OneToOne as MikroORM_OneToOne, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, type Ref as MikroORM_Ref, Unique as MikroORM_Unique } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 import { FooBaz4 } from './FooBaz4';
 
@@ -8030,12 +9361,12 @@ export class FooBar4 extends BaseEntity {
   name: string & MikroORM_Opt = 'asd';
 
   @MikroORM_Unique({ name: 'foo_bar4_baz_id_unique' })
-  @MikroORM_OneToOne({ entity: () => FooBaz4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  baz?: FooBaz4;
+  @MikroORM_OneToOne({ entity: () => FooBaz4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  baz?: MikroORM_Ref<FooBaz4>;
 
   @MikroORM_Unique({ name: 'foo_bar4_foo_bar_id_unique' })
-  @MikroORM_OneToOne({ entity: () => FooBar4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  fooBar?: FooBar4;
+  @MikroORM_OneToOne({ entity: () => FooBar4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  fooBar?: MikroORM_Ref<FooBar4>;
 
   @MikroORM_Property({ type: 'integer' })
   version: number & MikroORM_Opt = 1;
@@ -8052,10 +9383,14 @@ export class FooBar4 extends BaseEntity {
   @MikroORM_Property({ type: 'json', nullable: true })
   object?: any;
 
+  @MikroORM_OneToOne({ entity: () => FooBar4, ref: true, mappedBy: 'fooBar' })
+  fooBar4?: MikroORM_Ref<FooBar4>;
+
 }
 ",
-  "import { Entity as MikroORM_Entity, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Entity as MikroORM_Entity, OneToOne as MikroORM_OneToOne, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
+import { FooBar4 } from './FooBar4';
 
 @MikroORM_Entity()
 export class FooBaz4 extends BaseEntity {
@@ -8075,10 +9410,15 @@ export class FooBaz4 extends BaseEntity {
   @MikroORM_Property({ type: 'datetime', defaultRaw: \`current_timestamp\` })
   version!: Date & MikroORM_Opt;
 
+  @MikroORM_OneToOne({ entity: () => FooBar4, ref: true, mappedBy: 'baz' })
+  fooBar4?: MikroORM_Ref<FooBar4>;
+
 }
 ",
-  "import { Entity as MikroORM_Entity, Enum as MikroORM_Enum, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, Enum as MikroORM_Enum, OneToMany as MikroORM_OneToMany, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
+import { Book4 } from './Book4';
+import { Publisher4Tests } from './Publisher4Tests';
 
 @MikroORM_Entity()
 export class Publisher4 extends BaseEntity {
@@ -8096,19 +9436,27 @@ export class Publisher4 extends BaseEntity {
   name: string & MikroORM_Opt = 'asd';
 
   @MikroORM_Enum({ items: () => Publisher4Type })
-  type: Publisher4Type & MikroORM_Opt = Publisher4Type.LOCAL;
+  type: TPublisher4Type & MikroORM_Opt = Publisher4Type.LOCAL;
 
   @MikroORM_Property({ nullable: true })
   enum3?: number;
 
+  @MikroORM_OneToMany({ entity: () => Book4, mappedBy: 'publisher' })
+  book4Collection = new MikroORM_Collection<Book4>(this);
+
+  @MikroORM_OneToMany({ entity: () => Publisher4Tests, mappedBy: 'publisher4' })
+  publisher4TestsCollection = new MikroORM_Collection<Publisher4Tests>(this);
+
 }
 
-export enum Publisher4Type {
-  LOCAL = 'local',
-  GLOBAL = 'global',
-}
+export const Publisher4Type = {
+  LOCAL: 'local',
+  GLOBAL: 'global',
+} as const;
+
+export type TPublisher4Type = (typeof Publisher4Type)[keyof typeof Publisher4Type];
 ",
-  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey } from '@mikro-orm/core';
+  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 import { Publisher4 } from './Publisher4';
 import { Test4 } from './Test4';
@@ -8120,16 +9468,16 @@ export class Publisher4Tests extends BaseEntity {
   id!: number;
 
   @MikroORM_Index({ name: 'publisher4_tests_publisher4_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Publisher4, updateRule: 'cascade', deleteRule: 'cascade' })
-  publisher4!: Publisher4;
+  @MikroORM_ManyToOne({ entity: () => Publisher4, ref: true, updateRule: 'cascade', deleteRule: 'cascade' })
+  publisher4!: MikroORM_Ref<Publisher4>;
 
   @MikroORM_Index({ name: 'publisher4_tests_test4_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Test4, updateRule: 'cascade', deleteRule: 'cascade' })
-  test4!: Test4;
+  @MikroORM_ManyToOne({ entity: () => Test4, ref: true, updateRule: 'cascade', deleteRule: 'cascade' })
+  test4!: MikroORM_Ref<Test4>;
 
 }
 ",
-  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey } from '@mikro-orm/core';
+  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 import { Book4 } from './Book4';
 import { BookTag4 } from './BookTag4';
@@ -8141,17 +9489,18 @@ export class TagsOrdered extends BaseEntity {
   id!: number;
 
   @MikroORM_Index({ name: 'tags_ordered_book4_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Book4, updateRule: 'cascade', deleteRule: 'cascade' })
-  book4!: Book4;
+  @MikroORM_ManyToOne({ entity: () => Book4, ref: true, updateRule: 'cascade', deleteRule: 'cascade' })
+  book4!: MikroORM_Ref<Book4>;
 
   @MikroORM_Index({ name: 'tags_ordered_book_tag4_id_index' })
-  @MikroORM_ManyToOne({ entity: () => BookTag4, updateRule: 'cascade', deleteRule: 'cascade' })
-  bookTag4!: BookTag4;
+  @MikroORM_ManyToOne({ entity: () => BookTag4, ref: true, updateRule: 'cascade', deleteRule: 'cascade' })
+  bookTag4!: MikroORM_Ref<BookTag4>;
 
 }
 ",
-  "import { Entity as MikroORM_Entity, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, OneToMany as MikroORM_OneToMany, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
+import { Publisher4Tests } from './Publisher4Tests';
 
 @MikroORM_Entity()
 export class Test4 extends BaseEntity {
@@ -8170,6 +9519,9 @@ export class Test4 extends BaseEntity {
 
   @MikroORM_Property({ type: 'integer' })
   version: number & MikroORM_Opt = 1;
+
+  @MikroORM_OneToMany({ entity: () => Publisher4Tests, mappedBy: 'test4' })
+  publisher4TestsCollection = new MikroORM_Collection<Publisher4Tests>(this);
 
 }
 ",
@@ -8196,7 +9548,7 @@ export abstract class BaseEntity extends MikroORM_BaseEntity {
 
 exports[`CustomBase > forceObject=true > useCoreBaseEntity=true > customBaseEntityName=BaseEntity > entitySchema > dump 1`] = `
 [
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 import { Book4 } from './Book4';
 
@@ -8211,8 +9563,9 @@ export class Author4 extends BaseEntity {
   identities?: string;
   born?: string;
   bornTime?: string;
-  favouriteBook?: Book4;
+  favouriteBook?: MikroORM_Ref<Book4>;
   identity?: any;
+  book4Collection = new MikroORM_Collection<Book4>(this);
 }
 
 export const Author4Schema = new MikroORM_EntitySchema({
@@ -8231,16 +9584,20 @@ export const Author4Schema = new MikroORM_EntitySchema({
     favouriteBook: {
       kind: 'm:1',
       entity: () => Book4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
     },
     identity: { type: 'json', nullable: true },
+    book4Collection: { kind: '1:m', entity: () => Book4, mappedBy: 'author' },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
+import { Book4 } from './Book4';
+import { TagsOrdered } from './TagsOrdered';
 
 export class BookTag4 extends BaseEntity {
   id!: number;
@@ -8248,6 +9605,8 @@ export class BookTag4 extends BaseEntity {
   updatedAt?: Date;
   name!: string;
   version!: Date & MikroORM_Opt;
+  tagsUnorderedInverse = new MikroORM_Collection<Book4>(this);
+  tagsOrderedCollection = new MikroORM_Collection<TagsOrdered>(this);
 }
 
 export const BookTag4Schema = new MikroORM_EntitySchema({
@@ -8258,14 +9617,25 @@ export const BookTag4Schema = new MikroORM_EntitySchema({
     updatedAt: { type: 'datetime', nullable: true },
     name: { type: 'text' },
     version: { type: 'datetime', defaultRaw: \`current_timestamp\` },
+    tagsUnorderedInverse: {
+      kind: 'm:n',
+      entity: () => Book4,
+      mappedBy: 'tagsUnordered',
+    },
+    tagsOrderedCollection: {
+      kind: '1:m',
+      entity: () => TagsOrdered,
+      mappedBy: 'bookTag4',
+    },
   },
 });
 ",
-  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Author4 } from './Author4';
 import { BaseEntity } from './BaseEntity';
 import { BookTag4 } from './BookTag4';
 import { Publisher4 } from './Publisher4';
+import { TagsOrdered } from './TagsOrdered';
 
 export class Book4 extends BaseEntity {
   id!: number;
@@ -8273,10 +9643,12 @@ export class Book4 extends BaseEntity {
   updatedAt?: Date;
   title!: string;
   price?: unknown;
-  author?: Author4;
-  publisher?: Publisher4;
+  author?: MikroORM_Ref<Author4>;
+  publisher?: MikroORM_Ref<Publisher4>;
   meta?: any;
   tagsUnordered = new MikroORM_Collection<BookTag4>(this);
+  author4Collection = new MikroORM_Collection<Author4>(this);
+  tagsOrderedCollection = new MikroORM_Collection<TagsOrdered>(this);
 }
 
 export const Book4Schema = new MikroORM_EntitySchema({
@@ -8290,6 +9662,7 @@ export const Book4Schema = new MikroORM_EntitySchema({
     author: {
       kind: 'm:1',
       entity: () => Author4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
@@ -8297,6 +9670,7 @@ export const Book4Schema = new MikroORM_EntitySchema({
     publisher: {
       kind: 'm:1',
       entity: () => Publisher4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
@@ -8309,10 +9683,20 @@ export const Book4Schema = new MikroORM_EntitySchema({
       joinColumn: 'book4_id',
       inverseJoinColumn: 'book_tag4_id',
     },
+    author4Collection: {
+      kind: '1:m',
+      entity: () => Author4,
+      mappedBy: 'favouriteBook',
+    },
+    tagsOrderedCollection: {
+      kind: '1:m',
+      entity: () => TagsOrdered,
+      mappedBy: 'book4',
+    },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 import { FooBaz4 } from './FooBaz4';
 
@@ -8321,13 +9705,14 @@ export class FooBar4 extends BaseEntity {
   createdAt?: Date;
   updatedAt?: Date;
   name: string & MikroORM_Opt = 'asd';
-  baz?: FooBaz4;
-  fooBar?: FooBar4;
+  baz?: MikroORM_Ref<FooBaz4>;
+  fooBar?: MikroORM_Ref<FooBar4>;
   version: number & MikroORM_Opt = 1;
   blob?: Buffer;
   blob2?: Buffer;
   array?: string;
   object?: any;
+  fooBar4?: MikroORM_Ref<FooBar4>;
 }
 
 export const FooBar4Schema = new MikroORM_EntitySchema({
@@ -8340,6 +9725,7 @@ export const FooBar4Schema = new MikroORM_EntitySchema({
     baz: {
       kind: '1:1',
       entity: () => FooBaz4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
@@ -8347,6 +9733,7 @@ export const FooBar4Schema = new MikroORM_EntitySchema({
     fooBar: {
       kind: '1:1',
       entity: () => FooBar4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
@@ -8356,11 +9743,13 @@ export const FooBar4Schema = new MikroORM_EntitySchema({
     blob2: { type: 'blob', nullable: true },
     array: { type: 'text', nullable: true },
     object: { type: 'json', nullable: true },
+    fooBar4: { kind: '1:1', entity: () => FooBar4, ref: true, mappedBy: 'fooBar' },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
+import { FooBar4 } from './FooBar4';
 
 export class FooBaz4 extends BaseEntity {
   id!: number;
@@ -8368,6 +9757,7 @@ export class FooBaz4 extends BaseEntity {
   updatedAt?: Date;
   name!: string;
   version!: Date & MikroORM_Opt;
+  fooBar4?: MikroORM_Ref<FooBar4>;
 }
 
 export const FooBaz4Schema = new MikroORM_EntitySchema({
@@ -8378,25 +9768,32 @@ export const FooBaz4Schema = new MikroORM_EntitySchema({
     updatedAt: { type: 'datetime', nullable: true },
     name: { type: 'text' },
     version: { type: 'datetime', defaultRaw: \`current_timestamp\` },
+    fooBar4: { kind: '1:1', entity: () => FooBar4, ref: true, mappedBy: 'baz' },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
+import { Book4 } from './Book4';
+import { Publisher4Tests } from './Publisher4Tests';
 
 export class Publisher4 extends BaseEntity {
   id!: number;
   createdAt?: Date;
   updatedAt?: Date;
   name: string & MikroORM_Opt = 'asd';
-  type: Publisher4Type & MikroORM_Opt = Publisher4Type.LOCAL;
+  type: TPublisher4Type & MikroORM_Opt = Publisher4Type.LOCAL;
   enum3?: number;
+  book4Collection = new MikroORM_Collection<Book4>(this);
+  publisher4TestsCollection = new MikroORM_Collection<Publisher4Tests>(this);
 }
 
-export enum Publisher4Type {
-  LOCAL = 'local',
-  GLOBAL = 'global',
-}
+export const Publisher4Type = {
+  LOCAL: 'local',
+  GLOBAL: 'global',
+} as const;
+
+export type TPublisher4Type = (typeof Publisher4Type)[keyof typeof Publisher4Type];
 
 export const Publisher4Schema = new MikroORM_EntitySchema({
   class: Publisher4,
@@ -8407,18 +9804,24 @@ export const Publisher4Schema = new MikroORM_EntitySchema({
     name: { type: 'text' },
     type: { enum: true, items: () => Publisher4Type },
     enum3: { type: 'integer', nullable: true },
+    book4Collection: { kind: '1:m', entity: () => Book4, mappedBy: 'publisher' },
+    publisher4TestsCollection: {
+      kind: '1:m',
+      entity: () => Publisher4Tests,
+      mappedBy: 'publisher4',
+    },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema } from '@mikro-orm/core';
+  "import { EntitySchema as MikroORM_EntitySchema, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 import { Publisher4 } from './Publisher4';
 import { Test4 } from './Test4';
 
 export class Publisher4Tests extends BaseEntity {
   id!: number;
-  publisher4!: Publisher4;
-  test4!: Test4;
+  publisher4!: MikroORM_Ref<Publisher4>;
+  test4!: MikroORM_Ref<Test4>;
 }
 
 export const Publisher4TestsSchema = new MikroORM_EntitySchema({
@@ -8429,27 +9832,29 @@ export const Publisher4TestsSchema = new MikroORM_EntitySchema({
     publisher4: {
       kind: 'm:1',
       entity: () => Publisher4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
     test4: {
       kind: 'm:1',
       entity: () => Test4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema } from '@mikro-orm/core';
+  "import { EntitySchema as MikroORM_EntitySchema, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
 import { Book4 } from './Book4';
 import { BookTag4 } from './BookTag4';
 
 export class TagsOrdered extends BaseEntity {
   id!: number;
-  book4!: Book4;
-  bookTag4!: BookTag4;
+  book4!: MikroORM_Ref<Book4>;
+  bookTag4!: MikroORM_Ref<BookTag4>;
 }
 
 export const TagsOrderedSchema = new MikroORM_EntitySchema({
@@ -8459,20 +9864,23 @@ export const TagsOrderedSchema = new MikroORM_EntitySchema({
     book4: {
       kind: 'm:1',
       entity: () => Book4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
     bookTag4: {
       kind: 'm:1',
       entity: () => BookTag4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
 import { BaseEntity } from './BaseEntity';
+import { Publisher4Tests } from './Publisher4Tests';
 
 export class Test4 extends BaseEntity {
   id!: number;
@@ -8480,6 +9888,7 @@ export class Test4 extends BaseEntity {
   updatedAt?: Date;
   name?: string;
   version: number & MikroORM_Opt = 1;
+  publisher4TestsCollection = new MikroORM_Collection<Publisher4Tests>(this);
 }
 
 export const Test4Schema = new MikroORM_EntitySchema({
@@ -8490,6 +9899,11 @@ export const Test4Schema = new MikroORM_EntitySchema({
     updatedAt: { type: 'datetime', nullable: true },
     name: { type: 'text', nullable: true },
     version: { type: 'integer' },
+    publisher4TestsCollection: {
+      kind: '1:m',
+      entity: () => Publisher4Tests,
+      mappedBy: 'test4',
+    },
   },
 });
 ",
@@ -8524,7 +9938,7 @@ export const BaseEntitySchema = new MikroORM_EntitySchema({
 
 exports[`CustomBase > forceObject=true > useCoreBaseEntity=true > customBaseEntityName=BaseEntity2 > decorators > dump 1`] = `
 [
-  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, OneToMany as MikroORM_OneToMany, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity2 } from './BaseEntity2';
 import { Book4 } from './Book4';
 
@@ -8562,16 +9976,21 @@ export class Author4 extends BaseEntity2 {
   bornTime?: string;
 
   @MikroORM_Index({ name: 'author4_favourite_book_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Book4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  favouriteBook?: Book4;
+  @MikroORM_ManyToOne({ entity: () => Book4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  favouriteBook?: MikroORM_Ref<Book4>;
 
   @MikroORM_Property({ type: 'json', nullable: true })
   identity?: any;
 
+  @MikroORM_OneToMany({ entity: () => Book4, mappedBy: 'author' })
+  book4Collection = new MikroORM_Collection<Book4>(this);
+
 }
 ",
-  "import { Entity as MikroORM_Entity, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, ManyToMany as MikroORM_ManyToMany, OneToMany as MikroORM_OneToMany, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
 import { BaseEntity2 } from './BaseEntity2';
+import { Book4 } from './Book4';
+import { TagsOrdered } from './TagsOrdered';
 
 @MikroORM_Entity()
 export class BookTag4 extends BaseEntity2 {
@@ -8591,13 +10010,20 @@ export class BookTag4 extends BaseEntity2 {
   @MikroORM_Property({ type: 'datetime', defaultRaw: \`current_timestamp\` })
   version!: Date & MikroORM_Opt;
 
+  @MikroORM_ManyToMany({ entity: () => Book4, mappedBy: 'tagsUnordered' })
+  tagsUnorderedInverse = new MikroORM_Collection<Book4>(this);
+
+  @MikroORM_OneToMany({ entity: () => TagsOrdered, mappedBy: 'bookTag4' })
+  tagsOrderedCollection = new MikroORM_Collection<TagsOrdered>(this);
+
 }
 ",
-  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToMany as MikroORM_ManyToMany, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToMany as MikroORM_ManyToMany, ManyToOne as MikroORM_ManyToOne, OneToMany as MikroORM_OneToMany, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Author4 } from './Author4';
 import { BaseEntity2 } from './BaseEntity2';
 import { BookTag4 } from './BookTag4';
 import { Publisher4 } from './Publisher4';
+import { TagsOrdered } from './TagsOrdered';
 
 @MikroORM_Entity()
 export class Book4 extends BaseEntity2 {
@@ -8618,12 +10044,12 @@ export class Book4 extends BaseEntity2 {
   price?: unknown;
 
   @MikroORM_Index({ name: 'book4_author_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Author4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  author?: Author4;
+  @MikroORM_ManyToOne({ entity: () => Author4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  author?: MikroORM_Ref<Author4>;
 
   @MikroORM_Index({ name: 'book4_publisher_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Publisher4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  publisher?: Publisher4;
+  @MikroORM_ManyToOne({ entity: () => Publisher4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  publisher?: MikroORM_Ref<Publisher4>;
 
   @MikroORM_Property({ type: 'json', nullable: true })
   meta?: any;
@@ -8631,9 +10057,15 @@ export class Book4 extends BaseEntity2 {
   @MikroORM_ManyToMany({ entity: () => BookTag4, pivotTable: 'tags_unordered', joinColumn: 'book4_id', inverseJoinColumn: 'book_tag4_id' })
   tagsUnordered = new MikroORM_Collection<BookTag4>(this);
 
+  @MikroORM_OneToMany({ entity: () => Author4, mappedBy: 'favouriteBook' })
+  author4Collection = new MikroORM_Collection<Author4>(this);
+
+  @MikroORM_OneToMany({ entity: () => TagsOrdered, mappedBy: 'book4' })
+  tagsOrderedCollection = new MikroORM_Collection<TagsOrdered>(this);
+
 }
 ",
-  "import { Entity as MikroORM_Entity, OneToOne as MikroORM_OneToOne, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, Unique as MikroORM_Unique } from '@mikro-orm/core';
+  "import { Entity as MikroORM_Entity, OneToOne as MikroORM_OneToOne, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, type Ref as MikroORM_Ref, Unique as MikroORM_Unique } from '@mikro-orm/core';
 import { BaseEntity2 } from './BaseEntity2';
 import { FooBaz4 } from './FooBaz4';
 
@@ -8653,12 +10085,12 @@ export class FooBar4 extends BaseEntity2 {
   name: string & MikroORM_Opt = 'asd';
 
   @MikroORM_Unique({ name: 'foo_bar4_baz_id_unique' })
-  @MikroORM_OneToOne({ entity: () => FooBaz4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  baz?: FooBaz4;
+  @MikroORM_OneToOne({ entity: () => FooBaz4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  baz?: MikroORM_Ref<FooBaz4>;
 
   @MikroORM_Unique({ name: 'foo_bar4_foo_bar_id_unique' })
-  @MikroORM_OneToOne({ entity: () => FooBar4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  fooBar?: FooBar4;
+  @MikroORM_OneToOne({ entity: () => FooBar4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  fooBar?: MikroORM_Ref<FooBar4>;
 
   @MikroORM_Property({ type: 'integer' })
   version: number & MikroORM_Opt = 1;
@@ -8675,10 +10107,14 @@ export class FooBar4 extends BaseEntity2 {
   @MikroORM_Property({ type: 'json', nullable: true })
   object?: any;
 
+  @MikroORM_OneToOne({ entity: () => FooBar4, ref: true, mappedBy: 'fooBar' })
+  fooBar4?: MikroORM_Ref<FooBar4>;
+
 }
 ",
-  "import { Entity as MikroORM_Entity, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Entity as MikroORM_Entity, OneToOne as MikroORM_OneToOne, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity2 } from './BaseEntity2';
+import { FooBar4 } from './FooBar4';
 
 @MikroORM_Entity()
 export class FooBaz4 extends BaseEntity2 {
@@ -8698,10 +10134,15 @@ export class FooBaz4 extends BaseEntity2 {
   @MikroORM_Property({ type: 'datetime', defaultRaw: \`current_timestamp\` })
   version!: Date & MikroORM_Opt;
 
+  @MikroORM_OneToOne({ entity: () => FooBar4, ref: true, mappedBy: 'baz' })
+  fooBar4?: MikroORM_Ref<FooBar4>;
+
 }
 ",
-  "import { Entity as MikroORM_Entity, Enum as MikroORM_Enum, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, Enum as MikroORM_Enum, OneToMany as MikroORM_OneToMany, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
 import { BaseEntity2 } from './BaseEntity2';
+import { Book4 } from './Book4';
+import { Publisher4Tests } from './Publisher4Tests';
 
 @MikroORM_Entity()
 export class Publisher4 extends BaseEntity2 {
@@ -8719,19 +10160,27 @@ export class Publisher4 extends BaseEntity2 {
   name: string & MikroORM_Opt = 'asd';
 
   @MikroORM_Enum({ items: () => Publisher4Type })
-  type: Publisher4Type & MikroORM_Opt = Publisher4Type.LOCAL;
+  type: TPublisher4Type & MikroORM_Opt = Publisher4Type.LOCAL;
 
   @MikroORM_Property({ nullable: true })
   enum3?: number;
 
+  @MikroORM_OneToMany({ entity: () => Book4, mappedBy: 'publisher' })
+  book4Collection = new MikroORM_Collection<Book4>(this);
+
+  @MikroORM_OneToMany({ entity: () => Publisher4Tests, mappedBy: 'publisher4' })
+  publisher4TestsCollection = new MikroORM_Collection<Publisher4Tests>(this);
+
 }
 
-export enum Publisher4Type {
-  LOCAL = 'local',
-  GLOBAL = 'global',
-}
+export const Publisher4Type = {
+  LOCAL: 'local',
+  GLOBAL: 'global',
+} as const;
+
+export type TPublisher4Type = (typeof Publisher4Type)[keyof typeof Publisher4Type];
 ",
-  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey } from '@mikro-orm/core';
+  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity2 } from './BaseEntity2';
 import { Publisher4 } from './Publisher4';
 import { Test4 } from './Test4';
@@ -8743,16 +10192,16 @@ export class Publisher4Tests extends BaseEntity2 {
   id!: number;
 
   @MikroORM_Index({ name: 'publisher4_tests_publisher4_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Publisher4, updateRule: 'cascade', deleteRule: 'cascade' })
-  publisher4!: Publisher4;
+  @MikroORM_ManyToOne({ entity: () => Publisher4, ref: true, updateRule: 'cascade', deleteRule: 'cascade' })
+  publisher4!: MikroORM_Ref<Publisher4>;
 
   @MikroORM_Index({ name: 'publisher4_tests_test4_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Test4, updateRule: 'cascade', deleteRule: 'cascade' })
-  test4!: Test4;
+  @MikroORM_ManyToOne({ entity: () => Test4, ref: true, updateRule: 'cascade', deleteRule: 'cascade' })
+  test4!: MikroORM_Ref<Test4>;
 
 }
 ",
-  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey } from '@mikro-orm/core';
+  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity2 } from './BaseEntity2';
 import { Book4 } from './Book4';
 import { BookTag4 } from './BookTag4';
@@ -8764,17 +10213,18 @@ export class TagsOrdered extends BaseEntity2 {
   id!: number;
 
   @MikroORM_Index({ name: 'tags_ordered_book4_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Book4, updateRule: 'cascade', deleteRule: 'cascade' })
-  book4!: Book4;
+  @MikroORM_ManyToOne({ entity: () => Book4, ref: true, updateRule: 'cascade', deleteRule: 'cascade' })
+  book4!: MikroORM_Ref<Book4>;
 
   @MikroORM_Index({ name: 'tags_ordered_book_tag4_id_index' })
-  @MikroORM_ManyToOne({ entity: () => BookTag4, updateRule: 'cascade', deleteRule: 'cascade' })
-  bookTag4!: BookTag4;
+  @MikroORM_ManyToOne({ entity: () => BookTag4, ref: true, updateRule: 'cascade', deleteRule: 'cascade' })
+  bookTag4!: MikroORM_Ref<BookTag4>;
 
 }
 ",
-  "import { Entity as MikroORM_Entity, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, OneToMany as MikroORM_OneToMany, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
 import { BaseEntity2 } from './BaseEntity2';
+import { Publisher4Tests } from './Publisher4Tests';
 
 @MikroORM_Entity()
 export class Test4 extends BaseEntity2 {
@@ -8793,6 +10243,9 @@ export class Test4 extends BaseEntity2 {
 
   @MikroORM_Property({ type: 'integer' })
   version: number & MikroORM_Opt = 1;
+
+  @MikroORM_OneToMany({ entity: () => Publisher4Tests, mappedBy: 'test4' })
+  publisher4TestsCollection = new MikroORM_Collection<Publisher4Tests>(this);
 
 }
 ",
@@ -8813,7 +10266,7 @@ export abstract class BaseEntity2 extends MikroORM_BaseEntity {
 
 exports[`CustomBase > forceObject=true > useCoreBaseEntity=true > customBaseEntityName=BaseEntity2 > entitySchema > dump 1`] = `
 [
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity2 } from './BaseEntity2';
 import { Book4 } from './Book4';
 
@@ -8828,8 +10281,9 @@ export class Author4 extends BaseEntity2 {
   identities?: string;
   born?: string;
   bornTime?: string;
-  favouriteBook?: Book4;
+  favouriteBook?: MikroORM_Ref<Book4>;
   identity?: any;
+  book4Collection = new MikroORM_Collection<Book4>(this);
 }
 
 export const Author4Schema = new MikroORM_EntitySchema({
@@ -8848,16 +10302,20 @@ export const Author4Schema = new MikroORM_EntitySchema({
     favouriteBook: {
       kind: 'm:1',
       entity: () => Book4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
     },
     identity: { type: 'json', nullable: true },
+    book4Collection: { kind: '1:m', entity: () => Book4, mappedBy: 'author' },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
 import { BaseEntity2 } from './BaseEntity2';
+import { Book4 } from './Book4';
+import { TagsOrdered } from './TagsOrdered';
 
 export class BookTag4 extends BaseEntity2 {
   id!: number;
@@ -8865,6 +10323,8 @@ export class BookTag4 extends BaseEntity2 {
   updatedAt?: Date;
   name!: string;
   version!: Date & MikroORM_Opt;
+  tagsUnorderedInverse = new MikroORM_Collection<Book4>(this);
+  tagsOrderedCollection = new MikroORM_Collection<TagsOrdered>(this);
 }
 
 export const BookTag4Schema = new MikroORM_EntitySchema({
@@ -8875,14 +10335,25 @@ export const BookTag4Schema = new MikroORM_EntitySchema({
     updatedAt: { type: 'datetime', nullable: true },
     name: { type: 'text' },
     version: { type: 'datetime', defaultRaw: \`current_timestamp\` },
+    tagsUnorderedInverse: {
+      kind: 'm:n',
+      entity: () => Book4,
+      mappedBy: 'tagsUnordered',
+    },
+    tagsOrderedCollection: {
+      kind: '1:m',
+      entity: () => TagsOrdered,
+      mappedBy: 'bookTag4',
+    },
   },
 });
 ",
-  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Author4 } from './Author4';
 import { BaseEntity2 } from './BaseEntity2';
 import { BookTag4 } from './BookTag4';
 import { Publisher4 } from './Publisher4';
+import { TagsOrdered } from './TagsOrdered';
 
 export class Book4 extends BaseEntity2 {
   id!: number;
@@ -8890,10 +10361,12 @@ export class Book4 extends BaseEntity2 {
   updatedAt?: Date;
   title!: string;
   price?: unknown;
-  author?: Author4;
-  publisher?: Publisher4;
+  author?: MikroORM_Ref<Author4>;
+  publisher?: MikroORM_Ref<Publisher4>;
   meta?: any;
   tagsUnordered = new MikroORM_Collection<BookTag4>(this);
+  author4Collection = new MikroORM_Collection<Author4>(this);
+  tagsOrderedCollection = new MikroORM_Collection<TagsOrdered>(this);
 }
 
 export const Book4Schema = new MikroORM_EntitySchema({
@@ -8907,6 +10380,7 @@ export const Book4Schema = new MikroORM_EntitySchema({
     author: {
       kind: 'm:1',
       entity: () => Author4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
@@ -8914,6 +10388,7 @@ export const Book4Schema = new MikroORM_EntitySchema({
     publisher: {
       kind: 'm:1',
       entity: () => Publisher4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
@@ -8926,10 +10401,20 @@ export const Book4Schema = new MikroORM_EntitySchema({
       joinColumn: 'book4_id',
       inverseJoinColumn: 'book_tag4_id',
     },
+    author4Collection: {
+      kind: '1:m',
+      entity: () => Author4,
+      mappedBy: 'favouriteBook',
+    },
+    tagsOrderedCollection: {
+      kind: '1:m',
+      entity: () => TagsOrdered,
+      mappedBy: 'book4',
+    },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity2 } from './BaseEntity2';
 import { FooBaz4 } from './FooBaz4';
 
@@ -8938,13 +10423,14 @@ export class FooBar4 extends BaseEntity2 {
   createdAt?: Date;
   updatedAt?: Date;
   name: string & MikroORM_Opt = 'asd';
-  baz?: FooBaz4;
-  fooBar?: FooBar4;
+  baz?: MikroORM_Ref<FooBaz4>;
+  fooBar?: MikroORM_Ref<FooBar4>;
   version: number & MikroORM_Opt = 1;
   blob?: Buffer;
   blob2?: Buffer;
   array?: string;
   object?: any;
+  fooBar4?: MikroORM_Ref<FooBar4>;
 }
 
 export const FooBar4Schema = new MikroORM_EntitySchema({
@@ -8957,6 +10443,7 @@ export const FooBar4Schema = new MikroORM_EntitySchema({
     baz: {
       kind: '1:1',
       entity: () => FooBaz4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
@@ -8964,6 +10451,7 @@ export const FooBar4Schema = new MikroORM_EntitySchema({
     fooBar: {
       kind: '1:1',
       entity: () => FooBar4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
@@ -8973,11 +10461,13 @@ export const FooBar4Schema = new MikroORM_EntitySchema({
     blob2: { type: 'blob', nullable: true },
     array: { type: 'text', nullable: true },
     object: { type: 'json', nullable: true },
+    fooBar4: { kind: '1:1', entity: () => FooBar4, ref: true, mappedBy: 'fooBar' },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity2 } from './BaseEntity2';
+import { FooBar4 } from './FooBar4';
 
 export class FooBaz4 extends BaseEntity2 {
   id!: number;
@@ -8985,6 +10475,7 @@ export class FooBaz4 extends BaseEntity2 {
   updatedAt?: Date;
   name!: string;
   version!: Date & MikroORM_Opt;
+  fooBar4?: MikroORM_Ref<FooBar4>;
 }
 
 export const FooBaz4Schema = new MikroORM_EntitySchema({
@@ -8995,25 +10486,32 @@ export const FooBaz4Schema = new MikroORM_EntitySchema({
     updatedAt: { type: 'datetime', nullable: true },
     name: { type: 'text' },
     version: { type: 'datetime', defaultRaw: \`current_timestamp\` },
+    fooBar4: { kind: '1:1', entity: () => FooBar4, ref: true, mappedBy: 'baz' },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
 import { BaseEntity2 } from './BaseEntity2';
+import { Book4 } from './Book4';
+import { Publisher4Tests } from './Publisher4Tests';
 
 export class Publisher4 extends BaseEntity2 {
   id!: number;
   createdAt?: Date;
   updatedAt?: Date;
   name: string & MikroORM_Opt = 'asd';
-  type: Publisher4Type & MikroORM_Opt = Publisher4Type.LOCAL;
+  type: TPublisher4Type & MikroORM_Opt = Publisher4Type.LOCAL;
   enum3?: number;
+  book4Collection = new MikroORM_Collection<Book4>(this);
+  publisher4TestsCollection = new MikroORM_Collection<Publisher4Tests>(this);
 }
 
-export enum Publisher4Type {
-  LOCAL = 'local',
-  GLOBAL = 'global',
-}
+export const Publisher4Type = {
+  LOCAL: 'local',
+  GLOBAL: 'global',
+} as const;
+
+export type TPublisher4Type = (typeof Publisher4Type)[keyof typeof Publisher4Type];
 
 export const Publisher4Schema = new MikroORM_EntitySchema({
   class: Publisher4,
@@ -9024,18 +10522,24 @@ export const Publisher4Schema = new MikroORM_EntitySchema({
     name: { type: 'text' },
     type: { enum: true, items: () => Publisher4Type },
     enum3: { type: 'integer', nullable: true },
+    book4Collection: { kind: '1:m', entity: () => Book4, mappedBy: 'publisher' },
+    publisher4TestsCollection: {
+      kind: '1:m',
+      entity: () => Publisher4Tests,
+      mappedBy: 'publisher4',
+    },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema } from '@mikro-orm/core';
+  "import { EntitySchema as MikroORM_EntitySchema, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity2 } from './BaseEntity2';
 import { Publisher4 } from './Publisher4';
 import { Test4 } from './Test4';
 
 export class Publisher4Tests extends BaseEntity2 {
   id!: number;
-  publisher4!: Publisher4;
-  test4!: Test4;
+  publisher4!: MikroORM_Ref<Publisher4>;
+  test4!: MikroORM_Ref<Test4>;
 }
 
 export const Publisher4TestsSchema = new MikroORM_EntitySchema({
@@ -9046,27 +10550,29 @@ export const Publisher4TestsSchema = new MikroORM_EntitySchema({
     publisher4: {
       kind: 'm:1',
       entity: () => Publisher4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
     test4: {
       kind: 'm:1',
       entity: () => Test4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema } from '@mikro-orm/core';
+  "import { EntitySchema as MikroORM_EntitySchema, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { BaseEntity2 } from './BaseEntity2';
 import { Book4 } from './Book4';
 import { BookTag4 } from './BookTag4';
 
 export class TagsOrdered extends BaseEntity2 {
   id!: number;
-  book4!: Book4;
-  bookTag4!: BookTag4;
+  book4!: MikroORM_Ref<Book4>;
+  bookTag4!: MikroORM_Ref<BookTag4>;
 }
 
 export const TagsOrderedSchema = new MikroORM_EntitySchema({
@@ -9076,20 +10582,23 @@ export const TagsOrderedSchema = new MikroORM_EntitySchema({
     book4: {
       kind: 'm:1',
       entity: () => Book4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
     bookTag4: {
       kind: 'm:1',
       entity: () => BookTag4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
 import { BaseEntity2 } from './BaseEntity2';
+import { Publisher4Tests } from './Publisher4Tests';
 
 export class Test4 extends BaseEntity2 {
   id!: number;
@@ -9097,6 +10606,7 @@ export class Test4 extends BaseEntity2 {
   updatedAt?: Date;
   name?: string;
   version: number & MikroORM_Opt = 1;
+  publisher4TestsCollection = new MikroORM_Collection<Publisher4Tests>(this);
 }
 
 export const Test4Schema = new MikroORM_EntitySchema({
@@ -9107,6 +10617,11 @@ export const Test4Schema = new MikroORM_EntitySchema({
     updatedAt: { type: 'datetime', nullable: true },
     name: { type: 'text', nullable: true },
     version: { type: 'integer' },
+    publisher4TestsCollection: {
+      kind: '1:m',
+      entity: () => Publisher4Tests,
+      mappedBy: 'test4',
+    },
   },
 });
 ",
@@ -9129,7 +10644,7 @@ export const BaseEntity2Schema = new MikroORM_EntitySchema({
 
 exports[`CustomBase > forceObject=true > useCoreBaseEntity=true > customBaseEntityName=CustomBase > decorators > dump 1`] = `
 [
-  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, OneToMany as MikroORM_OneToMany, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Book4 } from './Book4';
 import { CustomBase } from './CustomBase';
 
@@ -9167,16 +10682,21 @@ export class Author4 extends CustomBase {
   bornTime?: string;
 
   @MikroORM_Index({ name: 'author4_favourite_book_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Book4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  favouriteBook?: Book4;
+  @MikroORM_ManyToOne({ entity: () => Book4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  favouriteBook?: MikroORM_Ref<Book4>;
 
   @MikroORM_Property({ type: 'json', nullable: true })
   identity?: any;
 
+  @MikroORM_OneToMany({ entity: () => Book4, mappedBy: 'author' })
+  book4Collection = new MikroORM_Collection<Book4>(this);
+
 }
 ",
-  "import { Entity as MikroORM_Entity, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, ManyToMany as MikroORM_ManyToMany, OneToMany as MikroORM_OneToMany, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+import { Book4 } from './Book4';
 import { CustomBase } from './CustomBase';
+import { TagsOrdered } from './TagsOrdered';
 
 @MikroORM_Entity()
 export class BookTag4 extends CustomBase {
@@ -9196,13 +10716,20 @@ export class BookTag4 extends CustomBase {
   @MikroORM_Property({ type: 'datetime', defaultRaw: \`current_timestamp\` })
   version!: Date & MikroORM_Opt;
 
+  @MikroORM_ManyToMany({ entity: () => Book4, mappedBy: 'tagsUnordered' })
+  tagsUnorderedInverse = new MikroORM_Collection<Book4>(this);
+
+  @MikroORM_OneToMany({ entity: () => TagsOrdered, mappedBy: 'bookTag4' })
+  tagsOrderedCollection = new MikroORM_Collection<TagsOrdered>(this);
+
 }
 ",
-  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToMany as MikroORM_ManyToMany, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToMany as MikroORM_ManyToMany, ManyToOne as MikroORM_ManyToOne, OneToMany as MikroORM_OneToMany, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Author4 } from './Author4';
 import { BookTag4 } from './BookTag4';
 import { CustomBase } from './CustomBase';
 import { Publisher4 } from './Publisher4';
+import { TagsOrdered } from './TagsOrdered';
 
 @MikroORM_Entity()
 export class Book4 extends CustomBase {
@@ -9223,12 +10750,12 @@ export class Book4 extends CustomBase {
   price?: unknown;
 
   @MikroORM_Index({ name: 'book4_author_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Author4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  author?: Author4;
+  @MikroORM_ManyToOne({ entity: () => Author4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  author?: MikroORM_Ref<Author4>;
 
   @MikroORM_Index({ name: 'book4_publisher_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Publisher4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  publisher?: Publisher4;
+  @MikroORM_ManyToOne({ entity: () => Publisher4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  publisher?: MikroORM_Ref<Publisher4>;
 
   @MikroORM_Property({ type: 'json', nullable: true })
   meta?: any;
@@ -9236,9 +10763,15 @@ export class Book4 extends CustomBase {
   @MikroORM_ManyToMany({ entity: () => BookTag4, pivotTable: 'tags_unordered', joinColumn: 'book4_id', inverseJoinColumn: 'book_tag4_id' })
   tagsUnordered = new MikroORM_Collection<BookTag4>(this);
 
+  @MikroORM_OneToMany({ entity: () => Author4, mappedBy: 'favouriteBook' })
+  author4Collection = new MikroORM_Collection<Author4>(this);
+
+  @MikroORM_OneToMany({ entity: () => TagsOrdered, mappedBy: 'book4' })
+  tagsOrderedCollection = new MikroORM_Collection<TagsOrdered>(this);
+
 }
 ",
-  "import { Entity as MikroORM_Entity, OneToOne as MikroORM_OneToOne, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, Unique as MikroORM_Unique } from '@mikro-orm/core';
+  "import { Entity as MikroORM_Entity, OneToOne as MikroORM_OneToOne, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, type Ref as MikroORM_Ref, Unique as MikroORM_Unique } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
 import { FooBaz4 } from './FooBaz4';
 
@@ -9258,12 +10791,12 @@ export class FooBar4 extends CustomBase {
   name: string & MikroORM_Opt = 'asd';
 
   @MikroORM_Unique({ name: 'foo_bar4_baz_id_unique' })
-  @MikroORM_OneToOne({ entity: () => FooBaz4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  baz?: FooBaz4;
+  @MikroORM_OneToOne({ entity: () => FooBaz4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  baz?: MikroORM_Ref<FooBaz4>;
 
   @MikroORM_Unique({ name: 'foo_bar4_foo_bar_id_unique' })
-  @MikroORM_OneToOne({ entity: () => FooBar4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  fooBar?: FooBar4;
+  @MikroORM_OneToOne({ entity: () => FooBar4, ref: true, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
+  fooBar?: MikroORM_Ref<FooBar4>;
 
   @MikroORM_Property({ type: 'integer' })
   version: number & MikroORM_Opt = 1;
@@ -9280,10 +10813,14 @@ export class FooBar4 extends CustomBase {
   @MikroORM_Property({ type: 'json', nullable: true })
   object?: any;
 
+  @MikroORM_OneToOne({ entity: () => FooBar4, ref: true, mappedBy: 'fooBar' })
+  fooBar4?: MikroORM_Ref<FooBar4>;
+
 }
 ",
-  "import { Entity as MikroORM_Entity, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Entity as MikroORM_Entity, OneToOne as MikroORM_OneToOne, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
+import { FooBar4 } from './FooBar4';
 
 @MikroORM_Entity()
 export class FooBaz4 extends CustomBase {
@@ -9303,10 +10840,15 @@ export class FooBaz4 extends CustomBase {
   @MikroORM_Property({ type: 'datetime', defaultRaw: \`current_timestamp\` })
   version!: Date & MikroORM_Opt;
 
+  @MikroORM_OneToOne({ entity: () => FooBar4, ref: true, mappedBy: 'baz' })
+  fooBar4?: MikroORM_Ref<FooBar4>;
+
 }
 ",
-  "import { Entity as MikroORM_Entity, Enum as MikroORM_Enum, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, Enum as MikroORM_Enum, OneToMany as MikroORM_OneToMany, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+import { Book4 } from './Book4';
 import { CustomBase } from './CustomBase';
+import { Publisher4Tests } from './Publisher4Tests';
 
 @MikroORM_Entity()
 export class Publisher4 extends CustomBase {
@@ -9324,19 +10866,27 @@ export class Publisher4 extends CustomBase {
   name: string & MikroORM_Opt = 'asd';
 
   @MikroORM_Enum({ items: () => Publisher4Type })
-  type: Publisher4Type & MikroORM_Opt = Publisher4Type.LOCAL;
+  type: TPublisher4Type & MikroORM_Opt = Publisher4Type.LOCAL;
 
   @MikroORM_Property({ nullable: true })
   enum3?: number;
 
+  @MikroORM_OneToMany({ entity: () => Book4, mappedBy: 'publisher' })
+  book4Collection = new MikroORM_Collection<Book4>(this);
+
+  @MikroORM_OneToMany({ entity: () => Publisher4Tests, mappedBy: 'publisher4' })
+  publisher4TestsCollection = new MikroORM_Collection<Publisher4Tests>(this);
+
 }
 
-export enum Publisher4Type {
-  LOCAL = 'local',
-  GLOBAL = 'global',
-}
+export const Publisher4Type = {
+  LOCAL: 'local',
+  GLOBAL: 'global',
+} as const;
+
+export type TPublisher4Type = (typeof Publisher4Type)[keyof typeof Publisher4Type];
 ",
-  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey } from '@mikro-orm/core';
+  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
 import { Publisher4 } from './Publisher4';
 import { Test4 } from './Test4';
@@ -9348,16 +10898,16 @@ export class Publisher4Tests extends CustomBase {
   id!: number;
 
   @MikroORM_Index({ name: 'publisher4_tests_publisher4_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Publisher4, updateRule: 'cascade', deleteRule: 'cascade' })
-  publisher4!: Publisher4;
+  @MikroORM_ManyToOne({ entity: () => Publisher4, ref: true, updateRule: 'cascade', deleteRule: 'cascade' })
+  publisher4!: MikroORM_Ref<Publisher4>;
 
   @MikroORM_Index({ name: 'publisher4_tests_test4_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Test4, updateRule: 'cascade', deleteRule: 'cascade' })
-  test4!: Test4;
+  @MikroORM_ManyToOne({ entity: () => Test4, ref: true, updateRule: 'cascade', deleteRule: 'cascade' })
+  test4!: MikroORM_Ref<Test4>;
 
 }
 ",
-  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey } from '@mikro-orm/core';
+  "import { Entity as MikroORM_Entity, Index as MikroORM_Index, ManyToOne as MikroORM_ManyToOne, PrimaryKey as MikroORM_PrimaryKey, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Book4 } from './Book4';
 import { BookTag4 } from './BookTag4';
 import { CustomBase } from './CustomBase';
@@ -9369,17 +10919,18 @@ export class TagsOrdered extends CustomBase {
   id!: number;
 
   @MikroORM_Index({ name: 'tags_ordered_book4_id_index' })
-  @MikroORM_ManyToOne({ entity: () => Book4, updateRule: 'cascade', deleteRule: 'cascade' })
-  book4!: Book4;
+  @MikroORM_ManyToOne({ entity: () => Book4, ref: true, updateRule: 'cascade', deleteRule: 'cascade' })
+  book4!: MikroORM_Ref<Book4>;
 
   @MikroORM_Index({ name: 'tags_ordered_book_tag4_id_index' })
-  @MikroORM_ManyToOne({ entity: () => BookTag4, updateRule: 'cascade', deleteRule: 'cascade' })
-  bookTag4!: BookTag4;
+  @MikroORM_ManyToOne({ entity: () => BookTag4, ref: true, updateRule: 'cascade', deleteRule: 'cascade' })
+  bookTag4!: MikroORM_Ref<BookTag4>;
 
 }
 ",
-  "import { Entity as MikroORM_Entity, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, Entity as MikroORM_Entity, OneToMany as MikroORM_OneToMany, type Opt as MikroORM_Opt, PrimaryKey as MikroORM_PrimaryKey, Property as MikroORM_Property } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
+import { Publisher4Tests } from './Publisher4Tests';
 
 @MikroORM_Entity()
 export class Test4 extends CustomBase {
@@ -9398,6 +10949,9 @@ export class Test4 extends CustomBase {
 
   @MikroORM_Property({ type: 'integer' })
   version: number & MikroORM_Opt = 1;
+
+  @MikroORM_OneToMany({ entity: () => Publisher4Tests, mappedBy: 'test4' })
+  publisher4TestsCollection = new MikroORM_Collection<Publisher4Tests>(this);
 
 }
 ",
@@ -9424,7 +10978,7 @@ export abstract class CustomBase extends MikroORM_BaseEntity {
 
 exports[`CustomBase > forceObject=true > useCoreBaseEntity=true > customBaseEntityName=CustomBase > entitySchema > dump 1`] = `
 [
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Book4 } from './Book4';
 import { CustomBase } from './CustomBase';
 
@@ -9439,8 +10993,9 @@ export class Author4 extends CustomBase {
   identities?: string;
   born?: string;
   bornTime?: string;
-  favouriteBook?: Book4;
+  favouriteBook?: MikroORM_Ref<Book4>;
   identity?: any;
+  book4Collection = new MikroORM_Collection<Book4>(this);
 }
 
 export const Author4Schema = new MikroORM_EntitySchema({
@@ -9459,16 +11014,20 @@ export const Author4Schema = new MikroORM_EntitySchema({
     favouriteBook: {
       kind: 'm:1',
       entity: () => Book4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
     },
     identity: { type: 'json', nullable: true },
+    book4Collection: { kind: '1:m', entity: () => Book4, mappedBy: 'author' },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+import { Book4 } from './Book4';
 import { CustomBase } from './CustomBase';
+import { TagsOrdered } from './TagsOrdered';
 
 export class BookTag4 extends CustomBase {
   id!: number;
@@ -9476,6 +11035,8 @@ export class BookTag4 extends CustomBase {
   updatedAt?: Date;
   name!: string;
   version!: Date & MikroORM_Opt;
+  tagsUnorderedInverse = new MikroORM_Collection<Book4>(this);
+  tagsOrderedCollection = new MikroORM_Collection<TagsOrdered>(this);
 }
 
 export const BookTag4Schema = new MikroORM_EntitySchema({
@@ -9486,14 +11047,25 @@ export const BookTag4Schema = new MikroORM_EntitySchema({
     updatedAt: { type: 'datetime', nullable: true },
     name: { type: 'text' },
     version: { type: 'datetime', defaultRaw: \`current_timestamp\` },
+    tagsUnorderedInverse: {
+      kind: 'm:n',
+      entity: () => Book4,
+      mappedBy: 'tagsUnordered',
+    },
+    tagsOrderedCollection: {
+      kind: '1:m',
+      entity: () => TagsOrdered,
+      mappedBy: 'bookTag4',
+    },
   },
 });
 ",
-  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Author4 } from './Author4';
 import { BookTag4 } from './BookTag4';
 import { CustomBase } from './CustomBase';
 import { Publisher4 } from './Publisher4';
+import { TagsOrdered } from './TagsOrdered';
 
 export class Book4 extends CustomBase {
   id!: number;
@@ -9501,10 +11073,12 @@ export class Book4 extends CustomBase {
   updatedAt?: Date;
   title!: string;
   price?: unknown;
-  author?: Author4;
-  publisher?: Publisher4;
+  author?: MikroORM_Ref<Author4>;
+  publisher?: MikroORM_Ref<Publisher4>;
   meta?: any;
   tagsUnordered = new MikroORM_Collection<BookTag4>(this);
+  author4Collection = new MikroORM_Collection<Author4>(this);
+  tagsOrderedCollection = new MikroORM_Collection<TagsOrdered>(this);
 }
 
 export const Book4Schema = new MikroORM_EntitySchema({
@@ -9518,6 +11092,7 @@ export const Book4Schema = new MikroORM_EntitySchema({
     author: {
       kind: 'm:1',
       entity: () => Author4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
@@ -9525,6 +11100,7 @@ export const Book4Schema = new MikroORM_EntitySchema({
     publisher: {
       kind: 'm:1',
       entity: () => Publisher4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
@@ -9537,10 +11113,20 @@ export const Book4Schema = new MikroORM_EntitySchema({
       joinColumn: 'book4_id',
       inverseJoinColumn: 'book_tag4_id',
     },
+    author4Collection: {
+      kind: '1:m',
+      entity: () => Author4,
+      mappedBy: 'favouriteBook',
+    },
+    tagsOrderedCollection: {
+      kind: '1:m',
+      entity: () => TagsOrdered,
+      mappedBy: 'book4',
+    },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
 import { FooBaz4 } from './FooBaz4';
 
@@ -9549,13 +11135,14 @@ export class FooBar4 extends CustomBase {
   createdAt?: Date;
   updatedAt?: Date;
   name: string & MikroORM_Opt = 'asd';
-  baz?: FooBaz4;
-  fooBar?: FooBar4;
+  baz?: MikroORM_Ref<FooBaz4>;
+  fooBar?: MikroORM_Ref<FooBar4>;
   version: number & MikroORM_Opt = 1;
   blob?: Buffer;
   blob2?: Buffer;
   array?: string;
   object?: any;
+  fooBar4?: MikroORM_Ref<FooBar4>;
 }
 
 export const FooBar4Schema = new MikroORM_EntitySchema({
@@ -9568,6 +11155,7 @@ export const FooBar4Schema = new MikroORM_EntitySchema({
     baz: {
       kind: '1:1',
       entity: () => FooBaz4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
@@ -9575,6 +11163,7 @@ export const FooBar4Schema = new MikroORM_EntitySchema({
     fooBar: {
       kind: '1:1',
       entity: () => FooBar4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'set null',
       nullable: true,
@@ -9584,11 +11173,13 @@ export const FooBar4Schema = new MikroORM_EntitySchema({
     blob2: { type: 'blob', nullable: true },
     array: { type: 'text', nullable: true },
     object: { type: 'json', nullable: true },
+    fooBar4: { kind: '1:1', entity: () => FooBar4, ref: true, mappedBy: 'fooBar' },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
+import { FooBar4 } from './FooBar4';
 
 export class FooBaz4 extends CustomBase {
   id!: number;
@@ -9596,6 +11187,7 @@ export class FooBaz4 extends CustomBase {
   updatedAt?: Date;
   name!: string;
   version!: Date & MikroORM_Opt;
+  fooBar4?: MikroORM_Ref<FooBar4>;
 }
 
 export const FooBaz4Schema = new MikroORM_EntitySchema({
@@ -9606,25 +11198,32 @@ export const FooBaz4Schema = new MikroORM_EntitySchema({
     updatedAt: { type: 'datetime', nullable: true },
     name: { type: 'text' },
     version: { type: 'datetime', defaultRaw: \`current_timestamp\` },
+    fooBar4: { kind: '1:1', entity: () => FooBar4, ref: true, mappedBy: 'baz' },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+import { Book4 } from './Book4';
 import { CustomBase } from './CustomBase';
+import { Publisher4Tests } from './Publisher4Tests';
 
 export class Publisher4 extends CustomBase {
   id!: number;
   createdAt?: Date;
   updatedAt?: Date;
   name: string & MikroORM_Opt = 'asd';
-  type: Publisher4Type & MikroORM_Opt = Publisher4Type.LOCAL;
+  type: TPublisher4Type & MikroORM_Opt = Publisher4Type.LOCAL;
   enum3?: number;
+  book4Collection = new MikroORM_Collection<Book4>(this);
+  publisher4TestsCollection = new MikroORM_Collection<Publisher4Tests>(this);
 }
 
-export enum Publisher4Type {
-  LOCAL = 'local',
-  GLOBAL = 'global',
-}
+export const Publisher4Type = {
+  LOCAL: 'local',
+  GLOBAL: 'global',
+} as const;
+
+export type TPublisher4Type = (typeof Publisher4Type)[keyof typeof Publisher4Type];
 
 export const Publisher4Schema = new MikroORM_EntitySchema({
   class: Publisher4,
@@ -9635,18 +11234,24 @@ export const Publisher4Schema = new MikroORM_EntitySchema({
     name: { type: 'text' },
     type: { enum: true, items: () => Publisher4Type },
     enum3: { type: 'integer', nullable: true },
+    book4Collection: { kind: '1:m', entity: () => Book4, mappedBy: 'publisher' },
+    publisher4TestsCollection: {
+      kind: '1:m',
+      entity: () => Publisher4Tests,
+      mappedBy: 'publisher4',
+    },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema } from '@mikro-orm/core';
+  "import { EntitySchema as MikroORM_EntitySchema, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
 import { Publisher4 } from './Publisher4';
 import { Test4 } from './Test4';
 
 export class Publisher4Tests extends CustomBase {
   id!: number;
-  publisher4!: Publisher4;
-  test4!: Test4;
+  publisher4!: MikroORM_Ref<Publisher4>;
+  test4!: MikroORM_Ref<Test4>;
 }
 
 export const Publisher4TestsSchema = new MikroORM_EntitySchema({
@@ -9657,27 +11262,29 @@ export const Publisher4TestsSchema = new MikroORM_EntitySchema({
     publisher4: {
       kind: 'm:1',
       entity: () => Publisher4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
     test4: {
       kind: 'm:1',
       entity: () => Test4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema } from '@mikro-orm/core';
+  "import { EntitySchema as MikroORM_EntitySchema, type Ref as MikroORM_Ref } from '@mikro-orm/core';
 import { Book4 } from './Book4';
 import { BookTag4 } from './BookTag4';
 import { CustomBase } from './CustomBase';
 
 export class TagsOrdered extends CustomBase {
   id!: number;
-  book4!: Book4;
-  bookTag4!: BookTag4;
+  book4!: MikroORM_Ref<Book4>;
+  bookTag4!: MikroORM_Ref<BookTag4>;
 }
 
 export const TagsOrderedSchema = new MikroORM_EntitySchema({
@@ -9687,20 +11294,23 @@ export const TagsOrderedSchema = new MikroORM_EntitySchema({
     book4: {
       kind: 'm:1',
       entity: () => Book4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
     bookTag4: {
       kind: 'm:1',
       entity: () => BookTag4,
+      ref: true,
       updateRule: 'cascade',
       deleteRule: 'cascade',
     },
   },
 });
 ",
-  "import { EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
+  "import { Collection as MikroORM_Collection, EntitySchema as MikroORM_EntitySchema, type Opt as MikroORM_Opt } from '@mikro-orm/core';
 import { CustomBase } from './CustomBase';
+import { Publisher4Tests } from './Publisher4Tests';
 
 export class Test4 extends CustomBase {
   id!: number;
@@ -9708,6 +11318,7 @@ export class Test4 extends CustomBase {
   updatedAt?: Date;
   name?: string;
   version: number & MikroORM_Opt = 1;
+  publisher4TestsCollection = new MikroORM_Collection<Publisher4Tests>(this);
 }
 
 export const Test4Schema = new MikroORM_EntitySchema({
@@ -9718,6 +11329,11 @@ export const Test4Schema = new MikroORM_EntitySchema({
     updatedAt: { type: 'datetime', nullable: true },
     name: { type: 'text', nullable: true },
     version: { type: 'integer' },
+    publisher4TestsCollection: {
+      kind: '1:m',
+      entity: () => Publisher4Tests,
+      mappedBy: 'test4',
+    },
   },
 });
 ",

--- a/tests/features/entity-generator/__snapshots__/DeferMode.postgresql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/DeferMode.postgresql.test.ts.snap
@@ -2,44 +2,53 @@
 
 exports[`defer-mode 1`] = `
 [
-  "import { Entity, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, PrimaryKeyProp, defineEntity, p } from '@mikro-orm/core';
+import { Test } from './Test';
 
-@Entity()
 export class Locale {
-
   [PrimaryKeyProp]?: 'code';
-
-  @PrimaryKey({ length: 10 })
   code!: string;
-
+  testCollection = new Collection<Test>(this);
 }
+
+export const LocaleSchema = defineEntity({
+  class: Locale,
+  properties: {
+    code: p.string().primary().length(10),
+    testCollection: () => p.oneToMany(Test).mappedBy('locale'),
+  },
+});
 ",
-  "import { DeferMode, Entity, ManyToOne, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { DeferMode, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Locale } from './Locale';
 
-@Entity()
 export class Test {
-
-  @PrimaryKey({ autoincrement: false })
   id!: bigint;
-
-  @Property({ length: -1, nullable: true })
   firstName?: string;
-
-  @Property({ type: 'character', nullable: true })
   middleInitial?: string;
-
-  @Property({ nullable: true })
   lastName?: string;
-
-  @Unique({ name: 'must_be_different', deferMode: DeferMode.INITIALLY_DEFERRED })
-  @Property({ type: 'character', length: 10, nullable: true })
   governmentId?: string;
-
-  @ManyToOne({ entity: () => Locale, fieldName: 'locale', nullable: true, deferMode: DeferMode.INITIALLY_DEFERRED })
-  locale?: Locale;
-
+  locale?: Ref<Locale>;
 }
+
+export const TestSchema = defineEntity({
+  class: Test,
+  uniques: [
+    {
+      name: 'must_be_different',
+      properties: ['governmentId'],
+      deferMode: DeferMode.INITIALLY_DEFERRED,
+    },
+  ],
+  properties: {
+    id: p.bigint().primary().autoincrement(false),
+    firstName: p.string().length(-1).nullable(),
+    middleInitial: p.character().nullable(),
+    lastName: p.string().nullable(),
+    governmentId: p.character().length(10).nullable().unique('must_be_different'),
+    locale: () => p.manyToOne(Locale).ref().name('locale').nullable().deferMode(DeferMode.INITIALLY_DEFERRED),
+  },
+});
 ",
 ]
 `;

--- a/tests/features/entity-generator/__snapshots__/EntityGenerator.mssql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/EntityGenerator.mssql.test.ts.snap
@@ -2,1416 +2,1653 @@
 
 exports[`EntityGenerator > generate entities from schema [mssql] > mssql-entity-dump 1`] = `
 [
-  "import { Entity, OneToOne, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { PrimaryKeyProp, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 
-@Entity({ comment: 'This is address table' })
 export class Address2 {
-
   [PrimaryKeyProp]?: 'author';
-
-  @OneToOne({ entity: () => Author2, updateRule: 'cascade', deleteRule: 'cascade', primary: true })
-  author!: Author2;
-
-  @Property({ comment: 'This is address property' })
+  author!: Ref<Author2>;
   value!: string;
-
 }
+
+export const Address2Schema = defineEntity({
+  class: Address2,
+  comment: 'This is address table',
+  properties: {
+    author: () => p.oneToOne(Author2).primary().ref().updateRule('cascade').deleteRule('cascade'),
+    value: p.string().comment('This is address property'),
+  },
+});
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, type Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, type Opt, type Ref, defineEntity, p } from '@mikro-orm/core';
+import { Address2 } from './Address2';
 import { Book2 } from './Book2';
 
-@Entity()
-@Index({ name: 'author2_name_age_index', properties: ['name', 'age'] })
-@Unique({ name: 'author2_name_email_unique', properties: ['name', 'email'] })
 export class Author2 {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property({ type: 'datetime', length: 3, defaultRaw: \`current_timestamp\` })
   createdAt!: Date & Opt;
-
-  @Property({ type: 'datetime', length: 3, defaultRaw: \`current_timestamp\` })
   updatedAt!: Date & Opt;
-
-  @Property({ index: 'custom_idx_name_123' })
   name!: string;
-
-  @Property({ index: 'custom_email_index_name', unique: 'custom_email_unique_name' })
   email!: string;
-
-  @Property({ nullable: true })
   age?: number;
-
-  @Property({ type: 'boolean', defaultRaw: \`0\`, index: true })
   termsAccepted: boolean & Opt = false;
-
-  @Property({ nullable: true })
   optional?: boolean;
-
-  @Property({ type: 'text', nullable: true })
   identities?: string;
-
-  @Property({ type: 'date', nullable: true, index: true })
   born?: string;
-
-  @Property({ type: 'time', nullable: true, index: 'born_time_idx' })
   bornTime?: string;
-
-  @ManyToOne({ entity: () => Book2, deleteRule: 'cascade', nullable: true })
-  favouriteBook?: Book2;
-
-  @ManyToOne({ entity: () => Author2, nullable: true })
-  favouriteAuthor?: Author2;
-
-  @ManyToMany({ entity: () => Author2, pivotTable: 'author_to_friend', joinColumn: 'author2_1_id', inverseJoinColumn: 'author2_2_id' })
+  favouriteBook?: Ref<Book2>;
+  favouriteAuthor?: Ref<Author2>;
   authorToFriend = new Collection<Author2>(this);
-
-  @ManyToMany({ entity: () => Author2, joinColumn: 'author2_1_id', inverseJoinColumn: 'author2_2_id' })
   following = new Collection<Author2>(this);
-
+  address2?: Ref<Address2>;
+  author2Collection = new Collection<Author2>(this);
+  authorToFriendInverse = new Collection<Author2>(this);
+  followingInverse = new Collection<Author2>(this);
+  book2Collection = new Collection<Book2>(this);
 }
-",
-  "import { Entity, Enum, ManyToOne, OneToOne, PrimaryKey, Property, Unique } from '@mikro-orm/core';
 
-@Entity()
+export const Author2Schema = defineEntity({
+  class: Author2,
+  indexes: [{ name: 'author2_name_age_index', properties: ['name', 'age'] }],
+  uniques: [{ name: 'author2_name_email_unique', properties: ['name', 'email'] }],
+  properties: {
+    id: p.integer().primary(),
+    createdAt: p.datetime().length(3).defaultRaw(\`current_timestamp\`),
+    updatedAt: p.datetime().length(3).defaultRaw(\`current_timestamp\`),
+    name: p.string().index('custom_idx_name_123'),
+    email: p.string().index('custom_email_index_name').unique('custom_email_unique_name'),
+    age: p.integer().nullable(),
+    termsAccepted: p.boolean().defaultRaw(\`0\`).index('author2_terms_accepted_index'),
+    optional: p.boolean().nullable(),
+    identities: p.text().nullable(),
+    born: p.date().nullable().index('author2_born_index'),
+    bornTime: p.time().nullable().index('born_time_idx'),
+    favouriteBook: () => p.manyToOne(Book2).ref().deleteRule('cascade').nullable(),
+    favouriteAuthor: () => p.manyToOne(Author2).ref().nullable(),
+    authorToFriend: () => p.manyToMany(Author2).pivotTable('author_to_friend').joinColumn('author2_1_id').inverseJoinColumn('author2_2_id'),
+    following: () => p.manyToMany(Author2).joinColumn('author2_1_id').inverseJoinColumn('author2_2_id'),
+    address2: () => p.oneToOne(Address2).ref().mappedBy('author'),
+    author2Collection: () => p.oneToMany(Author2).mappedBy('favouriteAuthor'),
+    authorToFriendInverse: () => p.manyToMany(Author2).mappedBy('authorToFriend'),
+    followingInverse: () => p.manyToMany(Author2).mappedBy('following'),
+    book2Collection: () => p.oneToMany(Book2).mappedBy('author'),
+  },
+});
+",
+  "import { Collection, type Ref, defineEntity, p } from '@mikro-orm/core';
+
 export class BaseUser2 {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property({ length: 100 })
   firstName!: string;
-
-  @Property({ length: 100 })
   lastName!: string;
-
-  @Enum({ items: () => BaseUser2Type, index: true })
-  type!: BaseUser2Type;
-
-  @Property({ nullable: true })
+  type!: TBaseUser2Type;
   ownerProp?: string;
-
-  @ManyToOne({ entity: () => BaseUser2, nullable: true })
-  favouriteEmployee?: BaseUser2;
-
-  @Unique({ name: 'base_user2_favourite_manager_id_unique', expression: 'create unique index [base_user2_favourite_manager_id_unique] on [base_user2] (where ([favourite_manager_id] IS NOT NULL))' })
-  @OneToOne({ entity: () => BaseUser2, nullable: true })
-  favouriteManager?: BaseUser2;
-
-  @Property({ nullable: true })
+  favouriteEmployee?: Ref<BaseUser2>;
+  favouriteManager?: Ref<BaseUser2>;
   employeeProp?: number;
-
-  @Property({ nullable: true })
   managerProp?: string;
-
+  baseUser2Collection = new Collection<BaseUser2>(this);
+  baseUser2?: Ref<BaseUser2>;
 }
 
-export enum BaseUser2Type {
-  EMPLOYEE = 'employee',
-  MANAGER = 'manager',
-  OWNER = 'owner',
-}
+export const BaseUser2Type = {
+  EMPLOYEE: 'employee',
+  MANAGER: 'manager',
+  OWNER: 'owner',
+} as const;
+
+export type TBaseUser2Type = (typeof BaseUser2Type)[keyof typeof BaseUser2Type];
+
+export const BaseUser2Schema = defineEntity({
+  class: BaseUser2,
+  uniques: [
+    {
+      name: 'base_user2_favourite_manager_id_unique',
+      expression: 'create unique index [base_user2_favourite_manager_id_unique] on [base_user2] (where ([favourite_manager_id] IS NOT NULL))',
+      properties: ['favouriteManager'],
+    },
+  ],
+  properties: {
+    id: p.integer().primary(),
+    firstName: p.string().length(100),
+    lastName: p.string().length(100),
+    type: p.enum(() => BaseUser2Type).index('base_user2_type_index'),
+    ownerProp: p.string().nullable(),
+    favouriteEmployee: () => p.manyToOne(BaseUser2).ref().nullable(),
+    favouriteManager: () => p.oneToOne(BaseUser2).ref().nullable(),
+    employeeProp: p.integer().nullable(),
+    managerProp: p.string().nullable(),
+    baseUser2Collection: () => p.oneToMany(BaseUser2).mappedBy('favouriteEmployee'),
+    baseUser2: () => p.oneToOne(BaseUser2).ref().mappedBy('favouriteManager'),
+  },
+});
 ",
-  "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, defineEntity, p } from '@mikro-orm/core';
+import { Book2 } from './Book2';
+import { Book2Tags } from './Book2Tags';
 
-@Entity()
 export class BookTag2 {
-
-  @PrimaryKey()
   id!: bigint;
-
-  @Property({ length: 50 })
   name!: string;
-
+  bookToTagUnorderedInverse = new Collection<Book2>(this);
+  book2TagsCollection = new Collection<Book2Tags>(this);
 }
+
+export const BookTag2Schema = defineEntity({
+  class: BookTag2,
+  properties: {
+    id: p.bigint().primary(),
+    name: p.string().length(50),
+    bookToTagUnorderedInverse: () => p.manyToMany(Book2).mappedBy('bookToTagUnordered'),
+    book2TagsCollection: () => p.oneToMany(Book2Tags).mappedBy('bookTag2'),
+  },
+});
 ",
-  "import { Collection, Entity, ManyToMany, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, type Opt, PrimaryKeyProp, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Author2 } from './Author2';
+import { Book2Tags } from './Book2Tags';
 import { BookTag2 } from './BookTag2';
 import { Publisher2 } from './Publisher2';
+import { Test2 } from './Test2';
 
-@Entity()
 export class Book2 {
-
   [PrimaryKeyProp]?: 'uuidPk';
-
-  @PrimaryKey({ type: 'uuid' })
   uuidPk!: string;
-
-  @Property({ type: 'datetime', length: 3, defaultRaw: \`current_timestamp\` })
   createdAt!: Date & Opt;
-
-  @Unique({ name: 'book2_isbn_unique', expression: 'create unique index [book2_isbn_unique] on [book2] (where ([isbn] IS NOT NULL))' })
-  @Property({ type: 'character', length: 13, nullable: true })
   isbn?: string;
-
-  @Property({ type: 'string', nullable: true })
   title?: string = '';
-
-  @Property({ type: 'text', nullable: true })
   perex?: string;
-
-  @Property({ type: 'decimal', precision: 8, scale: 2, nullable: true })
   price?: string;
-
-  @Property({ type: 'float', nullable: true })
   float?: number;
-
-  @Property({ type: 'double', nullable: true })
   float36?: number;
-
-  @Property({ type: 'double', nullable: true })
   double?: number;
-
-  @Property({ length: -1, nullable: true })
   meta?: string;
-
-  @ManyToOne({ entity: () => Author2 })
-  author!: Author2;
-
-  @ManyToOne({ entity: () => Publisher2, updateRule: 'cascade', deleteRule: 'cascade', nullable: true })
-  publisher?: Publisher2;
-
-  @ManyToMany({ entity: () => BookTag2, pivotTable: 'book_to_tag_unordered', joinColumn: 'book2_uuid_pk', inverseJoinColumn: 'book_tag2_id' })
+  author!: Ref<Author2>;
+  publisher?: Ref<Publisher2>;
   bookToTagUnordered = new Collection<BookTag2>(this);
-
+  author2Collection = new Collection<Author2>(this);
+  book2TagsCollection = new Collection<Book2Tags>(this);
+  test2?: Ref<Test2>;
 }
+
+export const Book2Schema = defineEntity({
+  class: Book2,
+  uniques: [
+    {
+      name: 'book2_isbn_unique',
+      expression: 'create unique index [book2_isbn_unique] on [book2] (where ([isbn] IS NOT NULL))',
+      properties: ['isbn'],
+    },
+  ],
+  properties: {
+    uuidPk: p.uuid().primary(),
+    createdAt: p.datetime().length(3).defaultRaw(\`current_timestamp\`),
+    isbn: p.character().length(13).nullable().unique('book2_isbn_unique'),
+    title: p.string().nullable(),
+    perex: p.text().nullable(),
+    price: p.decimal().precision(8).scale(2).nullable(),
+    float: p.float().nullable(),
+    float36: p.double().nullable(),
+    double: p.double().nullable(),
+    meta: p.string().length(-1).nullable(),
+    author: () => p.manyToOne(Author2).ref(),
+    publisher: () => p.manyToOne(Publisher2).ref().updateRule('cascade').deleteRule('cascade').nullable(),
+    bookToTagUnordered: () => p.manyToMany(BookTag2).pivotTable('book_to_tag_unordered').joinColumn('book2_uuid_pk').inverseJoinColumn('book_tag2_id'),
+    author2Collection: () => p.oneToMany(Author2).mappedBy('favouriteBook'),
+    book2TagsCollection: () => p.oneToMany(Book2Tags).mappedBy('book2'),
+    test2: () => p.oneToOne(Test2).ref().mappedBy('book'),
+  },
+});
 ",
-  "import { Entity, ManyToOne, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { PrimaryKeyProp, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { BookTag2 } from './BookTag2';
 
-@Entity({ tableName: 'book2_tags' })
 export class Book2Tags {
-
   [PrimaryKeyProp]?: 'order';
-
-  @PrimaryKey()
   order!: number;
-
-  @ManyToOne({ entity: () => Book2, updateRule: 'cascade', deleteRule: 'cascade' })
-  book2!: Book2;
-
-  @ManyToOne({ entity: () => BookTag2, updateRule: 'cascade', deleteRule: 'cascade' })
-  bookTag2!: BookTag2;
-
+  book2!: Ref<Book2>;
+  bookTag2!: Ref<BookTag2>;
 }
+
+export const Book2TagsSchema = defineEntity({
+  class: Book2Tags,
+  tableName: 'book2_tags',
+  properties: {
+    order: p.integer().primary(),
+    book2: () => p.manyToOne(Book2).ref().updateRule('cascade').deleteRule('cascade'),
+    bookTag2: () => p.manyToOne(BookTag2).ref().updateRule('cascade').deleteRule('cascade'),
+  },
+});
 ",
-  "import { Entity, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Car2 } from './Car2';
 
-@Entity()
 export class CarOwner2 {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property()
   name!: string;
-
-  @ManyToOne({ entity: () => Car2, updateRule: 'cascade', index: true })
-  car!: Car2;
-
+  car!: Ref<Car2>;
 }
-",
-  "import { Entity, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 
-@Entity()
+export const CarOwner2Schema = defineEntity({
+  class: CarOwner2,
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+    car: () => p.manyToOne(Car2).ref().updateRule('cascade').index(true),
+  },
+});
+",
+  "import { Collection, PrimaryKeyProp, type Ref, defineEntity, p } from '@mikro-orm/core';
+import { CarOwner2 } from './CarOwner2';
+import { User2 } from './User2';
+
 export class Car2 {
-
   [PrimaryKeyProp]?: ['name', 'year'];
-
-  @PrimaryKey({ length: 100, index: true })
   name!: string;
-
-  @PrimaryKey({ index: true })
   year!: number;
-
-  @Property()
   price!: number;
-
+  carOwner2Collection = new Collection<CarOwner2>(this);
+  user2?: Ref<User2>;
+  carsInverse = new Collection<User2>(this);
 }
+
+export const Car2Schema = defineEntity({
+  class: Car2,
+  properties: {
+    name: p.string().primary().length(100).index('car2_name_index'),
+    year: p.integer().primary().index('car2_year_index'),
+    price: p.integer(),
+    carOwner2Collection: () => p.oneToMany(CarOwner2).mappedBy('car'),
+    user2: () => p.oneToOne(User2).ref().mappedBy('favouriteCar'),
+    carsInverse: () => p.manyToMany(User2).mappedBy('cars'),
+  },
+});
 ",
-  "import { Entity, ManyToOne, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { PrimaryKeyProp, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Test2 } from './Test2';
 
-@Entity()
 export class Configuration2 {
-
   [PrimaryKeyProp]?: ['property', 'test'];
-
-  @PrimaryKey()
   property!: string;
-
-  @ManyToOne({ entity: () => Test2, updateRule: 'cascade', primary: true })
-  test!: Test2;
-
-  @Property()
+  test!: Ref<Test2>;
   value!: string;
-
 }
-",
-  "import { Entity, PrimaryKey } from '@mikro-orm/core';
 
-@Entity()
+export const Configuration2Schema = defineEntity({
+  class: Configuration2,
+  properties: {
+    property: p.string().primary(),
+    test: () => p.manyToOne(Test2).primary().ref().updateRule('cascade'),
+    value: p.string(),
+  },
+});
+",
+  "import { defineEntity, p } from '@mikro-orm/core';
+
 export class Dummy2 {
-
-  @PrimaryKey()
   id!: number;
-
 }
+
+export const Dummy2Schema = defineEntity({
+  class: Dummy2,
+  properties: {
+    id: p.integer().primary(),
+  },
+});
 ",
-  "import { Entity, OneToOne, type Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, type Opt, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { FooBaz2 } from './FooBaz2';
+import { FooParam2 } from './FooParam2';
 
-@Entity()
 export class FooBar2 {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property()
   name!: string;
-
-  @Unique({ name: 'foo_bar2_baz_id_unique', expression: 'create unique index [foo_bar2_baz_id_unique] on [foo_bar2] (where ([baz_id] IS NOT NULL))' })
-  @OneToOne({ entity: () => FooBaz2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  baz?: FooBaz2;
-
-  @Unique({ name: 'foo_bar2_foo_bar_id_unique', expression: 'create unique index [foo_bar2_foo_bar_id_unique] on [foo_bar2] (where ([foo_bar_id] IS NOT NULL))' })
-  @OneToOne({ entity: () => FooBar2, nullable: true })
-  fooBar?: FooBar2;
-
-  @Property({ type: 'datetime', length: 0, defaultRaw: \`current_timestamp\` })
+  baz?: Ref<FooBaz2>;
+  fooBar?: Ref<FooBar2>;
   version!: Date & Opt;
-
-  @Property({ length: -1, nullable: true })
   blob?: Buffer;
-
-  @Property({ type: 'text', nullable: true })
   array?: string;
-
-  @Property({ length: -1, nullable: true })
   object?: string;
-
+  fooBar2?: Ref<FooBar2>;
+  fooParam2Collection = new Collection<FooParam2>(this);
 }
-",
-  "import { Entity, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 
-@Entity()
+export const FooBar2Schema = defineEntity({
+  class: FooBar2,
+  uniques: [
+    {
+      name: 'foo_bar2_baz_id_unique',
+      expression: 'create unique index [foo_bar2_baz_id_unique] on [foo_bar2] (where ([baz_id] IS NOT NULL))',
+      properties: ['baz'],
+    },
+    {
+      name: 'foo_bar2_foo_bar_id_unique',
+      expression: 'create unique index [foo_bar2_foo_bar_id_unique] on [foo_bar2] (where ([foo_bar_id] IS NOT NULL))',
+      properties: ['fooBar'],
+    },
+  ],
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+    baz: () => p.oneToOne(FooBaz2).ref().updateRule('cascade').deleteRule('set null').nullable(),
+    fooBar: () => p.oneToOne(FooBar2).ref().nullable(),
+    version: p.datetime().length(0).defaultRaw(\`current_timestamp\`),
+    blob: p.blob().length(-1).nullable(),
+    array: p.text().nullable(),
+    object: p.string().length(-1).nullable(),
+    fooBar2: () => p.oneToOne(FooBar2).ref().mappedBy('fooBar'),
+    fooParam2Collection: () => p.oneToMany(FooParam2).mappedBy('bar'),
+  },
+});
+",
+  "import { Collection, type Opt, type Ref, defineEntity, p } from '@mikro-orm/core';
+import { FooBar2 } from './FooBar2';
+import { FooParam2 } from './FooParam2';
+
 export class FooBaz2 {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property()
   name!: string;
-
-  @Property({ type: 'string', columnType: 'varchar(255)' })
   code!: string;
-
-  @Property({ type: 'datetime', length: 3, defaultRaw: \`current_timestamp\` })
   version!: Date & Opt;
-
+  fooBar2?: Ref<FooBar2>;
+  fooParam2Collection = new Collection<FooParam2>(this);
 }
+
+export const FooBaz2Schema = defineEntity({
+  class: FooBaz2,
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+    code: p.string().columnType('varchar(255)'),
+    version: p.datetime().length(3).defaultRaw(\`current_timestamp\`),
+    fooBar2: () => p.oneToOne(FooBar2).ref().mappedBy('baz'),
+    fooParam2Collection: () => p.oneToMany(FooParam2).mappedBy('baz'),
+  },
+});
 ",
-  "import { Entity, ManyToOne, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { PrimaryKeyProp, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { FooBar2 } from './FooBar2';
 import { FooBaz2 } from './FooBaz2';
 
-@Entity()
 export class FooParam2 {
-
   [PrimaryKeyProp]?: ['bar', 'baz'];
-
-  @ManyToOne({ entity: () => FooBar2, updateRule: 'cascade', primary: true })
-  bar!: FooBar2;
-
-  @ManyToOne({ entity: () => FooBaz2, primary: true })
-  baz!: FooBaz2;
-
-  @Property()
+  bar!: Ref<FooBar2>;
+  baz!: Ref<FooBaz2>;
   value!: string;
-
 }
-",
-  "import { Entity, Enum, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 
-@Entity()
+export const FooParam2Schema = defineEntity({
+  class: FooParam2,
+  properties: {
+    bar: () => p.manyToOne(FooBar2).primary().ref().updateRule('cascade'),
+    baz: () => p.manyToOne(FooBaz2).primary().ref(),
+    value: p.string(),
+  },
+});
+",
+  "import { Collection, type Opt, defineEntity, p } from '@mikro-orm/core';
+import { Book2 } from './Book2';
+import { Publisher2Tests } from './Publisher2Tests';
+
 export class Publisher2 {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property({ type: 'string' })
   name: string & Opt = 'asd';
-
-  @Enum({ items: () => Publisher2Type })
-  type: Publisher2Type & Opt = Publisher2Type.LOCAL;
-
-  @Enum({ items: () => Publisher2Type2 })
-  type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
-
-  @Property({ type: 'tinyint', nullable: true })
+  type: TPublisher2Type & Opt = Publisher2Type.LOCAL;
+  type2: TPublisher2Type2 & Opt = Publisher2Type2.LOCAL;
   enum1?: number;
-
-  @Property({ type: 'tinyint', nullable: true })
   enum2?: number;
-
-  @Property({ type: 'tinyint', nullable: true })
   enum3?: number;
-
-  @Enum({ items: () => Publisher2Enum4, nullable: true })
-  enum4?: Publisher2Enum4;
-
+  enum4?: TPublisher2Enum4;
+  book2Collection = new Collection<Book2>(this);
+  publisher2TestsCollection = new Collection<Publisher2Tests>(this);
 }
 
-export enum Publisher2Type {
-  LOCAL = 'local',
-  GLOBAL = 'global',
-}
+export const Publisher2Type = {
+  LOCAL: 'local',
+  GLOBAL: 'global',
+} as const;
 
-export enum Publisher2Type2 {
-  LOCAL = 'LOCAL',
-  GLOBAL = 'GLOBAL',
-}
+export type TPublisher2Type = (typeof Publisher2Type)[keyof typeof Publisher2Type];
 
-export enum Publisher2Enum4 {
-  A = 'a',
-  B = 'b',
-  C = 'c',
-}
+export const Publisher2Type2 = {
+  LOCAL: 'LOCAL',
+  GLOBAL: 'GLOBAL',
+} as const;
+
+export type TPublisher2Type2 = (typeof Publisher2Type2)[keyof typeof Publisher2Type2];
+
+export const Publisher2Enum4 = {
+  A: 'a',
+  B: 'b',
+  C: 'c',
+} as const;
+
+export type TPublisher2Enum4 = (typeof Publisher2Enum4)[keyof typeof Publisher2Enum4];
+
+export const Publisher2Schema = defineEntity({
+  class: Publisher2,
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+    type: p.enum(() => Publisher2Type),
+    type2: p.enum(() => Publisher2Type2),
+    enum1: p.tinyint().nullable(),
+    enum2: p.tinyint().nullable(),
+    enum3: p.tinyint().nullable(),
+    enum4: p.enum(() => Publisher2Enum4).nullable(),
+    book2Collection: () => p.oneToMany(Book2).mappedBy('publisher'),
+    publisher2TestsCollection: () => p.oneToMany(Publisher2Tests).mappedBy('publisher2'),
+  },
+});
 ",
-  "import { Entity, ManyToOne, PrimaryKey } from '@mikro-orm/core';
+  "import { type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Publisher2 } from './Publisher2';
 import { Test2 } from './Test2';
 
-@Entity({ tableName: 'publisher2_tests' })
 export class Publisher2Tests {
-
-  @PrimaryKey()
   id!: number;
-
-  @ManyToOne({ entity: () => Publisher2, updateRule: 'cascade', deleteRule: 'cascade' })
-  publisher2!: Publisher2;
-
-  @ManyToOne({ entity: () => Test2, updateRule: 'cascade', deleteRule: 'cascade' })
-  test2!: Test2;
-
+  publisher2!: Ref<Publisher2>;
+  test2!: Ref<Test2>;
 }
-",
-  "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
 
-@Entity()
+export const Publisher2TestsSchema = defineEntity({
+  class: Publisher2Tests,
+  tableName: 'publisher2_tests',
+  properties: {
+    id: p.integer().primary(),
+    publisher2: () => p.manyToOne(Publisher2).ref().updateRule('cascade').deleteRule('cascade'),
+    test2: () => p.manyToOne(Test2).ref().updateRule('cascade').deleteRule('cascade'),
+  },
+});
+",
+  "import { Collection, defineEntity, p } from '@mikro-orm/core';
+import { User2 } from './User2';
+
 export class Sandwich {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property()
   name!: string;
-
-  @Property()
   price!: number;
-
+  sandwichesInverse = new Collection<User2>(this);
 }
+
+export const SandwichSchema = defineEntity({
+  class: Sandwich,
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+    price: p.integer(),
+    sandwichesInverse: () => p.manyToMany(User2).mappedBy('sandwiches'),
+  },
+});
 ",
-  "import { Entity, OneToOne, type Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, type Opt, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Book2 } from './Book2';
+import { Configuration2 } from './Configuration2';
+import { Publisher2Tests } from './Publisher2Tests';
 
-@Entity()
 export class Test2 {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property({ nullable: true })
   name?: string;
-
-  @Unique({ name: 'test2_book_uuid_pk_unique', expression: 'create unique index [test2_book_uuid_pk_unique] on [test2] (where ([book_uuid_pk] IS NOT NULL))' })
-  @OneToOne({ entity: () => Book2, nullable: true })
-  book?: Book2;
-
-  @Property({ type: 'integer' })
+  book?: Ref<Book2>;
   version: number & Opt = 1;
-
+  configuration2Collection = new Collection<Configuration2>(this);
+  publisher2TestsCollection = new Collection<Publisher2Tests>(this);
 }
+
+export const Test2Schema = defineEntity({
+  class: Test2,
+  uniques: [
+    {
+      name: 'test2_book_uuid_pk_unique',
+      expression: 'create unique index [test2_book_uuid_pk_unique] on [test2] (where ([book_uuid_pk] IS NOT NULL))',
+      properties: ['book'],
+    },
+  ],
+  properties: {
+    id: p.integer().primary(),
+    name: p.string().nullable(),
+    book: () => p.oneToOne(Book2).ref().nullable(),
+    version: p.integer(),
+    configuration2Collection: () => p.oneToMany(Configuration2).mappedBy('test'),
+    publisher2TestsCollection: () => p.oneToMany(Publisher2Tests).mappedBy('test2'),
+  },
+});
 ",
-  "import { Collection, Entity, ManyToMany, OneToOne, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, PrimaryKeyProp, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Car2 } from './Car2';
 import { Sandwich } from './Sandwich';
 
-@Entity()
-@Unique({ name: 'user2_favourite_car_name_favourite_car_year_unique', expression: 'create unique index [user2_favourite_car_name_favourite_car_year_unique] on [user2] (where ([favourite_car_name] IS NOT NULL AND [favourite_car_year] IS NOT NULL))', properties: ['favouriteCarName'] })
 export class User2 {
-
   [PrimaryKeyProp]?: ['firstName', 'lastName'];
-
-  @PrimaryKey({ length: 100 })
   firstName!: string;
-
-  @PrimaryKey({ length: 100 })
   lastName!: string;
-
-  @Property({ nullable: true })
   foo?: number;
-
-  @Unique({ name: 'user2_favourite_car_name_favourite_car_year_unique' })
-  @OneToOne({ entity: () => Car2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  favouriteCar?: Car2;
-
-  @ManyToMany({ entity: () => Car2, joinColumns: ['user2_first_name', 'user2_last_name'], inverseJoinColumns: ['car2_name', 'car2_year'] })
+  favouriteCar?: Ref<Car2>;
   cars = new Collection<Car2>(this);
-
-  @ManyToMany({ entity: () => Sandwich, joinColumns: ['user2_first_name', 'user2_last_name'], inverseJoinColumn: 'sandwich_id' })
   sandwiches = new Collection<Sandwich>(this);
-
 }
+
+export const User2Schema = defineEntity({
+  class: User2,
+  uniques: [
+    {
+      name: 'user2_favourite_car_name_favourite_car_year_unique',
+      expression: 'create unique index [user2_favourite_car_name_favourite_car_year_unique] on [user2] (where ([favourite_car_name] IS NOT NULL AND [favourite_car_year] IS NOT NULL))',
+      properties: ['favouriteCarName'],
+    },
+  ],
+  properties: {
+    firstName: p.string().primary().length(100),
+    lastName: p.string().primary().length(100),
+    foo: p.integer().nullable(),
+    favouriteCar: () => p.oneToOne(Car2).ref().updateRule('cascade').deleteRule('set null').nullable(),
+    cars: () => p.manyToMany(Car2).joinColumns('user2_first_name', 'user2_last_name').inverseJoinColumns('car2_name', 'car2_year'),
+    sandwiches: () => p.manyToMany(Sandwich).joinColumns('user2_first_name', 'user2_last_name').inverseJoinColumn('sandwich_id'),
+  },
+});
 ",
 ]
 `;
 
 exports[`EntityGenerator > generate entities from schema with forceUndefined = false [mssql] > mssql-entity-dump 1`] = `
 [
-  "import { Entity, OneToOne, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { PrimaryKeyProp, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 
-@Entity({ comment: 'This is address table' })
 export class Address2 {
-
   [PrimaryKeyProp]?: 'author';
-
-  @OneToOne({ entity: () => Author2, updateRule: 'cascade', deleteRule: 'cascade', primary: true })
-  author!: Author2;
-
-  @Property({ comment: 'This is address property' })
+  author!: Ref<Author2>;
   value!: string;
-
 }
+
+export const Address2Schema = defineEntity({
+  class: Address2,
+  comment: 'This is address table',
+  properties: {
+    author: () => p.oneToOne(Author2).primary().ref().updateRule('cascade').deleteRule('cascade'),
+    value: p.string().comment('This is address property'),
+  },
+});
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, type Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, type Opt, type Ref, defineEntity, p } from '@mikro-orm/core';
+import { Address2 } from './Address2';
 import { Book2 } from './Book2';
 
-@Entity()
-@Index({ name: 'author2_name_age_index', properties: ['name', 'age'] })
-@Unique({ name: 'author2_name_email_unique', properties: ['name', 'email'] })
 export class Author2 {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property({ type: 'datetime', length: 3, defaultRaw: \`current_timestamp\` })
   createdAt!: Date & Opt;
-
-  @Property({ type: 'datetime', length: 3, defaultRaw: \`current_timestamp\` })
   updatedAt!: Date & Opt;
-
-  @Property({ index: 'custom_idx_name_123' })
   name!: string;
-
-  @Property({ index: 'custom_email_index_name', unique: 'custom_email_unique_name' })
   email!: string;
-
-  @Property({ type: 'integer', nullable: true })
   age: number | null = null;
-
-  @Property({ type: 'boolean', defaultRaw: \`0\`, index: true })
   termsAccepted: boolean & Opt = false;
-
-  @Property({ type: 'boolean', nullable: true })
   optional: boolean | null = null;
-
-  @Property({ type: 'text', nullable: true })
   identities: string | null = null;
-
-  @Property({ type: 'date', nullable: true, index: true })
   born: string | null = null;
-
-  @Property({ type: 'time', nullable: true, index: 'born_time_idx' })
   bornTime: string | null = null;
-
-  @ManyToOne({ entity: () => Book2, deleteRule: 'cascade', nullable: true })
-  favouriteBook: Book2 | null = null;
-
-  @ManyToOne({ entity: () => Author2, nullable: true })
-  favouriteAuthor: Author2 | null = null;
-
-  @ManyToMany({ entity: () => Author2, pivotTable: 'author_to_friend', joinColumn: 'author2_1_id', inverseJoinColumn: 'author2_2_id' })
+  favouriteBook: Ref<Book2> | null = null;
+  favouriteAuthor: Ref<Author2> | null = null;
   authorToFriend = new Collection<Author2>(this);
-
-  @ManyToMany({ entity: () => Author2, joinColumn: 'author2_1_id', inverseJoinColumn: 'author2_2_id' })
   following = new Collection<Author2>(this);
-
+  address2: Ref<Address2> | null = null;
+  author2Collection = new Collection<Author2>(this);
+  authorToFriendInverse = new Collection<Author2>(this);
+  followingInverse = new Collection<Author2>(this);
+  book2Collection = new Collection<Book2>(this);
 }
-",
-  "import { Entity, Enum, ManyToOne, OneToOne, PrimaryKey, Property, Unique } from '@mikro-orm/core';
 
-@Entity()
+export const Author2Schema = defineEntity({
+  class: Author2,
+  indexes: [{ name: 'author2_name_age_index', properties: ['name', 'age'] }],
+  uniques: [{ name: 'author2_name_email_unique', properties: ['name', 'email'] }],
+  properties: {
+    id: p.integer().primary(),
+    createdAt: p.datetime().length(3).defaultRaw(\`current_timestamp\`),
+    updatedAt: p.datetime().length(3).defaultRaw(\`current_timestamp\`),
+    name: p.string().index('custom_idx_name_123'),
+    email: p.string().index('custom_email_index_name').unique('custom_email_unique_name'),
+    age: p.integer().nullable(),
+    termsAccepted: p.boolean().defaultRaw(\`0\`).index('author2_terms_accepted_index'),
+    optional: p.boolean().nullable(),
+    identities: p.text().nullable(),
+    born: p.date().nullable().index('author2_born_index'),
+    bornTime: p.time().nullable().index('born_time_idx'),
+    favouriteBook: () => p.manyToOne(Book2).ref().deleteRule('cascade').nullable(),
+    favouriteAuthor: () => p.manyToOne(Author2).ref().nullable(),
+    authorToFriend: () => p.manyToMany(Author2).pivotTable('author_to_friend').joinColumn('author2_1_id').inverseJoinColumn('author2_2_id'),
+    following: () => p.manyToMany(Author2).joinColumn('author2_1_id').inverseJoinColumn('author2_2_id'),
+    address2: () => p.oneToOne(Address2).ref().mappedBy('author'),
+    author2Collection: () => p.oneToMany(Author2).mappedBy('favouriteAuthor'),
+    authorToFriendInverse: () => p.manyToMany(Author2).mappedBy('authorToFriend'),
+    followingInverse: () => p.manyToMany(Author2).mappedBy('following'),
+    book2Collection: () => p.oneToMany(Book2).mappedBy('author'),
+  },
+});
+",
+  "import { Collection, type Ref, defineEntity, p } from '@mikro-orm/core';
+
 export class BaseUser2 {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property({ length: 100 })
   firstName!: string;
-
-  @Property({ length: 100 })
   lastName!: string;
-
-  @Enum({ items: () => BaseUser2Type, index: true })
-  type!: BaseUser2Type;
-
-  @Property({ type: 'string', nullable: true })
+  type!: TBaseUser2Type;
   ownerProp: string | null = null;
-
-  @ManyToOne({ entity: () => BaseUser2, nullable: true })
-  favouriteEmployee: BaseUser2 | null = null;
-
-  @Unique({ name: 'base_user2_favourite_manager_id_unique', expression: 'create unique index [base_user2_favourite_manager_id_unique] on [base_user2] (where ([favourite_manager_id] IS NOT NULL))' })
-  @OneToOne({ entity: () => BaseUser2, nullable: true })
-  favouriteManager: BaseUser2 | null = null;
-
-  @Property({ type: 'integer', nullable: true })
+  favouriteEmployee: Ref<BaseUser2> | null = null;
+  favouriteManager: Ref<BaseUser2> | null = null;
   employeeProp: number | null = null;
-
-  @Property({ type: 'string', nullable: true })
   managerProp: string | null = null;
-
+  baseUser2Collection = new Collection<BaseUser2>(this);
+  baseUser2: Ref<BaseUser2> | null = null;
 }
 
-export enum BaseUser2Type {
-  EMPLOYEE = 'employee',
-  MANAGER = 'manager',
-  OWNER = 'owner',
-}
+export const BaseUser2Type = {
+  EMPLOYEE: 'employee',
+  MANAGER: 'manager',
+  OWNER: 'owner',
+} as const;
+
+export type TBaseUser2Type = (typeof BaseUser2Type)[keyof typeof BaseUser2Type];
+
+export const BaseUser2Schema = defineEntity({
+  class: BaseUser2,
+  uniques: [
+    {
+      name: 'base_user2_favourite_manager_id_unique',
+      expression: 'create unique index [base_user2_favourite_manager_id_unique] on [base_user2] (where ([favourite_manager_id] IS NOT NULL))',
+      properties: ['favouriteManager'],
+    },
+  ],
+  properties: {
+    id: p.integer().primary(),
+    firstName: p.string().length(100),
+    lastName: p.string().length(100),
+    type: p.enum(() => BaseUser2Type).index('base_user2_type_index'),
+    ownerProp: p.string().nullable(),
+    favouriteEmployee: () => p.manyToOne(BaseUser2).ref().nullable(),
+    favouriteManager: () => p.oneToOne(BaseUser2).ref().nullable(),
+    employeeProp: p.integer().nullable(),
+    managerProp: p.string().nullable(),
+    baseUser2Collection: () => p.oneToMany(BaseUser2).mappedBy('favouriteEmployee'),
+    baseUser2: () => p.oneToOne(BaseUser2).ref().mappedBy('favouriteManager'),
+  },
+});
 ",
-  "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, defineEntity, p } from '@mikro-orm/core';
+import { Book2 } from './Book2';
+import { Book2Tags } from './Book2Tags';
 
-@Entity()
 export class BookTag2 {
-
-  @PrimaryKey()
   id!: bigint;
-
-  @Property({ length: 50 })
   name!: string;
-
+  bookToTagUnorderedInverse = new Collection<Book2>(this);
+  book2TagsCollection = new Collection<Book2Tags>(this);
 }
+
+export const BookTag2Schema = defineEntity({
+  class: BookTag2,
+  properties: {
+    id: p.bigint().primary(),
+    name: p.string().length(50),
+    bookToTagUnorderedInverse: () => p.manyToMany(Book2).mappedBy('bookToTagUnordered'),
+    book2TagsCollection: () => p.oneToMany(Book2Tags).mappedBy('bookTag2'),
+  },
+});
 ",
-  "import { Collection, Entity, ManyToMany, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, type Opt, PrimaryKeyProp, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Author2 } from './Author2';
+import { Book2Tags } from './Book2Tags';
 import { BookTag2 } from './BookTag2';
 import { Publisher2 } from './Publisher2';
+import { Test2 } from './Test2';
 
-@Entity()
 export class Book2 {
-
   [PrimaryKeyProp]?: 'uuidPk';
-
-  @PrimaryKey({ type: 'uuid' })
   uuidPk!: string;
-
-  @Property({ type: 'datetime', length: 3, defaultRaw: \`current_timestamp\` })
   createdAt!: Date & Opt;
-
-  @Unique({ name: 'book2_isbn_unique', expression: 'create unique index [book2_isbn_unique] on [book2] (where ([isbn] IS NOT NULL))' })
-  @Property({ type: 'character', length: 13, nullable: true })
   isbn: string | null = null;
-
-  @Property({ type: 'string', nullable: true })
   title?: string | null = '';
-
-  @Property({ type: 'text', nullable: true })
   perex: string | null = null;
-
-  @Property({ type: 'decimal', precision: 8, scale: 2, nullable: true })
   price: string | null = null;
-
-  @Property({ type: 'float', nullable: true })
   float: number | null = null;
-
-  @Property({ type: 'double', nullable: true })
   float36: number | null = null;
-
-  @Property({ type: 'double', nullable: true })
   double: number | null = null;
-
-  @Property({ type: 'string', length: -1, nullable: true })
   meta: string | null = null;
-
-  @ManyToOne({ entity: () => Author2 })
-  author!: Author2;
-
-  @ManyToOne({ entity: () => Publisher2, updateRule: 'cascade', deleteRule: 'cascade', nullable: true })
-  publisher: Publisher2 | null = null;
-
-  @ManyToMany({ entity: () => BookTag2, pivotTable: 'book_to_tag_unordered', joinColumn: 'book2_uuid_pk', inverseJoinColumn: 'book_tag2_id' })
+  author!: Ref<Author2>;
+  publisher: Ref<Publisher2> | null = null;
   bookToTagUnordered = new Collection<BookTag2>(this);
-
+  author2Collection = new Collection<Author2>(this);
+  book2TagsCollection = new Collection<Book2Tags>(this);
+  test2: Ref<Test2> | null = null;
 }
+
+export const Book2Schema = defineEntity({
+  class: Book2,
+  uniques: [
+    {
+      name: 'book2_isbn_unique',
+      expression: 'create unique index [book2_isbn_unique] on [book2] (where ([isbn] IS NOT NULL))',
+      properties: ['isbn'],
+    },
+  ],
+  properties: {
+    uuidPk: p.uuid().primary(),
+    createdAt: p.datetime().length(3).defaultRaw(\`current_timestamp\`),
+    isbn: p.character().length(13).nullable().unique('book2_isbn_unique'),
+    title: p.string().nullable(),
+    perex: p.text().nullable(),
+    price: p.decimal().precision(8).scale(2).nullable(),
+    float: p.float().nullable(),
+    float36: p.double().nullable(),
+    double: p.double().nullable(),
+    meta: p.string().length(-1).nullable(),
+    author: () => p.manyToOne(Author2).ref(),
+    publisher: () => p.manyToOne(Publisher2).ref().updateRule('cascade').deleteRule('cascade').nullable(),
+    bookToTagUnordered: () => p.manyToMany(BookTag2).pivotTable('book_to_tag_unordered').joinColumn('book2_uuid_pk').inverseJoinColumn('book_tag2_id'),
+    author2Collection: () => p.oneToMany(Author2).mappedBy('favouriteBook'),
+    book2TagsCollection: () => p.oneToMany(Book2Tags).mappedBy('book2'),
+    test2: () => p.oneToOne(Test2).ref().mappedBy('book'),
+  },
+});
 ",
-  "import { Entity, ManyToOne, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { PrimaryKeyProp, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { BookTag2 } from './BookTag2';
 
-@Entity({ tableName: 'book2_tags' })
 export class Book2Tags {
-
   [PrimaryKeyProp]?: 'order';
-
-  @PrimaryKey()
   order!: number;
-
-  @ManyToOne({ entity: () => Book2, updateRule: 'cascade', deleteRule: 'cascade' })
-  book2!: Book2;
-
-  @ManyToOne({ entity: () => BookTag2, updateRule: 'cascade', deleteRule: 'cascade' })
-  bookTag2!: BookTag2;
-
+  book2!: Ref<Book2>;
+  bookTag2!: Ref<BookTag2>;
 }
+
+export const Book2TagsSchema = defineEntity({
+  class: Book2Tags,
+  tableName: 'book2_tags',
+  properties: {
+    order: p.integer().primary(),
+    book2: () => p.manyToOne(Book2).ref().updateRule('cascade').deleteRule('cascade'),
+    bookTag2: () => p.manyToOne(BookTag2).ref().updateRule('cascade').deleteRule('cascade'),
+  },
+});
 ",
-  "import { Entity, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Car2 } from './Car2';
 
-@Entity()
 export class CarOwner2 {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property()
   name!: string;
-
-  @ManyToOne({ entity: () => Car2, updateRule: 'cascade', index: true })
-  car!: Car2;
-
+  car!: Ref<Car2>;
 }
-",
-  "import { Entity, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 
-@Entity()
+export const CarOwner2Schema = defineEntity({
+  class: CarOwner2,
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+    car: () => p.manyToOne(Car2).ref().updateRule('cascade').index(true),
+  },
+});
+",
+  "import { Collection, PrimaryKeyProp, type Ref, defineEntity, p } from '@mikro-orm/core';
+import { CarOwner2 } from './CarOwner2';
+import { User2 } from './User2';
+
 export class Car2 {
-
   [PrimaryKeyProp]?: ['name', 'year'];
-
-  @PrimaryKey({ length: 100, index: true })
   name!: string;
-
-  @PrimaryKey({ index: true })
   year!: number;
-
-  @Property()
   price!: number;
-
+  carOwner2Collection = new Collection<CarOwner2>(this);
+  user2: Ref<User2> | null = null;
+  carsInverse = new Collection<User2>(this);
 }
+
+export const Car2Schema = defineEntity({
+  class: Car2,
+  properties: {
+    name: p.string().primary().length(100).index('car2_name_index'),
+    year: p.integer().primary().index('car2_year_index'),
+    price: p.integer(),
+    carOwner2Collection: () => p.oneToMany(CarOwner2).mappedBy('car'),
+    user2: () => p.oneToOne(User2).ref().mappedBy('favouriteCar'),
+    carsInverse: () => p.manyToMany(User2).mappedBy('cars'),
+  },
+});
 ",
-  "import { Entity, ManyToOne, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { PrimaryKeyProp, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Test2 } from './Test2';
 
-@Entity()
 export class Configuration2 {
-
   [PrimaryKeyProp]?: ['property', 'test'];
-
-  @PrimaryKey()
   property!: string;
-
-  @ManyToOne({ entity: () => Test2, updateRule: 'cascade', primary: true })
-  test!: Test2;
-
-  @Property()
+  test!: Ref<Test2>;
   value!: string;
-
 }
-",
-  "import { Entity, PrimaryKey } from '@mikro-orm/core';
 
-@Entity()
+export const Configuration2Schema = defineEntity({
+  class: Configuration2,
+  properties: {
+    property: p.string().primary(),
+    test: () => p.manyToOne(Test2).primary().ref().updateRule('cascade'),
+    value: p.string(),
+  },
+});
+",
+  "import { defineEntity, p } from '@mikro-orm/core';
+
 export class Dummy2 {
-
-  @PrimaryKey()
   id!: number;
-
 }
+
+export const Dummy2Schema = defineEntity({
+  class: Dummy2,
+  properties: {
+    id: p.integer().primary(),
+  },
+});
 ",
-  "import { Entity, OneToOne, type Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, type Opt, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { FooBaz2 } from './FooBaz2';
+import { FooParam2 } from './FooParam2';
 
-@Entity()
 export class FooBar2 {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property()
   name!: string;
-
-  @Unique({ name: 'foo_bar2_baz_id_unique', expression: 'create unique index [foo_bar2_baz_id_unique] on [foo_bar2] (where ([baz_id] IS NOT NULL))' })
-  @OneToOne({ entity: () => FooBaz2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  baz: FooBaz2 | null = null;
-
-  @Unique({ name: 'foo_bar2_foo_bar_id_unique', expression: 'create unique index [foo_bar2_foo_bar_id_unique] on [foo_bar2] (where ([foo_bar_id] IS NOT NULL))' })
-  @OneToOne({ entity: () => FooBar2, nullable: true })
-  fooBar: FooBar2 | null = null;
-
-  @Property({ type: 'datetime', length: 0, defaultRaw: \`current_timestamp\` })
+  baz: Ref<FooBaz2> | null = null;
+  fooBar: Ref<FooBar2> | null = null;
   version!: Date & Opt;
-
-  @Property({ type: 'blob', length: -1, nullable: true })
   blob: Buffer | null = null;
-
-  @Property({ type: 'text', nullable: true })
   array: string | null = null;
-
-  @Property({ type: 'string', length: -1, nullable: true })
   object: string | null = null;
-
+  fooBar2: Ref<FooBar2> | null = null;
+  fooParam2Collection = new Collection<FooParam2>(this);
 }
-",
-  "import { Entity, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 
-@Entity()
+export const FooBar2Schema = defineEntity({
+  class: FooBar2,
+  uniques: [
+    {
+      name: 'foo_bar2_baz_id_unique',
+      expression: 'create unique index [foo_bar2_baz_id_unique] on [foo_bar2] (where ([baz_id] IS NOT NULL))',
+      properties: ['baz'],
+    },
+    {
+      name: 'foo_bar2_foo_bar_id_unique',
+      expression: 'create unique index [foo_bar2_foo_bar_id_unique] on [foo_bar2] (where ([foo_bar_id] IS NOT NULL))',
+      properties: ['fooBar'],
+    },
+  ],
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+    baz: () => p.oneToOne(FooBaz2).ref().updateRule('cascade').deleteRule('set null').nullable(),
+    fooBar: () => p.oneToOne(FooBar2).ref().nullable(),
+    version: p.datetime().length(0).defaultRaw(\`current_timestamp\`),
+    blob: p.blob().length(-1).nullable(),
+    array: p.text().nullable(),
+    object: p.string().length(-1).nullable(),
+    fooBar2: () => p.oneToOne(FooBar2).ref().mappedBy('fooBar'),
+    fooParam2Collection: () => p.oneToMany(FooParam2).mappedBy('bar'),
+  },
+});
+",
+  "import { Collection, type Opt, type Ref, defineEntity, p } from '@mikro-orm/core';
+import { FooBar2 } from './FooBar2';
+import { FooParam2 } from './FooParam2';
+
 export class FooBaz2 {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property()
   name!: string;
-
-  @Property({ type: 'string', columnType: 'varchar(255)' })
   code!: string;
-
-  @Property({ type: 'datetime', length: 3, defaultRaw: \`current_timestamp\` })
   version!: Date & Opt;
-
+  fooBar2: Ref<FooBar2> | null = null;
+  fooParam2Collection = new Collection<FooParam2>(this);
 }
+
+export const FooBaz2Schema = defineEntity({
+  class: FooBaz2,
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+    code: p.string().columnType('varchar(255)'),
+    version: p.datetime().length(3).defaultRaw(\`current_timestamp\`),
+    fooBar2: () => p.oneToOne(FooBar2).ref().mappedBy('baz'),
+    fooParam2Collection: () => p.oneToMany(FooParam2).mappedBy('baz'),
+  },
+});
 ",
-  "import { Entity, ManyToOne, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { PrimaryKeyProp, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { FooBar2 } from './FooBar2';
 import { FooBaz2 } from './FooBaz2';
 
-@Entity()
 export class FooParam2 {
-
   [PrimaryKeyProp]?: ['bar', 'baz'];
-
-  @ManyToOne({ entity: () => FooBar2, updateRule: 'cascade', primary: true })
-  bar!: FooBar2;
-
-  @ManyToOne({ entity: () => FooBaz2, primary: true })
-  baz!: FooBaz2;
-
-  @Property()
+  bar!: Ref<FooBar2>;
+  baz!: Ref<FooBaz2>;
   value!: string;
-
 }
-",
-  "import { Entity, Enum, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 
-@Entity()
+export const FooParam2Schema = defineEntity({
+  class: FooParam2,
+  properties: {
+    bar: () => p.manyToOne(FooBar2).primary().ref().updateRule('cascade'),
+    baz: () => p.manyToOne(FooBaz2).primary().ref(),
+    value: p.string(),
+  },
+});
+",
+  "import { Collection, type Opt, defineEntity, p } from '@mikro-orm/core';
+import { Book2 } from './Book2';
+import { Publisher2Tests } from './Publisher2Tests';
+
 export class Publisher2 {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property({ type: 'string' })
   name: string & Opt = 'asd';
-
-  @Enum({ items: () => Publisher2Type })
-  type: Publisher2Type & Opt = Publisher2Type.LOCAL;
-
-  @Enum({ items: () => Publisher2Type2 })
-  type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
-
-  @Property({ type: 'tinyint', nullable: true })
+  type: TPublisher2Type & Opt = Publisher2Type.LOCAL;
+  type2: TPublisher2Type2 & Opt = Publisher2Type2.LOCAL;
   enum1: number | null = null;
-
-  @Property({ type: 'tinyint', nullable: true })
   enum2: number | null = null;
-
-  @Property({ type: 'tinyint', nullable: true })
   enum3: number | null = null;
-
-  @Enum({ items: () => Publisher2Enum4, nullable: true })
-  enum4: Publisher2Enum4 | null = null;
-
+  enum4: TPublisher2Enum4 | null = null;
+  book2Collection = new Collection<Book2>(this);
+  publisher2TestsCollection = new Collection<Publisher2Tests>(this);
 }
 
-export enum Publisher2Type {
-  LOCAL = 'local',
-  GLOBAL = 'global',
-}
+export const Publisher2Type = {
+  LOCAL: 'local',
+  GLOBAL: 'global',
+} as const;
 
-export enum Publisher2Type2 {
-  LOCAL = 'LOCAL',
-  GLOBAL = 'GLOBAL',
-}
+export type TPublisher2Type = (typeof Publisher2Type)[keyof typeof Publisher2Type];
 
-export enum Publisher2Enum4 {
-  A = 'a',
-  B = 'b',
-  C = 'c',
-}
+export const Publisher2Type2 = {
+  LOCAL: 'LOCAL',
+  GLOBAL: 'GLOBAL',
+} as const;
+
+export type TPublisher2Type2 = (typeof Publisher2Type2)[keyof typeof Publisher2Type2];
+
+export const Publisher2Enum4 = {
+  A: 'a',
+  B: 'b',
+  C: 'c',
+} as const;
+
+export type TPublisher2Enum4 = (typeof Publisher2Enum4)[keyof typeof Publisher2Enum4];
+
+export const Publisher2Schema = defineEntity({
+  class: Publisher2,
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+    type: p.enum(() => Publisher2Type),
+    type2: p.enum(() => Publisher2Type2),
+    enum1: p.tinyint().nullable(),
+    enum2: p.tinyint().nullable(),
+    enum3: p.tinyint().nullable(),
+    enum4: p.enum(() => Publisher2Enum4).nullable(),
+    book2Collection: () => p.oneToMany(Book2).mappedBy('publisher'),
+    publisher2TestsCollection: () => p.oneToMany(Publisher2Tests).mappedBy('publisher2'),
+  },
+});
 ",
-  "import { Entity, ManyToOne, PrimaryKey } from '@mikro-orm/core';
+  "import { type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Publisher2 } from './Publisher2';
 import { Test2 } from './Test2';
 
-@Entity({ tableName: 'publisher2_tests' })
 export class Publisher2Tests {
-
-  @PrimaryKey()
   id!: number;
-
-  @ManyToOne({ entity: () => Publisher2, updateRule: 'cascade', deleteRule: 'cascade' })
-  publisher2!: Publisher2;
-
-  @ManyToOne({ entity: () => Test2, updateRule: 'cascade', deleteRule: 'cascade' })
-  test2!: Test2;
-
+  publisher2!: Ref<Publisher2>;
+  test2!: Ref<Test2>;
 }
-",
-  "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
 
-@Entity()
+export const Publisher2TestsSchema = defineEntity({
+  class: Publisher2Tests,
+  tableName: 'publisher2_tests',
+  properties: {
+    id: p.integer().primary(),
+    publisher2: () => p.manyToOne(Publisher2).ref().updateRule('cascade').deleteRule('cascade'),
+    test2: () => p.manyToOne(Test2).ref().updateRule('cascade').deleteRule('cascade'),
+  },
+});
+",
+  "import { Collection, defineEntity, p } from '@mikro-orm/core';
+import { User2 } from './User2';
+
 export class Sandwich {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property()
   name!: string;
-
-  @Property()
   price!: number;
-
+  sandwichesInverse = new Collection<User2>(this);
 }
+
+export const SandwichSchema = defineEntity({
+  class: Sandwich,
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+    price: p.integer(),
+    sandwichesInverse: () => p.manyToMany(User2).mappedBy('sandwiches'),
+  },
+});
 ",
-  "import { Entity, OneToOne, type Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, type Opt, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Book2 } from './Book2';
+import { Configuration2 } from './Configuration2';
+import { Publisher2Tests } from './Publisher2Tests';
 
-@Entity()
 export class Test2 {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property({ type: 'string', nullable: true })
   name: string | null = null;
-
-  @Unique({ name: 'test2_book_uuid_pk_unique', expression: 'create unique index [test2_book_uuid_pk_unique] on [test2] (where ([book_uuid_pk] IS NOT NULL))' })
-  @OneToOne({ entity: () => Book2, nullable: true })
-  book: Book2 | null = null;
-
-  @Property({ type: 'integer' })
+  book: Ref<Book2> | null = null;
   version: number & Opt = 1;
-
+  configuration2Collection = new Collection<Configuration2>(this);
+  publisher2TestsCollection = new Collection<Publisher2Tests>(this);
 }
+
+export const Test2Schema = defineEntity({
+  class: Test2,
+  uniques: [
+    {
+      name: 'test2_book_uuid_pk_unique',
+      expression: 'create unique index [test2_book_uuid_pk_unique] on [test2] (where ([book_uuid_pk] IS NOT NULL))',
+      properties: ['book'],
+    },
+  ],
+  properties: {
+    id: p.integer().primary(),
+    name: p.string().nullable(),
+    book: () => p.oneToOne(Book2).ref().nullable(),
+    version: p.integer(),
+    configuration2Collection: () => p.oneToMany(Configuration2).mappedBy('test'),
+    publisher2TestsCollection: () => p.oneToMany(Publisher2Tests).mappedBy('test2'),
+  },
+});
 ",
-  "import { Collection, Entity, ManyToMany, OneToOne, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, PrimaryKeyProp, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Car2 } from './Car2';
 import { Sandwich } from './Sandwich';
 
-@Entity()
-@Unique({ name: 'user2_favourite_car_name_favourite_car_year_unique', expression: 'create unique index [user2_favourite_car_name_favourite_car_year_unique] on [user2] (where ([favourite_car_name] IS NOT NULL AND [favourite_car_year] IS NOT NULL))', properties: ['favouriteCarName'] })
 export class User2 {
-
   [PrimaryKeyProp]?: ['firstName', 'lastName'];
-
-  @PrimaryKey({ length: 100 })
   firstName!: string;
-
-  @PrimaryKey({ length: 100 })
   lastName!: string;
-
-  @Property({ type: 'integer', nullable: true })
   foo: number | null = null;
-
-  @Unique({ name: 'user2_favourite_car_name_favourite_car_year_unique' })
-  @OneToOne({ entity: () => Car2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  favouriteCar!: Car2 | null;
-
-  @ManyToMany({ entity: () => Car2, joinColumns: ['user2_first_name', 'user2_last_name'], inverseJoinColumns: ['car2_name', 'car2_year'] })
+  favouriteCar!: Ref<Car2> | null;
   cars = new Collection<Car2>(this);
-
-  @ManyToMany({ entity: () => Sandwich, joinColumns: ['user2_first_name', 'user2_last_name'], inverseJoinColumn: 'sandwich_id' })
   sandwiches = new Collection<Sandwich>(this);
-
 }
+
+export const User2Schema = defineEntity({
+  class: User2,
+  uniques: [
+    {
+      name: 'user2_favourite_car_name_favourite_car_year_unique',
+      expression: 'create unique index [user2_favourite_car_name_favourite_car_year_unique] on [user2] (where ([favourite_car_name] IS NOT NULL AND [favourite_car_year] IS NOT NULL))',
+      properties: ['favouriteCarName'],
+    },
+  ],
+  properties: {
+    firstName: p.string().primary().length(100),
+    lastName: p.string().primary().length(100),
+    foo: p.integer().nullable(),
+    favouriteCar: () => p.oneToOne(Car2).ref().updateRule('cascade').deleteRule('set null').nullable(),
+    cars: () => p.manyToMany(Car2).joinColumns('user2_first_name', 'user2_last_name').inverseJoinColumns('car2_name', 'car2_year'),
+    sandwiches: () => p.manyToMany(Sandwich).joinColumns('user2_first_name', 'user2_last_name').inverseJoinColumn('sandwich_id'),
+  },
+});
 ",
 ]
 `;
 
 exports[`EntityGenerator > generate entities from schema with forceUndefined = true and undefinedDefaults = true [mssql] > mssql-entity-dump 1`] = `
 [
-  "import { Entity, OneToOne, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { PrimaryKeyProp, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 
-@Entity({ comment: 'This is address table' })
 export class Address2 {
-
   [PrimaryKeyProp]?: 'author';
-
-  @OneToOne({ entity: () => Author2, updateRule: 'cascade', deleteRule: 'cascade', primary: true })
-  author!: Author2;
-
-  @Property({ comment: 'This is address property' })
+  author!: Ref<Author2>;
   value!: string;
-
 }
+
+export const Address2Schema = defineEntity({
+  class: Address2,
+  comment: 'This is address table',
+  properties: {
+    author: () => p.oneToOne(Author2).primary().ref().updateRule('cascade').deleteRule('cascade'),
+    value: p.string().comment('This is address property'),
+  },
+});
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, type Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, type Opt, type Ref, defineEntity, p } from '@mikro-orm/core';
+import { Address2 } from './Address2';
 import { Book2 } from './Book2';
 
-@Entity()
-@Index({ name: 'author2_name_age_index', properties: ['name', 'age'] })
-@Unique({ name: 'author2_name_email_unique', properties: ['name', 'email'] })
 export class Author2 {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property({ type: 'datetime', length: 3, defaultRaw: \`current_timestamp\` })
   createdAt!: Date & Opt;
-
-  @Property({ type: 'datetime', length: 3, defaultRaw: \`current_timestamp\` })
   updatedAt!: Date & Opt;
-
-  @Property({ index: 'custom_idx_name_123' })
   name!: string;
-
-  @Property({ index: 'custom_email_index_name', unique: 'custom_email_unique_name' })
   email!: string;
-
-  @Property({ type: 'integer', nullable: true })
   age?: number | null;
-
-  @Property({ type: 'boolean', defaultRaw: \`0\`, index: true })
   termsAccepted: boolean & Opt = false;
-
-  @Property({ type: 'boolean', nullable: true })
   optional?: boolean | null;
-
-  @Property({ type: 'text', nullable: true })
   identities?: string | null;
-
-  @Property({ type: 'date', nullable: true, index: true })
   born?: string | null;
-
-  @Property({ type: 'time', nullable: true, index: 'born_time_idx' })
   bornTime?: string | null;
-
-  @ManyToOne({ entity: () => Book2, deleteRule: 'cascade', nullable: true })
-  favouriteBook?: Book2 | null;
-
-  @ManyToOne({ entity: () => Author2, nullable: true })
-  favouriteAuthor?: Author2 | null;
-
-  @ManyToMany({ entity: () => Author2, pivotTable: 'author_to_friend', joinColumn: 'author2_1_id', inverseJoinColumn: 'author2_2_id' })
+  favouriteBook?: Ref<Book2> | null;
+  favouriteAuthor?: Ref<Author2> | null;
   authorToFriend = new Collection<Author2>(this);
-
-  @ManyToMany({ entity: () => Author2, joinColumn: 'author2_1_id', inverseJoinColumn: 'author2_2_id' })
   following = new Collection<Author2>(this);
-
+  address2: Ref<Address2> | null = null;
+  author2Collection = new Collection<Author2>(this);
+  authorToFriendInverse = new Collection<Author2>(this);
+  followingInverse = new Collection<Author2>(this);
+  book2Collection = new Collection<Book2>(this);
 }
-",
-  "import { Entity, Enum, ManyToOne, OneToOne, PrimaryKey, Property, Unique } from '@mikro-orm/core';
 
-@Entity()
+export const Author2Schema = defineEntity({
+  class: Author2,
+  indexes: [{ name: 'author2_name_age_index', properties: ['name', 'age'] }],
+  uniques: [{ name: 'author2_name_email_unique', properties: ['name', 'email'] }],
+  properties: {
+    id: p.integer().primary(),
+    createdAt: p.datetime().length(3).defaultRaw(\`current_timestamp\`),
+    updatedAt: p.datetime().length(3).defaultRaw(\`current_timestamp\`),
+    name: p.string().index('custom_idx_name_123'),
+    email: p.string().index('custom_email_index_name').unique('custom_email_unique_name'),
+    age: p.integer().nullable(),
+    termsAccepted: p.boolean().defaultRaw(\`0\`).index('author2_terms_accepted_index'),
+    optional: p.boolean().nullable(),
+    identities: p.text().nullable(),
+    born: p.date().nullable().index('author2_born_index'),
+    bornTime: p.time().nullable().index('born_time_idx'),
+    favouriteBook: () => p.manyToOne(Book2).ref().deleteRule('cascade').nullable(),
+    favouriteAuthor: () => p.manyToOne(Author2).ref().nullable(),
+    authorToFriend: () => p.manyToMany(Author2).pivotTable('author_to_friend').joinColumn('author2_1_id').inverseJoinColumn('author2_2_id'),
+    following: () => p.manyToMany(Author2).joinColumn('author2_1_id').inverseJoinColumn('author2_2_id'),
+    address2: () => p.oneToOne(Address2).ref().mappedBy('author'),
+    author2Collection: () => p.oneToMany(Author2).mappedBy('favouriteAuthor'),
+    authorToFriendInverse: () => p.manyToMany(Author2).mappedBy('authorToFriend'),
+    followingInverse: () => p.manyToMany(Author2).mappedBy('following'),
+    book2Collection: () => p.oneToMany(Book2).mappedBy('author'),
+  },
+});
+",
+  "import { Collection, type Ref, defineEntity, p } from '@mikro-orm/core';
+
 export class BaseUser2 {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property({ length: 100 })
   firstName!: string;
-
-  @Property({ length: 100 })
   lastName!: string;
-
-  @Enum({ items: () => BaseUser2Type, index: true })
-  type!: BaseUser2Type;
-
-  @Property({ type: 'string', nullable: true })
+  type!: TBaseUser2Type;
   ownerProp?: string | null;
-
-  @ManyToOne({ entity: () => BaseUser2, nullable: true })
-  favouriteEmployee?: BaseUser2 | null;
-
-  @Unique({ name: 'base_user2_favourite_manager_id_unique', expression: 'create unique index [base_user2_favourite_manager_id_unique] on [base_user2] (where ([favourite_manager_id] IS NOT NULL))' })
-  @OneToOne({ entity: () => BaseUser2, nullable: true })
-  favouriteManager?: BaseUser2 | null;
-
-  @Property({ type: 'integer', nullable: true })
+  favouriteEmployee?: Ref<BaseUser2> | null;
+  favouriteManager?: Ref<BaseUser2> | null;
   employeeProp?: number | null;
-
-  @Property({ type: 'string', nullable: true })
   managerProp?: string | null;
-
+  baseUser2Collection = new Collection<BaseUser2>(this);
+  baseUser2: Ref<BaseUser2> | null = null;
 }
 
-export enum BaseUser2Type {
-  EMPLOYEE = 'employee',
-  MANAGER = 'manager',
-  OWNER = 'owner',
-}
+export const BaseUser2Type = {
+  EMPLOYEE: 'employee',
+  MANAGER: 'manager',
+  OWNER: 'owner',
+} as const;
+
+export type TBaseUser2Type = (typeof BaseUser2Type)[keyof typeof BaseUser2Type];
+
+export const BaseUser2Schema = defineEntity({
+  class: BaseUser2,
+  uniques: [
+    {
+      name: 'base_user2_favourite_manager_id_unique',
+      expression: 'create unique index [base_user2_favourite_manager_id_unique] on [base_user2] (where ([favourite_manager_id] IS NOT NULL))',
+      properties: ['favouriteManager'],
+    },
+  ],
+  properties: {
+    id: p.integer().primary(),
+    firstName: p.string().length(100),
+    lastName: p.string().length(100),
+    type: p.enum(() => BaseUser2Type).index('base_user2_type_index'),
+    ownerProp: p.string().nullable(),
+    favouriteEmployee: () => p.manyToOne(BaseUser2).ref().nullable(),
+    favouriteManager: () => p.oneToOne(BaseUser2).ref().nullable(),
+    employeeProp: p.integer().nullable(),
+    managerProp: p.string().nullable(),
+    baseUser2Collection: () => p.oneToMany(BaseUser2).mappedBy('favouriteEmployee'),
+    baseUser2: () => p.oneToOne(BaseUser2).ref().mappedBy('favouriteManager'),
+  },
+});
 ",
-  "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, defineEntity, p } from '@mikro-orm/core';
+import { Book2 } from './Book2';
+import { Book2Tags } from './Book2Tags';
 
-@Entity()
 export class BookTag2 {
-
-  @PrimaryKey()
   id!: bigint;
-
-  @Property({ length: 50 })
   name!: string;
-
+  bookToTagUnorderedInverse = new Collection<Book2>(this);
+  book2TagsCollection = new Collection<Book2Tags>(this);
 }
+
+export const BookTag2Schema = defineEntity({
+  class: BookTag2,
+  properties: {
+    id: p.bigint().primary(),
+    name: p.string().length(50),
+    bookToTagUnorderedInverse: () => p.manyToMany(Book2).mappedBy('bookToTagUnordered'),
+    book2TagsCollection: () => p.oneToMany(Book2Tags).mappedBy('bookTag2'),
+  },
+});
 ",
-  "import { Collection, Entity, ManyToMany, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, type Opt, PrimaryKeyProp, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Author2 } from './Author2';
+import { Book2Tags } from './Book2Tags';
 import { BookTag2 } from './BookTag2';
 import { Publisher2 } from './Publisher2';
+import { Test2 } from './Test2';
 
-@Entity()
 export class Book2 {
-
   [PrimaryKeyProp]?: 'uuidPk';
-
-  @PrimaryKey({ type: 'uuid' })
   uuidPk!: string;
-
-  @Property({ type: 'datetime', length: 3, defaultRaw: \`current_timestamp\` })
   createdAt!: Date & Opt;
-
-  @Unique({ name: 'book2_isbn_unique', expression: 'create unique index [book2_isbn_unique] on [book2] (where ([isbn] IS NOT NULL))' })
-  @Property({ type: 'character', length: 13, nullable: true })
   isbn?: string | null;
-
-  @Property({ type: 'string', nullable: true })
   title?: string | null = '';
-
-  @Property({ type: 'text', nullable: true })
   perex?: string | null;
-
-  @Property({ type: 'decimal', precision: 8, scale: 2, nullable: true })
   price?: string | null;
-
-  @Property({ type: 'float', nullable: true })
   float?: number | null;
-
-  @Property({ type: 'double', nullable: true })
   float36?: number | null;
-
-  @Property({ type: 'double', nullable: true })
   double?: number | null;
-
-  @Property({ type: 'string', length: -1, nullable: true })
   meta?: string | null;
-
-  @ManyToOne({ entity: () => Author2 })
-  author!: Author2;
-
-  @ManyToOne({ entity: () => Publisher2, updateRule: 'cascade', deleteRule: 'cascade', nullable: true })
-  publisher?: Publisher2 | null;
-
-  @ManyToMany({ entity: () => BookTag2, pivotTable: 'book_to_tag_unordered', joinColumn: 'book2_uuid_pk', inverseJoinColumn: 'book_tag2_id' })
+  author!: Ref<Author2>;
+  publisher?: Ref<Publisher2> | null;
   bookToTagUnordered = new Collection<BookTag2>(this);
-
+  author2Collection = new Collection<Author2>(this);
+  book2TagsCollection = new Collection<Book2Tags>(this);
+  test2: Ref<Test2> | null = null;
 }
+
+export const Book2Schema = defineEntity({
+  class: Book2,
+  uniques: [
+    {
+      name: 'book2_isbn_unique',
+      expression: 'create unique index [book2_isbn_unique] on [book2] (where ([isbn] IS NOT NULL))',
+      properties: ['isbn'],
+    },
+  ],
+  properties: {
+    uuidPk: p.uuid().primary(),
+    createdAt: p.datetime().length(3).defaultRaw(\`current_timestamp\`),
+    isbn: p.character().length(13).nullable().unique('book2_isbn_unique'),
+    title: p.string().nullable(),
+    perex: p.text().nullable(),
+    price: p.decimal().precision(8).scale(2).nullable(),
+    float: p.float().nullable(),
+    float36: p.double().nullable(),
+    double: p.double().nullable(),
+    meta: p.string().length(-1).nullable(),
+    author: () => p.manyToOne(Author2).ref(),
+    publisher: () => p.manyToOne(Publisher2).ref().updateRule('cascade').deleteRule('cascade').nullable(),
+    bookToTagUnordered: () => p.manyToMany(BookTag2).pivotTable('book_to_tag_unordered').joinColumn('book2_uuid_pk').inverseJoinColumn('book_tag2_id'),
+    author2Collection: () => p.oneToMany(Author2).mappedBy('favouriteBook'),
+    book2TagsCollection: () => p.oneToMany(Book2Tags).mappedBy('book2'),
+    test2: () => p.oneToOne(Test2).ref().mappedBy('book'),
+  },
+});
 ",
-  "import { Entity, ManyToOne, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { PrimaryKeyProp, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { BookTag2 } from './BookTag2';
 
-@Entity({ tableName: 'book2_tags' })
 export class Book2Tags {
-
   [PrimaryKeyProp]?: 'order';
-
-  @PrimaryKey()
   order!: number;
-
-  @ManyToOne({ entity: () => Book2, updateRule: 'cascade', deleteRule: 'cascade' })
-  book2!: Book2;
-
-  @ManyToOne({ entity: () => BookTag2, updateRule: 'cascade', deleteRule: 'cascade' })
-  bookTag2!: BookTag2;
-
+  book2!: Ref<Book2>;
+  bookTag2!: Ref<BookTag2>;
 }
+
+export const Book2TagsSchema = defineEntity({
+  class: Book2Tags,
+  tableName: 'book2_tags',
+  properties: {
+    order: p.integer().primary(),
+    book2: () => p.manyToOne(Book2).ref().updateRule('cascade').deleteRule('cascade'),
+    bookTag2: () => p.manyToOne(BookTag2).ref().updateRule('cascade').deleteRule('cascade'),
+  },
+});
 ",
-  "import { Entity, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Car2 } from './Car2';
 
-@Entity()
 export class CarOwner2 {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property()
   name!: string;
-
-  @ManyToOne({ entity: () => Car2, updateRule: 'cascade', index: true })
-  car!: Car2;
-
+  car!: Ref<Car2>;
 }
-",
-  "import { Entity, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 
-@Entity()
+export const CarOwner2Schema = defineEntity({
+  class: CarOwner2,
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+    car: () => p.manyToOne(Car2).ref().updateRule('cascade').index(true),
+  },
+});
+",
+  "import { Collection, PrimaryKeyProp, type Ref, defineEntity, p } from '@mikro-orm/core';
+import { CarOwner2 } from './CarOwner2';
+import { User2 } from './User2';
+
 export class Car2 {
-
   [PrimaryKeyProp]?: ['name', 'year'];
-
-  @PrimaryKey({ length: 100, index: true })
   name!: string;
-
-  @PrimaryKey({ index: true })
   year!: number;
-
-  @Property()
   price!: number;
-
+  carOwner2Collection = new Collection<CarOwner2>(this);
+  user2: Ref<User2> | null = null;
+  carsInverse = new Collection<User2>(this);
 }
+
+export const Car2Schema = defineEntity({
+  class: Car2,
+  properties: {
+    name: p.string().primary().length(100).index('car2_name_index'),
+    year: p.integer().primary().index('car2_year_index'),
+    price: p.integer(),
+    carOwner2Collection: () => p.oneToMany(CarOwner2).mappedBy('car'),
+    user2: () => p.oneToOne(User2).ref().mappedBy('favouriteCar'),
+    carsInverse: () => p.manyToMany(User2).mappedBy('cars'),
+  },
+});
 ",
-  "import { Entity, ManyToOne, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { PrimaryKeyProp, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Test2 } from './Test2';
 
-@Entity()
 export class Configuration2 {
-
   [PrimaryKeyProp]?: ['property', 'test'];
-
-  @PrimaryKey()
   property!: string;
-
-  @ManyToOne({ entity: () => Test2, updateRule: 'cascade', primary: true })
-  test!: Test2;
-
-  @Property()
+  test!: Ref<Test2>;
   value!: string;
-
 }
-",
-  "import { Entity, PrimaryKey } from '@mikro-orm/core';
 
-@Entity()
+export const Configuration2Schema = defineEntity({
+  class: Configuration2,
+  properties: {
+    property: p.string().primary(),
+    test: () => p.manyToOne(Test2).primary().ref().updateRule('cascade'),
+    value: p.string(),
+  },
+});
+",
+  "import { defineEntity, p } from '@mikro-orm/core';
+
 export class Dummy2 {
-
-  @PrimaryKey()
   id!: number;
-
 }
+
+export const Dummy2Schema = defineEntity({
+  class: Dummy2,
+  properties: {
+    id: p.integer().primary(),
+  },
+});
 ",
-  "import { Entity, OneToOne, type Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, type Opt, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { FooBaz2 } from './FooBaz2';
+import { FooParam2 } from './FooParam2';
 
-@Entity()
 export class FooBar2 {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property()
   name!: string;
-
-  @Unique({ name: 'foo_bar2_baz_id_unique', expression: 'create unique index [foo_bar2_baz_id_unique] on [foo_bar2] (where ([baz_id] IS NOT NULL))' })
-  @OneToOne({ entity: () => FooBaz2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  baz?: FooBaz2 | null;
-
-  @Unique({ name: 'foo_bar2_foo_bar_id_unique', expression: 'create unique index [foo_bar2_foo_bar_id_unique] on [foo_bar2] (where ([foo_bar_id] IS NOT NULL))' })
-  @OneToOne({ entity: () => FooBar2, nullable: true })
-  fooBar?: FooBar2 | null;
-
-  @Property({ type: 'datetime', length: 0, defaultRaw: \`current_timestamp\` })
+  baz?: Ref<FooBaz2> | null;
+  fooBar?: Ref<FooBar2> | null;
   version!: Date & Opt;
-
-  @Property({ type: 'blob', length: -1, nullable: true })
   blob?: Buffer | null;
-
-  @Property({ type: 'text', nullable: true })
   array?: string | null;
-
-  @Property({ type: 'string', length: -1, nullable: true })
   object?: string | null;
-
+  fooBar2: Ref<FooBar2> | null = null;
+  fooParam2Collection = new Collection<FooParam2>(this);
 }
-",
-  "import { Entity, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 
-@Entity()
+export const FooBar2Schema = defineEntity({
+  class: FooBar2,
+  uniques: [
+    {
+      name: 'foo_bar2_baz_id_unique',
+      expression: 'create unique index [foo_bar2_baz_id_unique] on [foo_bar2] (where ([baz_id] IS NOT NULL))',
+      properties: ['baz'],
+    },
+    {
+      name: 'foo_bar2_foo_bar_id_unique',
+      expression: 'create unique index [foo_bar2_foo_bar_id_unique] on [foo_bar2] (where ([foo_bar_id] IS NOT NULL))',
+      properties: ['fooBar'],
+    },
+  ],
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+    baz: () => p.oneToOne(FooBaz2).ref().updateRule('cascade').deleteRule('set null').nullable(),
+    fooBar: () => p.oneToOne(FooBar2).ref().nullable(),
+    version: p.datetime().length(0).defaultRaw(\`current_timestamp\`),
+    blob: p.blob().length(-1).nullable(),
+    array: p.text().nullable(),
+    object: p.string().length(-1).nullable(),
+    fooBar2: () => p.oneToOne(FooBar2).ref().mappedBy('fooBar'),
+    fooParam2Collection: () => p.oneToMany(FooParam2).mappedBy('bar'),
+  },
+});
+",
+  "import { Collection, type Opt, type Ref, defineEntity, p } from '@mikro-orm/core';
+import { FooBar2 } from './FooBar2';
+import { FooParam2 } from './FooParam2';
+
 export class FooBaz2 {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property()
   name!: string;
-
-  @Property({ type: 'string', columnType: 'varchar(255)' })
   code!: string;
-
-  @Property({ type: 'datetime', length: 3, defaultRaw: \`current_timestamp\` })
   version!: Date & Opt;
-
+  fooBar2: Ref<FooBar2> | null = null;
+  fooParam2Collection = new Collection<FooParam2>(this);
 }
+
+export const FooBaz2Schema = defineEntity({
+  class: FooBaz2,
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+    code: p.string().columnType('varchar(255)'),
+    version: p.datetime().length(3).defaultRaw(\`current_timestamp\`),
+    fooBar2: () => p.oneToOne(FooBar2).ref().mappedBy('baz'),
+    fooParam2Collection: () => p.oneToMany(FooParam2).mappedBy('baz'),
+  },
+});
 ",
-  "import { Entity, ManyToOne, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { PrimaryKeyProp, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { FooBar2 } from './FooBar2';
 import { FooBaz2 } from './FooBaz2';
 
-@Entity()
 export class FooParam2 {
-
   [PrimaryKeyProp]?: ['bar', 'baz'];
-
-  @ManyToOne({ entity: () => FooBar2, updateRule: 'cascade', primary: true })
-  bar!: FooBar2;
-
-  @ManyToOne({ entity: () => FooBaz2, primary: true })
-  baz!: FooBaz2;
-
-  @Property()
+  bar!: Ref<FooBar2>;
+  baz!: Ref<FooBaz2>;
   value!: string;
-
 }
-",
-  "import { Entity, Enum, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 
-@Entity()
+export const FooParam2Schema = defineEntity({
+  class: FooParam2,
+  properties: {
+    bar: () => p.manyToOne(FooBar2).primary().ref().updateRule('cascade'),
+    baz: () => p.manyToOne(FooBaz2).primary().ref(),
+    value: p.string(),
+  },
+});
+",
+  "import { Collection, type Opt, defineEntity, p } from '@mikro-orm/core';
+import { Book2 } from './Book2';
+import { Publisher2Tests } from './Publisher2Tests';
+
 export class Publisher2 {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property({ type: 'string' })
   name: string & Opt = 'asd';
-
-  @Enum({ items: () => Publisher2Type })
-  type: Publisher2Type & Opt = Publisher2Type.LOCAL;
-
-  @Enum({ items: () => Publisher2Type2 })
-  type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
-
-  @Property({ type: 'tinyint', nullable: true })
+  type: TPublisher2Type & Opt = Publisher2Type.LOCAL;
+  type2: TPublisher2Type2 & Opt = Publisher2Type2.LOCAL;
   enum1?: number | null;
-
-  @Property({ type: 'tinyint', nullable: true })
   enum2?: number | null;
-
-  @Property({ type: 'tinyint', nullable: true })
   enum3?: number | null;
-
-  @Enum({ items: () => Publisher2Enum4, nullable: true })
-  enum4?: Publisher2Enum4 | null;
-
+  enum4?: TPublisher2Enum4 | null;
+  book2Collection = new Collection<Book2>(this);
+  publisher2TestsCollection = new Collection<Publisher2Tests>(this);
 }
 
-export enum Publisher2Type {
-  LOCAL = 'local',
-  GLOBAL = 'global',
-}
+export const Publisher2Type = {
+  LOCAL: 'local',
+  GLOBAL: 'global',
+} as const;
 
-export enum Publisher2Type2 {
-  LOCAL = 'LOCAL',
-  GLOBAL = 'GLOBAL',
-}
+export type TPublisher2Type = (typeof Publisher2Type)[keyof typeof Publisher2Type];
 
-export enum Publisher2Enum4 {
-  A = 'a',
-  B = 'b',
-  C = 'c',
-}
+export const Publisher2Type2 = {
+  LOCAL: 'LOCAL',
+  GLOBAL: 'GLOBAL',
+} as const;
+
+export type TPublisher2Type2 = (typeof Publisher2Type2)[keyof typeof Publisher2Type2];
+
+export const Publisher2Enum4 = {
+  A: 'a',
+  B: 'b',
+  C: 'c',
+} as const;
+
+export type TPublisher2Enum4 = (typeof Publisher2Enum4)[keyof typeof Publisher2Enum4];
+
+export const Publisher2Schema = defineEntity({
+  class: Publisher2,
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+    type: p.enum(() => Publisher2Type),
+    type2: p.enum(() => Publisher2Type2),
+    enum1: p.tinyint().nullable(),
+    enum2: p.tinyint().nullable(),
+    enum3: p.tinyint().nullable(),
+    enum4: p.enum(() => Publisher2Enum4).nullable(),
+    book2Collection: () => p.oneToMany(Book2).mappedBy('publisher'),
+    publisher2TestsCollection: () => p.oneToMany(Publisher2Tests).mappedBy('publisher2'),
+  },
+});
 ",
-  "import { Entity, ManyToOne, PrimaryKey } from '@mikro-orm/core';
+  "import { type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Publisher2 } from './Publisher2';
 import { Test2 } from './Test2';
 
-@Entity({ tableName: 'publisher2_tests' })
 export class Publisher2Tests {
-
-  @PrimaryKey()
   id!: number;
-
-  @ManyToOne({ entity: () => Publisher2, updateRule: 'cascade', deleteRule: 'cascade' })
-  publisher2!: Publisher2;
-
-  @ManyToOne({ entity: () => Test2, updateRule: 'cascade', deleteRule: 'cascade' })
-  test2!: Test2;
-
+  publisher2!: Ref<Publisher2>;
+  test2!: Ref<Test2>;
 }
-",
-  "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
 
-@Entity()
+export const Publisher2TestsSchema = defineEntity({
+  class: Publisher2Tests,
+  tableName: 'publisher2_tests',
+  properties: {
+    id: p.integer().primary(),
+    publisher2: () => p.manyToOne(Publisher2).ref().updateRule('cascade').deleteRule('cascade'),
+    test2: () => p.manyToOne(Test2).ref().updateRule('cascade').deleteRule('cascade'),
+  },
+});
+",
+  "import { Collection, defineEntity, p } from '@mikro-orm/core';
+import { User2 } from './User2';
+
 export class Sandwich {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property()
   name!: string;
-
-  @Property()
   price!: number;
-
+  sandwichesInverse = new Collection<User2>(this);
 }
+
+export const SandwichSchema = defineEntity({
+  class: Sandwich,
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+    price: p.integer(),
+    sandwichesInverse: () => p.manyToMany(User2).mappedBy('sandwiches'),
+  },
+});
 ",
-  "import { Entity, OneToOne, type Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, type Opt, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Book2 } from './Book2';
+import { Configuration2 } from './Configuration2';
+import { Publisher2Tests } from './Publisher2Tests';
 
-@Entity()
 export class Test2 {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property({ type: 'string', nullable: true })
   name?: string | null;
-
-  @Unique({ name: 'test2_book_uuid_pk_unique', expression: 'create unique index [test2_book_uuid_pk_unique] on [test2] (where ([book_uuid_pk] IS NOT NULL))' })
-  @OneToOne({ entity: () => Book2, nullable: true })
-  book?: Book2 | null;
-
-  @Property({ type: 'integer' })
+  book?: Ref<Book2> | null;
   version: number & Opt = 1;
-
+  configuration2Collection = new Collection<Configuration2>(this);
+  publisher2TestsCollection = new Collection<Publisher2Tests>(this);
 }
+
+export const Test2Schema = defineEntity({
+  class: Test2,
+  uniques: [
+    {
+      name: 'test2_book_uuid_pk_unique',
+      expression: 'create unique index [test2_book_uuid_pk_unique] on [test2] (where ([book_uuid_pk] IS NOT NULL))',
+      properties: ['book'],
+    },
+  ],
+  properties: {
+    id: p.integer().primary(),
+    name: p.string().nullable(),
+    book: () => p.oneToOne(Book2).ref().nullable(),
+    version: p.integer(),
+    configuration2Collection: () => p.oneToMany(Configuration2).mappedBy('test'),
+    publisher2TestsCollection: () => p.oneToMany(Publisher2Tests).mappedBy('test2'),
+  },
+});
 ",
-  "import { Collection, Entity, ManyToMany, OneToOne, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, PrimaryKeyProp, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Car2 } from './Car2';
 import { Sandwich } from './Sandwich';
 
-@Entity()
-@Unique({ name: 'user2_favourite_car_name_favourite_car_year_unique', expression: 'create unique index [user2_favourite_car_name_favourite_car_year_unique] on [user2] (where ([favourite_car_name] IS NOT NULL AND [favourite_car_year] IS NOT NULL))', properties: ['favouriteCarName'] })
 export class User2 {
-
   [PrimaryKeyProp]?: ['firstName', 'lastName'];
-
-  @PrimaryKey({ length: 100 })
   firstName!: string;
-
-  @PrimaryKey({ length: 100 })
   lastName!: string;
-
-  @Property({ type: 'integer', nullable: true })
   foo?: number | null;
-
-  @Unique({ name: 'user2_favourite_car_name_favourite_car_year_unique' })
-  @OneToOne({ entity: () => Car2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  favouriteCar!: Car2 | null;
-
-  @ManyToMany({ entity: () => Car2, joinColumns: ['user2_first_name', 'user2_last_name'], inverseJoinColumns: ['car2_name', 'car2_year'] })
+  favouriteCar!: Ref<Car2> | null;
   cars = new Collection<Car2>(this);
-
-  @ManyToMany({ entity: () => Sandwich, joinColumns: ['user2_first_name', 'user2_last_name'], inverseJoinColumn: 'sandwich_id' })
   sandwiches = new Collection<Sandwich>(this);
-
 }
+
+export const User2Schema = defineEntity({
+  class: User2,
+  uniques: [
+    {
+      name: 'user2_favourite_car_name_favourite_car_year_unique',
+      expression: 'create unique index [user2_favourite_car_name_favourite_car_year_unique] on [user2] (where ([favourite_car_name] IS NOT NULL AND [favourite_car_year] IS NOT NULL))',
+      properties: ['favouriteCarName'],
+    },
+  ],
+  properties: {
+    firstName: p.string().primary().length(100),
+    lastName: p.string().primary().length(100),
+    foo: p.integer().nullable(),
+    favouriteCar: () => p.oneToOne(Car2).ref().updateRule('cascade').deleteRule('set null').nullable(),
+    cars: () => p.manyToMany(Car2).joinColumns('user2_first_name', 'user2_last_name').inverseJoinColumns('car2_name', 'car2_year'),
+    sandwiches: () => p.manyToMany(Sandwich).joinColumns('user2_first_name', 'user2_last_name').inverseJoinColumn('sandwich_id'),
+  },
+});
 ",
 ]
 `;

--- a/tests/features/entity-generator/__snapshots__/EntityGenerator.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/EntityGenerator.mysql.test.ts.snap
@@ -21017,109 +21017,112 @@ export const User2Schema = new EntitySchema({
 
 exports[`enum with default value [mysql] > mysql-entity-dump-enum-default-value 1`] = `
 [
-  "import { Entity, Enum, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { type Opt, defineEntity, p } from '@mikro-orm/core';
 
-@Entity()
 export class Publisher2 {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property({ type: 'string', length: 100, nullable: true })
   test?: string = '123';
-
-  @Enum({ items: () => Publisher2Type })
-  type: Publisher2Type & Opt = Publisher2Type.LOCAL;
-
-  @Enum({ items: () => Publisher2Type2, nullable: true })
-  type2?: Publisher2Type2 = Publisher2Type2.LOCAL;
-
+  type: TPublisher2Type & Opt = Publisher2Type.LOCAL;
+  type2?: TPublisher2Type2 = Publisher2Type2.LOCAL;
 }
 
-export enum Publisher2Type {
-  LOCAL = 'local',
-  GLOBAL = 'global',
-}
+export const Publisher2Type = {
+  LOCAL: 'local',
+  GLOBAL: 'global',
+} as const;
 
-export enum Publisher2Type2 {
-  LOCAL = 'LOCAL',
-  GLOBAL = 'GLOBAL',
-}
+export type TPublisher2Type = (typeof Publisher2Type)[keyof typeof Publisher2Type];
+
+export const Publisher2Type2 = {
+  LOCAL: 'LOCAL',
+  GLOBAL: 'GLOBAL',
+} as const;
+
+export type TPublisher2Type2 = (typeof Publisher2Type2)[keyof typeof Publisher2Type2];
+
+export const Publisher2Schema = defineEntity({
+  class: Publisher2,
+  properties: {
+    id: p.integer().primary(),
+    test: p.string().length(100).nullable(),
+    type: p.enum(() => Publisher2Type),
+    type2: p.enum(() => Publisher2Type2).nullable(),
+  },
+});
 ",
 ]
 `;
 
 exports[`generate OptionalProps and include properties for columns that are not nullable, but have defaults > generate-OptionalProps 1`] = `
 [
-  "import { Entity, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { type Opt, defineEntity, p } from '@mikro-orm/core';
 
-@Entity()
 export class Account {
-
-  @PrimaryKey()
   id!: bigint;
-
-  @Property({ type: 'boolean' })
   active: boolean & Opt = false;
-
-  @Property({ type: 'boolean' })
   receiveEmailNotifications: boolean & Opt = true;
-
 }
+
+export const AccountSchema = defineEntity({
+  class: Account,
+  properties: {
+    id: p.bigint().primary(),
+    active: p.boolean(),
+    receiveEmailNotifications: p.boolean(),
+  },
+});
 ",
 ]
 `;
 
 exports[`numeric nullable columns with null default [mariadb] > mariadb-entity-gh-3285 1`] = `
 [
-  "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { defineEntity, p } from '@mikro-orm/core';
 
-@Entity()
 export class Vrf {
-
-  @PrimaryKey({ unsigned: false })
   id!: number;
-
-  @Property({ nullable: true })
   vrfId?: number;
-
-  @Property({ length: 150, nullable: true })
   comments?: string;
-
-  @Property({ columnType: 'timestamp', nullable: true, defaultRaw: \`current_timestamp()\` })
   createdAt?: Date;
-
-  @Property({ columnType: 'timestamp', nullable: true, defaultRaw: \`current_timestamp()\`, extra: 'on update current_timestamp()' })
   updatedAt?: Date;
-
 }
+
+export const VrfSchema = defineEntity({
+  class: Vrf,
+  properties: {
+    id: p.integer().primary().unsigned(false),
+    vrfId: p.integer().nullable(),
+    comments: p.string().length(150).nullable(),
+    createdAt: p.datetime().columnType('timestamp').nullable().defaultRaw(\`current_timestamp()\`),
+    updatedAt: p.datetime().columnType('timestamp').nullable().defaultRaw(\`current_timestamp()\`).extra('on update current_timestamp()'),
+  },
+});
 ",
 ]
 `;
 
 exports[`numeric nullable columns with null default [mysql] > mysql-entity-gh-3285 1`] = `
 [
-  "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { defineEntity, p } from '@mikro-orm/core';
 
-@Entity()
 export class Vrf {
-
-  @PrimaryKey({ unsigned: false })
   id!: number;
-
-  @Property({ nullable: true })
   vrfId?: number;
-
-  @Property({ length: 150, nullable: true })
   comments?: string;
-
-  @Property({ columnType: 'timestamp', nullable: true, defaultRaw: \`CURRENT_TIMESTAMP\` })
   createdAt?: Date;
-
-  @Property({ columnType: 'timestamp', nullable: true, defaultRaw: \`CURRENT_TIMESTAMP\`, extra: 'on update CURRENT_TIMESTAMP' })
   updatedAt?: Date;
-
 }
+
+export const VrfSchema = defineEntity({
+  class: Vrf,
+  properties: {
+    id: p.integer().primary().unsigned(false),
+    vrfId: p.integer().nullable(),
+    comments: p.string().length(150).nullable(),
+    createdAt: p.datetime().columnType('timestamp').nullable().defaultRaw(\`CURRENT_TIMESTAMP\`),
+    updatedAt: p.datetime().columnType('timestamp').nullable().defaultRaw(\`CURRENT_TIMESTAMP\`).extra('on update CURRENT_TIMESTAMP'),
+  },
+});
 ",
 ]
 `;

--- a/tests/features/entity-generator/__snapshots__/EntityGenerator.postgres.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/EntityGenerator.postgres.test.ts.snap
@@ -2,1672 +2,1820 @@
 
 exports[`EntityGenerator > enum with default value [postgres] > postgres-entity-dump-enum-default-value 1`] = `
 [
-  "import { Entity, Enum, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { type Opt, defineEntity, p } from '@mikro-orm/core';
 
-@Entity()
 export class Publisher2 {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property({ type: 'string', length: -1, nullable: true })
   test?: string = '123';
-
-  @Enum({ items: () => Publisher2Type })
-  type: Publisher2Type & Opt = Publisher2Type.LOCAL;
-
-  @Enum({ items: () => Publisher2Type2, nullable: true })
-  type2?: Publisher2Type2 = Publisher2Type2.LOCAL;
-
+  type: TPublisher2Type & Opt = Publisher2Type.LOCAL;
+  type2?: TPublisher2Type2 = Publisher2Type2.LOCAL;
 }
 
-export enum Publisher2Type {
-  LOCAL = 'local',
-  GLOBAL = 'global',
-}
+export const Publisher2Type = {
+  LOCAL: 'local',
+  GLOBAL: 'global',
+} as const;
 
-export enum Publisher2Type2 {
-  LOCAL = 'LOCAL',
-  GLOBAL = 'GLOBAL',
-}
+export type TPublisher2Type = (typeof Publisher2Type)[keyof typeof Publisher2Type];
+
+export const Publisher2Type2 = {
+  LOCAL: 'LOCAL',
+  GLOBAL: 'GLOBAL',
+} as const;
+
+export type TPublisher2Type2 = (typeof Publisher2Type2)[keyof typeof Publisher2Type2];
+
+export const Publisher2Schema = defineEntity({
+  class: Publisher2,
+  properties: {
+    id: p.integer().primary(),
+    test: p.string().length(-1).nullable(),
+    type: p.enum(() => Publisher2Type),
+    type2: p.enum(() => Publisher2Type2).nullable(),
+  },
+});
 ",
 ]
 `;
 
 exports[`EntityGenerator > generate entities from schema [postgres] > postgres-entity-dump 1`] = `
 [
-  "import { Entity, ManyToOne, PrimaryKey } from '@mikro-orm/core';
+  "import { type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Label2 } from './Label2';
 import { Test2 } from './Test2';
 
-@Entity({ tableName: 'label2_tests', schema: 'label_schema' })
 export class Label2Tests {
-
-  @PrimaryKey()
   id!: number;
-
-  @ManyToOne({ entity: () => Label2, updateRule: 'cascade', deleteRule: 'cascade' })
-  label2!: Label2;
-
-  @ManyToOne({ entity: () => Test2, updateRule: 'cascade', deleteRule: 'cascade' })
-  test2!: Test2;
-
+  label2!: Ref<Label2>;
+  test2!: Ref<Test2>;
 }
+
+export const Label2TestsSchema = defineEntity({
+  class: Label2Tests,
+  tableName: 'label2_tests',
+  schema: 'label_schema',
+  properties: {
+    id: p.integer().primary(),
+    label2: () => p.manyToOne(Label2).ref().updateRule('cascade').deleteRule('cascade'),
+    test2: () => p.manyToOne(Test2).ref().updateRule('cascade').deleteRule('cascade'),
+  },
+});
 ",
-  "import { Entity, OneToOne, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { PrimaryKeyProp, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 
-@Entity({ comment: 'This is address table' })
 export class Address2 {
-
   [PrimaryKeyProp]?: 'author';
-
-  @OneToOne({ entity: () => Author2, updateRule: 'cascade', deleteRule: 'cascade', primary: true })
-  author!: Author2;
-
-  @Property({ comment: 'This is address property' })
+  author!: Ref<Author2>;
   value!: string;
-
 }
+
+export const Address2Schema = defineEntity({
+  class: Address2,
+  comment: 'This is address table',
+  properties: {
+    author: () => p.oneToOne(Author2).primary().ref().updateRule('cascade').deleteRule('cascade'),
+    value: p.string().comment('This is address property'),
+  },
+});
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, type Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, type Opt, type Ref, defineEntity, p } from '@mikro-orm/core';
+import { Address2 } from './Address2';
 import { Book2 } from './Book2';
 
-@Entity()
-@Index({ name: 'author2_name_age_index', properties: ['name', 'age'] })
-@Unique({ name: 'author2_name_email_unique', properties: ['name', 'email'] })
 export class Author2 {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property({ type: 'datetime', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
-
-  @Property({ type: 'datetime', columnType: 'timestamp(3)', defaultRaw: \`current_timestamp(3)\` })
   updatedAt!: Date & Opt;
-
-  @Property({ index: 'custom_idx_name_123' })
   name!: string;
-
-  @Property({ index: 'custom_email_index_name', unique: 'custom_email_unique_name' })
   email!: string;
-
-  @Property({ nullable: true })
   age?: number;
-
-  @Property({ type: 'boolean', index: true })
   termsAccepted: boolean & Opt = false;
-
-  @Property({ nullable: true })
   optional?: boolean;
-
-  @Property({ nullable: true })
   identities?: string[];
-
-  @Property({ type: 'date', nullable: true, index: true })
   born?: string;
-
-  @Property({ type: 'time', length: 0, nullable: true, index: 'born_time_idx' })
   bornTime?: string;
-
-  @ManyToOne({ entity: () => Book2, deleteRule: 'cascade', nullable: true })
-  favouriteBook?: Book2;
-
-  @ManyToOne({ entity: () => Author2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  favouriteAuthor?: Author2;
-
-  @Property({ type: 'json', nullable: true })
+  favouriteBook?: Ref<Book2>;
+  favouriteAuthor?: Ref<Author2>;
   identity?: any;
-
-  @ManyToMany({ entity: () => Author2, pivotTable: 'author_to_friend', joinColumn: 'author2_1_id', inverseJoinColumn: 'author2_2_id' })
   authorToFriend = new Collection<Author2>(this);
-
-  @ManyToMany({ entity: () => Author2, joinColumn: 'author2_1_id', inverseJoinColumn: 'author2_2_id' })
   following = new Collection<Author2>(this);
-
+  address2?: Ref<Address2>;
+  author2Collection = new Collection<Author2>(this);
+  authorToFriendInverse = new Collection<Author2>(this);
+  followingInverse = new Collection<Author2>(this);
+  book2Collection = new Collection<Book2>(this);
 }
-",
-  "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
 
-@Entity()
+export const Author2Schema = defineEntity({
+  class: Author2,
+  indexes: [{ name: 'author2_name_age_index', properties: ['name', 'age'] }],
+  uniques: [{ name: 'author2_name_email_unique', properties: ['name', 'email'] }],
+  properties: {
+    id: p.integer().primary(),
+    createdAt: p.datetime().length(3).defaultRaw(\`current_timestamp(3)\`),
+    updatedAt: p.datetime().columnType('timestamp(3)').defaultRaw(\`current_timestamp(3)\`),
+    name: p.string().index('custom_idx_name_123'),
+    email: p.string().index('custom_email_index_name').unique('custom_email_unique_name'),
+    age: p.integer().nullable(),
+    termsAccepted: p.boolean().index('author2_terms_accepted_index'),
+    optional: p.boolean().nullable(),
+    identities: p.type(string[]).nullable(),
+    born: p.date().nullable().index('author2_born_index'),
+    bornTime: p.time().length(0).nullable().index('born_time_idx'),
+    favouriteBook: () => p.manyToOne(Book2).ref().deleteRule('cascade').nullable(),
+    favouriteAuthor: () => p.manyToOne(Author2).ref().updateRule('cascade').deleteRule('set null').nullable(),
+    identity: p.json().nullable(),
+    authorToFriend: () => p.manyToMany(Author2).pivotTable('author_to_friend').joinColumn('author2_1_id').inverseJoinColumn('author2_2_id'),
+    following: () => p.manyToMany(Author2).joinColumn('author2_1_id').inverseJoinColumn('author2_2_id'),
+    address2: () => p.oneToOne(Address2).ref().mappedBy('author'),
+    author2Collection: () => p.oneToMany(Author2).mappedBy('favouriteAuthor'),
+    authorToFriendInverse: () => p.manyToMany(Author2).mappedBy('authorToFriend'),
+    followingInverse: () => p.manyToMany(Author2).mappedBy('following'),
+    book2Collection: () => p.oneToMany(Book2).mappedBy('author'),
+  },
+});
+",
+  "import { Collection, defineEntity, p } from '@mikro-orm/core';
+import { Book2 } from './Book2';
+import { Book2Tags } from './Book2Tags';
+
 export class BookTag2 {
-
-  @PrimaryKey()
   id!: bigint;
-
-  @Property({ length: 50 })
   name!: string;
-
+  bookToTagUnorderedInverse = new Collection<Book2>(this);
+  book2TagsCollection = new Collection<Book2Tags>(this);
 }
+
+export const BookTag2Schema = defineEntity({
+  class: BookTag2,
+  properties: {
+    id: p.bigint().primary(),
+    name: p.string().length(50),
+    bookToTagUnorderedInverse: () => p.manyToMany(Book2).mappedBy('bookToTagUnordered'),
+    book2TagsCollection: () => p.oneToMany(Book2Tags).mappedBy('bookTag2'),
+  },
+});
 ",
-  "import { Collection, Entity, ManyToMany, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, type Opt, PrimaryKeyProp, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Author2 } from './Author2';
+import { Book2Tags } from './Book2Tags';
 import { BookTag2 } from './BookTag2';
 import { Publisher2 } from './Publisher2';
+import { Test2 } from './Test2';
 
-@Entity()
 export class Book2 {
-
   [PrimaryKeyProp]?: 'uuidPk';
-
-  @PrimaryKey({ type: 'uuid' })
   uuidPk!: string;
-
-  @Property({ type: 'datetime', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
-
-  @Property({ type: 'character', length: 13, nullable: true, unique: 'book_isbn_unique' })
   isbn?: string;
-
-  @Property({ type: 'string', nullable: true })
   title?: string = '';
-
-  @Property({ type: 'text', nullable: true })
   perex?: string;
-
-  @Property({ type: 'decimal', precision: 8, scale: 2, nullable: true })
   price?: string;
-
-  @Property({ type: 'decimal', nullable: true })
   double?: string;
-
-  @Property({ type: 'json', nullable: true })
   meta?: any;
-
-  @ManyToOne({ entity: () => Author2 })
-  author!: Author2;
-
-  @ManyToOne({ entity: () => Publisher2, updateRule: 'cascade', deleteRule: 'cascade', nullable: true })
-  publisher?: Publisher2;
-
-  @Property({ type: 'string', nullable: true })
+  author!: Ref<Author2>;
+  publisher?: Ref<Publisher2>;
   foo?: string = 'lol';
-
-  @ManyToMany({ entity: () => BookTag2, pivotTable: 'book_to_tag_unordered', joinColumn: 'book2_uuid_pk', inverseJoinColumn: 'book_tag2_id' })
   bookToTagUnordered = new Collection<BookTag2>(this);
-
+  author2Collection = new Collection<Author2>(this);
+  book2TagsCollection = new Collection<Book2Tags>(this);
+  test2?: Ref<Test2>;
 }
+
+export const Book2Schema = defineEntity({
+  class: Book2,
+  properties: {
+    uuidPk: p.uuid().primary(),
+    createdAt: p.datetime().length(3).defaultRaw(\`current_timestamp(3)\`),
+    isbn: p.character().length(13).nullable().unique('book_isbn_unique'),
+    title: p.string().nullable(),
+    perex: p.text().nullable(),
+    price: p.decimal().precision(8).scale(2).nullable(),
+    double: p.decimal().nullable(),
+    meta: p.json().nullable(),
+    author: () => p.manyToOne(Author2).ref(),
+    publisher: () => p.manyToOne(Publisher2).ref().updateRule('cascade').deleteRule('cascade').nullable(),
+    foo: p.string().nullable(),
+    bookToTagUnordered: () => p.manyToMany(BookTag2).pivotTable('book_to_tag_unordered').joinColumn('book2_uuid_pk').inverseJoinColumn('book_tag2_id'),
+    author2Collection: () => p.oneToMany(Author2).mappedBy('favouriteBook'),
+    book2TagsCollection: () => p.oneToMany(Book2Tags).mappedBy('book2'),
+    test2: () => p.oneToOne(Test2).ref().mappedBy('book'),
+  },
+});
 ",
-  "import { Entity, ManyToOne, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { PrimaryKeyProp, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { BookTag2 } from './BookTag2';
 
-@Entity({ tableName: 'book2_tags' })
 export class Book2Tags {
-
   [PrimaryKeyProp]?: 'order';
-
-  @PrimaryKey()
   order!: number;
-
-  @ManyToOne({ entity: () => Book2, updateRule: 'cascade', deleteRule: 'cascade' })
-  book2!: Book2;
-
-  @ManyToOne({ entity: () => BookTag2, updateRule: 'cascade', deleteRule: 'cascade' })
-  bookTag2!: BookTag2;
-
+  book2!: Ref<Book2>;
+  bookTag2!: Ref<BookTag2>;
 }
+
+export const Book2TagsSchema = defineEntity({
+  class: Book2Tags,
+  tableName: 'book2_tags',
+  properties: {
+    order: p.integer().primary(),
+    book2: () => p.manyToOne(Book2).ref().updateRule('cascade').deleteRule('cascade'),
+    bookTag2: () => p.manyToOne(BookTag2).ref().updateRule('cascade').deleteRule('cascade'),
+  },
+});
 ",
-  "import { Entity, ManyToOne, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { PrimaryKeyProp, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Test2 } from './Test2';
 
-@Entity()
 export class Configuration2 {
-
   [PrimaryKeyProp]?: ['property', 'test'];
-
-  @PrimaryKey()
   property!: string;
-
-  @ManyToOne({ entity: () => Test2, updateRule: 'cascade', primary: true })
-  test!: Test2;
-
-  @Property()
+  test!: Ref<Test2>;
   value!: string;
-
 }
+
+export const Configuration2Schema = defineEntity({
+  class: Configuration2,
+  properties: {
+    property: p.string().primary(),
+    test: () => p.manyToOne(Test2).primary().ref().updateRule('cascade'),
+    value: p.string(),
+  },
+});
 ",
-  "import { Entity, OneToOne, type Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, type Opt, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { FooBaz2 } from './FooBaz2';
+import { FooParam2 } from './FooParam2';
+import { Test2 } from './Test2';
 
-@Entity()
 export class FooBar2 {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property()
   name!: string;
-
-  @Property({ fieldName: 'name with space', nullable: true })
   nameWithSpace?: string;
-
-  @Unique({ name: 'foo_bar2_baz_id_unique' })
-  @OneToOne({ entity: () => FooBaz2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  baz?: FooBaz2;
-
-  @Unique({ name: 'foo_bar2_foo_bar_id_unique' })
-  @OneToOne({ entity: () => FooBar2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  fooBar?: FooBar2;
-
-  @Property({ type: 'datetime', length: 0, defaultRaw: \`current_timestamp(0)\` })
+  baz?: Ref<FooBaz2>;
+  fooBar?: Ref<FooBar2>;
   version!: Date & Opt;
-
-  @Property({ nullable: true })
   blob?: Buffer;
-
-  @Property({ nullable: true })
   blob2?: Buffer;
-
-  @Property({ nullable: true })
   array?: string[];
-
-  @Property({ type: 'json', nullable: true })
   objectProperty?: any;
-
+  fooBar2?: Ref<FooBar2>;
+  fooParam2Collection = new Collection<FooParam2>(this);
+  barsInverse = new Collection<Test2>(this);
 }
-",
-  "import { Entity, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 
-@Entity()
+export const FooBar2Schema = defineEntity({
+  class: FooBar2,
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+    nameWithSpace: p.string().name('name with space').nullable(),
+    baz: () => p.oneToOne(FooBaz2).ref().updateRule('cascade').deleteRule('set null').nullable(),
+    fooBar: () => p.oneToOne(FooBar2).ref().updateRule('cascade').deleteRule('set null').nullable(),
+    version: p.datetime().length(0).defaultRaw(\`current_timestamp(0)\`),
+    blob: p.blob().nullable(),
+    blob2: p.blob().nullable(),
+    array: p.type(string[]).nullable(),
+    objectProperty: p.json().nullable(),
+    fooBar2: () => p.oneToOne(FooBar2).ref().mappedBy('fooBar'),
+    fooParam2Collection: () => p.oneToMany(FooParam2).mappedBy('bar'),
+    barsInverse: () => p.manyToMany(Test2).mappedBy('bars'),
+  },
+});
+",
+  "import { Collection, type Opt, type Ref, defineEntity, p } from '@mikro-orm/core';
+import { FooBar2 } from './FooBar2';
+import { FooParam2 } from './FooParam2';
+
 export class FooBaz2 {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property()
   name!: string;
-
-  @Property()
   code!: string;
-
-  @Property({ type: 'datetime', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
-
+  fooBar2?: Ref<FooBar2>;
+  fooParam2Collection = new Collection<FooParam2>(this);
 }
+
+export const FooBaz2Schema = defineEntity({
+  class: FooBaz2,
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+    code: p.string(),
+    version: p.datetime().length(3).defaultRaw(\`current_timestamp(3)\`),
+    fooBar2: () => p.oneToOne(FooBar2).ref().mappedBy('baz'),
+    fooParam2Collection: () => p.oneToMany(FooParam2).mappedBy('baz'),
+  },
+});
 ",
-  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { type Opt, PrimaryKeyProp, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { FooBar2 } from './FooBar2';
 import { FooBaz2 } from './FooBaz2';
 
-@Entity()
 export class FooParam2 {
-
   [PrimaryKeyProp]?: ['bar', 'baz'];
-
-  @ManyToOne({ entity: () => FooBar2, updateRule: 'cascade', primary: true })
-  bar!: FooBar2;
-
-  @ManyToOne({ entity: () => FooBaz2, updateRule: 'cascade', primary: true })
-  baz!: FooBaz2;
-
-  @Property()
+  bar!: Ref<FooBar2>;
+  baz!: Ref<FooBaz2>;
   value!: string;
-
-  @Property({ type: 'datetime', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
-
 }
-",
-  "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
 
-@Entity()
+export const FooParam2Schema = defineEntity({
+  class: FooParam2,
+  properties: {
+    bar: () => p.manyToOne(FooBar2).primary().ref().updateRule('cascade'),
+    baz: () => p.manyToOne(FooBaz2).primary().ref().updateRule('cascade'),
+    value: p.string(),
+    version: p.datetime().length(3).defaultRaw(\`current_timestamp(3)\`),
+  },
+});
+",
+  "import { Collection, defineEntity, p } from '@mikro-orm/core';
+import { Label2Tests } from './Label2Tests';
+
 export class Label2 {
-
-  @PrimaryKey({ type: 'uuid' })
   uuid!: string;
-
-  @Property()
   name!: string;
-
+  label2TestsCollection = new Collection<Label2Tests>(this);
 }
-",
-  "import { Entity, Enum, PrimaryKey, Property } from '@mikro-orm/core';
 
-@Entity()
+export const Label2Schema = defineEntity({
+  class: Label2,
+  properties: {
+    uuid: p.uuid().primary(),
+    name: p.string(),
+    label2TestsCollection: () => p.oneToMany(Label2Tests).mappedBy('label2'),
+  },
+});
+",
+  "import { Collection, defineEntity, p } from '@mikro-orm/core';
+import { Book2 } from './Book2';
+import { Publisher2Tests } from './Publisher2Tests';
+
 export class Publisher2 {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property()
   name!: string;
-
-  @Enum({ items: () => Publisher2Type })
-  type!: Publisher2Type;
-
-  @Enum({ items: () => Publisher2Type2 })
-  type2!: Publisher2Type2;
-
-  @Property({ type: 'smallint', nullable: true })
+  type!: TPublisher2Type;
+  type2!: TPublisher2Type2;
   enum1?: number;
-
-  @Property({ type: 'smallint', nullable: true })
   enum2?: number;
-
-  @Property({ type: 'smallint', nullable: true })
   enum3?: number;
-
-  @Enum({ items: () => Publisher2Enum4, nullable: true })
-  enum4?: Publisher2Enum4;
-
-  @Enum({ items: () => Publisher2Enum5, nullable: true })
-  enum5?: Publisher2Enum5;
-
+  enum4?: TPublisher2Enum4;
+  enum5?: TPublisher2Enum5;
+  book2Collection = new Collection<Book2>(this);
+  publisher2TestsCollection = new Collection<Publisher2Tests>(this);
 }
 
-export enum Publisher2Type {
-  LOCAL = 'local',
-  GLOBAL = 'global',
-}
+export const Publisher2Type = {
+  LOCAL: 'local',
+  GLOBAL: 'global',
+} as const;
 
-export enum Publisher2Type2 {
-  LOCAL = 'LOCAL',
-  GLOBAL = 'GLOBAL',
-}
+export type TPublisher2Type = (typeof Publisher2Type)[keyof typeof Publisher2Type];
 
-export enum Publisher2Enum4 {
-  A = 'a',
-  B = 'b',
-  C = 'c',
-}
+export const Publisher2Type2 = {
+  LOCAL: 'LOCAL',
+  GLOBAL: 'GLOBAL',
+} as const;
 
-export enum Publisher2Enum5 {
-  A = 'a',
-}
+export type TPublisher2Type2 = (typeof Publisher2Type2)[keyof typeof Publisher2Type2];
+
+export const Publisher2Enum4 = {
+  A: 'a',
+  B: 'b',
+  C: 'c',
+} as const;
+
+export type TPublisher2Enum4 = (typeof Publisher2Enum4)[keyof typeof Publisher2Enum4];
+
+export const Publisher2Enum5 = {
+  A: 'a',
+} as const;
+
+export type TPublisher2Enum5 = (typeof Publisher2Enum5)[keyof typeof Publisher2Enum5];
+
+export const Publisher2Schema = defineEntity({
+  class: Publisher2,
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+    type: p.enum(() => Publisher2Type),
+    type2: p.enum(() => Publisher2Type2),
+    enum1: p.smallint().nullable(),
+    enum2: p.smallint().nullable(),
+    enum3: p.smallint().nullable(),
+    enum4: p.enum(() => Publisher2Enum4).nullable(),
+    enum5: p.enum(() => Publisher2Enum5).nullable(),
+    book2Collection: () => p.oneToMany(Book2).mappedBy('publisher'),
+    publisher2TestsCollection: () => p.oneToMany(Publisher2Tests).mappedBy('publisher2'),
+  },
+});
 ",
-  "import { Entity, ManyToOne, PrimaryKey } from '@mikro-orm/core';
+  "import { type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Publisher2 } from './Publisher2';
 import { Test2 } from './Test2';
 
-@Entity({ tableName: 'publisher2_tests' })
 export class Publisher2Tests {
-
-  @PrimaryKey()
   id!: number;
-
-  @ManyToOne({ entity: () => Publisher2, updateRule: 'cascade', deleteRule: 'cascade' })
-  publisher2!: Publisher2;
-
-  @ManyToOne({ entity: () => Test2, updateRule: 'cascade', deleteRule: 'cascade' })
-  test2!: Test2;
-
+  publisher2!: Ref<Publisher2>;
+  test2!: Ref<Test2>;
 }
+
+export const Publisher2TestsSchema = defineEntity({
+  class: Publisher2Tests,
+  tableName: 'publisher2_tests',
+  properties: {
+    id: p.integer().primary(),
+    publisher2: () => p.manyToOne(Publisher2).ref().updateRule('cascade').deleteRule('cascade'),
+    test2: () => p.manyToOne(Test2).ref().updateRule('cascade').deleteRule('cascade'),
+  },
+});
 ",
-  "import { Collection, Entity, ManyToMany, ManyToOne, OneToOne, type Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, type Opt, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Book2 } from './Book2';
+import { Configuration2 } from './Configuration2';
 import { FooBar2 } from './FooBar2';
+import { Label2Tests } from './Label2Tests';
+import { Publisher2Tests } from './Publisher2Tests';
 
-@Entity()
 export class Test2 {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property({ nullable: true })
   name?: string;
-
-  @Unique({ name: 'test2_book_uuid_pk_unique' })
-  @OneToOne({ entity: () => Book2, deleteRule: 'set null', nullable: true })
-  book?: Book2;
-
-  @ManyToOne({ entity: () => Test2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  parent?: Test2;
-
-  @Property({ type: 'integer' })
+  book?: Ref<Book2>;
+  parent?: Ref<Test2>;
   version: number & Opt = 1;
-
-  @Property({ columnType: 'polygon', nullable: true })
   path?: unknown;
-
-  @ManyToMany({ entity: () => FooBar2, joinColumn: 'test2_id', inverseJoinColumn: 'foo_bar2_id' })
   bars = new Collection<FooBar2>(this);
-
+  label2TestsCollection = new Collection<Label2Tests>(this);
+  configuration2Collection = new Collection<Configuration2>(this);
+  publisher2TestsCollection = new Collection<Publisher2Tests>(this);
+  test2Collection = new Collection<Test2>(this);
 }
+
+export const Test2Schema = defineEntity({
+  class: Test2,
+  properties: {
+    id: p.integer().primary(),
+    name: p.string().nullable(),
+    book: () => p.oneToOne(Book2).ref().deleteRule('set null').nullable(),
+    parent: () => p.manyToOne(Test2).ref().updateRule('cascade').deleteRule('set null').nullable(),
+    version: p.integer(),
+    path: p.unknown().columnType('polygon').nullable(),
+    bars: () => p.manyToMany(FooBar2).joinColumn('test2_id').inverseJoinColumn('foo_bar2_id'),
+    label2TestsCollection: () => p.oneToMany(Label2Tests).mappedBy('test2'),
+    configuration2Collection: () => p.oneToMany(Configuration2).mappedBy('test'),
+    publisher2TestsCollection: () => p.oneToMany(Publisher2Tests).mappedBy('test2'),
+    test2Collection: () => p.oneToMany(Test2).mappedBy('parent'),
+  },
+});
 ",
 ]
 `;
 
 exports[`EntityGenerator > generate entities from schema with forceUndefined = false [postgres] > postgres-entity-dump 1`] = `
 [
-  "import { Entity, ManyToOne, PrimaryKey } from '@mikro-orm/core';
+  "import { type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Label2 } from './Label2';
 import { Test2 } from './Test2';
 
-@Entity({ tableName: 'label2_tests', schema: 'label_schema' })
 export class Label2Tests {
-
-  @PrimaryKey()
   id!: number;
-
-  @ManyToOne({ entity: () => Label2, updateRule: 'cascade', deleteRule: 'cascade' })
-  label2!: Label2;
-
-  @ManyToOne({ entity: () => Test2, updateRule: 'cascade', deleteRule: 'cascade' })
-  test2!: Test2;
-
+  label2!: Ref<Label2>;
+  test2!: Ref<Test2>;
 }
+
+export const Label2TestsSchema = defineEntity({
+  class: Label2Tests,
+  tableName: 'label2_tests',
+  schema: 'label_schema',
+  properties: {
+    id: p.integer().primary(),
+    label2: () => p.manyToOne(Label2).ref().updateRule('cascade').deleteRule('cascade'),
+    test2: () => p.manyToOne(Test2).ref().updateRule('cascade').deleteRule('cascade'),
+  },
+});
 ",
-  "import { Entity, OneToOne, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { PrimaryKeyProp, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 
-@Entity({ comment: 'This is address table' })
 export class Address2 {
-
   [PrimaryKeyProp]?: 'author';
-
-  @OneToOne({ entity: () => Author2, updateRule: 'cascade', deleteRule: 'cascade', primary: true })
-  author!: Author2;
-
-  @Property({ comment: 'This is address property' })
+  author!: Ref<Author2>;
   value!: string;
-
 }
+
+export const Address2Schema = defineEntity({
+  class: Address2,
+  comment: 'This is address table',
+  properties: {
+    author: () => p.oneToOne(Author2).primary().ref().updateRule('cascade').deleteRule('cascade'),
+    value: p.string().comment('This is address property'),
+  },
+});
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, type Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, type Opt, type Ref, defineEntity, p } from '@mikro-orm/core';
+import { Address2 } from './Address2';
 import { Book2 } from './Book2';
 
-@Entity()
-@Index({ name: 'author2_name_age_index', properties: ['name', 'age'] })
-@Unique({ name: 'author2_name_email_unique', properties: ['name', 'email'] })
 export class Author2 {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property({ type: 'datetime', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
-
-  @Property({ type: 'datetime', columnType: 'timestamp(3)', defaultRaw: \`current_timestamp(3)\` })
   updatedAt!: Date & Opt;
-
-  @Property({ index: 'custom_idx_name_123' })
   name!: string;
-
-  @Property({ index: 'custom_email_index_name', unique: 'custom_email_unique_name' })
   email!: string;
-
-  @Property({ type: 'integer', nullable: true })
   age: number | null = null;
-
-  @Property({ type: 'boolean', index: true })
   termsAccepted: boolean & Opt = false;
-
-  @Property({ type: 'boolean', nullable: true })
   optional: boolean | null = null;
-
-  @Property({ type: 'string[]', nullable: true })
   identities: string[] | null = null;
-
-  @Property({ type: 'date', nullable: true, index: true })
   born: string | null = null;
-
-  @Property({ type: 'time', length: 0, nullable: true, index: 'born_time_idx' })
   bornTime: string | null = null;
-
-  @ManyToOne({ entity: () => Book2, deleteRule: 'cascade', nullable: true })
-  favouriteBook: Book2 | null = null;
-
-  @ManyToOne({ entity: () => Author2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  favouriteAuthor: Author2 | null = null;
-
-  @Property({ type: 'json', nullable: true })
+  favouriteBook: Ref<Book2> | null = null;
+  favouriteAuthor: Ref<Author2> | null = null;
   identity: any | null = null;
-
-  @ManyToMany({ entity: () => Author2, pivotTable: 'author_to_friend', joinColumn: 'author2_1_id', inverseJoinColumn: 'author2_2_id' })
   authorToFriend = new Collection<Author2>(this);
-
-  @ManyToMany({ entity: () => Author2, joinColumn: 'author2_1_id', inverseJoinColumn: 'author2_2_id' })
   following = new Collection<Author2>(this);
-
+  address2: Ref<Address2> | null = null;
+  author2Collection = new Collection<Author2>(this);
+  authorToFriendInverse = new Collection<Author2>(this);
+  followingInverse = new Collection<Author2>(this);
+  book2Collection = new Collection<Book2>(this);
 }
-",
-  "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
 
-@Entity()
+export const Author2Schema = defineEntity({
+  class: Author2,
+  indexes: [{ name: 'author2_name_age_index', properties: ['name', 'age'] }],
+  uniques: [{ name: 'author2_name_email_unique', properties: ['name', 'email'] }],
+  properties: {
+    id: p.integer().primary(),
+    createdAt: p.datetime().length(3).defaultRaw(\`current_timestamp(3)\`),
+    updatedAt: p.datetime().columnType('timestamp(3)').defaultRaw(\`current_timestamp(3)\`),
+    name: p.string().index('custom_idx_name_123'),
+    email: p.string().index('custom_email_index_name').unique('custom_email_unique_name'),
+    age: p.integer().nullable(),
+    termsAccepted: p.boolean().index('author2_terms_accepted_index'),
+    optional: p.boolean().nullable(),
+    identities: p.type(string[]).nullable(),
+    born: p.date().nullable().index('author2_born_index'),
+    bornTime: p.time().length(0).nullable().index('born_time_idx'),
+    favouriteBook: () => p.manyToOne(Book2).ref().deleteRule('cascade').nullable(),
+    favouriteAuthor: () => p.manyToOne(Author2).ref().updateRule('cascade').deleteRule('set null').nullable(),
+    identity: p.json().nullable(),
+    authorToFriend: () => p.manyToMany(Author2).pivotTable('author_to_friend').joinColumn('author2_1_id').inverseJoinColumn('author2_2_id'),
+    following: () => p.manyToMany(Author2).joinColumn('author2_1_id').inverseJoinColumn('author2_2_id'),
+    address2: () => p.oneToOne(Address2).ref().mappedBy('author'),
+    author2Collection: () => p.oneToMany(Author2).mappedBy('favouriteAuthor'),
+    authorToFriendInverse: () => p.manyToMany(Author2).mappedBy('authorToFriend'),
+    followingInverse: () => p.manyToMany(Author2).mappedBy('following'),
+    book2Collection: () => p.oneToMany(Book2).mappedBy('author'),
+  },
+});
+",
+  "import { Collection, defineEntity, p } from '@mikro-orm/core';
+import { Book2 } from './Book2';
+import { Book2Tags } from './Book2Tags';
+
 export class BookTag2 {
-
-  @PrimaryKey()
   id!: bigint;
-
-  @Property({ length: 50 })
   name!: string;
-
+  bookToTagUnorderedInverse = new Collection<Book2>(this);
+  book2TagsCollection = new Collection<Book2Tags>(this);
 }
+
+export const BookTag2Schema = defineEntity({
+  class: BookTag2,
+  properties: {
+    id: p.bigint().primary(),
+    name: p.string().length(50),
+    bookToTagUnorderedInverse: () => p.manyToMany(Book2).mappedBy('bookToTagUnordered'),
+    book2TagsCollection: () => p.oneToMany(Book2Tags).mappedBy('bookTag2'),
+  },
+});
 ",
-  "import { Collection, Entity, ManyToMany, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, type Opt, PrimaryKeyProp, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Author2 } from './Author2';
+import { Book2Tags } from './Book2Tags';
 import { BookTag2 } from './BookTag2';
 import { Publisher2 } from './Publisher2';
+import { Test2 } from './Test2';
 
-@Entity()
 export class Book2 {
-
   [PrimaryKeyProp]?: 'uuidPk';
-
-  @PrimaryKey({ type: 'uuid' })
   uuidPk!: string;
-
-  @Property({ type: 'datetime', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
-
-  @Property({ type: 'character', length: 13, nullable: true, unique: 'book_isbn_unique' })
   isbn: string | null = null;
-
-  @Property({ type: 'string', nullable: true })
   title?: string | null = '';
-
-  @Property({ type: 'text', nullable: true })
   perex: string | null = null;
-
-  @Property({ type: 'decimal', precision: 8, scale: 2, nullable: true })
   price: string | null = null;
-
-  @Property({ type: 'decimal', nullable: true })
   double: string | null = null;
-
-  @Property({ type: 'json', nullable: true })
   meta: any | null = null;
-
-  @ManyToOne({ entity: () => Author2 })
-  author!: Author2;
-
-  @ManyToOne({ entity: () => Publisher2, updateRule: 'cascade', deleteRule: 'cascade', nullable: true })
-  publisher: Publisher2 | null = null;
-
-  @Property({ type: 'string', nullable: true })
+  author!: Ref<Author2>;
+  publisher: Ref<Publisher2> | null = null;
   foo?: string | null = 'lol';
-
-  @ManyToMany({ entity: () => BookTag2, pivotTable: 'book_to_tag_unordered', joinColumn: 'book2_uuid_pk', inverseJoinColumn: 'book_tag2_id' })
   bookToTagUnordered = new Collection<BookTag2>(this);
-
+  author2Collection = new Collection<Author2>(this);
+  book2TagsCollection = new Collection<Book2Tags>(this);
+  test2: Ref<Test2> | null = null;
 }
+
+export const Book2Schema = defineEntity({
+  class: Book2,
+  properties: {
+    uuidPk: p.uuid().primary(),
+    createdAt: p.datetime().length(3).defaultRaw(\`current_timestamp(3)\`),
+    isbn: p.character().length(13).nullable().unique('book_isbn_unique'),
+    title: p.string().nullable(),
+    perex: p.text().nullable(),
+    price: p.decimal().precision(8).scale(2).nullable(),
+    double: p.decimal().nullable(),
+    meta: p.json().nullable(),
+    author: () => p.manyToOne(Author2).ref(),
+    publisher: () => p.manyToOne(Publisher2).ref().updateRule('cascade').deleteRule('cascade').nullable(),
+    foo: p.string().nullable(),
+    bookToTagUnordered: () => p.manyToMany(BookTag2).pivotTable('book_to_tag_unordered').joinColumn('book2_uuid_pk').inverseJoinColumn('book_tag2_id'),
+    author2Collection: () => p.oneToMany(Author2).mappedBy('favouriteBook'),
+    book2TagsCollection: () => p.oneToMany(Book2Tags).mappedBy('book2'),
+    test2: () => p.oneToOne(Test2).ref().mappedBy('book'),
+  },
+});
 ",
-  "import { Entity, ManyToOne, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { PrimaryKeyProp, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { BookTag2 } from './BookTag2';
 
-@Entity({ tableName: 'book2_tags' })
 export class Book2Tags {
-
   [PrimaryKeyProp]?: 'order';
-
-  @PrimaryKey()
   order!: number;
-
-  @ManyToOne({ entity: () => Book2, updateRule: 'cascade', deleteRule: 'cascade' })
-  book2!: Book2;
-
-  @ManyToOne({ entity: () => BookTag2, updateRule: 'cascade', deleteRule: 'cascade' })
-  bookTag2!: BookTag2;
-
+  book2!: Ref<Book2>;
+  bookTag2!: Ref<BookTag2>;
 }
+
+export const Book2TagsSchema = defineEntity({
+  class: Book2Tags,
+  tableName: 'book2_tags',
+  properties: {
+    order: p.integer().primary(),
+    book2: () => p.manyToOne(Book2).ref().updateRule('cascade').deleteRule('cascade'),
+    bookTag2: () => p.manyToOne(BookTag2).ref().updateRule('cascade').deleteRule('cascade'),
+  },
+});
 ",
-  "import { Entity, ManyToOne, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { PrimaryKeyProp, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Test2 } from './Test2';
 
-@Entity()
 export class Configuration2 {
-
   [PrimaryKeyProp]?: ['property', 'test'];
-
-  @PrimaryKey()
   property!: string;
-
-  @ManyToOne({ entity: () => Test2, updateRule: 'cascade', primary: true })
-  test!: Test2;
-
-  @Property()
+  test!: Ref<Test2>;
   value!: string;
-
 }
+
+export const Configuration2Schema = defineEntity({
+  class: Configuration2,
+  properties: {
+    property: p.string().primary(),
+    test: () => p.manyToOne(Test2).primary().ref().updateRule('cascade'),
+    value: p.string(),
+  },
+});
 ",
-  "import { Entity, OneToOne, type Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, type Opt, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { FooBaz2 } from './FooBaz2';
+import { FooParam2 } from './FooParam2';
+import { Test2 } from './Test2';
 
-@Entity()
 export class FooBar2 {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property()
   name!: string;
-
-  @Property({ fieldName: 'name with space', type: 'string', nullable: true })
   nameWithSpace: string | null = null;
-
-  @Unique({ name: 'foo_bar2_baz_id_unique' })
-  @OneToOne({ entity: () => FooBaz2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  baz: FooBaz2 | null = null;
-
-  @Unique({ name: 'foo_bar2_foo_bar_id_unique' })
-  @OneToOne({ entity: () => FooBar2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  fooBar: FooBar2 | null = null;
-
-  @Property({ type: 'datetime', length: 0, defaultRaw: \`current_timestamp(0)\` })
+  baz: Ref<FooBaz2> | null = null;
+  fooBar: Ref<FooBar2> | null = null;
   version!: Date & Opt;
-
-  @Property({ type: 'blob', nullable: true })
   blob: Buffer | null = null;
-
-  @Property({ type: 'blob', nullable: true })
   blob2: Buffer | null = null;
-
-  @Property({ type: 'string[]', nullable: true })
   array: string[] | null = null;
-
-  @Property({ type: 'json', nullable: true })
   objectProperty: any | null = null;
-
+  fooBar2: Ref<FooBar2> | null = null;
+  fooParam2Collection = new Collection<FooParam2>(this);
+  barsInverse = new Collection<Test2>(this);
 }
-",
-  "import { Entity, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 
-@Entity()
+export const FooBar2Schema = defineEntity({
+  class: FooBar2,
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+    nameWithSpace: p.string().name('name with space').nullable(),
+    baz: () => p.oneToOne(FooBaz2).ref().updateRule('cascade').deleteRule('set null').nullable(),
+    fooBar: () => p.oneToOne(FooBar2).ref().updateRule('cascade').deleteRule('set null').nullable(),
+    version: p.datetime().length(0).defaultRaw(\`current_timestamp(0)\`),
+    blob: p.blob().nullable(),
+    blob2: p.blob().nullable(),
+    array: p.type(string[]).nullable(),
+    objectProperty: p.json().nullable(),
+    fooBar2: () => p.oneToOne(FooBar2).ref().mappedBy('fooBar'),
+    fooParam2Collection: () => p.oneToMany(FooParam2).mappedBy('bar'),
+    barsInverse: () => p.manyToMany(Test2).mappedBy('bars'),
+  },
+});
+",
+  "import { Collection, type Opt, type Ref, defineEntity, p } from '@mikro-orm/core';
+import { FooBar2 } from './FooBar2';
+import { FooParam2 } from './FooParam2';
+
 export class FooBaz2 {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property()
   name!: string;
-
-  @Property()
   code!: string;
-
-  @Property({ type: 'datetime', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
-
+  fooBar2: Ref<FooBar2> | null = null;
+  fooParam2Collection = new Collection<FooParam2>(this);
 }
+
+export const FooBaz2Schema = defineEntity({
+  class: FooBaz2,
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+    code: p.string(),
+    version: p.datetime().length(3).defaultRaw(\`current_timestamp(3)\`),
+    fooBar2: () => p.oneToOne(FooBar2).ref().mappedBy('baz'),
+    fooParam2Collection: () => p.oneToMany(FooParam2).mappedBy('baz'),
+  },
+});
 ",
-  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { type Opt, PrimaryKeyProp, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { FooBar2 } from './FooBar2';
 import { FooBaz2 } from './FooBaz2';
 
-@Entity()
 export class FooParam2 {
-
   [PrimaryKeyProp]?: ['bar', 'baz'];
-
-  @ManyToOne({ entity: () => FooBar2, updateRule: 'cascade', primary: true })
-  bar!: FooBar2;
-
-  @ManyToOne({ entity: () => FooBaz2, updateRule: 'cascade', primary: true })
-  baz!: FooBaz2;
-
-  @Property()
+  bar!: Ref<FooBar2>;
+  baz!: Ref<FooBaz2>;
   value!: string;
-
-  @Property({ type: 'datetime', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
-
 }
-",
-  "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
 
-@Entity()
+export const FooParam2Schema = defineEntity({
+  class: FooParam2,
+  properties: {
+    bar: () => p.manyToOne(FooBar2).primary().ref().updateRule('cascade'),
+    baz: () => p.manyToOne(FooBaz2).primary().ref().updateRule('cascade'),
+    value: p.string(),
+    version: p.datetime().length(3).defaultRaw(\`current_timestamp(3)\`),
+  },
+});
+",
+  "import { Collection, defineEntity, p } from '@mikro-orm/core';
+import { Label2Tests } from './Label2Tests';
+
 export class Label2 {
-
-  @PrimaryKey({ type: 'uuid' })
   uuid!: string;
-
-  @Property()
   name!: string;
-
+  label2TestsCollection = new Collection<Label2Tests>(this);
 }
-",
-  "import { Entity, Enum, PrimaryKey, Property } from '@mikro-orm/core';
 
-@Entity()
+export const Label2Schema = defineEntity({
+  class: Label2,
+  properties: {
+    uuid: p.uuid().primary(),
+    name: p.string(),
+    label2TestsCollection: () => p.oneToMany(Label2Tests).mappedBy('label2'),
+  },
+});
+",
+  "import { Collection, defineEntity, p } from '@mikro-orm/core';
+import { Book2 } from './Book2';
+import { Publisher2Tests } from './Publisher2Tests';
+
 export class Publisher2 {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property()
   name!: string;
-
-  @Enum({ items: () => Publisher2Type })
-  type!: Publisher2Type;
-
-  @Enum({ items: () => Publisher2Type2 })
-  type2!: Publisher2Type2;
-
-  @Property({ type: 'smallint', nullable: true })
+  type!: TPublisher2Type;
+  type2!: TPublisher2Type2;
   enum1: number | null = null;
-
-  @Property({ type: 'smallint', nullable: true })
   enum2: number | null = null;
-
-  @Property({ type: 'smallint', nullable: true })
   enum3: number | null = null;
-
-  @Enum({ items: () => Publisher2Enum4, nullable: true })
-  enum4: Publisher2Enum4 | null = null;
-
-  @Enum({ items: () => Publisher2Enum5, nullable: true })
-  enum5: Publisher2Enum5 | null = null;
-
+  enum4: TPublisher2Enum4 | null = null;
+  enum5: TPublisher2Enum5 | null = null;
+  book2Collection = new Collection<Book2>(this);
+  publisher2TestsCollection = new Collection<Publisher2Tests>(this);
 }
 
-export enum Publisher2Type {
-  LOCAL = 'local',
-  GLOBAL = 'global',
-}
+export const Publisher2Type = {
+  LOCAL: 'local',
+  GLOBAL: 'global',
+} as const;
 
-export enum Publisher2Type2 {
-  LOCAL = 'LOCAL',
-  GLOBAL = 'GLOBAL',
-}
+export type TPublisher2Type = (typeof Publisher2Type)[keyof typeof Publisher2Type];
 
-export enum Publisher2Enum4 {
-  A = 'a',
-  B = 'b',
-  C = 'c',
-}
+export const Publisher2Type2 = {
+  LOCAL: 'LOCAL',
+  GLOBAL: 'GLOBAL',
+} as const;
 
-export enum Publisher2Enum5 {
-  A = 'a',
-}
+export type TPublisher2Type2 = (typeof Publisher2Type2)[keyof typeof Publisher2Type2];
+
+export const Publisher2Enum4 = {
+  A: 'a',
+  B: 'b',
+  C: 'c',
+} as const;
+
+export type TPublisher2Enum4 = (typeof Publisher2Enum4)[keyof typeof Publisher2Enum4];
+
+export const Publisher2Enum5 = {
+  A: 'a',
+} as const;
+
+export type TPublisher2Enum5 = (typeof Publisher2Enum5)[keyof typeof Publisher2Enum5];
+
+export const Publisher2Schema = defineEntity({
+  class: Publisher2,
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+    type: p.enum(() => Publisher2Type),
+    type2: p.enum(() => Publisher2Type2),
+    enum1: p.smallint().nullable(),
+    enum2: p.smallint().nullable(),
+    enum3: p.smallint().nullable(),
+    enum4: p.enum(() => Publisher2Enum4).nullable(),
+    enum5: p.enum(() => Publisher2Enum5).nullable(),
+    book2Collection: () => p.oneToMany(Book2).mappedBy('publisher'),
+    publisher2TestsCollection: () => p.oneToMany(Publisher2Tests).mappedBy('publisher2'),
+  },
+});
 ",
-  "import { Entity, ManyToOne, PrimaryKey } from '@mikro-orm/core';
+  "import { type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Publisher2 } from './Publisher2';
 import { Test2 } from './Test2';
 
-@Entity({ tableName: 'publisher2_tests' })
 export class Publisher2Tests {
-
-  @PrimaryKey()
   id!: number;
-
-  @ManyToOne({ entity: () => Publisher2, updateRule: 'cascade', deleteRule: 'cascade' })
-  publisher2!: Publisher2;
-
-  @ManyToOne({ entity: () => Test2, updateRule: 'cascade', deleteRule: 'cascade' })
-  test2!: Test2;
-
+  publisher2!: Ref<Publisher2>;
+  test2!: Ref<Test2>;
 }
+
+export const Publisher2TestsSchema = defineEntity({
+  class: Publisher2Tests,
+  tableName: 'publisher2_tests',
+  properties: {
+    id: p.integer().primary(),
+    publisher2: () => p.manyToOne(Publisher2).ref().updateRule('cascade').deleteRule('cascade'),
+    test2: () => p.manyToOne(Test2).ref().updateRule('cascade').deleteRule('cascade'),
+  },
+});
 ",
-  "import { Collection, Entity, ManyToMany, ManyToOne, OneToOne, type Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, type Opt, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Book2 } from './Book2';
+import { Configuration2 } from './Configuration2';
 import { FooBar2 } from './FooBar2';
+import { Label2Tests } from './Label2Tests';
+import { Publisher2Tests } from './Publisher2Tests';
 
-@Entity()
 export class Test2 {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property({ type: 'string', nullable: true })
   name: string | null = null;
-
-  @Unique({ name: 'test2_book_uuid_pk_unique' })
-  @OneToOne({ entity: () => Book2, deleteRule: 'set null', nullable: true })
-  book: Book2 | null = null;
-
-  @ManyToOne({ entity: () => Test2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  parent: Test2 | null = null;
-
-  @Property({ type: 'integer' })
+  book: Ref<Book2> | null = null;
+  parent: Ref<Test2> | null = null;
   version: number & Opt = 1;
-
-  @Property({ type: 'unknown', columnType: 'polygon', nullable: true })
   path: unknown | null = null;
-
-  @ManyToMany({ entity: () => FooBar2, joinColumn: 'test2_id', inverseJoinColumn: 'foo_bar2_id' })
   bars = new Collection<FooBar2>(this);
-
+  label2TestsCollection = new Collection<Label2Tests>(this);
+  configuration2Collection = new Collection<Configuration2>(this);
+  publisher2TestsCollection = new Collection<Publisher2Tests>(this);
+  test2Collection = new Collection<Test2>(this);
 }
+
+export const Test2Schema = defineEntity({
+  class: Test2,
+  properties: {
+    id: p.integer().primary(),
+    name: p.string().nullable(),
+    book: () => p.oneToOne(Book2).ref().deleteRule('set null').nullable(),
+    parent: () => p.manyToOne(Test2).ref().updateRule('cascade').deleteRule('set null').nullable(),
+    version: p.integer(),
+    path: p.unknown().columnType('polygon').nullable(),
+    bars: () => p.manyToMany(FooBar2).joinColumn('test2_id').inverseJoinColumn('foo_bar2_id'),
+    label2TestsCollection: () => p.oneToMany(Label2Tests).mappedBy('test2'),
+    configuration2Collection: () => p.oneToMany(Configuration2).mappedBy('test'),
+    publisher2TestsCollection: () => p.oneToMany(Publisher2Tests).mappedBy('test2'),
+    test2Collection: () => p.oneToMany(Test2).mappedBy('parent'),
+  },
+});
 ",
 ]
 `;
 
 exports[`EntityGenerator > generate entities from schema with forceUndefined = false and undefinedDefaults = true [postgres] > postgres-entity-dump 1`] = `
 [
-  "import { Entity, ManyToOne, PrimaryKey } from '@mikro-orm/core';
+  "import { type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Label2 } from './Label2';
 import { Test2 } from './Test2';
 
-@Entity({ tableName: 'label2_tests', schema: 'label_schema' })
 export class Label2Tests {
-
-  @PrimaryKey()
   id!: number;
-
-  @ManyToOne({ entity: () => Label2, updateRule: 'cascade', deleteRule: 'cascade' })
-  label2!: Label2;
-
-  @ManyToOne({ entity: () => Test2, updateRule: 'cascade', deleteRule: 'cascade' })
-  test2!: Test2;
-
+  label2!: Ref<Label2>;
+  test2!: Ref<Test2>;
 }
+
+export const Label2TestsSchema = defineEntity({
+  class: Label2Tests,
+  tableName: 'label2_tests',
+  schema: 'label_schema',
+  properties: {
+    id: p.integer().primary(),
+    label2: () => p.manyToOne(Label2).ref().updateRule('cascade').deleteRule('cascade'),
+    test2: () => p.manyToOne(Test2).ref().updateRule('cascade').deleteRule('cascade'),
+  },
+});
 ",
-  "import { Entity, OneToOne, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { PrimaryKeyProp, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 
-@Entity({ comment: 'This is address table' })
 export class Address2 {
-
   [PrimaryKeyProp]?: 'author';
-
-  @OneToOne({ entity: () => Author2, updateRule: 'cascade', deleteRule: 'cascade', primary: true })
-  author!: Author2;
-
-  @Property({ comment: 'This is address property' })
+  author!: Ref<Author2>;
   value!: string;
-
 }
+
+export const Address2Schema = defineEntity({
+  class: Address2,
+  comment: 'This is address table',
+  properties: {
+    author: () => p.oneToOne(Author2).primary().ref().updateRule('cascade').deleteRule('cascade'),
+    value: p.string().comment('This is address property'),
+  },
+});
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, type Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, type Opt, type Ref, defineEntity, p } from '@mikro-orm/core';
+import { Address2 } from './Address2';
 import { Book2 } from './Book2';
 
-@Entity()
-@Index({ name: 'author2_name_age_index', properties: ['name', 'age'] })
-@Unique({ name: 'author2_name_email_unique', properties: ['name', 'email'] })
 export class Author2 {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property({ type: 'datetime', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
-
-  @Property({ type: 'datetime', columnType: 'timestamp(3)', defaultRaw: \`current_timestamp(3)\` })
   updatedAt!: Date & Opt;
-
-  @Property({ index: 'custom_idx_name_123' })
   name!: string;
-
-  @Property({ index: 'custom_email_index_name', unique: 'custom_email_unique_name' })
   email!: string;
-
-  @Property({ type: 'integer', nullable: true })
   age?: number | null;
-
-  @Property({ type: 'boolean', index: true })
   termsAccepted: boolean & Opt = false;
-
-  @Property({ type: 'boolean', nullable: true })
   optional?: boolean | null;
-
-  @Property({ type: 'string[]', nullable: true })
   identities?: string[] | null;
-
-  @Property({ type: 'date', nullable: true, index: true })
   born?: string | null;
-
-  @Property({ type: 'time', length: 0, nullable: true, index: 'born_time_idx' })
   bornTime?: string | null;
-
-  @ManyToOne({ entity: () => Book2, deleteRule: 'cascade', nullable: true })
-  favouriteBook?: Book2 | null;
-
-  @ManyToOne({ entity: () => Author2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  favouriteAuthor?: Author2 | null;
-
-  @Property({ type: 'json', nullable: true })
+  favouriteBook?: Ref<Book2> | null;
+  favouriteAuthor?: Ref<Author2> | null;
   identity?: any | null;
-
-  @ManyToMany({ entity: () => Author2, pivotTable: 'author_to_friend', joinColumn: 'author2_1_id', inverseJoinColumn: 'author2_2_id' })
   authorToFriend = new Collection<Author2>(this);
-
-  @ManyToMany({ entity: () => Author2, joinColumn: 'author2_1_id', inverseJoinColumn: 'author2_2_id' })
   following = new Collection<Author2>(this);
-
+  address2: Ref<Address2> | null = null;
+  author2Collection = new Collection<Author2>(this);
+  authorToFriendInverse = new Collection<Author2>(this);
+  followingInverse = new Collection<Author2>(this);
+  book2Collection = new Collection<Book2>(this);
 }
-",
-  "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
 
-@Entity()
+export const Author2Schema = defineEntity({
+  class: Author2,
+  indexes: [{ name: 'author2_name_age_index', properties: ['name', 'age'] }],
+  uniques: [{ name: 'author2_name_email_unique', properties: ['name', 'email'] }],
+  properties: {
+    id: p.integer().primary(),
+    createdAt: p.datetime().length(3).defaultRaw(\`current_timestamp(3)\`),
+    updatedAt: p.datetime().columnType('timestamp(3)').defaultRaw(\`current_timestamp(3)\`),
+    name: p.string().index('custom_idx_name_123'),
+    email: p.string().index('custom_email_index_name').unique('custom_email_unique_name'),
+    age: p.integer().nullable(),
+    termsAccepted: p.boolean().index('author2_terms_accepted_index'),
+    optional: p.boolean().nullable(),
+    identities: p.type(string[]).nullable(),
+    born: p.date().nullable().index('author2_born_index'),
+    bornTime: p.time().length(0).nullable().index('born_time_idx'),
+    favouriteBook: () => p.manyToOne(Book2).ref().deleteRule('cascade').nullable(),
+    favouriteAuthor: () => p.manyToOne(Author2).ref().updateRule('cascade').deleteRule('set null').nullable(),
+    identity: p.json().nullable(),
+    authorToFriend: () => p.manyToMany(Author2).pivotTable('author_to_friend').joinColumn('author2_1_id').inverseJoinColumn('author2_2_id'),
+    following: () => p.manyToMany(Author2).joinColumn('author2_1_id').inverseJoinColumn('author2_2_id'),
+    address2: () => p.oneToOne(Address2).ref().mappedBy('author'),
+    author2Collection: () => p.oneToMany(Author2).mappedBy('favouriteAuthor'),
+    authorToFriendInverse: () => p.manyToMany(Author2).mappedBy('authorToFriend'),
+    followingInverse: () => p.manyToMany(Author2).mappedBy('following'),
+    book2Collection: () => p.oneToMany(Book2).mappedBy('author'),
+  },
+});
+",
+  "import { Collection, defineEntity, p } from '@mikro-orm/core';
+import { Book2 } from './Book2';
+import { Book2Tags } from './Book2Tags';
+
 export class BookTag2 {
-
-  @PrimaryKey()
   id!: bigint;
-
-  @Property({ length: 50 })
   name!: string;
-
+  bookToTagUnorderedInverse = new Collection<Book2>(this);
+  book2TagsCollection = new Collection<Book2Tags>(this);
 }
+
+export const BookTag2Schema = defineEntity({
+  class: BookTag2,
+  properties: {
+    id: p.bigint().primary(),
+    name: p.string().length(50),
+    bookToTagUnorderedInverse: () => p.manyToMany(Book2).mappedBy('bookToTagUnordered'),
+    book2TagsCollection: () => p.oneToMany(Book2Tags).mappedBy('bookTag2'),
+  },
+});
 ",
-  "import { Collection, Entity, ManyToMany, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, type Opt, PrimaryKeyProp, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Author2 } from './Author2';
+import { Book2Tags } from './Book2Tags';
 import { BookTag2 } from './BookTag2';
 import { Publisher2 } from './Publisher2';
+import { Test2 } from './Test2';
 
-@Entity()
 export class Book2 {
-
   [PrimaryKeyProp]?: 'uuidPk';
-
-  @PrimaryKey({ type: 'uuid' })
   uuidPk!: string;
-
-  @Property({ type: 'datetime', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
-
-  @Property({ type: 'character', length: 13, nullable: true, unique: 'book_isbn_unique' })
   isbn?: string | null;
-
-  @Property({ type: 'string', nullable: true })
   title?: string | null = '';
-
-  @Property({ type: 'text', nullable: true })
   perex?: string | null;
-
-  @Property({ type: 'decimal', precision: 8, scale: 2, nullable: true })
   price?: string | null;
-
-  @Property({ type: 'decimal', nullable: true })
   double?: string | null;
-
-  @Property({ type: 'json', nullable: true })
   meta?: any | null;
-
-  @ManyToOne({ entity: () => Author2 })
-  author!: Author2;
-
-  @ManyToOne({ entity: () => Publisher2, updateRule: 'cascade', deleteRule: 'cascade', nullable: true })
-  publisher?: Publisher2 | null;
-
-  @Property({ type: 'string', nullable: true })
+  author!: Ref<Author2>;
+  publisher?: Ref<Publisher2> | null;
   foo?: string | null = 'lol';
-
-  @ManyToMany({ entity: () => BookTag2, pivotTable: 'book_to_tag_unordered', joinColumn: 'book2_uuid_pk', inverseJoinColumn: 'book_tag2_id' })
   bookToTagUnordered = new Collection<BookTag2>(this);
-
+  author2Collection = new Collection<Author2>(this);
+  book2TagsCollection = new Collection<Book2Tags>(this);
+  test2: Ref<Test2> | null = null;
 }
+
+export const Book2Schema = defineEntity({
+  class: Book2,
+  properties: {
+    uuidPk: p.uuid().primary(),
+    createdAt: p.datetime().length(3).defaultRaw(\`current_timestamp(3)\`),
+    isbn: p.character().length(13).nullable().unique('book_isbn_unique'),
+    title: p.string().nullable(),
+    perex: p.text().nullable(),
+    price: p.decimal().precision(8).scale(2).nullable(),
+    double: p.decimal().nullable(),
+    meta: p.json().nullable(),
+    author: () => p.manyToOne(Author2).ref(),
+    publisher: () => p.manyToOne(Publisher2).ref().updateRule('cascade').deleteRule('cascade').nullable(),
+    foo: p.string().nullable(),
+    bookToTagUnordered: () => p.manyToMany(BookTag2).pivotTable('book_to_tag_unordered').joinColumn('book2_uuid_pk').inverseJoinColumn('book_tag2_id'),
+    author2Collection: () => p.oneToMany(Author2).mappedBy('favouriteBook'),
+    book2TagsCollection: () => p.oneToMany(Book2Tags).mappedBy('book2'),
+    test2: () => p.oneToOne(Test2).ref().mappedBy('book'),
+  },
+});
 ",
-  "import { Entity, ManyToOne, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { PrimaryKeyProp, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { BookTag2 } from './BookTag2';
 
-@Entity({ tableName: 'book2_tags' })
 export class Book2Tags {
-
   [PrimaryKeyProp]?: 'order';
-
-  @PrimaryKey()
   order!: number;
-
-  @ManyToOne({ entity: () => Book2, updateRule: 'cascade', deleteRule: 'cascade' })
-  book2!: Book2;
-
-  @ManyToOne({ entity: () => BookTag2, updateRule: 'cascade', deleteRule: 'cascade' })
-  bookTag2!: BookTag2;
-
+  book2!: Ref<Book2>;
+  bookTag2!: Ref<BookTag2>;
 }
+
+export const Book2TagsSchema = defineEntity({
+  class: Book2Tags,
+  tableName: 'book2_tags',
+  properties: {
+    order: p.integer().primary(),
+    book2: () => p.manyToOne(Book2).ref().updateRule('cascade').deleteRule('cascade'),
+    bookTag2: () => p.manyToOne(BookTag2).ref().updateRule('cascade').deleteRule('cascade'),
+  },
+});
 ",
-  "import { Entity, ManyToOne, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { PrimaryKeyProp, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Test2 } from './Test2';
 
-@Entity()
 export class Configuration2 {
-
   [PrimaryKeyProp]?: ['property', 'test'];
-
-  @PrimaryKey()
   property!: string;
-
-  @ManyToOne({ entity: () => Test2, updateRule: 'cascade', primary: true })
-  test!: Test2;
-
-  @Property()
+  test!: Ref<Test2>;
   value!: string;
-
 }
+
+export const Configuration2Schema = defineEntity({
+  class: Configuration2,
+  properties: {
+    property: p.string().primary(),
+    test: () => p.manyToOne(Test2).primary().ref().updateRule('cascade'),
+    value: p.string(),
+  },
+});
 ",
-  "import { Entity, OneToOne, type Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, type Opt, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { FooBaz2 } from './FooBaz2';
+import { FooParam2 } from './FooParam2';
+import { Test2 } from './Test2';
 
-@Entity()
 export class FooBar2 {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property()
   name!: string;
-
-  @Property({ fieldName: 'name with space', type: 'string', nullable: true })
   nameWithSpace?: string | null;
-
-  @Unique({ name: 'foo_bar2_baz_id_unique' })
-  @OneToOne({ entity: () => FooBaz2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  baz?: FooBaz2 | null;
-
-  @Unique({ name: 'foo_bar2_foo_bar_id_unique' })
-  @OneToOne({ entity: () => FooBar2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  fooBar?: FooBar2 | null;
-
-  @Property({ type: 'datetime', length: 0, defaultRaw: \`current_timestamp(0)\` })
+  baz?: Ref<FooBaz2> | null;
+  fooBar?: Ref<FooBar2> | null;
   version!: Date & Opt;
-
-  @Property({ type: 'blob', nullable: true })
   blob?: Buffer | null;
-
-  @Property({ type: 'blob', nullable: true })
   blob2?: Buffer | null;
-
-  @Property({ type: 'string[]', nullable: true })
   array?: string[] | null;
-
-  @Property({ type: 'json', nullable: true })
   objectProperty?: any | null;
-
+  fooBar2: Ref<FooBar2> | null = null;
+  fooParam2Collection = new Collection<FooParam2>(this);
+  barsInverse = new Collection<Test2>(this);
 }
-",
-  "import { Entity, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 
-@Entity()
+export const FooBar2Schema = defineEntity({
+  class: FooBar2,
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+    nameWithSpace: p.string().name('name with space').nullable(),
+    baz: () => p.oneToOne(FooBaz2).ref().updateRule('cascade').deleteRule('set null').nullable(),
+    fooBar: () => p.oneToOne(FooBar2).ref().updateRule('cascade').deleteRule('set null').nullable(),
+    version: p.datetime().length(0).defaultRaw(\`current_timestamp(0)\`),
+    blob: p.blob().nullable(),
+    blob2: p.blob().nullable(),
+    array: p.type(string[]).nullable(),
+    objectProperty: p.json().nullable(),
+    fooBar2: () => p.oneToOne(FooBar2).ref().mappedBy('fooBar'),
+    fooParam2Collection: () => p.oneToMany(FooParam2).mappedBy('bar'),
+    barsInverse: () => p.manyToMany(Test2).mappedBy('bars'),
+  },
+});
+",
+  "import { Collection, type Opt, type Ref, defineEntity, p } from '@mikro-orm/core';
+import { FooBar2 } from './FooBar2';
+import { FooParam2 } from './FooParam2';
+
 export class FooBaz2 {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property()
   name!: string;
-
-  @Property()
   code!: string;
-
-  @Property({ type: 'datetime', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
-
+  fooBar2: Ref<FooBar2> | null = null;
+  fooParam2Collection = new Collection<FooParam2>(this);
 }
+
+export const FooBaz2Schema = defineEntity({
+  class: FooBaz2,
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+    code: p.string(),
+    version: p.datetime().length(3).defaultRaw(\`current_timestamp(3)\`),
+    fooBar2: () => p.oneToOne(FooBar2).ref().mappedBy('baz'),
+    fooParam2Collection: () => p.oneToMany(FooParam2).mappedBy('baz'),
+  },
+});
 ",
-  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { type Opt, PrimaryKeyProp, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { FooBar2 } from './FooBar2';
 import { FooBaz2 } from './FooBaz2';
 
-@Entity()
 export class FooParam2 {
-
   [PrimaryKeyProp]?: ['bar', 'baz'];
-
-  @ManyToOne({ entity: () => FooBar2, updateRule: 'cascade', primary: true })
-  bar!: FooBar2;
-
-  @ManyToOne({ entity: () => FooBaz2, updateRule: 'cascade', primary: true })
-  baz!: FooBaz2;
-
-  @Property()
+  bar!: Ref<FooBar2>;
+  baz!: Ref<FooBaz2>;
   value!: string;
-
-  @Property({ type: 'datetime', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
-
 }
-",
-  "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
 
-@Entity()
+export const FooParam2Schema = defineEntity({
+  class: FooParam2,
+  properties: {
+    bar: () => p.manyToOne(FooBar2).primary().ref().updateRule('cascade'),
+    baz: () => p.manyToOne(FooBaz2).primary().ref().updateRule('cascade'),
+    value: p.string(),
+    version: p.datetime().length(3).defaultRaw(\`current_timestamp(3)\`),
+  },
+});
+",
+  "import { Collection, defineEntity, p } from '@mikro-orm/core';
+import { Label2Tests } from './Label2Tests';
+
 export class Label2 {
-
-  @PrimaryKey({ type: 'uuid' })
   uuid!: string;
-
-  @Property()
   name!: string;
-
+  label2TestsCollection = new Collection<Label2Tests>(this);
 }
-",
-  "import { Entity, Enum, PrimaryKey, Property } from '@mikro-orm/core';
 
-@Entity()
+export const Label2Schema = defineEntity({
+  class: Label2,
+  properties: {
+    uuid: p.uuid().primary(),
+    name: p.string(),
+    label2TestsCollection: () => p.oneToMany(Label2Tests).mappedBy('label2'),
+  },
+});
+",
+  "import { Collection, defineEntity, p } from '@mikro-orm/core';
+import { Book2 } from './Book2';
+import { Publisher2Tests } from './Publisher2Tests';
+
 export class Publisher2 {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property()
   name!: string;
-
-  @Enum({ items: () => Publisher2Type })
-  type!: Publisher2Type;
-
-  @Enum({ items: () => Publisher2Type2 })
-  type2!: Publisher2Type2;
-
-  @Property({ type: 'smallint', nullable: true })
+  type!: TPublisher2Type;
+  type2!: TPublisher2Type2;
   enum1?: number | null;
-
-  @Property({ type: 'smallint', nullable: true })
   enum2?: number | null;
-
-  @Property({ type: 'smallint', nullable: true })
   enum3?: number | null;
-
-  @Enum({ items: () => Publisher2Enum4, nullable: true })
-  enum4?: Publisher2Enum4 | null;
-
-  @Enum({ items: () => Publisher2Enum5, nullable: true })
-  enum5?: Publisher2Enum5 | null;
-
+  enum4?: TPublisher2Enum4 | null;
+  enum5?: TPublisher2Enum5 | null;
+  book2Collection = new Collection<Book2>(this);
+  publisher2TestsCollection = new Collection<Publisher2Tests>(this);
 }
 
-export enum Publisher2Type {
-  LOCAL = 'local',
-  GLOBAL = 'global',
-}
+export const Publisher2Type = {
+  LOCAL: 'local',
+  GLOBAL: 'global',
+} as const;
 
-export enum Publisher2Type2 {
-  LOCAL = 'LOCAL',
-  GLOBAL = 'GLOBAL',
-}
+export type TPublisher2Type = (typeof Publisher2Type)[keyof typeof Publisher2Type];
 
-export enum Publisher2Enum4 {
-  A = 'a',
-  B = 'b',
-  C = 'c',
-}
+export const Publisher2Type2 = {
+  LOCAL: 'LOCAL',
+  GLOBAL: 'GLOBAL',
+} as const;
 
-export enum Publisher2Enum5 {
-  A = 'a',
-}
+export type TPublisher2Type2 = (typeof Publisher2Type2)[keyof typeof Publisher2Type2];
+
+export const Publisher2Enum4 = {
+  A: 'a',
+  B: 'b',
+  C: 'c',
+} as const;
+
+export type TPublisher2Enum4 = (typeof Publisher2Enum4)[keyof typeof Publisher2Enum4];
+
+export const Publisher2Enum5 = {
+  A: 'a',
+} as const;
+
+export type TPublisher2Enum5 = (typeof Publisher2Enum5)[keyof typeof Publisher2Enum5];
+
+export const Publisher2Schema = defineEntity({
+  class: Publisher2,
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+    type: p.enum(() => Publisher2Type),
+    type2: p.enum(() => Publisher2Type2),
+    enum1: p.smallint().nullable(),
+    enum2: p.smallint().nullable(),
+    enum3: p.smallint().nullable(),
+    enum4: p.enum(() => Publisher2Enum4).nullable(),
+    enum5: p.enum(() => Publisher2Enum5).nullable(),
+    book2Collection: () => p.oneToMany(Book2).mappedBy('publisher'),
+    publisher2TestsCollection: () => p.oneToMany(Publisher2Tests).mappedBy('publisher2'),
+  },
+});
 ",
-  "import { Entity, ManyToOne, PrimaryKey } from '@mikro-orm/core';
+  "import { type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Publisher2 } from './Publisher2';
 import { Test2 } from './Test2';
 
-@Entity({ tableName: 'publisher2_tests' })
 export class Publisher2Tests {
-
-  @PrimaryKey()
   id!: number;
-
-  @ManyToOne({ entity: () => Publisher2, updateRule: 'cascade', deleteRule: 'cascade' })
-  publisher2!: Publisher2;
-
-  @ManyToOne({ entity: () => Test2, updateRule: 'cascade', deleteRule: 'cascade' })
-  test2!: Test2;
-
+  publisher2!: Ref<Publisher2>;
+  test2!: Ref<Test2>;
 }
+
+export const Publisher2TestsSchema = defineEntity({
+  class: Publisher2Tests,
+  tableName: 'publisher2_tests',
+  properties: {
+    id: p.integer().primary(),
+    publisher2: () => p.manyToOne(Publisher2).ref().updateRule('cascade').deleteRule('cascade'),
+    test2: () => p.manyToOne(Test2).ref().updateRule('cascade').deleteRule('cascade'),
+  },
+});
 ",
-  "import { Collection, Entity, ManyToMany, ManyToOne, OneToOne, type Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, type Opt, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Book2 } from './Book2';
+import { Configuration2 } from './Configuration2';
 import { FooBar2 } from './FooBar2';
+import { Label2Tests } from './Label2Tests';
+import { Publisher2Tests } from './Publisher2Tests';
 
-@Entity()
 export class Test2 {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property({ type: 'string', nullable: true })
   name?: string | null;
-
-  @Unique({ name: 'test2_book_uuid_pk_unique' })
-  @OneToOne({ entity: () => Book2, deleteRule: 'set null', nullable: true })
-  book?: Book2 | null;
-
-  @ManyToOne({ entity: () => Test2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  parent?: Test2 | null;
-
-  @Property({ type: 'integer' })
+  book?: Ref<Book2> | null;
+  parent?: Ref<Test2> | null;
   version: number & Opt = 1;
-
-  @Property({ type: 'unknown', columnType: 'polygon', nullable: true })
   path?: unknown | null;
-
-  @ManyToMany({ entity: () => FooBar2, joinColumn: 'test2_id', inverseJoinColumn: 'foo_bar2_id' })
   bars = new Collection<FooBar2>(this);
-
+  label2TestsCollection = new Collection<Label2Tests>(this);
+  configuration2Collection = new Collection<Configuration2>(this);
+  publisher2TestsCollection = new Collection<Publisher2Tests>(this);
+  test2Collection = new Collection<Test2>(this);
 }
+
+export const Test2Schema = defineEntity({
+  class: Test2,
+  properties: {
+    id: p.integer().primary(),
+    name: p.string().nullable(),
+    book: () => p.oneToOne(Book2).ref().deleteRule('set null').nullable(),
+    parent: () => p.manyToOne(Test2).ref().updateRule('cascade').deleteRule('set null').nullable(),
+    version: p.integer(),
+    path: p.unknown().columnType('polygon').nullable(),
+    bars: () => p.manyToMany(FooBar2).joinColumn('test2_id').inverseJoinColumn('foo_bar2_id'),
+    label2TestsCollection: () => p.oneToMany(Label2Tests).mappedBy('test2'),
+    configuration2Collection: () => p.oneToMany(Configuration2).mappedBy('test'),
+    publisher2TestsCollection: () => p.oneToMany(Publisher2Tests).mappedBy('test2'),
+    test2Collection: () => p.oneToMany(Test2).mappedBy('parent'),
+  },
+});
 ",
 ]
 `;
 
 exports[`EntityGenerator > skipTables [postgres] > postgres-entity-dump-skipTables 1`] = `
 [
-  "import { Entity, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Label2 } from './Label2';
 
-@Entity({ tableName: 'label2_tests', schema: 'label_schema' })
 export class Label2Tests {
-
-  @PrimaryKey()
   id!: number;
-
-  @ManyToOne({ entity: () => Label2, updateRule: 'cascade', deleteRule: 'cascade' })
-  label2!: Label2;
-
-  @Property({ fieldName: 'test2_id' })
+  label2!: Ref<Label2>;
   test2!: number;
-
 }
+
+export const Label2TestsSchema = defineEntity({
+  class: Label2Tests,
+  tableName: 'label2_tests',
+  schema: 'label_schema',
+  properties: {
+    id: p.integer().primary(),
+    label2: () => p.manyToOne(Label2).ref().updateRule('cascade').deleteRule('cascade'),
+    test2: p.integer().name('test2_id'),
+  },
+});
 ",
-  "import { Entity, OneToOne, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { PrimaryKeyProp, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 
-@Entity({ comment: 'This is address table' })
 export class Address2 {
-
   [PrimaryKeyProp]?: 'author';
-
-  @OneToOne({ entity: () => Author2, updateRule: 'cascade', deleteRule: 'cascade', primary: true })
-  author!: Author2;
-
-  @Property({ comment: 'This is address property' })
+  author!: Ref<Author2>;
   value!: string;
-
 }
+
+export const Address2Schema = defineEntity({
+  class: Address2,
+  comment: 'This is address table',
+  properties: {
+    author: () => p.oneToOne(Author2).primary().ref().updateRule('cascade').deleteRule('cascade'),
+    value: p.string().comment('This is address property'),
+  },
+});
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, type Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, type Opt, type Ref, defineEntity, p } from '@mikro-orm/core';
+import { Address2 } from './Address2';
 import { Book2 } from './Book2';
 
-@Entity()
-@Index({ name: 'author2_name_age_index', properties: ['name', 'age'] })
-@Unique({ name: 'author2_name_email_unique', properties: ['name', 'email'] })
 export class Author2 {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property({ type: 'datetime', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
-
-  @Property({ type: 'datetime', columnType: 'timestamp(3)', defaultRaw: \`current_timestamp(3)\` })
   updatedAt!: Date & Opt;
-
-  @Property({ index: 'custom_idx_name_123' })
   name!: string;
-
-  @Property({ index: 'custom_email_index_name', unique: 'custom_email_unique_name' })
   email!: string;
-
-  @Property({ nullable: true })
   age?: number;
-
-  @Property({ type: 'boolean', index: true })
   termsAccepted: boolean & Opt = false;
-
-  @Property({ nullable: true })
   optional?: boolean;
-
-  @Property({ nullable: true })
   identities?: string[];
-
-  @Property({ type: 'date', nullable: true, index: true })
   born?: string;
-
-  @Property({ type: 'time', length: 0, nullable: true, index: 'born_time_idx' })
   bornTime?: string;
-
-  @ManyToOne({ entity: () => Book2, deleteRule: 'cascade', nullable: true })
-  favouriteBook?: Book2;
-
-  @ManyToOne({ entity: () => Author2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  favouriteAuthor?: Author2;
-
-  @Property({ type: 'json', nullable: true })
+  favouriteBook?: Ref<Book2>;
+  favouriteAuthor?: Ref<Author2>;
   identity?: any;
-
-  @ManyToMany({ entity: () => Author2, pivotTable: 'author_to_friend', joinColumn: 'author2_1_id', inverseJoinColumn: 'author2_2_id' })
   authorToFriend = new Collection<Author2>(this);
-
-  @ManyToMany({ entity: () => Author2, joinColumn: 'author2_1_id', inverseJoinColumn: 'author2_2_id' })
   following = new Collection<Author2>(this);
-
+  address2?: Ref<Address2>;
+  author2Collection = new Collection<Author2>(this);
+  authorToFriendInverse = new Collection<Author2>(this);
+  followingInverse = new Collection<Author2>(this);
+  book2Collection = new Collection<Book2>(this);
 }
-",
-  "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
 
-@Entity()
+export const Author2Schema = defineEntity({
+  class: Author2,
+  indexes: [{ name: 'author2_name_age_index', properties: ['name', 'age'] }],
+  uniques: [{ name: 'author2_name_email_unique', properties: ['name', 'email'] }],
+  properties: {
+    id: p.integer().primary(),
+    createdAt: p.datetime().length(3).defaultRaw(\`current_timestamp(3)\`),
+    updatedAt: p.datetime().columnType('timestamp(3)').defaultRaw(\`current_timestamp(3)\`),
+    name: p.string().index('custom_idx_name_123'),
+    email: p.string().index('custom_email_index_name').unique('custom_email_unique_name'),
+    age: p.integer().nullable(),
+    termsAccepted: p.boolean().index('author2_terms_accepted_index'),
+    optional: p.boolean().nullable(),
+    identities: p.type(string[]).nullable(),
+    born: p.date().nullable().index('author2_born_index'),
+    bornTime: p.time().length(0).nullable().index('born_time_idx'),
+    favouriteBook: () => p.manyToOne(Book2).ref().deleteRule('cascade').nullable(),
+    favouriteAuthor: () => p.manyToOne(Author2).ref().updateRule('cascade').deleteRule('set null').nullable(),
+    identity: p.json().nullable(),
+    authorToFriend: () => p.manyToMany(Author2).pivotTable('author_to_friend').joinColumn('author2_1_id').inverseJoinColumn('author2_2_id'),
+    following: () => p.manyToMany(Author2).joinColumn('author2_1_id').inverseJoinColumn('author2_2_id'),
+    address2: () => p.oneToOne(Address2).ref().mappedBy('author'),
+    author2Collection: () => p.oneToMany(Author2).mappedBy('favouriteAuthor'),
+    authorToFriendInverse: () => p.manyToMany(Author2).mappedBy('authorToFriend'),
+    followingInverse: () => p.manyToMany(Author2).mappedBy('following'),
+    book2Collection: () => p.oneToMany(Book2).mappedBy('author'),
+  },
+});
+",
+  "import { Collection, defineEntity, p } from '@mikro-orm/core';
+import { Book2 } from './Book2';
+import { Book2Tags } from './Book2Tags';
+
 export class BookTag2 {
-
-  @PrimaryKey()
   id!: bigint;
-
-  @Property({ length: 50 })
   name!: string;
-
+  bookToTagUnorderedInverse = new Collection<Book2>(this);
+  book2TagsCollection = new Collection<Book2Tags>(this);
 }
+
+export const BookTag2Schema = defineEntity({
+  class: BookTag2,
+  properties: {
+    id: p.bigint().primary(),
+    name: p.string().length(50),
+    bookToTagUnorderedInverse: () => p.manyToMany(Book2).mappedBy('bookToTagUnordered'),
+    book2TagsCollection: () => p.oneToMany(Book2Tags).mappedBy('bookTag2'),
+  },
+});
 ",
-  "import { Collection, Entity, ManyToMany, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, type Opt, PrimaryKeyProp, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Author2 } from './Author2';
+import { Book2Tags } from './Book2Tags';
 import { BookTag2 } from './BookTag2';
 import { Publisher2 } from './Publisher2';
 
-@Entity()
 export class Book2 {
-
   [PrimaryKeyProp]?: 'uuidPk';
-
-  @PrimaryKey({ type: 'uuid' })
   uuidPk!: string;
-
-  @Property({ type: 'datetime', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
-
-  @Property({ type: 'character', length: 13, nullable: true, unique: 'book_isbn_unique' })
   isbn?: string;
-
-  @Property({ type: 'string', nullable: true })
   title?: string = '';
-
-  @Property({ type: 'text', nullable: true })
   perex?: string;
-
-  @Property({ type: 'decimal', nullable: true })
   double?: string;
-
-  @Property({ type: 'json', nullable: true })
   meta?: any;
-
-  @ManyToOne({ entity: () => Author2 })
-  author!: Author2;
-
-  @ManyToOne({ entity: () => Publisher2, updateRule: 'cascade', deleteRule: 'cascade', nullable: true })
-  publisher?: Publisher2;
-
-  @Property({ type: 'string', nullable: true })
+  author!: Ref<Author2>;
+  publisher?: Ref<Publisher2>;
   foo?: string = 'lol';
-
-  @ManyToMany({ entity: () => BookTag2, pivotTable: 'book_to_tag_unordered', joinColumn: 'book2_uuid_pk', inverseJoinColumn: 'book_tag2_id' })
   bookToTagUnordered = new Collection<BookTag2>(this);
-
+  author2Collection = new Collection<Author2>(this);
+  book2TagsCollection = new Collection<Book2Tags>(this);
 }
+
+export const Book2Schema = defineEntity({
+  class: Book2,
+  properties: {
+    uuidPk: p.uuid().primary(),
+    createdAt: p.datetime().length(3).defaultRaw(\`current_timestamp(3)\`),
+    isbn: p.character().length(13).nullable().unique('book_isbn_unique'),
+    title: p.string().nullable(),
+    perex: p.text().nullable(),
+    double: p.decimal().nullable(),
+    meta: p.json().nullable(),
+    author: () => p.manyToOne(Author2).ref(),
+    publisher: () => p.manyToOne(Publisher2).ref().updateRule('cascade').deleteRule('cascade').nullable(),
+    foo: p.string().nullable(),
+    bookToTagUnordered: () => p.manyToMany(BookTag2).pivotTable('book_to_tag_unordered').joinColumn('book2_uuid_pk').inverseJoinColumn('book_tag2_id'),
+    author2Collection: () => p.oneToMany(Author2).mappedBy('favouriteBook'),
+    book2TagsCollection: () => p.oneToMany(Book2Tags).mappedBy('book2'),
+  },
+});
 ",
-  "import { Entity, ManyToOne, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { PrimaryKeyProp, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { BookTag2 } from './BookTag2';
 
-@Entity({ tableName: 'book2_tags' })
 export class Book2Tags {
-
   [PrimaryKeyProp]?: 'order';
-
-  @PrimaryKey()
   order!: number;
-
-  @ManyToOne({ entity: () => Book2, updateRule: 'cascade', deleteRule: 'cascade' })
-  book2!: Book2;
-
-  @ManyToOne({ entity: () => BookTag2, updateRule: 'cascade', deleteRule: 'cascade' })
-  bookTag2!: BookTag2;
-
+  book2!: Ref<Book2>;
+  bookTag2!: Ref<BookTag2>;
 }
-",
-  "import { Entity, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 
-@Entity()
+export const Book2TagsSchema = defineEntity({
+  class: Book2Tags,
+  tableName: 'book2_tags',
+  properties: {
+    order: p.integer().primary(),
+    book2: () => p.manyToOne(Book2).ref().updateRule('cascade').deleteRule('cascade'),
+    bookTag2: () => p.manyToOne(BookTag2).ref().updateRule('cascade').deleteRule('cascade'),
+  },
+});
+",
+  "import { PrimaryKeyProp, defineEntity, p } from '@mikro-orm/core';
+
 export class Configuration2 {
-
   [PrimaryKeyProp]?: ['property', 'test'];
-
-  @PrimaryKey()
   property!: string;
-
-  @PrimaryKey({ fieldName: 'test_id' })
   test!: number;
-
-  @Property()
   value!: string;
-
 }
+
+export const Configuration2Schema = defineEntity({
+  class: Configuration2,
+  properties: {
+    property: p.string().primary(),
+    test: p.integer().primary().name('test_id'),
+    value: p.string(),
+  },
+});
 ",
-  "import { Entity, OneToOne, type Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, type Opt, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { FooBaz2 } from './FooBaz2';
+import { FooParam2 } from './FooParam2';
 
-@Entity()
 export class FooBar2 {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property()
   name!: string;
-
-  @Property({ fieldName: 'name with space', nullable: true })
   nameWithSpace?: string;
-
-  @Unique({ name: 'foo_bar2_baz_id_unique' })
-  @OneToOne({ entity: () => FooBaz2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  baz?: FooBaz2;
-
-  @Unique({ name: 'foo_bar2_foo_bar_id_unique' })
-  @OneToOne({ entity: () => FooBar2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  fooBar?: FooBar2;
-
-  @Property({ type: 'datetime', length: 0, defaultRaw: \`current_timestamp(0)\` })
+  baz?: Ref<FooBaz2>;
+  fooBar?: Ref<FooBar2>;
   version!: Date & Opt;
-
-  @Property({ nullable: true })
   blob?: Buffer;
-
-  @Property({ nullable: true })
   blob2?: Buffer;
-
-  @Property({ nullable: true })
   array?: string[];
-
-  @Property({ type: 'json', nullable: true })
   objectProperty?: any;
-
+  fooBar2?: Ref<FooBar2>;
+  fooParam2Collection = new Collection<FooParam2>(this);
 }
-",
-  "import { Entity, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 
-@Entity()
+export const FooBar2Schema = defineEntity({
+  class: FooBar2,
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+    nameWithSpace: p.string().name('name with space').nullable(),
+    baz: () => p.oneToOne(FooBaz2).ref().updateRule('cascade').deleteRule('set null').nullable(),
+    fooBar: () => p.oneToOne(FooBar2).ref().updateRule('cascade').deleteRule('set null').nullable(),
+    version: p.datetime().length(0).defaultRaw(\`current_timestamp(0)\`),
+    blob: p.blob().nullable(),
+    blob2: p.blob().nullable(),
+    array: p.type(string[]).nullable(),
+    objectProperty: p.json().nullable(),
+    fooBar2: () => p.oneToOne(FooBar2).ref().mappedBy('fooBar'),
+    fooParam2Collection: () => p.oneToMany(FooParam2).mappedBy('bar'),
+  },
+});
+",
+  "import { Collection, type Opt, type Ref, defineEntity, p } from '@mikro-orm/core';
+import { FooBar2 } from './FooBar2';
+import { FooParam2 } from './FooParam2';
+
 export class FooBaz2 {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property()
   code!: string;
-
-  @Property({ type: 'datetime', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
-
+  fooBar2?: Ref<FooBar2>;
+  fooParam2Collection = new Collection<FooParam2>(this);
 }
+
+export const FooBaz2Schema = defineEntity({
+  class: FooBaz2,
+  properties: {
+    id: p.integer().primary(),
+    code: p.string(),
+    version: p.datetime().length(3).defaultRaw(\`current_timestamp(3)\`),
+    fooBar2: () => p.oneToOne(FooBar2).ref().mappedBy('baz'),
+    fooParam2Collection: () => p.oneToMany(FooParam2).mappedBy('baz'),
+  },
+});
 ",
-  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { type Opt, PrimaryKeyProp, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { FooBar2 } from './FooBar2';
 import { FooBaz2 } from './FooBaz2';
 
-@Entity()
 export class FooParam2 {
-
   [PrimaryKeyProp]?: ['bar', 'baz'];
-
-  @ManyToOne({ entity: () => FooBar2, updateRule: 'cascade', primary: true })
-  bar!: FooBar2;
-
-  @ManyToOne({ entity: () => FooBaz2, updateRule: 'cascade', primary: true })
-  baz!: FooBaz2;
-
-  @Property()
+  bar!: Ref<FooBar2>;
+  baz!: Ref<FooBaz2>;
   value!: string;
-
-  @Property({ type: 'datetime', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
-
 }
-",
-  "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
 
-@Entity()
+export const FooParam2Schema = defineEntity({
+  class: FooParam2,
+  properties: {
+    bar: () => p.manyToOne(FooBar2).primary().ref().updateRule('cascade'),
+    baz: () => p.manyToOne(FooBaz2).primary().ref().updateRule('cascade'),
+    value: p.string(),
+    version: p.datetime().length(3).defaultRaw(\`current_timestamp(3)\`),
+  },
+});
+",
+  "import { Collection, defineEntity, p } from '@mikro-orm/core';
+import { Label2Tests } from './Label2Tests';
+
 export class Label2 {
-
-  @PrimaryKey({ type: 'uuid' })
   uuid!: string;
-
-  @Property()
   name!: string;
-
+  label2TestsCollection = new Collection<Label2Tests>(this);
 }
-",
-  "import { Entity, Enum, PrimaryKey, Property } from '@mikro-orm/core';
 
-@Entity()
+export const Label2Schema = defineEntity({
+  class: Label2,
+  properties: {
+    uuid: p.uuid().primary(),
+    name: p.string(),
+    label2TestsCollection: () => p.oneToMany(Label2Tests).mappedBy('label2'),
+  },
+});
+",
+  "import { Collection, defineEntity, p } from '@mikro-orm/core';
+import { Book2 } from './Book2';
+import { Publisher2Tests } from './Publisher2Tests';
+
 export class Publisher2 {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property()
   name!: string;
-
-  @Enum({ items: () => Publisher2Type })
-  type!: Publisher2Type;
-
-  @Enum({ items: () => Publisher2Type2 })
-  type2!: Publisher2Type2;
-
-  @Property({ type: 'smallint', nullable: true })
+  type!: TPublisher2Type;
+  type2!: TPublisher2Type2;
   enum1?: number;
-
-  @Property({ type: 'smallint', nullable: true })
   enum2?: number;
-
-  @Property({ type: 'smallint', nullable: true })
   enum3?: number;
-
-  @Enum({ items: () => Publisher2Enum4, nullable: true })
-  enum4?: Publisher2Enum4;
-
-  @Enum({ items: () => Publisher2Enum5, nullable: true })
-  enum5?: Publisher2Enum5;
-
+  enum4?: TPublisher2Enum4;
+  enum5?: TPublisher2Enum5;
+  book2Collection = new Collection<Book2>(this);
+  publisher2TestsCollection = new Collection<Publisher2Tests>(this);
 }
 
-export enum Publisher2Type {
-  LOCAL = 'local',
-  GLOBAL = 'global',
-}
+export const Publisher2Type = {
+  LOCAL: 'local',
+  GLOBAL: 'global',
+} as const;
 
-export enum Publisher2Type2 {
-  LOCAL = 'LOCAL',
-  GLOBAL = 'GLOBAL',
-}
+export type TPublisher2Type = (typeof Publisher2Type)[keyof typeof Publisher2Type];
 
-export enum Publisher2Enum4 {
-  A = 'a',
-  B = 'b',
-  C = 'c',
-}
+export const Publisher2Type2 = {
+  LOCAL: 'LOCAL',
+  GLOBAL: 'GLOBAL',
+} as const;
 
-export enum Publisher2Enum5 {
-  A = 'a',
-}
+export type TPublisher2Type2 = (typeof Publisher2Type2)[keyof typeof Publisher2Type2];
+
+export const Publisher2Enum4 = {
+  A: 'a',
+  B: 'b',
+  C: 'c',
+} as const;
+
+export type TPublisher2Enum4 = (typeof Publisher2Enum4)[keyof typeof Publisher2Enum4];
+
+export const Publisher2Enum5 = {
+  A: 'a',
+} as const;
+
+export type TPublisher2Enum5 = (typeof Publisher2Enum5)[keyof typeof Publisher2Enum5];
+
+export const Publisher2Schema = defineEntity({
+  class: Publisher2,
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+    type: p.enum(() => Publisher2Type),
+    type2: p.enum(() => Publisher2Type2),
+    enum1: p.smallint().nullable(),
+    enum2: p.smallint().nullable(),
+    enum3: p.smallint().nullable(),
+    enum4: p.enum(() => Publisher2Enum4).nullable(),
+    enum5: p.enum(() => Publisher2Enum5).nullable(),
+    book2Collection: () => p.oneToMany(Book2).mappedBy('publisher'),
+    publisher2TestsCollection: () => p.oneToMany(Publisher2Tests).mappedBy('publisher2'),
+  },
+});
 ",
-  "import { Entity, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Publisher2 } from './Publisher2';
 
-@Entity({ tableName: 'publisher2_tests' })
 export class Publisher2Tests {
-
-  @PrimaryKey()
   id!: number;
-
-  @ManyToOne({ entity: () => Publisher2, updateRule: 'cascade', deleteRule: 'cascade' })
-  publisher2!: Publisher2;
-
-  @Property({ fieldName: 'test2_id' })
+  publisher2!: Ref<Publisher2>;
   test2!: number;
-
 }
+
+export const Publisher2TestsSchema = defineEntity({
+  class: Publisher2Tests,
+  tableName: 'publisher2_tests',
+  properties: {
+    id: p.integer().primary(),
+    publisher2: () => p.manyToOne(Publisher2).ref().updateRule('cascade').deleteRule('cascade'),
+    test2: p.integer().name('test2_id'),
+  },
+});
 ",
 ]
 `;
 
 exports[`EntityGenerator > takeTables [postgres] > postgres-entity-dump-takeTables 1`] = `
 [
-  "import { Entity, OneToOne, type Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { type Opt, type Ref, defineEntity, p } from '@mikro-orm/core';
 
-@Entity()
 export class FooBar2 {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property()
   name!: string;
-
-  @Property({ fieldName: 'name with space', nullable: true })
   nameWithSpace?: string;
-
-  @Property({ fieldName: 'baz_id', nullable: true, unique: true })
   baz?: number;
-
-  @Unique({ name: 'foo_bar2_foo_bar_id_unique' })
-  @OneToOne({ entity: () => FooBar2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  fooBar?: FooBar2;
-
-  @Property({ type: 'datetime', length: 0, defaultRaw: \`current_timestamp(0)\` })
+  fooBar?: Ref<FooBar2>;
   version!: Date & Opt;
-
-  @Property({ nullable: true })
   blob?: Buffer;
-
-  @Property({ nullable: true })
   blob2?: Buffer;
-
-  @Property({ nullable: true })
   array?: string[];
-
-  @Property({ type: 'json', nullable: true })
   objectProperty?: any;
-
+  fooBar2?: Ref<FooBar2>;
 }
+
+export const FooBar2Schema = defineEntity({
+  class: FooBar2,
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+    nameWithSpace: p.string().name('name with space').nullable(),
+    baz: p.integer().name('baz_id').nullable().unique('foo_bar2_baz_id_unique'),
+    fooBar: () => p.oneToOne(FooBar2).ref().updateRule('cascade').deleteRule('set null').nullable(),
+    version: p.datetime().length(0).defaultRaw(\`current_timestamp(0)\`),
+    blob: p.blob().nullable(),
+    blob2: p.blob().nullable(),
+    array: p.type(string[]).nullable(),
+    objectProperty: p.json().nullable(),
+    fooBar2: () => p.oneToOne(FooBar2).ref().mappedBy('fooBar'),
+  },
+});
 ",
-  "import { Entity, ManyToOne, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, type Opt, type Ref, defineEntity, p } from '@mikro-orm/core';
 
-@Entity()
 export class Test2 {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property({ nullable: true })
   name?: string;
-
-  @Property({ fieldName: 'book_uuid_pk', type: 'uuid', nullable: true, unique: true })
   book?: string;
-
-  @ManyToOne({ entity: () => Test2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  parent?: Test2;
-
-  @Property({ type: 'integer' })
+  parent?: Ref<Test2>;
   version: number & Opt = 1;
-
-  @Property({ columnType: 'polygon', nullable: true })
   path?: unknown;
-
+  test2Collection = new Collection<Test2>(this);
 }
+
+export const Test2Schema = defineEntity({
+  class: Test2,
+  properties: {
+    id: p.integer().primary(),
+    name: p.string().nullable(),
+    book: p.uuid().name('book_uuid_pk').nullable().unique('test2_book_uuid_pk_unique'),
+    parent: () => p.manyToOne(Test2).ref().updateRule('cascade').deleteRule('set null').nullable(),
+    version: p.integer(),
+    path: p.unknown().columnType('polygon').nullable(),
+    test2Collection: () => p.oneToMany(Test2).mappedBy('parent'),
+  },
+});
 ",
 ]
 `;
 
 exports[`EntityGenerator > takeTables and skipTables [postgres] > postgres-entity-dump-takeTables-skipTables 1`] = `
 [
-  "import { Entity, ManyToOne, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, type Opt, type Ref, defineEntity, p } from '@mikro-orm/core';
 
-@Entity()
 export class Test2 {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property({ nullable: true })
   name?: string;
-
-  @Property({ fieldName: 'book_uuid_pk', type: 'uuid', nullable: true, unique: true })
   book?: string;
-
-  @ManyToOne({ entity: () => Test2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  parent?: Test2;
-
-  @Property({ type: 'integer' })
+  parent?: Ref<Test2>;
   version: number & Opt = 1;
-
-  @Property({ columnType: 'polygon', nullable: true })
   path?: unknown;
-
+  test2Collection = new Collection<Test2>(this);
 }
+
+export const Test2Schema = defineEntity({
+  class: Test2,
+  properties: {
+    id: p.integer().primary(),
+    name: p.string().nullable(),
+    book: p.uuid().name('book_uuid_pk').nullable().unique('test2_book_uuid_pk_unique'),
+    parent: () => p.manyToOne(Test2).ref().updateRule('cascade').deleteRule('set null').nullable(),
+    version: p.integer(),
+    path: p.unknown().columnType('polygon').nullable(),
+    test2Collection: () => p.oneToMany(Test2).mappedBy('parent'),
+  },
+});
 ",
 ]
 `;

--- a/tests/features/entity-generator/__snapshots__/EntityGenerator.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/EntityGenerator.test.ts.snap
@@ -2,268 +2,266 @@
 
 exports[`EntityGenerator > generate entities from schema [sqlite] > sqlite-entity-dump 1`] = `
 [
-  "import { Entity, Index, ManyToOne, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, type Opt, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Book4 } from './book4';
 
-@Entity()
 export class Author4 {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property({ nullable: true })
   createdAt?: Date;
-
-  @Property({ nullable: true })
   updatedAt?: Date;
-
-  @Property({ type: 'text' })
   name!: string;
-
-  @Property({ type: 'text', unique: true })
   email!: string;
-
-  @Property({ nullable: true })
   age?: number;
-
-  @Property({ type: 'integer' })
   termsAccepted: number & Opt = 0;
-
-  @Property({ type: 'text', nullable: true })
   identities?: string;
-
-  @Property({ type: 'date', nullable: true })
   born?: string;
-
-  @Property({ type: 'time', nullable: true })
   bornTime?: string;
-
-  @Index({ name: 'author4_favourite_book_id_index' })
-  @ManyToOne({ entity: () => Book4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  favouriteBook?: Book4;
-
-  @Property({ type: 'json', nullable: true })
+  favouriteBook?: Ref<Book4>;
   identity?: any;
-
+  book4Collection = new Collection<Book4>(this);
 }
-",
-  "import { Entity, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 
-@Entity()
+export const Author4Schema = defineEntity({
+  class: Author4,
+  properties: {
+    id: p.integer().primary(),
+    createdAt: p.datetime().nullable(),
+    updatedAt: p.datetime().nullable(),
+    name: p.text(),
+    email: p.text().unique('author4_email_unique'),
+    age: p.integer().nullable(),
+    termsAccepted: p.integer(),
+    identities: p.text().nullable(),
+    born: p.date().nullable(),
+    bornTime: p.time().nullable(),
+    favouriteBook: () => p.manyToOne(Book4).ref().updateRule('cascade').deleteRule('set null').nullable(),
+    identity: p.json().nullable(),
+    book4Collection: () => p.oneToMany(Book4).mappedBy('author'),
+  },
+});
+",
+  "import { Collection, type Opt, defineEntity, p } from '@mikro-orm/core';
+import { Book4 } from './book4';
+import { TagsOrdered } from './tags-ordered';
+
 export class BookTag4 {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property({ nullable: true })
   createdAt?: Date;
-
-  @Property({ nullable: true })
   updatedAt?: Date;
-
-  @Property({ type: 'text' })
   name!: string;
-
-  @Property({ type: 'datetime', defaultRaw: \`current_timestamp\` })
   version!: Date & Opt;
-
+  tagsUnorderedInverse = new Collection<Book4>(this);
+  tagsOrderedCollection = new Collection<TagsOrdered>(this);
 }
+
+export const BookTag4Schema = defineEntity({
+  class: BookTag4,
+  properties: {
+    id: p.integer().primary(),
+    createdAt: p.datetime().nullable(),
+    updatedAt: p.datetime().nullable(),
+    name: p.text(),
+    version: p.datetime().defaultRaw(\`current_timestamp\`),
+    tagsUnorderedInverse: () => p.manyToMany(Book4).mappedBy('tagsUnordered'),
+    tagsOrderedCollection: () => p.oneToMany(TagsOrdered).mappedBy('bookTag4'),
+  },
+});
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Author4 } from './author4';
 import { BookTag4 } from './book-tag4';
 import { Publisher4 } from './publisher4';
+import { TagsOrdered } from './tags-ordered';
 
-@Entity()
 export class Book4 {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property({ nullable: true })
   createdAt?: Date;
-
-  @Property({ nullable: true })
   updatedAt?: Date;
-
-  @Property({ type: 'text' })
   title!: string;
-
-  @Property({ columnType: 'REAL', nullable: true })
   price?: unknown;
-
-  @Index({ name: 'book4_author_id_index' })
-  @ManyToOne({ entity: () => Author4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  author?: Author4;
-
-  @Index({ name: 'book4_publisher_id_index' })
-  @ManyToOne({ entity: () => Publisher4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  publisher?: Publisher4;
-
-  @Property({ type: 'json', nullable: true })
+  author?: Ref<Author4>;
+  publisher?: Ref<Publisher4>;
   meta?: any;
-
-  @ManyToMany({ entity: () => BookTag4, pivotTable: 'tags_unordered', joinColumn: 'book4_id', inverseJoinColumn: 'book_tag4_id' })
   tagsUnordered = new Collection<BookTag4>(this);
-
+  author4Collection = new Collection<Author4>(this);
+  tagsOrderedCollection = new Collection<TagsOrdered>(this);
 }
+
+export const Book4Schema = defineEntity({
+  class: Book4,
+  properties: {
+    id: p.integer().primary(),
+    createdAt: p.datetime().nullable(),
+    updatedAt: p.datetime().nullable(),
+    title: p.text(),
+    price: p.unknown().columnType('REAL').nullable(),
+    author: () => p.manyToOne(Author4).ref().updateRule('cascade').deleteRule('set null').nullable(),
+    publisher: () => p.manyToOne(Publisher4).ref().updateRule('cascade').deleteRule('set null').nullable(),
+    meta: p.json().nullable(),
+    tagsUnordered: () => p.manyToMany(BookTag4).pivotTable('tags_unordered').joinColumn('book4_id').inverseJoinColumn('book_tag4_id'),
+    author4Collection: () => p.oneToMany(Author4).mappedBy('favouriteBook'),
+    tagsOrderedCollection: () => p.oneToMany(TagsOrdered).mappedBy('book4'),
+  },
+});
 ",
-  "import { Entity, OneToOne, type Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { type Opt, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { FooBaz4 } from './foo-baz4';
 
-@Entity()
 export class FooBar4 {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property({ nullable: true })
   createdAt?: Date;
-
-  @Property({ nullable: true })
   updatedAt?: Date;
-
-  @Property({ type: 'text' })
   name: string & Opt = 'asd';
-
-  @Unique({ name: 'foo_bar4_baz_id_unique' })
-  @OneToOne({ entity: () => FooBaz4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  baz?: FooBaz4;
-
-  @Unique({ name: 'foo_bar4_foo_bar_id_unique' })
-  @OneToOne({ entity: () => FooBar4, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  fooBar?: FooBar4;
-
-  @Property({ type: 'integer' })
+  baz?: Ref<FooBaz4>;
+  fooBar?: Ref<FooBar4>;
   version: number & Opt = 1;
-
-  @Property({ nullable: true })
   blob?: Buffer;
-
-  @Property({ nullable: true })
   blob2?: Buffer;
-
-  @Property({ type: 'text', nullable: true })
   array?: string;
-
-  @Property({ type: 'json', nullable: true })
   object?: any;
-
+  fooBar4?: Ref<FooBar4>;
 }
-",
-  "import { Entity, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 
-@Entity()
+export const FooBar4Schema = defineEntity({
+  class: FooBar4,
+  properties: {
+    id: p.integer().primary(),
+    createdAt: p.datetime().nullable(),
+    updatedAt: p.datetime().nullable(),
+    name: p.text(),
+    baz: () => p.oneToOne(FooBaz4).ref().updateRule('cascade').deleteRule('set null').nullable(),
+    fooBar: () => p.oneToOne(FooBar4).ref().updateRule('cascade').deleteRule('set null').nullable(),
+    version: p.integer(),
+    blob: p.blob().nullable(),
+    blob2: p.blob().nullable(),
+    array: p.text().nullable(),
+    object: p.json().nullable(),
+    fooBar4: () => p.oneToOne(FooBar4).ref().mappedBy('fooBar'),
+  },
+});
+",
+  "import { type Opt, type Ref, defineEntity, p } from '@mikro-orm/core';
+import { FooBar4 } from './foo-bar4';
+
 export class FooBaz4 {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property({ nullable: true })
   createdAt?: Date;
-
-  @Property({ nullable: true })
   updatedAt?: Date;
-
-  @Property({ type: 'text' })
   name!: string;
-
-  @Property({ type: 'datetime', defaultRaw: \`current_timestamp\` })
   version!: Date & Opt;
-
+  fooBar4?: Ref<FooBar4>;
 }
-",
-  "import { Entity, Enum, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 
-@Entity()
+export const FooBaz4Schema = defineEntity({
+  class: FooBaz4,
+  properties: {
+    id: p.integer().primary(),
+    createdAt: p.datetime().nullable(),
+    updatedAt: p.datetime().nullable(),
+    name: p.text(),
+    version: p.datetime().defaultRaw(\`current_timestamp\`),
+    fooBar4: () => p.oneToOne(FooBar4).ref().mappedBy('baz'),
+  },
+});
+",
+  "import { Collection, type Opt, defineEntity, p } from '@mikro-orm/core';
+import { Book4 } from './book4';
+import { Publisher4Tests } from './publisher4tests';
+
 export class Publisher4 {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property({ nullable: true })
   createdAt?: Date;
-
-  @Property({ nullable: true })
   updatedAt?: Date;
-
-  @Property({ type: 'text' })
   name: string & Opt = 'asd';
-
-  @Enum({ items: () => Publisher4Type })
-  type: Publisher4Type & Opt = Publisher4Type.LOCAL;
-
-  @Property({ nullable: true })
+  type: TPublisher4Type & Opt = Publisher4Type.LOCAL;
   enum3?: number;
-
+  book4Collection = new Collection<Book4>(this);
+  publisher4TestsCollection = new Collection<Publisher4Tests>(this);
 }
 
-export enum Publisher4Type {
-  LOCAL = 'local',
-  GLOBAL = 'global',
-}
+export const Publisher4Type = {
+  LOCAL: 'local',
+  GLOBAL: 'global',
+} as const;
+
+export type TPublisher4Type = (typeof Publisher4Type)[keyof typeof Publisher4Type];
+
+export const Publisher4Schema = defineEntity({
+  class: Publisher4,
+  properties: {
+    id: p.integer().primary(),
+    createdAt: p.datetime().nullable(),
+    updatedAt: p.datetime().nullable(),
+    name: p.text(),
+    type: p.enum(() => Publisher4Type),
+    enum3: p.integer().nullable(),
+    book4Collection: () => p.oneToMany(Book4).mappedBy('publisher'),
+    publisher4TestsCollection: () => p.oneToMany(Publisher4Tests).mappedBy('publisher4'),
+  },
+});
 ",
-  "import { Entity, Index, ManyToOne, PrimaryKey } from '@mikro-orm/core';
+  "import { type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Publisher4 } from './publisher4';
 import { Test4 } from './test4';
 
-@Entity({ tableName: 'publisher4_tests' })
 export class Publisher4Tests {
-
-  @PrimaryKey()
   id!: number;
-
-  @Index({ name: 'publisher4_tests_publisher4_id_index' })
-  @ManyToOne({ entity: () => Publisher4, updateRule: 'cascade', deleteRule: 'cascade' })
-  publisher4!: Publisher4;
-
-  @Index({ name: 'publisher4_tests_test4_id_index' })
-  @ManyToOne({ entity: () => Test4, updateRule: 'cascade', deleteRule: 'cascade' })
-  test4!: Test4;
-
+  publisher4!: Ref<Publisher4>;
+  test4!: Ref<Test4>;
 }
+
+export const Publisher4TestsSchema = defineEntity({
+  class: Publisher4Tests,
+  tableName: 'publisher4_tests',
+  properties: {
+    id: p.integer().primary(),
+    publisher4: () => p.manyToOne(Publisher4).ref().updateRule('cascade').deleteRule('cascade'),
+    test4: () => p.manyToOne(Test4).ref().updateRule('cascade').deleteRule('cascade'),
+  },
+});
 ",
-  "import { Entity, Index, ManyToOne, PrimaryKey } from '@mikro-orm/core';
+  "import { type Ref, defineEntity, p } from '@mikro-orm/core';
 import { BookTag4 } from './book-tag4';
 import { Book4 } from './book4';
 
-@Entity()
 export class TagsOrdered {
-
-  @PrimaryKey()
   id!: number;
-
-  @Index({ name: 'tags_ordered_book4_id_index' })
-  @ManyToOne({ entity: () => Book4, updateRule: 'cascade', deleteRule: 'cascade' })
-  book4!: Book4;
-
-  @Index({ name: 'tags_ordered_book_tag4_id_index' })
-  @ManyToOne({ entity: () => BookTag4, updateRule: 'cascade', deleteRule: 'cascade' })
-  bookTag4!: BookTag4;
-
+  book4!: Ref<Book4>;
+  bookTag4!: Ref<BookTag4>;
 }
+
+export const TagsOrderedSchema = defineEntity({
+  class: TagsOrdered,
+  properties: {
+    id: p.integer().primary(),
+    book4: () => p.manyToOne(Book4).ref().updateRule('cascade').deleteRule('cascade'),
+    bookTag4: () => p.manyToOne(BookTag4).ref().updateRule('cascade').deleteRule('cascade'),
+  },
+});
 ",
-  "import { Entity, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, type Opt, defineEntity, p } from '@mikro-orm/core';
+import { Publisher4Tests } from './publisher4tests';
 
-@Entity()
 export class Test4 {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property({ nullable: true })
   createdAt?: Date;
-
-  @Property({ nullable: true })
   updatedAt?: Date;
-
-  @Property({ type: 'text', nullable: true })
   name?: string;
-
-  @Property({ type: 'integer' })
   version: number & Opt = 1;
-
+  publisher4TestsCollection = new Collection<Publisher4Tests>(this);
 }
+
+export const Test4Schema = defineEntity({
+  class: Test4,
+  properties: {
+    id: p.integer().primary(),
+    createdAt: p.datetime().nullable(),
+    updatedAt: p.datetime().nullable(),
+    name: p.text().nullable(),
+    version: p.integer(),
+    publisher4TestsCollection: () => p.oneToMany(Publisher4Tests).mappedBy('test4'),
+  },
+});
 ",
 ]
 `;

--- a/tests/features/entity-generator/__snapshots__/FkIndexSelection.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/FkIndexSelection.mysql.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`fk_index_selection_example > scalarPropertiesForRelations=always > bidirectionalRelations=false > identifiedReferences=false > entitySchema=false > dump 1`] = `
+exports[`fk_index_selection_example > scalarPropertiesForRelations=always > bidirectionalRelations=false > identifiedReferences=false > entityDefinition=decorators > dump 1`] = `
 [
   "import { Entity, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
 
@@ -69,7 +69,7 @@ export class Users {
 ]
 `;
 
-exports[`fk_index_selection_example > scalarPropertiesForRelations=always > bidirectionalRelations=false > identifiedReferences=false > entitySchema=true > dump 1`] = `
+exports[`fk_index_selection_example > scalarPropertiesForRelations=always > bidirectionalRelations=false > identifiedReferences=false > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 
@@ -159,7 +159,7 @@ export const UsersSchema = new EntitySchema({
 ]
 `;
 
-exports[`fk_index_selection_example > scalarPropertiesForRelations=always > bidirectionalRelations=false > identifiedReferences=true > entitySchema=false > dump 1`] = `
+exports[`fk_index_selection_example > scalarPropertiesForRelations=always > bidirectionalRelations=false > identifiedReferences=true > entityDefinition=decorators > dump 1`] = `
 [
   "import { Entity, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
 
@@ -228,7 +228,7 @@ export class Users {
 ]
 `;
 
-exports[`fk_index_selection_example > scalarPropertiesForRelations=always > bidirectionalRelations=false > identifiedReferences=true > entitySchema=true > dump 1`] = `
+exports[`fk_index_selection_example > scalarPropertiesForRelations=always > bidirectionalRelations=false > identifiedReferences=true > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 
@@ -320,7 +320,7 @@ export const UsersSchema = new EntitySchema({
 ]
 `;
 
-exports[`fk_index_selection_example > scalarPropertiesForRelations=always > bidirectionalRelations=true > identifiedReferences=false > entitySchema=false > dump 1`] = `
+exports[`fk_index_selection_example > scalarPropertiesForRelations=always > bidirectionalRelations=true > identifiedReferences=false > entityDefinition=decorators > dump 1`] = `
 [
   "import { Collection, Entity, OneToMany, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
 import { Users } from './Users';
@@ -397,7 +397,7 @@ export class Users {
 ]
 `;
 
-exports[`fk_index_selection_example > scalarPropertiesForRelations=always > bidirectionalRelations=true > identifiedReferences=false > entitySchema=true > dump 1`] = `
+exports[`fk_index_selection_example > scalarPropertiesForRelations=always > bidirectionalRelations=true > identifiedReferences=false > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { Users } from './Users';
@@ -497,7 +497,7 @@ export const UsersSchema = new EntitySchema({
 ]
 `;
 
-exports[`fk_index_selection_example > scalarPropertiesForRelations=always > bidirectionalRelations=true > identifiedReferences=true > entitySchema=false > dump 1`] = `
+exports[`fk_index_selection_example > scalarPropertiesForRelations=always > bidirectionalRelations=true > identifiedReferences=true > entityDefinition=decorators > dump 1`] = `
 [
   "import { Collection, Entity, OneToMany, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
 import { Users } from './Users';
@@ -574,7 +574,7 @@ export class Users {
 ]
 `;
 
-exports[`fk_index_selection_example > scalarPropertiesForRelations=always > bidirectionalRelations=true > identifiedReferences=true > entitySchema=true > dump 1`] = `
+exports[`fk_index_selection_example > scalarPropertiesForRelations=always > bidirectionalRelations=true > identifiedReferences=true > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { Users } from './Users';
@@ -676,7 +676,7 @@ export const UsersSchema = new EntitySchema({
 ]
 `;
 
-exports[`fk_index_selection_example > scalarPropertiesForRelations=never > bidirectionalRelations=false > identifiedReferences=false > entitySchema=false > dump 1`] = `
+exports[`fk_index_selection_example > scalarPropertiesForRelations=never > bidirectionalRelations=false > identifiedReferences=false > entityDefinition=decorators > dump 1`] = `
 [
   "import { Entity, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
 
@@ -733,7 +733,7 @@ export class Users {
 ]
 `;
 
-exports[`fk_index_selection_example > scalarPropertiesForRelations=never > bidirectionalRelations=false > identifiedReferences=false > entitySchema=true > dump 1`] = `
+exports[`fk_index_selection_example > scalarPropertiesForRelations=never > bidirectionalRelations=false > identifiedReferences=false > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 
@@ -808,7 +808,7 @@ export const UsersSchema = new EntitySchema({
 ]
 `;
 
-exports[`fk_index_selection_example > scalarPropertiesForRelations=never > bidirectionalRelations=false > identifiedReferences=true > entitySchema=false > dump 1`] = `
+exports[`fk_index_selection_example > scalarPropertiesForRelations=never > bidirectionalRelations=false > identifiedReferences=true > entityDefinition=decorators > dump 1`] = `
 [
   "import { Entity, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
 
@@ -865,7 +865,7 @@ export class Users {
 ]
 `;
 
-exports[`fk_index_selection_example > scalarPropertiesForRelations=never > bidirectionalRelations=false > identifiedReferences=true > entitySchema=true > dump 1`] = `
+exports[`fk_index_selection_example > scalarPropertiesForRelations=never > bidirectionalRelations=false > identifiedReferences=true > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 
@@ -941,7 +941,7 @@ export const UsersSchema = new EntitySchema({
 ]
 `;
 
-exports[`fk_index_selection_example > scalarPropertiesForRelations=never > bidirectionalRelations=true > identifiedReferences=false > entitySchema=false > dump 1`] = `
+exports[`fk_index_selection_example > scalarPropertiesForRelations=never > bidirectionalRelations=true > identifiedReferences=false > entityDefinition=decorators > dump 1`] = `
 [
   "import { Entity, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
 
@@ -1002,7 +1002,7 @@ export class Users {
 ]
 `;
 
-exports[`fk_index_selection_example > scalarPropertiesForRelations=never > bidirectionalRelations=true > identifiedReferences=false > entitySchema=true > dump 1`] = `
+exports[`fk_index_selection_example > scalarPropertiesForRelations=never > bidirectionalRelations=true > identifiedReferences=false > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 
@@ -1080,7 +1080,7 @@ export const UsersSchema = new EntitySchema({
 ]
 `;
 
-exports[`fk_index_selection_example > scalarPropertiesForRelations=never > bidirectionalRelations=true > identifiedReferences=true > entitySchema=false > dump 1`] = `
+exports[`fk_index_selection_example > scalarPropertiesForRelations=never > bidirectionalRelations=true > identifiedReferences=true > entityDefinition=decorators > dump 1`] = `
 [
   "import { Entity, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
 
@@ -1141,7 +1141,7 @@ export class Users {
 ]
 `;
 
-exports[`fk_index_selection_example > scalarPropertiesForRelations=never > bidirectionalRelations=true > identifiedReferences=true > entitySchema=true > dump 1`] = `
+exports[`fk_index_selection_example > scalarPropertiesForRelations=never > bidirectionalRelations=true > identifiedReferences=true > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 
@@ -1220,7 +1220,7 @@ export const UsersSchema = new EntitySchema({
 ]
 `;
 
-exports[`fk_index_selection_example > scalarPropertiesForRelations=smart > bidirectionalRelations=false > identifiedReferences=false > entitySchema=false > dump 1`] = `
+exports[`fk_index_selection_example > scalarPropertiesForRelations=smart > bidirectionalRelations=false > identifiedReferences=false > entityDefinition=decorators > dump 1`] = `
 [
   "import { Entity, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
 
@@ -1280,7 +1280,7 @@ export class Users {
 ]
 `;
 
-exports[`fk_index_selection_example > scalarPropertiesForRelations=smart > bidirectionalRelations=false > identifiedReferences=false > entitySchema=true > dump 1`] = `
+exports[`fk_index_selection_example > scalarPropertiesForRelations=smart > bidirectionalRelations=false > identifiedReferences=false > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 
@@ -1362,7 +1362,7 @@ export const UsersSchema = new EntitySchema({
 ]
 `;
 
-exports[`fk_index_selection_example > scalarPropertiesForRelations=smart > bidirectionalRelations=false > identifiedReferences=true > entitySchema=false > dump 1`] = `
+exports[`fk_index_selection_example > scalarPropertiesForRelations=smart > bidirectionalRelations=false > identifiedReferences=true > entityDefinition=decorators > dump 1`] = `
 [
   "import { Entity, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
 
@@ -1422,7 +1422,7 @@ export class Users {
 ]
 `;
 
-exports[`fk_index_selection_example > scalarPropertiesForRelations=smart > bidirectionalRelations=false > identifiedReferences=true > entitySchema=true > dump 1`] = `
+exports[`fk_index_selection_example > scalarPropertiesForRelations=smart > bidirectionalRelations=false > identifiedReferences=true > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 
@@ -1505,7 +1505,7 @@ export const UsersSchema = new EntitySchema({
 ]
 `;
 
-exports[`fk_index_selection_example > scalarPropertiesForRelations=smart > bidirectionalRelations=true > identifiedReferences=false > entitySchema=false > dump 1`] = `
+exports[`fk_index_selection_example > scalarPropertiesForRelations=smart > bidirectionalRelations=true > identifiedReferences=false > entityDefinition=decorators > dump 1`] = `
 [
   "import { Entity, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
 
@@ -1569,7 +1569,7 @@ export class Users {
 ]
 `;
 
-exports[`fk_index_selection_example > scalarPropertiesForRelations=smart > bidirectionalRelations=true > identifiedReferences=false > entitySchema=true > dump 1`] = `
+exports[`fk_index_selection_example > scalarPropertiesForRelations=smart > bidirectionalRelations=true > identifiedReferences=false > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 
@@ -1654,7 +1654,7 @@ export const UsersSchema = new EntitySchema({
 ]
 `;
 
-exports[`fk_index_selection_example > scalarPropertiesForRelations=smart > bidirectionalRelations=true > identifiedReferences=true > entitySchema=false > dump 1`] = `
+exports[`fk_index_selection_example > scalarPropertiesForRelations=smart > bidirectionalRelations=true > identifiedReferences=true > entityDefinition=decorators > dump 1`] = `
 [
   "import { Entity, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
 
@@ -1718,7 +1718,7 @@ export class Users {
 ]
 `;
 
-exports[`fk_index_selection_example > scalarPropertiesForRelations=smart > bidirectionalRelations=true > identifiedReferences=true > entitySchema=true > dump 1`] = `
+exports[`fk_index_selection_example > scalarPropertiesForRelations=smart > bidirectionalRelations=true > identifiedReferences=true > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 

--- a/tests/features/entity-generator/__snapshots__/FkSharedWithColumn.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/FkSharedWithColumn.mysql.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`fk_shared_with_column_example > scalarPropertiesForRelations=always > bidirectionalRelations=false > identifiedReferences=false > entitySchema=false > dump 1`] = `
+exports[`fk_shared_with_column_example > scalarPropertiesForRelations=always > bidirectionalRelations=false > identifiedReferences=false > entityDefinition=decorators > dump 1`] = `
 [
   "import { Entity, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
 
@@ -62,7 +62,7 @@ export class Users {
 ]
 `;
 
-exports[`fk_shared_with_column_example > scalarPropertiesForRelations=always > bidirectionalRelations=false > identifiedReferences=false > entitySchema=true > dump 1`] = `
+exports[`fk_shared_with_column_example > scalarPropertiesForRelations=always > bidirectionalRelations=false > identifiedReferences=false > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 
@@ -156,7 +156,7 @@ export const UsersSchema = new EntitySchema({
 ]
 `;
 
-exports[`fk_shared_with_column_example > scalarPropertiesForRelations=always > bidirectionalRelations=false > identifiedReferences=true > entitySchema=false > dump 1`] = `
+exports[`fk_shared_with_column_example > scalarPropertiesForRelations=always > bidirectionalRelations=false > identifiedReferences=true > entityDefinition=decorators > dump 1`] = `
 [
   "import { Entity, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
 
@@ -218,7 +218,7 @@ export class Users {
 ]
 `;
 
-exports[`fk_shared_with_column_example > scalarPropertiesForRelations=always > bidirectionalRelations=false > identifiedReferences=true > entitySchema=true > dump 1`] = `
+exports[`fk_shared_with_column_example > scalarPropertiesForRelations=always > bidirectionalRelations=false > identifiedReferences=true > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 
@@ -316,7 +316,7 @@ export const UsersSchema = new EntitySchema({
 ]
 `;
 
-exports[`fk_shared_with_column_example > scalarPropertiesForRelations=always > bidirectionalRelations=true > identifiedReferences=false > entitySchema=false > dump 1`] = `
+exports[`fk_shared_with_column_example > scalarPropertiesForRelations=always > bidirectionalRelations=true > identifiedReferences=false > entityDefinition=decorators > dump 1`] = `
 [
   "import { Collection, Entity, OneToMany, OneToOne, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
 import { LegalUserCountries } from './LegalUserCountries';
@@ -393,7 +393,7 @@ export class Users {
 ]
 `;
 
-exports[`fk_shared_with_column_example > scalarPropertiesForRelations=always > bidirectionalRelations=true > identifiedReferences=false > entitySchema=true > dump 1`] = `
+exports[`fk_shared_with_column_example > scalarPropertiesForRelations=always > bidirectionalRelations=true > identifiedReferences=false > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { LegalUserCountries } from './LegalUserCountries';
@@ -514,7 +514,7 @@ export const UsersSchema = new EntitySchema({
 ]
 `;
 
-exports[`fk_shared_with_column_example > scalarPropertiesForRelations=always > bidirectionalRelations=true > identifiedReferences=true > entitySchema=false > dump 1`] = `
+exports[`fk_shared_with_column_example > scalarPropertiesForRelations=always > bidirectionalRelations=true > identifiedReferences=true > entityDefinition=decorators > dump 1`] = `
 [
   "import { Collection, Entity, OneToMany, OneToOne, PrimaryKey, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { LegalUserCountries } from './LegalUserCountries';
@@ -591,7 +591,7 @@ export class Users {
 ]
 `;
 
-exports[`fk_shared_with_column_example > scalarPropertiesForRelations=always > bidirectionalRelations=true > identifiedReferences=true > entitySchema=true > dump 1`] = `
+exports[`fk_shared_with_column_example > scalarPropertiesForRelations=always > bidirectionalRelations=true > identifiedReferences=true > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { Collection, EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { LegalUserCountries } from './LegalUserCountries';
@@ -717,7 +717,7 @@ export const UsersSchema = new EntitySchema({
 ]
 `;
 
-exports[`fk_shared_with_column_example > scalarPropertiesForRelations=never > bidirectionalRelations=false > identifiedReferences=false > entitySchema=false > dump 1`] = `
+exports[`fk_shared_with_column_example > scalarPropertiesForRelations=never > bidirectionalRelations=false > identifiedReferences=false > entityDefinition=decorators > dump 1`] = `
 [
   "import { Entity, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
 
@@ -770,7 +770,7 @@ export class Users {
 ]
 `;
 
-exports[`fk_shared_with_column_example > scalarPropertiesForRelations=never > bidirectionalRelations=false > identifiedReferences=false > entitySchema=true > dump 1`] = `
+exports[`fk_shared_with_column_example > scalarPropertiesForRelations=never > bidirectionalRelations=false > identifiedReferences=false > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 
@@ -848,7 +848,7 @@ export const UsersSchema = new EntitySchema({
 ]
 `;
 
-exports[`fk_shared_with_column_example > scalarPropertiesForRelations=never > bidirectionalRelations=false > identifiedReferences=true > entitySchema=false > dump 1`] = `
+exports[`fk_shared_with_column_example > scalarPropertiesForRelations=never > bidirectionalRelations=false > identifiedReferences=true > entityDefinition=decorators > dump 1`] = `
 [
   "import { Entity, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
 
@@ -901,7 +901,7 @@ export class Users {
 ]
 `;
 
-exports[`fk_shared_with_column_example > scalarPropertiesForRelations=never > bidirectionalRelations=false > identifiedReferences=true > entitySchema=true > dump 1`] = `
+exports[`fk_shared_with_column_example > scalarPropertiesForRelations=never > bidirectionalRelations=false > identifiedReferences=true > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 
@@ -983,7 +983,7 @@ export const UsersSchema = new EntitySchema({
 ]
 `;
 
-exports[`fk_shared_with_column_example > scalarPropertiesForRelations=never > bidirectionalRelations=true > identifiedReferences=false > entitySchema=false > dump 1`] = `
+exports[`fk_shared_with_column_example > scalarPropertiesForRelations=never > bidirectionalRelations=true > identifiedReferences=false > entityDefinition=decorators > dump 1`] = `
 [
   "import { Collection, Entity, OneToMany, OneToOne, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
 import { LegalUserCountries } from './LegalUserCountries';
@@ -1051,7 +1051,7 @@ export class Users {
 ]
 `;
 
-exports[`fk_shared_with_column_example > scalarPropertiesForRelations=never > bidirectionalRelations=true > identifiedReferences=false > entitySchema=true > dump 1`] = `
+exports[`fk_shared_with_column_example > scalarPropertiesForRelations=never > bidirectionalRelations=true > identifiedReferences=false > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { LegalUserCountries } from './LegalUserCountries';
@@ -1156,7 +1156,7 @@ export const UsersSchema = new EntitySchema({
 ]
 `;
 
-exports[`fk_shared_with_column_example > scalarPropertiesForRelations=never > bidirectionalRelations=true > identifiedReferences=true > entitySchema=false > dump 1`] = `
+exports[`fk_shared_with_column_example > scalarPropertiesForRelations=never > bidirectionalRelations=true > identifiedReferences=true > entityDefinition=decorators > dump 1`] = `
 [
   "import { Collection, Entity, OneToMany, OneToOne, PrimaryKey, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { LegalUserCountries } from './LegalUserCountries';
@@ -1224,7 +1224,7 @@ export class Users {
 ]
 `;
 
-exports[`fk_shared_with_column_example > scalarPropertiesForRelations=never > bidirectionalRelations=true > identifiedReferences=true > entitySchema=true > dump 1`] = `
+exports[`fk_shared_with_column_example > scalarPropertiesForRelations=never > bidirectionalRelations=true > identifiedReferences=true > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { Collection, EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { LegalUserCountries } from './LegalUserCountries';
@@ -1334,7 +1334,7 @@ export const UsersSchema = new EntitySchema({
 ]
 `;
 
-exports[`fk_shared_with_column_example > scalarPropertiesForRelations=smart > bidirectionalRelations=false > identifiedReferences=false > entitySchema=false > dump 1`] = `
+exports[`fk_shared_with_column_example > scalarPropertiesForRelations=smart > bidirectionalRelations=false > identifiedReferences=false > entityDefinition=decorators > dump 1`] = `
 [
   "import { Entity, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
 
@@ -1387,7 +1387,7 @@ export class Users {
 ]
 `;
 
-exports[`fk_shared_with_column_example > scalarPropertiesForRelations=smart > bidirectionalRelations=false > identifiedReferences=false > entitySchema=true > dump 1`] = `
+exports[`fk_shared_with_column_example > scalarPropertiesForRelations=smart > bidirectionalRelations=false > identifiedReferences=false > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 
@@ -1465,7 +1465,7 @@ export const UsersSchema = new EntitySchema({
 ]
 `;
 
-exports[`fk_shared_with_column_example > scalarPropertiesForRelations=smart > bidirectionalRelations=false > identifiedReferences=true > entitySchema=false > dump 1`] = `
+exports[`fk_shared_with_column_example > scalarPropertiesForRelations=smart > bidirectionalRelations=false > identifiedReferences=true > entityDefinition=decorators > dump 1`] = `
 [
   "import { Entity, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
 
@@ -1518,7 +1518,7 @@ export class Users {
 ]
 `;
 
-exports[`fk_shared_with_column_example > scalarPropertiesForRelations=smart > bidirectionalRelations=false > identifiedReferences=true > entitySchema=true > dump 1`] = `
+exports[`fk_shared_with_column_example > scalarPropertiesForRelations=smart > bidirectionalRelations=false > identifiedReferences=true > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 
@@ -1600,7 +1600,7 @@ export const UsersSchema = new EntitySchema({
 ]
 `;
 
-exports[`fk_shared_with_column_example > scalarPropertiesForRelations=smart > bidirectionalRelations=true > identifiedReferences=false > entitySchema=false > dump 1`] = `
+exports[`fk_shared_with_column_example > scalarPropertiesForRelations=smart > bidirectionalRelations=true > identifiedReferences=false > entityDefinition=decorators > dump 1`] = `
 [
   "import { Collection, Entity, OneToMany, OneToOne, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
 import { LegalUserCountries } from './LegalUserCountries';
@@ -1668,7 +1668,7 @@ export class Users {
 ]
 `;
 
-exports[`fk_shared_with_column_example > scalarPropertiesForRelations=smart > bidirectionalRelations=true > identifiedReferences=false > entitySchema=true > dump 1`] = `
+exports[`fk_shared_with_column_example > scalarPropertiesForRelations=smart > bidirectionalRelations=true > identifiedReferences=false > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { LegalUserCountries } from './LegalUserCountries';
@@ -1773,7 +1773,7 @@ export const UsersSchema = new EntitySchema({
 ]
 `;
 
-exports[`fk_shared_with_column_example > scalarPropertiesForRelations=smart > bidirectionalRelations=true > identifiedReferences=true > entitySchema=false > dump 1`] = `
+exports[`fk_shared_with_column_example > scalarPropertiesForRelations=smart > bidirectionalRelations=true > identifiedReferences=true > entityDefinition=decorators > dump 1`] = `
 [
   "import { Collection, Entity, OneToMany, OneToOne, PrimaryKey, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { LegalUserCountries } from './LegalUserCountries';
@@ -1841,7 +1841,7 @@ export class Users {
 ]
 `;
 
-exports[`fk_shared_with_column_example > scalarPropertiesForRelations=smart > bidirectionalRelations=true > identifiedReferences=true > entitySchema=true > dump 1`] = `
+exports[`fk_shared_with_column_example > scalarPropertiesForRelations=smart > bidirectionalRelations=true > identifiedReferences=true > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { Collection, EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { LegalUserCountries } from './LegalUserCountries';

--- a/tests/features/entity-generator/__snapshots__/FksWithDefaults.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/FksWithDefaults.mysql.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`fk_defaults_example > scalarPropertiesForRelations=always > bidirectionalRelations=false > identifiedReferences=false > esmImport=false > entitySchema=false > dump 1`] = `
+exports[`fk_defaults_example > scalarPropertiesForRelations=always > bidirectionalRelations=false > identifiedReferences=false > esmImport=false > entityDefinition=decorators > dump 1`] = `
 [
   "import { Entity, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 
@@ -78,7 +78,7 @@ export class WalletType {
 ]
 `;
 
-exports[`fk_defaults_example > scalarPropertiesForRelations=always > bidirectionalRelations=false > identifiedReferences=false > esmImport=false > entitySchema=true > dump 1`] = `
+exports[`fk_defaults_example > scalarPropertiesForRelations=always > bidirectionalRelations=false > identifiedReferences=false > esmImport=false > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 
@@ -172,7 +172,7 @@ export const WalletTypeSchema = new EntitySchema({
 ]
 `;
 
-exports[`fk_defaults_example > scalarPropertiesForRelations=always > bidirectionalRelations=false > identifiedReferences=false > esmImport=true > entitySchema=false > dump 1`] = `
+exports[`fk_defaults_example > scalarPropertiesForRelations=always > bidirectionalRelations=false > identifiedReferences=false > esmImport=true > entityDefinition=decorators > dump 1`] = `
 [
   "import { Entity, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 
@@ -250,7 +250,7 @@ export class WalletType {
 ]
 `;
 
-exports[`fk_defaults_example > scalarPropertiesForRelations=always > bidirectionalRelations=false > identifiedReferences=false > esmImport=true > entitySchema=true > dump 1`] = `
+exports[`fk_defaults_example > scalarPropertiesForRelations=always > bidirectionalRelations=false > identifiedReferences=false > esmImport=true > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 
@@ -344,7 +344,7 @@ export const WalletTypeSchema = new EntitySchema({
 ]
 `;
 
-exports[`fk_defaults_example > scalarPropertiesForRelations=always > bidirectionalRelations=false > identifiedReferences=true > esmImport=false > entitySchema=false > dump 1`] = `
+exports[`fk_defaults_example > scalarPropertiesForRelations=always > bidirectionalRelations=false > identifiedReferences=true > esmImport=false > entityDefinition=decorators > dump 1`] = `
 [
   "import { Entity, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 
@@ -422,7 +422,7 @@ export class WalletType {
 ]
 `;
 
-exports[`fk_defaults_example > scalarPropertiesForRelations=always > bidirectionalRelations=false > identifiedReferences=true > esmImport=false > entitySchema=true > dump 1`] = `
+exports[`fk_defaults_example > scalarPropertiesForRelations=always > bidirectionalRelations=false > identifiedReferences=true > esmImport=false > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 
@@ -520,7 +520,7 @@ export const WalletTypeSchema = new EntitySchema({
 ]
 `;
 
-exports[`fk_defaults_example > scalarPropertiesForRelations=always > bidirectionalRelations=false > identifiedReferences=true > esmImport=true > entitySchema=false > dump 1`] = `
+exports[`fk_defaults_example > scalarPropertiesForRelations=always > bidirectionalRelations=false > identifiedReferences=true > esmImport=true > entityDefinition=decorators > dump 1`] = `
 [
   "import { Entity, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 
@@ -598,7 +598,7 @@ export class WalletType {
 ]
 `;
 
-exports[`fk_defaults_example > scalarPropertiesForRelations=always > bidirectionalRelations=false > identifiedReferences=true > esmImport=true > entitySchema=true > dump 1`] = `
+exports[`fk_defaults_example > scalarPropertiesForRelations=always > bidirectionalRelations=false > identifiedReferences=true > esmImport=true > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 
@@ -696,7 +696,7 @@ export const WalletTypeSchema = new EntitySchema({
 ]
 `;
 
-exports[`fk_defaults_example > scalarPropertiesForRelations=always > bidirectionalRelations=true > identifiedReferences=false > esmImport=false > entitySchema=false > dump 1`] = `
+exports[`fk_defaults_example > scalarPropertiesForRelations=always > bidirectionalRelations=true > identifiedReferences=false > esmImport=false > entityDefinition=decorators > dump 1`] = `
 [
   "import { Collection, Entity, OneToMany, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { WalletType } from './WalletType';
@@ -786,7 +786,7 @@ export class WalletType {
 ]
 `;
 
-exports[`fk_defaults_example > scalarPropertiesForRelations=always > bidirectionalRelations=true > identifiedReferences=false > esmImport=false > entitySchema=true > dump 1`] = `
+exports[`fk_defaults_example > scalarPropertiesForRelations=always > bidirectionalRelations=true > identifiedReferences=false > esmImport=false > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { WalletType } from './WalletType';
@@ -901,7 +901,7 @@ export const WalletTypeSchema = new EntitySchema({
 ]
 `;
 
-exports[`fk_defaults_example > scalarPropertiesForRelations=always > bidirectionalRelations=true > identifiedReferences=false > esmImport=true > entitySchema=false > dump 1`] = `
+exports[`fk_defaults_example > scalarPropertiesForRelations=always > bidirectionalRelations=true > identifiedReferences=false > esmImport=true > entityDefinition=decorators > dump 1`] = `
 [
   "import { Collection, Entity, OneToMany, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { WalletType } from './WalletType.js';
@@ -991,7 +991,7 @@ export class WalletType {
 ]
 `;
 
-exports[`fk_defaults_example > scalarPropertiesForRelations=always > bidirectionalRelations=true > identifiedReferences=false > esmImport=true > entitySchema=true > dump 1`] = `
+exports[`fk_defaults_example > scalarPropertiesForRelations=always > bidirectionalRelations=true > identifiedReferences=false > esmImport=true > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { WalletType } from './WalletType.js';
@@ -1106,7 +1106,7 @@ export const WalletTypeSchema = new EntitySchema({
 ]
 `;
 
-exports[`fk_defaults_example > scalarPropertiesForRelations=always > bidirectionalRelations=true > identifiedReferences=true > esmImport=false > entitySchema=false > dump 1`] = `
+exports[`fk_defaults_example > scalarPropertiesForRelations=always > bidirectionalRelations=true > identifiedReferences=true > esmImport=false > entityDefinition=decorators > dump 1`] = `
 [
   "import { Collection, Entity, OneToMany, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { WalletType } from './WalletType';
@@ -1196,7 +1196,7 @@ export class WalletType {
 ]
 `;
 
-exports[`fk_defaults_example > scalarPropertiesForRelations=always > bidirectionalRelations=true > identifiedReferences=true > esmImport=false > entitySchema=true > dump 1`] = `
+exports[`fk_defaults_example > scalarPropertiesForRelations=always > bidirectionalRelations=true > identifiedReferences=true > esmImport=false > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { WalletType } from './WalletType';
@@ -1316,7 +1316,7 @@ export const WalletTypeSchema = new EntitySchema({
 ]
 `;
 
-exports[`fk_defaults_example > scalarPropertiesForRelations=always > bidirectionalRelations=true > identifiedReferences=true > esmImport=true > entitySchema=false > dump 1`] = `
+exports[`fk_defaults_example > scalarPropertiesForRelations=always > bidirectionalRelations=true > identifiedReferences=true > esmImport=true > entityDefinition=decorators > dump 1`] = `
 [
   "import { Collection, Entity, OneToMany, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { WalletType } from './WalletType.js';
@@ -1406,7 +1406,7 @@ export class WalletType {
 ]
 `;
 
-exports[`fk_defaults_example > scalarPropertiesForRelations=always > bidirectionalRelations=true > identifiedReferences=true > esmImport=true > entitySchema=true > dump 1`] = `
+exports[`fk_defaults_example > scalarPropertiesForRelations=always > bidirectionalRelations=true > identifiedReferences=true > esmImport=true > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { WalletType } from './WalletType.js';
@@ -1526,7 +1526,7 @@ export const WalletTypeSchema = new EntitySchema({
 ]
 `;
 
-exports[`fk_defaults_example > scalarPropertiesForRelations=never > bidirectionalRelations=false > identifiedReferences=false > esmImport=false > entitySchema=false > dump 1`] = `
+exports[`fk_defaults_example > scalarPropertiesForRelations=never > bidirectionalRelations=false > identifiedReferences=false > esmImport=false > entityDefinition=decorators > dump 1`] = `
 [
   "import { Entity, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 
@@ -1590,7 +1590,7 @@ export class WalletType {
 ]
 `;
 
-exports[`fk_defaults_example > scalarPropertiesForRelations=never > bidirectionalRelations=false > identifiedReferences=false > esmImport=false > entitySchema=true > dump 1`] = `
+exports[`fk_defaults_example > scalarPropertiesForRelations=never > bidirectionalRelations=false > identifiedReferences=false > esmImport=false > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 
@@ -1671,7 +1671,7 @@ export const WalletTypeSchema = new EntitySchema({
 ]
 `;
 
-exports[`fk_defaults_example > scalarPropertiesForRelations=never > bidirectionalRelations=false > identifiedReferences=false > esmImport=true > entitySchema=false > dump 1`] = `
+exports[`fk_defaults_example > scalarPropertiesForRelations=never > bidirectionalRelations=false > identifiedReferences=false > esmImport=true > entityDefinition=decorators > dump 1`] = `
 [
   "import { Entity, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 
@@ -1735,7 +1735,7 @@ export class WalletType {
 ]
 `;
 
-exports[`fk_defaults_example > scalarPropertiesForRelations=never > bidirectionalRelations=false > identifiedReferences=false > esmImport=true > entitySchema=true > dump 1`] = `
+exports[`fk_defaults_example > scalarPropertiesForRelations=never > bidirectionalRelations=false > identifiedReferences=false > esmImport=true > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 
@@ -1816,7 +1816,7 @@ export const WalletTypeSchema = new EntitySchema({
 ]
 `;
 
-exports[`fk_defaults_example > scalarPropertiesForRelations=never > bidirectionalRelations=false > identifiedReferences=true > esmImport=false > entitySchema=false > dump 1`] = `
+exports[`fk_defaults_example > scalarPropertiesForRelations=never > bidirectionalRelations=false > identifiedReferences=true > esmImport=false > entityDefinition=decorators > dump 1`] = `
 [
   "import { Entity, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 
@@ -1880,7 +1880,7 @@ export class WalletType {
 ]
 `;
 
-exports[`fk_defaults_example > scalarPropertiesForRelations=never > bidirectionalRelations=false > identifiedReferences=true > esmImport=false > entitySchema=true > dump 1`] = `
+exports[`fk_defaults_example > scalarPropertiesForRelations=never > bidirectionalRelations=false > identifiedReferences=true > esmImport=false > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 
@@ -1970,7 +1970,7 @@ export const WalletTypeSchema = new EntitySchema({
 ]
 `;
 
-exports[`fk_defaults_example > scalarPropertiesForRelations=never > bidirectionalRelations=false > identifiedReferences=true > esmImport=true > entitySchema=false > dump 1`] = `
+exports[`fk_defaults_example > scalarPropertiesForRelations=never > bidirectionalRelations=false > identifiedReferences=true > esmImport=true > entityDefinition=decorators > dump 1`] = `
 [
   "import { Entity, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 
@@ -2034,7 +2034,7 @@ export class WalletType {
 ]
 `;
 
-exports[`fk_defaults_example > scalarPropertiesForRelations=never > bidirectionalRelations=false > identifiedReferences=true > esmImport=true > entitySchema=true > dump 1`] = `
+exports[`fk_defaults_example > scalarPropertiesForRelations=never > bidirectionalRelations=false > identifiedReferences=true > esmImport=true > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 
@@ -2124,7 +2124,7 @@ export const WalletTypeSchema = new EntitySchema({
 ]
 `;
 
-exports[`fk_defaults_example > scalarPropertiesForRelations=never > bidirectionalRelations=true > identifiedReferences=false > esmImport=false > entitySchema=false > dump 1`] = `
+exports[`fk_defaults_example > scalarPropertiesForRelations=never > bidirectionalRelations=true > identifiedReferences=false > esmImport=false > entityDefinition=decorators > dump 1`] = `
 [
   "import { Collection, Entity, OneToMany, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { WalletType } from './WalletType';
@@ -2200,7 +2200,7 @@ export class WalletType {
 ]
 `;
 
-exports[`fk_defaults_example > scalarPropertiesForRelations=never > bidirectionalRelations=true > identifiedReferences=false > esmImport=false > entitySchema=true > dump 1`] = `
+exports[`fk_defaults_example > scalarPropertiesForRelations=never > bidirectionalRelations=true > identifiedReferences=false > esmImport=false > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { WalletType } from './WalletType';
@@ -2298,7 +2298,7 @@ export const WalletTypeSchema = new EntitySchema({
 ]
 `;
 
-exports[`fk_defaults_example > scalarPropertiesForRelations=never > bidirectionalRelations=true > identifiedReferences=false > esmImport=true > entitySchema=false > dump 1`] = `
+exports[`fk_defaults_example > scalarPropertiesForRelations=never > bidirectionalRelations=true > identifiedReferences=false > esmImport=true > entityDefinition=decorators > dump 1`] = `
 [
   "import { Collection, Entity, OneToMany, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { WalletType } from './WalletType.js';
@@ -2374,7 +2374,7 @@ export class WalletType {
 ]
 `;
 
-exports[`fk_defaults_example > scalarPropertiesForRelations=never > bidirectionalRelations=true > identifiedReferences=false > esmImport=true > entitySchema=true > dump 1`] = `
+exports[`fk_defaults_example > scalarPropertiesForRelations=never > bidirectionalRelations=true > identifiedReferences=false > esmImport=true > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { WalletType } from './WalletType.js';
@@ -2472,7 +2472,7 @@ export const WalletTypeSchema = new EntitySchema({
 ]
 `;
 
-exports[`fk_defaults_example > scalarPropertiesForRelations=never > bidirectionalRelations=true > identifiedReferences=true > esmImport=false > entitySchema=false > dump 1`] = `
+exports[`fk_defaults_example > scalarPropertiesForRelations=never > bidirectionalRelations=true > identifiedReferences=true > esmImport=false > entityDefinition=decorators > dump 1`] = `
 [
   "import { Collection, Entity, OneToMany, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { WalletType } from './WalletType';
@@ -2548,7 +2548,7 @@ export class WalletType {
 ]
 `;
 
-exports[`fk_defaults_example > scalarPropertiesForRelations=never > bidirectionalRelations=true > identifiedReferences=true > esmImport=false > entitySchema=true > dump 1`] = `
+exports[`fk_defaults_example > scalarPropertiesForRelations=never > bidirectionalRelations=true > identifiedReferences=true > esmImport=false > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { WalletType } from './WalletType';
@@ -2660,7 +2660,7 @@ export const WalletTypeSchema = new EntitySchema({
 ]
 `;
 
-exports[`fk_defaults_example > scalarPropertiesForRelations=never > bidirectionalRelations=true > identifiedReferences=true > esmImport=true > entitySchema=false > dump 1`] = `
+exports[`fk_defaults_example > scalarPropertiesForRelations=never > bidirectionalRelations=true > identifiedReferences=true > esmImport=true > entityDefinition=decorators > dump 1`] = `
 [
   "import { Collection, Entity, OneToMany, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { WalletType } from './WalletType.js';
@@ -2736,7 +2736,7 @@ export class WalletType {
 ]
 `;
 
-exports[`fk_defaults_example > scalarPropertiesForRelations=never > bidirectionalRelations=true > identifiedReferences=true > esmImport=true > entitySchema=true > dump 1`] = `
+exports[`fk_defaults_example > scalarPropertiesForRelations=never > bidirectionalRelations=true > identifiedReferences=true > esmImport=true > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { WalletType } from './WalletType.js';
@@ -2848,7 +2848,7 @@ export const WalletTypeSchema = new EntitySchema({
 ]
 `;
 
-exports[`fk_defaults_example > scalarPropertiesForRelations=smart > bidirectionalRelations=false > identifiedReferences=false > esmImport=false > entitySchema=false > dump 1`] = `
+exports[`fk_defaults_example > scalarPropertiesForRelations=smart > bidirectionalRelations=false > identifiedReferences=false > esmImport=false > entityDefinition=decorators > dump 1`] = `
 [
   "import { Entity, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 
@@ -2912,7 +2912,7 @@ export class WalletType {
 ]
 `;
 
-exports[`fk_defaults_example > scalarPropertiesForRelations=smart > bidirectionalRelations=false > identifiedReferences=false > esmImport=false > entitySchema=true > dump 1`] = `
+exports[`fk_defaults_example > scalarPropertiesForRelations=smart > bidirectionalRelations=false > identifiedReferences=false > esmImport=false > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 
@@ -2993,7 +2993,7 @@ export const WalletTypeSchema = new EntitySchema({
 ]
 `;
 
-exports[`fk_defaults_example > scalarPropertiesForRelations=smart > bidirectionalRelations=false > identifiedReferences=false > esmImport=true > entitySchema=false > dump 1`] = `
+exports[`fk_defaults_example > scalarPropertiesForRelations=smart > bidirectionalRelations=false > identifiedReferences=false > esmImport=true > entityDefinition=decorators > dump 1`] = `
 [
   "import { Entity, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 
@@ -3057,7 +3057,7 @@ export class WalletType {
 ]
 `;
 
-exports[`fk_defaults_example > scalarPropertiesForRelations=smart > bidirectionalRelations=false > identifiedReferences=false > esmImport=true > entitySchema=true > dump 1`] = `
+exports[`fk_defaults_example > scalarPropertiesForRelations=smart > bidirectionalRelations=false > identifiedReferences=false > esmImport=true > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 
@@ -3138,7 +3138,7 @@ export const WalletTypeSchema = new EntitySchema({
 ]
 `;
 
-exports[`fk_defaults_example > scalarPropertiesForRelations=smart > bidirectionalRelations=false > identifiedReferences=true > esmImport=false > entitySchema=false > dump 1`] = `
+exports[`fk_defaults_example > scalarPropertiesForRelations=smart > bidirectionalRelations=false > identifiedReferences=true > esmImport=false > entityDefinition=decorators > dump 1`] = `
 [
   "import { Entity, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 
@@ -3202,7 +3202,7 @@ export class WalletType {
 ]
 `;
 
-exports[`fk_defaults_example > scalarPropertiesForRelations=smart > bidirectionalRelations=false > identifiedReferences=true > esmImport=false > entitySchema=true > dump 1`] = `
+exports[`fk_defaults_example > scalarPropertiesForRelations=smart > bidirectionalRelations=false > identifiedReferences=true > esmImport=false > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 
@@ -3292,7 +3292,7 @@ export const WalletTypeSchema = new EntitySchema({
 ]
 `;
 
-exports[`fk_defaults_example > scalarPropertiesForRelations=smart > bidirectionalRelations=false > identifiedReferences=true > esmImport=true > entitySchema=false > dump 1`] = `
+exports[`fk_defaults_example > scalarPropertiesForRelations=smart > bidirectionalRelations=false > identifiedReferences=true > esmImport=true > entityDefinition=decorators > dump 1`] = `
 [
   "import { Entity, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 
@@ -3356,7 +3356,7 @@ export class WalletType {
 ]
 `;
 
-exports[`fk_defaults_example > scalarPropertiesForRelations=smart > bidirectionalRelations=false > identifiedReferences=true > esmImport=true > entitySchema=true > dump 1`] = `
+exports[`fk_defaults_example > scalarPropertiesForRelations=smart > bidirectionalRelations=false > identifiedReferences=true > esmImport=true > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 
@@ -3446,7 +3446,7 @@ export const WalletTypeSchema = new EntitySchema({
 ]
 `;
 
-exports[`fk_defaults_example > scalarPropertiesForRelations=smart > bidirectionalRelations=true > identifiedReferences=false > esmImport=false > entitySchema=false > dump 1`] = `
+exports[`fk_defaults_example > scalarPropertiesForRelations=smart > bidirectionalRelations=true > identifiedReferences=false > esmImport=false > entityDefinition=decorators > dump 1`] = `
 [
   "import { Collection, Entity, OneToMany, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { WalletType } from './WalletType';
@@ -3522,7 +3522,7 @@ export class WalletType {
 ]
 `;
 
-exports[`fk_defaults_example > scalarPropertiesForRelations=smart > bidirectionalRelations=true > identifiedReferences=false > esmImport=false > entitySchema=true > dump 1`] = `
+exports[`fk_defaults_example > scalarPropertiesForRelations=smart > bidirectionalRelations=true > identifiedReferences=false > esmImport=false > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { WalletType } from './WalletType';
@@ -3620,7 +3620,7 @@ export const WalletTypeSchema = new EntitySchema({
 ]
 `;
 
-exports[`fk_defaults_example > scalarPropertiesForRelations=smart > bidirectionalRelations=true > identifiedReferences=false > esmImport=true > entitySchema=false > dump 1`] = `
+exports[`fk_defaults_example > scalarPropertiesForRelations=smart > bidirectionalRelations=true > identifiedReferences=false > esmImport=true > entityDefinition=decorators > dump 1`] = `
 [
   "import { Collection, Entity, OneToMany, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { WalletType } from './WalletType.js';
@@ -3696,7 +3696,7 @@ export class WalletType {
 ]
 `;
 
-exports[`fk_defaults_example > scalarPropertiesForRelations=smart > bidirectionalRelations=true > identifiedReferences=false > esmImport=true > entitySchema=true > dump 1`] = `
+exports[`fk_defaults_example > scalarPropertiesForRelations=smart > bidirectionalRelations=true > identifiedReferences=false > esmImport=true > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { WalletType } from './WalletType.js';
@@ -3794,7 +3794,7 @@ export const WalletTypeSchema = new EntitySchema({
 ]
 `;
 
-exports[`fk_defaults_example > scalarPropertiesForRelations=smart > bidirectionalRelations=true > identifiedReferences=true > esmImport=false > entitySchema=false > dump 1`] = `
+exports[`fk_defaults_example > scalarPropertiesForRelations=smart > bidirectionalRelations=true > identifiedReferences=true > esmImport=false > entityDefinition=decorators > dump 1`] = `
 [
   "import { Collection, Entity, OneToMany, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { WalletType } from './WalletType';
@@ -3870,7 +3870,7 @@ export class WalletType {
 ]
 `;
 
-exports[`fk_defaults_example > scalarPropertiesForRelations=smart > bidirectionalRelations=true > identifiedReferences=true > esmImport=false > entitySchema=true > dump 1`] = `
+exports[`fk_defaults_example > scalarPropertiesForRelations=smart > bidirectionalRelations=true > identifiedReferences=true > esmImport=false > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { WalletType } from './WalletType';
@@ -3982,7 +3982,7 @@ export const WalletTypeSchema = new EntitySchema({
 ]
 `;
 
-exports[`fk_defaults_example > scalarPropertiesForRelations=smart > bidirectionalRelations=true > identifiedReferences=true > esmImport=true > entitySchema=false > dump 1`] = `
+exports[`fk_defaults_example > scalarPropertiesForRelations=smart > bidirectionalRelations=true > identifiedReferences=true > esmImport=true > entityDefinition=decorators > dump 1`] = `
 [
   "import { Collection, Entity, OneToMany, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { WalletType } from './WalletType.js';
@@ -4058,7 +4058,7 @@ export class WalletType {
 ]
 `;
 
-exports[`fk_defaults_example > scalarPropertiesForRelations=smart > bidirectionalRelations=true > identifiedReferences=true > esmImport=true > entitySchema=true > dump 1`] = `
+exports[`fk_defaults_example > scalarPropertiesForRelations=smart > bidirectionalRelations=true > identifiedReferences=true > esmImport=true > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { WalletType } from './WalletType.js';

--- a/tests/features/entity-generator/__snapshots__/GH5912.postgresql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/GH5912.postgresql.test.ts.snap
@@ -2,64 +2,69 @@
 
 exports[`gh5912 1`] = `
 [
-  "import { BaseEntity, Collection, Entity, OneToMany, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { BaseEntity, Collection, PrimaryKeyProp, defineEntity, p } from '@mikro-orm/core';
 import { UserDepartment } from './UserDepartment';
 
-@Entity()
 export class Department extends BaseEntity {
-
   [PrimaryKeyProp]?: 'departmentId';
-
-  @PrimaryKey({ type: 'integer' })
   departmentId!: number;
-
-  @OneToMany({ entity: () => UserDepartment, mappedBy: 'department' })
   userDepartmentCollection = new Collection<UserDepartment>(this);
-
 }
+
+export const DepartmentSchema = defineEntity({
+  class: Department,
+  properties: {
+    departmentId: p.integer().primary(),
+    userDepartmentCollection: () => p.oneToMany(UserDepartment).mappedBy('department'),
+  },
+});
 ",
-  "import { BaseEntity, Collection, Entity, OneToMany, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { BaseEntity, Collection, PrimaryKeyProp, defineEntity, p } from '@mikro-orm/core';
 import { UserDepartment } from './UserDepartment';
 
-@Entity()
 export class User extends BaseEntity {
-
   [PrimaryKeyProp]?: 'userId';
-
-  @PrimaryKey({ type: 'integer' })
   userId!: number;
-
-  @OneToMany({ entity: () => UserDepartment, mappedBy: 'user' })
   userDepartmentCollection = new Collection<UserDepartment>(this);
-
 }
+
+export const UserSchema = defineEntity({
+  class: User,
+  properties: {
+    userId: p.integer().primary(),
+    userDepartmentCollection: () => p.oneToMany(UserDepartment).mappedBy('user'),
+  },
+});
 ",
-  "import { BaseEntity, Entity, ManyToOne, PrimaryKey, PrimaryKeyProp, Property, type Ref, Unique } from '@mikro-orm/core';
+  "import { BaseEntity, PrimaryKeyProp, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Department } from './Department';
 import { User } from './User';
 
-@Entity()
-@Unique({ name: 'user_department_department_id_user_id_unique', properties: ['departmentId', 'userId'] })
 export class UserDepartment extends BaseEntity {
-
   [PrimaryKeyProp]?: 'userDepartmentId';
-
-  @PrimaryKey({ type: 'integer' })
   userDepartmentId!: number;
-
-  @ManyToOne({ entity: () => Department, ref: true, fieldName: 'department_id' })
   department!: Ref<Department>;
-
-  @Property({ type: 'integer', persist: false })
   departmentId!: number;
-
-  @ManyToOne({ entity: () => User, ref: true, fieldName: 'user_id' })
   user!: Ref<User>;
-
-  @Property({ type: 'integer', persist: false })
   userId!: number;
-
 }
+
+export const UserDepartmentSchema = defineEntity({
+  class: UserDepartment,
+  uniques: [
+    {
+      name: 'user_department_department_id_user_id_unique',
+      properties: ['departmentId', 'userId'],
+    },
+  ],
+  properties: {
+    userDepartmentId: p.integer().primary(),
+    department: () => p.manyToOne(Department).ref().name('department_id'),
+    departmentId: p.integer().persist(false),
+    user: () => p.manyToOne(User).ref().name('user_id'),
+    userId: p.integer().persist(false),
+  },
+});
 ",
 ]
 `;

--- a/tests/features/entity-generator/__snapshots__/GeneratedColumns.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/GeneratedColumns.mysql.test.ts.snap
@@ -2,7 +2,8 @@
 
 exports[`generated_columns_example > decorators > as functions from extensions > dump 1`] = `
 [
-  "import { Entity, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, Entity, OneToMany, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
+import { Users } from './Users';
 
 @Entity()
 export class AllowedAgesAtCreation {
@@ -12,9 +13,12 @@ export class AllowedAgesAtCreation {
   @PrimaryKey({ type: 'tinyint', autoincrement: false })
   age!: number;
 
+  @OneToMany({ entity: () => Users, mappedBy: 'ageAtCreation' })
+  usersCollection = new Collection<Users>(this);
+
 }
 ",
-  "import { Entity, ManyToOne, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKey, Property, type Ref } from '@mikro-orm/core';
 import { AllowedAgesAtCreation } from './AllowedAgesAtCreation';
 
 @Entity()
@@ -38,8 +42,8 @@ export class Users {
   @Property({ type: 'date' })
   dateOfBirth!: string;
 
-  @ManyToOne({ entity: () => AllowedAgesAtCreation, fieldName: 'age_at_creation', deleteRule: 'cascade', generated: () => "(timestampdiff(YEAR,\`date_of_birth\`,\`created_at\`)) stored", nullable: true, index: 'fk_users_allowed_ages_at_creation_idx' })
-  ageAtCreation?: AllowedAgesAtCreation;
+  @ManyToOne({ entity: () => AllowedAgesAtCreation, ref: true, fieldName: 'age_at_creation', deleteRule: 'cascade', generated: () => "(timestampdiff(YEAR,\`date_of_birth\`,\`created_at\`)) stored", nullable: true, index: 'fk_users_allowed_ages_at_creation_idx' })
+  ageAtCreation?: Ref<AllowedAgesAtCreation>;
 
 }
 ",
@@ -48,7 +52,8 @@ export class Users {
 
 exports[`generated_columns_example > decorators > generates from db > dump 1`] = `
 [
-  "import { Entity, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, Entity, OneToMany, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
+import { Users } from './Users';
 
 @Entity()
 export class AllowedAgesAtCreation {
@@ -58,9 +63,12 @@ export class AllowedAgesAtCreation {
   @PrimaryKey({ type: 'tinyint', autoincrement: false })
   age!: number;
 
+  @OneToMany({ entity: () => Users, mappedBy: 'ageAtCreation' })
+  usersCollection = new Collection<Users>(this);
+
 }
 ",
-  "import { Entity, ManyToOne, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKey, Property, type Ref } from '@mikro-orm/core';
 import { AllowedAgesAtCreation } from './AllowedAgesAtCreation';
 
 @Entity()
@@ -84,8 +92,8 @@ export class Users {
   @Property({ type: 'date' })
   dateOfBirth!: string;
 
-  @ManyToOne({ entity: () => AllowedAgesAtCreation, fieldName: 'age_at_creation', deleteRule: 'cascade', generated: '(timestampdiff(YEAR,\`date_of_birth\`,\`created_at\`)) stored', nullable: true, index: 'fk_users_allowed_ages_at_creation_idx' })
-  ageAtCreation?: AllowedAgesAtCreation;
+  @ManyToOne({ entity: () => AllowedAgesAtCreation, ref: true, fieldName: 'age_at_creation', deleteRule: 'cascade', generated: '(timestampdiff(YEAR,\`date_of_birth\`,\`created_at\`)) stored', nullable: true, index: 'fk_users_allowed_ages_at_creation_idx' })
+  ageAtCreation?: Ref<AllowedAgesAtCreation>;
 
 }
 ",
@@ -94,21 +102,28 @@ export class Users {
 
 exports[`generated_columns_example > entitySchema > as functions from extensions > dump 1`] = `
 [
-  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Users } from './Users';
 
 export class AllowedAgesAtCreation {
   [PrimaryKeyProp]?: 'age';
   age!: number;
+  usersCollection = new Collection<Users>(this);
 }
 
 export const AllowedAgesAtCreationSchema = new EntitySchema({
   class: AllowedAgesAtCreation,
   properties: {
     age: { primary: true, type: 'tinyint', autoincrement: false },
+    usersCollection: {
+      kind: '1:m',
+      entity: () => Users,
+      mappedBy: 'ageAtCreation',
+    },
   },
 });
 ",
-  "import { EntitySchema, type Opt } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, type Ref } from '@mikro-orm/core';
 import { AllowedAgesAtCreation } from './AllowedAgesAtCreation';
 
 export class Users {
@@ -118,7 +133,7 @@ export class Users {
   fullName!: string & Opt;
   createdAt!: Date & Opt;
   dateOfBirth!: string;
-  ageAtCreation?: AllowedAgesAtCreation;
+  ageAtCreation?: Ref<AllowedAgesAtCreation>;
 }
 
 export const UsersSchema = new EntitySchema({
@@ -137,6 +152,7 @@ export const UsersSchema = new EntitySchema({
     ageAtCreation: {
       kind: 'm:1',
       entity: () => AllowedAgesAtCreation,
+      ref: true,
       fieldName: 'age_at_creation',
       deleteRule: 'cascade',
       generated: () => "(timestampdiff(YEAR,\`date_of_birth\`,\`created_at\`)) stored",
@@ -151,21 +167,28 @@ export const UsersSchema = new EntitySchema({
 
 exports[`generated_columns_example > entitySchema > generates from db > dump 1`] = `
 [
-  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Users } from './Users';
 
 export class AllowedAgesAtCreation {
   [PrimaryKeyProp]?: 'age';
   age!: number;
+  usersCollection = new Collection<Users>(this);
 }
 
 export const AllowedAgesAtCreationSchema = new EntitySchema({
   class: AllowedAgesAtCreation,
   properties: {
     age: { primary: true, type: 'tinyint', autoincrement: false },
+    usersCollection: {
+      kind: '1:m',
+      entity: () => Users,
+      mappedBy: 'ageAtCreation',
+    },
   },
 });
 ",
-  "import { EntitySchema, type Opt } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, type Ref } from '@mikro-orm/core';
 import { AllowedAgesAtCreation } from './AllowedAgesAtCreation';
 
 export class Users {
@@ -175,7 +198,7 @@ export class Users {
   fullName!: string & Opt;
   createdAt!: Date & Opt;
   dateOfBirth!: string;
-  ageAtCreation?: AllowedAgesAtCreation;
+  ageAtCreation?: Ref<AllowedAgesAtCreation>;
 }
 
 export const UsersSchema = new EntitySchema({
@@ -194,6 +217,7 @@ export const UsersSchema = new EntitySchema({
     ageAtCreation: {
       kind: 'm:1',
       entity: () => AllowedAgesAtCreation,
+      ref: true,
       fieldName: 'age_at_creation',
       deleteRule: 'cascade',
       generated: '(timestampdiff(YEAR,\`date_of_birth\`,\`created_at\`)) stored',

--- a/tests/features/entity-generator/__snapshots__/GeneratedColumns.postgresql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/GeneratedColumns.postgresql.test.ts.snap
@@ -2,7 +2,8 @@
 
 exports[`generated_columns_example > decorators > as functions from extensions > dump 1`] = `
 [
-  "import { Entity, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, Entity, OneToMany, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
+import { Users } from './Users';
 
 @Entity()
 export class AllowedAgesAtCreation {
@@ -12,9 +13,12 @@ export class AllowedAgesAtCreation {
   @PrimaryKey({ type: 'smallint', autoincrement: false })
   age!: number;
 
+  @OneToMany({ entity: () => Users, mappedBy: 'ageAtCreation' })
+  usersCollection = new Collection<Users>(this);
+
 }
 ",
-  "import { Entity, ManyToOne, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKey, Property, type Ref } from '@mikro-orm/core';
 import { AllowedAgesAtCreation } from './AllowedAgesAtCreation';
 
 @Entity()
@@ -38,8 +42,8 @@ export class Users {
   @Property({ type: 'date' })
   dateOfBirth!: string;
 
-  @ManyToOne({ entity: () => AllowedAgesAtCreation, fieldName: 'age_at_creation', deleteRule: 'cascade', generated: () => "(EXTRACT(year FROM created_at) - EXTRACT(year FROM date_of_birth)) stored", nullable: true })
-  ageAtCreation?: AllowedAgesAtCreation;
+  @ManyToOne({ entity: () => AllowedAgesAtCreation, ref: true, fieldName: 'age_at_creation', deleteRule: 'cascade', generated: () => "(EXTRACT(year FROM created_at) - EXTRACT(year FROM date_of_birth)) stored", nullable: true })
+  ageAtCreation?: Ref<AllowedAgesAtCreation>;
 
 }
 ",
@@ -48,7 +52,8 @@ export class Users {
 
 exports[`generated_columns_example > decorators > generates from db > dump 1`] = `
 [
-  "import { Entity, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, Entity, OneToMany, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
+import { Users } from './Users';
 
 @Entity()
 export class AllowedAgesAtCreation {
@@ -58,9 +63,12 @@ export class AllowedAgesAtCreation {
   @PrimaryKey({ type: 'smallint', autoincrement: false })
   age!: number;
 
+  @OneToMany({ entity: () => Users, mappedBy: 'ageAtCreation' })
+  usersCollection = new Collection<Users>(this);
+
 }
 ",
-  "import { Entity, ManyToOne, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKey, Property, type Ref } from '@mikro-orm/core';
 import { AllowedAgesAtCreation } from './AllowedAgesAtCreation';
 
 @Entity()
@@ -84,8 +92,8 @@ export class Users {
   @Property({ type: 'date' })
   dateOfBirth!: string;
 
-  @ManyToOne({ entity: () => AllowedAgesAtCreation, fieldName: 'age_at_creation', deleteRule: 'cascade', generated: '(EXTRACT(year FROM created_at) - EXTRACT(year FROM date_of_birth)) stored', nullable: true })
-  ageAtCreation?: AllowedAgesAtCreation;
+  @ManyToOne({ entity: () => AllowedAgesAtCreation, ref: true, fieldName: 'age_at_creation', deleteRule: 'cascade', generated: '(EXTRACT(year FROM created_at) - EXTRACT(year FROM date_of_birth)) stored', nullable: true })
+  ageAtCreation?: Ref<AllowedAgesAtCreation>;
 
 }
 ",
@@ -94,21 +102,28 @@ export class Users {
 
 exports[`generated_columns_example > entitySchema > as functions from extensions > dump 1`] = `
 [
-  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Users } from './Users';
 
 export class AllowedAgesAtCreation {
   [PrimaryKeyProp]?: 'age';
   age!: number;
+  usersCollection = new Collection<Users>(this);
 }
 
 export const AllowedAgesAtCreationSchema = new EntitySchema({
   class: AllowedAgesAtCreation,
   properties: {
     age: { primary: true, type: 'smallint', autoincrement: false },
+    usersCollection: {
+      kind: '1:m',
+      entity: () => Users,
+      mappedBy: 'ageAtCreation',
+    },
   },
 });
 ",
-  "import { EntitySchema, type Opt } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, type Ref } from '@mikro-orm/core';
 import { AllowedAgesAtCreation } from './AllowedAgesAtCreation';
 
 export class Users {
@@ -118,7 +133,7 @@ export class Users {
   fullName!: string & Opt;
   createdAt!: Date & Opt;
   dateOfBirth!: string;
-  ageAtCreation?: AllowedAgesAtCreation;
+  ageAtCreation?: Ref<AllowedAgesAtCreation>;
 }
 
 export const UsersSchema = new EntitySchema({
@@ -141,6 +156,7 @@ export const UsersSchema = new EntitySchema({
     ageAtCreation: {
       kind: 'm:1',
       entity: () => AllowedAgesAtCreation,
+      ref: true,
       fieldName: 'age_at_creation',
       deleteRule: 'cascade',
       generated: () => "(EXTRACT(year FROM created_at) - EXTRACT(year FROM date_of_birth)) stored",
@@ -154,21 +170,28 @@ export const UsersSchema = new EntitySchema({
 
 exports[`generated_columns_example > entitySchema > generates from db > dump 1`] = `
 [
-  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Users } from './Users';
 
 export class AllowedAgesAtCreation {
   [PrimaryKeyProp]?: 'age';
   age!: number;
+  usersCollection = new Collection<Users>(this);
 }
 
 export const AllowedAgesAtCreationSchema = new EntitySchema({
   class: AllowedAgesAtCreation,
   properties: {
     age: { primary: true, type: 'smallint', autoincrement: false },
+    usersCollection: {
+      kind: '1:m',
+      entity: () => Users,
+      mappedBy: 'ageAtCreation',
+    },
   },
 });
 ",
-  "import { EntitySchema, type Opt } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, type Ref } from '@mikro-orm/core';
 import { AllowedAgesAtCreation } from './AllowedAgesAtCreation';
 
 export class Users {
@@ -178,7 +201,7 @@ export class Users {
   fullName!: string & Opt;
   createdAt!: Date & Opt;
   dateOfBirth!: string;
-  ageAtCreation?: AllowedAgesAtCreation;
+  ageAtCreation?: Ref<AllowedAgesAtCreation>;
 }
 
 export const UsersSchema = new EntitySchema({
@@ -201,6 +224,7 @@ export const UsersSchema = new EntitySchema({
     ageAtCreation: {
       kind: 'm:1',
       entity: () => AllowedAgesAtCreation,
+      ref: true,
       fieldName: 'age_at_creation',
       deleteRule: 'cascade',
       generated: '(EXTRACT(year FROM created_at) - EXTRACT(year FROM date_of_birth)) stored',

--- a/tests/features/entity-generator/__snapshots__/IntervalTypeGen.postgresql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/IntervalTypeGen.postgresql.test.ts.snap
@@ -2,27 +2,26 @@
 
 exports[`IntervalTypeGen 1`] = `
 [
-  "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { defineEntity, p } from '@mikro-orm/core';
 
-@Entity()
 export class Range {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property({ nullable: true })
   start?: Date;
-
-  @Property({ type: 'interval', nullable: true })
   duration?: string;
-
-  @Property({ type: 'interval', nullable: true })
   aftermath?: string;
-
-  @Property({ type: 'interval', length: 0, nullable: true })
   cooldown?: string;
-
 }
+
+export const RangeSchema = defineEntity({
+  class: Range,
+  properties: {
+    id: p.integer().primary(),
+    start: p.datetime().nullable(),
+    duration: p.interval().nullable(),
+    aftermath: p.interval().nullable(),
+    cooldown: p.interval().length(0).nullable(),
+  },
+});
 ",
 ]
 `;

--- a/tests/features/entity-generator/__snapshots__/ManyToManyRelations.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/ManyToManyRelations.mysql.test.ts.snap
@@ -1,8 +1,8 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`many_to_many_variants > bidirectionalRelations=false > onlyPurePivotTables=false > outputPurePivotTables=false > readOnlyPivotTables=false > entitySchema=false > dump 1`] = `
+exports[`many_to_many_variants > bidirectionalRelations=false > onlyPurePivotTables=false > outputPurePivotTables=false > readOnlyPivotTables=false > entityDefinition=decorators > dump 1`] = `
 [
-  "import { Entity, ManyToOne, PrimaryKey, Unique } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKey, type Ref, Unique } from '@mikro-orm/core';
 import { Orders } from './Orders';
 import { Users } from './Users';
 
@@ -13,11 +13,11 @@ export class CompletedOrders {
   @PrimaryKey()
   id!: number;
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', index: 'fk_completed_orders_users1_idx' })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', index: 'fk_completed_orders_users1_idx' })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Orders, fieldName: 'order_id', index: 'fk_completed_orders_orders1_idx' })
-  order!: Orders;
+  @ManyToOne({ entity: () => Orders, ref: true, fieldName: 'order_id', index: 'fk_completed_orders_orders1_idx' })
+  order!: Ref<Orders>;
 
 }
 ",
@@ -66,7 +66,7 @@ export class Orders {
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
@@ -75,18 +75,18 @@ export class UserEmailAvatars {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Emails, fieldName: 'email_id', primary: true, index: 'fk_user_email_avatars_emails1_idx' })
-  email!: Emails;
+  @ManyToOne({ entity: () => Emails, ref: true, fieldName: 'email_id', primary: true, index: 'fk_user_email_avatars_emails1_idx' })
+  email!: Ref<Emails>;
 
   @Property()
   avatarUrl!: string;
 
 }
 ",
-  "import { Entity, ManyToOne, OneToOne, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, OneToOne, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Flags } from './Flags';
 import { Users } from './Users';
@@ -96,18 +96,18 @@ export class UserEmailFlags {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Emails, fieldName: 'email_id', primary: true, index: 'fk_user_email_flags_emails1_idx' })
-  email!: Emails;
+  @ManyToOne({ entity: () => Emails, ref: true, fieldName: 'email_id', primary: true, index: 'fk_user_email_flags_emails1_idx' })
+  email!: Ref<Emails>;
 
-  @OneToOne({ entity: () => Flags, fieldName: 'flag_id', defaultRaw: \`1\`, index: 'fk_user_email_flags_flags1_idx', unique: 'flag_id_UNIQUE' })
-  flag!: Flags & Opt;
+  @OneToOne({ entity: () => Flags, ref: true, fieldName: 'flag_id', defaultRaw: \`1\`, index: 'fk_user_email_flags_flags1_idx', unique: 'flag_id_UNIQUE' })
+  flag!: Ref<Flags> & Opt;
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Orders } from './Orders';
 import { Users } from './Users';
@@ -117,18 +117,18 @@ export class UserEmailOrders {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Emails, fieldName: 'email_id', primary: true, index: 'fk_user_email_orders_emails1_idx' })
-  email!: Emails;
+  @ManyToOne({ entity: () => Emails, ref: true, fieldName: 'email_id', primary: true, index: 'fk_user_email_orders_emails1_idx' })
+  email!: Ref<Emails>;
 
-  @ManyToOne({ entity: () => Orders, fieldName: 'order_id', index: 'fk_user_email_orders_orders1_idx' })
-  order!: Orders;
+  @ManyToOne({ entity: () => Orders, ref: true, fieldName: 'order_id', index: 'fk_user_email_orders_orders1_idx' })
+  order!: Ref<Orders>;
 
 }
 ",
-  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
@@ -137,11 +137,11 @@ export class UserEmails {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Emails, fieldName: 'email_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true, index: 'fk_user_emails_emails1_idx' })
-  email!: Emails;
+  @ManyToOne({ entity: () => Emails, ref: true, fieldName: 'email_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true, index: 'fk_user_emails_emails1_idx' })
+  email!: Ref<Emails>;
 
   @Property({ type: 'boolean' })
   isVerified: boolean & Opt = false;
@@ -179,16 +179,16 @@ export class Users {
 ]
 `;
 
-exports[`many_to_many_variants > bidirectionalRelations=false > onlyPurePivotTables=false > outputPurePivotTables=false > readOnlyPivotTables=false > entitySchema=true > dump 1`] = `
+exports[`many_to_many_variants > bidirectionalRelations=false > onlyPurePivotTables=false > outputPurePivotTables=false > readOnlyPivotTables=false > entityDefinition=entitySchema > dump 1`] = `
 [
-  "import { EntitySchema } from '@mikro-orm/core';
+  "import { EntitySchema, type Ref } from '@mikro-orm/core';
 import { Orders } from './Orders';
 import { Users } from './Users';
 
 export class CompletedOrders {
   id!: number;
-  user!: Users;
-  order!: Orders;
+  user!: Ref<Users>;
+  order!: Ref<Orders>;
 }
 
 export const CompletedOrdersSchema = new EntitySchema({
@@ -199,12 +199,14 @@ export const CompletedOrdersSchema = new EntitySchema({
     user: {
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
       index: 'fk_completed_orders_users1_idx',
     },
     order: {
       kind: 'm:1',
       entity: () => Orders,
+      ref: true,
       fieldName: 'order_id',
       index: 'fk_completed_orders_orders1_idx',
     },
@@ -259,14 +261,14 @@ export const OrdersSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
 export class UserEmailAvatars {
   [PrimaryKeyProp]?: ['user', 'email'];
-  user!: Users;
-  email!: Emails;
+  user!: Ref<Users>;
+  email!: Ref<Emails>;
   avatarUrl!: string;
 }
 
@@ -277,6 +279,7 @@ export const UserEmailAvatarsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
       updateRule: 'cascade',
       deleteRule: 'cascade',
@@ -285,6 +288,7 @@ export const UserEmailAvatarsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Emails,
+      ref: true,
       fieldName: 'email_id',
       index: 'fk_user_email_avatars_emails1_idx',
     },
@@ -292,16 +296,16 @@ export const UserEmailAvatarsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Flags } from './Flags';
 import { Users } from './Users';
 
 export class UserEmailFlags {
   [PrimaryKeyProp]?: ['user', 'email'];
-  user!: Users;
-  email!: Emails;
-  flag!: Flags & Opt;
+  user!: Ref<Users>;
+  email!: Ref<Emails>;
+  flag!: Ref<Flags> & Opt;
 }
 
 export const UserEmailFlagsSchema = new EntitySchema({
@@ -311,18 +315,21 @@ export const UserEmailFlagsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
     },
     email: {
       primary: true,
       kind: 'm:1',
       entity: () => Emails,
+      ref: true,
       fieldName: 'email_id',
       index: 'fk_user_email_flags_emails1_idx',
     },
     flag: {
       kind: '1:1',
       entity: () => Flags,
+      ref: true,
       fieldName: 'flag_id',
       defaultRaw: \`1\`,
       index: 'fk_user_email_flags_flags1_idx',
@@ -331,16 +338,16 @@ export const UserEmailFlagsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Orders } from './Orders';
 import { Users } from './Users';
 
 export class UserEmailOrders {
   [PrimaryKeyProp]?: ['user', 'email'];
-  user!: Users;
-  email!: Emails;
-  order!: Orders;
+  user!: Ref<Users>;
+  email!: Ref<Emails>;
+  order!: Ref<Orders>;
 }
 
 export const UserEmailOrdersSchema = new EntitySchema({
@@ -350,32 +357,35 @@ export const UserEmailOrdersSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
     },
     email: {
       primary: true,
       kind: 'm:1',
       entity: () => Emails,
+      ref: true,
       fieldName: 'email_id',
       index: 'fk_user_email_orders_emails1_idx',
     },
     order: {
       kind: 'm:1',
       entity: () => Orders,
+      ref: true,
       fieldName: 'order_id',
       index: 'fk_user_email_orders_orders1_idx',
     },
   },
 });
 ",
-  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
 export class UserEmails {
   [PrimaryKeyProp]?: ['user', 'email'];
-  user!: Users;
-  email!: Emails;
+  user!: Ref<Users>;
+  email!: Ref<Emails>;
   isVerified: boolean & Opt = false;
 }
 
@@ -386,6 +396,7 @@ export const UserEmailsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
       updateRule: 'cascade',
       deleteRule: 'cascade',
@@ -394,6 +405,7 @@ export const UserEmailsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Emails,
+      ref: true,
       fieldName: 'email_id',
       updateRule: 'cascade',
       deleteRule: 'cascade',
@@ -453,9 +465,9 @@ export const UsersSchema = new EntitySchema({
 ]
 `;
 
-exports[`many_to_many_variants > bidirectionalRelations=false > onlyPurePivotTables=false > outputPurePivotTables=false > readOnlyPivotTables=true > entitySchema=false > dump 1`] = `
+exports[`many_to_many_variants > bidirectionalRelations=false > onlyPurePivotTables=false > outputPurePivotTables=false > readOnlyPivotTables=true > entityDefinition=decorators > dump 1`] = `
 [
-  "import { Entity, ManyToOne, PrimaryKey, Unique } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKey, type Ref, Unique } from '@mikro-orm/core';
 import { Orders } from './Orders';
 import { Users } from './Users';
 
@@ -466,11 +478,11 @@ export class CompletedOrders {
   @PrimaryKey()
   id!: number;
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', index: 'fk_completed_orders_users1_idx' })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', index: 'fk_completed_orders_users1_idx' })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Orders, fieldName: 'order_id', index: 'fk_completed_orders_orders1_idx' })
-  order!: Orders;
+  @ManyToOne({ entity: () => Orders, ref: true, fieldName: 'order_id', index: 'fk_completed_orders_orders1_idx' })
+  order!: Ref<Orders>;
 
 }
 ",
@@ -519,7 +531,7 @@ export class Orders {
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
@@ -528,18 +540,18 @@ export class UserEmailAvatars {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Emails, fieldName: 'email_id', primary: true, index: 'fk_user_email_avatars_emails1_idx' })
-  email!: Emails;
+  @ManyToOne({ entity: () => Emails, ref: true, fieldName: 'email_id', primary: true, index: 'fk_user_email_avatars_emails1_idx' })
+  email!: Ref<Emails>;
 
   @Property()
   avatarUrl!: string;
 
 }
 ",
-  "import { Entity, ManyToOne, OneToOne, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, OneToOne, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Flags } from './Flags';
 import { Users } from './Users';
@@ -549,18 +561,18 @@ export class UserEmailFlags {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Emails, fieldName: 'email_id', primary: true, index: 'fk_user_email_flags_emails1_idx' })
-  email!: Emails;
+  @ManyToOne({ entity: () => Emails, ref: true, fieldName: 'email_id', primary: true, index: 'fk_user_email_flags_emails1_idx' })
+  email!: Ref<Emails>;
 
-  @OneToOne({ entity: () => Flags, fieldName: 'flag_id', defaultRaw: \`1\`, index: 'fk_user_email_flags_flags1_idx', unique: 'flag_id_UNIQUE' })
-  flag!: Flags & Opt;
+  @OneToOne({ entity: () => Flags, ref: true, fieldName: 'flag_id', defaultRaw: \`1\`, index: 'fk_user_email_flags_flags1_idx', unique: 'flag_id_UNIQUE' })
+  flag!: Ref<Flags> & Opt;
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Orders } from './Orders';
 import { Users } from './Users';
@@ -570,18 +582,18 @@ export class UserEmailOrders {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Emails, fieldName: 'email_id', primary: true, index: 'fk_user_email_orders_emails1_idx' })
-  email!: Emails;
+  @ManyToOne({ entity: () => Emails, ref: true, fieldName: 'email_id', primary: true, index: 'fk_user_email_orders_emails1_idx' })
+  email!: Ref<Emails>;
 
-  @ManyToOne({ entity: () => Orders, fieldName: 'order_id', index: 'fk_user_email_orders_orders1_idx' })
-  order!: Orders;
+  @ManyToOne({ entity: () => Orders, ref: true, fieldName: 'order_id', index: 'fk_user_email_orders_orders1_idx' })
+  order!: Ref<Orders>;
 
 }
 ",
-  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
@@ -590,11 +602,11 @@ export class UserEmails {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Emails, fieldName: 'email_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true, index: 'fk_user_emails_emails1_idx' })
-  email!: Emails;
+  @ManyToOne({ entity: () => Emails, ref: true, fieldName: 'email_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true, index: 'fk_user_emails_emails1_idx' })
+  email!: Ref<Emails>;
 
   @Property({ type: 'boolean' })
   isVerified: boolean & Opt = false;
@@ -644,16 +656,16 @@ export class Users {
 ]
 `;
 
-exports[`many_to_many_variants > bidirectionalRelations=false > onlyPurePivotTables=false > outputPurePivotTables=false > readOnlyPivotTables=true > entitySchema=true > dump 1`] = `
+exports[`many_to_many_variants > bidirectionalRelations=false > onlyPurePivotTables=false > outputPurePivotTables=false > readOnlyPivotTables=true > entityDefinition=entitySchema > dump 1`] = `
 [
-  "import { EntitySchema } from '@mikro-orm/core';
+  "import { EntitySchema, type Ref } from '@mikro-orm/core';
 import { Orders } from './Orders';
 import { Users } from './Users';
 
 export class CompletedOrders {
   id!: number;
-  user!: Users;
-  order!: Orders;
+  user!: Ref<Users>;
+  order!: Ref<Orders>;
 }
 
 export const CompletedOrdersSchema = new EntitySchema({
@@ -664,12 +676,14 @@ export const CompletedOrdersSchema = new EntitySchema({
     user: {
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
       index: 'fk_completed_orders_users1_idx',
     },
     order: {
       kind: 'm:1',
       entity: () => Orders,
+      ref: true,
       fieldName: 'order_id',
       index: 'fk_completed_orders_orders1_idx',
     },
@@ -724,14 +738,14 @@ export const OrdersSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
 export class UserEmailAvatars {
   [PrimaryKeyProp]?: ['user', 'email'];
-  user!: Users;
-  email!: Emails;
+  user!: Ref<Users>;
+  email!: Ref<Emails>;
   avatarUrl!: string;
 }
 
@@ -742,6 +756,7 @@ export const UserEmailAvatarsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
       updateRule: 'cascade',
       deleteRule: 'cascade',
@@ -750,6 +765,7 @@ export const UserEmailAvatarsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Emails,
+      ref: true,
       fieldName: 'email_id',
       index: 'fk_user_email_avatars_emails1_idx',
     },
@@ -757,16 +773,16 @@ export const UserEmailAvatarsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Flags } from './Flags';
 import { Users } from './Users';
 
 export class UserEmailFlags {
   [PrimaryKeyProp]?: ['user', 'email'];
-  user!: Users;
-  email!: Emails;
-  flag!: Flags & Opt;
+  user!: Ref<Users>;
+  email!: Ref<Emails>;
+  flag!: Ref<Flags> & Opt;
 }
 
 export const UserEmailFlagsSchema = new EntitySchema({
@@ -776,18 +792,21 @@ export const UserEmailFlagsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
     },
     email: {
       primary: true,
       kind: 'm:1',
       entity: () => Emails,
+      ref: true,
       fieldName: 'email_id',
       index: 'fk_user_email_flags_emails1_idx',
     },
     flag: {
       kind: '1:1',
       entity: () => Flags,
+      ref: true,
       fieldName: 'flag_id',
       defaultRaw: \`1\`,
       index: 'fk_user_email_flags_flags1_idx',
@@ -796,16 +815,16 @@ export const UserEmailFlagsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Orders } from './Orders';
 import { Users } from './Users';
 
 export class UserEmailOrders {
   [PrimaryKeyProp]?: ['user', 'email'];
-  user!: Users;
-  email!: Emails;
-  order!: Orders;
+  user!: Ref<Users>;
+  email!: Ref<Emails>;
+  order!: Ref<Orders>;
 }
 
 export const UserEmailOrdersSchema = new EntitySchema({
@@ -815,32 +834,35 @@ export const UserEmailOrdersSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
     },
     email: {
       primary: true,
       kind: 'm:1',
       entity: () => Emails,
+      ref: true,
       fieldName: 'email_id',
       index: 'fk_user_email_orders_emails1_idx',
     },
     order: {
       kind: 'm:1',
       entity: () => Orders,
+      ref: true,
       fieldName: 'order_id',
       index: 'fk_user_email_orders_orders1_idx',
     },
   },
 });
 ",
-  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
 export class UserEmails {
   [PrimaryKeyProp]?: ['user', 'email'];
-  user!: Users;
-  email!: Emails;
+  user!: Ref<Users>;
+  email!: Ref<Emails>;
   isVerified: boolean & Opt = false;
 }
 
@@ -851,6 +873,7 @@ export const UserEmailsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
       updateRule: 'cascade',
       deleteRule: 'cascade',
@@ -859,6 +882,7 @@ export const UserEmailsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Emails,
+      ref: true,
       fieldName: 'email_id',
       updateRule: 'cascade',
       deleteRule: 'cascade',
@@ -951,9 +975,9 @@ export const UsersSchema = new EntitySchema({
 ]
 `;
 
-exports[`many_to_many_variants > bidirectionalRelations=false > onlyPurePivotTables=false > outputPurePivotTables=true > readOnlyPivotTables=false > entitySchema=false > dump 1`] = `
+exports[`many_to_many_variants > bidirectionalRelations=false > onlyPurePivotTables=false > outputPurePivotTables=true > readOnlyPivotTables=false > entityDefinition=decorators > dump 1`] = `
 [
-  "import { Entity, ManyToOne, PrimaryKey, Unique } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKey, type Ref, Unique } from '@mikro-orm/core';
 import { Orders } from './Orders';
 import { Users } from './Users';
 
@@ -964,11 +988,11 @@ export class CompletedOrders {
   @PrimaryKey()
   id!: number;
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', index: 'fk_completed_orders_users1_idx' })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', index: 'fk_completed_orders_users1_idx' })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Orders, fieldName: 'order_id', index: 'fk_completed_orders_orders1_idx' })
-  order!: Orders;
+  @ManyToOne({ entity: () => Orders, ref: true, fieldName: 'order_id', index: 'fk_completed_orders_orders1_idx' })
+  order!: Ref<Orders>;
 
 }
 ",
@@ -1017,7 +1041,7 @@ export class Orders {
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
@@ -1026,18 +1050,18 @@ export class UserEmailAvatars {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Emails, fieldName: 'email_id', primary: true, index: 'fk_user_email_avatars_emails1_idx' })
-  email!: Emails;
+  @ManyToOne({ entity: () => Emails, ref: true, fieldName: 'email_id', primary: true, index: 'fk_user_email_avatars_emails1_idx' })
+  email!: Ref<Emails>;
 
   @Property()
   avatarUrl!: string;
 
 }
 ",
-  "import { Entity, ManyToOne, OneToOne, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, OneToOne, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Flags } from './Flags';
 import { Users } from './Users';
@@ -1047,18 +1071,18 @@ export class UserEmailFlags {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Emails, fieldName: 'email_id', primary: true, index: 'fk_user_email_flags_emails1_idx' })
-  email!: Emails;
+  @ManyToOne({ entity: () => Emails, ref: true, fieldName: 'email_id', primary: true, index: 'fk_user_email_flags_emails1_idx' })
+  email!: Ref<Emails>;
 
-  @OneToOne({ entity: () => Flags, fieldName: 'flag_id', defaultRaw: \`1\`, index: 'fk_user_email_flags_flags1_idx', unique: 'flag_id_UNIQUE' })
-  flag!: Flags & Opt;
+  @OneToOne({ entity: () => Flags, ref: true, fieldName: 'flag_id', defaultRaw: \`1\`, index: 'fk_user_email_flags_flags1_idx', unique: 'flag_id_UNIQUE' })
+  flag!: Ref<Flags> & Opt;
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Orders } from './Orders';
 import { Users } from './Users';
@@ -1068,18 +1092,18 @@ export class UserEmailOrders {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Emails, fieldName: 'email_id', primary: true, index: 'fk_user_email_orders_emails1_idx' })
-  email!: Emails;
+  @ManyToOne({ entity: () => Emails, ref: true, fieldName: 'email_id', primary: true, index: 'fk_user_email_orders_emails1_idx' })
+  email!: Ref<Emails>;
 
-  @ManyToOne({ entity: () => Orders, fieldName: 'order_id', index: 'fk_user_email_orders_orders1_idx' })
-  order!: Orders;
+  @ManyToOne({ entity: () => Orders, ref: true, fieldName: 'order_id', index: 'fk_user_email_orders_orders1_idx' })
+  order!: Ref<Orders>;
 
 }
 ",
-  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
@@ -1088,11 +1112,11 @@ export class UserEmails {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Emails, fieldName: 'email_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true, index: 'fk_user_emails_emails1_idx' })
-  email!: Emails;
+  @ManyToOne({ entity: () => Emails, ref: true, fieldName: 'email_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true, index: 'fk_user_emails_emails1_idx' })
+  email!: Ref<Emails>;
 
   @Property({ type: 'boolean' })
   isVerified: boolean & Opt = false;
@@ -1169,16 +1193,16 @@ export class Users {
 ]
 `;
 
-exports[`many_to_many_variants > bidirectionalRelations=false > onlyPurePivotTables=false > outputPurePivotTables=true > readOnlyPivotTables=false > entitySchema=true > dump 1`] = `
+exports[`many_to_many_variants > bidirectionalRelations=false > onlyPurePivotTables=false > outputPurePivotTables=true > readOnlyPivotTables=false > entityDefinition=entitySchema > dump 1`] = `
 [
-  "import { EntitySchema } from '@mikro-orm/core';
+  "import { EntitySchema, type Ref } from '@mikro-orm/core';
 import { Orders } from './Orders';
 import { Users } from './Users';
 
 export class CompletedOrders {
   id!: number;
-  user!: Users;
-  order!: Orders;
+  user!: Ref<Users>;
+  order!: Ref<Orders>;
 }
 
 export const CompletedOrdersSchema = new EntitySchema({
@@ -1189,12 +1213,14 @@ export const CompletedOrdersSchema = new EntitySchema({
     user: {
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
       index: 'fk_completed_orders_users1_idx',
     },
     order: {
       kind: 'm:1',
       entity: () => Orders,
+      ref: true,
       fieldName: 'order_id',
       index: 'fk_completed_orders_orders1_idx',
     },
@@ -1249,14 +1275,14 @@ export const OrdersSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
 export class UserEmailAvatars {
   [PrimaryKeyProp]?: ['user', 'email'];
-  user!: Users;
-  email!: Emails;
+  user!: Ref<Users>;
+  email!: Ref<Emails>;
   avatarUrl!: string;
 }
 
@@ -1267,6 +1293,7 @@ export const UserEmailAvatarsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
       updateRule: 'cascade',
       deleteRule: 'cascade',
@@ -1275,6 +1302,7 @@ export const UserEmailAvatarsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Emails,
+      ref: true,
       fieldName: 'email_id',
       index: 'fk_user_email_avatars_emails1_idx',
     },
@@ -1282,16 +1310,16 @@ export const UserEmailAvatarsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Flags } from './Flags';
 import { Users } from './Users';
 
 export class UserEmailFlags {
   [PrimaryKeyProp]?: ['user', 'email'];
-  user!: Users;
-  email!: Emails;
-  flag!: Flags & Opt;
+  user!: Ref<Users>;
+  email!: Ref<Emails>;
+  flag!: Ref<Flags> & Opt;
 }
 
 export const UserEmailFlagsSchema = new EntitySchema({
@@ -1301,18 +1329,21 @@ export const UserEmailFlagsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
     },
     email: {
       primary: true,
       kind: 'm:1',
       entity: () => Emails,
+      ref: true,
       fieldName: 'email_id',
       index: 'fk_user_email_flags_emails1_idx',
     },
     flag: {
       kind: '1:1',
       entity: () => Flags,
+      ref: true,
       fieldName: 'flag_id',
       defaultRaw: \`1\`,
       index: 'fk_user_email_flags_flags1_idx',
@@ -1321,16 +1352,16 @@ export const UserEmailFlagsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Orders } from './Orders';
 import { Users } from './Users';
 
 export class UserEmailOrders {
   [PrimaryKeyProp]?: ['user', 'email'];
-  user!: Users;
-  email!: Emails;
-  order!: Orders;
+  user!: Ref<Users>;
+  email!: Ref<Emails>;
+  order!: Ref<Orders>;
 }
 
 export const UserEmailOrdersSchema = new EntitySchema({
@@ -1340,32 +1371,35 @@ export const UserEmailOrdersSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
     },
     email: {
       primary: true,
       kind: 'm:1',
       entity: () => Emails,
+      ref: true,
       fieldName: 'email_id',
       index: 'fk_user_email_orders_emails1_idx',
     },
     order: {
       kind: 'm:1',
       entity: () => Orders,
+      ref: true,
       fieldName: 'order_id',
       index: 'fk_user_email_orders_orders1_idx',
     },
   },
 });
 ",
-  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
 export class UserEmails {
   [PrimaryKeyProp]?: ['user', 'email'];
-  user!: Users;
-  email!: Emails;
+  user!: Ref<Users>;
+  email!: Ref<Emails>;
   isVerified: boolean & Opt = false;
 }
 
@@ -1376,6 +1410,7 @@ export const UserEmailsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
       updateRule: 'cascade',
       deleteRule: 'cascade',
@@ -1384,6 +1419,7 @@ export const UserEmailsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Emails,
+      ref: true,
       fieldName: 'email_id',
       updateRule: 'cascade',
       deleteRule: 'cascade',
@@ -1517,9 +1553,9 @@ export const UsersSchema = new EntitySchema({
 ]
 `;
 
-exports[`many_to_many_variants > bidirectionalRelations=false > onlyPurePivotTables=false > outputPurePivotTables=true > readOnlyPivotTables=true > entitySchema=false > dump 1`] = `
+exports[`many_to_many_variants > bidirectionalRelations=false > onlyPurePivotTables=false > outputPurePivotTables=true > readOnlyPivotTables=true > entityDefinition=decorators > dump 1`] = `
 [
-  "import { Entity, ManyToOne, PrimaryKey, Unique } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKey, type Ref, Unique } from '@mikro-orm/core';
 import { Orders } from './Orders';
 import { Users } from './Users';
 
@@ -1530,11 +1566,11 @@ export class CompletedOrders {
   @PrimaryKey()
   id!: number;
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', index: 'fk_completed_orders_users1_idx' })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', index: 'fk_completed_orders_users1_idx' })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Orders, fieldName: 'order_id', index: 'fk_completed_orders_orders1_idx' })
-  order!: Orders;
+  @ManyToOne({ entity: () => Orders, ref: true, fieldName: 'order_id', index: 'fk_completed_orders_orders1_idx' })
+  order!: Ref<Orders>;
 
 }
 ",
@@ -1583,7 +1619,7 @@ export class Orders {
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
@@ -1592,18 +1628,18 @@ export class UserEmailAvatars {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Emails, fieldName: 'email_id', primary: true, index: 'fk_user_email_avatars_emails1_idx' })
-  email!: Emails;
+  @ManyToOne({ entity: () => Emails, ref: true, fieldName: 'email_id', primary: true, index: 'fk_user_email_avatars_emails1_idx' })
+  email!: Ref<Emails>;
 
   @Property()
   avatarUrl!: string;
 
 }
 ",
-  "import { Entity, ManyToOne, OneToOne, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, OneToOne, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Flags } from './Flags';
 import { Users } from './Users';
@@ -1613,18 +1649,18 @@ export class UserEmailFlags {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Emails, fieldName: 'email_id', primary: true, index: 'fk_user_email_flags_emails1_idx' })
-  email!: Emails;
+  @ManyToOne({ entity: () => Emails, ref: true, fieldName: 'email_id', primary: true, index: 'fk_user_email_flags_emails1_idx' })
+  email!: Ref<Emails>;
 
-  @OneToOne({ entity: () => Flags, fieldName: 'flag_id', defaultRaw: \`1\`, index: 'fk_user_email_flags_flags1_idx', unique: 'flag_id_UNIQUE' })
-  flag!: Flags & Opt;
+  @OneToOne({ entity: () => Flags, ref: true, fieldName: 'flag_id', defaultRaw: \`1\`, index: 'fk_user_email_flags_flags1_idx', unique: 'flag_id_UNIQUE' })
+  flag!: Ref<Flags> & Opt;
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Orders } from './Orders';
 import { Users } from './Users';
@@ -1634,18 +1670,18 @@ export class UserEmailOrders {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Emails, fieldName: 'email_id', primary: true, index: 'fk_user_email_orders_emails1_idx' })
-  email!: Emails;
+  @ManyToOne({ entity: () => Emails, ref: true, fieldName: 'email_id', primary: true, index: 'fk_user_email_orders_emails1_idx' })
+  email!: Ref<Emails>;
 
-  @ManyToOne({ entity: () => Orders, fieldName: 'order_id', index: 'fk_user_email_orders_orders1_idx' })
-  order!: Orders;
+  @ManyToOne({ entity: () => Orders, ref: true, fieldName: 'order_id', index: 'fk_user_email_orders_orders1_idx' })
+  order!: Ref<Orders>;
 
 }
 ",
-  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
@@ -1654,11 +1690,11 @@ export class UserEmails {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Emails, fieldName: 'email_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true, index: 'fk_user_emails_emails1_idx' })
-  email!: Emails;
+  @ManyToOne({ entity: () => Emails, ref: true, fieldName: 'email_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true, index: 'fk_user_emails_emails1_idx' })
+  email!: Ref<Emails>;
 
   @Property({ type: 'boolean' })
   isVerified: boolean & Opt = false;
@@ -1747,16 +1783,16 @@ export class Users {
 ]
 `;
 
-exports[`many_to_many_variants > bidirectionalRelations=false > onlyPurePivotTables=false > outputPurePivotTables=true > readOnlyPivotTables=true > entitySchema=true > dump 1`] = `
+exports[`many_to_many_variants > bidirectionalRelations=false > onlyPurePivotTables=false > outputPurePivotTables=true > readOnlyPivotTables=true > entityDefinition=entitySchema > dump 1`] = `
 [
-  "import { EntitySchema } from '@mikro-orm/core';
+  "import { EntitySchema, type Ref } from '@mikro-orm/core';
 import { Orders } from './Orders';
 import { Users } from './Users';
 
 export class CompletedOrders {
   id!: number;
-  user!: Users;
-  order!: Orders;
+  user!: Ref<Users>;
+  order!: Ref<Orders>;
 }
 
 export const CompletedOrdersSchema = new EntitySchema({
@@ -1767,12 +1803,14 @@ export const CompletedOrdersSchema = new EntitySchema({
     user: {
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
       index: 'fk_completed_orders_users1_idx',
     },
     order: {
       kind: 'm:1',
       entity: () => Orders,
+      ref: true,
       fieldName: 'order_id',
       index: 'fk_completed_orders_orders1_idx',
     },
@@ -1827,14 +1865,14 @@ export const OrdersSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
 export class UserEmailAvatars {
   [PrimaryKeyProp]?: ['user', 'email'];
-  user!: Users;
-  email!: Emails;
+  user!: Ref<Users>;
+  email!: Ref<Emails>;
   avatarUrl!: string;
 }
 
@@ -1845,6 +1883,7 @@ export const UserEmailAvatarsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
       updateRule: 'cascade',
       deleteRule: 'cascade',
@@ -1853,6 +1892,7 @@ export const UserEmailAvatarsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Emails,
+      ref: true,
       fieldName: 'email_id',
       index: 'fk_user_email_avatars_emails1_idx',
     },
@@ -1860,16 +1900,16 @@ export const UserEmailAvatarsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Flags } from './Flags';
 import { Users } from './Users';
 
 export class UserEmailFlags {
   [PrimaryKeyProp]?: ['user', 'email'];
-  user!: Users;
-  email!: Emails;
-  flag!: Flags & Opt;
+  user!: Ref<Users>;
+  email!: Ref<Emails>;
+  flag!: Ref<Flags> & Opt;
 }
 
 export const UserEmailFlagsSchema = new EntitySchema({
@@ -1879,18 +1919,21 @@ export const UserEmailFlagsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
     },
     email: {
       primary: true,
       kind: 'm:1',
       entity: () => Emails,
+      ref: true,
       fieldName: 'email_id',
       index: 'fk_user_email_flags_emails1_idx',
     },
     flag: {
       kind: '1:1',
       entity: () => Flags,
+      ref: true,
       fieldName: 'flag_id',
       defaultRaw: \`1\`,
       index: 'fk_user_email_flags_flags1_idx',
@@ -1899,16 +1942,16 @@ export const UserEmailFlagsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Orders } from './Orders';
 import { Users } from './Users';
 
 export class UserEmailOrders {
   [PrimaryKeyProp]?: ['user', 'email'];
-  user!: Users;
-  email!: Emails;
-  order!: Orders;
+  user!: Ref<Users>;
+  email!: Ref<Emails>;
+  order!: Ref<Orders>;
 }
 
 export const UserEmailOrdersSchema = new EntitySchema({
@@ -1918,32 +1961,35 @@ export const UserEmailOrdersSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
     },
     email: {
       primary: true,
       kind: 'm:1',
       entity: () => Emails,
+      ref: true,
       fieldName: 'email_id',
       index: 'fk_user_email_orders_emails1_idx',
     },
     order: {
       kind: 'm:1',
       entity: () => Orders,
+      ref: true,
       fieldName: 'order_id',
       index: 'fk_user_email_orders_orders1_idx',
     },
   },
 });
 ",
-  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
 export class UserEmails {
   [PrimaryKeyProp]?: ['user', 'email'];
-  user!: Users;
-  email!: Emails;
+  user!: Ref<Users>;
+  email!: Ref<Emails>;
   isVerified: boolean & Opt = false;
 }
 
@@ -1954,6 +2000,7 @@ export const UserEmailsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
       updateRule: 'cascade',
       deleteRule: 'cascade',
@@ -1962,6 +2009,7 @@ export const UserEmailsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Emails,
+      ref: true,
       fieldName: 'email_id',
       updateRule: 'cascade',
       deleteRule: 'cascade',
@@ -2128,9 +2176,9 @@ export const UsersSchema = new EntitySchema({
 ]
 `;
 
-exports[`many_to_many_variants > bidirectionalRelations=false > onlyPurePivotTables=true > outputPurePivotTables=false > readOnlyPivotTables=false > entitySchema=false > dump 1`] = `
+exports[`many_to_many_variants > bidirectionalRelations=false > onlyPurePivotTables=true > outputPurePivotTables=false > readOnlyPivotTables=false > entityDefinition=decorators > dump 1`] = `
 [
-  "import { Entity, ManyToOne, PrimaryKey, Unique } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKey, type Ref, Unique } from '@mikro-orm/core';
 import { Orders } from './Orders';
 import { Users } from './Users';
 
@@ -2141,11 +2189,11 @@ export class CompletedOrders {
   @PrimaryKey()
   id!: number;
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', index: 'fk_completed_orders_users1_idx' })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', index: 'fk_completed_orders_users1_idx' })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Orders, fieldName: 'order_id', index: 'fk_completed_orders_orders1_idx' })
-  order!: Orders;
+  @ManyToOne({ entity: () => Orders, ref: true, fieldName: 'order_id', index: 'fk_completed_orders_orders1_idx' })
+  order!: Ref<Orders>;
 
 }
 ",
@@ -2194,7 +2242,7 @@ export class Orders {
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
@@ -2203,18 +2251,18 @@ export class UserEmailAvatars {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Emails, fieldName: 'email_id', primary: true, index: 'fk_user_email_avatars_emails1_idx' })
-  email!: Emails;
+  @ManyToOne({ entity: () => Emails, ref: true, fieldName: 'email_id', primary: true, index: 'fk_user_email_avatars_emails1_idx' })
+  email!: Ref<Emails>;
 
   @Property()
   avatarUrl!: string;
 
 }
 ",
-  "import { Entity, ManyToOne, OneToOne, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, OneToOne, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Flags } from './Flags';
 import { Users } from './Users';
@@ -2224,18 +2272,18 @@ export class UserEmailFlags {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Emails, fieldName: 'email_id', primary: true, index: 'fk_user_email_flags_emails1_idx' })
-  email!: Emails;
+  @ManyToOne({ entity: () => Emails, ref: true, fieldName: 'email_id', primary: true, index: 'fk_user_email_flags_emails1_idx' })
+  email!: Ref<Emails>;
 
-  @OneToOne({ entity: () => Flags, fieldName: 'flag_id', defaultRaw: \`1\`, index: 'fk_user_email_flags_flags1_idx', unique: 'flag_id_UNIQUE' })
-  flag!: Flags & Opt;
+  @OneToOne({ entity: () => Flags, ref: true, fieldName: 'flag_id', defaultRaw: \`1\`, index: 'fk_user_email_flags_flags1_idx', unique: 'flag_id_UNIQUE' })
+  flag!: Ref<Flags> & Opt;
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Orders } from './Orders';
 import { Users } from './Users';
@@ -2245,18 +2293,18 @@ export class UserEmailOrders {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Emails, fieldName: 'email_id', primary: true, index: 'fk_user_email_orders_emails1_idx' })
-  email!: Emails;
+  @ManyToOne({ entity: () => Emails, ref: true, fieldName: 'email_id', primary: true, index: 'fk_user_email_orders_emails1_idx' })
+  email!: Ref<Emails>;
 
-  @ManyToOne({ entity: () => Orders, fieldName: 'order_id', index: 'fk_user_email_orders_orders1_idx' })
-  order!: Orders;
+  @ManyToOne({ entity: () => Orders, ref: true, fieldName: 'order_id', index: 'fk_user_email_orders_orders1_idx' })
+  order!: Ref<Orders>;
 
 }
 ",
-  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
@@ -2265,18 +2313,18 @@ export class UserEmails {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Emails, fieldName: 'email_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true, index: 'fk_user_emails_emails1_idx' })
-  email!: Emails;
+  @ManyToOne({ entity: () => Emails, ref: true, fieldName: 'email_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true, index: 'fk_user_emails_emails1_idx' })
+  email!: Ref<Emails>;
 
   @Property({ type: 'boolean' })
   isVerified: boolean & Opt = false;
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Orders } from './Orders';
 import { Users } from './Users';
 
@@ -2285,11 +2333,11 @@ export class UserOrders {
 
   [PrimaryKeyProp]?: ['user', 'order'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Orders, fieldName: 'order_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true, index: 'fk_user_orders_orders1_idx' })
-  order!: Orders;
+  @ManyToOne({ entity: () => Orders, ref: true, fieldName: 'order_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true, index: 'fk_user_orders_orders1_idx' })
+  order!: Ref<Orders>;
 
   @Property({ unsigned: true, autoincrement: true, unique: 'priority_UNIQUE' })
   priority!: number;
@@ -2318,16 +2366,16 @@ export class Users {
 ]
 `;
 
-exports[`many_to_many_variants > bidirectionalRelations=false > onlyPurePivotTables=true > outputPurePivotTables=false > readOnlyPivotTables=false > entitySchema=true > dump 1`] = `
+exports[`many_to_many_variants > bidirectionalRelations=false > onlyPurePivotTables=true > outputPurePivotTables=false > readOnlyPivotTables=false > entityDefinition=entitySchema > dump 1`] = `
 [
-  "import { EntitySchema } from '@mikro-orm/core';
+  "import { EntitySchema, type Ref } from '@mikro-orm/core';
 import { Orders } from './Orders';
 import { Users } from './Users';
 
 export class CompletedOrders {
   id!: number;
-  user!: Users;
-  order!: Orders;
+  user!: Ref<Users>;
+  order!: Ref<Orders>;
 }
 
 export const CompletedOrdersSchema = new EntitySchema({
@@ -2338,12 +2386,14 @@ export const CompletedOrdersSchema = new EntitySchema({
     user: {
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
       index: 'fk_completed_orders_users1_idx',
     },
     order: {
       kind: 'm:1',
       entity: () => Orders,
+      ref: true,
       fieldName: 'order_id',
       index: 'fk_completed_orders_orders1_idx',
     },
@@ -2398,14 +2448,14 @@ export const OrdersSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
 export class UserEmailAvatars {
   [PrimaryKeyProp]?: ['user', 'email'];
-  user!: Users;
-  email!: Emails;
+  user!: Ref<Users>;
+  email!: Ref<Emails>;
   avatarUrl!: string;
 }
 
@@ -2416,6 +2466,7 @@ export const UserEmailAvatarsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
       updateRule: 'cascade',
       deleteRule: 'cascade',
@@ -2424,6 +2475,7 @@ export const UserEmailAvatarsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Emails,
+      ref: true,
       fieldName: 'email_id',
       index: 'fk_user_email_avatars_emails1_idx',
     },
@@ -2431,16 +2483,16 @@ export const UserEmailAvatarsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Flags } from './Flags';
 import { Users } from './Users';
 
 export class UserEmailFlags {
   [PrimaryKeyProp]?: ['user', 'email'];
-  user!: Users;
-  email!: Emails;
-  flag!: Flags & Opt;
+  user!: Ref<Users>;
+  email!: Ref<Emails>;
+  flag!: Ref<Flags> & Opt;
 }
 
 export const UserEmailFlagsSchema = new EntitySchema({
@@ -2450,18 +2502,21 @@ export const UserEmailFlagsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
     },
     email: {
       primary: true,
       kind: 'm:1',
       entity: () => Emails,
+      ref: true,
       fieldName: 'email_id',
       index: 'fk_user_email_flags_emails1_idx',
     },
     flag: {
       kind: '1:1',
       entity: () => Flags,
+      ref: true,
       fieldName: 'flag_id',
       defaultRaw: \`1\`,
       index: 'fk_user_email_flags_flags1_idx',
@@ -2470,16 +2525,16 @@ export const UserEmailFlagsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Orders } from './Orders';
 import { Users } from './Users';
 
 export class UserEmailOrders {
   [PrimaryKeyProp]?: ['user', 'email'];
-  user!: Users;
-  email!: Emails;
-  order!: Orders;
+  user!: Ref<Users>;
+  email!: Ref<Emails>;
+  order!: Ref<Orders>;
 }
 
 export const UserEmailOrdersSchema = new EntitySchema({
@@ -2489,32 +2544,35 @@ export const UserEmailOrdersSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
     },
     email: {
       primary: true,
       kind: 'm:1',
       entity: () => Emails,
+      ref: true,
       fieldName: 'email_id',
       index: 'fk_user_email_orders_emails1_idx',
     },
     order: {
       kind: 'm:1',
       entity: () => Orders,
+      ref: true,
       fieldName: 'order_id',
       index: 'fk_user_email_orders_orders1_idx',
     },
   },
 });
 ",
-  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
 export class UserEmails {
   [PrimaryKeyProp]?: ['user', 'email'];
-  user!: Users;
-  email!: Emails;
+  user!: Ref<Users>;
+  email!: Ref<Emails>;
   isVerified: boolean & Opt = false;
 }
 
@@ -2525,6 +2583,7 @@ export const UserEmailsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
       updateRule: 'cascade',
       deleteRule: 'cascade',
@@ -2533,6 +2592,7 @@ export const UserEmailsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Emails,
+      ref: true,
       fieldName: 'email_id',
       updateRule: 'cascade',
       deleteRule: 'cascade',
@@ -2542,14 +2602,14 @@ export const UserEmailsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Orders } from './Orders';
 import { Users } from './Users';
 
 export class UserOrders {
   [PrimaryKeyProp]?: ['user', 'order'];
-  user!: Users;
-  order!: Orders;
+  user!: Ref<Users>;
+  order!: Ref<Orders>;
   priority!: number;
 }
 
@@ -2560,12 +2620,14 @@ export const UserOrdersSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
     },
     order: {
       primary: true,
       kind: 'm:1',
       entity: () => Orders,
+      ref: true,
       fieldName: 'order_id',
       updateRule: 'cascade',
       deleteRule: 'cascade',
@@ -2608,9 +2670,9 @@ export const UsersSchema = new EntitySchema({
 ]
 `;
 
-exports[`many_to_many_variants > bidirectionalRelations=false > onlyPurePivotTables=true > outputPurePivotTables=false > readOnlyPivotTables=true > entitySchema=false > dump 1`] = `
+exports[`many_to_many_variants > bidirectionalRelations=false > onlyPurePivotTables=true > outputPurePivotTables=false > readOnlyPivotTables=true > entityDefinition=decorators > dump 1`] = `
 [
-  "import { Entity, ManyToOne, PrimaryKey, Unique } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKey, type Ref, Unique } from '@mikro-orm/core';
 import { Orders } from './Orders';
 import { Users } from './Users';
 
@@ -2621,11 +2683,11 @@ export class CompletedOrders {
   @PrimaryKey()
   id!: number;
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', index: 'fk_completed_orders_users1_idx' })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', index: 'fk_completed_orders_users1_idx' })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Orders, fieldName: 'order_id', index: 'fk_completed_orders_orders1_idx' })
-  order!: Orders;
+  @ManyToOne({ entity: () => Orders, ref: true, fieldName: 'order_id', index: 'fk_completed_orders_orders1_idx' })
+  order!: Ref<Orders>;
 
 }
 ",
@@ -2674,7 +2736,7 @@ export class Orders {
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
@@ -2683,18 +2745,18 @@ export class UserEmailAvatars {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Emails, fieldName: 'email_id', primary: true, index: 'fk_user_email_avatars_emails1_idx' })
-  email!: Emails;
+  @ManyToOne({ entity: () => Emails, ref: true, fieldName: 'email_id', primary: true, index: 'fk_user_email_avatars_emails1_idx' })
+  email!: Ref<Emails>;
 
   @Property()
   avatarUrl!: string;
 
 }
 ",
-  "import { Entity, ManyToOne, OneToOne, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, OneToOne, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Flags } from './Flags';
 import { Users } from './Users';
@@ -2704,18 +2766,18 @@ export class UserEmailFlags {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Emails, fieldName: 'email_id', primary: true, index: 'fk_user_email_flags_emails1_idx' })
-  email!: Emails;
+  @ManyToOne({ entity: () => Emails, ref: true, fieldName: 'email_id', primary: true, index: 'fk_user_email_flags_emails1_idx' })
+  email!: Ref<Emails>;
 
-  @OneToOne({ entity: () => Flags, fieldName: 'flag_id', defaultRaw: \`1\`, index: 'fk_user_email_flags_flags1_idx', unique: 'flag_id_UNIQUE' })
-  flag!: Flags & Opt;
+  @OneToOne({ entity: () => Flags, ref: true, fieldName: 'flag_id', defaultRaw: \`1\`, index: 'fk_user_email_flags_flags1_idx', unique: 'flag_id_UNIQUE' })
+  flag!: Ref<Flags> & Opt;
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Orders } from './Orders';
 import { Users } from './Users';
@@ -2725,18 +2787,18 @@ export class UserEmailOrders {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Emails, fieldName: 'email_id', primary: true, index: 'fk_user_email_orders_emails1_idx' })
-  email!: Emails;
+  @ManyToOne({ entity: () => Emails, ref: true, fieldName: 'email_id', primary: true, index: 'fk_user_email_orders_emails1_idx' })
+  email!: Ref<Emails>;
 
-  @ManyToOne({ entity: () => Orders, fieldName: 'order_id', index: 'fk_user_email_orders_orders1_idx' })
-  order!: Orders;
+  @ManyToOne({ entity: () => Orders, ref: true, fieldName: 'order_id', index: 'fk_user_email_orders_orders1_idx' })
+  order!: Ref<Orders>;
 
 }
 ",
-  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
@@ -2745,18 +2807,18 @@ export class UserEmails {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Emails, fieldName: 'email_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true, index: 'fk_user_emails_emails1_idx' })
-  email!: Emails;
+  @ManyToOne({ entity: () => Emails, ref: true, fieldName: 'email_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true, index: 'fk_user_emails_emails1_idx' })
+  email!: Ref<Emails>;
 
   @Property({ type: 'boolean' })
   isVerified: boolean & Opt = false;
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Orders } from './Orders';
 import { Users } from './Users';
 
@@ -2765,11 +2827,11 @@ export class UserOrders {
 
   [PrimaryKeyProp]?: ['user', 'order'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Orders, fieldName: 'order_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true, index: 'fk_user_orders_orders1_idx' })
-  order!: Orders;
+  @ManyToOne({ entity: () => Orders, ref: true, fieldName: 'order_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true, index: 'fk_user_orders_orders1_idx' })
+  order!: Ref<Orders>;
 
   @Property({ unsigned: true, autoincrement: true, unique: 'priority_UNIQUE' })
   priority!: number;
@@ -2798,16 +2860,16 @@ export class Users {
 ]
 `;
 
-exports[`many_to_many_variants > bidirectionalRelations=false > onlyPurePivotTables=true > outputPurePivotTables=false > readOnlyPivotTables=true > entitySchema=true > dump 1`] = `
+exports[`many_to_many_variants > bidirectionalRelations=false > onlyPurePivotTables=true > outputPurePivotTables=false > readOnlyPivotTables=true > entityDefinition=entitySchema > dump 1`] = `
 [
-  "import { EntitySchema } from '@mikro-orm/core';
+  "import { EntitySchema, type Ref } from '@mikro-orm/core';
 import { Orders } from './Orders';
 import { Users } from './Users';
 
 export class CompletedOrders {
   id!: number;
-  user!: Users;
-  order!: Orders;
+  user!: Ref<Users>;
+  order!: Ref<Orders>;
 }
 
 export const CompletedOrdersSchema = new EntitySchema({
@@ -2818,12 +2880,14 @@ export const CompletedOrdersSchema = new EntitySchema({
     user: {
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
       index: 'fk_completed_orders_users1_idx',
     },
     order: {
       kind: 'm:1',
       entity: () => Orders,
+      ref: true,
       fieldName: 'order_id',
       index: 'fk_completed_orders_orders1_idx',
     },
@@ -2878,14 +2942,14 @@ export const OrdersSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
 export class UserEmailAvatars {
   [PrimaryKeyProp]?: ['user', 'email'];
-  user!: Users;
-  email!: Emails;
+  user!: Ref<Users>;
+  email!: Ref<Emails>;
   avatarUrl!: string;
 }
 
@@ -2896,6 +2960,7 @@ export const UserEmailAvatarsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
       updateRule: 'cascade',
       deleteRule: 'cascade',
@@ -2904,6 +2969,7 @@ export const UserEmailAvatarsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Emails,
+      ref: true,
       fieldName: 'email_id',
       index: 'fk_user_email_avatars_emails1_idx',
     },
@@ -2911,16 +2977,16 @@ export const UserEmailAvatarsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Flags } from './Flags';
 import { Users } from './Users';
 
 export class UserEmailFlags {
   [PrimaryKeyProp]?: ['user', 'email'];
-  user!: Users;
-  email!: Emails;
-  flag!: Flags & Opt;
+  user!: Ref<Users>;
+  email!: Ref<Emails>;
+  flag!: Ref<Flags> & Opt;
 }
 
 export const UserEmailFlagsSchema = new EntitySchema({
@@ -2930,18 +2996,21 @@ export const UserEmailFlagsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
     },
     email: {
       primary: true,
       kind: 'm:1',
       entity: () => Emails,
+      ref: true,
       fieldName: 'email_id',
       index: 'fk_user_email_flags_emails1_idx',
     },
     flag: {
       kind: '1:1',
       entity: () => Flags,
+      ref: true,
       fieldName: 'flag_id',
       defaultRaw: \`1\`,
       index: 'fk_user_email_flags_flags1_idx',
@@ -2950,16 +3019,16 @@ export const UserEmailFlagsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Orders } from './Orders';
 import { Users } from './Users';
 
 export class UserEmailOrders {
   [PrimaryKeyProp]?: ['user', 'email'];
-  user!: Users;
-  email!: Emails;
-  order!: Orders;
+  user!: Ref<Users>;
+  email!: Ref<Emails>;
+  order!: Ref<Orders>;
 }
 
 export const UserEmailOrdersSchema = new EntitySchema({
@@ -2969,32 +3038,35 @@ export const UserEmailOrdersSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
     },
     email: {
       primary: true,
       kind: 'm:1',
       entity: () => Emails,
+      ref: true,
       fieldName: 'email_id',
       index: 'fk_user_email_orders_emails1_idx',
     },
     order: {
       kind: 'm:1',
       entity: () => Orders,
+      ref: true,
       fieldName: 'order_id',
       index: 'fk_user_email_orders_orders1_idx',
     },
   },
 });
 ",
-  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
 export class UserEmails {
   [PrimaryKeyProp]?: ['user', 'email'];
-  user!: Users;
-  email!: Emails;
+  user!: Ref<Users>;
+  email!: Ref<Emails>;
   isVerified: boolean & Opt = false;
 }
 
@@ -3005,6 +3077,7 @@ export const UserEmailsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
       updateRule: 'cascade',
       deleteRule: 'cascade',
@@ -3013,6 +3086,7 @@ export const UserEmailsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Emails,
+      ref: true,
       fieldName: 'email_id',
       updateRule: 'cascade',
       deleteRule: 'cascade',
@@ -3022,14 +3096,14 @@ export const UserEmailsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Orders } from './Orders';
 import { Users } from './Users';
 
 export class UserOrders {
   [PrimaryKeyProp]?: ['user', 'order'];
-  user!: Users;
-  order!: Orders;
+  user!: Ref<Users>;
+  order!: Ref<Orders>;
   priority!: number;
 }
 
@@ -3040,12 +3114,14 @@ export const UserOrdersSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
     },
     order: {
       primary: true,
       kind: 'm:1',
       entity: () => Orders,
+      ref: true,
       fieldName: 'order_id',
       updateRule: 'cascade',
       deleteRule: 'cascade',
@@ -3088,9 +3164,9 @@ export const UsersSchema = new EntitySchema({
 ]
 `;
 
-exports[`many_to_many_variants > bidirectionalRelations=false > onlyPurePivotTables=true > outputPurePivotTables=true > readOnlyPivotTables=false > entitySchema=false > dump 1`] = `
+exports[`many_to_many_variants > bidirectionalRelations=false > onlyPurePivotTables=true > outputPurePivotTables=true > readOnlyPivotTables=false > entityDefinition=decorators > dump 1`] = `
 [
-  "import { Entity, ManyToOne, PrimaryKey, Unique } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKey, type Ref, Unique } from '@mikro-orm/core';
 import { Orders } from './Orders';
 import { Users } from './Users';
 
@@ -3101,11 +3177,11 @@ export class CompletedOrders {
   @PrimaryKey()
   id!: number;
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', index: 'fk_completed_orders_users1_idx' })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', index: 'fk_completed_orders_users1_idx' })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Orders, fieldName: 'order_id', index: 'fk_completed_orders_orders1_idx' })
-  order!: Orders;
+  @ManyToOne({ entity: () => Orders, ref: true, fieldName: 'order_id', index: 'fk_completed_orders_orders1_idx' })
+  order!: Ref<Orders>;
 
 }
 ",
@@ -3154,7 +3230,7 @@ export class Orders {
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
@@ -3163,18 +3239,18 @@ export class UserEmailAvatars {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Emails, fieldName: 'email_id', primary: true, index: 'fk_user_email_avatars_emails1_idx' })
-  email!: Emails;
+  @ManyToOne({ entity: () => Emails, ref: true, fieldName: 'email_id', primary: true, index: 'fk_user_email_avatars_emails1_idx' })
+  email!: Ref<Emails>;
 
   @Property()
   avatarUrl!: string;
 
 }
 ",
-  "import { Entity, ManyToOne, OneToOne, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, OneToOne, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Flags } from './Flags';
 import { Users } from './Users';
@@ -3184,18 +3260,18 @@ export class UserEmailFlags {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Emails, fieldName: 'email_id', primary: true, index: 'fk_user_email_flags_emails1_idx' })
-  email!: Emails;
+  @ManyToOne({ entity: () => Emails, ref: true, fieldName: 'email_id', primary: true, index: 'fk_user_email_flags_emails1_idx' })
+  email!: Ref<Emails>;
 
-  @OneToOne({ entity: () => Flags, fieldName: 'flag_id', defaultRaw: \`1\`, index: 'fk_user_email_flags_flags1_idx', unique: 'flag_id_UNIQUE' })
-  flag!: Flags & Opt;
+  @OneToOne({ entity: () => Flags, ref: true, fieldName: 'flag_id', defaultRaw: \`1\`, index: 'fk_user_email_flags_flags1_idx', unique: 'flag_id_UNIQUE' })
+  flag!: Ref<Flags> & Opt;
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Orders } from './Orders';
 import { Users } from './Users';
@@ -3205,18 +3281,18 @@ export class UserEmailOrders {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Emails, fieldName: 'email_id', primary: true, index: 'fk_user_email_orders_emails1_idx' })
-  email!: Emails;
+  @ManyToOne({ entity: () => Emails, ref: true, fieldName: 'email_id', primary: true, index: 'fk_user_email_orders_emails1_idx' })
+  email!: Ref<Emails>;
 
-  @ManyToOne({ entity: () => Orders, fieldName: 'order_id', index: 'fk_user_email_orders_orders1_idx' })
-  order!: Orders;
+  @ManyToOne({ entity: () => Orders, ref: true, fieldName: 'order_id', index: 'fk_user_email_orders_orders1_idx' })
+  order!: Ref<Orders>;
 
 }
 ",
-  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
@@ -3225,11 +3301,11 @@ export class UserEmails {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Emails, fieldName: 'email_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true, index: 'fk_user_emails_emails1_idx' })
-  email!: Emails;
+  @ManyToOne({ entity: () => Emails, ref: true, fieldName: 'email_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true, index: 'fk_user_emails_emails1_idx' })
+  email!: Ref<Emails>;
 
   @Property({ type: 'boolean' })
   isVerified: boolean & Opt = false;
@@ -3253,7 +3329,7 @@ export class UserFlags {
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Orders } from './Orders';
 import { Users } from './Users';
 
@@ -3262,11 +3338,11 @@ export class UserOrders {
 
   [PrimaryKeyProp]?: ['user', 'order'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Orders, fieldName: 'order_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true, index: 'fk_user_orders_orders1_idx' })
-  order!: Orders;
+  @ManyToOne({ entity: () => Orders, ref: true, fieldName: 'order_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true, index: 'fk_user_orders_orders1_idx' })
+  order!: Ref<Orders>;
 
   @Property({ unsigned: true, autoincrement: true, unique: 'priority_UNIQUE' })
   priority!: number;
@@ -3296,16 +3372,16 @@ export class Users {
 ]
 `;
 
-exports[`many_to_many_variants > bidirectionalRelations=false > onlyPurePivotTables=true > outputPurePivotTables=true > readOnlyPivotTables=false > entitySchema=true > dump 1`] = `
+exports[`many_to_many_variants > bidirectionalRelations=false > onlyPurePivotTables=true > outputPurePivotTables=true > readOnlyPivotTables=false > entityDefinition=entitySchema > dump 1`] = `
 [
-  "import { EntitySchema } from '@mikro-orm/core';
+  "import { EntitySchema, type Ref } from '@mikro-orm/core';
 import { Orders } from './Orders';
 import { Users } from './Users';
 
 export class CompletedOrders {
   id!: number;
-  user!: Users;
-  order!: Orders;
+  user!: Ref<Users>;
+  order!: Ref<Orders>;
 }
 
 export const CompletedOrdersSchema = new EntitySchema({
@@ -3316,12 +3392,14 @@ export const CompletedOrdersSchema = new EntitySchema({
     user: {
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
       index: 'fk_completed_orders_users1_idx',
     },
     order: {
       kind: 'm:1',
       entity: () => Orders,
+      ref: true,
       fieldName: 'order_id',
       index: 'fk_completed_orders_orders1_idx',
     },
@@ -3376,14 +3454,14 @@ export const OrdersSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
 export class UserEmailAvatars {
   [PrimaryKeyProp]?: ['user', 'email'];
-  user!: Users;
-  email!: Emails;
+  user!: Ref<Users>;
+  email!: Ref<Emails>;
   avatarUrl!: string;
 }
 
@@ -3394,6 +3472,7 @@ export const UserEmailAvatarsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
       updateRule: 'cascade',
       deleteRule: 'cascade',
@@ -3402,6 +3481,7 @@ export const UserEmailAvatarsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Emails,
+      ref: true,
       fieldName: 'email_id',
       index: 'fk_user_email_avatars_emails1_idx',
     },
@@ -3409,16 +3489,16 @@ export const UserEmailAvatarsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Flags } from './Flags';
 import { Users } from './Users';
 
 export class UserEmailFlags {
   [PrimaryKeyProp]?: ['user', 'email'];
-  user!: Users;
-  email!: Emails;
-  flag!: Flags & Opt;
+  user!: Ref<Users>;
+  email!: Ref<Emails>;
+  flag!: Ref<Flags> & Opt;
 }
 
 export const UserEmailFlagsSchema = new EntitySchema({
@@ -3428,18 +3508,21 @@ export const UserEmailFlagsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
     },
     email: {
       primary: true,
       kind: 'm:1',
       entity: () => Emails,
+      ref: true,
       fieldName: 'email_id',
       index: 'fk_user_email_flags_emails1_idx',
     },
     flag: {
       kind: '1:1',
       entity: () => Flags,
+      ref: true,
       fieldName: 'flag_id',
       defaultRaw: \`1\`,
       index: 'fk_user_email_flags_flags1_idx',
@@ -3448,16 +3531,16 @@ export const UserEmailFlagsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Orders } from './Orders';
 import { Users } from './Users';
 
 export class UserEmailOrders {
   [PrimaryKeyProp]?: ['user', 'email'];
-  user!: Users;
-  email!: Emails;
-  order!: Orders;
+  user!: Ref<Users>;
+  email!: Ref<Emails>;
+  order!: Ref<Orders>;
 }
 
 export const UserEmailOrdersSchema = new EntitySchema({
@@ -3467,32 +3550,35 @@ export const UserEmailOrdersSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
     },
     email: {
       primary: true,
       kind: 'm:1',
       entity: () => Emails,
+      ref: true,
       fieldName: 'email_id',
       index: 'fk_user_email_orders_emails1_idx',
     },
     order: {
       kind: 'm:1',
       entity: () => Orders,
+      ref: true,
       fieldName: 'order_id',
       index: 'fk_user_email_orders_orders1_idx',
     },
   },
 });
 ",
-  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
 export class UserEmails {
   [PrimaryKeyProp]?: ['user', 'email'];
-  user!: Users;
-  email!: Emails;
+  user!: Ref<Users>;
+  email!: Ref<Emails>;
   isVerified: boolean & Opt = false;
 }
 
@@ -3503,6 +3589,7 @@ export const UserEmailsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
       updateRule: 'cascade',
       deleteRule: 'cascade',
@@ -3511,6 +3598,7 @@ export const UserEmailsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Emails,
+      ref: true,
       fieldName: 'email_id',
       updateRule: 'cascade',
       deleteRule: 'cascade',
@@ -3552,14 +3640,14 @@ export const UserFlagsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Orders } from './Orders';
 import { Users } from './Users';
 
 export class UserOrders {
   [PrimaryKeyProp]?: ['user', 'order'];
-  user!: Users;
-  order!: Orders;
+  user!: Ref<Users>;
+  order!: Ref<Orders>;
   priority!: number;
 }
 
@@ -3570,12 +3658,14 @@ export const UserOrdersSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
     },
     order: {
       primary: true,
       kind: 'm:1',
       entity: () => Orders,
+      ref: true,
       fieldName: 'order_id',
       updateRule: 'cascade',
       deleteRule: 'cascade',
@@ -3620,9 +3710,9 @@ export const UsersSchema = new EntitySchema({
 ]
 `;
 
-exports[`many_to_many_variants > bidirectionalRelations=false > onlyPurePivotTables=true > outputPurePivotTables=true > readOnlyPivotTables=true > entitySchema=false > dump 1`] = `
+exports[`many_to_many_variants > bidirectionalRelations=false > onlyPurePivotTables=true > outputPurePivotTables=true > readOnlyPivotTables=true > entityDefinition=decorators > dump 1`] = `
 [
-  "import { Entity, ManyToOne, PrimaryKey, Unique } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKey, type Ref, Unique } from '@mikro-orm/core';
 import { Orders } from './Orders';
 import { Users } from './Users';
 
@@ -3633,11 +3723,11 @@ export class CompletedOrders {
   @PrimaryKey()
   id!: number;
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', index: 'fk_completed_orders_users1_idx' })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', index: 'fk_completed_orders_users1_idx' })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Orders, fieldName: 'order_id', index: 'fk_completed_orders_orders1_idx' })
-  order!: Orders;
+  @ManyToOne({ entity: () => Orders, ref: true, fieldName: 'order_id', index: 'fk_completed_orders_orders1_idx' })
+  order!: Ref<Orders>;
 
 }
 ",
@@ -3686,7 +3776,7 @@ export class Orders {
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
@@ -3695,18 +3785,18 @@ export class UserEmailAvatars {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Emails, fieldName: 'email_id', primary: true, index: 'fk_user_email_avatars_emails1_idx' })
-  email!: Emails;
+  @ManyToOne({ entity: () => Emails, ref: true, fieldName: 'email_id', primary: true, index: 'fk_user_email_avatars_emails1_idx' })
+  email!: Ref<Emails>;
 
   @Property()
   avatarUrl!: string;
 
 }
 ",
-  "import { Entity, ManyToOne, OneToOne, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, OneToOne, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Flags } from './Flags';
 import { Users } from './Users';
@@ -3716,18 +3806,18 @@ export class UserEmailFlags {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Emails, fieldName: 'email_id', primary: true, index: 'fk_user_email_flags_emails1_idx' })
-  email!: Emails;
+  @ManyToOne({ entity: () => Emails, ref: true, fieldName: 'email_id', primary: true, index: 'fk_user_email_flags_emails1_idx' })
+  email!: Ref<Emails>;
 
-  @OneToOne({ entity: () => Flags, fieldName: 'flag_id', defaultRaw: \`1\`, index: 'fk_user_email_flags_flags1_idx', unique: 'flag_id_UNIQUE' })
-  flag!: Flags & Opt;
+  @OneToOne({ entity: () => Flags, ref: true, fieldName: 'flag_id', defaultRaw: \`1\`, index: 'fk_user_email_flags_flags1_idx', unique: 'flag_id_UNIQUE' })
+  flag!: Ref<Flags> & Opt;
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Orders } from './Orders';
 import { Users } from './Users';
@@ -3737,18 +3827,18 @@ export class UserEmailOrders {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Emails, fieldName: 'email_id', primary: true, index: 'fk_user_email_orders_emails1_idx' })
-  email!: Emails;
+  @ManyToOne({ entity: () => Emails, ref: true, fieldName: 'email_id', primary: true, index: 'fk_user_email_orders_emails1_idx' })
+  email!: Ref<Emails>;
 
-  @ManyToOne({ entity: () => Orders, fieldName: 'order_id', index: 'fk_user_email_orders_orders1_idx' })
-  order!: Orders;
+  @ManyToOne({ entity: () => Orders, ref: true, fieldName: 'order_id', index: 'fk_user_email_orders_orders1_idx' })
+  order!: Ref<Orders>;
 
 }
 ",
-  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
@@ -3757,11 +3847,11 @@ export class UserEmails {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Emails, fieldName: 'email_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true, index: 'fk_user_emails_emails1_idx' })
-  email!: Emails;
+  @ManyToOne({ entity: () => Emails, ref: true, fieldName: 'email_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true, index: 'fk_user_emails_emails1_idx' })
+  email!: Ref<Emails>;
 
   @Property({ type: 'boolean' })
   isVerified: boolean & Opt = false;
@@ -3785,7 +3875,7 @@ export class UserFlags {
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Orders } from './Orders';
 import { Users } from './Users';
 
@@ -3794,11 +3884,11 @@ export class UserOrders {
 
   [PrimaryKeyProp]?: ['user', 'order'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Orders, fieldName: 'order_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true, index: 'fk_user_orders_orders1_idx' })
-  order!: Orders;
+  @ManyToOne({ entity: () => Orders, ref: true, fieldName: 'order_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true, index: 'fk_user_orders_orders1_idx' })
+  order!: Ref<Orders>;
 
   @Property({ unsigned: true, autoincrement: true, unique: 'priority_UNIQUE' })
   priority!: number;
@@ -3828,16 +3918,16 @@ export class Users {
 ]
 `;
 
-exports[`many_to_many_variants > bidirectionalRelations=false > onlyPurePivotTables=true > outputPurePivotTables=true > readOnlyPivotTables=true > entitySchema=true > dump 1`] = `
+exports[`many_to_many_variants > bidirectionalRelations=false > onlyPurePivotTables=true > outputPurePivotTables=true > readOnlyPivotTables=true > entityDefinition=entitySchema > dump 1`] = `
 [
-  "import { EntitySchema } from '@mikro-orm/core';
+  "import { EntitySchema, type Ref } from '@mikro-orm/core';
 import { Orders } from './Orders';
 import { Users } from './Users';
 
 export class CompletedOrders {
   id!: number;
-  user!: Users;
-  order!: Orders;
+  user!: Ref<Users>;
+  order!: Ref<Orders>;
 }
 
 export const CompletedOrdersSchema = new EntitySchema({
@@ -3848,12 +3938,14 @@ export const CompletedOrdersSchema = new EntitySchema({
     user: {
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
       index: 'fk_completed_orders_users1_idx',
     },
     order: {
       kind: 'm:1',
       entity: () => Orders,
+      ref: true,
       fieldName: 'order_id',
       index: 'fk_completed_orders_orders1_idx',
     },
@@ -3908,14 +4000,14 @@ export const OrdersSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
 export class UserEmailAvatars {
   [PrimaryKeyProp]?: ['user', 'email'];
-  user!: Users;
-  email!: Emails;
+  user!: Ref<Users>;
+  email!: Ref<Emails>;
   avatarUrl!: string;
 }
 
@@ -3926,6 +4018,7 @@ export const UserEmailAvatarsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
       updateRule: 'cascade',
       deleteRule: 'cascade',
@@ -3934,6 +4027,7 @@ export const UserEmailAvatarsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Emails,
+      ref: true,
       fieldName: 'email_id',
       index: 'fk_user_email_avatars_emails1_idx',
     },
@@ -3941,16 +4035,16 @@ export const UserEmailAvatarsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Flags } from './Flags';
 import { Users } from './Users';
 
 export class UserEmailFlags {
   [PrimaryKeyProp]?: ['user', 'email'];
-  user!: Users;
-  email!: Emails;
-  flag!: Flags & Opt;
+  user!: Ref<Users>;
+  email!: Ref<Emails>;
+  flag!: Ref<Flags> & Opt;
 }
 
 export const UserEmailFlagsSchema = new EntitySchema({
@@ -3960,18 +4054,21 @@ export const UserEmailFlagsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
     },
     email: {
       primary: true,
       kind: 'm:1',
       entity: () => Emails,
+      ref: true,
       fieldName: 'email_id',
       index: 'fk_user_email_flags_emails1_idx',
     },
     flag: {
       kind: '1:1',
       entity: () => Flags,
+      ref: true,
       fieldName: 'flag_id',
       defaultRaw: \`1\`,
       index: 'fk_user_email_flags_flags1_idx',
@@ -3980,16 +4077,16 @@ export const UserEmailFlagsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Orders } from './Orders';
 import { Users } from './Users';
 
 export class UserEmailOrders {
   [PrimaryKeyProp]?: ['user', 'email'];
-  user!: Users;
-  email!: Emails;
-  order!: Orders;
+  user!: Ref<Users>;
+  email!: Ref<Emails>;
+  order!: Ref<Orders>;
 }
 
 export const UserEmailOrdersSchema = new EntitySchema({
@@ -3999,32 +4096,35 @@ export const UserEmailOrdersSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
     },
     email: {
       primary: true,
       kind: 'm:1',
       entity: () => Emails,
+      ref: true,
       fieldName: 'email_id',
       index: 'fk_user_email_orders_emails1_idx',
     },
     order: {
       kind: 'm:1',
       entity: () => Orders,
+      ref: true,
       fieldName: 'order_id',
       index: 'fk_user_email_orders_orders1_idx',
     },
   },
 });
 ",
-  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
 export class UserEmails {
   [PrimaryKeyProp]?: ['user', 'email'];
-  user!: Users;
-  email!: Emails;
+  user!: Ref<Users>;
+  email!: Ref<Emails>;
   isVerified: boolean & Opt = false;
 }
 
@@ -4035,6 +4135,7 @@ export const UserEmailsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
       updateRule: 'cascade',
       deleteRule: 'cascade',
@@ -4043,6 +4144,7 @@ export const UserEmailsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Emails,
+      ref: true,
       fieldName: 'email_id',
       updateRule: 'cascade',
       deleteRule: 'cascade',
@@ -4084,14 +4186,14 @@ export const UserFlagsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Orders } from './Orders';
 import { Users } from './Users';
 
 export class UserOrders {
   [PrimaryKeyProp]?: ['user', 'order'];
-  user!: Users;
-  order!: Orders;
+  user!: Ref<Users>;
+  order!: Ref<Orders>;
   priority!: number;
 }
 
@@ -4102,12 +4204,14 @@ export const UserOrdersSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
     },
     order: {
       primary: true,
       kind: 'm:1',
       entity: () => Orders,
+      ref: true,
       fieldName: 'order_id',
       updateRule: 'cascade',
       deleteRule: 'cascade',
@@ -4152,9 +4256,9 @@ export const UsersSchema = new EntitySchema({
 ]
 `;
 
-exports[`many_to_many_variants > bidirectionalRelations=true > onlyPurePivotTables=false > outputPurePivotTables=false > readOnlyPivotTables=false > entitySchema=false > dump 1`] = `
+exports[`many_to_many_variants > bidirectionalRelations=true > onlyPurePivotTables=false > outputPurePivotTables=false > readOnlyPivotTables=false > entityDefinition=decorators > dump 1`] = `
 [
-  "import { Entity, ManyToOne, PrimaryKey, Unique } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKey, type Ref, Unique } from '@mikro-orm/core';
 import { Orders } from './Orders';
 import { Users } from './Users';
 
@@ -4165,11 +4269,11 @@ export class CompletedOrders {
   @PrimaryKey()
   id!: number;
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', index: 'fk_completed_orders_users1_idx' })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', index: 'fk_completed_orders_users1_idx' })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Orders, fieldName: 'order_id', index: 'fk_completed_orders_orders1_idx' })
-  order!: Orders;
+  @ManyToOne({ entity: () => Orders, ref: true, fieldName: 'order_id', index: 'fk_completed_orders_orders1_idx' })
+  order!: Ref<Orders>;
 
 }
 ",
@@ -4208,7 +4312,7 @@ export class Emails {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, OneToOne, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, OneToOne, PrimaryKey, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { UserEmailFlags } from './UserEmailFlags';
 import { Users } from './Users';
 
@@ -4223,8 +4327,8 @@ export class Flags {
   @Property({ unique: 'name_UNIQUE' })
   name!: string;
 
-  @OneToOne({ entity: () => UserEmailFlags, mappedBy: 'flag' })
-  userEmailFlags?: UserEmailFlags;
+  @OneToOne({ entity: () => UserEmailFlags, ref: true, mappedBy: 'flag' })
+  userEmailFlags?: Ref<UserEmailFlags>;
 
   @ManyToMany({ entity: () => Users, mappedBy: 'userFlags' })
   userFlagsInverse = new Collection<Users>(this);
@@ -4258,7 +4362,7 @@ export class Orders {
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
@@ -4267,18 +4371,18 @@ export class UserEmailAvatars {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Emails, fieldName: 'email_id', primary: true, index: 'fk_user_email_avatars_emails1_idx' })
-  email!: Emails;
+  @ManyToOne({ entity: () => Emails, ref: true, fieldName: 'email_id', primary: true, index: 'fk_user_email_avatars_emails1_idx' })
+  email!: Ref<Emails>;
 
   @Property()
   avatarUrl!: string;
 
 }
 ",
-  "import { Entity, ManyToOne, OneToOne, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, OneToOne, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Flags } from './Flags';
 import { Users } from './Users';
@@ -4288,18 +4392,18 @@ export class UserEmailFlags {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Emails, fieldName: 'email_id', primary: true, index: 'fk_user_email_flags_emails1_idx' })
-  email!: Emails;
+  @ManyToOne({ entity: () => Emails, ref: true, fieldName: 'email_id', primary: true, index: 'fk_user_email_flags_emails1_idx' })
+  email!: Ref<Emails>;
 
-  @OneToOne({ entity: () => Flags, fieldName: 'flag_id', defaultRaw: \`1\`, index: 'fk_user_email_flags_flags1_idx', unique: 'flag_id_UNIQUE' })
-  flag!: Flags & Opt;
+  @OneToOne({ entity: () => Flags, ref: true, fieldName: 'flag_id', defaultRaw: \`1\`, index: 'fk_user_email_flags_flags1_idx', unique: 'flag_id_UNIQUE' })
+  flag!: Ref<Flags> & Opt;
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Orders } from './Orders';
 import { Users } from './Users';
@@ -4309,18 +4413,18 @@ export class UserEmailOrders {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Emails, fieldName: 'email_id', primary: true, index: 'fk_user_email_orders_emails1_idx' })
-  email!: Emails;
+  @ManyToOne({ entity: () => Emails, ref: true, fieldName: 'email_id', primary: true, index: 'fk_user_email_orders_emails1_idx' })
+  email!: Ref<Emails>;
 
-  @ManyToOne({ entity: () => Orders, fieldName: 'order_id', index: 'fk_user_email_orders_orders1_idx' })
-  order!: Orders;
+  @ManyToOne({ entity: () => Orders, ref: true, fieldName: 'order_id', index: 'fk_user_email_orders_orders1_idx' })
+  order!: Ref<Orders>;
 
 }
 ",
-  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
@@ -4329,11 +4433,11 @@ export class UserEmails {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Emails, fieldName: 'email_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true, index: 'fk_user_emails_emails1_idx' })
-  email!: Emails;
+  @ManyToOne({ entity: () => Emails, ref: true, fieldName: 'email_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true, index: 'fk_user_emails_emails1_idx' })
+  email!: Ref<Emails>;
 
   @Property({ type: 'boolean' })
   isVerified: boolean & Opt = false;
@@ -4390,16 +4494,16 @@ export class Users {
 ]
 `;
 
-exports[`many_to_many_variants > bidirectionalRelations=true > onlyPurePivotTables=false > outputPurePivotTables=false > readOnlyPivotTables=false > entitySchema=true > dump 1`] = `
+exports[`many_to_many_variants > bidirectionalRelations=true > onlyPurePivotTables=false > outputPurePivotTables=false > readOnlyPivotTables=false > entityDefinition=entitySchema > dump 1`] = `
 [
-  "import { EntitySchema } from '@mikro-orm/core';
+  "import { EntitySchema, type Ref } from '@mikro-orm/core';
 import { Orders } from './Orders';
 import { Users } from './Users';
 
 export class CompletedOrders {
   id!: number;
-  user!: Users;
-  order!: Orders;
+  user!: Ref<Users>;
+  order!: Ref<Orders>;
 }
 
 export const CompletedOrdersSchema = new EntitySchema({
@@ -4410,12 +4514,14 @@ export const CompletedOrdersSchema = new EntitySchema({
     user: {
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
       index: 'fk_completed_orders_users1_idx',
     },
     order: {
       kind: 'm:1',
       entity: () => Orders,
+      ref: true,
       fieldName: 'order_id',
       index: 'fk_completed_orders_orders1_idx',
     },
@@ -4473,7 +4579,7 @@ export const EmailsSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { UserEmailFlags } from './UserEmailFlags';
 import { Users } from './Users';
 
@@ -4481,7 +4587,7 @@ export class Flags {
   [PrimaryKeyProp]?: 'flagId';
   flagId!: number;
   name!: string;
-  userEmailFlags?: UserEmailFlags;
+  userEmailFlags?: Ref<UserEmailFlags>;
   userFlagsInverse = new Collection<Users>(this);
 }
 
@@ -4493,6 +4599,7 @@ export const FlagsSchema = new EntitySchema({
     userEmailFlags: {
       kind: '1:1',
       entity: () => UserEmailFlags,
+      ref: true,
       mappedBy: 'flag',
     },
     userFlagsInverse: { kind: 'm:n', entity: () => Users, mappedBy: 'userFlags' },
@@ -4536,14 +4643,14 @@ export const OrdersSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
 export class UserEmailAvatars {
   [PrimaryKeyProp]?: ['user', 'email'];
-  user!: Users;
-  email!: Emails;
+  user!: Ref<Users>;
+  email!: Ref<Emails>;
   avatarUrl!: string;
 }
 
@@ -4554,6 +4661,7 @@ export const UserEmailAvatarsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
       updateRule: 'cascade',
       deleteRule: 'cascade',
@@ -4562,6 +4670,7 @@ export const UserEmailAvatarsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Emails,
+      ref: true,
       fieldName: 'email_id',
       index: 'fk_user_email_avatars_emails1_idx',
     },
@@ -4569,16 +4678,16 @@ export const UserEmailAvatarsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Flags } from './Flags';
 import { Users } from './Users';
 
 export class UserEmailFlags {
   [PrimaryKeyProp]?: ['user', 'email'];
-  user!: Users;
-  email!: Emails;
-  flag!: Flags & Opt;
+  user!: Ref<Users>;
+  email!: Ref<Emails>;
+  flag!: Ref<Flags> & Opt;
 }
 
 export const UserEmailFlagsSchema = new EntitySchema({
@@ -4588,18 +4697,21 @@ export const UserEmailFlagsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
     },
     email: {
       primary: true,
       kind: 'm:1',
       entity: () => Emails,
+      ref: true,
       fieldName: 'email_id',
       index: 'fk_user_email_flags_emails1_idx',
     },
     flag: {
       kind: '1:1',
       entity: () => Flags,
+      ref: true,
       fieldName: 'flag_id',
       defaultRaw: \`1\`,
       index: 'fk_user_email_flags_flags1_idx',
@@ -4608,16 +4720,16 @@ export const UserEmailFlagsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Orders } from './Orders';
 import { Users } from './Users';
 
 export class UserEmailOrders {
   [PrimaryKeyProp]?: ['user', 'email'];
-  user!: Users;
-  email!: Emails;
-  order!: Orders;
+  user!: Ref<Users>;
+  email!: Ref<Emails>;
+  order!: Ref<Orders>;
 }
 
 export const UserEmailOrdersSchema = new EntitySchema({
@@ -4627,32 +4739,35 @@ export const UserEmailOrdersSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
     },
     email: {
       primary: true,
       kind: 'm:1',
       entity: () => Emails,
+      ref: true,
       fieldName: 'email_id',
       index: 'fk_user_email_orders_emails1_idx',
     },
     order: {
       kind: 'm:1',
       entity: () => Orders,
+      ref: true,
       fieldName: 'order_id',
       index: 'fk_user_email_orders_orders1_idx',
     },
   },
 });
 ",
-  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
 export class UserEmails {
   [PrimaryKeyProp]?: ['user', 'email'];
-  user!: Users;
-  email!: Emails;
+  user!: Ref<Users>;
+  email!: Ref<Emails>;
   isVerified: boolean & Opt = false;
 }
 
@@ -4663,6 +4778,7 @@ export const UserEmailsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
       updateRule: 'cascade',
       deleteRule: 'cascade',
@@ -4671,6 +4787,7 @@ export const UserEmailsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Emails,
+      ref: true,
       fieldName: 'email_id',
       updateRule: 'cascade',
       deleteRule: 'cascade',
@@ -4764,9 +4881,9 @@ export const UsersSchema = new EntitySchema({
 ]
 `;
 
-exports[`many_to_many_variants > bidirectionalRelations=true > onlyPurePivotTables=false > outputPurePivotTables=false > readOnlyPivotTables=true > entitySchema=false > dump 1`] = `
+exports[`many_to_many_variants > bidirectionalRelations=true > onlyPurePivotTables=false > outputPurePivotTables=false > readOnlyPivotTables=true > entityDefinition=decorators > dump 1`] = `
 [
-  "import { Entity, ManyToOne, PrimaryKey, Unique } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKey, type Ref, Unique } from '@mikro-orm/core';
 import { Orders } from './Orders';
 import { Users } from './Users';
 
@@ -4777,11 +4894,11 @@ export class CompletedOrders {
   @PrimaryKey()
   id!: number;
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', index: 'fk_completed_orders_users1_idx' })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', index: 'fk_completed_orders_users1_idx' })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Orders, fieldName: 'order_id', index: 'fk_completed_orders_orders1_idx' })
-  order!: Orders;
+  @ManyToOne({ entity: () => Orders, ref: true, fieldName: 'order_id', index: 'fk_completed_orders_orders1_idx' })
+  order!: Ref<Orders>;
 
 }
 ",
@@ -4829,7 +4946,7 @@ export class Emails {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, OneToOne, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, OneToOne, PrimaryKey, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { UserEmailFlags } from './UserEmailFlags';
 import { Users } from './Users';
 
@@ -4844,8 +4961,8 @@ export class Flags {
   @Property({ unique: 'name_UNIQUE' })
   name!: string;
 
-  @OneToOne({ entity: () => UserEmailFlags, mappedBy: 'flag' })
-  userEmailFlags?: UserEmailFlags;
+  @OneToOne({ entity: () => UserEmailFlags, ref: true, mappedBy: 'flag' })
+  userEmailFlags?: Ref<UserEmailFlags>;
 
   @ManyToMany({ entity: () => Users, mappedBy: 'userFlags' })
   userFlagsInverse = new Collection<Users>(this);
@@ -4879,7 +4996,7 @@ export class Orders {
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
@@ -4888,18 +5005,18 @@ export class UserEmailAvatars {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Emails, fieldName: 'email_id', primary: true, index: 'fk_user_email_avatars_emails1_idx' })
-  email!: Emails;
+  @ManyToOne({ entity: () => Emails, ref: true, fieldName: 'email_id', primary: true, index: 'fk_user_email_avatars_emails1_idx' })
+  email!: Ref<Emails>;
 
   @Property()
   avatarUrl!: string;
 
 }
 ",
-  "import { Entity, ManyToOne, OneToOne, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, OneToOne, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Flags } from './Flags';
 import { Users } from './Users';
@@ -4909,18 +5026,18 @@ export class UserEmailFlags {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Emails, fieldName: 'email_id', primary: true, index: 'fk_user_email_flags_emails1_idx' })
-  email!: Emails;
+  @ManyToOne({ entity: () => Emails, ref: true, fieldName: 'email_id', primary: true, index: 'fk_user_email_flags_emails1_idx' })
+  email!: Ref<Emails>;
 
-  @OneToOne({ entity: () => Flags, fieldName: 'flag_id', defaultRaw: \`1\`, index: 'fk_user_email_flags_flags1_idx', unique: 'flag_id_UNIQUE' })
-  flag!: Flags & Opt;
+  @OneToOne({ entity: () => Flags, ref: true, fieldName: 'flag_id', defaultRaw: \`1\`, index: 'fk_user_email_flags_flags1_idx', unique: 'flag_id_UNIQUE' })
+  flag!: Ref<Flags> & Opt;
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Orders } from './Orders';
 import { Users } from './Users';
@@ -4930,18 +5047,18 @@ export class UserEmailOrders {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Emails, fieldName: 'email_id', primary: true, index: 'fk_user_email_orders_emails1_idx' })
-  email!: Emails;
+  @ManyToOne({ entity: () => Emails, ref: true, fieldName: 'email_id', primary: true, index: 'fk_user_email_orders_emails1_idx' })
+  email!: Ref<Emails>;
 
-  @ManyToOne({ entity: () => Orders, fieldName: 'order_id', index: 'fk_user_email_orders_orders1_idx' })
-  order!: Orders;
+  @ManyToOne({ entity: () => Orders, ref: true, fieldName: 'order_id', index: 'fk_user_email_orders_orders1_idx' })
+  order!: Ref<Orders>;
 
 }
 ",
-  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
@@ -4950,11 +5067,11 @@ export class UserEmails {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Emails, fieldName: 'email_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true, index: 'fk_user_emails_emails1_idx' })
-  email!: Emails;
+  @ManyToOne({ entity: () => Emails, ref: true, fieldName: 'email_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true, index: 'fk_user_emails_emails1_idx' })
+  email!: Ref<Emails>;
 
   @Property({ type: 'boolean' })
   isVerified: boolean & Opt = false;
@@ -5020,16 +5137,16 @@ export class Users {
 ]
 `;
 
-exports[`many_to_many_variants > bidirectionalRelations=true > onlyPurePivotTables=false > outputPurePivotTables=false > readOnlyPivotTables=true > entitySchema=true > dump 1`] = `
+exports[`many_to_many_variants > bidirectionalRelations=true > onlyPurePivotTables=false > outputPurePivotTables=false > readOnlyPivotTables=true > entityDefinition=entitySchema > dump 1`] = `
 [
-  "import { EntitySchema } from '@mikro-orm/core';
+  "import { EntitySchema, type Ref } from '@mikro-orm/core';
 import { Orders } from './Orders';
 import { Users } from './Users';
 
 export class CompletedOrders {
   id!: number;
-  user!: Users;
-  order!: Orders;
+  user!: Ref<Users>;
+  order!: Ref<Orders>;
 }
 
 export const CompletedOrdersSchema = new EntitySchema({
@@ -5040,12 +5157,14 @@ export const CompletedOrdersSchema = new EntitySchema({
     user: {
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
       index: 'fk_completed_orders_users1_idx',
     },
     order: {
       kind: 'm:1',
       entity: () => Orders,
+      ref: true,
       fieldName: 'order_id',
       index: 'fk_completed_orders_orders1_idx',
     },
@@ -5124,7 +5243,7 @@ export const EmailsSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { UserEmailFlags } from './UserEmailFlags';
 import { Users } from './Users';
 
@@ -5132,7 +5251,7 @@ export class Flags {
   [PrimaryKeyProp]?: 'flagId';
   flagId!: number;
   name!: string;
-  userEmailFlags?: UserEmailFlags;
+  userEmailFlags?: Ref<UserEmailFlags>;
   userFlagsInverse = new Collection<Users>(this);
 }
 
@@ -5144,6 +5263,7 @@ export const FlagsSchema = new EntitySchema({
     userEmailFlags: {
       kind: '1:1',
       entity: () => UserEmailFlags,
+      ref: true,
       mappedBy: 'flag',
     },
     userFlagsInverse: { kind: 'm:n', entity: () => Users, mappedBy: 'userFlags' },
@@ -5187,14 +5307,14 @@ export const OrdersSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
 export class UserEmailAvatars {
   [PrimaryKeyProp]?: ['user', 'email'];
-  user!: Users;
-  email!: Emails;
+  user!: Ref<Users>;
+  email!: Ref<Emails>;
   avatarUrl!: string;
 }
 
@@ -5205,6 +5325,7 @@ export const UserEmailAvatarsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
       updateRule: 'cascade',
       deleteRule: 'cascade',
@@ -5213,6 +5334,7 @@ export const UserEmailAvatarsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Emails,
+      ref: true,
       fieldName: 'email_id',
       index: 'fk_user_email_avatars_emails1_idx',
     },
@@ -5220,16 +5342,16 @@ export const UserEmailAvatarsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Flags } from './Flags';
 import { Users } from './Users';
 
 export class UserEmailFlags {
   [PrimaryKeyProp]?: ['user', 'email'];
-  user!: Users;
-  email!: Emails;
-  flag!: Flags & Opt;
+  user!: Ref<Users>;
+  email!: Ref<Emails>;
+  flag!: Ref<Flags> & Opt;
 }
 
 export const UserEmailFlagsSchema = new EntitySchema({
@@ -5239,18 +5361,21 @@ export const UserEmailFlagsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
     },
     email: {
       primary: true,
       kind: 'm:1',
       entity: () => Emails,
+      ref: true,
       fieldName: 'email_id',
       index: 'fk_user_email_flags_emails1_idx',
     },
     flag: {
       kind: '1:1',
       entity: () => Flags,
+      ref: true,
       fieldName: 'flag_id',
       defaultRaw: \`1\`,
       index: 'fk_user_email_flags_flags1_idx',
@@ -5259,16 +5384,16 @@ export const UserEmailFlagsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Orders } from './Orders';
 import { Users } from './Users';
 
 export class UserEmailOrders {
   [PrimaryKeyProp]?: ['user', 'email'];
-  user!: Users;
-  email!: Emails;
-  order!: Orders;
+  user!: Ref<Users>;
+  email!: Ref<Emails>;
+  order!: Ref<Orders>;
 }
 
 export const UserEmailOrdersSchema = new EntitySchema({
@@ -5278,32 +5403,35 @@ export const UserEmailOrdersSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
     },
     email: {
       primary: true,
       kind: 'm:1',
       entity: () => Emails,
+      ref: true,
       fieldName: 'email_id',
       index: 'fk_user_email_orders_emails1_idx',
     },
     order: {
       kind: 'm:1',
       entity: () => Orders,
+      ref: true,
       fieldName: 'order_id',
       index: 'fk_user_email_orders_orders1_idx',
     },
   },
 });
 ",
-  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
 export class UserEmails {
   [PrimaryKeyProp]?: ['user', 'email'];
-  user!: Users;
-  email!: Emails;
+  user!: Ref<Users>;
+  email!: Ref<Emails>;
   isVerified: boolean & Opt = false;
 }
 
@@ -5314,6 +5442,7 @@ export const UserEmailsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
       updateRule: 'cascade',
       deleteRule: 'cascade',
@@ -5322,6 +5451,7 @@ export const UserEmailsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Emails,
+      ref: true,
       fieldName: 'email_id',
       updateRule: 'cascade',
       deleteRule: 'cascade',
@@ -5445,9 +5575,9 @@ export const UsersSchema = new EntitySchema({
 ]
 `;
 
-exports[`many_to_many_variants > bidirectionalRelations=true > onlyPurePivotTables=false > outputPurePivotTables=true > readOnlyPivotTables=false > entitySchema=false > dump 1`] = `
+exports[`many_to_many_variants > bidirectionalRelations=true > onlyPurePivotTables=false > outputPurePivotTables=true > readOnlyPivotTables=false > entityDefinition=decorators > dump 1`] = `
 [
-  "import { Entity, ManyToOne, PrimaryKey, Unique } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKey, type Ref, Unique } from '@mikro-orm/core';
 import { Orders } from './Orders';
 import { Users } from './Users';
 
@@ -5458,11 +5588,11 @@ export class CompletedOrders {
   @PrimaryKey()
   id!: number;
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', index: 'fk_completed_orders_users1_idx' })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', index: 'fk_completed_orders_users1_idx' })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Orders, fieldName: 'order_id', index: 'fk_completed_orders_orders1_idx' })
-  order!: Orders;
+  @ManyToOne({ entity: () => Orders, ref: true, fieldName: 'order_id', index: 'fk_completed_orders_orders1_idx' })
+  order!: Ref<Orders>;
 
 }
 ",
@@ -5501,7 +5631,7 @@ export class Emails {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, OneToMany, OneToOne, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, OneToMany, OneToOne, PrimaryKey, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { UserEmailFlags } from './UserEmailFlags';
 import { UserFlags } from './UserFlags';
 import { Users } from './Users';
@@ -5517,8 +5647,8 @@ export class Flags {
   @Property({ unique: 'name_UNIQUE' })
   name!: string;
 
-  @OneToOne({ entity: () => UserEmailFlags, mappedBy: 'flag' })
-  userEmailFlags?: UserEmailFlags;
+  @OneToOne({ entity: () => UserEmailFlags, ref: true, mappedBy: 'flag' })
+  userEmailFlags?: Ref<UserEmailFlags>;
 
   @OneToMany({ entity: () => UserFlags, mappedBy: 'flag' })
   userFlagsCollection = new Collection<UserFlags>(this);
@@ -5559,7 +5689,7 @@ export class Orders {
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
@@ -5568,18 +5698,18 @@ export class UserEmailAvatars {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Emails, fieldName: 'email_id', primary: true, index: 'fk_user_email_avatars_emails1_idx' })
-  email!: Emails;
+  @ManyToOne({ entity: () => Emails, ref: true, fieldName: 'email_id', primary: true, index: 'fk_user_email_avatars_emails1_idx' })
+  email!: Ref<Emails>;
 
   @Property()
   avatarUrl!: string;
 
 }
 ",
-  "import { Entity, ManyToOne, OneToOne, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, OneToOne, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Flags } from './Flags';
 import { Users } from './Users';
@@ -5589,18 +5719,18 @@ export class UserEmailFlags {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Emails, fieldName: 'email_id', primary: true, index: 'fk_user_email_flags_emails1_idx' })
-  email!: Emails;
+  @ManyToOne({ entity: () => Emails, ref: true, fieldName: 'email_id', primary: true, index: 'fk_user_email_flags_emails1_idx' })
+  email!: Ref<Emails>;
 
-  @OneToOne({ entity: () => Flags, fieldName: 'flag_id', defaultRaw: \`1\`, index: 'fk_user_email_flags_flags1_idx', unique: 'flag_id_UNIQUE' })
-  flag!: Flags & Opt;
+  @OneToOne({ entity: () => Flags, ref: true, fieldName: 'flag_id', defaultRaw: \`1\`, index: 'fk_user_email_flags_flags1_idx', unique: 'flag_id_UNIQUE' })
+  flag!: Ref<Flags> & Opt;
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Orders } from './Orders';
 import { Users } from './Users';
@@ -5610,18 +5740,18 @@ export class UserEmailOrders {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Emails, fieldName: 'email_id', primary: true, index: 'fk_user_email_orders_emails1_idx' })
-  email!: Emails;
+  @ManyToOne({ entity: () => Emails, ref: true, fieldName: 'email_id', primary: true, index: 'fk_user_email_orders_emails1_idx' })
+  email!: Ref<Emails>;
 
-  @ManyToOne({ entity: () => Orders, fieldName: 'order_id', index: 'fk_user_email_orders_orders1_idx' })
-  order!: Orders;
+  @ManyToOne({ entity: () => Orders, ref: true, fieldName: 'order_id', index: 'fk_user_email_orders_orders1_idx' })
+  order!: Ref<Orders>;
 
 }
 ",
-  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
@@ -5630,11 +5760,11 @@ export class UserEmails {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Emails, fieldName: 'email_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true, index: 'fk_user_emails_emails1_idx' })
-  email!: Emails;
+  @ManyToOne({ entity: () => Emails, ref: true, fieldName: 'email_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true, index: 'fk_user_emails_emails1_idx' })
+  email!: Ref<Emails>;
 
   @Property({ type: 'boolean' })
   isVerified: boolean & Opt = false;
@@ -5736,16 +5866,16 @@ export class Users {
 ]
 `;
 
-exports[`many_to_many_variants > bidirectionalRelations=true > onlyPurePivotTables=false > outputPurePivotTables=true > readOnlyPivotTables=false > entitySchema=true > dump 1`] = `
+exports[`many_to_many_variants > bidirectionalRelations=true > onlyPurePivotTables=false > outputPurePivotTables=true > readOnlyPivotTables=false > entityDefinition=entitySchema > dump 1`] = `
 [
-  "import { EntitySchema } from '@mikro-orm/core';
+  "import { EntitySchema, type Ref } from '@mikro-orm/core';
 import { Orders } from './Orders';
 import { Users } from './Users';
 
 export class CompletedOrders {
   id!: number;
-  user!: Users;
-  order!: Orders;
+  user!: Ref<Users>;
+  order!: Ref<Orders>;
 }
 
 export const CompletedOrdersSchema = new EntitySchema({
@@ -5756,12 +5886,14 @@ export const CompletedOrdersSchema = new EntitySchema({
     user: {
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
       index: 'fk_completed_orders_users1_idx',
     },
     order: {
       kind: 'm:1',
       entity: () => Orders,
+      ref: true,
       fieldName: 'order_id',
       index: 'fk_completed_orders_orders1_idx',
     },
@@ -5819,7 +5951,7 @@ export const EmailsSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { UserEmailFlags } from './UserEmailFlags';
 import { UserFlags } from './UserFlags';
 import { Users } from './Users';
@@ -5828,7 +5960,7 @@ export class Flags {
   [PrimaryKeyProp]?: 'flagId';
   flagId!: number;
   name!: string;
-  userEmailFlags?: UserEmailFlags;
+  userEmailFlags?: Ref<UserEmailFlags>;
   userFlagsCollection = new Collection<UserFlags>(this);
   userFlagsInverse = new Collection<Users>(this);
 }
@@ -5841,6 +5973,7 @@ export const FlagsSchema = new EntitySchema({
     userEmailFlags: {
       kind: '1:1',
       entity: () => UserEmailFlags,
+      ref: true,
       mappedBy: 'flag',
     },
     userFlagsCollection: {
@@ -5896,14 +6029,14 @@ export const OrdersSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
 export class UserEmailAvatars {
   [PrimaryKeyProp]?: ['user', 'email'];
-  user!: Users;
-  email!: Emails;
+  user!: Ref<Users>;
+  email!: Ref<Emails>;
   avatarUrl!: string;
 }
 
@@ -5914,6 +6047,7 @@ export const UserEmailAvatarsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
       updateRule: 'cascade',
       deleteRule: 'cascade',
@@ -5922,6 +6056,7 @@ export const UserEmailAvatarsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Emails,
+      ref: true,
       fieldName: 'email_id',
       index: 'fk_user_email_avatars_emails1_idx',
     },
@@ -5929,16 +6064,16 @@ export const UserEmailAvatarsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Flags } from './Flags';
 import { Users } from './Users';
 
 export class UserEmailFlags {
   [PrimaryKeyProp]?: ['user', 'email'];
-  user!: Users;
-  email!: Emails;
-  flag!: Flags & Opt;
+  user!: Ref<Users>;
+  email!: Ref<Emails>;
+  flag!: Ref<Flags> & Opt;
 }
 
 export const UserEmailFlagsSchema = new EntitySchema({
@@ -5948,18 +6083,21 @@ export const UserEmailFlagsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
     },
     email: {
       primary: true,
       kind: 'm:1',
       entity: () => Emails,
+      ref: true,
       fieldName: 'email_id',
       index: 'fk_user_email_flags_emails1_idx',
     },
     flag: {
       kind: '1:1',
       entity: () => Flags,
+      ref: true,
       fieldName: 'flag_id',
       defaultRaw: \`1\`,
       index: 'fk_user_email_flags_flags1_idx',
@@ -5968,16 +6106,16 @@ export const UserEmailFlagsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Orders } from './Orders';
 import { Users } from './Users';
 
 export class UserEmailOrders {
   [PrimaryKeyProp]?: ['user', 'email'];
-  user!: Users;
-  email!: Emails;
-  order!: Orders;
+  user!: Ref<Users>;
+  email!: Ref<Emails>;
+  order!: Ref<Orders>;
 }
 
 export const UserEmailOrdersSchema = new EntitySchema({
@@ -5987,32 +6125,35 @@ export const UserEmailOrdersSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
     },
     email: {
       primary: true,
       kind: 'm:1',
       entity: () => Emails,
+      ref: true,
       fieldName: 'email_id',
       index: 'fk_user_email_orders_emails1_idx',
     },
     order: {
       kind: 'm:1',
       entity: () => Orders,
+      ref: true,
       fieldName: 'order_id',
       index: 'fk_user_email_orders_orders1_idx',
     },
   },
 });
 ",
-  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
 export class UserEmails {
   [PrimaryKeyProp]?: ['user', 'email'];
-  user!: Users;
-  email!: Emails;
+  user!: Ref<Users>;
+  email!: Ref<Emails>;
   isVerified: boolean & Opt = false;
 }
 
@@ -6023,6 +6164,7 @@ export const UserEmailsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
       updateRule: 'cascade',
       deleteRule: 'cascade',
@@ -6031,6 +6173,7 @@ export const UserEmailsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Emails,
+      ref: true,
       fieldName: 'email_id',
       updateRule: 'cascade',
       deleteRule: 'cascade',
@@ -6210,9 +6353,9 @@ export const UsersSchema = new EntitySchema({
 ]
 `;
 
-exports[`many_to_many_variants > bidirectionalRelations=true > onlyPurePivotTables=false > outputPurePivotTables=true > readOnlyPivotTables=true > entitySchema=false > dump 1`] = `
+exports[`many_to_many_variants > bidirectionalRelations=true > onlyPurePivotTables=false > outputPurePivotTables=true > readOnlyPivotTables=true > entityDefinition=decorators > dump 1`] = `
 [
-  "import { Entity, ManyToOne, PrimaryKey, Unique } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKey, type Ref, Unique } from '@mikro-orm/core';
 import { Orders } from './Orders';
 import { Users } from './Users';
 
@@ -6223,11 +6366,11 @@ export class CompletedOrders {
   @PrimaryKey()
   id!: number;
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', index: 'fk_completed_orders_users1_idx' })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', index: 'fk_completed_orders_users1_idx' })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Orders, fieldName: 'order_id', index: 'fk_completed_orders_orders1_idx' })
-  order!: Orders;
+  @ManyToOne({ entity: () => Orders, ref: true, fieldName: 'order_id', index: 'fk_completed_orders_orders1_idx' })
+  order!: Ref<Orders>;
 
 }
 ",
@@ -6275,7 +6418,7 @@ export class Emails {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, OneToMany, OneToOne, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, OneToMany, OneToOne, PrimaryKey, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { UserEmailFlags } from './UserEmailFlags';
 import { UserFlags } from './UserFlags';
 import { Users } from './Users';
@@ -6291,8 +6434,8 @@ export class Flags {
   @Property({ unique: 'name_UNIQUE' })
   name!: string;
 
-  @OneToOne({ entity: () => UserEmailFlags, mappedBy: 'flag' })
-  userEmailFlags?: UserEmailFlags;
+  @OneToOne({ entity: () => UserEmailFlags, ref: true, mappedBy: 'flag' })
+  userEmailFlags?: Ref<UserEmailFlags>;
 
   @OneToMany({ entity: () => UserFlags, mappedBy: 'flag' })
   userFlagsCollection = new Collection<UserFlags>(this);
@@ -6333,7 +6476,7 @@ export class Orders {
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
@@ -6342,18 +6485,18 @@ export class UserEmailAvatars {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Emails, fieldName: 'email_id', primary: true, index: 'fk_user_email_avatars_emails1_idx' })
-  email!: Emails;
+  @ManyToOne({ entity: () => Emails, ref: true, fieldName: 'email_id', primary: true, index: 'fk_user_email_avatars_emails1_idx' })
+  email!: Ref<Emails>;
 
   @Property()
   avatarUrl!: string;
 
 }
 ",
-  "import { Entity, ManyToOne, OneToOne, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, OneToOne, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Flags } from './Flags';
 import { Users } from './Users';
@@ -6363,18 +6506,18 @@ export class UserEmailFlags {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Emails, fieldName: 'email_id', primary: true, index: 'fk_user_email_flags_emails1_idx' })
-  email!: Emails;
+  @ManyToOne({ entity: () => Emails, ref: true, fieldName: 'email_id', primary: true, index: 'fk_user_email_flags_emails1_idx' })
+  email!: Ref<Emails>;
 
-  @OneToOne({ entity: () => Flags, fieldName: 'flag_id', defaultRaw: \`1\`, index: 'fk_user_email_flags_flags1_idx', unique: 'flag_id_UNIQUE' })
-  flag!: Flags & Opt;
+  @OneToOne({ entity: () => Flags, ref: true, fieldName: 'flag_id', defaultRaw: \`1\`, index: 'fk_user_email_flags_flags1_idx', unique: 'flag_id_UNIQUE' })
+  flag!: Ref<Flags> & Opt;
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Orders } from './Orders';
 import { Users } from './Users';
@@ -6384,18 +6527,18 @@ export class UserEmailOrders {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Emails, fieldName: 'email_id', primary: true, index: 'fk_user_email_orders_emails1_idx' })
-  email!: Emails;
+  @ManyToOne({ entity: () => Emails, ref: true, fieldName: 'email_id', primary: true, index: 'fk_user_email_orders_emails1_idx' })
+  email!: Ref<Emails>;
 
-  @ManyToOne({ entity: () => Orders, fieldName: 'order_id', index: 'fk_user_email_orders_orders1_idx' })
-  order!: Orders;
+  @ManyToOne({ entity: () => Orders, ref: true, fieldName: 'order_id', index: 'fk_user_email_orders_orders1_idx' })
+  order!: Ref<Orders>;
 
 }
 ",
-  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
@@ -6404,11 +6547,11 @@ export class UserEmails {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Emails, fieldName: 'email_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true, index: 'fk_user_emails_emails1_idx' })
-  email!: Emails;
+  @ManyToOne({ entity: () => Emails, ref: true, fieldName: 'email_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true, index: 'fk_user_emails_emails1_idx' })
+  email!: Ref<Emails>;
 
   @Property({ type: 'boolean' })
   isVerified: boolean & Opt = false;
@@ -6519,16 +6662,16 @@ export class Users {
 ]
 `;
 
-exports[`many_to_many_variants > bidirectionalRelations=true > onlyPurePivotTables=false > outputPurePivotTables=true > readOnlyPivotTables=true > entitySchema=true > dump 1`] = `
+exports[`many_to_many_variants > bidirectionalRelations=true > onlyPurePivotTables=false > outputPurePivotTables=true > readOnlyPivotTables=true > entityDefinition=entitySchema > dump 1`] = `
 [
-  "import { EntitySchema } from '@mikro-orm/core';
+  "import { EntitySchema, type Ref } from '@mikro-orm/core';
 import { Orders } from './Orders';
 import { Users } from './Users';
 
 export class CompletedOrders {
   id!: number;
-  user!: Users;
-  order!: Orders;
+  user!: Ref<Users>;
+  order!: Ref<Orders>;
 }
 
 export const CompletedOrdersSchema = new EntitySchema({
@@ -6539,12 +6682,14 @@ export const CompletedOrdersSchema = new EntitySchema({
     user: {
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
       index: 'fk_completed_orders_users1_idx',
     },
     order: {
       kind: 'm:1',
       entity: () => Orders,
+      ref: true,
       fieldName: 'order_id',
       index: 'fk_completed_orders_orders1_idx',
     },
@@ -6623,7 +6768,7 @@ export const EmailsSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { UserEmailFlags } from './UserEmailFlags';
 import { UserFlags } from './UserFlags';
 import { Users } from './Users';
@@ -6632,7 +6777,7 @@ export class Flags {
   [PrimaryKeyProp]?: 'flagId';
   flagId!: number;
   name!: string;
-  userEmailFlags?: UserEmailFlags;
+  userEmailFlags?: Ref<UserEmailFlags>;
   userFlagsCollection = new Collection<UserFlags>(this);
   userFlagsInverse = new Collection<Users>(this);
 }
@@ -6645,6 +6790,7 @@ export const FlagsSchema = new EntitySchema({
     userEmailFlags: {
       kind: '1:1',
       entity: () => UserEmailFlags,
+      ref: true,
       mappedBy: 'flag',
     },
     userFlagsCollection: {
@@ -6700,14 +6846,14 @@ export const OrdersSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
 export class UserEmailAvatars {
   [PrimaryKeyProp]?: ['user', 'email'];
-  user!: Users;
-  email!: Emails;
+  user!: Ref<Users>;
+  email!: Ref<Emails>;
   avatarUrl!: string;
 }
 
@@ -6718,6 +6864,7 @@ export const UserEmailAvatarsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
       updateRule: 'cascade',
       deleteRule: 'cascade',
@@ -6726,6 +6873,7 @@ export const UserEmailAvatarsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Emails,
+      ref: true,
       fieldName: 'email_id',
       index: 'fk_user_email_avatars_emails1_idx',
     },
@@ -6733,16 +6881,16 @@ export const UserEmailAvatarsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Flags } from './Flags';
 import { Users } from './Users';
 
 export class UserEmailFlags {
   [PrimaryKeyProp]?: ['user', 'email'];
-  user!: Users;
-  email!: Emails;
-  flag!: Flags & Opt;
+  user!: Ref<Users>;
+  email!: Ref<Emails>;
+  flag!: Ref<Flags> & Opt;
 }
 
 export const UserEmailFlagsSchema = new EntitySchema({
@@ -6752,18 +6900,21 @@ export const UserEmailFlagsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
     },
     email: {
       primary: true,
       kind: 'm:1',
       entity: () => Emails,
+      ref: true,
       fieldName: 'email_id',
       index: 'fk_user_email_flags_emails1_idx',
     },
     flag: {
       kind: '1:1',
       entity: () => Flags,
+      ref: true,
       fieldName: 'flag_id',
       defaultRaw: \`1\`,
       index: 'fk_user_email_flags_flags1_idx',
@@ -6772,16 +6923,16 @@ export const UserEmailFlagsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Orders } from './Orders';
 import { Users } from './Users';
 
 export class UserEmailOrders {
   [PrimaryKeyProp]?: ['user', 'email'];
-  user!: Users;
-  email!: Emails;
-  order!: Orders;
+  user!: Ref<Users>;
+  email!: Ref<Emails>;
+  order!: Ref<Orders>;
 }
 
 export const UserEmailOrdersSchema = new EntitySchema({
@@ -6791,32 +6942,35 @@ export const UserEmailOrdersSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
     },
     email: {
       primary: true,
       kind: 'm:1',
       entity: () => Emails,
+      ref: true,
       fieldName: 'email_id',
       index: 'fk_user_email_orders_emails1_idx',
     },
     order: {
       kind: 'm:1',
       entity: () => Orders,
+      ref: true,
       fieldName: 'order_id',
       index: 'fk_user_email_orders_orders1_idx',
     },
   },
 });
 ",
-  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
 export class UserEmails {
   [PrimaryKeyProp]?: ['user', 'email'];
-  user!: Users;
-  email!: Emails;
+  user!: Ref<Users>;
+  email!: Ref<Emails>;
   isVerified: boolean & Opt = false;
 }
 
@@ -6827,6 +6981,7 @@ export const UserEmailsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
       updateRule: 'cascade',
       deleteRule: 'cascade',
@@ -6835,6 +6990,7 @@ export const UserEmailsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Emails,
+      ref: true,
       fieldName: 'email_id',
       updateRule: 'cascade',
       deleteRule: 'cascade',
@@ -7044,9 +7200,9 @@ export const UsersSchema = new EntitySchema({
 ]
 `;
 
-exports[`many_to_many_variants > bidirectionalRelations=true > onlyPurePivotTables=true > outputPurePivotTables=false > readOnlyPivotTables=false > entitySchema=false > dump 1`] = `
+exports[`many_to_many_variants > bidirectionalRelations=true > onlyPurePivotTables=true > outputPurePivotTables=false > readOnlyPivotTables=false > entityDefinition=decorators > dump 1`] = `
 [
-  "import { Entity, ManyToOne, PrimaryKey, Unique } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKey, type Ref, Unique } from '@mikro-orm/core';
 import { Orders } from './Orders';
 import { Users } from './Users';
 
@@ -7057,11 +7213,11 @@ export class CompletedOrders {
   @PrimaryKey()
   id!: number;
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', index: 'fk_completed_orders_users1_idx' })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', index: 'fk_completed_orders_users1_idx' })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Orders, fieldName: 'order_id', index: 'fk_completed_orders_orders1_idx' })
-  order!: Orders;
+  @ManyToOne({ entity: () => Orders, ref: true, fieldName: 'order_id', index: 'fk_completed_orders_orders1_idx' })
+  order!: Ref<Orders>;
 
 }
 ",
@@ -7096,7 +7252,7 @@ export class Emails {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, OneToOne, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, OneToOne, PrimaryKey, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { UserEmailFlags } from './UserEmailFlags';
 import { Users } from './Users';
 
@@ -7111,8 +7267,8 @@ export class Flags {
   @Property({ unique: 'name_UNIQUE' })
   name!: string;
 
-  @OneToOne({ entity: () => UserEmailFlags, mappedBy: 'flag' })
-  userEmailFlags?: UserEmailFlags;
+  @OneToOne({ entity: () => UserEmailFlags, ref: true, mappedBy: 'flag' })
+  userEmailFlags?: Ref<UserEmailFlags>;
 
   @ManyToMany({ entity: () => Users, mappedBy: 'userFlags' })
   userFlagsInverse = new Collection<Users>(this);
@@ -7146,7 +7302,7 @@ export class Orders {
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
@@ -7155,18 +7311,18 @@ export class UserEmailAvatars {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Emails, fieldName: 'email_id', primary: true, index: 'fk_user_email_avatars_emails1_idx' })
-  email!: Emails;
+  @ManyToOne({ entity: () => Emails, ref: true, fieldName: 'email_id', primary: true, index: 'fk_user_email_avatars_emails1_idx' })
+  email!: Ref<Emails>;
 
   @Property()
   avatarUrl!: string;
 
 }
 ",
-  "import { Entity, ManyToOne, OneToOne, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, OneToOne, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Flags } from './Flags';
 import { Users } from './Users';
@@ -7176,18 +7332,18 @@ export class UserEmailFlags {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Emails, fieldName: 'email_id', primary: true, index: 'fk_user_email_flags_emails1_idx' })
-  email!: Emails;
+  @ManyToOne({ entity: () => Emails, ref: true, fieldName: 'email_id', primary: true, index: 'fk_user_email_flags_emails1_idx' })
+  email!: Ref<Emails>;
 
-  @OneToOne({ entity: () => Flags, fieldName: 'flag_id', defaultRaw: \`1\`, index: 'fk_user_email_flags_flags1_idx', unique: 'flag_id_UNIQUE' })
-  flag!: Flags & Opt;
+  @OneToOne({ entity: () => Flags, ref: true, fieldName: 'flag_id', defaultRaw: \`1\`, index: 'fk_user_email_flags_flags1_idx', unique: 'flag_id_UNIQUE' })
+  flag!: Ref<Flags> & Opt;
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Orders } from './Orders';
 import { Users } from './Users';
@@ -7197,18 +7353,18 @@ export class UserEmailOrders {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Emails, fieldName: 'email_id', primary: true, index: 'fk_user_email_orders_emails1_idx' })
-  email!: Emails;
+  @ManyToOne({ entity: () => Emails, ref: true, fieldName: 'email_id', primary: true, index: 'fk_user_email_orders_emails1_idx' })
+  email!: Ref<Emails>;
 
-  @ManyToOne({ entity: () => Orders, fieldName: 'order_id', index: 'fk_user_email_orders_orders1_idx' })
-  order!: Orders;
+  @ManyToOne({ entity: () => Orders, ref: true, fieldName: 'order_id', index: 'fk_user_email_orders_orders1_idx' })
+  order!: Ref<Orders>;
 
 }
 ",
-  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
@@ -7217,18 +7373,18 @@ export class UserEmails {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Emails, fieldName: 'email_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true, index: 'fk_user_emails_emails1_idx' })
-  email!: Emails;
+  @ManyToOne({ entity: () => Emails, ref: true, fieldName: 'email_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true, index: 'fk_user_emails_emails1_idx' })
+  email!: Ref<Emails>;
 
   @Property({ type: 'boolean' })
   isVerified: boolean & Opt = false;
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Orders } from './Orders';
 import { Users } from './Users';
 
@@ -7237,11 +7393,11 @@ export class UserOrders {
 
   [PrimaryKeyProp]?: ['user', 'order'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Orders, fieldName: 'order_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true, index: 'fk_user_orders_orders1_idx' })
-  order!: Orders;
+  @ManyToOne({ entity: () => Orders, ref: true, fieldName: 'order_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true, index: 'fk_user_orders_orders1_idx' })
+  order!: Ref<Orders>;
 
   @Property({ unsigned: true, autoincrement: true, unique: 'priority_UNIQUE' })
   priority!: number;
@@ -7294,16 +7450,16 @@ export class Users {
 ]
 `;
 
-exports[`many_to_many_variants > bidirectionalRelations=true > onlyPurePivotTables=true > outputPurePivotTables=false > readOnlyPivotTables=false > entitySchema=true > dump 1`] = `
+exports[`many_to_many_variants > bidirectionalRelations=true > onlyPurePivotTables=true > outputPurePivotTables=false > readOnlyPivotTables=false > entityDefinition=entitySchema > dump 1`] = `
 [
-  "import { EntitySchema } from '@mikro-orm/core';
+  "import { EntitySchema, type Ref } from '@mikro-orm/core';
 import { Orders } from './Orders';
 import { Users } from './Users';
 
 export class CompletedOrders {
   id!: number;
-  user!: Users;
-  order!: Orders;
+  user!: Ref<Users>;
+  order!: Ref<Orders>;
 }
 
 export const CompletedOrdersSchema = new EntitySchema({
@@ -7314,12 +7470,14 @@ export const CompletedOrdersSchema = new EntitySchema({
     user: {
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
       index: 'fk_completed_orders_users1_idx',
     },
     order: {
       kind: 'm:1',
       entity: () => Orders,
+      ref: true,
       fieldName: 'order_id',
       index: 'fk_completed_orders_orders1_idx',
     },
@@ -7370,7 +7528,7 @@ export const EmailsSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { UserEmailFlags } from './UserEmailFlags';
 import { Users } from './Users';
 
@@ -7378,7 +7536,7 @@ export class Flags {
   [PrimaryKeyProp]?: 'flagId';
   flagId!: number;
   name!: string;
-  userEmailFlags?: UserEmailFlags;
+  userEmailFlags?: Ref<UserEmailFlags>;
   userFlagsInverse = new Collection<Users>(this);
 }
 
@@ -7390,6 +7548,7 @@ export const FlagsSchema = new EntitySchema({
     userEmailFlags: {
       kind: '1:1',
       entity: () => UserEmailFlags,
+      ref: true,
       mappedBy: 'flag',
     },
     userFlagsInverse: { kind: 'm:n', entity: () => Users, mappedBy: 'userFlags' },
@@ -7433,14 +7592,14 @@ export const OrdersSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
 export class UserEmailAvatars {
   [PrimaryKeyProp]?: ['user', 'email'];
-  user!: Users;
-  email!: Emails;
+  user!: Ref<Users>;
+  email!: Ref<Emails>;
   avatarUrl!: string;
 }
 
@@ -7451,6 +7610,7 @@ export const UserEmailAvatarsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
       updateRule: 'cascade',
       deleteRule: 'cascade',
@@ -7459,6 +7619,7 @@ export const UserEmailAvatarsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Emails,
+      ref: true,
       fieldName: 'email_id',
       index: 'fk_user_email_avatars_emails1_idx',
     },
@@ -7466,16 +7627,16 @@ export const UserEmailAvatarsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Flags } from './Flags';
 import { Users } from './Users';
 
 export class UserEmailFlags {
   [PrimaryKeyProp]?: ['user', 'email'];
-  user!: Users;
-  email!: Emails;
-  flag!: Flags & Opt;
+  user!: Ref<Users>;
+  email!: Ref<Emails>;
+  flag!: Ref<Flags> & Opt;
 }
 
 export const UserEmailFlagsSchema = new EntitySchema({
@@ -7485,18 +7646,21 @@ export const UserEmailFlagsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
     },
     email: {
       primary: true,
       kind: 'm:1',
       entity: () => Emails,
+      ref: true,
       fieldName: 'email_id',
       index: 'fk_user_email_flags_emails1_idx',
     },
     flag: {
       kind: '1:1',
       entity: () => Flags,
+      ref: true,
       fieldName: 'flag_id',
       defaultRaw: \`1\`,
       index: 'fk_user_email_flags_flags1_idx',
@@ -7505,16 +7669,16 @@ export const UserEmailFlagsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Orders } from './Orders';
 import { Users } from './Users';
 
 export class UserEmailOrders {
   [PrimaryKeyProp]?: ['user', 'email'];
-  user!: Users;
-  email!: Emails;
-  order!: Orders;
+  user!: Ref<Users>;
+  email!: Ref<Emails>;
+  order!: Ref<Orders>;
 }
 
 export const UserEmailOrdersSchema = new EntitySchema({
@@ -7524,32 +7688,35 @@ export const UserEmailOrdersSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
     },
     email: {
       primary: true,
       kind: 'm:1',
       entity: () => Emails,
+      ref: true,
       fieldName: 'email_id',
       index: 'fk_user_email_orders_emails1_idx',
     },
     order: {
       kind: 'm:1',
       entity: () => Orders,
+      ref: true,
       fieldName: 'order_id',
       index: 'fk_user_email_orders_orders1_idx',
     },
   },
 });
 ",
-  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
 export class UserEmails {
   [PrimaryKeyProp]?: ['user', 'email'];
-  user!: Users;
-  email!: Emails;
+  user!: Ref<Users>;
+  email!: Ref<Emails>;
   isVerified: boolean & Opt = false;
 }
 
@@ -7560,6 +7727,7 @@ export const UserEmailsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
       updateRule: 'cascade',
       deleteRule: 'cascade',
@@ -7568,6 +7736,7 @@ export const UserEmailsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Emails,
+      ref: true,
       fieldName: 'email_id',
       updateRule: 'cascade',
       deleteRule: 'cascade',
@@ -7577,14 +7746,14 @@ export const UserEmailsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Orders } from './Orders';
 import { Users } from './Users';
 
 export class UserOrders {
   [PrimaryKeyProp]?: ['user', 'order'];
-  user!: Users;
-  order!: Orders;
+  user!: Ref<Users>;
+  order!: Ref<Orders>;
   priority!: number;
 }
 
@@ -7595,12 +7764,14 @@ export const UserOrdersSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
     },
     order: {
       primary: true,
       kind: 'm:1',
       entity: () => Orders,
+      ref: true,
       fieldName: 'order_id',
       updateRule: 'cascade',
       deleteRule: 'cascade',
@@ -7685,9 +7856,9 @@ export const UsersSchema = new EntitySchema({
 ]
 `;
 
-exports[`many_to_many_variants > bidirectionalRelations=true > onlyPurePivotTables=true > outputPurePivotTables=false > readOnlyPivotTables=true > entitySchema=false > dump 1`] = `
+exports[`many_to_many_variants > bidirectionalRelations=true > onlyPurePivotTables=true > outputPurePivotTables=false > readOnlyPivotTables=true > entityDefinition=decorators > dump 1`] = `
 [
-  "import { Entity, ManyToOne, PrimaryKey, Unique } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKey, type Ref, Unique } from '@mikro-orm/core';
 import { Orders } from './Orders';
 import { Users } from './Users';
 
@@ -7698,11 +7869,11 @@ export class CompletedOrders {
   @PrimaryKey()
   id!: number;
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', index: 'fk_completed_orders_users1_idx' })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', index: 'fk_completed_orders_users1_idx' })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Orders, fieldName: 'order_id', index: 'fk_completed_orders_orders1_idx' })
-  order!: Orders;
+  @ManyToOne({ entity: () => Orders, ref: true, fieldName: 'order_id', index: 'fk_completed_orders_orders1_idx' })
+  order!: Ref<Orders>;
 
 }
 ",
@@ -7737,7 +7908,7 @@ export class Emails {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, OneToOne, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, OneToOne, PrimaryKey, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { UserEmailFlags } from './UserEmailFlags';
 import { Users } from './Users';
 
@@ -7752,8 +7923,8 @@ export class Flags {
   @Property({ unique: 'name_UNIQUE' })
   name!: string;
 
-  @OneToOne({ entity: () => UserEmailFlags, mappedBy: 'flag' })
-  userEmailFlags?: UserEmailFlags;
+  @OneToOne({ entity: () => UserEmailFlags, ref: true, mappedBy: 'flag' })
+  userEmailFlags?: Ref<UserEmailFlags>;
 
   @ManyToMany({ entity: () => Users, mappedBy: 'userFlags' })
   userFlagsInverse = new Collection<Users>(this);
@@ -7787,7 +7958,7 @@ export class Orders {
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
@@ -7796,18 +7967,18 @@ export class UserEmailAvatars {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Emails, fieldName: 'email_id', primary: true, index: 'fk_user_email_avatars_emails1_idx' })
-  email!: Emails;
+  @ManyToOne({ entity: () => Emails, ref: true, fieldName: 'email_id', primary: true, index: 'fk_user_email_avatars_emails1_idx' })
+  email!: Ref<Emails>;
 
   @Property()
   avatarUrl!: string;
 
 }
 ",
-  "import { Entity, ManyToOne, OneToOne, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, OneToOne, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Flags } from './Flags';
 import { Users } from './Users';
@@ -7817,18 +7988,18 @@ export class UserEmailFlags {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Emails, fieldName: 'email_id', primary: true, index: 'fk_user_email_flags_emails1_idx' })
-  email!: Emails;
+  @ManyToOne({ entity: () => Emails, ref: true, fieldName: 'email_id', primary: true, index: 'fk_user_email_flags_emails1_idx' })
+  email!: Ref<Emails>;
 
-  @OneToOne({ entity: () => Flags, fieldName: 'flag_id', defaultRaw: \`1\`, index: 'fk_user_email_flags_flags1_idx', unique: 'flag_id_UNIQUE' })
-  flag!: Flags & Opt;
+  @OneToOne({ entity: () => Flags, ref: true, fieldName: 'flag_id', defaultRaw: \`1\`, index: 'fk_user_email_flags_flags1_idx', unique: 'flag_id_UNIQUE' })
+  flag!: Ref<Flags> & Opt;
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Orders } from './Orders';
 import { Users } from './Users';
@@ -7838,18 +8009,18 @@ export class UserEmailOrders {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Emails, fieldName: 'email_id', primary: true, index: 'fk_user_email_orders_emails1_idx' })
-  email!: Emails;
+  @ManyToOne({ entity: () => Emails, ref: true, fieldName: 'email_id', primary: true, index: 'fk_user_email_orders_emails1_idx' })
+  email!: Ref<Emails>;
 
-  @ManyToOne({ entity: () => Orders, fieldName: 'order_id', index: 'fk_user_email_orders_orders1_idx' })
-  order!: Orders;
+  @ManyToOne({ entity: () => Orders, ref: true, fieldName: 'order_id', index: 'fk_user_email_orders_orders1_idx' })
+  order!: Ref<Orders>;
 
 }
 ",
-  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
@@ -7858,18 +8029,18 @@ export class UserEmails {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Emails, fieldName: 'email_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true, index: 'fk_user_emails_emails1_idx' })
-  email!: Emails;
+  @ManyToOne({ entity: () => Emails, ref: true, fieldName: 'email_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true, index: 'fk_user_emails_emails1_idx' })
+  email!: Ref<Emails>;
 
   @Property({ type: 'boolean' })
   isVerified: boolean & Opt = false;
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Orders } from './Orders';
 import { Users } from './Users';
 
@@ -7878,11 +8049,11 @@ export class UserOrders {
 
   [PrimaryKeyProp]?: ['user', 'order'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Orders, fieldName: 'order_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true, index: 'fk_user_orders_orders1_idx' })
-  order!: Orders;
+  @ManyToOne({ entity: () => Orders, ref: true, fieldName: 'order_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true, index: 'fk_user_orders_orders1_idx' })
+  order!: Ref<Orders>;
 
   @Property({ unsigned: true, autoincrement: true, unique: 'priority_UNIQUE' })
   priority!: number;
@@ -7935,16 +8106,16 @@ export class Users {
 ]
 `;
 
-exports[`many_to_many_variants > bidirectionalRelations=true > onlyPurePivotTables=true > outputPurePivotTables=false > readOnlyPivotTables=true > entitySchema=true > dump 1`] = `
+exports[`many_to_many_variants > bidirectionalRelations=true > onlyPurePivotTables=true > outputPurePivotTables=false > readOnlyPivotTables=true > entityDefinition=entitySchema > dump 1`] = `
 [
-  "import { EntitySchema } from '@mikro-orm/core';
+  "import { EntitySchema, type Ref } from '@mikro-orm/core';
 import { Orders } from './Orders';
 import { Users } from './Users';
 
 export class CompletedOrders {
   id!: number;
-  user!: Users;
-  order!: Orders;
+  user!: Ref<Users>;
+  order!: Ref<Orders>;
 }
 
 export const CompletedOrdersSchema = new EntitySchema({
@@ -7955,12 +8126,14 @@ export const CompletedOrdersSchema = new EntitySchema({
     user: {
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
       index: 'fk_completed_orders_users1_idx',
     },
     order: {
       kind: 'm:1',
       entity: () => Orders,
+      ref: true,
       fieldName: 'order_id',
       index: 'fk_completed_orders_orders1_idx',
     },
@@ -8011,7 +8184,7 @@ export const EmailsSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { UserEmailFlags } from './UserEmailFlags';
 import { Users } from './Users';
 
@@ -8019,7 +8192,7 @@ export class Flags {
   [PrimaryKeyProp]?: 'flagId';
   flagId!: number;
   name!: string;
-  userEmailFlags?: UserEmailFlags;
+  userEmailFlags?: Ref<UserEmailFlags>;
   userFlagsInverse = new Collection<Users>(this);
 }
 
@@ -8031,6 +8204,7 @@ export const FlagsSchema = new EntitySchema({
     userEmailFlags: {
       kind: '1:1',
       entity: () => UserEmailFlags,
+      ref: true,
       mappedBy: 'flag',
     },
     userFlagsInverse: { kind: 'm:n', entity: () => Users, mappedBy: 'userFlags' },
@@ -8074,14 +8248,14 @@ export const OrdersSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
 export class UserEmailAvatars {
   [PrimaryKeyProp]?: ['user', 'email'];
-  user!: Users;
-  email!: Emails;
+  user!: Ref<Users>;
+  email!: Ref<Emails>;
   avatarUrl!: string;
 }
 
@@ -8092,6 +8266,7 @@ export const UserEmailAvatarsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
       updateRule: 'cascade',
       deleteRule: 'cascade',
@@ -8100,6 +8275,7 @@ export const UserEmailAvatarsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Emails,
+      ref: true,
       fieldName: 'email_id',
       index: 'fk_user_email_avatars_emails1_idx',
     },
@@ -8107,16 +8283,16 @@ export const UserEmailAvatarsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Flags } from './Flags';
 import { Users } from './Users';
 
 export class UserEmailFlags {
   [PrimaryKeyProp]?: ['user', 'email'];
-  user!: Users;
-  email!: Emails;
-  flag!: Flags & Opt;
+  user!: Ref<Users>;
+  email!: Ref<Emails>;
+  flag!: Ref<Flags> & Opt;
 }
 
 export const UserEmailFlagsSchema = new EntitySchema({
@@ -8126,18 +8302,21 @@ export const UserEmailFlagsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
     },
     email: {
       primary: true,
       kind: 'm:1',
       entity: () => Emails,
+      ref: true,
       fieldName: 'email_id',
       index: 'fk_user_email_flags_emails1_idx',
     },
     flag: {
       kind: '1:1',
       entity: () => Flags,
+      ref: true,
       fieldName: 'flag_id',
       defaultRaw: \`1\`,
       index: 'fk_user_email_flags_flags1_idx',
@@ -8146,16 +8325,16 @@ export const UserEmailFlagsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Orders } from './Orders';
 import { Users } from './Users';
 
 export class UserEmailOrders {
   [PrimaryKeyProp]?: ['user', 'email'];
-  user!: Users;
-  email!: Emails;
-  order!: Orders;
+  user!: Ref<Users>;
+  email!: Ref<Emails>;
+  order!: Ref<Orders>;
 }
 
 export const UserEmailOrdersSchema = new EntitySchema({
@@ -8165,32 +8344,35 @@ export const UserEmailOrdersSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
     },
     email: {
       primary: true,
       kind: 'm:1',
       entity: () => Emails,
+      ref: true,
       fieldName: 'email_id',
       index: 'fk_user_email_orders_emails1_idx',
     },
     order: {
       kind: 'm:1',
       entity: () => Orders,
+      ref: true,
       fieldName: 'order_id',
       index: 'fk_user_email_orders_orders1_idx',
     },
   },
 });
 ",
-  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
 export class UserEmails {
   [PrimaryKeyProp]?: ['user', 'email'];
-  user!: Users;
-  email!: Emails;
+  user!: Ref<Users>;
+  email!: Ref<Emails>;
   isVerified: boolean & Opt = false;
 }
 
@@ -8201,6 +8383,7 @@ export const UserEmailsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
       updateRule: 'cascade',
       deleteRule: 'cascade',
@@ -8209,6 +8392,7 @@ export const UserEmailsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Emails,
+      ref: true,
       fieldName: 'email_id',
       updateRule: 'cascade',
       deleteRule: 'cascade',
@@ -8218,14 +8402,14 @@ export const UserEmailsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Orders } from './Orders';
 import { Users } from './Users';
 
 export class UserOrders {
   [PrimaryKeyProp]?: ['user', 'order'];
-  user!: Users;
-  order!: Orders;
+  user!: Ref<Users>;
+  order!: Ref<Orders>;
   priority!: number;
 }
 
@@ -8236,12 +8420,14 @@ export const UserOrdersSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
     },
     order: {
       primary: true,
       kind: 'm:1',
       entity: () => Orders,
+      ref: true,
       fieldName: 'order_id',
       updateRule: 'cascade',
       deleteRule: 'cascade',
@@ -8326,9 +8512,9 @@ export const UsersSchema = new EntitySchema({
 ]
 `;
 
-exports[`many_to_many_variants > bidirectionalRelations=true > onlyPurePivotTables=true > outputPurePivotTables=true > readOnlyPivotTables=false > entitySchema=false > dump 1`] = `
+exports[`many_to_many_variants > bidirectionalRelations=true > onlyPurePivotTables=true > outputPurePivotTables=true > readOnlyPivotTables=false > entityDefinition=decorators > dump 1`] = `
 [
-  "import { Entity, ManyToOne, PrimaryKey, Unique } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKey, type Ref, Unique } from '@mikro-orm/core';
 import { Orders } from './Orders';
 import { Users } from './Users';
 
@@ -8339,11 +8525,11 @@ export class CompletedOrders {
   @PrimaryKey()
   id!: number;
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', index: 'fk_completed_orders_users1_idx' })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', index: 'fk_completed_orders_users1_idx' })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Orders, fieldName: 'order_id', index: 'fk_completed_orders_orders1_idx' })
-  order!: Orders;
+  @ManyToOne({ entity: () => Orders, ref: true, fieldName: 'order_id', index: 'fk_completed_orders_orders1_idx' })
+  order!: Ref<Orders>;
 
 }
 ",
@@ -8378,7 +8564,7 @@ export class Emails {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, OneToMany, OneToOne, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, OneToMany, OneToOne, PrimaryKey, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { UserEmailFlags } from './UserEmailFlags';
 import { UserFlags } from './UserFlags';
 import { Users } from './Users';
@@ -8394,8 +8580,8 @@ export class Flags {
   @Property({ unique: 'name_UNIQUE' })
   name!: string;
 
-  @OneToOne({ entity: () => UserEmailFlags, mappedBy: 'flag' })
-  userEmailFlags?: UserEmailFlags;
+  @OneToOne({ entity: () => UserEmailFlags, ref: true, mappedBy: 'flag' })
+  userEmailFlags?: Ref<UserEmailFlags>;
 
   @OneToMany({ entity: () => UserFlags, mappedBy: 'flag' })
   userFlagsCollection = new Collection<UserFlags>(this);
@@ -8432,7 +8618,7 @@ export class Orders {
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
@@ -8441,18 +8627,18 @@ export class UserEmailAvatars {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Emails, fieldName: 'email_id', primary: true, index: 'fk_user_email_avatars_emails1_idx' })
-  email!: Emails;
+  @ManyToOne({ entity: () => Emails, ref: true, fieldName: 'email_id', primary: true, index: 'fk_user_email_avatars_emails1_idx' })
+  email!: Ref<Emails>;
 
   @Property()
   avatarUrl!: string;
 
 }
 ",
-  "import { Entity, ManyToOne, OneToOne, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, OneToOne, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Flags } from './Flags';
 import { Users } from './Users';
@@ -8462,18 +8648,18 @@ export class UserEmailFlags {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Emails, fieldName: 'email_id', primary: true, index: 'fk_user_email_flags_emails1_idx' })
-  email!: Emails;
+  @ManyToOne({ entity: () => Emails, ref: true, fieldName: 'email_id', primary: true, index: 'fk_user_email_flags_emails1_idx' })
+  email!: Ref<Emails>;
 
-  @OneToOne({ entity: () => Flags, fieldName: 'flag_id', defaultRaw: \`1\`, index: 'fk_user_email_flags_flags1_idx', unique: 'flag_id_UNIQUE' })
-  flag!: Flags & Opt;
+  @OneToOne({ entity: () => Flags, ref: true, fieldName: 'flag_id', defaultRaw: \`1\`, index: 'fk_user_email_flags_flags1_idx', unique: 'flag_id_UNIQUE' })
+  flag!: Ref<Flags> & Opt;
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Orders } from './Orders';
 import { Users } from './Users';
@@ -8483,18 +8669,18 @@ export class UserEmailOrders {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Emails, fieldName: 'email_id', primary: true, index: 'fk_user_email_orders_emails1_idx' })
-  email!: Emails;
+  @ManyToOne({ entity: () => Emails, ref: true, fieldName: 'email_id', primary: true, index: 'fk_user_email_orders_emails1_idx' })
+  email!: Ref<Emails>;
 
-  @ManyToOne({ entity: () => Orders, fieldName: 'order_id', index: 'fk_user_email_orders_orders1_idx' })
-  order!: Orders;
+  @ManyToOne({ entity: () => Orders, ref: true, fieldName: 'order_id', index: 'fk_user_email_orders_orders1_idx' })
+  order!: Ref<Orders>;
 
 }
 ",
-  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
@@ -8503,11 +8689,11 @@ export class UserEmails {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Emails, fieldName: 'email_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true, index: 'fk_user_emails_emails1_idx' })
-  email!: Emails;
+  @ManyToOne({ entity: () => Emails, ref: true, fieldName: 'email_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true, index: 'fk_user_emails_emails1_idx' })
+  email!: Ref<Emails>;
 
   @Property({ type: 'boolean' })
   isVerified: boolean & Opt = false;
@@ -8531,7 +8717,7 @@ export class UserFlags {
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Orders } from './Orders';
 import { Users } from './Users';
 
@@ -8540,11 +8726,11 @@ export class UserOrders {
 
   [PrimaryKeyProp]?: ['user', 'order'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Orders, fieldName: 'order_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true, index: 'fk_user_orders_orders1_idx' })
-  order!: Orders;
+  @ManyToOne({ entity: () => Orders, ref: true, fieldName: 'order_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true, index: 'fk_user_orders_orders1_idx' })
+  order!: Ref<Orders>;
 
   @Property({ unsigned: true, autoincrement: true, unique: 'priority_UNIQUE' })
   priority!: number;
@@ -8601,16 +8787,16 @@ export class Users {
 ]
 `;
 
-exports[`many_to_many_variants > bidirectionalRelations=true > onlyPurePivotTables=true > outputPurePivotTables=true > readOnlyPivotTables=false > entitySchema=true > dump 1`] = `
+exports[`many_to_many_variants > bidirectionalRelations=true > onlyPurePivotTables=true > outputPurePivotTables=true > readOnlyPivotTables=false > entityDefinition=entitySchema > dump 1`] = `
 [
-  "import { EntitySchema } from '@mikro-orm/core';
+  "import { EntitySchema, type Ref } from '@mikro-orm/core';
 import { Orders } from './Orders';
 import { Users } from './Users';
 
 export class CompletedOrders {
   id!: number;
-  user!: Users;
-  order!: Orders;
+  user!: Ref<Users>;
+  order!: Ref<Orders>;
 }
 
 export const CompletedOrdersSchema = new EntitySchema({
@@ -8621,12 +8807,14 @@ export const CompletedOrdersSchema = new EntitySchema({
     user: {
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
       index: 'fk_completed_orders_users1_idx',
     },
     order: {
       kind: 'm:1',
       entity: () => Orders,
+      ref: true,
       fieldName: 'order_id',
       index: 'fk_completed_orders_orders1_idx',
     },
@@ -8677,7 +8865,7 @@ export const EmailsSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { UserEmailFlags } from './UserEmailFlags';
 import { UserFlags } from './UserFlags';
 import { Users } from './Users';
@@ -8686,7 +8874,7 @@ export class Flags {
   [PrimaryKeyProp]?: 'flagId';
   flagId!: number;
   name!: string;
-  userEmailFlags?: UserEmailFlags;
+  userEmailFlags?: Ref<UserEmailFlags>;
   userFlagsCollection = new Collection<UserFlags>(this);
   userFlagsInverse = new Collection<Users>(this);
 }
@@ -8699,6 +8887,7 @@ export const FlagsSchema = new EntitySchema({
     userEmailFlags: {
       kind: '1:1',
       entity: () => UserEmailFlags,
+      ref: true,
       mappedBy: 'flag',
     },
     userFlagsCollection: {
@@ -8747,14 +8936,14 @@ export const OrdersSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
 export class UserEmailAvatars {
   [PrimaryKeyProp]?: ['user', 'email'];
-  user!: Users;
-  email!: Emails;
+  user!: Ref<Users>;
+  email!: Ref<Emails>;
   avatarUrl!: string;
 }
 
@@ -8765,6 +8954,7 @@ export const UserEmailAvatarsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
       updateRule: 'cascade',
       deleteRule: 'cascade',
@@ -8773,6 +8963,7 @@ export const UserEmailAvatarsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Emails,
+      ref: true,
       fieldName: 'email_id',
       index: 'fk_user_email_avatars_emails1_idx',
     },
@@ -8780,16 +8971,16 @@ export const UserEmailAvatarsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Flags } from './Flags';
 import { Users } from './Users';
 
 export class UserEmailFlags {
   [PrimaryKeyProp]?: ['user', 'email'];
-  user!: Users;
-  email!: Emails;
-  flag!: Flags & Opt;
+  user!: Ref<Users>;
+  email!: Ref<Emails>;
+  flag!: Ref<Flags> & Opt;
 }
 
 export const UserEmailFlagsSchema = new EntitySchema({
@@ -8799,18 +8990,21 @@ export const UserEmailFlagsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
     },
     email: {
       primary: true,
       kind: 'm:1',
       entity: () => Emails,
+      ref: true,
       fieldName: 'email_id',
       index: 'fk_user_email_flags_emails1_idx',
     },
     flag: {
       kind: '1:1',
       entity: () => Flags,
+      ref: true,
       fieldName: 'flag_id',
       defaultRaw: \`1\`,
       index: 'fk_user_email_flags_flags1_idx',
@@ -8819,16 +9013,16 @@ export const UserEmailFlagsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Orders } from './Orders';
 import { Users } from './Users';
 
 export class UserEmailOrders {
   [PrimaryKeyProp]?: ['user', 'email'];
-  user!: Users;
-  email!: Emails;
-  order!: Orders;
+  user!: Ref<Users>;
+  email!: Ref<Emails>;
+  order!: Ref<Orders>;
 }
 
 export const UserEmailOrdersSchema = new EntitySchema({
@@ -8838,32 +9032,35 @@ export const UserEmailOrdersSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
     },
     email: {
       primary: true,
       kind: 'm:1',
       entity: () => Emails,
+      ref: true,
       fieldName: 'email_id',
       index: 'fk_user_email_orders_emails1_idx',
     },
     order: {
       kind: 'm:1',
       entity: () => Orders,
+      ref: true,
       fieldName: 'order_id',
       index: 'fk_user_email_orders_orders1_idx',
     },
   },
 });
 ",
-  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
 export class UserEmails {
   [PrimaryKeyProp]?: ['user', 'email'];
-  user!: Users;
-  email!: Emails;
+  user!: Ref<Users>;
+  email!: Ref<Emails>;
   isVerified: boolean & Opt = false;
 }
 
@@ -8874,6 +9071,7 @@ export const UserEmailsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
       updateRule: 'cascade',
       deleteRule: 'cascade',
@@ -8882,6 +9080,7 @@ export const UserEmailsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Emails,
+      ref: true,
       fieldName: 'email_id',
       updateRule: 'cascade',
       deleteRule: 'cascade',
@@ -8923,14 +9122,14 @@ export const UserFlagsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Orders } from './Orders';
 import { Users } from './Users';
 
 export class UserOrders {
   [PrimaryKeyProp]?: ['user', 'order'];
-  user!: Users;
-  order!: Orders;
+  user!: Ref<Users>;
+  order!: Ref<Orders>;
   priority!: number;
 }
 
@@ -8941,12 +9140,14 @@ export const UserOrdersSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
     },
     order: {
       primary: true,
       kind: 'm:1',
       entity: () => Orders,
+      ref: true,
       fieldName: 'order_id',
       updateRule: 'cascade',
       deleteRule: 'cascade',
@@ -9039,9 +9240,9 @@ export const UsersSchema = new EntitySchema({
 ]
 `;
 
-exports[`many_to_many_variants > bidirectionalRelations=true > onlyPurePivotTables=true > outputPurePivotTables=true > readOnlyPivotTables=true > entitySchema=false > dump 1`] = `
+exports[`many_to_many_variants > bidirectionalRelations=true > onlyPurePivotTables=true > outputPurePivotTables=true > readOnlyPivotTables=true > entityDefinition=decorators > dump 1`] = `
 [
-  "import { Entity, ManyToOne, PrimaryKey, Unique } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKey, type Ref, Unique } from '@mikro-orm/core';
 import { Orders } from './Orders';
 import { Users } from './Users';
 
@@ -9052,11 +9253,11 @@ export class CompletedOrders {
   @PrimaryKey()
   id!: number;
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', index: 'fk_completed_orders_users1_idx' })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', index: 'fk_completed_orders_users1_idx' })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Orders, fieldName: 'order_id', index: 'fk_completed_orders_orders1_idx' })
-  order!: Orders;
+  @ManyToOne({ entity: () => Orders, ref: true, fieldName: 'order_id', index: 'fk_completed_orders_orders1_idx' })
+  order!: Ref<Orders>;
 
 }
 ",
@@ -9091,7 +9292,7 @@ export class Emails {
 
 }
 ",
-  "import { Collection, Entity, ManyToMany, OneToMany, OneToOne, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, ManyToMany, OneToMany, OneToOne, PrimaryKey, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { UserEmailFlags } from './UserEmailFlags';
 import { UserFlags } from './UserFlags';
 import { Users } from './Users';
@@ -9107,8 +9308,8 @@ export class Flags {
   @Property({ unique: 'name_UNIQUE' })
   name!: string;
 
-  @OneToOne({ entity: () => UserEmailFlags, mappedBy: 'flag' })
-  userEmailFlags?: UserEmailFlags;
+  @OneToOne({ entity: () => UserEmailFlags, ref: true, mappedBy: 'flag' })
+  userEmailFlags?: Ref<UserEmailFlags>;
 
   @OneToMany({ entity: () => UserFlags, mappedBy: 'flag' })
   userFlagsCollection = new Collection<UserFlags>(this);
@@ -9145,7 +9346,7 @@ export class Orders {
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
@@ -9154,18 +9355,18 @@ export class UserEmailAvatars {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Emails, fieldName: 'email_id', primary: true, index: 'fk_user_email_avatars_emails1_idx' })
-  email!: Emails;
+  @ManyToOne({ entity: () => Emails, ref: true, fieldName: 'email_id', primary: true, index: 'fk_user_email_avatars_emails1_idx' })
+  email!: Ref<Emails>;
 
   @Property()
   avatarUrl!: string;
 
 }
 ",
-  "import { Entity, ManyToOne, OneToOne, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, OneToOne, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Flags } from './Flags';
 import { Users } from './Users';
@@ -9175,18 +9376,18 @@ export class UserEmailFlags {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Emails, fieldName: 'email_id', primary: true, index: 'fk_user_email_flags_emails1_idx' })
-  email!: Emails;
+  @ManyToOne({ entity: () => Emails, ref: true, fieldName: 'email_id', primary: true, index: 'fk_user_email_flags_emails1_idx' })
+  email!: Ref<Emails>;
 
-  @OneToOne({ entity: () => Flags, fieldName: 'flag_id', defaultRaw: \`1\`, index: 'fk_user_email_flags_flags1_idx', unique: 'flag_id_UNIQUE' })
-  flag!: Flags & Opt;
+  @OneToOne({ entity: () => Flags, ref: true, fieldName: 'flag_id', defaultRaw: \`1\`, index: 'fk_user_email_flags_flags1_idx', unique: 'flag_id_UNIQUE' })
+  flag!: Ref<Flags> & Opt;
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Orders } from './Orders';
 import { Users } from './Users';
@@ -9196,18 +9397,18 @@ export class UserEmailOrders {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Emails, fieldName: 'email_id', primary: true, index: 'fk_user_email_orders_emails1_idx' })
-  email!: Emails;
+  @ManyToOne({ entity: () => Emails, ref: true, fieldName: 'email_id', primary: true, index: 'fk_user_email_orders_emails1_idx' })
+  email!: Ref<Emails>;
 
-  @ManyToOne({ entity: () => Orders, fieldName: 'order_id', index: 'fk_user_email_orders_orders1_idx' })
-  order!: Orders;
+  @ManyToOne({ entity: () => Orders, ref: true, fieldName: 'order_id', index: 'fk_user_email_orders_orders1_idx' })
+  order!: Ref<Orders>;
 
 }
 ",
-  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
@@ -9216,11 +9417,11 @@ export class UserEmails {
 
   [PrimaryKeyProp]?: ['user', 'email'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Emails, fieldName: 'email_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true, index: 'fk_user_emails_emails1_idx' })
-  email!: Emails;
+  @ManyToOne({ entity: () => Emails, ref: true, fieldName: 'email_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true, index: 'fk_user_emails_emails1_idx' })
+  email!: Ref<Emails>;
 
   @Property({ type: 'boolean' })
   isVerified: boolean & Opt = false;
@@ -9244,7 +9445,7 @@ export class UserFlags {
 
 }
 ",
-  "import { Entity, ManyToOne, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Orders } from './Orders';
 import { Users } from './Users';
 
@@ -9253,11 +9454,11 @@ export class UserOrders {
 
   [PrimaryKeyProp]?: ['user', 'order'];
 
-  @ManyToOne({ entity: () => Users, fieldName: 'user_id', primary: true })
-  user!: Users;
+  @ManyToOne({ entity: () => Users, ref: true, fieldName: 'user_id', primary: true })
+  user!: Ref<Users>;
 
-  @ManyToOne({ entity: () => Orders, fieldName: 'order_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true, index: 'fk_user_orders_orders1_idx' })
-  order!: Orders;
+  @ManyToOne({ entity: () => Orders, ref: true, fieldName: 'order_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true, index: 'fk_user_orders_orders1_idx' })
+  order!: Ref<Orders>;
 
   @Property({ unsigned: true, autoincrement: true, unique: 'priority_UNIQUE' })
   priority!: number;
@@ -9314,16 +9515,16 @@ export class Users {
 ]
 `;
 
-exports[`many_to_many_variants > bidirectionalRelations=true > onlyPurePivotTables=true > outputPurePivotTables=true > readOnlyPivotTables=true > entitySchema=true > dump 1`] = `
+exports[`many_to_many_variants > bidirectionalRelations=true > onlyPurePivotTables=true > outputPurePivotTables=true > readOnlyPivotTables=true > entityDefinition=entitySchema > dump 1`] = `
 [
-  "import { EntitySchema } from '@mikro-orm/core';
+  "import { EntitySchema, type Ref } from '@mikro-orm/core';
 import { Orders } from './Orders';
 import { Users } from './Users';
 
 export class CompletedOrders {
   id!: number;
-  user!: Users;
-  order!: Orders;
+  user!: Ref<Users>;
+  order!: Ref<Orders>;
 }
 
 export const CompletedOrdersSchema = new EntitySchema({
@@ -9334,12 +9535,14 @@ export const CompletedOrdersSchema = new EntitySchema({
     user: {
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
       index: 'fk_completed_orders_users1_idx',
     },
     order: {
       kind: 'm:1',
       entity: () => Orders,
+      ref: true,
       fieldName: 'order_id',
       index: 'fk_completed_orders_orders1_idx',
     },
@@ -9390,7 +9593,7 @@ export const EmailsSchema = new EntitySchema({
   },
 });
 ",
-  "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { UserEmailFlags } from './UserEmailFlags';
 import { UserFlags } from './UserFlags';
 import { Users } from './Users';
@@ -9399,7 +9602,7 @@ export class Flags {
   [PrimaryKeyProp]?: 'flagId';
   flagId!: number;
   name!: string;
-  userEmailFlags?: UserEmailFlags;
+  userEmailFlags?: Ref<UserEmailFlags>;
   userFlagsCollection = new Collection<UserFlags>(this);
   userFlagsInverse = new Collection<Users>(this);
 }
@@ -9412,6 +9615,7 @@ export const FlagsSchema = new EntitySchema({
     userEmailFlags: {
       kind: '1:1',
       entity: () => UserEmailFlags,
+      ref: true,
       mappedBy: 'flag',
     },
     userFlagsCollection: {
@@ -9460,14 +9664,14 @@ export const OrdersSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
 export class UserEmailAvatars {
   [PrimaryKeyProp]?: ['user', 'email'];
-  user!: Users;
-  email!: Emails;
+  user!: Ref<Users>;
+  email!: Ref<Emails>;
   avatarUrl!: string;
 }
 
@@ -9478,6 +9682,7 @@ export const UserEmailAvatarsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
       updateRule: 'cascade',
       deleteRule: 'cascade',
@@ -9486,6 +9691,7 @@ export const UserEmailAvatarsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Emails,
+      ref: true,
       fieldName: 'email_id',
       index: 'fk_user_email_avatars_emails1_idx',
     },
@@ -9493,16 +9699,16 @@ export const UserEmailAvatarsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Flags } from './Flags';
 import { Users } from './Users';
 
 export class UserEmailFlags {
   [PrimaryKeyProp]?: ['user', 'email'];
-  user!: Users;
-  email!: Emails;
-  flag!: Flags & Opt;
+  user!: Ref<Users>;
+  email!: Ref<Emails>;
+  flag!: Ref<Flags> & Opt;
 }
 
 export const UserEmailFlagsSchema = new EntitySchema({
@@ -9512,18 +9718,21 @@ export const UserEmailFlagsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
     },
     email: {
       primary: true,
       kind: 'm:1',
       entity: () => Emails,
+      ref: true,
       fieldName: 'email_id',
       index: 'fk_user_email_flags_emails1_idx',
     },
     flag: {
       kind: '1:1',
       entity: () => Flags,
+      ref: true,
       fieldName: 'flag_id',
       defaultRaw: \`1\`,
       index: 'fk_user_email_flags_flags1_idx',
@@ -9532,16 +9741,16 @@ export const UserEmailFlagsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Orders } from './Orders';
 import { Users } from './Users';
 
 export class UserEmailOrders {
   [PrimaryKeyProp]?: ['user', 'email'];
-  user!: Users;
-  email!: Emails;
-  order!: Orders;
+  user!: Ref<Users>;
+  email!: Ref<Emails>;
+  order!: Ref<Orders>;
 }
 
 export const UserEmailOrdersSchema = new EntitySchema({
@@ -9551,32 +9760,35 @@ export const UserEmailOrdersSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
     },
     email: {
       primary: true,
       kind: 'm:1',
       entity: () => Emails,
+      ref: true,
       fieldName: 'email_id',
       index: 'fk_user_email_orders_emails1_idx',
     },
     order: {
       kind: 'm:1',
       entity: () => Orders,
+      ref: true,
       fieldName: 'order_id',
       index: 'fk_user_email_orders_orders1_idx',
     },
   },
 });
 ",
-  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { Users } from './Users';
 
 export class UserEmails {
   [PrimaryKeyProp]?: ['user', 'email'];
-  user!: Users;
-  email!: Emails;
+  user!: Ref<Users>;
+  email!: Ref<Emails>;
   isVerified: boolean & Opt = false;
 }
 
@@ -9587,6 +9799,7 @@ export const UserEmailsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
       updateRule: 'cascade',
       deleteRule: 'cascade',
@@ -9595,6 +9808,7 @@ export const UserEmailsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Emails,
+      ref: true,
       fieldName: 'email_id',
       updateRule: 'cascade',
       deleteRule: 'cascade',
@@ -9636,14 +9850,14 @@ export const UserFlagsSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Orders } from './Orders';
 import { Users } from './Users';
 
 export class UserOrders {
   [PrimaryKeyProp]?: ['user', 'order'];
-  user!: Users;
-  order!: Orders;
+  user!: Ref<Users>;
+  order!: Ref<Orders>;
   priority!: number;
 }
 
@@ -9654,12 +9868,14 @@ export const UserOrdersSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Users,
+      ref: true,
       fieldName: 'user_id',
     },
     order: {
       primary: true,
       kind: 'm:1',
       entity: () => Orders,
+      ref: true,
       fieldName: 'order_id',
       updateRule: 'cascade',
       deleteRule: 'cascade',

--- a/tests/features/entity-generator/__snapshots__/MetadataHooks.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/MetadataHooks.mysql.test.ts.snap
@@ -128,7 +128,7 @@ export abstract class BaseUser2 extends CustomBase2 {
 
   @Index({ name: 'base_user2_type_index' })
   @Enum({ items: () => BaseUser2Type })
-  type!: BaseUser2Type;
+  type!: TBaseUser2Type;
 
   @Property({ type: 'string', nullable: true })
   ownerProp: string | null = null;
@@ -155,11 +155,13 @@ export abstract class BaseUser2 extends CustomBase2 {
 
 }
 
-export enum BaseUser2Type {
-  EMPLOYEE = 'employee',
-  MANAGER = 'manager',
-  OWNER = 'owner',
-}
+export const BaseUser2Type = {
+  EMPLOYEE: 'employee',
+  MANAGER: 'manager',
+  OWNER: 'owner',
+} as const;
+
+export type TBaseUser2Type = (typeof BaseUser2Type)[keyof typeof BaseUser2Type];
 ",
   "import { Collection, Entity, ManyToMany, OneToMany, PrimaryKey, Property } from '@mikro-orm/core';
 import { Book2 } from './Book2';
@@ -468,10 +470,10 @@ export class Publisher2 {
   name!: IType<URL, string> & Opt;
 
   @Enum({ items: () => Publisher2Type })
-  type: Publisher2Type & Opt = Publisher2Type.LOCAL;
+  type: TPublisher2Type & Opt = Publisher2Type.LOCAL;
 
   @Enum({ items: () => Publisher2Type2 })
-  type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
+  type2: TPublisher2Type2 & Opt = Publisher2Type2.LOCAL;
 
   @Property({ type: 'tinyint', nullable: true })
   enum1: number | null = null;
@@ -483,10 +485,10 @@ export class Publisher2 {
   enum3: number | null = null;
 
   @Enum({ items: () => Publisher2Enum4, nullable: true })
-  enum4: Publisher2Enum4 | null = null;
+  enum4: TPublisher2Enum4 | null = null;
 
   @Enum({ items: () => Publisher2Enum5, nullable: true })
-  enum5: Publisher2Enum5 | null = null;
+  enum5: TPublisher2Enum5 | null = null;
 
   @OneToMany({ entity: () => Book2, mappedBy: 'publisher' })
   book2Collection = new Collection<Book2>(this);
@@ -496,25 +498,33 @@ export class Publisher2 {
 
 }
 
-export enum Publisher2Type {
-  LOCAL = 'local',
-  GLOBAL = 'global',
-}
+export const Publisher2Type = {
+  LOCAL: 'local',
+  GLOBAL: 'global',
+} as const;
 
-export enum Publisher2Type2 {
-  LOCAL = 'LOCAL',
-  GLOBAL = 'GLOBAL',
-}
+export type TPublisher2Type = (typeof Publisher2Type)[keyof typeof Publisher2Type];
 
-export enum Publisher2Enum4 {
-  A = 'a',
-  B = 'b',
-  C = 'c',
-}
+export const Publisher2Type2 = {
+  LOCAL: 'LOCAL',
+  GLOBAL: 'GLOBAL',
+} as const;
 
-export enum Publisher2Enum5 {
-  A = 'a',
-}
+export type TPublisher2Type2 = (typeof Publisher2Type2)[keyof typeof Publisher2Type2];
+
+export const Publisher2Enum4 = {
+  A: 'a',
+  B: 'b',
+  C: 'c',
+} as const;
+
+export type TPublisher2Enum4 = (typeof Publisher2Enum4)[keyof typeof Publisher2Enum4];
+
+export const Publisher2Enum5 = {
+  A: 'a',
+} as const;
+
+export type TPublisher2Enum5 = (typeof Publisher2Enum5)[keyof typeof Publisher2Enum5];
 ",
   "import { Entity, Index, ManyToOne, PrimaryKey } from '@mikro-orm/core';
 import { Publisher2 } from './Publisher2';
@@ -822,7 +832,7 @@ export abstract class BaseUser2 extends CustomBase2 {
   id!: number;
   firstName!: string;
   lastName!: string;
-  type!: BaseUser2Type;
+  type!: TBaseUser2Type;
   ownerProp: string | null = null;
   favouriteEmployee: BaseUser2 | null = null;
   favouriteManager: BaseUser2 | null = null;
@@ -832,11 +842,13 @@ export abstract class BaseUser2 extends CustomBase2 {
   baseUser2: BaseUser2 | null = null;
 }
 
-export enum BaseUser2Type {
-  EMPLOYEE = 'employee',
-  MANAGER = 'manager',
-  OWNER = 'owner',
-}
+export const BaseUser2Type = {
+  EMPLOYEE: 'employee',
+  MANAGER: 'manager',
+  OWNER: 'owner',
+} as const;
+
+export type TBaseUser2Type = (typeof BaseUser2Type)[keyof typeof BaseUser2Type];
 
 export const BaseUser2Schema = defineEntity({
   class: BaseUser2,
@@ -1122,36 +1134,44 @@ import { Publisher2Tests } from './Publisher2Tests';
 export class Publisher2 {
   id!: number;
   name!: IType<URL, string> & Opt;
-  type: Publisher2Type & Opt = Publisher2Type.LOCAL;
-  type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
+  type: TPublisher2Type & Opt = Publisher2Type.LOCAL;
+  type2: TPublisher2Type2 & Opt = Publisher2Type2.LOCAL;
   enum1: number | null = null;
   enum2: number | null = null;
   enum3: number | null = null;
-  enum4: Publisher2Enum4 | null = null;
-  enum5: Publisher2Enum5 | null = null;
+  enum4: TPublisher2Enum4 | null = null;
+  enum5: TPublisher2Enum5 | null = null;
   book2Collection = new Collection<Book2>(this);
   publisher2TestsCollection = new Collection<Publisher2Tests>(this);
 }
 
-export enum Publisher2Type {
-  LOCAL = 'local',
-  GLOBAL = 'global',
-}
+export const Publisher2Type = {
+  LOCAL: 'local',
+  GLOBAL: 'global',
+} as const;
 
-export enum Publisher2Type2 {
-  LOCAL = 'LOCAL',
-  GLOBAL = 'GLOBAL',
-}
+export type TPublisher2Type = (typeof Publisher2Type)[keyof typeof Publisher2Type];
 
-export enum Publisher2Enum4 {
-  A = 'a',
-  B = 'b',
-  C = 'c',
-}
+export const Publisher2Type2 = {
+  LOCAL: 'LOCAL',
+  GLOBAL: 'GLOBAL',
+} as const;
 
-export enum Publisher2Enum5 {
-  A = 'a',
-}
+export type TPublisher2Type2 = (typeof Publisher2Type2)[keyof typeof Publisher2Type2];
+
+export const Publisher2Enum4 = {
+  A: 'a',
+  B: 'b',
+  C: 'c',
+} as const;
+
+export type TPublisher2Enum4 = (typeof Publisher2Enum4)[keyof typeof Publisher2Enum4];
+
+export const Publisher2Enum5 = {
+  A: 'a',
+} as const;
+
+export type TPublisher2Enum5 = (typeof Publisher2Enum5)[keyof typeof Publisher2Enum5];
 
 export const Publisher2Schema = defineEntity({
   class: Publisher2,
@@ -1583,7 +1603,7 @@ export abstract class BaseUser2 extends CustomBase2 {
   id!: number;
   firstName!: string;
   lastName!: string;
-  type!: BaseUser2Type;
+  type!: TBaseUser2Type;
   ownerProp: string | null = null;
   favouriteEmployee: BaseUser2 | null = null;
   favouriteManager: BaseUser2 | null = null;
@@ -1593,11 +1613,13 @@ export abstract class BaseUser2 extends CustomBase2 {
   baseUser2: BaseUser2 | null = null;
 }
 
-export enum BaseUser2Type {
-  EMPLOYEE = 'employee',
-  MANAGER = 'manager',
-  OWNER = 'owner',
-}
+export const BaseUser2Type = {
+  EMPLOYEE: 'employee',
+  MANAGER: 'manager',
+  OWNER: 'owner',
+} as const;
+
+export type TBaseUser2Type = (typeof BaseUser2Type)[keyof typeof BaseUser2Type];
 
 export const BaseUser2Schema = new EntitySchema({
   class: BaseUser2,
@@ -1999,36 +2021,44 @@ import { Publisher2Tests } from './Publisher2Tests';
 export class Publisher2 {
   id!: number;
   name!: IType<URL, string> & Opt;
-  type: Publisher2Type & Opt = Publisher2Type.LOCAL;
-  type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
+  type: TPublisher2Type & Opt = Publisher2Type.LOCAL;
+  type2: TPublisher2Type2 & Opt = Publisher2Type2.LOCAL;
   enum1: number | null = null;
   enum2: number | null = null;
   enum3: number | null = null;
-  enum4: Publisher2Enum4 | null = null;
-  enum5: Publisher2Enum5 | null = null;
+  enum4: TPublisher2Enum4 | null = null;
+  enum5: TPublisher2Enum5 | null = null;
   book2Collection = new Collection<Book2>(this);
   publisher2TestsCollection = new Collection<Publisher2Tests>(this);
 }
 
-export enum Publisher2Type {
-  LOCAL = 'local',
-  GLOBAL = 'global',
-}
+export const Publisher2Type = {
+  LOCAL: 'local',
+  GLOBAL: 'global',
+} as const;
 
-export enum Publisher2Type2 {
-  LOCAL = 'LOCAL',
-  GLOBAL = 'GLOBAL',
-}
+export type TPublisher2Type = (typeof Publisher2Type)[keyof typeof Publisher2Type];
 
-export enum Publisher2Enum4 {
-  A = 'a',
-  B = 'b',
-  C = 'c',
-}
+export const Publisher2Type2 = {
+  LOCAL: 'LOCAL',
+  GLOBAL: 'GLOBAL',
+} as const;
 
-export enum Publisher2Enum5 {
-  A = 'a',
-}
+export type TPublisher2Type2 = (typeof Publisher2Type2)[keyof typeof Publisher2Type2];
+
+export const Publisher2Enum4 = {
+  A: 'a',
+  B: 'b',
+  C: 'c',
+} as const;
+
+export type TPublisher2Enum4 = (typeof Publisher2Enum4)[keyof typeof Publisher2Enum4];
+
+export const Publisher2Enum5 = {
+  A: 'a',
+} as const;
+
+export type TPublisher2Enum5 = (typeof Publisher2Enum5)[keyof typeof Publisher2Enum5];
 
 export const Publisher2Schema = new EntitySchema({
   class: Publisher2,
@@ -2487,7 +2517,7 @@ export abstract class BaseUser2 extends CustomBase2 {
 
   @Index({ name: 'base_user2_type_index' })
   @Enum({ items: () => BaseUser2Type })
-  type!: BaseUser2Type;
+  type!: TBaseUser2Type;
 
   @Property({ type: 'string', nullable: true })
   ownerProp: string | null = null;
@@ -2514,11 +2544,13 @@ export abstract class BaseUser2 extends CustomBase2 {
 
 }
 
-export enum BaseUser2Type {
-  EMPLOYEE = 'employee',
-  MANAGER = 'manager',
-  OWNER = 'owner',
-}
+export const BaseUser2Type = {
+  EMPLOYEE: 'employee',
+  MANAGER: 'manager',
+  OWNER: 'owner',
+} as const;
+
+export type TBaseUser2Type = (typeof BaseUser2Type)[keyof typeof BaseUser2Type];
 ",
   "import { Collection, Entity, ManyToMany, OneToMany, PrimaryKey, Property } from '@mikro-orm/core';
 import { Book2 } from './Book2';
@@ -2827,10 +2859,10 @@ export class Publisher2 {
   name!: IType<URL, string> & Opt;
 
   @Enum({ items: () => Publisher2Type })
-  type: Publisher2Type & Opt = Publisher2Type.LOCAL;
+  type: TPublisher2Type & Opt = Publisher2Type.LOCAL;
 
   @Enum({ items: () => Publisher2Type2 })
-  type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
+  type2: TPublisher2Type2 & Opt = Publisher2Type2.LOCAL;
 
   @Property({ type: 'tinyint', nullable: true })
   enum1: number | null = null;
@@ -2842,10 +2874,10 @@ export class Publisher2 {
   enum3: number | null = null;
 
   @Enum({ items: () => Publisher2Enum4, nullable: true })
-  enum4: Publisher2Enum4 | null = null;
+  enum4: TPublisher2Enum4 | null = null;
 
   @Enum({ items: () => Publisher2Enum5, nullable: true })
-  enum5: Publisher2Enum5 | null = null;
+  enum5: TPublisher2Enum5 | null = null;
 
   @OneToMany({ entity: () => Book2, mappedBy: 'publisher' })
   book2Collection = new Collection<Book2>(this);
@@ -2855,25 +2887,33 @@ export class Publisher2 {
 
 }
 
-export enum Publisher2Type {
-  LOCAL = 'local',
-  GLOBAL = 'global',
-}
+export const Publisher2Type = {
+  LOCAL: 'local',
+  GLOBAL: 'global',
+} as const;
 
-export enum Publisher2Type2 {
-  LOCAL = 'LOCAL',
-  GLOBAL = 'GLOBAL',
-}
+export type TPublisher2Type = (typeof Publisher2Type)[keyof typeof Publisher2Type];
 
-export enum Publisher2Enum4 {
-  A = 'a',
-  B = 'b',
-  C = 'c',
-}
+export const Publisher2Type2 = {
+  LOCAL: 'LOCAL',
+  GLOBAL: 'GLOBAL',
+} as const;
 
-export enum Publisher2Enum5 {
-  A = 'a',
-}
+export type TPublisher2Type2 = (typeof Publisher2Type2)[keyof typeof Publisher2Type2];
+
+export const Publisher2Enum4 = {
+  A: 'a',
+  B: 'b',
+  C: 'c',
+} as const;
+
+export type TPublisher2Enum4 = (typeof Publisher2Enum4)[keyof typeof Publisher2Enum4];
+
+export const Publisher2Enum5 = {
+  A: 'a',
+} as const;
+
+export type TPublisher2Enum5 = (typeof Publisher2Enum5)[keyof typeof Publisher2Enum5];
 ",
   "import { Entity, Index, ManyToOne, PrimaryKey, type Ref } from '@mikro-orm/core';
 import { Publisher2 } from './Publisher2';
@@ -3181,7 +3221,7 @@ export abstract class BaseUser2 extends CustomBase2 {
   id!: number;
   firstName!: string;
   lastName!: string;
-  type!: BaseUser2Type;
+  type!: TBaseUser2Type;
   ownerProp: string | null = null;
   favouriteEmployee: Ref<BaseUser2> | null = null;
   favouriteManager: Ref<BaseUser2> | null = null;
@@ -3191,11 +3231,13 @@ export abstract class BaseUser2 extends CustomBase2 {
   baseUser2: Ref<BaseUser2> | null = null;
 }
 
-export enum BaseUser2Type {
-  EMPLOYEE = 'employee',
-  MANAGER = 'manager',
-  OWNER = 'owner',
-}
+export const BaseUser2Type = {
+  EMPLOYEE: 'employee',
+  MANAGER: 'manager',
+  OWNER: 'owner',
+} as const;
+
+export type TBaseUser2Type = (typeof BaseUser2Type)[keyof typeof BaseUser2Type];
 
 export const BaseUser2Schema = defineEntity({
   class: BaseUser2,
@@ -3481,36 +3523,44 @@ import { Publisher2Tests } from './Publisher2Tests';
 export class Publisher2 {
   id!: number;
   name!: IType<URL, string> & Opt;
-  type: Publisher2Type & Opt = Publisher2Type.LOCAL;
-  type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
+  type: TPublisher2Type & Opt = Publisher2Type.LOCAL;
+  type2: TPublisher2Type2 & Opt = Publisher2Type2.LOCAL;
   enum1: number | null = null;
   enum2: number | null = null;
   enum3: number | null = null;
-  enum4: Publisher2Enum4 | null = null;
-  enum5: Publisher2Enum5 | null = null;
+  enum4: TPublisher2Enum4 | null = null;
+  enum5: TPublisher2Enum5 | null = null;
   book2Collection = new Collection<Book2>(this);
   publisher2TestsCollection = new Collection<Publisher2Tests>(this);
 }
 
-export enum Publisher2Type {
-  LOCAL = 'local',
-  GLOBAL = 'global',
-}
+export const Publisher2Type = {
+  LOCAL: 'local',
+  GLOBAL: 'global',
+} as const;
 
-export enum Publisher2Type2 {
-  LOCAL = 'LOCAL',
-  GLOBAL = 'GLOBAL',
-}
+export type TPublisher2Type = (typeof Publisher2Type)[keyof typeof Publisher2Type];
 
-export enum Publisher2Enum4 {
-  A = 'a',
-  B = 'b',
-  C = 'c',
-}
+export const Publisher2Type2 = {
+  LOCAL: 'LOCAL',
+  GLOBAL: 'GLOBAL',
+} as const;
 
-export enum Publisher2Enum5 {
-  A = 'a',
-}
+export type TPublisher2Type2 = (typeof Publisher2Type2)[keyof typeof Publisher2Type2];
+
+export const Publisher2Enum4 = {
+  A: 'a',
+  B: 'b',
+  C: 'c',
+} as const;
+
+export type TPublisher2Enum4 = (typeof Publisher2Enum4)[keyof typeof Publisher2Enum4];
+
+export const Publisher2Enum5 = {
+  A: 'a',
+} as const;
+
+export type TPublisher2Enum5 = (typeof Publisher2Enum5)[keyof typeof Publisher2Enum5];
 
 export const Publisher2Schema = defineEntity({
   class: Publisher2,
@@ -3951,7 +4001,7 @@ export abstract class BaseUser2 extends CustomBase2 {
   id!: number;
   firstName!: string;
   lastName!: string;
-  type!: BaseUser2Type;
+  type!: TBaseUser2Type;
   ownerProp: string | null = null;
   favouriteEmployee: Ref<BaseUser2> | null = null;
   favouriteManager: Ref<BaseUser2> | null = null;
@@ -3961,11 +4011,13 @@ export abstract class BaseUser2 extends CustomBase2 {
   baseUser2: Ref<BaseUser2> | null = null;
 }
 
-export enum BaseUser2Type {
-  EMPLOYEE = 'employee',
-  MANAGER = 'manager',
-  OWNER = 'owner',
-}
+export const BaseUser2Type = {
+  EMPLOYEE: 'employee',
+  MANAGER: 'manager',
+  OWNER: 'owner',
+} as const;
+
+export type TBaseUser2Type = (typeof BaseUser2Type)[keyof typeof BaseUser2Type];
 
 export const BaseUser2Schema = new EntitySchema({
   class: BaseUser2,
@@ -4383,36 +4435,44 @@ import { Publisher2Tests } from './Publisher2Tests';
 export class Publisher2 {
   id!: number;
   name!: IType<URL, string> & Opt;
-  type: Publisher2Type & Opt = Publisher2Type.LOCAL;
-  type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
+  type: TPublisher2Type & Opt = Publisher2Type.LOCAL;
+  type2: TPublisher2Type2 & Opt = Publisher2Type2.LOCAL;
   enum1: number | null = null;
   enum2: number | null = null;
   enum3: number | null = null;
-  enum4: Publisher2Enum4 | null = null;
-  enum5: Publisher2Enum5 | null = null;
+  enum4: TPublisher2Enum4 | null = null;
+  enum5: TPublisher2Enum5 | null = null;
   book2Collection = new Collection<Book2>(this);
   publisher2TestsCollection = new Collection<Publisher2Tests>(this);
 }
 
-export enum Publisher2Type {
-  LOCAL = 'local',
-  GLOBAL = 'global',
-}
+export const Publisher2Type = {
+  LOCAL: 'local',
+  GLOBAL: 'global',
+} as const;
 
-export enum Publisher2Type2 {
-  LOCAL = 'LOCAL',
-  GLOBAL = 'GLOBAL',
-}
+export type TPublisher2Type = (typeof Publisher2Type)[keyof typeof Publisher2Type];
 
-export enum Publisher2Enum4 {
-  A = 'a',
-  B = 'b',
-  C = 'c',
-}
+export const Publisher2Type2 = {
+  LOCAL: 'LOCAL',
+  GLOBAL: 'GLOBAL',
+} as const;
 
-export enum Publisher2Enum5 {
-  A = 'a',
-}
+export type TPublisher2Type2 = (typeof Publisher2Type2)[keyof typeof Publisher2Type2];
+
+export const Publisher2Enum4 = {
+  A: 'a',
+  B: 'b',
+  C: 'c',
+} as const;
+
+export type TPublisher2Enum4 = (typeof Publisher2Enum4)[keyof typeof Publisher2Enum4];
+
+export const Publisher2Enum5 = {
+  A: 'a',
+} as const;
+
+export type TPublisher2Enum5 = (typeof Publisher2Enum5)[keyof typeof Publisher2Enum5];
 
 export const Publisher2Schema = new EntitySchema({
   class: Publisher2,
@@ -4877,7 +4937,7 @@ export abstract class BaseUser2 extends CustomBase2 {
 
   @Index({ name: 'base_user2_type_index' })
   @Enum({ items: () => BaseUser2Type })
-  type!: BaseUser2Type;
+  type!: TBaseUser2Type;
 
   @Property({ nullable: true })
   ownerProp?: string;
@@ -4904,11 +4964,13 @@ export abstract class BaseUser2 extends CustomBase2 {
 
 }
 
-export enum BaseUser2Type {
-  EMPLOYEE = 'employee',
-  MANAGER = 'manager',
-  OWNER = 'owner',
-}
+export const BaseUser2Type = {
+  EMPLOYEE: 'employee',
+  MANAGER: 'manager',
+  OWNER: 'owner',
+} as const;
+
+export type TBaseUser2Type = (typeof BaseUser2Type)[keyof typeof BaseUser2Type];
 ",
   "import { Collection, Entity, ManyToMany, OneToMany, PrimaryKey, Property } from '@mikro-orm/core';
 import { Book2 } from './Book2';
@@ -5217,10 +5279,10 @@ export class Publisher2 {
   name!: IType<URL, string> & Opt;
 
   @Enum({ items: () => Publisher2Type })
-  type: Publisher2Type & Opt = Publisher2Type.LOCAL;
+  type: TPublisher2Type & Opt = Publisher2Type.LOCAL;
 
   @Enum({ items: () => Publisher2Type2 })
-  type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
+  type2: TPublisher2Type2 & Opt = Publisher2Type2.LOCAL;
 
   @Property({ type: 'tinyint', nullable: true })
   enum1?: number;
@@ -5232,10 +5294,10 @@ export class Publisher2 {
   enum3?: number;
 
   @Enum({ items: () => Publisher2Enum4, nullable: true })
-  enum4?: Publisher2Enum4;
+  enum4?: TPublisher2Enum4;
 
   @Enum({ items: () => Publisher2Enum5, nullable: true })
-  enum5?: Publisher2Enum5;
+  enum5?: TPublisher2Enum5;
 
   @OneToMany({ entity: () => Book2, mappedBy: 'publisher' })
   book2Collection = new Collection<Book2>(this);
@@ -5245,25 +5307,33 @@ export class Publisher2 {
 
 }
 
-export enum Publisher2Type {
-  LOCAL = 'local',
-  GLOBAL = 'global',
-}
+export const Publisher2Type = {
+  LOCAL: 'local',
+  GLOBAL: 'global',
+} as const;
 
-export enum Publisher2Type2 {
-  LOCAL = 'LOCAL',
-  GLOBAL = 'GLOBAL',
-}
+export type TPublisher2Type = (typeof Publisher2Type)[keyof typeof Publisher2Type];
 
-export enum Publisher2Enum4 {
-  A = 'a',
-  B = 'b',
-  C = 'c',
-}
+export const Publisher2Type2 = {
+  LOCAL: 'LOCAL',
+  GLOBAL: 'GLOBAL',
+} as const;
 
-export enum Publisher2Enum5 {
-  A = 'a',
-}
+export type TPublisher2Type2 = (typeof Publisher2Type2)[keyof typeof Publisher2Type2];
+
+export const Publisher2Enum4 = {
+  A: 'a',
+  B: 'b',
+  C: 'c',
+} as const;
+
+export type TPublisher2Enum4 = (typeof Publisher2Enum4)[keyof typeof Publisher2Enum4];
+
+export const Publisher2Enum5 = {
+  A: 'a',
+} as const;
+
+export type TPublisher2Enum5 = (typeof Publisher2Enum5)[keyof typeof Publisher2Enum5];
 ",
   "import { Entity, Index, ManyToOne, PrimaryKey } from '@mikro-orm/core';
 import { Publisher2 } from './Publisher2';
@@ -5571,7 +5641,7 @@ export abstract class BaseUser2 extends CustomBase2 {
   id!: number;
   firstName!: string;
   lastName!: string;
-  type!: BaseUser2Type;
+  type!: TBaseUser2Type;
   ownerProp?: string;
   favouriteEmployee?: BaseUser2;
   favouriteManager?: BaseUser2;
@@ -5581,11 +5651,13 @@ export abstract class BaseUser2 extends CustomBase2 {
   baseUser2?: BaseUser2;
 }
 
-export enum BaseUser2Type {
-  EMPLOYEE = 'employee',
-  MANAGER = 'manager',
-  OWNER = 'owner',
-}
+export const BaseUser2Type = {
+  EMPLOYEE: 'employee',
+  MANAGER: 'manager',
+  OWNER: 'owner',
+} as const;
+
+export type TBaseUser2Type = (typeof BaseUser2Type)[keyof typeof BaseUser2Type];
 
 export const BaseUser2Schema = defineEntity({
   class: BaseUser2,
@@ -5871,36 +5943,44 @@ import { Publisher2Tests } from './Publisher2Tests';
 export class Publisher2 {
   id!: number;
   name!: IType<URL, string> & Opt;
-  type: Publisher2Type & Opt = Publisher2Type.LOCAL;
-  type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
+  type: TPublisher2Type & Opt = Publisher2Type.LOCAL;
+  type2: TPublisher2Type2 & Opt = Publisher2Type2.LOCAL;
   enum1?: number;
   enum2?: number;
   enum3?: number;
-  enum4?: Publisher2Enum4;
-  enum5?: Publisher2Enum5;
+  enum4?: TPublisher2Enum4;
+  enum5?: TPublisher2Enum5;
   book2Collection = new Collection<Book2>(this);
   publisher2TestsCollection = new Collection<Publisher2Tests>(this);
 }
 
-export enum Publisher2Type {
-  LOCAL = 'local',
-  GLOBAL = 'global',
-}
+export const Publisher2Type = {
+  LOCAL: 'local',
+  GLOBAL: 'global',
+} as const;
 
-export enum Publisher2Type2 {
-  LOCAL = 'LOCAL',
-  GLOBAL = 'GLOBAL',
-}
+export type TPublisher2Type = (typeof Publisher2Type)[keyof typeof Publisher2Type];
 
-export enum Publisher2Enum4 {
-  A = 'a',
-  B = 'b',
-  C = 'c',
-}
+export const Publisher2Type2 = {
+  LOCAL: 'LOCAL',
+  GLOBAL: 'GLOBAL',
+} as const;
 
-export enum Publisher2Enum5 {
-  A = 'a',
-}
+export type TPublisher2Type2 = (typeof Publisher2Type2)[keyof typeof Publisher2Type2];
+
+export const Publisher2Enum4 = {
+  A: 'a',
+  B: 'b',
+  C: 'c',
+} as const;
+
+export type TPublisher2Enum4 = (typeof Publisher2Enum4)[keyof typeof Publisher2Enum4];
+
+export const Publisher2Enum5 = {
+  A: 'a',
+} as const;
+
+export type TPublisher2Enum5 = (typeof Publisher2Enum5)[keyof typeof Publisher2Enum5];
 
 export const Publisher2Schema = defineEntity({
   class: Publisher2,
@@ -6332,7 +6412,7 @@ export abstract class BaseUser2 extends CustomBase2 {
   id!: number;
   firstName!: string;
   lastName!: string;
-  type!: BaseUser2Type;
+  type!: TBaseUser2Type;
   ownerProp?: string;
   favouriteEmployee?: BaseUser2;
   favouriteManager?: BaseUser2;
@@ -6342,11 +6422,13 @@ export abstract class BaseUser2 extends CustomBase2 {
   baseUser2?: BaseUser2;
 }
 
-export enum BaseUser2Type {
-  EMPLOYEE = 'employee',
-  MANAGER = 'manager',
-  OWNER = 'owner',
-}
+export const BaseUser2Type = {
+  EMPLOYEE: 'employee',
+  MANAGER: 'manager',
+  OWNER: 'owner',
+} as const;
+
+export type TBaseUser2Type = (typeof BaseUser2Type)[keyof typeof BaseUser2Type];
 
 export const BaseUser2Schema = new EntitySchema({
   class: BaseUser2,
@@ -6748,36 +6830,44 @@ import { Publisher2Tests } from './Publisher2Tests';
 export class Publisher2 {
   id!: number;
   name!: IType<URL, string> & Opt;
-  type: Publisher2Type & Opt = Publisher2Type.LOCAL;
-  type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
+  type: TPublisher2Type & Opt = Publisher2Type.LOCAL;
+  type2: TPublisher2Type2 & Opt = Publisher2Type2.LOCAL;
   enum1?: number;
   enum2?: number;
   enum3?: number;
-  enum4?: Publisher2Enum4;
-  enum5?: Publisher2Enum5;
+  enum4?: TPublisher2Enum4;
+  enum5?: TPublisher2Enum5;
   book2Collection = new Collection<Book2>(this);
   publisher2TestsCollection = new Collection<Publisher2Tests>(this);
 }
 
-export enum Publisher2Type {
-  LOCAL = 'local',
-  GLOBAL = 'global',
-}
+export const Publisher2Type = {
+  LOCAL: 'local',
+  GLOBAL: 'global',
+} as const;
 
-export enum Publisher2Type2 {
-  LOCAL = 'LOCAL',
-  GLOBAL = 'GLOBAL',
-}
+export type TPublisher2Type = (typeof Publisher2Type)[keyof typeof Publisher2Type];
 
-export enum Publisher2Enum4 {
-  A = 'a',
-  B = 'b',
-  C = 'c',
-}
+export const Publisher2Type2 = {
+  LOCAL: 'LOCAL',
+  GLOBAL: 'GLOBAL',
+} as const;
 
-export enum Publisher2Enum5 {
-  A = 'a',
-}
+export type TPublisher2Type2 = (typeof Publisher2Type2)[keyof typeof Publisher2Type2];
+
+export const Publisher2Enum4 = {
+  A: 'a',
+  B: 'b',
+  C: 'c',
+} as const;
+
+export type TPublisher2Enum4 = (typeof Publisher2Enum4)[keyof typeof Publisher2Enum4];
+
+export const Publisher2Enum5 = {
+  A: 'a',
+} as const;
+
+export type TPublisher2Enum5 = (typeof Publisher2Enum5)[keyof typeof Publisher2Enum5];
 
 export const Publisher2Schema = new EntitySchema({
   class: Publisher2,
@@ -7236,7 +7326,7 @@ export abstract class BaseUser2 extends CustomBase2 {
 
   @Index({ name: 'base_user2_type_index' })
   @Enum({ items: () => BaseUser2Type })
-  type!: BaseUser2Type;
+  type!: TBaseUser2Type;
 
   @Property({ nullable: true })
   ownerProp?: string;
@@ -7263,11 +7353,13 @@ export abstract class BaseUser2 extends CustomBase2 {
 
 }
 
-export enum BaseUser2Type {
-  EMPLOYEE = 'employee',
-  MANAGER = 'manager',
-  OWNER = 'owner',
-}
+export const BaseUser2Type = {
+  EMPLOYEE: 'employee',
+  MANAGER: 'manager',
+  OWNER: 'owner',
+} as const;
+
+export type TBaseUser2Type = (typeof BaseUser2Type)[keyof typeof BaseUser2Type];
 ",
   "import { Collection, Entity, ManyToMany, OneToMany, PrimaryKey, Property } from '@mikro-orm/core';
 import { Book2 } from './Book2';
@@ -7576,10 +7668,10 @@ export class Publisher2 {
   name!: IType<URL, string> & Opt;
 
   @Enum({ items: () => Publisher2Type })
-  type: Publisher2Type & Opt = Publisher2Type.LOCAL;
+  type: TPublisher2Type & Opt = Publisher2Type.LOCAL;
 
   @Enum({ items: () => Publisher2Type2 })
-  type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
+  type2: TPublisher2Type2 & Opt = Publisher2Type2.LOCAL;
 
   @Property({ type: 'tinyint', nullable: true })
   enum1?: number;
@@ -7591,10 +7683,10 @@ export class Publisher2 {
   enum3?: number;
 
   @Enum({ items: () => Publisher2Enum4, nullable: true })
-  enum4?: Publisher2Enum4;
+  enum4?: TPublisher2Enum4;
 
   @Enum({ items: () => Publisher2Enum5, nullable: true })
-  enum5?: Publisher2Enum5;
+  enum5?: TPublisher2Enum5;
 
   @OneToMany({ entity: () => Book2, mappedBy: 'publisher' })
   book2Collection = new Collection<Book2>(this);
@@ -7604,25 +7696,33 @@ export class Publisher2 {
 
 }
 
-export enum Publisher2Type {
-  LOCAL = 'local',
-  GLOBAL = 'global',
-}
+export const Publisher2Type = {
+  LOCAL: 'local',
+  GLOBAL: 'global',
+} as const;
 
-export enum Publisher2Type2 {
-  LOCAL = 'LOCAL',
-  GLOBAL = 'GLOBAL',
-}
+export type TPublisher2Type = (typeof Publisher2Type)[keyof typeof Publisher2Type];
 
-export enum Publisher2Enum4 {
-  A = 'a',
-  B = 'b',
-  C = 'c',
-}
+export const Publisher2Type2 = {
+  LOCAL: 'LOCAL',
+  GLOBAL: 'GLOBAL',
+} as const;
 
-export enum Publisher2Enum5 {
-  A = 'a',
-}
+export type TPublisher2Type2 = (typeof Publisher2Type2)[keyof typeof Publisher2Type2];
+
+export const Publisher2Enum4 = {
+  A: 'a',
+  B: 'b',
+  C: 'c',
+} as const;
+
+export type TPublisher2Enum4 = (typeof Publisher2Enum4)[keyof typeof Publisher2Enum4];
+
+export const Publisher2Enum5 = {
+  A: 'a',
+} as const;
+
+export type TPublisher2Enum5 = (typeof Publisher2Enum5)[keyof typeof Publisher2Enum5];
 ",
   "import { Entity, Index, ManyToOne, PrimaryKey, type Ref } from '@mikro-orm/core';
 import { Publisher2 } from './Publisher2';
@@ -7930,7 +8030,7 @@ export abstract class BaseUser2 extends CustomBase2 {
   id!: number;
   firstName!: string;
   lastName!: string;
-  type!: BaseUser2Type;
+  type!: TBaseUser2Type;
   ownerProp?: string;
   favouriteEmployee?: Ref<BaseUser2>;
   favouriteManager?: Ref<BaseUser2>;
@@ -7940,11 +8040,13 @@ export abstract class BaseUser2 extends CustomBase2 {
   baseUser2?: Ref<BaseUser2>;
 }
 
-export enum BaseUser2Type {
-  EMPLOYEE = 'employee',
-  MANAGER = 'manager',
-  OWNER = 'owner',
-}
+export const BaseUser2Type = {
+  EMPLOYEE: 'employee',
+  MANAGER: 'manager',
+  OWNER: 'owner',
+} as const;
+
+export type TBaseUser2Type = (typeof BaseUser2Type)[keyof typeof BaseUser2Type];
 
 export const BaseUser2Schema = defineEntity({
   class: BaseUser2,
@@ -8230,36 +8332,44 @@ import { Publisher2Tests } from './Publisher2Tests';
 export class Publisher2 {
   id!: number;
   name!: IType<URL, string> & Opt;
-  type: Publisher2Type & Opt = Publisher2Type.LOCAL;
-  type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
+  type: TPublisher2Type & Opt = Publisher2Type.LOCAL;
+  type2: TPublisher2Type2 & Opt = Publisher2Type2.LOCAL;
   enum1?: number;
   enum2?: number;
   enum3?: number;
-  enum4?: Publisher2Enum4;
-  enum5?: Publisher2Enum5;
+  enum4?: TPublisher2Enum4;
+  enum5?: TPublisher2Enum5;
   book2Collection = new Collection<Book2>(this);
   publisher2TestsCollection = new Collection<Publisher2Tests>(this);
 }
 
-export enum Publisher2Type {
-  LOCAL = 'local',
-  GLOBAL = 'global',
-}
+export const Publisher2Type = {
+  LOCAL: 'local',
+  GLOBAL: 'global',
+} as const;
 
-export enum Publisher2Type2 {
-  LOCAL = 'LOCAL',
-  GLOBAL = 'GLOBAL',
-}
+export type TPublisher2Type = (typeof Publisher2Type)[keyof typeof Publisher2Type];
 
-export enum Publisher2Enum4 {
-  A = 'a',
-  B = 'b',
-  C = 'c',
-}
+export const Publisher2Type2 = {
+  LOCAL: 'LOCAL',
+  GLOBAL: 'GLOBAL',
+} as const;
 
-export enum Publisher2Enum5 {
-  A = 'a',
-}
+export type TPublisher2Type2 = (typeof Publisher2Type2)[keyof typeof Publisher2Type2];
+
+export const Publisher2Enum4 = {
+  A: 'a',
+  B: 'b',
+  C: 'c',
+} as const;
+
+export type TPublisher2Enum4 = (typeof Publisher2Enum4)[keyof typeof Publisher2Enum4];
+
+export const Publisher2Enum5 = {
+  A: 'a',
+} as const;
+
+export type TPublisher2Enum5 = (typeof Publisher2Enum5)[keyof typeof Publisher2Enum5];
 
 export const Publisher2Schema = defineEntity({
   class: Publisher2,
@@ -8700,7 +8810,7 @@ export abstract class BaseUser2 extends CustomBase2 {
   id!: number;
   firstName!: string;
   lastName!: string;
-  type!: BaseUser2Type;
+  type!: TBaseUser2Type;
   ownerProp?: string;
   favouriteEmployee?: Ref<BaseUser2>;
   favouriteManager?: Ref<BaseUser2>;
@@ -8710,11 +8820,13 @@ export abstract class BaseUser2 extends CustomBase2 {
   baseUser2?: Ref<BaseUser2>;
 }
 
-export enum BaseUser2Type {
-  EMPLOYEE = 'employee',
-  MANAGER = 'manager',
-  OWNER = 'owner',
-}
+export const BaseUser2Type = {
+  EMPLOYEE: 'employee',
+  MANAGER: 'manager',
+  OWNER: 'owner',
+} as const;
+
+export type TBaseUser2Type = (typeof BaseUser2Type)[keyof typeof BaseUser2Type];
 
 export const BaseUser2Schema = new EntitySchema({
   class: BaseUser2,
@@ -9132,36 +9244,44 @@ import { Publisher2Tests } from './Publisher2Tests';
 export class Publisher2 {
   id!: number;
   name!: IType<URL, string> & Opt;
-  type: Publisher2Type & Opt = Publisher2Type.LOCAL;
-  type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
+  type: TPublisher2Type & Opt = Publisher2Type.LOCAL;
+  type2: TPublisher2Type2 & Opt = Publisher2Type2.LOCAL;
   enum1?: number;
   enum2?: number;
   enum3?: number;
-  enum4?: Publisher2Enum4;
-  enum5?: Publisher2Enum5;
+  enum4?: TPublisher2Enum4;
+  enum5?: TPublisher2Enum5;
   book2Collection = new Collection<Book2>(this);
   publisher2TestsCollection = new Collection<Publisher2Tests>(this);
 }
 
-export enum Publisher2Type {
-  LOCAL = 'local',
-  GLOBAL = 'global',
-}
+export const Publisher2Type = {
+  LOCAL: 'local',
+  GLOBAL: 'global',
+} as const;
 
-export enum Publisher2Type2 {
-  LOCAL = 'LOCAL',
-  GLOBAL = 'GLOBAL',
-}
+export type TPublisher2Type = (typeof Publisher2Type)[keyof typeof Publisher2Type];
 
-export enum Publisher2Enum4 {
-  A = 'a',
-  B = 'b',
-  C = 'c',
-}
+export const Publisher2Type2 = {
+  LOCAL: 'LOCAL',
+  GLOBAL: 'GLOBAL',
+} as const;
 
-export enum Publisher2Enum5 {
-  A = 'a',
-}
+export type TPublisher2Type2 = (typeof Publisher2Type2)[keyof typeof Publisher2Type2];
+
+export const Publisher2Enum4 = {
+  A: 'a',
+  B: 'b',
+  C: 'c',
+} as const;
+
+export type TPublisher2Enum4 = (typeof Publisher2Enum4)[keyof typeof Publisher2Enum4];
+
+export const Publisher2Enum5 = {
+  A: 'a',
+} as const;
+
+export type TPublisher2Enum5 = (typeof Publisher2Enum5)[keyof typeof Publisher2Enum5];
 
 export const Publisher2Schema = new EntitySchema({
   class: Publisher2,

--- a/tests/features/entity-generator/__snapshots__/NonCompositeAmbiguousFks.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/NonCompositeAmbiguousFks.mysql.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`non_composite_ambiguous_fk_example > scalarPropertiesForRelations=always > bidirectionalRelations=false > identifiedReferences=false > entitySchema=false > dump 1`] = `
+exports[`non_composite_ambiguous_fk_example > scalarPropertiesForRelations=always > bidirectionalRelations=false > identifiedReferences=false > entityDefinition=decorators > dump 1`] = `
 [
   "import { Entity, OneToOne, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Products } from './Products';
@@ -103,7 +103,7 @@ export class ShippableProducts {
 ]
 `;
 
-exports[`non_composite_ambiguous_fk_example > scalarPropertiesForRelations=always > bidirectionalRelations=false > identifiedReferences=false > entitySchema=true > dump 1`] = `
+exports[`non_composite_ambiguous_fk_example > scalarPropertiesForRelations=always > bidirectionalRelations=false > identifiedReferences=false > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { Products } from './Products';
@@ -239,7 +239,7 @@ export const ShippableProductsSchema = new EntitySchema({
 ]
 `;
 
-exports[`non_composite_ambiguous_fk_example > scalarPropertiesForRelations=always > bidirectionalRelations=false > identifiedReferences=true > entitySchema=false > dump 1`] = `
+exports[`non_composite_ambiguous_fk_example > scalarPropertiesForRelations=always > bidirectionalRelations=false > identifiedReferences=true > entityDefinition=decorators > dump 1`] = `
 [
   "import { Entity, OneToOne, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Products } from './Products';
@@ -342,7 +342,7 @@ export class ShippableProducts {
 ]
 `;
 
-exports[`non_composite_ambiguous_fk_example > scalarPropertiesForRelations=always > bidirectionalRelations=false > identifiedReferences=true > entitySchema=true > dump 1`] = `
+exports[`non_composite_ambiguous_fk_example > scalarPropertiesForRelations=always > bidirectionalRelations=false > identifiedReferences=true > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Products } from './Products';
@@ -484,7 +484,7 @@ export const ShippableProductsSchema = new EntitySchema({
 ]
 `;
 
-exports[`non_composite_ambiguous_fk_example > scalarPropertiesForRelations=always > bidirectionalRelations=true > identifiedReferences=false > entitySchema=false > dump 1`] = `
+exports[`non_composite_ambiguous_fk_example > scalarPropertiesForRelations=always > bidirectionalRelations=true > identifiedReferences=false > entityDefinition=decorators > dump 1`] = `
 [
   "import { Collection, Entity, OneToMany, OneToOne, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Products } from './Products';
@@ -610,7 +610,7 @@ export class ShippableProducts {
 ]
 `;
 
-exports[`non_composite_ambiguous_fk_example > scalarPropertiesForRelations=always > bidirectionalRelations=true > identifiedReferences=false > entitySchema=true > dump 1`] = `
+exports[`non_composite_ambiguous_fk_example > scalarPropertiesForRelations=always > bidirectionalRelations=true > identifiedReferences=false > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { Products } from './Products';
@@ -787,7 +787,7 @@ export const ShippableProductsSchema = new EntitySchema({
 ]
 `;
 
-exports[`non_composite_ambiguous_fk_example > scalarPropertiesForRelations=always > bidirectionalRelations=true > identifiedReferences=true > entitySchema=false > dump 1`] = `
+exports[`non_composite_ambiguous_fk_example > scalarPropertiesForRelations=always > bidirectionalRelations=true > identifiedReferences=true > entityDefinition=decorators > dump 1`] = `
 [
   "import { Collection, Entity, OneToMany, OneToOne, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Products } from './Products';
@@ -913,7 +913,7 @@ export class ShippableProducts {
 ]
 `;
 
-exports[`non_composite_ambiguous_fk_example > scalarPropertiesForRelations=always > bidirectionalRelations=true > identifiedReferences=true > entitySchema=true > dump 1`] = `
+exports[`non_composite_ambiguous_fk_example > scalarPropertiesForRelations=always > bidirectionalRelations=true > identifiedReferences=true > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { Collection, EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Products } from './Products';
@@ -1098,7 +1098,7 @@ export const ShippableProductsSchema = new EntitySchema({
 ]
 `;
 
-exports[`non_composite_ambiguous_fk_example > scalarPropertiesForRelations=never > bidirectionalRelations=false > identifiedReferences=false > entitySchema=false > dump 1`] = `
+exports[`non_composite_ambiguous_fk_example > scalarPropertiesForRelations=never > bidirectionalRelations=false > identifiedReferences=false > entityDefinition=decorators > dump 1`] = `
 [
   "import { Entity, OneToOne, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Products } from './Products';
@@ -1189,7 +1189,7 @@ export class ShippableProducts {
 ]
 `;
 
-exports[`non_composite_ambiguous_fk_example > scalarPropertiesForRelations=never > bidirectionalRelations=false > identifiedReferences=false > entitySchema=true > dump 1`] = `
+exports[`non_composite_ambiguous_fk_example > scalarPropertiesForRelations=never > bidirectionalRelations=false > identifiedReferences=false > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { Products } from './Products';
@@ -1313,7 +1313,7 @@ export const ShippableProductsSchema = new EntitySchema({
 ]
 `;
 
-exports[`non_composite_ambiguous_fk_example > scalarPropertiesForRelations=never > bidirectionalRelations=false > identifiedReferences=true > entitySchema=false > dump 1`] = `
+exports[`non_composite_ambiguous_fk_example > scalarPropertiesForRelations=never > bidirectionalRelations=false > identifiedReferences=true > entityDefinition=decorators > dump 1`] = `
 [
   "import { Entity, OneToOne, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Products } from './Products';
@@ -1404,7 +1404,7 @@ export class ShippableProducts {
 ]
 `;
 
-exports[`non_composite_ambiguous_fk_example > scalarPropertiesForRelations=never > bidirectionalRelations=false > identifiedReferences=true > entitySchema=true > dump 1`] = `
+exports[`non_composite_ambiguous_fk_example > scalarPropertiesForRelations=never > bidirectionalRelations=false > identifiedReferences=true > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Products } from './Products';
@@ -1534,7 +1534,7 @@ export const ShippableProductsSchema = new EntitySchema({
 ]
 `;
 
-exports[`non_composite_ambiguous_fk_example > scalarPropertiesForRelations=never > bidirectionalRelations=true > identifiedReferences=false > entitySchema=false > dump 1`] = `
+exports[`non_composite_ambiguous_fk_example > scalarPropertiesForRelations=never > bidirectionalRelations=true > identifiedReferences=false > entityDefinition=decorators > dump 1`] = `
 [
   "import { Collection, Entity, OneToMany, OneToOne, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Products } from './Products';
@@ -1648,7 +1648,7 @@ export class ShippableProducts {
 ]
 `;
 
-exports[`non_composite_ambiguous_fk_example > scalarPropertiesForRelations=never > bidirectionalRelations=true > identifiedReferences=false > entitySchema=true > dump 1`] = `
+exports[`non_composite_ambiguous_fk_example > scalarPropertiesForRelations=never > bidirectionalRelations=true > identifiedReferences=false > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { Products } from './Products';
@@ -1813,7 +1813,7 @@ export const ShippableProductsSchema = new EntitySchema({
 ]
 `;
 
-exports[`non_composite_ambiguous_fk_example > scalarPropertiesForRelations=never > bidirectionalRelations=true > identifiedReferences=true > entitySchema=false > dump 1`] = `
+exports[`non_composite_ambiguous_fk_example > scalarPropertiesForRelations=never > bidirectionalRelations=true > identifiedReferences=true > entityDefinition=decorators > dump 1`] = `
 [
   "import { Collection, Entity, OneToMany, OneToOne, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Products } from './Products';
@@ -1927,7 +1927,7 @@ export class ShippableProducts {
 ]
 `;
 
-exports[`non_composite_ambiguous_fk_example > scalarPropertiesForRelations=never > bidirectionalRelations=true > identifiedReferences=true > entitySchema=true > dump 1`] = `
+exports[`non_composite_ambiguous_fk_example > scalarPropertiesForRelations=never > bidirectionalRelations=true > identifiedReferences=true > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { Collection, EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Products } from './Products';
@@ -2100,7 +2100,7 @@ export const ShippableProductsSchema = new EntitySchema({
 ]
 `;
 
-exports[`non_composite_ambiguous_fk_example > scalarPropertiesForRelations=smart > bidirectionalRelations=false > identifiedReferences=false > entitySchema=false > dump 1`] = `
+exports[`non_composite_ambiguous_fk_example > scalarPropertiesForRelations=smart > bidirectionalRelations=false > identifiedReferences=false > entityDefinition=decorators > dump 1`] = `
 [
   "import { Entity, OneToOne, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Products } from './Products';
@@ -2191,7 +2191,7 @@ export class ShippableProducts {
 ]
 `;
 
-exports[`non_composite_ambiguous_fk_example > scalarPropertiesForRelations=smart > bidirectionalRelations=false > identifiedReferences=false > entitySchema=true > dump 1`] = `
+exports[`non_composite_ambiguous_fk_example > scalarPropertiesForRelations=smart > bidirectionalRelations=false > identifiedReferences=false > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { Products } from './Products';
@@ -2315,7 +2315,7 @@ export const ShippableProductsSchema = new EntitySchema({
 ]
 `;
 
-exports[`non_composite_ambiguous_fk_example > scalarPropertiesForRelations=smart > bidirectionalRelations=false > identifiedReferences=true > entitySchema=false > dump 1`] = `
+exports[`non_composite_ambiguous_fk_example > scalarPropertiesForRelations=smart > bidirectionalRelations=false > identifiedReferences=true > entityDefinition=decorators > dump 1`] = `
 [
   "import { Entity, OneToOne, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Products } from './Products';
@@ -2406,7 +2406,7 @@ export class ShippableProducts {
 ]
 `;
 
-exports[`non_composite_ambiguous_fk_example > scalarPropertiesForRelations=smart > bidirectionalRelations=false > identifiedReferences=true > entitySchema=true > dump 1`] = `
+exports[`non_composite_ambiguous_fk_example > scalarPropertiesForRelations=smart > bidirectionalRelations=false > identifiedReferences=true > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Products } from './Products';
@@ -2536,7 +2536,7 @@ export const ShippableProductsSchema = new EntitySchema({
 ]
 `;
 
-exports[`non_composite_ambiguous_fk_example > scalarPropertiesForRelations=smart > bidirectionalRelations=true > identifiedReferences=false > entitySchema=false > dump 1`] = `
+exports[`non_composite_ambiguous_fk_example > scalarPropertiesForRelations=smart > bidirectionalRelations=true > identifiedReferences=false > entityDefinition=decorators > dump 1`] = `
 [
   "import { Collection, Entity, OneToMany, OneToOne, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { Products } from './Products';
@@ -2650,7 +2650,7 @@ export class ShippableProducts {
 ]
 `;
 
-exports[`non_composite_ambiguous_fk_example > scalarPropertiesForRelations=smart > bidirectionalRelations=true > identifiedReferences=false > entitySchema=true > dump 1`] = `
+exports[`non_composite_ambiguous_fk_example > scalarPropertiesForRelations=smart > bidirectionalRelations=true > identifiedReferences=false > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { Products } from './Products';
@@ -2815,7 +2815,7 @@ export const ShippableProductsSchema = new EntitySchema({
 ]
 `;
 
-exports[`non_composite_ambiguous_fk_example > scalarPropertiesForRelations=smart > bidirectionalRelations=true > identifiedReferences=true > entitySchema=false > dump 1`] = `
+exports[`non_composite_ambiguous_fk_example > scalarPropertiesForRelations=smart > bidirectionalRelations=true > identifiedReferences=true > entityDefinition=decorators > dump 1`] = `
 [
   "import { Collection, Entity, OneToMany, OneToOne, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Products } from './Products';
@@ -2929,7 +2929,7 @@ export class ShippableProducts {
 ]
 `;
 
-exports[`non_composite_ambiguous_fk_example > scalarPropertiesForRelations=smart > bidirectionalRelations=true > identifiedReferences=true > entitySchema=true > dump 1`] = `
+exports[`non_composite_ambiguous_fk_example > scalarPropertiesForRelations=smart > bidirectionalRelations=true > identifiedReferences=true > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { Collection, EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Products } from './Products';

--- a/tests/features/entity-generator/__snapshots__/NullableFks.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/NullableFks.mysql.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`nullable_fk_example > scalarPropertiesForRelations=always > bidirectionalRelations=false > identifiedReferences=false > entitySchema=false > dump 1`] = `
+exports[`nullable_fk_example > scalarPropertiesForRelations=always > bidirectionalRelations=false > identifiedReferences=false > entityDefinition=decorators > dump 1`] = `
 [
   "import { Entity, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { RecepientEmails } from './RecepientEmails';
@@ -147,7 +147,7 @@ export class Senders {
 ]
 `;
 
-exports[`nullable_fk_example > scalarPropertiesForRelations=always > bidirectionalRelations=false > identifiedReferences=false > entitySchema=true > dump 1`] = `
+exports[`nullable_fk_example > scalarPropertiesForRelations=always > bidirectionalRelations=false > identifiedReferences=false > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { RecepientEmails } from './RecepientEmails';
@@ -353,7 +353,7 @@ export const SendersSchema = new EntitySchema({
 ]
 `;
 
-exports[`nullable_fk_example > scalarPropertiesForRelations=always > bidirectionalRelations=false > identifiedReferences=true > entitySchema=false > dump 1`] = `
+exports[`nullable_fk_example > scalarPropertiesForRelations=always > bidirectionalRelations=false > identifiedReferences=true > entityDefinition=decorators > dump 1`] = `
 [
   "import { Entity, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { RecepientEmails } from './RecepientEmails';
@@ -500,7 +500,7 @@ export class Senders {
 ]
 `;
 
-exports[`nullable_fk_example > scalarPropertiesForRelations=always > bidirectionalRelations=false > identifiedReferences=true > entitySchema=true > dump 1`] = `
+exports[`nullable_fk_example > scalarPropertiesForRelations=always > bidirectionalRelations=false > identifiedReferences=true > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { RecepientEmails } from './RecepientEmails';
@@ -713,7 +713,7 @@ export const SendersSchema = new EntitySchema({
 ]
 `;
 
-exports[`nullable_fk_example > scalarPropertiesForRelations=always > bidirectionalRelations=true > identifiedReferences=false > entitySchema=false > dump 1`] = `
+exports[`nullable_fk_example > scalarPropertiesForRelations=always > bidirectionalRelations=true > identifiedReferences=false > entityDefinition=decorators > dump 1`] = `
 [
   "import { Entity, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { RecepientEmails } from './RecepientEmails';
@@ -893,7 +893,7 @@ export class Senders {
 ]
 `;
 
-exports[`nullable_fk_example > scalarPropertiesForRelations=always > bidirectionalRelations=true > identifiedReferences=false > entitySchema=true > dump 1`] = `
+exports[`nullable_fk_example > scalarPropertiesForRelations=always > bidirectionalRelations=true > identifiedReferences=false > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { RecepientEmails } from './RecepientEmails';
@@ -1159,7 +1159,7 @@ export const SendersSchema = new EntitySchema({
 ]
 `;
 
-exports[`nullable_fk_example > scalarPropertiesForRelations=always > bidirectionalRelations=true > identifiedReferences=true > entitySchema=false > dump 1`] = `
+exports[`nullable_fk_example > scalarPropertiesForRelations=always > bidirectionalRelations=true > identifiedReferences=true > entityDefinition=decorators > dump 1`] = `
 [
   "import { Entity, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { RecepientEmails } from './RecepientEmails';
@@ -1339,7 +1339,7 @@ export class Senders {
 ]
 `;
 
-exports[`nullable_fk_example > scalarPropertiesForRelations=always > bidirectionalRelations=true > identifiedReferences=true > entitySchema=true > dump 1`] = `
+exports[`nullable_fk_example > scalarPropertiesForRelations=always > bidirectionalRelations=true > identifiedReferences=true > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { RecepientEmails } from './RecepientEmails';
@@ -1612,7 +1612,7 @@ export const SendersSchema = new EntitySchema({
 ]
 `;
 
-exports[`nullable_fk_example > scalarPropertiesForRelations=never > bidirectionalRelations=false > identifiedReferences=false > entitySchema=false > dump 1`] = `
+exports[`nullable_fk_example > scalarPropertiesForRelations=never > bidirectionalRelations=false > identifiedReferences=false > entityDefinition=decorators > dump 1`] = `
 [
   "import { Entity, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { RecepientEmails } from './RecepientEmails';
@@ -1732,7 +1732,7 @@ export class Senders {
 ]
 `;
 
-exports[`nullable_fk_example > scalarPropertiesForRelations=never > bidirectionalRelations=false > identifiedReferences=false > entitySchema=true > dump 1`] = `
+exports[`nullable_fk_example > scalarPropertiesForRelations=never > bidirectionalRelations=false > identifiedReferences=false > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { RecepientEmails } from './RecepientEmails';
@@ -1905,7 +1905,7 @@ export const SendersSchema = new EntitySchema({
 ]
 `;
 
-exports[`nullable_fk_example > scalarPropertiesForRelations=never > bidirectionalRelations=false > identifiedReferences=true > entitySchema=false > dump 1`] = `
+exports[`nullable_fk_example > scalarPropertiesForRelations=never > bidirectionalRelations=false > identifiedReferences=true > entityDefinition=decorators > dump 1`] = `
 [
   "import { Entity, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { RecepientEmails } from './RecepientEmails';
@@ -2025,7 +2025,7 @@ export class Senders {
 ]
 `;
 
-exports[`nullable_fk_example > scalarPropertiesForRelations=never > bidirectionalRelations=false > identifiedReferences=true > entitySchema=true > dump 1`] = `
+exports[`nullable_fk_example > scalarPropertiesForRelations=never > bidirectionalRelations=false > identifiedReferences=true > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { RecepientEmails } from './RecepientEmails';
@@ -2205,7 +2205,7 @@ export const SendersSchema = new EntitySchema({
 ]
 `;
 
-exports[`nullable_fk_example > scalarPropertiesForRelations=never > bidirectionalRelations=true > identifiedReferences=false > entitySchema=false > dump 1`] = `
+exports[`nullable_fk_example > scalarPropertiesForRelations=never > bidirectionalRelations=true > identifiedReferences=false > entityDefinition=decorators > dump 1`] = `
 [
   "import { Entity, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { RecepientEmails } from './RecepientEmails';
@@ -2358,7 +2358,7 @@ export class Senders {
 ]
 `;
 
-exports[`nullable_fk_example > scalarPropertiesForRelations=never > bidirectionalRelations=true > identifiedReferences=false > entitySchema=true > dump 1`] = `
+exports[`nullable_fk_example > scalarPropertiesForRelations=never > bidirectionalRelations=true > identifiedReferences=false > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { RecepientEmails } from './RecepientEmails';
@@ -2591,7 +2591,7 @@ export const SendersSchema = new EntitySchema({
 ]
 `;
 
-exports[`nullable_fk_example > scalarPropertiesForRelations=never > bidirectionalRelations=true > identifiedReferences=true > entitySchema=false > dump 1`] = `
+exports[`nullable_fk_example > scalarPropertiesForRelations=never > bidirectionalRelations=true > identifiedReferences=true > entityDefinition=decorators > dump 1`] = `
 [
   "import { Entity, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { RecepientEmails } from './RecepientEmails';
@@ -2744,7 +2744,7 @@ export class Senders {
 ]
 `;
 
-exports[`nullable_fk_example > scalarPropertiesForRelations=never > bidirectionalRelations=true > identifiedReferences=true > entitySchema=true > dump 1`] = `
+exports[`nullable_fk_example > scalarPropertiesForRelations=never > bidirectionalRelations=true > identifiedReferences=true > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { RecepientEmails } from './RecepientEmails';
@@ -2984,7 +2984,7 @@ export const SendersSchema = new EntitySchema({
 ]
 `;
 
-exports[`nullable_fk_example > scalarPropertiesForRelations=smart > bidirectionalRelations=false > identifiedReferences=false > entitySchema=false > dump 1`] = `
+exports[`nullable_fk_example > scalarPropertiesForRelations=smart > bidirectionalRelations=false > identifiedReferences=false > entityDefinition=decorators > dump 1`] = `
 [
   "import { Entity, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { RecepientEmails } from './RecepientEmails';
@@ -3104,7 +3104,7 @@ export class Senders {
 ]
 `;
 
-exports[`nullable_fk_example > scalarPropertiesForRelations=smart > bidirectionalRelations=false > identifiedReferences=false > entitySchema=true > dump 1`] = `
+exports[`nullable_fk_example > scalarPropertiesForRelations=smart > bidirectionalRelations=false > identifiedReferences=false > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { RecepientEmails } from './RecepientEmails';
@@ -3277,7 +3277,7 @@ export const SendersSchema = new EntitySchema({
 ]
 `;
 
-exports[`nullable_fk_example > scalarPropertiesForRelations=smart > bidirectionalRelations=false > identifiedReferences=true > entitySchema=false > dump 1`] = `
+exports[`nullable_fk_example > scalarPropertiesForRelations=smart > bidirectionalRelations=false > identifiedReferences=true > entityDefinition=decorators > dump 1`] = `
 [
   "import { Entity, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { RecepientEmails } from './RecepientEmails';
@@ -3397,7 +3397,7 @@ export class Senders {
 ]
 `;
 
-exports[`nullable_fk_example > scalarPropertiesForRelations=smart > bidirectionalRelations=false > identifiedReferences=true > entitySchema=true > dump 1`] = `
+exports[`nullable_fk_example > scalarPropertiesForRelations=smart > bidirectionalRelations=false > identifiedReferences=true > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { RecepientEmails } from './RecepientEmails';
@@ -3577,7 +3577,7 @@ export const SendersSchema = new EntitySchema({
 ]
 `;
 
-exports[`nullable_fk_example > scalarPropertiesForRelations=smart > bidirectionalRelations=true > identifiedReferences=false > entitySchema=false > dump 1`] = `
+exports[`nullable_fk_example > scalarPropertiesForRelations=smart > bidirectionalRelations=true > identifiedReferences=false > entityDefinition=decorators > dump 1`] = `
 [
   "import { Entity, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 import { RecepientEmails } from './RecepientEmails';
@@ -3730,7 +3730,7 @@ export class Senders {
 ]
 `;
 
-exports[`nullable_fk_example > scalarPropertiesForRelations=smart > bidirectionalRelations=true > identifiedReferences=false > entitySchema=true > dump 1`] = `
+exports[`nullable_fk_example > scalarPropertiesForRelations=smart > bidirectionalRelations=true > identifiedReferences=false > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
 import { RecepientEmails } from './RecepientEmails';
@@ -3963,7 +3963,7 @@ export const SendersSchema = new EntitySchema({
 ]
 `;
 
-exports[`nullable_fk_example > scalarPropertiesForRelations=smart > bidirectionalRelations=true > identifiedReferences=true > entitySchema=false > dump 1`] = `
+exports[`nullable_fk_example > scalarPropertiesForRelations=smart > bidirectionalRelations=true > identifiedReferences=true > entityDefinition=decorators > dump 1`] = `
 [
   "import { Entity, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { RecepientEmails } from './RecepientEmails';
@@ -4116,7 +4116,7 @@ export class Senders {
 ]
 `;
 
-exports[`nullable_fk_example > scalarPropertiesForRelations=smart > bidirectionalRelations=true > identifiedReferences=true > entitySchema=true > dump 1`] = `
+exports[`nullable_fk_example > scalarPropertiesForRelations=smart > bidirectionalRelations=true > identifiedReferences=true > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { RecepientEmails } from './RecepientEmails';

--- a/tests/features/entity-generator/__snapshots__/OddPkTypes.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/OddPkTypes.mysql.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`complex_pks_example > decorators > mysql 1`] = `
 [
-  "import { Entity, OneToOne, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, OneToOne, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Events } from './Events';
 
 @Entity()
@@ -10,25 +10,28 @@ export class EventDetails {
 
   [PrimaryKeyProp]?: 'weekday';
 
-  @OneToOne({ entity: () => Events, fieldNames: ['weekday', 'at'], primary: true })
-  weekday!: Events;
+  @OneToOne({ entity: () => Events, ref: true, fieldNames: ['weekday', 'at'], primary: true })
+  weekday!: Ref<Events>;
 
   @Property({ type: 'text', length: 65535, nullable: true })
   moreInfo?: string;
 
 }
 
-export enum EventDetailsWeekday {
-  MONDAY = 'Monday',
-  TUESDAY = 'Tuesday',
-  WEDNESDAY = 'Wednesday',
-  THURSDAY = 'Thursday',
-  FRIDAY = 'Friday',
-  SATURDAY = 'Saturday',
-  SUNDAY = 'Sunday',
-}
+export const EventDetailsWeekday = {
+  MONDAY: 'Monday',
+  TUESDAY: 'Tuesday',
+  WEDNESDAY: 'Wednesday',
+  THURSDAY: 'Thursday',
+  FRIDAY: 'Friday',
+  SATURDAY: 'Saturday',
+  SUNDAY: 'Sunday',
+} as const;
+
+export type TEventDetailsWeekday = (typeof EventDetailsWeekday)[keyof typeof EventDetailsWeekday];
 ",
-  "import { Entity, ManyToOne, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, OneToOne, PrimaryKey, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
+import { EventDetails } from './EventDetails';
 import { Worktime } from './Worktime';
 
 @Entity()
@@ -36,8 +39,8 @@ export class Events {
 
   [PrimaryKeyProp]?: ['weekday', 'at'];
 
-  @ManyToOne({ entity: () => Worktime, fieldName: 'weekday', primary: true })
-  weekday!: Worktime;
+  @ManyToOne({ entity: () => Worktime, ref: true, fieldName: 'weekday', primary: true })
+  weekday!: Ref<Worktime>;
 
   @PrimaryKey({ type: 'time' })
   at!: string;
@@ -45,19 +48,25 @@ export class Events {
   @Property()
   what!: string;
 
+  @OneToOne({ entity: () => EventDetails, ref: true, mappedBy: 'weekday' })
+  eventDetails?: Ref<EventDetails>;
+
 }
 
-export enum EventsWeekday {
-  MONDAY = 'Monday',
-  TUESDAY = 'Tuesday',
-  WEDNESDAY = 'Wednesday',
-  THURSDAY = 'Thursday',
-  FRIDAY = 'Friday',
-  SATURDAY = 'Saturday',
-  SUNDAY = 'Sunday',
-}
+export const EventsWeekday = {
+  MONDAY: 'Monday',
+  TUESDAY: 'Tuesday',
+  WEDNESDAY: 'Wednesday',
+  THURSDAY: 'Thursday',
+  FRIDAY: 'Friday',
+  SATURDAY: 'Saturday',
+  SUNDAY: 'Sunday',
+} as const;
+
+export type TEventsWeekday = (typeof EventsWeekday)[keyof typeof EventsWeekday];
 ",
-  "import { Entity, Enum, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, Enum, OneToMany, PrimaryKeyProp, Property } from '@mikro-orm/core';
+import { Events } from './Events';
 
 @Entity({ comment: 'Worktime. If a day is holiday, remove the row.' })
 export class Worktime {
@@ -65,7 +74,7 @@ export class Worktime {
   [PrimaryKeyProp]?: 'weekday';
 
   @Enum({ items: () => WorktimeWeekday, primary: true })
-  weekday!: WorktimeWeekday;
+  weekday!: TWorktimeWeekday;
 
   @Property({ type: 'time' })
   from!: string;
@@ -73,29 +82,34 @@ export class Worktime {
   @Property({ type: 'time' })
   to!: string;
 
+  @OneToMany({ entity: () => Events, mappedBy: 'weekday' })
+  eventsCollection = new Collection<Events>(this);
+
 }
 
-export enum WorktimeWeekday {
-  MONDAY = 'Monday',
-  TUESDAY = 'Tuesday',
-  WEDNESDAY = 'Wednesday',
-  THURSDAY = 'Thursday',
-  FRIDAY = 'Friday',
-  SATURDAY = 'Saturday',
-  SUNDAY = 'Sunday',
-}
+export const WorktimeWeekday = {
+  MONDAY: 'Monday',
+  TUESDAY: 'Tuesday',
+  WEDNESDAY: 'Wednesday',
+  THURSDAY: 'Thursday',
+  FRIDAY: 'Friday',
+  SATURDAY: 'Saturday',
+  SUNDAY: 'Sunday',
+} as const;
+
+export type TWorktimeWeekday = (typeof WorktimeWeekday)[keyof typeof WorktimeWeekday];
 ",
 ]
 `;
 
 exports[`complex_pks_example > entitySchema > mysql 1`] = `
 [
-  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Events } from './Events';
 
 export class EventDetails {
   [PrimaryKeyProp]?: 'weekday';
-  weekday!: Events;
+  weekday!: Ref<Events>;
   moreInfo?: string;
 }
 
@@ -106,20 +120,23 @@ export const EventDetailsSchema = new EntitySchema({
       primary: true,
       kind: '1:1',
       entity: () => Events,
+      ref: true,
       fieldNames: ['weekday', 'at'],
     },
     moreInfo: { type: 'text', length: 65535, nullable: true },
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
+import { EventDetails } from './EventDetails';
 import { Worktime } from './Worktime';
 
 export class Events {
   [PrimaryKeyProp]?: ['weekday', 'at'];
-  weekday!: Worktime;
+  weekday!: Ref<Worktime>;
   at!: string;
   what!: string;
+  eventDetails?: Ref<EventDetails>;
 }
 
 export const EventsSchema = new EntitySchema({
@@ -129,31 +146,42 @@ export const EventsSchema = new EntitySchema({
       primary: true,
       kind: 'm:1',
       entity: () => Worktime,
+      ref: true,
       fieldName: 'weekday',
     },
     at: { primary: true, type: 'time' },
     what: { type: 'string' },
+    eventDetails: {
+      kind: '1:1',
+      entity: () => EventDetails,
+      ref: true,
+      mappedBy: 'weekday',
+    },
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+import { Events } from './Events';
 
 export class Worktime {
   [PrimaryKeyProp]?: 'weekday';
-  weekday!: WorktimeWeekday;
+  weekday!: TWorktimeWeekday;
   from!: string;
   to!: string;
+  eventsCollection = new Collection<Events>(this);
 }
 
-export enum WorktimeWeekday {
-  MONDAY = 'Monday',
-  TUESDAY = 'Tuesday',
-  WEDNESDAY = 'Wednesday',
-  THURSDAY = 'Thursday',
-  FRIDAY = 'Friday',
-  SATURDAY = 'Saturday',
-  SUNDAY = 'Sunday',
-}
+export const WorktimeWeekday = {
+  MONDAY: 'Monday',
+  TUESDAY: 'Tuesday',
+  WEDNESDAY: 'Wednesday',
+  THURSDAY: 'Thursday',
+  FRIDAY: 'Friday',
+  SATURDAY: 'Saturday',
+  SUNDAY: 'Sunday',
+} as const;
+
+export type TWorktimeWeekday = (typeof WorktimeWeekday)[keyof typeof WorktimeWeekday];
 
 export const WorktimeSchema = new EntitySchema({
   class: Worktime,
@@ -162,6 +190,7 @@ export const WorktimeSchema = new EntitySchema({
     weekday: { primary: true, enum: true, items: () => WorktimeWeekday },
     from: { type: 'time' },
     to: { type: 'time' },
+    eventsCollection: { kind: '1:m', entity: () => Events, mappedBy: 'weekday' },
   },
 });
 ",

--- a/tests/features/entity-generator/__snapshots__/OddTableNames.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/OddTableNames.mysql.test.ts.snap
@@ -2,35 +2,43 @@
 
 exports[`odd_table_names_example:100% > decorators > mysql 1`] = `
 [
-  "import { Entity, Enum, OneToOne, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Entity, Enum, OneToOne, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { E50$37$32of$32stuff } from './E50$37$32of$32stuff';
+import { This$43that } from './This$43that';
 
 @Entity({ tableName: '*misc' })
 export class E_$42misc {
 
   [PrimaryKeyProp]?: '@ref';
 
-  @OneToOne({ entity: () => E50$37$32of$32stuff, fieldName: '@ref', primary: true })
-  '@ref'!: E50$37$32of$32stuff;
+  @OneToOne({ entity: () => E50$37$32of$32stuff, ref: true, fieldName: '@ref', primary: true })
+  '@ref'!: Ref<E50$37$32of$32stuff>;
 
   @Enum({ items: () => E_$42miscType, nullable: true })
-  type?: E_$42miscType;
+  type?: TE_$42miscType;
 
   @Enum({ items: () => E_$42miscEnum, nullable: true })
-  enum?: E_$42miscEnum = E_$42miscEnum['A+B'];
+  enum?: TE_$42miscEnum = E_$42miscEnum['A+B'];
+
+  @OneToOne({ entity: () => This$43that, ref: true, mappedBy: '80%OfStuff' })
+  this$43that?: Ref<This$43that>;
 
 }
 
-export enum E_$42miscType {
-  'APPLICATION/SVG+XML' = 'application/svg+xml',
-  'IMAGE/PNG' = 'image/png',
-}
+export const E_$42miscType = {
+  'APPLICATION/SVG+XML': 'application/svg+xml',
+  'IMAGE/PNG': 'image/png',
+} as const;
 
-export enum E_$42miscEnum {
-  A = 'a',
-  B = 'b',
-  'A+B' = 'a+b',
-}
+export type TE_$42miscType = (typeof E_$42miscType)[keyof typeof E_$42miscType];
+
+export const E_$42miscEnum = {
+  A: 'a',
+  B: 'b',
+  'A+B': 'a+b',
+} as const;
+
+export type TE_$42miscEnum = (typeof E_$42miscEnum)[keyof typeof E_$42miscEnum];
 ",
   "import { Entity, Index, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 
@@ -63,7 +71,8 @@ export class E123TableName {
 
 }
 ",
-  "import { Entity, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+  "import { Entity, OneToOne, PrimaryKey, PrimaryKeyProp, Property, type Ref, Unique } from '@mikro-orm/core';
+import { E_$42misc } from './E_$42misc';
 
 @Entity({ tableName: '50% of stuff' })
 @Unique({ name: 'odd columns\\' unique index', properties: ['columnWithApostropheInIt\\'sName', 'columnWithBacktickInIt\`sName'] })
@@ -82,6 +91,9 @@ export class E50$37$32of$32stuff {
 
   @Property({ fieldName: 'column with backtick in it\`s name', length: 45 })
   'columnWithBacktickInIt\`sName'!: string;
+
+  @OneToOne({ entity: () => E_$42misc, ref: true, mappedBy: '@ref' })
+  e_$42misc?: Ref<E_$42misc>;
 
 }
 ",
@@ -104,7 +116,7 @@ export class NsSubnsTheName {
 
 }
 ",
-  "import { Entity, OneToOne, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Entity, OneToOne, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { E_$42misc } from './E_$42misc';
 
 @Entity({ tableName: 'this+that' })
@@ -112,8 +124,8 @@ export class This$43that {
 
   [PrimaryKeyProp]?: '80%OfStuff';
 
-  @OneToOne({ entity: () => E_$42misc, fieldName: '80% of stuff', primary: true })
-  '80%OfStuff'!: E_$42misc;
+  @OneToOne({ entity: () => E_$42misc, ref: true, fieldName: '80% of stuff', primary: true })
+  '80%OfStuff'!: Ref<E_$42misc>;
 
 }
 ",
@@ -122,26 +134,32 @@ export class This$43that {
 
 exports[`odd_table_names_example:100% > entitySchema > mysql 1`] = `
 [
-  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { E50$37$32of$32stuff } from './E50$37$32of$32stuff';
+import { This$43that } from './This$43that';
 
 export class E_$42misc {
   [PrimaryKeyProp]?: '@ref';
-  '@ref'!: E50$37$32of$32stuff;
-  type?: E_$42miscType;
-  enum?: E_$42miscEnum = E_$42miscEnum['A+B'];
+  '@ref'!: Ref<E50$37$32of$32stuff>;
+  type?: TE_$42miscType;
+  enum?: TE_$42miscEnum = E_$42miscEnum['A+B'];
+  this$43that?: Ref<This$43that>;
 }
 
-export enum E_$42miscType {
-  'APPLICATION/SVG+XML' = 'application/svg+xml',
-  'IMAGE/PNG' = 'image/png',
-}
+export const E_$42miscType = {
+  'APPLICATION/SVG+XML': 'application/svg+xml',
+  'IMAGE/PNG': 'image/png',
+} as const;
 
-export enum E_$42miscEnum {
-  A = 'a',
-  B = 'b',
-  'A+B' = 'a+b',
-}
+export type TE_$42miscType = (typeof E_$42miscType)[keyof typeof E_$42miscType];
+
+export const E_$42miscEnum = {
+  A: 'a',
+  B: 'b',
+  'A+B': 'a+b',
+} as const;
+
+export type TE_$42miscEnum = (typeof E_$42miscEnum)[keyof typeof E_$42miscEnum];
 
 export const E_$42miscSchema = new EntitySchema({
   class: E_$42misc,
@@ -151,10 +169,17 @@ export const E_$42miscSchema = new EntitySchema({
       primary: true,
       kind: '1:1',
       entity: () => E50$37$32of$32stuff,
+      ref: true,
       fieldName: '@ref',
     },
     type: { enum: true, items: () => E_$42miscType, nullable: true },
     enum: { enum: true, items: () => E_$42miscEnum, nullable: true },
+    this$43that: {
+      kind: '1:1',
+      entity: () => This$43that,
+      ref: true,
+      mappedBy: '80%OfStuff',
+    },
   },
 });
 ",
@@ -190,7 +215,8 @@ export const E123TableNameSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
+import { E_$42misc } from './E_$42misc';
 
 export class E50$37$32of$32stuff {
   [PrimaryKeyProp]?: '+20%';
@@ -198,6 +224,7 @@ export class E50$37$32of$32stuff {
   'my@odd.column'!: string;
   'columnWithApostropheInIt\\'sName'!: string;
   'columnWithBacktickInIt\`sName'!: string;
+  e_$42misc?: Ref<E_$42misc>;
 }
 
 export const E50$37$32of$32stuffSchema = new EntitySchema({
@@ -225,6 +252,12 @@ export const E50$37$32of$32stuffSchema = new EntitySchema({
       fieldName: 'column with backtick in it\`s name',
       length: 45,
     },
+    e_$42misc: {
+      kind: '1:1',
+      entity: () => E_$42misc,
+      ref: true,
+      mappedBy: '@ref',
+    },
   },
 });
 ",
@@ -248,12 +281,12 @@ export const NsSubnsTheNameSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { E_$42misc } from './E_$42misc';
 
 export class This$43that {
   [PrimaryKeyProp]?: '80%OfStuff';
-  '80%OfStuff'!: E_$42misc;
+  '80%OfStuff'!: Ref<E_$42misc>;
 }
 
 export const This$43thatSchema = new EntitySchema({
@@ -264,6 +297,7 @@ export const This$43thatSchema = new EntitySchema({
       primary: true,
       kind: '1:1',
       entity: () => E_$42misc,
+      ref: true,
       fieldName: '80% of stuff',
     },
   },

--- a/tests/features/entity-generator/__snapshots__/OddTableNames.postgres.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/OddTableNames.postgres.test.ts.snap
@@ -2,20 +2,28 @@
 
 exports[`odd_db_name100 > decorators > postgre 1`] = `
 [
-  "import { Entity, OneToOne, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Entity, OneToOne, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { E50$37$32of$32stuff } from './E50$37$32of$32stuff';
+import { Table$39s$32name$32has$32apostrophe$44$32Also$32$96$96$32this } from './Table$39s$32name$32has$32apostrophe$44$32Also$32$96$96$32this';
+import { This$43that } from './This$43that';
 
 @Entity({ tableName: '*misc', schema: 'odd table_names_example:100%' })
 export class E_$42misc {
 
   [PrimaryKeyProp]?: '@ref';
 
-  @OneToOne({ entity: () => E50$37$32of$32stuff, fieldName: '@ref', primary: true })
-  '@ref'!: E50$37$32of$32stuff;
+  @OneToOne({ entity: () => E50$37$32of$32stuff, ref: true, fieldName: '@ref', primary: true })
+  '@ref'!: Ref<E50$37$32of$32stuff>;
+
+  @OneToOne({ entity: () => This$43that, ref: true, mappedBy: '80OfStuff' })
+  this$43that?: Ref<This$43that>;
+
+  @OneToOne({ entity: () => Table$39s$32name$32has$32apostrophe$44$32Also$32$96$96$32this, ref: true, mappedBy: '!cool' })
+  table$39s$32name$32has$32apostrophe$44$32Also$32$96$96$32this?: Ref<Table$39s$32name$32has$32apostrophe$44$32Also$32$96$96$32this>;
 
 }
 ",
-  "import { Entity, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Entity, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
 import { Table$39s$32name$32has$32apostrophe$44$32Also$32$96$96$32this } from './Table$39s$32name$32has$32apostrophe$44$32Also$32$96$96$32this';
 
 @Entity({ tableName: '123_table_name', schema: 'odd table_names_example:100%' })
@@ -26,8 +34,8 @@ export class E123TableName {
   @PrimaryKey({ autoincrement: false })
   $!: number;
 
-  @ManyToOne({ entity: () => Table$39s$32name$32has$32apostrophe$44$32Also$32$96$96$32this, fieldName: 'prototype' })
-  prototype!: Table$39s$32name$32has$32apostrophe$44$32Also$32$96$96$32this;
+  @ManyToOne({ entity: () => Table$39s$32name$32has$32apostrophe$44$32Also$32$96$96$32this, ref: true, fieldName: 'prototype' })
+  prototype!: Ref<Table$39s$32name$32has$32apostrophe$44$32Also$32$96$96$32this>;
 
   @Property({ fieldName: 'oh_captain__my___captain', type: 'string' })
   ohCaptainMyCaptain: string & Opt = 'test';
@@ -43,7 +51,8 @@ export class E123TableName {
 
 }
 ",
-  "import { Entity, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+  "import { Entity, OneToOne, PrimaryKey, PrimaryKeyProp, Property, type Ref, Unique } from '@mikro-orm/core';
+import { E_$42misc } from './E_$42misc';
 
 @Entity({ tableName: '50% of stuff', schema: 'odd table_names_example:100%' })
 @Unique({ name: 'odd columns\\' unique index', expression: 'CREATE UNIQUE INDEX "odd columns\\' unique index" ON "odd table_names_example:100%"."50% of stuff" USING btree ("column with apostrophe in it\\'s name", "column with backtick in it\`\`s name")' })
@@ -63,9 +72,12 @@ export class E50$37$32of$32stuff {
   @Property({ fieldName: 'column with backtick in it\`\`s name', length: 45 })
   'columnWithBacktickInIt\`\`sName'!: string;
 
+  @OneToOne({ entity: () => E_$42misc, ref: true, mappedBy: '@ref' })
+  e_$42misc?: Ref<E_$42misc>;
+
 }
 ",
-  "import { Entity, OneToOne, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Entity, OneToOne, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { E_$42misc } from './E_$42misc';
 
 @Entity({ tableName: 'this+that', schema: 'odd table_names_example:100%' })
@@ -73,8 +85,8 @@ export class This$43that {
 
   [PrimaryKeyProp]?: '80OfStuff';
 
-  @OneToOne({ entity: () => E_$42misc, fieldName: '80 of stuff', primary: true })
-  '80OfStuff'!: E_$42misc;
+  @OneToOne({ entity: () => E_$42misc, ref: true, fieldName: '80 of stuff', primary: true })
+  '80OfStuff'!: Ref<E_$42misc>;
 
 }
 ",
@@ -97,7 +109,8 @@ export class NsSubnsTheName {
 
 }
 ",
-  "import { Entity, OneToOne, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, Entity, OneToMany, OneToOne, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
+import { E123TableName } from './E123TableName';
 import { E_$42misc } from './E_$42misc';
 
 @Entity({ tableName: 'table\\'s name has apostrophe, Also \`\` this', schema: 'odd_identifier\\'s_example\\'s_second' })
@@ -105,11 +118,14 @@ export class Table$39s$32name$32has$32apostrophe$44$32Also$32$96$96$32this {
 
   [PrimaryKeyProp]?: '!cool';
 
-  @OneToOne({ entity: () => E_$42misc, fieldName: '!cool', primary: true })
-  '!cool'!: E_$42misc;
+  @OneToOne({ entity: () => E_$42misc, ref: true, fieldName: '!cool', primary: true })
+  '!cool'!: Ref<E_$42misc>;
 
   @Property({ length: 45, nullable: true })
   \`'derive\`?: string;
+
+  @OneToMany({ entity: () => E123TableName, mappedBy: 'prototype' })
+  e123TableNameCollection = new Collection<E123TableName>(this);
 
 }
 ",
@@ -118,12 +134,16 @@ export class Table$39s$32name$32has$32apostrophe$44$32Also$32$96$96$32this {
 
 exports[`odd_db_name100 > entitySchema > postgre 1`] = `
 [
-  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { E50$37$32of$32stuff } from './E50$37$32of$32stuff';
+import { Table$39s$32name$32has$32apostrophe$44$32Also$32$96$96$32this } from './Table$39s$32name$32has$32apostrophe$44$32Also$32$96$96$32this';
+import { This$43that } from './This$43that';
 
 export class E_$42misc {
   [PrimaryKeyProp]?: '@ref';
-  '@ref'!: E50$37$32of$32stuff;
+  '@ref'!: Ref<E50$37$32of$32stuff>;
+  this$43that?: Ref<This$43that>;
+  table$39s$32name$32has$32apostrophe$44$32Also$32$96$96$32this?: Ref<Table$39s$32name$32has$32apostrophe$44$32Also$32$96$96$32this>;
 }
 
 export const E_$42miscSchema = new EntitySchema({
@@ -135,18 +155,31 @@ export const E_$42miscSchema = new EntitySchema({
       primary: true,
       kind: '1:1',
       entity: () => E50$37$32of$32stuff,
+      ref: true,
       fieldName: '@ref',
+    },
+    this$43that: {
+      kind: '1:1',
+      entity: () => This$43that,
+      ref: true,
+      mappedBy: '80OfStuff',
+    },
+    table$39s$32name$32has$32apostrophe$44$32Also$32$96$96$32this: {
+      kind: '1:1',
+      entity: () => Table$39s$32name$32has$32apostrophe$44$32Also$32$96$96$32this,
+      ref: true,
+      mappedBy: '!cool',
     },
   },
 });
 ",
-  "import { EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { Table$39s$32name$32has$32apostrophe$44$32Also$32$96$96$32this } from './Table$39s$32name$32has$32apostrophe$44$32Also$32$96$96$32this';
 
 export class E123TableName {
   [PrimaryKeyProp]?: '$';
   $!: number;
-  prototype!: Table$39s$32name$32has$32apostrophe$44$32Also$32$96$96$32this;
+  prototype!: Ref<Table$39s$32name$32has$32apostrophe$44$32Also$32$96$96$32this>;
   ohCaptainMyCaptain: string & Opt = 'test';
   infer!: string;
   $$infer!: string;
@@ -162,6 +195,7 @@ export const E123TableNameSchema = new EntitySchema({
     prototype: {
       kind: 'm:1',
       entity: () => Table$39s$32name$32has$32apostrophe$44$32Also$32$96$96$32this,
+      ref: true,
       fieldName: 'prototype',
     },
     ohCaptainMyCaptain: { type: 'string', fieldName: 'oh_captain__my___captain' },
@@ -171,7 +205,8 @@ export const E123TableNameSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
+import { E_$42misc } from './E_$42misc';
 
 export class E50$37$32of$32stuff {
   [PrimaryKeyProp]?: '+20%';
@@ -179,6 +214,7 @@ export class E50$37$32of$32stuff {
   'my@odd.column'!: string;
   'columnWithApostropheInIt\\'sName'!: string;
   'columnWithBacktickInIt\`\`sName'!: string;
+  e_$42misc?: Ref<E_$42misc>;
 }
 
 export const E50$37$32of$32stuffSchema = new EntitySchema({
@@ -204,15 +240,21 @@ export const E50$37$32of$32stuffSchema = new EntitySchema({
       fieldName: 'column with backtick in it\`\`s name',
       length: 45,
     },
+    e_$42misc: {
+      kind: '1:1',
+      entity: () => E_$42misc,
+      ref: true,
+      mappedBy: '@ref',
+    },
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
 import { E_$42misc } from './E_$42misc';
 
 export class This$43that {
   [PrimaryKeyProp]?: '80OfStuff';
-  '80OfStuff'!: E_$42misc;
+  '80OfStuff'!: Ref<E_$42misc>;
 }
 
 export const This$43thatSchema = new EntitySchema({
@@ -224,6 +266,7 @@ export const This$43thatSchema = new EntitySchema({
       primary: true,
       kind: '1:1',
       entity: () => E_$42misc,
+      ref: true,
       fieldName: '80 of stuff',
     },
   },
@@ -250,13 +293,15 @@ export const NsSubnsTheNameSchema = new EntitySchema({
   },
 });
 ",
-  "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, EntitySchema, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
+import { E123TableName } from './E123TableName';
 import { E_$42misc } from './E_$42misc';
 
 export class Table$39s$32name$32has$32apostrophe$44$32Also$32$96$96$32this {
   [PrimaryKeyProp]?: '!cool';
-  '!cool'!: E_$42misc;
+  '!cool'!: Ref<E_$42misc>;
   \`'derive\`?: string;
+  e123TableNameCollection = new Collection<E123TableName>(this);
 }
 
 export const Table$39s$32name$32has$32apostrophe$44$32Also$32$96$96$32thisSchema = new EntitySchema({
@@ -268,12 +313,18 @@ export const Table$39s$32name$32has$32apostrophe$44$32Also$32$96$96$32thisSchema
       primary: true,
       kind: '1:1',
       entity: () => E_$42misc,
+      ref: true,
       fieldName: '!cool',
     },
     \`'derive\`: {
       type: 'string',
       length: 45,
       nullable: true,
+    },
+    e123TableNameCollection: {
+      kind: '1:m',
+      entity: () => E123TableName,
+      mappedBy: 'prototype',
     },
   },
 });

--- a/tests/features/entity-generator/__snapshots__/OverlapFks.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/OverlapFks.mysql.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`overlap_fk_example > scalarPropertiesForRelations=always > bidirectionalRelations=false > identifiedReferences=false > entitySchema=false > dump 1`] = `
+exports[`overlap_fk_example > scalarPropertiesForRelations=always > bidirectionalRelations=false > identifiedReferences=false > entityDefinition=decorators > dump 1`] = `
 [
   "import { Entity, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
 
@@ -152,7 +152,7 @@ export class Sellers {
 ]
 `;
 
-exports[`overlap_fk_example > scalarPropertiesForRelations=always > bidirectionalRelations=false > identifiedReferences=false > entitySchema=true > dump 1`] = `
+exports[`overlap_fk_example > scalarPropertiesForRelations=always > bidirectionalRelations=false > identifiedReferences=false > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 
@@ -367,7 +367,7 @@ export const SellersSchema = new EntitySchema({
 ]
 `;
 
-exports[`overlap_fk_example > scalarPropertiesForRelations=always > bidirectionalRelations=false > identifiedReferences=true > entitySchema=false > dump 1`] = `
+exports[`overlap_fk_example > scalarPropertiesForRelations=always > bidirectionalRelations=false > identifiedReferences=true > entityDefinition=decorators > dump 1`] = `
 [
   "import { Entity, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
 
@@ -519,7 +519,7 @@ export class Sellers {
 ]
 `;
 
-exports[`overlap_fk_example > scalarPropertiesForRelations=always > bidirectionalRelations=false > identifiedReferences=true > entitySchema=true > dump 1`] = `
+exports[`overlap_fk_example > scalarPropertiesForRelations=always > bidirectionalRelations=false > identifiedReferences=true > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 
@@ -740,7 +740,7 @@ export const SellersSchema = new EntitySchema({
 ]
 `;
 
-exports[`overlap_fk_example > scalarPropertiesForRelations=always > bidirectionalRelations=true > identifiedReferences=false > entitySchema=false > dump 1`] = `
+exports[`overlap_fk_example > scalarPropertiesForRelations=always > bidirectionalRelations=true > identifiedReferences=false > entityDefinition=decorators > dump 1`] = `
 [
   "import { Collection, Entity, ManyToMany, OneToMany, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
@@ -922,7 +922,7 @@ export class Sellers {
 ]
 `;
 
-exports[`overlap_fk_example > scalarPropertiesForRelations=always > bidirectionalRelations=true > identifiedReferences=false > entitySchema=true > dump 1`] = `
+exports[`overlap_fk_example > scalarPropertiesForRelations=always > bidirectionalRelations=true > identifiedReferences=false > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
@@ -1187,7 +1187,7 @@ export const SellersSchema = new EntitySchema({
 ]
 `;
 
-exports[`overlap_fk_example > scalarPropertiesForRelations=always > bidirectionalRelations=true > identifiedReferences=true > entitySchema=false > dump 1`] = `
+exports[`overlap_fk_example > scalarPropertiesForRelations=always > bidirectionalRelations=true > identifiedReferences=true > entityDefinition=decorators > dump 1`] = `
 [
   "import { Collection, Entity, ManyToMany, OneToMany, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
@@ -1369,7 +1369,7 @@ export class Sellers {
 ]
 `;
 
-exports[`overlap_fk_example > scalarPropertiesForRelations=always > bidirectionalRelations=true > identifiedReferences=true > entitySchema=true > dump 1`] = `
+exports[`overlap_fk_example > scalarPropertiesForRelations=always > bidirectionalRelations=true > identifiedReferences=true > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
@@ -1640,7 +1640,7 @@ export const SellersSchema = new EntitySchema({
 ]
 `;
 
-exports[`overlap_fk_example > scalarPropertiesForRelations=never > bidirectionalRelations=false > identifiedReferences=false > entitySchema=false > dump 1`] = `
+exports[`overlap_fk_example > scalarPropertiesForRelations=never > bidirectionalRelations=false > identifiedReferences=false > entityDefinition=decorators > dump 1`] = `
 [
   "import { Collection, Entity, ManyToMany, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
@@ -1772,7 +1772,7 @@ export class Sellers {
 ]
 `;
 
-exports[`overlap_fk_example > scalarPropertiesForRelations=never > bidirectionalRelations=false > identifiedReferences=false > entitySchema=true > dump 1`] = `
+exports[`overlap_fk_example > scalarPropertiesForRelations=never > bidirectionalRelations=false > identifiedReferences=false > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
@@ -1961,7 +1961,7 @@ export const SellersSchema = new EntitySchema({
 ]
 `;
 
-exports[`overlap_fk_example > scalarPropertiesForRelations=never > bidirectionalRelations=false > identifiedReferences=true > entitySchema=false > dump 1`] = `
+exports[`overlap_fk_example > scalarPropertiesForRelations=never > bidirectionalRelations=false > identifiedReferences=true > entityDefinition=decorators > dump 1`] = `
 [
   "import { Collection, Entity, ManyToMany, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
@@ -2093,7 +2093,7 @@ export class Sellers {
 ]
 `;
 
-exports[`overlap_fk_example > scalarPropertiesForRelations=never > bidirectionalRelations=false > identifiedReferences=true > entitySchema=true > dump 1`] = `
+exports[`overlap_fk_example > scalarPropertiesForRelations=never > bidirectionalRelations=false > identifiedReferences=true > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
@@ -2288,7 +2288,7 @@ export const SellersSchema = new EntitySchema({
 ]
 `;
 
-exports[`overlap_fk_example > scalarPropertiesForRelations=never > bidirectionalRelations=true > identifiedReferences=false > entitySchema=false > dump 1`] = `
+exports[`overlap_fk_example > scalarPropertiesForRelations=never > bidirectionalRelations=true > identifiedReferences=false > entityDefinition=decorators > dump 1`] = `
 [
   "import { Collection, Entity, ManyToMany, OneToMany, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
@@ -2450,7 +2450,7 @@ export class Sellers {
 ]
 `;
 
-exports[`overlap_fk_example > scalarPropertiesForRelations=never > bidirectionalRelations=true > identifiedReferences=false > entitySchema=true > dump 1`] = `
+exports[`overlap_fk_example > scalarPropertiesForRelations=never > bidirectionalRelations=true > identifiedReferences=false > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
@@ -2685,7 +2685,7 @@ export const SellersSchema = new EntitySchema({
 ]
 `;
 
-exports[`overlap_fk_example > scalarPropertiesForRelations=never > bidirectionalRelations=true > identifiedReferences=true > entitySchema=false > dump 1`] = `
+exports[`overlap_fk_example > scalarPropertiesForRelations=never > bidirectionalRelations=true > identifiedReferences=true > entityDefinition=decorators > dump 1`] = `
 [
   "import { Collection, Entity, ManyToMany, OneToMany, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
@@ -2847,7 +2847,7 @@ export class Sellers {
 ]
 `;
 
-exports[`overlap_fk_example > scalarPropertiesForRelations=never > bidirectionalRelations=true > identifiedReferences=true > entitySchema=true > dump 1`] = `
+exports[`overlap_fk_example > scalarPropertiesForRelations=never > bidirectionalRelations=true > identifiedReferences=true > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
@@ -3088,7 +3088,7 @@ export const SellersSchema = new EntitySchema({
 ]
 `;
 
-exports[`overlap_fk_example > scalarPropertiesForRelations=smart > bidirectionalRelations=false > identifiedReferences=false > entitySchema=false > dump 1`] = `
+exports[`overlap_fk_example > scalarPropertiesForRelations=smart > bidirectionalRelations=false > identifiedReferences=false > entityDefinition=decorators > dump 1`] = `
 [
   "import { Collection, Entity, ManyToMany, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
@@ -3220,7 +3220,7 @@ export class Sellers {
 ]
 `;
 
-exports[`overlap_fk_example > scalarPropertiesForRelations=smart > bidirectionalRelations=false > identifiedReferences=false > entitySchema=true > dump 1`] = `
+exports[`overlap_fk_example > scalarPropertiesForRelations=smart > bidirectionalRelations=false > identifiedReferences=false > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
@@ -3409,7 +3409,7 @@ export const SellersSchema = new EntitySchema({
 ]
 `;
 
-exports[`overlap_fk_example > scalarPropertiesForRelations=smart > bidirectionalRelations=false > identifiedReferences=true > entitySchema=false > dump 1`] = `
+exports[`overlap_fk_example > scalarPropertiesForRelations=smart > bidirectionalRelations=false > identifiedReferences=true > entityDefinition=decorators > dump 1`] = `
 [
   "import { Collection, Entity, ManyToMany, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
@@ -3541,7 +3541,7 @@ export class Sellers {
 ]
 `;
 
-exports[`overlap_fk_example > scalarPropertiesForRelations=smart > bidirectionalRelations=false > identifiedReferences=true > entitySchema=true > dump 1`] = `
+exports[`overlap_fk_example > scalarPropertiesForRelations=smart > bidirectionalRelations=false > identifiedReferences=true > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
@@ -3736,7 +3736,7 @@ export const SellersSchema = new EntitySchema({
 ]
 `;
 
-exports[`overlap_fk_example > scalarPropertiesForRelations=smart > bidirectionalRelations=true > identifiedReferences=false > entitySchema=false > dump 1`] = `
+exports[`overlap_fk_example > scalarPropertiesForRelations=smart > bidirectionalRelations=true > identifiedReferences=false > entityDefinition=decorators > dump 1`] = `
 [
   "import { Collection, Entity, ManyToMany, OneToMany, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
@@ -3898,7 +3898,7 @@ export class Sellers {
 ]
 `;
 
-exports[`overlap_fk_example > scalarPropertiesForRelations=smart > bidirectionalRelations=true > identifiedReferences=false > entitySchema=true > dump 1`] = `
+exports[`overlap_fk_example > scalarPropertiesForRelations=smart > bidirectionalRelations=true > identifiedReferences=false > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
@@ -4133,7 +4133,7 @@ export const SellersSchema = new EntitySchema({
 ]
 `;
 
-exports[`overlap_fk_example > scalarPropertiesForRelations=smart > bidirectionalRelations=true > identifiedReferences=true > entitySchema=false > dump 1`] = `
+exports[`overlap_fk_example > scalarPropertiesForRelations=smart > bidirectionalRelations=true > identifiedReferences=true > entityDefinition=decorators > dump 1`] = `
 [
   "import { Collection, Entity, ManyToMany, OneToMany, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';
@@ -4295,7 +4295,7 @@ export class Sellers {
 ]
 `;
 
-exports[`overlap_fk_example > scalarPropertiesForRelations=smart > bidirectionalRelations=true > identifiedReferences=true > entitySchema=true > dump 1`] = `
+exports[`overlap_fk_example > scalarPropertiesForRelations=smart > bidirectionalRelations=true > identifiedReferences=true > entityDefinition=entitySchema > dump 1`] = `
 [
   "import { Collection, EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
 import { ProductCountryMap } from './ProductCountryMap';

--- a/tests/features/entity-generator/__snapshots__/RefToPivotTable.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/RefToPivotTable.mysql.test.ts.snap
@@ -2,77 +2,93 @@
 
 exports[`RefToPivotTable > mysql-entity-dump 1`] = `
 [
-  "import { Entity, ManyToOne, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { PrimaryKeyProp, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { SenderEmails } from './SenderEmails';
 
-@Entity()
 export class EmailMessagesLog {
-
   [PrimaryKeyProp]?: 'logId';
-
-  @PrimaryKey()
   logId!: number;
-
-  @ManyToOne({ entity: () => SenderEmails, fieldNames: ['sender_id', 'sender_email_id'], updateRule: 'cascade', index: 'fk_email_messages_log_sender_emails1_idx' })
-  sender!: SenderEmails;
-
-  @ManyToOne({ entity: () => Emails, updateRule: 'cascade', deleteRule: 'cascade', index: 'fk_email_messages_log_emails1_idx' })
-  recepient!: Emails;
-
+  sender!: Ref<SenderEmails>;
+  recepient!: Ref<Emails>;
 }
-",
-  "import { Entity, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 
-@Entity()
+export const EmailMessagesLogSchema = defineEntity({
+  class: EmailMessagesLog,
+  properties: {
+    logId: p.integer().primary(),
+    sender: () => p.manyToOne(SenderEmails).ref().fieldNames('sender_id','sender_email_id').updateRule('cascade').index('fk_email_messages_log_sender_emails1_idx'),
+    recepient: () => p.manyToOne(Emails).ref().updateRule('cascade').deleteRule('cascade').index('fk_email_messages_log_emails1_idx'),
+  },
+});
+",
+  "import { Collection, PrimaryKeyProp, defineEntity, p } from '@mikro-orm/core';
+import { EmailMessagesLog } from './EmailMessagesLog';
+import { Sender } from './Sender';
+import { SenderEmails } from './SenderEmails';
+
 export class Emails {
-
   [PrimaryKeyProp]?: 'emailId';
-
-  @PrimaryKey()
   emailId!: number;
-
-  @Property({ unique: 'email_UNIQUE' })
   email!: string;
-
+  emailMessagesLogCollection = new Collection<EmailMessagesLog>(this);
+  emailsInverse = new Collection<Sender>(this);
+  senderEmailsCollection = new Collection<SenderEmails>(this);
 }
+
+export const EmailsSchema = defineEntity({
+  class: Emails,
+  properties: {
+    emailId: p.integer().primary(),
+    email: p.string().unique('email_UNIQUE'),
+    emailMessagesLogCollection: () => p.oneToMany(EmailMessagesLog).mappedBy('recepient'),
+    emailsInverse: () => p.manyToMany(Sender).mappedBy('emails'),
+    senderEmailsCollection: () => p.oneToMany(SenderEmails).mappedBy('email'),
+  },
+});
 ",
-  "import { Collection, Entity, ManyToMany, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, PrimaryKeyProp, defineEntity, p } from '@mikro-orm/core';
 import { Emails } from './Emails';
 import { SenderEmails } from './SenderEmails';
 
-@Entity()
 export class Sender {
-
   [PrimaryKeyProp]?: 'senderId';
-
-  @PrimaryKey({ type: 'smallint' })
   senderId!: number;
-
-  @Property({ unique: 'name_UNIQUE' })
   name!: string;
-
-  @ManyToMany({ entity: () => Emails, pivotEntity: () => SenderEmails, joinColumn: 'sender_id', inverseJoinColumn: 'email_id' })
   emails = new Collection<Emails>(this);
-
+  senderEmailsCollection = new Collection<SenderEmails>(this);
 }
+
+export const SenderSchema = defineEntity({
+  class: Sender,
+  properties: {
+    senderId: p.smallint().primary(),
+    name: p.string().unique('name_UNIQUE'),
+    emails: () => p.manyToMany(Emails).pivotEntity(() => SenderEmails).joinColumn('sender_id').inverseJoinColumn('email_id'),
+    senderEmailsCollection: () => p.oneToMany(SenderEmails).mappedBy('sender'),
+  },
+});
 ",
-  "import { Entity, ManyToOne, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { Collection, PrimaryKeyProp, type Ref, defineEntity, p } from '@mikro-orm/core';
+import { EmailMessagesLog } from './EmailMessagesLog';
 import { Emails } from './Emails';
 import { Sender } from './Sender';
 
-@Entity()
 export class SenderEmails {
-
   [PrimaryKeyProp]?: ['sender', 'email'];
-
-  @ManyToOne({ entity: () => Sender, fieldName: 'sender_id', updateRule: 'cascade', deleteRule: 'cascade', primary: true })
-  sender!: Sender;
-
-  @ManyToOne({ entity: () => Emails, fieldName: 'email_id', updateRule: 'cascade', primary: true, index: 'fk_sender_emails_emails1_idx' })
-  email!: Emails;
-
+  sender!: Ref<Sender>;
+  email!: Ref<Emails>;
+  emailMessagesLogCollection = new Collection<EmailMessagesLog>(this);
 }
+
+export const SenderEmailsSchema = defineEntity({
+  class: SenderEmails,
+  properties: {
+    sender: () => p.manyToOne(Sender).primary().ref().name('sender_id').updateRule('cascade').deleteRule('cascade'),
+    email: () => p.manyToOne(Emails).primary().ref().name('email_id').updateRule('cascade').index('fk_sender_emails_emails1_idx'),
+    emailMessagesLogCollection: () => p.oneToMany(EmailMessagesLog).mappedBy('sender'),
+  },
+});
 ",
 ]
 `;

--- a/tests/features/entity-generator/__snapshots__/ScalarPropsForFks.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/ScalarPropsForFks.mysql.test.ts.snap
@@ -2,1128 +2,1132 @@
 
 exports[`ScalarPropsForFks > generate entities with columns for all foreign key properties [mysql] > mysql-entity-composite-fk-prop-always-dump 1`] = `
 [
-  "import { Entity, OneToOne, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { PrimaryKeyProp, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 
-@Entity({ comment: 'This is address table' })
 export class Address2 {
-
   [PrimaryKeyProp]?: 'author';
-
-  @OneToOne({ entity: () => Author2, updateRule: 'cascade', deleteRule: 'cascade', primary: true })
-  author!: Author2;
-
-  @Property({ unsigned: true, persist: false })
+  author!: Ref<Author2>;
   authorId!: number;
-
-  @Property({ comment: 'This is address property' })
   value!: string;
-
 }
+
+export const Address2Schema = defineEntity({
+  class: Address2,
+  comment: 'This is address table',
+  properties: {
+    author: () => p.oneToOne(Author2).primary().ref().updateRule('cascade').deleteRule('cascade'),
+    authorId: p.integer().unsigned().persist(false),
+    value: p.string().comment('This is address property'),
+  },
+});
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, type Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, type Opt, type Ref, defineEntity, p } from '@mikro-orm/core';
+import { Address2 } from './Address2';
 import { Book2 } from './Book2';
 
-@Entity()
-@Index({ name: 'author2_name_age_index', properties: ['name', 'age'] })
-@Unique({ name: 'author2_name_email_unique', properties: ['name', 'email'] })
 export class Author2 {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property({ type: 'datetime', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
-
-  @Property({ type: 'datetime', length: 3, defaultRaw: \`current_timestamp(3)\` })
   updatedAt!: Date & Opt;
-
-  @Property({ index: 'custom_idx_name_123' })
   name!: string;
-
-  @Property({ index: 'custom_email_index_name', unique: 'custom_email_unique_name' })
   email!: string;
-
-  @Property({ nullable: true })
   age?: number;
-
-  @Index({ name: 'author2_terms_accepted_index' })
-  @Property({ type: 'boolean' })
   termsAccepted: boolean & Opt = false;
-
-  @Property({ nullable: true })
   optional?: boolean;
-
-  @Property({ type: 'text', length: 65535, nullable: true })
   identities?: string;
-
-  @Index({ name: 'author2_born_index' })
-  @Property({ type: 'date', nullable: true })
   born?: string;
-
-  @Property({ type: 'time', nullable: true, index: 'born_time_idx' })
   bornTime?: string;
-
-  @Index({ name: 'author2_favourite_book_uuid_pk_index' })
-  @ManyToOne({ entity: () => Book2, deleteRule: 'cascade', nullable: true })
-  favouriteBook?: Book2;
-
-  @Index({ name: 'author2_favourite_book_uuid_pk_index' })
-  @Property({ length: 36, nullable: true, persist: false })
+  favouriteBook?: Ref<Book2>;
   favouriteBookUuidPk?: string;
-
-  @Index({ name: 'author2_favourite_author_id_index' })
-  @ManyToOne({ entity: () => Author2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  favouriteAuthor?: Author2;
-
-  @Index({ name: 'author2_favourite_author_id_index' })
-  @Property({ unsigned: true, nullable: true, persist: false })
+  favouriteAuthor?: Ref<Author2>;
   favouriteAuthorId?: number;
-
-  @Property({ type: 'json', nullable: true })
   identity?: any;
-
-  @ManyToMany({ entity: () => Author2, pivotTable: 'author_to_friend', joinColumn: 'author2_1_id', inverseJoinColumn: 'author2_2_id' })
   authorToFriend = new Collection<Author2>(this);
-
-  @ManyToMany({ entity: () => Author2, joinColumn: 'author2_1_id', inverseJoinColumn: 'author2_2_id' })
   following = new Collection<Author2>(this);
-
+  address2?: Ref<Address2>;
+  author2Collection = new Collection<Author2>(this);
+  authorToFriendInverse = new Collection<Author2>(this);
+  followingInverse = new Collection<Author2>(this);
+  book2Collection = new Collection<Book2>(this);
 }
-",
-  "import { Entity, Enum, Index, ManyToOne, OneToOne, PrimaryKey, Property, Unique } from '@mikro-orm/core';
 
-@Entity()
+export const Author2Schema = defineEntity({
+  class: Author2,
+  indexes: [{ name: 'author2_name_age_index', properties: ['name', 'age'] }],
+  uniques: [{ name: 'author2_name_email_unique', properties: ['name', 'email'] }],
+  properties: {
+    id: p.integer().primary(),
+    createdAt: p.datetime().length(3).defaultRaw(\`current_timestamp(3)\`),
+    updatedAt: p.datetime().length(3).defaultRaw(\`current_timestamp(3)\`),
+    name: p.string().index('custom_idx_name_123'),
+    email: p.string().index('custom_email_index_name').unique('custom_email_unique_name'),
+    age: p.integer().nullable(),
+    termsAccepted: p.boolean().index('author2_terms_accepted_index'),
+    optional: p.boolean().nullable(),
+    identities: p.text().length(65535).nullable(),
+    born: p.date().nullable().index('author2_born_index'),
+    bornTime: p.time().nullable().index('born_time_idx'),
+    favouriteBook: () => p.manyToOne(Book2).ref().deleteRule('cascade').nullable(),
+    favouriteBookUuidPk: p.string().length(36).nullable().persist(false).index('author2_favourite_book_uuid_pk_index'),
+    favouriteAuthor: () => p.manyToOne(Author2).ref().updateRule('cascade').deleteRule('set null').nullable(),
+    favouriteAuthorId: p.integer().unsigned().nullable().persist(false).index('author2_favourite_author_id_index'),
+    identity: p.json().nullable(),
+    authorToFriend: () => p.manyToMany(Author2).pivotTable('author_to_friend').joinColumn('author2_1_id').inverseJoinColumn('author2_2_id'),
+    following: () => p.manyToMany(Author2).joinColumn('author2_1_id').inverseJoinColumn('author2_2_id'),
+    address2: () => p.oneToOne(Address2).ref().mappedBy('author'),
+    author2Collection: () => p.oneToMany(Author2).mappedBy('favouriteAuthor'),
+    authorToFriendInverse: () => p.manyToMany(Author2).mappedBy('authorToFriend'),
+    followingInverse: () => p.manyToMany(Author2).mappedBy('following'),
+    book2Collection: () => p.oneToMany(Book2).mappedBy('author'),
+  },
+});
+",
+  "import { Collection, type Ref, defineEntity, p } from '@mikro-orm/core';
+
 export class BaseUser2 {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property({ length: 100 })
   firstName!: string;
-
-  @Property({ length: 100 })
   lastName!: string;
-
-  @Index({ name: 'base_user2_type_index' })
-  @Enum({ items: () => BaseUser2Type })
-  type!: BaseUser2Type;
-
-  @Property({ nullable: true })
+  type!: TBaseUser2Type;
   ownerProp?: string;
-
-  @Index({ name: 'base_user2_favourite_employee_id_index' })
-  @ManyToOne({ entity: () => BaseUser2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  favouriteEmployee?: BaseUser2;
-
-  @Index({ name: 'base_user2_favourite_employee_id_index' })
-  @Property({ unsigned: true, nullable: true, persist: false })
+  favouriteEmployee?: Ref<BaseUser2>;
   favouriteEmployeeId?: number;
-
-  @Unique({ name: 'base_user2_favourite_manager_id_unique' })
-  @OneToOne({ entity: () => BaseUser2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  favouriteManager?: BaseUser2;
-
-  @Property({ unsigned: true, nullable: true, persist: false, unique: true })
+  favouriteManager?: Ref<BaseUser2>;
   favouriteManagerId?: number;
-
-  @Property({ nullable: true, unique: true })
   employeeProp?: number;
-
-  @Property({ nullable: true })
   managerProp?: string;
-
+  baseUser2Collection = new Collection<BaseUser2>(this);
+  baseUser2?: Ref<BaseUser2>;
 }
 
-export enum BaseUser2Type {
-  EMPLOYEE = 'employee',
-  MANAGER = 'manager',
-  OWNER = 'owner',
-}
+export const BaseUser2Type = {
+  EMPLOYEE: 'employee',
+  MANAGER: 'manager',
+  OWNER: 'owner',
+} as const;
+
+export type TBaseUser2Type = (typeof BaseUser2Type)[keyof typeof BaseUser2Type];
+
+export const BaseUser2Schema = defineEntity({
+  class: BaseUser2,
+  properties: {
+    id: p.integer().primary(),
+    firstName: p.string().length(100),
+    lastName: p.string().length(100),
+    type: p.enum(() => BaseUser2Type).index('base_user2_type_index'),
+    ownerProp: p.string().nullable(),
+    favouriteEmployee: () => p.manyToOne(BaseUser2).ref().updateRule('cascade').deleteRule('set null').nullable(),
+    favouriteEmployeeId: p.integer().unsigned().nullable().persist(false).index('base_user2_favourite_employee_id_index'),
+    favouriteManager: () => p.oneToOne(BaseUser2).ref().updateRule('cascade').deleteRule('set null').nullable(),
+    favouriteManagerId: p.integer().unsigned().nullable().persist(false).unique('base_user2_favourite_manager_id_unique'),
+    employeeProp: p.integer().nullable().unique('base_user2_employee_prop_unique'),
+    managerProp: p.string().nullable(),
+    baseUser2Collection: () => p.oneToMany(BaseUser2).mappedBy('favouriteEmployee'),
+    baseUser2: () => p.oneToOne(BaseUser2).ref().mappedBy('favouriteManager'),
+  },
+});
 ",
-  "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, defineEntity, p } from '@mikro-orm/core';
+import { Book2 } from './Book2';
+import { Book2Tags } from './Book2Tags';
 
-@Entity()
 export class BookTag2 {
-
-  @PrimaryKey()
   id!: bigint;
-
-  @Property({ length: 50 })
   name!: string;
-
+  bookToTagUnorderedInverse = new Collection<Book2>(this);
+  book2TagsCollection = new Collection<Book2Tags>(this);
 }
+
+export const BookTag2Schema = defineEntity({
+  class: BookTag2,
+  properties: {
+    id: p.bigint().primary(),
+    name: p.string().length(50),
+    bookToTagUnorderedInverse: () => p.manyToMany(Book2).mappedBy('bookToTagUnordered'),
+    book2TagsCollection: () => p.oneToMany(Book2Tags).mappedBy('bookTag2'),
+  },
+});
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, type Opt, PrimaryKeyProp, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Author2 } from './Author2';
+import { Book2Tags } from './Book2Tags';
 import { BookTag2 } from './BookTag2';
 import { Publisher2 } from './Publisher2';
+import { Test2 } from './Test2';
 
-@Entity()
 export class Book2 {
-
   [PrimaryKeyProp]?: 'uuidPk';
-
-  @PrimaryKey({ length: 36 })
   uuidPk!: string;
-
-  @Property({ type: 'datetime', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
-
-  @Property({ type: 'character', length: 13, nullable: true, unique: true })
   isbn?: string;
-
-  @Index({ name: 'book2_title_index' })
-  @Property({ type: 'string', nullable: true })
   title?: string = '';
-
-  @Property({ type: 'text', length: 65535, nullable: true })
   perex?: string;
-
-  @Property({ type: 'decimal', precision: 8, scale: 2, nullable: true })
   price?: string;
-
-  @Property({ type: 'double', nullable: true })
   double?: number;
-
-  @Property({ type: 'json', nullable: true })
   meta?: any;
-
-  @Index({ name: 'book2_author_id_index' })
-  @ManyToOne({ entity: () => Author2 })
-  author!: Author2;
-
-  @Index({ name: 'book2_author_id_index' })
-  @Property({ unsigned: true, persist: false })
+  author!: Ref<Author2>;
   authorId!: number;
-
-  @Index({ name: 'book2_publisher_id_index' })
-  @ManyToOne({ entity: () => Publisher2, updateRule: 'cascade', deleteRule: 'cascade', nullable: true })
-  publisher?: Publisher2;
-
-  @Index({ name: 'book2_publisher_id_index' })
-  @Property({ unsigned: true, nullable: true, persist: false })
+  publisher?: Ref<Publisher2>;
   publisherId?: number;
-
-  @Property({ type: 'string', nullable: true })
   foo?: string = 'lol';
-
-  @ManyToMany({ entity: () => BookTag2, pivotTable: 'book_to_tag_unordered', joinColumn: 'book2_uuid_pk', inverseJoinColumn: 'book_tag2_id' })
   bookToTagUnordered = new Collection<BookTag2>(this);
-
+  author2Collection = new Collection<Author2>(this);
+  book2TagsCollection = new Collection<Book2Tags>(this);
+  test2?: Ref<Test2>;
 }
+
+export const Book2Schema = defineEntity({
+  class: Book2,
+  properties: {
+    uuidPk: p.string().primary().length(36),
+    createdAt: p.datetime().length(3).defaultRaw(\`current_timestamp(3)\`),
+    isbn: p.character().length(13).nullable().unique('book2_isbn_unique'),
+    title: p.string().nullable().index('book2_title_index'),
+    perex: p.text().length(65535).nullable(),
+    price: p.decimal().precision(8).scale(2).nullable(),
+    double: p.double().nullable(),
+    meta: p.json().nullable(),
+    author: () => p.manyToOne(Author2).ref(),
+    authorId: p.integer().unsigned().persist(false).index('book2_author_id_index'),
+    publisher: () => p.manyToOne(Publisher2).ref().updateRule('cascade').deleteRule('cascade').nullable(),
+    publisherId: p.integer().unsigned().nullable().persist(false).index('book2_publisher_id_index'),
+    foo: p.string().nullable(),
+    bookToTagUnordered: () => p.manyToMany(BookTag2).pivotTable('book_to_tag_unordered').joinColumn('book2_uuid_pk').inverseJoinColumn('book_tag2_id'),
+    author2Collection: () => p.oneToMany(Author2).mappedBy('favouriteBook'),
+    book2TagsCollection: () => p.oneToMany(Book2Tags).mappedBy('book2'),
+    test2: () => p.oneToOne(Test2).ref().mappedBy('book'),
+  },
+});
 ",
-  "import { Entity, Index, ManyToOne, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { PrimaryKeyProp, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { BookTag2 } from './BookTag2';
 
-@Entity({ tableName: 'book2_tags' })
 export class Book2Tags {
-
   [PrimaryKeyProp]?: 'order';
-
-  @PrimaryKey()
   order!: number;
-
-  @Index({ name: 'book2_tags_book2_uuid_pk_index' })
-  @ManyToOne({ entity: () => Book2, updateRule: 'cascade', deleteRule: 'cascade' })
-  book2!: Book2;
-
-  @Index({ name: 'book2_tags_book2_uuid_pk_index' })
-  @Property({ fieldName: 'book2_uuid_pk', length: 36, persist: false })
+  book2!: Ref<Book2>;
   book2UuidPk!: string;
-
-  @Index({ name: 'book2_tags_book_tag2_id_index' })
-  @ManyToOne({ entity: () => BookTag2, updateRule: 'cascade', deleteRule: 'cascade' })
-  bookTag2!: BookTag2;
-
-  @Index({ name: 'book2_tags_book_tag2_id_index' })
-  @Property({ fieldName: 'book_tag2_id', unsigned: true, persist: false })
+  bookTag2!: Ref<BookTag2>;
   bookTag2Id!: bigint;
-
 }
+
+export const Book2TagsSchema = defineEntity({
+  class: Book2Tags,
+  tableName: 'book2_tags',
+  properties: {
+    order: p.integer().primary(),
+    book2: () => p.manyToOne(Book2).ref().updateRule('cascade').deleteRule('cascade'),
+    book2UuidPk: p.string().name('book2_uuid_pk').length(36).persist(false).index('book2_tags_book2_uuid_pk_index'),
+    bookTag2: () => p.manyToOne(BookTag2).ref().updateRule('cascade').deleteRule('cascade'),
+    bookTag2Id: p.bigint().name('book_tag2_id').unsigned().persist(false).index('book2_tags_book_tag2_id_index'),
+  },
+});
 ",
-  "import { Entity, Index, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Car2 } from './Car2';
 
-@Entity()
 export class CarOwner2 {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property()
   name!: string;
-
-  @Index({ name: 'car_owner2_car_name_car_year_index' })
-  @ManyToOne({ entity: () => Car2, updateRule: 'cascade' })
-  car!: Car2;
-
-  @Property({ length: 100, persist: false })
+  car!: Ref<Car2>;
   carName!: string;
-
-  @Property({ unsigned: true, persist: false })
   carYear!: number;
-
 }
-",
-  "import { Entity, Index, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 
-@Entity()
+export const CarOwner2Schema = defineEntity({
+  class: CarOwner2,
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+    car: () => p.manyToOne(Car2).ref().updateRule('cascade'),
+    carName: p.string().length(100).persist(false),
+    carYear: p.integer().unsigned().persist(false),
+  },
+});
+",
+  "import { Collection, PrimaryKeyProp, type Ref, defineEntity, p } from '@mikro-orm/core';
+import { CarOwner2 } from './CarOwner2';
+import { User2 } from './User2';
+
 export class Car2 {
-
   [PrimaryKeyProp]?: ['name', 'year'];
-
-  @Index({ name: 'car2_name_index' })
-  @PrimaryKey({ length: 100 })
   name!: string;
-
-  @Index({ name: 'car2_year_index' })
-  @PrimaryKey()
   year!: number;
-
-  @Property()
   price!: number;
-
+  carOwner2Collection = new Collection<CarOwner2>(this);
+  user2?: Ref<User2>;
+  carsInverse = new Collection<User2>(this);
 }
+
+export const Car2Schema = defineEntity({
+  class: Car2,
+  properties: {
+    name: p.string().primary().length(100).index('car2_name_index'),
+    year: p.integer().primary().index('car2_year_index'),
+    price: p.integer(),
+    carOwner2Collection: () => p.oneToMany(CarOwner2).mappedBy('car'),
+    user2: () => p.oneToOne(User2).ref().mappedBy('favouriteCar'),
+    carsInverse: () => p.manyToMany(User2).mappedBy('cars'),
+  },
+});
 ",
-  "import { Entity, Index, ManyToOne, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { PrimaryKeyProp, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Test2 } from './Test2';
 
-@Entity()
 export class Configuration2 {
-
   [PrimaryKeyProp]?: ['property', 'test'];
-
-  @PrimaryKey()
   property!: string;
-
-  @Index({ name: 'configuration2_test_id_index' })
-  @ManyToOne({ entity: () => Test2, updateRule: 'cascade', primary: true })
-  test!: Test2;
-
-  @Index({ name: 'configuration2_test_id_index' })
-  @Property({ unsigned: true, persist: false })
+  test!: Ref<Test2>;
   testId!: number;
-
-  @Property()
   value!: string;
-
 }
-",
-  "import { Entity, PrimaryKey } from '@mikro-orm/core';
 
-@Entity()
+export const Configuration2Schema = defineEntity({
+  class: Configuration2,
+  properties: {
+    property: p.string().primary(),
+    test: () => p.manyToOne(Test2).primary().ref().updateRule('cascade'),
+    testId: p.integer().unsigned().persist(false).index('configuration2_test_id_index'),
+    value: p.string(),
+  },
+});
+",
+  "import { defineEntity, p } from '@mikro-orm/core';
+
 export class Dummy2 {
-
-  @PrimaryKey()
   id!: number;
-
 }
+
+export const Dummy2Schema = defineEntity({
+  class: Dummy2,
+  properties: {
+    id: p.integer().primary(),
+  },
+});
 ",
-  "import { Entity, OneToOne, type Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, type Opt, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { FooBaz2 } from './FooBaz2';
+import { FooParam2 } from './FooParam2';
+import { Test2 } from './Test2';
 
-@Entity()
 export class FooBar2 {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property()
   name!: string;
-
-  @Property({ fieldName: 'name with space', nullable: true })
   nameWithSpace?: string;
-
-  @Unique({ name: 'foo_bar2_baz_id_unique' })
-  @OneToOne({ entity: () => FooBaz2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  baz?: FooBaz2;
-
-  @Property({ unsigned: true, nullable: true, persist: false, unique: true })
+  baz?: Ref<FooBaz2>;
   bazId?: number;
-
-  @Unique({ name: 'foo_bar2_foo_bar_id_unique' })
-  @OneToOne({ entity: () => FooBar2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  fooBar?: FooBar2;
-
-  @Property({ unsigned: true, nullable: true, persist: false, unique: true })
+  fooBar?: Ref<FooBar2>;
   fooBarId?: number;
-
-  @Property({ type: 'datetime', defaultRaw: \`CURRENT_TIMESTAMP\` })
   version!: Date & Opt;
-
-  @Property({ length: 65535, nullable: true })
   blob?: Buffer;
-
-  @Property({ length: 65535, nullable: true })
   blob2?: Buffer;
-
-  @Property({ type: 'text', length: 65535, nullable: true })
   array?: string;
-
-  @Property({ type: 'json', nullable: true })
   objectProperty?: any;
-
+  fooBar2?: Ref<FooBar2>;
+  fooParam2Collection = new Collection<FooParam2>(this);
+  test2?: Ref<Test2>;
+  barsInverse = new Collection<Test2>(this);
 }
-",
-  "import { Entity, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 
-@Entity()
+export const FooBar2Schema = defineEntity({
+  class: FooBar2,
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+    nameWithSpace: p.string().name('name with space').nullable(),
+    baz: () => p.oneToOne(FooBaz2).ref().updateRule('cascade').deleteRule('set null').nullable(),
+    bazId: p.integer().unsigned().nullable().persist(false).unique('foo_bar2_baz_id_unique'),
+    fooBar: () => p.oneToOne(FooBar2).ref().updateRule('cascade').deleteRule('set null').nullable(),
+    fooBarId: p.integer().unsigned().nullable().persist(false).unique('foo_bar2_foo_bar_id_unique'),
+    version: p.datetime().defaultRaw(\`CURRENT_TIMESTAMP\`),
+    blob: p.blob().length(65535).nullable(),
+    blob2: p.blob().length(65535).nullable(),
+    array: p.text().length(65535).nullable(),
+    objectProperty: p.json().nullable(),
+    fooBar2: () => p.oneToOne(FooBar2).ref().mappedBy('fooBar'),
+    fooParam2Collection: () => p.oneToMany(FooParam2).mappedBy('bar'),
+    test2: () => p.oneToOne(Test2).ref().mappedBy('fooBar2'),
+    barsInverse: () => p.manyToMany(Test2).mappedBy('bars'),
+  },
+});
+",
+  "import { Collection, type Opt, type Ref, defineEntity, p } from '@mikro-orm/core';
+import { FooBar2 } from './FooBar2';
+import { FooParam2 } from './FooParam2';
+
 export class FooBaz2 {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property()
   name!: string;
-
-  @Property()
   code!: string;
-
-  @Property({ type: 'datetime', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
-
+  fooBar2?: Ref<FooBar2>;
+  fooParam2Collection = new Collection<FooParam2>(this);
 }
+
+export const FooBaz2Schema = defineEntity({
+  class: FooBaz2,
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+    code: p.string(),
+    version: p.datetime().length(3).defaultRaw(\`current_timestamp(3)\`),
+    fooBar2: () => p.oneToOne(FooBar2).ref().mappedBy('baz'),
+    fooParam2Collection: () => p.oneToMany(FooParam2).mappedBy('baz'),
+  },
+});
 ",
-  "import { Entity, Index, ManyToOne, type Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { type Opt, PrimaryKeyProp, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { FooBar2 } from './FooBar2';
 import { FooBaz2 } from './FooBaz2';
 
-@Entity()
 export class FooParam2 {
-
   [PrimaryKeyProp]?: ['bar', 'baz'];
-
-  @Index({ name: 'foo_param2_bar_id_index' })
-  @ManyToOne({ entity: () => FooBar2, updateRule: 'cascade', primary: true })
-  bar!: FooBar2;
-
-  @Index({ name: 'foo_param2_bar_id_index' })
-  @Property({ unsigned: true, persist: false })
+  bar!: Ref<FooBar2>;
   barId!: number;
-
-  @Index({ name: 'foo_param2_baz_id_index' })
-  @ManyToOne({ entity: () => FooBaz2, updateRule: 'cascade', primary: true })
-  baz!: FooBaz2;
-
-  @Index({ name: 'foo_param2_baz_id_index' })
-  @Property({ unsigned: true, persist: false })
+  baz!: Ref<FooBaz2>;
   bazId!: number;
-
-  @Property()
   value!: string;
-
-  @Property({ type: 'datetime', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
-
 }
-",
-  "import { Entity, Enum, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 
-@Entity()
+export const FooParam2Schema = defineEntity({
+  class: FooParam2,
+  properties: {
+    bar: () => p.manyToOne(FooBar2).primary().ref().updateRule('cascade'),
+    barId: p.integer().unsigned().persist(false).index('foo_param2_bar_id_index'),
+    baz: () => p.manyToOne(FooBaz2).primary().ref().updateRule('cascade'),
+    bazId: p.integer().unsigned().persist(false).index('foo_param2_baz_id_index'),
+    value: p.string(),
+    version: p.datetime().length(3).defaultRaw(\`current_timestamp(3)\`),
+  },
+});
+",
+  "import { Collection, type Opt, defineEntity, p } from '@mikro-orm/core';
+import { Book2 } from './Book2';
+import { Publisher2Tests } from './Publisher2Tests';
+
 export class Publisher2 {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property({ type: 'string' })
   name: string & Opt = 'asd';
-
-  @Enum({ items: () => Publisher2Type })
-  type: Publisher2Type & Opt = Publisher2Type.LOCAL;
-
-  @Enum({ items: () => Publisher2Type2 })
-  type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
-
-  @Property({ type: 'tinyint', nullable: true })
+  type: TPublisher2Type & Opt = Publisher2Type.LOCAL;
+  type2: TPublisher2Type2 & Opt = Publisher2Type2.LOCAL;
   enum1?: number;
-
-  @Property({ type: 'tinyint', nullable: true })
   enum2?: number;
-
-  @Property({ type: 'tinyint', nullable: true })
   enum3?: number;
-
-  @Enum({ items: () => Publisher2Enum4, nullable: true })
-  enum4?: Publisher2Enum4;
-
-  @Enum({ items: () => Publisher2Enum5, nullable: true })
-  enum5?: Publisher2Enum5;
-
+  enum4?: TPublisher2Enum4;
+  enum5?: TPublisher2Enum5;
+  book2Collection = new Collection<Book2>(this);
+  publisher2TestsCollection = new Collection<Publisher2Tests>(this);
 }
 
-export enum Publisher2Type {
-  LOCAL = 'local',
-  GLOBAL = 'global',
-}
+export const Publisher2Type = {
+  LOCAL: 'local',
+  GLOBAL: 'global',
+} as const;
 
-export enum Publisher2Type2 {
-  LOCAL = 'LOCAL',
-  GLOBAL = 'GLOBAL',
-}
+export type TPublisher2Type = (typeof Publisher2Type)[keyof typeof Publisher2Type];
 
-export enum Publisher2Enum4 {
-  A = 'a',
-  B = 'b',
-  C = 'c',
-}
+export const Publisher2Type2 = {
+  LOCAL: 'LOCAL',
+  GLOBAL: 'GLOBAL',
+} as const;
 
-export enum Publisher2Enum5 {
-  A = 'a',
-}
+export type TPublisher2Type2 = (typeof Publisher2Type2)[keyof typeof Publisher2Type2];
+
+export const Publisher2Enum4 = {
+  A: 'a',
+  B: 'b',
+  C: 'c',
+} as const;
+
+export type TPublisher2Enum4 = (typeof Publisher2Enum4)[keyof typeof Publisher2Enum4];
+
+export const Publisher2Enum5 = {
+  A: 'a',
+} as const;
+
+export type TPublisher2Enum5 = (typeof Publisher2Enum5)[keyof typeof Publisher2Enum5];
+
+export const Publisher2Schema = defineEntity({
+  class: Publisher2,
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+    type: p.enum(() => Publisher2Type),
+    type2: p.enum(() => Publisher2Type2),
+    enum1: p.tinyint().nullable(),
+    enum2: p.tinyint().nullable(),
+    enum3: p.tinyint().nullable(),
+    enum4: p.enum(() => Publisher2Enum4).nullable(),
+    enum5: p.enum(() => Publisher2Enum5).nullable(),
+    book2Collection: () => p.oneToMany(Book2).mappedBy('publisher'),
+    publisher2TestsCollection: () => p.oneToMany(Publisher2Tests).mappedBy('publisher2'),
+  },
+});
 ",
-  "import { Entity, Index, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Publisher2 } from './Publisher2';
 import { Test2 } from './Test2';
 
-@Entity({ tableName: 'publisher2_tests' })
 export class Publisher2Tests {
-
-  @PrimaryKey()
   id!: number;
-
-  @Index({ name: 'publisher2_tests_publisher2_id_index' })
-  @ManyToOne({ entity: () => Publisher2, updateRule: 'cascade', deleteRule: 'cascade' })
-  publisher2!: Publisher2;
-
-  @Index({ name: 'publisher2_tests_publisher2_id_index' })
-  @Property({ fieldName: 'publisher2_id', unsigned: true, persist: false })
+  publisher2!: Ref<Publisher2>;
   publisher2Id!: number;
-
-  @Index({ name: 'publisher2_tests_test2_id_index' })
-  @ManyToOne({ entity: () => Test2, updateRule: 'cascade', deleteRule: 'cascade' })
-  test2!: Test2;
-
-  @Index({ name: 'publisher2_tests_test2_id_index' })
-  @Property({ fieldName: 'test2_id', unsigned: true, persist: false })
+  test2!: Ref<Test2>;
   test2Id!: number;
-
 }
-",
-  "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
 
-@Entity()
+export const Publisher2TestsSchema = defineEntity({
+  class: Publisher2Tests,
+  tableName: 'publisher2_tests',
+  properties: {
+    id: p.integer().primary(),
+    publisher2: () => p.manyToOne(Publisher2).ref().updateRule('cascade').deleteRule('cascade'),
+    publisher2Id: p.integer().name('publisher2_id').unsigned().persist(false).index('publisher2_tests_publisher2_id_index'),
+    test2: () => p.manyToOne(Test2).ref().updateRule('cascade').deleteRule('cascade'),
+    test2Id: p.integer().name('test2_id').unsigned().persist(false).index('publisher2_tests_test2_id_index'),
+  },
+});
+",
+  "import { Collection, defineEntity, p } from '@mikro-orm/core';
+import { User2 } from './User2';
+
 export class Sandwich {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property()
   name!: string;
-
-  @Property()
   price!: number;
-
+  sandwichesInverse = new Collection<User2>(this);
 }
+
+export const SandwichSchema = defineEntity({
+  class: Sandwich,
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+    price: p.integer(),
+    sandwichesInverse: () => p.manyToMany(User2).mappedBy('sandwiches'),
+  },
+});
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, OneToOne, type Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, type Opt, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Book2 } from './Book2';
+import { Configuration2 } from './Configuration2';
 import { FooBar2 } from './FooBar2';
+import { Publisher2Tests } from './Publisher2Tests';
 
-@Entity()
 export class Test2 {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property({ nullable: true })
   name?: string;
-
-  @Unique({ name: 'test2_book_uuid_pk_unique' })
-  @OneToOne({ entity: () => Book2, deleteRule: 'set null', nullable: true })
-  book?: Book2;
-
-  @Property({ length: 36, nullable: true, persist: false, unique: true })
+  book?: Ref<Book2>;
   bookUuidPk?: string;
-
-  @Index({ name: 'test2_parent_id_index' })
-  @ManyToOne({ entity: () => Test2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  parent?: Test2;
-
-  @Index({ name: 'test2_parent_id_index' })
-  @Property({ unsigned: true, nullable: true, persist: false })
+  parent?: Ref<Test2>;
   parentId?: number;
-
-  @Property({ type: 'integer' })
   version: number & Opt = 1;
-
-  @Property({ fieldName: 'foo___bar', unsigned: true, nullable: true, persist: false, unique: true })
   fooBar?: number;
-
-  @Property({ fieldName: 'foo___baz', unsigned: true, nullable: true })
   fooBaz?: number;
-
-  @Unique({ name: 'test2_foo___bar_unique' })
-  @OneToOne({ entity: () => FooBar2, fieldName: 'foo___bar', updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  fooBar2?: FooBar2;
-
-  @ManyToMany({ entity: () => FooBar2, joinColumn: 'test2_id', inverseJoinColumn: 'foo_bar2_id' })
+  fooBar2?: Ref<FooBar2>;
   bars = new Collection<FooBar2>(this);
-
+  configuration2Collection = new Collection<Configuration2>(this);
+  publisher2TestsCollection = new Collection<Publisher2Tests>(this);
+  test2Collection = new Collection<Test2>(this);
 }
+
+export const Test2Schema = defineEntity({
+  class: Test2,
+  properties: {
+    id: p.integer().primary(),
+    name: p.string().nullable(),
+    book: () => p.oneToOne(Book2).ref().deleteRule('set null').nullable(),
+    bookUuidPk: p.string().length(36).nullable().persist(false).unique('test2_book_uuid_pk_unique'),
+    parent: () => p.manyToOne(Test2).ref().updateRule('cascade').deleteRule('set null').nullable(),
+    parentId: p.integer().unsigned().nullable().persist(false).index('test2_parent_id_index'),
+    version: p.integer(),
+    fooBar: p.integer().name('foo___bar').unsigned().nullable().persist(false).unique('test2_foo___bar_unique'),
+    fooBaz: p.integer().name('foo___baz').unsigned().nullable(),
+    fooBar2: () => p.oneToOne(FooBar2).ref().name('foo___bar').updateRule('cascade').deleteRule('set null').nullable(),
+    bars: () => p.manyToMany(FooBar2).joinColumn('test2_id').inverseJoinColumn('foo_bar2_id'),
+    configuration2Collection: () => p.oneToMany(Configuration2).mappedBy('test'),
+    publisher2TestsCollection: () => p.oneToMany(Publisher2Tests).mappedBy('test2'),
+    test2Collection: () => p.oneToMany(Test2).mappedBy('parent'),
+  },
+});
 ",
-  "import { Collection, Entity, ManyToMany, OneToOne, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, PrimaryKeyProp, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Car2 } from './Car2';
 import { Sandwich } from './Sandwich';
 
-@Entity()
 export class User2 {
-
   [PrimaryKeyProp]?: ['firstName', 'lastName'];
-
-  @PrimaryKey({ length: 100 })
   firstName!: string;
-
-  @PrimaryKey({ length: 100 })
   lastName!: string;
-
-  @Property({ nullable: true })
   foo?: number;
-
-  @Unique({ name: 'user2_favourite_car_name_favourite_car_year_unique' })
-  @OneToOne({ entity: () => Car2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  favouriteCar?: Car2;
-
-  @Property({ length: 100, nullable: true, persist: false })
+  favouriteCar?: Ref<Car2>;
   favouriteCarName?: string;
-
-  @Property({ unsigned: true, nullable: true, persist: false })
   favouriteCarYear?: number;
-
-  @ManyToMany({ entity: () => Car2, joinColumns: ['user2_first_name', 'user2_last_name'], inverseJoinColumns: ['car2_name', 'car2_year'] })
   cars = new Collection<Car2>(this);
-
-  @ManyToMany({ entity: () => Sandwich, joinColumns: ['user2_first_name', 'user2_last_name'], inverseJoinColumn: 'sandwich_id' })
   sandwiches = new Collection<Sandwich>(this);
-
 }
+
+export const User2Schema = defineEntity({
+  class: User2,
+  properties: {
+    firstName: p.string().primary().length(100),
+    lastName: p.string().primary().length(100),
+    foo: p.integer().nullable(),
+    favouriteCar: () => p.oneToOne(Car2).ref().updateRule('cascade').deleteRule('set null').nullable(),
+    favouriteCarName: p.string().length(100).nullable().persist(false),
+    favouriteCarYear: p.integer().unsigned().nullable().persist(false),
+    cars: () => p.manyToMany(Car2).joinColumns('user2_first_name', 'user2_last_name').inverseJoinColumns('car2_name', 'car2_year'),
+    sandwiches: () => p.manyToMany(Sandwich).joinColumns('user2_first_name', 'user2_last_name').inverseJoinColumn('sandwich_id'),
+  },
+});
 ",
 ]
 `;
 
 exports[`ScalarPropsForFks > generate entities with columns for some foreign key properties [mysql] > mysql-entity-composite-fk-prop-smart-dump 1`] = `
 [
-  "import { Entity, OneToOne, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { PrimaryKeyProp, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Author2 } from './Author2';
 
-@Entity({ comment: 'This is address table' })
 export class Address2 {
-
   [PrimaryKeyProp]?: 'author';
-
-  @OneToOne({ entity: () => Author2, updateRule: 'cascade', deleteRule: 'cascade', primary: true })
-  author!: Author2;
-
-  @Property({ comment: 'This is address property' })
+  author!: Ref<Author2>;
   value!: string;
-
 }
+
+export const Address2Schema = defineEntity({
+  class: Address2,
+  comment: 'This is address table',
+  properties: {
+    author: () => p.oneToOne(Author2).primary().ref().updateRule('cascade').deleteRule('cascade'),
+    value: p.string().comment('This is address property'),
+  },
+});
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, type Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, type Opt, type Ref, defineEntity, p } from '@mikro-orm/core';
+import { Address2 } from './Address2';
 import { Book2 } from './Book2';
 
-@Entity()
-@Index({ name: 'author2_name_age_index', properties: ['name', 'age'] })
-@Unique({ name: 'author2_name_email_unique', properties: ['name', 'email'] })
 export class Author2 {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property({ type: 'datetime', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
-
-  @Property({ type: 'datetime', length: 3, defaultRaw: \`current_timestamp(3)\` })
   updatedAt!: Date & Opt;
-
-  @Property({ index: 'custom_idx_name_123' })
   name!: string;
-
-  @Property({ index: 'custom_email_index_name', unique: 'custom_email_unique_name' })
   email!: string;
-
-  @Property({ nullable: true })
   age?: number;
-
-  @Index({ name: 'author2_terms_accepted_index' })
-  @Property({ type: 'boolean' })
   termsAccepted: boolean & Opt = false;
-
-  @Property({ nullable: true })
   optional?: boolean;
-
-  @Property({ type: 'text', length: 65535, nullable: true })
   identities?: string;
-
-  @Index({ name: 'author2_born_index' })
-  @Property({ type: 'date', nullable: true })
   born?: string;
-
-  @Property({ type: 'time', nullable: true, index: 'born_time_idx' })
   bornTime?: string;
-
-  @Index({ name: 'author2_favourite_book_uuid_pk_index' })
-  @ManyToOne({ entity: () => Book2, deleteRule: 'cascade', nullable: true })
-  favouriteBook?: Book2;
-
-  @Index({ name: 'author2_favourite_author_id_index' })
-  @ManyToOne({ entity: () => Author2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  favouriteAuthor?: Author2;
-
-  @Property({ type: 'json', nullable: true })
+  favouriteBook?: Ref<Book2>;
+  favouriteAuthor?: Ref<Author2>;
   identity?: any;
-
-  @ManyToMany({ entity: () => Author2, pivotTable: 'author_to_friend', joinColumn: 'author2_1_id', inverseJoinColumn: 'author2_2_id' })
   authorToFriend = new Collection<Author2>(this);
-
-  @ManyToMany({ entity: () => Author2, joinColumn: 'author2_1_id', inverseJoinColumn: 'author2_2_id' })
   following = new Collection<Author2>(this);
-
+  address2?: Ref<Address2>;
+  author2Collection = new Collection<Author2>(this);
+  authorToFriendInverse = new Collection<Author2>(this);
+  followingInverse = new Collection<Author2>(this);
+  book2Collection = new Collection<Book2>(this);
 }
-",
-  "import { Entity, Enum, Index, ManyToOne, OneToOne, PrimaryKey, Property, Unique } from '@mikro-orm/core';
 
-@Entity()
+export const Author2Schema = defineEntity({
+  class: Author2,
+  indexes: [{ name: 'author2_name_age_index', properties: ['name', 'age'] }],
+  uniques: [{ name: 'author2_name_email_unique', properties: ['name', 'email'] }],
+  properties: {
+    id: p.integer().primary(),
+    createdAt: p.datetime().length(3).defaultRaw(\`current_timestamp(3)\`),
+    updatedAt: p.datetime().length(3).defaultRaw(\`current_timestamp(3)\`),
+    name: p.string().index('custom_idx_name_123'),
+    email: p.string().index('custom_email_index_name').unique('custom_email_unique_name'),
+    age: p.integer().nullable(),
+    termsAccepted: p.boolean().index('author2_terms_accepted_index'),
+    optional: p.boolean().nullable(),
+    identities: p.text().length(65535).nullable(),
+    born: p.date().nullable().index('author2_born_index'),
+    bornTime: p.time().nullable().index('born_time_idx'),
+    favouriteBook: () => p.manyToOne(Book2).ref().deleteRule('cascade').nullable(),
+    favouriteAuthor: () => p.manyToOne(Author2).ref().updateRule('cascade').deleteRule('set null').nullable(),
+    identity: p.json().nullable(),
+    authorToFriend: () => p.manyToMany(Author2).pivotTable('author_to_friend').joinColumn('author2_1_id').inverseJoinColumn('author2_2_id'),
+    following: () => p.manyToMany(Author2).joinColumn('author2_1_id').inverseJoinColumn('author2_2_id'),
+    address2: () => p.oneToOne(Address2).ref().mappedBy('author'),
+    author2Collection: () => p.oneToMany(Author2).mappedBy('favouriteAuthor'),
+    authorToFriendInverse: () => p.manyToMany(Author2).mappedBy('authorToFriend'),
+    followingInverse: () => p.manyToMany(Author2).mappedBy('following'),
+    book2Collection: () => p.oneToMany(Book2).mappedBy('author'),
+  },
+});
+",
+  "import { Collection, type Ref, defineEntity, p } from '@mikro-orm/core';
+
 export class BaseUser2 {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property({ length: 100 })
   firstName!: string;
-
-  @Property({ length: 100 })
   lastName!: string;
-
-  @Index({ name: 'base_user2_type_index' })
-  @Enum({ items: () => BaseUser2Type })
-  type!: BaseUser2Type;
-
-  @Property({ nullable: true })
+  type!: TBaseUser2Type;
   ownerProp?: string;
-
-  @Index({ name: 'base_user2_favourite_employee_id_index' })
-  @ManyToOne({ entity: () => BaseUser2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  favouriteEmployee?: BaseUser2;
-
-  @Unique({ name: 'base_user2_favourite_manager_id_unique' })
-  @OneToOne({ entity: () => BaseUser2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  favouriteManager?: BaseUser2;
-
-  @Property({ nullable: true, unique: true })
+  favouriteEmployee?: Ref<BaseUser2>;
+  favouriteManager?: Ref<BaseUser2>;
   employeeProp?: number;
-
-  @Property({ nullable: true })
   managerProp?: string;
-
+  baseUser2Collection = new Collection<BaseUser2>(this);
+  baseUser2?: Ref<BaseUser2>;
 }
 
-export enum BaseUser2Type {
-  EMPLOYEE = 'employee',
-  MANAGER = 'manager',
-  OWNER = 'owner',
-}
+export const BaseUser2Type = {
+  EMPLOYEE: 'employee',
+  MANAGER: 'manager',
+  OWNER: 'owner',
+} as const;
+
+export type TBaseUser2Type = (typeof BaseUser2Type)[keyof typeof BaseUser2Type];
+
+export const BaseUser2Schema = defineEntity({
+  class: BaseUser2,
+  properties: {
+    id: p.integer().primary(),
+    firstName: p.string().length(100),
+    lastName: p.string().length(100),
+    type: p.enum(() => BaseUser2Type).index('base_user2_type_index'),
+    ownerProp: p.string().nullable(),
+    favouriteEmployee: () => p.manyToOne(BaseUser2).ref().updateRule('cascade').deleteRule('set null').nullable(),
+    favouriteManager: () => p.oneToOne(BaseUser2).ref().updateRule('cascade').deleteRule('set null').nullable(),
+    employeeProp: p.integer().nullable().unique('base_user2_employee_prop_unique'),
+    managerProp: p.string().nullable(),
+    baseUser2Collection: () => p.oneToMany(BaseUser2).mappedBy('favouriteEmployee'),
+    baseUser2: () => p.oneToOne(BaseUser2).ref().mappedBy('favouriteManager'),
+  },
+});
 ",
-  "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, defineEntity, p } from '@mikro-orm/core';
+import { Book2 } from './Book2';
+import { Book2Tags } from './Book2Tags';
 
-@Entity()
 export class BookTag2 {
-
-  @PrimaryKey()
   id!: bigint;
-
-  @Property({ length: 50 })
   name!: string;
-
+  bookToTagUnorderedInverse = new Collection<Book2>(this);
+  book2TagsCollection = new Collection<Book2Tags>(this);
 }
+
+export const BookTag2Schema = defineEntity({
+  class: BookTag2,
+  properties: {
+    id: p.bigint().primary(),
+    name: p.string().length(50),
+    bookToTagUnorderedInverse: () => p.manyToMany(Book2).mappedBy('bookToTagUnordered'),
+    book2TagsCollection: () => p.oneToMany(Book2Tags).mappedBy('bookTag2'),
+  },
+});
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { Collection, type Opt, PrimaryKeyProp, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Author2 } from './Author2';
+import { Book2Tags } from './Book2Tags';
 import { BookTag2 } from './BookTag2';
 import { Publisher2 } from './Publisher2';
+import { Test2 } from './Test2';
 
-@Entity()
 export class Book2 {
-
   [PrimaryKeyProp]?: 'uuidPk';
-
-  @PrimaryKey({ length: 36 })
   uuidPk!: string;
-
-  @Property({ type: 'datetime', length: 3, defaultRaw: \`current_timestamp(3)\` })
   createdAt!: Date & Opt;
-
-  @Property({ type: 'character', length: 13, nullable: true, unique: true })
   isbn?: string;
-
-  @Index({ name: 'book2_title_index' })
-  @Property({ type: 'string', nullable: true })
   title?: string = '';
-
-  @Property({ type: 'text', length: 65535, nullable: true })
   perex?: string;
-
-  @Property({ type: 'decimal', precision: 8, scale: 2, nullable: true })
   price?: string;
-
-  @Property({ type: 'double', nullable: true })
   double?: number;
-
-  @Property({ type: 'json', nullable: true })
   meta?: any;
-
-  @Index({ name: 'book2_author_id_index' })
-  @ManyToOne({ entity: () => Author2 })
-  author!: Author2;
-
-  @Index({ name: 'book2_publisher_id_index' })
-  @ManyToOne({ entity: () => Publisher2, updateRule: 'cascade', deleteRule: 'cascade', nullable: true })
-  publisher?: Publisher2;
-
-  @Property({ type: 'string', nullable: true })
+  author!: Ref<Author2>;
+  publisher?: Ref<Publisher2>;
   foo?: string = 'lol';
-
-  @ManyToMany({ entity: () => BookTag2, pivotTable: 'book_to_tag_unordered', joinColumn: 'book2_uuid_pk', inverseJoinColumn: 'book_tag2_id' })
   bookToTagUnordered = new Collection<BookTag2>(this);
-
+  author2Collection = new Collection<Author2>(this);
+  book2TagsCollection = new Collection<Book2Tags>(this);
+  test2?: Ref<Test2>;
 }
+
+export const Book2Schema = defineEntity({
+  class: Book2,
+  properties: {
+    uuidPk: p.string().primary().length(36),
+    createdAt: p.datetime().length(3).defaultRaw(\`current_timestamp(3)\`),
+    isbn: p.character().length(13).nullable().unique('book2_isbn_unique'),
+    title: p.string().nullable().index('book2_title_index'),
+    perex: p.text().length(65535).nullable(),
+    price: p.decimal().precision(8).scale(2).nullable(),
+    double: p.double().nullable(),
+    meta: p.json().nullable(),
+    author: () => p.manyToOne(Author2).ref(),
+    publisher: () => p.manyToOne(Publisher2).ref().updateRule('cascade').deleteRule('cascade').nullable(),
+    foo: p.string().nullable(),
+    bookToTagUnordered: () => p.manyToMany(BookTag2).pivotTable('book_to_tag_unordered').joinColumn('book2_uuid_pk').inverseJoinColumn('book_tag2_id'),
+    author2Collection: () => p.oneToMany(Author2).mappedBy('favouriteBook'),
+    book2TagsCollection: () => p.oneToMany(Book2Tags).mappedBy('book2'),
+    test2: () => p.oneToOne(Test2).ref().mappedBy('book'),
+  },
+});
 ",
-  "import { Entity, Index, ManyToOne, PrimaryKey, PrimaryKeyProp } from '@mikro-orm/core';
+  "import { PrimaryKeyProp, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Book2 } from './Book2';
 import { BookTag2 } from './BookTag2';
 
-@Entity({ tableName: 'book2_tags' })
 export class Book2Tags {
-
   [PrimaryKeyProp]?: 'order';
-
-  @PrimaryKey()
   order!: number;
-
-  @Index({ name: 'book2_tags_book2_uuid_pk_index' })
-  @ManyToOne({ entity: () => Book2, updateRule: 'cascade', deleteRule: 'cascade' })
-  book2!: Book2;
-
-  @Index({ name: 'book2_tags_book_tag2_id_index' })
-  @ManyToOne({ entity: () => BookTag2, updateRule: 'cascade', deleteRule: 'cascade' })
-  bookTag2!: BookTag2;
-
+  book2!: Ref<Book2>;
+  bookTag2!: Ref<BookTag2>;
 }
+
+export const Book2TagsSchema = defineEntity({
+  class: Book2Tags,
+  tableName: 'book2_tags',
+  properties: {
+    order: p.integer().primary(),
+    book2: () => p.manyToOne(Book2).ref().updateRule('cascade').deleteRule('cascade'),
+    bookTag2: () => p.manyToOne(BookTag2).ref().updateRule('cascade').deleteRule('cascade'),
+  },
+});
 ",
-  "import { Entity, Index, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Car2 } from './Car2';
 
-@Entity()
 export class CarOwner2 {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property()
   name!: string;
-
-  @Index({ name: 'car_owner2_car_name_car_year_index' })
-  @ManyToOne({ entity: () => Car2, updateRule: 'cascade' })
-  car!: Car2;
-
+  car!: Ref<Car2>;
 }
-",
-  "import { Entity, Index, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
 
-@Entity()
+export const CarOwner2Schema = defineEntity({
+  class: CarOwner2,
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+    car: () => p.manyToOne(Car2).ref().updateRule('cascade'),
+  },
+});
+",
+  "import { Collection, PrimaryKeyProp, type Ref, defineEntity, p } from '@mikro-orm/core';
+import { CarOwner2 } from './CarOwner2';
+import { User2 } from './User2';
+
 export class Car2 {
-
   [PrimaryKeyProp]?: ['name', 'year'];
-
-  @Index({ name: 'car2_name_index' })
-  @PrimaryKey({ length: 100 })
   name!: string;
-
-  @Index({ name: 'car2_year_index' })
-  @PrimaryKey()
   year!: number;
-
-  @Property()
   price!: number;
-
+  carOwner2Collection = new Collection<CarOwner2>(this);
+  user2?: Ref<User2>;
+  carsInverse = new Collection<User2>(this);
 }
+
+export const Car2Schema = defineEntity({
+  class: Car2,
+  properties: {
+    name: p.string().primary().length(100).index('car2_name_index'),
+    year: p.integer().primary().index('car2_year_index'),
+    price: p.integer(),
+    carOwner2Collection: () => p.oneToMany(CarOwner2).mappedBy('car'),
+    user2: () => p.oneToOne(User2).ref().mappedBy('favouriteCar'),
+    carsInverse: () => p.manyToMany(User2).mappedBy('cars'),
+  },
+});
 ",
-  "import { Entity, Index, ManyToOne, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { PrimaryKeyProp, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Test2 } from './Test2';
 
-@Entity()
 export class Configuration2 {
-
   [PrimaryKeyProp]?: ['property', 'test'];
-
-  @PrimaryKey()
   property!: string;
-
-  @Index({ name: 'configuration2_test_id_index' })
-  @ManyToOne({ entity: () => Test2, updateRule: 'cascade', primary: true })
-  test!: Test2;
-
-  @Property()
+  test!: Ref<Test2>;
   value!: string;
-
 }
-",
-  "import { Entity, PrimaryKey } from '@mikro-orm/core';
 
-@Entity()
+export const Configuration2Schema = defineEntity({
+  class: Configuration2,
+  properties: {
+    property: p.string().primary(),
+    test: () => p.manyToOne(Test2).primary().ref().updateRule('cascade'),
+    value: p.string(),
+  },
+});
+",
+  "import { defineEntity, p } from '@mikro-orm/core';
+
 export class Dummy2 {
-
-  @PrimaryKey()
   id!: number;
-
 }
+
+export const Dummy2Schema = defineEntity({
+  class: Dummy2,
+  properties: {
+    id: p.integer().primary(),
+  },
+});
 ",
-  "import { Entity, OneToOne, type Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, type Opt, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { FooBaz2 } from './FooBaz2';
+import { FooParam2 } from './FooParam2';
+import { Test2 } from './Test2';
 
-@Entity()
 export class FooBar2 {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property()
   name!: string;
-
-  @Property({ fieldName: 'name with space', nullable: true })
   nameWithSpace?: string;
-
-  @Unique({ name: 'foo_bar2_baz_id_unique' })
-  @OneToOne({ entity: () => FooBaz2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  baz?: FooBaz2;
-
-  @Unique({ name: 'foo_bar2_foo_bar_id_unique' })
-  @OneToOne({ entity: () => FooBar2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  fooBar?: FooBar2;
-
-  @Property({ type: 'datetime', defaultRaw: \`CURRENT_TIMESTAMP\` })
+  baz?: Ref<FooBaz2>;
+  fooBar?: Ref<FooBar2>;
   version!: Date & Opt;
-
-  @Property({ length: 65535, nullable: true })
   blob?: Buffer;
-
-  @Property({ length: 65535, nullable: true })
   blob2?: Buffer;
-
-  @Property({ type: 'text', length: 65535, nullable: true })
   array?: string;
-
-  @Property({ type: 'json', nullable: true })
   objectProperty?: any;
-
+  fooBar2?: Ref<FooBar2>;
+  fooParam2Collection = new Collection<FooParam2>(this);
+  test2?: Ref<Test2>;
+  barsInverse = new Collection<Test2>(this);
 }
-",
-  "import { Entity, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 
-@Entity()
+export const FooBar2Schema = defineEntity({
+  class: FooBar2,
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+    nameWithSpace: p.string().name('name with space').nullable(),
+    baz: () => p.oneToOne(FooBaz2).ref().updateRule('cascade').deleteRule('set null').nullable(),
+    fooBar: () => p.oneToOne(FooBar2).ref().updateRule('cascade').deleteRule('set null').nullable(),
+    version: p.datetime().defaultRaw(\`CURRENT_TIMESTAMP\`),
+    blob: p.blob().length(65535).nullable(),
+    blob2: p.blob().length(65535).nullable(),
+    array: p.text().length(65535).nullable(),
+    objectProperty: p.json().nullable(),
+    fooBar2: () => p.oneToOne(FooBar2).ref().mappedBy('fooBar'),
+    fooParam2Collection: () => p.oneToMany(FooParam2).mappedBy('bar'),
+    test2: () => p.oneToOne(Test2).ref().mappedBy('fooBar'),
+    barsInverse: () => p.manyToMany(Test2).mappedBy('bars'),
+  },
+});
+",
+  "import { Collection, type Opt, type Ref, defineEntity, p } from '@mikro-orm/core';
+import { FooBar2 } from './FooBar2';
+import { FooParam2 } from './FooParam2';
+
 export class FooBaz2 {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property()
   name!: string;
-
-  @Property()
   code!: string;
-
-  @Property({ type: 'datetime', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
-
+  fooBar2?: Ref<FooBar2>;
+  fooParam2Collection = new Collection<FooParam2>(this);
 }
+
+export const FooBaz2Schema = defineEntity({
+  class: FooBaz2,
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+    code: p.string(),
+    version: p.datetime().length(3).defaultRaw(\`current_timestamp(3)\`),
+    fooBar2: () => p.oneToOne(FooBar2).ref().mappedBy('baz'),
+    fooParam2Collection: () => p.oneToMany(FooParam2).mappedBy('baz'),
+  },
+});
 ",
-  "import { Entity, Index, ManyToOne, type Opt, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { type Opt, PrimaryKeyProp, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { FooBar2 } from './FooBar2';
 import { FooBaz2 } from './FooBaz2';
 
-@Entity()
 export class FooParam2 {
-
   [PrimaryKeyProp]?: ['bar', 'baz'];
-
-  @Index({ name: 'foo_param2_bar_id_index' })
-  @ManyToOne({ entity: () => FooBar2, updateRule: 'cascade', primary: true })
-  bar!: FooBar2;
-
-  @Index({ name: 'foo_param2_baz_id_index' })
-  @ManyToOne({ entity: () => FooBaz2, updateRule: 'cascade', primary: true })
-  baz!: FooBaz2;
-
-  @Property()
+  bar!: Ref<FooBar2>;
+  baz!: Ref<FooBaz2>;
   value!: string;
-
-  @Property({ type: 'datetime', length: 3, defaultRaw: \`current_timestamp(3)\` })
   version!: Date & Opt;
-
 }
-",
-  "import { Entity, Enum, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
 
-@Entity()
+export const FooParam2Schema = defineEntity({
+  class: FooParam2,
+  properties: {
+    bar: () => p.manyToOne(FooBar2).primary().ref().updateRule('cascade'),
+    baz: () => p.manyToOne(FooBaz2).primary().ref().updateRule('cascade'),
+    value: p.string(),
+    version: p.datetime().length(3).defaultRaw(\`current_timestamp(3)\`),
+  },
+});
+",
+  "import { Collection, type Opt, defineEntity, p } from '@mikro-orm/core';
+import { Book2 } from './Book2';
+import { Publisher2Tests } from './Publisher2Tests';
+
 export class Publisher2 {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property({ type: 'string' })
   name: string & Opt = 'asd';
-
-  @Enum({ items: () => Publisher2Type })
-  type: Publisher2Type & Opt = Publisher2Type.LOCAL;
-
-  @Enum({ items: () => Publisher2Type2 })
-  type2: Publisher2Type2 & Opt = Publisher2Type2.LOCAL;
-
-  @Property({ type: 'tinyint', nullable: true })
+  type: TPublisher2Type & Opt = Publisher2Type.LOCAL;
+  type2: TPublisher2Type2 & Opt = Publisher2Type2.LOCAL;
   enum1?: number;
-
-  @Property({ type: 'tinyint', nullable: true })
   enum2?: number;
-
-  @Property({ type: 'tinyint', nullable: true })
   enum3?: number;
-
-  @Enum({ items: () => Publisher2Enum4, nullable: true })
-  enum4?: Publisher2Enum4;
-
-  @Enum({ items: () => Publisher2Enum5, nullable: true })
-  enum5?: Publisher2Enum5;
-
+  enum4?: TPublisher2Enum4;
+  enum5?: TPublisher2Enum5;
+  book2Collection = new Collection<Book2>(this);
+  publisher2TestsCollection = new Collection<Publisher2Tests>(this);
 }
 
-export enum Publisher2Type {
-  LOCAL = 'local',
-  GLOBAL = 'global',
-}
+export const Publisher2Type = {
+  LOCAL: 'local',
+  GLOBAL: 'global',
+} as const;
 
-export enum Publisher2Type2 {
-  LOCAL = 'LOCAL',
-  GLOBAL = 'GLOBAL',
-}
+export type TPublisher2Type = (typeof Publisher2Type)[keyof typeof Publisher2Type];
 
-export enum Publisher2Enum4 {
-  A = 'a',
-  B = 'b',
-  C = 'c',
-}
+export const Publisher2Type2 = {
+  LOCAL: 'LOCAL',
+  GLOBAL: 'GLOBAL',
+} as const;
 
-export enum Publisher2Enum5 {
-  A = 'a',
-}
+export type TPublisher2Type2 = (typeof Publisher2Type2)[keyof typeof Publisher2Type2];
+
+export const Publisher2Enum4 = {
+  A: 'a',
+  B: 'b',
+  C: 'c',
+} as const;
+
+export type TPublisher2Enum4 = (typeof Publisher2Enum4)[keyof typeof Publisher2Enum4];
+
+export const Publisher2Enum5 = {
+  A: 'a',
+} as const;
+
+export type TPublisher2Enum5 = (typeof Publisher2Enum5)[keyof typeof Publisher2Enum5];
+
+export const Publisher2Schema = defineEntity({
+  class: Publisher2,
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+    type: p.enum(() => Publisher2Type),
+    type2: p.enum(() => Publisher2Type2),
+    enum1: p.tinyint().nullable(),
+    enum2: p.tinyint().nullable(),
+    enum3: p.tinyint().nullable(),
+    enum4: p.enum(() => Publisher2Enum4).nullable(),
+    enum5: p.enum(() => Publisher2Enum5).nullable(),
+    book2Collection: () => p.oneToMany(Book2).mappedBy('publisher'),
+    publisher2TestsCollection: () => p.oneToMany(Publisher2Tests).mappedBy('publisher2'),
+  },
+});
 ",
-  "import { Entity, Index, ManyToOne, PrimaryKey } from '@mikro-orm/core';
+  "import { type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Publisher2 } from './Publisher2';
 import { Test2 } from './Test2';
 
-@Entity({ tableName: 'publisher2_tests' })
 export class Publisher2Tests {
-
-  @PrimaryKey()
   id!: number;
-
-  @Index({ name: 'publisher2_tests_publisher2_id_index' })
-  @ManyToOne({ entity: () => Publisher2, updateRule: 'cascade', deleteRule: 'cascade' })
-  publisher2!: Publisher2;
-
-  @Index({ name: 'publisher2_tests_test2_id_index' })
-  @ManyToOne({ entity: () => Test2, updateRule: 'cascade', deleteRule: 'cascade' })
-  test2!: Test2;
-
+  publisher2!: Ref<Publisher2>;
+  test2!: Ref<Test2>;
 }
-",
-  "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
 
-@Entity()
+export const Publisher2TestsSchema = defineEntity({
+  class: Publisher2Tests,
+  tableName: 'publisher2_tests',
+  properties: {
+    id: p.integer().primary(),
+    publisher2: () => p.manyToOne(Publisher2).ref().updateRule('cascade').deleteRule('cascade'),
+    test2: () => p.manyToOne(Test2).ref().updateRule('cascade').deleteRule('cascade'),
+  },
+});
+",
+  "import { Collection, defineEntity, p } from '@mikro-orm/core';
+import { User2 } from './User2';
+
 export class Sandwich {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property()
   name!: string;
-
-  @Property()
   price!: number;
-
+  sandwichesInverse = new Collection<User2>(this);
 }
+
+export const SandwichSchema = defineEntity({
+  class: Sandwich,
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+    price: p.integer(),
+    sandwichesInverse: () => p.manyToMany(User2).mappedBy('sandwiches'),
+  },
+});
 ",
-  "import { Collection, Entity, Index, ManyToMany, ManyToOne, OneToOne, type Opt, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, type Opt, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Book2 } from './Book2';
+import { Configuration2 } from './Configuration2';
 import { FooBar2 } from './FooBar2';
+import { Publisher2Tests } from './Publisher2Tests';
 
-@Entity()
 export class Test2 {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property({ nullable: true })
   name?: string;
-
-  @Unique({ name: 'test2_book_uuid_pk_unique' })
-  @OneToOne({ entity: () => Book2, deleteRule: 'set null', nullable: true })
-  book?: Book2;
-
-  @Index({ name: 'test2_parent_id_index' })
-  @ManyToOne({ entity: () => Test2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  parent?: Test2;
-
-  @Property({ type: 'integer' })
+  book?: Ref<Book2>;
+  parent?: Ref<Test2>;
   version: number & Opt = 1;
-
-  @Unique({ name: 'test2_foo___bar_unique' })
-  @OneToOne({ entity: () => FooBar2, fieldName: 'foo___bar', updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  fooBar?: FooBar2;
-
-  @Property({ fieldName: 'foo___baz', unsigned: true, nullable: true })
+  fooBar?: Ref<FooBar2>;
   fooBaz?: number;
-
-  @ManyToMany({ entity: () => FooBar2, joinColumn: 'test2_id', inverseJoinColumn: 'foo_bar2_id' })
   bars = new Collection<FooBar2>(this);
-
+  configuration2Collection = new Collection<Configuration2>(this);
+  publisher2TestsCollection = new Collection<Publisher2Tests>(this);
+  test2Collection = new Collection<Test2>(this);
 }
+
+export const Test2Schema = defineEntity({
+  class: Test2,
+  properties: {
+    id: p.integer().primary(),
+    name: p.string().nullable(),
+    book: () => p.oneToOne(Book2).ref().deleteRule('set null').nullable(),
+    parent: () => p.manyToOne(Test2).ref().updateRule('cascade').deleteRule('set null').nullable(),
+    version: p.integer(),
+    fooBar: () => p.oneToOne(FooBar2).ref().name('foo___bar').updateRule('cascade').deleteRule('set null').nullable(),
+    fooBaz: p.integer().name('foo___baz').unsigned().nullable(),
+    bars: () => p.manyToMany(FooBar2).joinColumn('test2_id').inverseJoinColumn('foo_bar2_id'),
+    configuration2Collection: () => p.oneToMany(Configuration2).mappedBy('test'),
+    publisher2TestsCollection: () => p.oneToMany(Publisher2Tests).mappedBy('test2'),
+    test2Collection: () => p.oneToMany(Test2).mappedBy('parent'),
+  },
+});
 ",
-  "import { Collection, Entity, ManyToMany, OneToOne, PrimaryKey, PrimaryKeyProp, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, PrimaryKeyProp, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Car2 } from './Car2';
 import { Sandwich } from './Sandwich';
 
-@Entity()
 export class User2 {
-
   [PrimaryKeyProp]?: ['firstName', 'lastName'];
-
-  @PrimaryKey({ length: 100 })
   firstName!: string;
-
-  @PrimaryKey({ length: 100 })
   lastName!: string;
-
-  @Property({ nullable: true })
   foo?: number;
-
-  @Unique({ name: 'user2_favourite_car_name_favourite_car_year_unique' })
-  @OneToOne({ entity: () => Car2, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  favouriteCar?: Car2;
-
-  @Property({ length: 100, nullable: true, persist: false })
+  favouriteCar?: Ref<Car2>;
   favouriteCarName?: string;
-
-  @Property({ unsigned: true, nullable: true, persist: false })
   favouriteCarYear?: number;
-
-  @ManyToMany({ entity: () => Car2, joinColumns: ['user2_first_name', 'user2_last_name'], inverseJoinColumns: ['car2_name', 'car2_year'] })
   cars = new Collection<Car2>(this);
-
-  @ManyToMany({ entity: () => Sandwich, joinColumns: ['user2_first_name', 'user2_last_name'], inverseJoinColumn: 'sandwich_id' })
   sandwiches = new Collection<Sandwich>(this);
-
 }
+
+export const User2Schema = defineEntity({
+  class: User2,
+  properties: {
+    firstName: p.string().primary().length(100),
+    lastName: p.string().primary().length(100),
+    foo: p.integer().nullable(),
+    favouriteCar: () => p.oneToOne(Car2).ref().updateRule('cascade').deleteRule('set null').nullable(),
+    favouriteCarName: p.string().length(100).nullable().persist(false),
+    favouriteCarYear: p.integer().unsigned().nullable().persist(false),
+    cars: () => p.manyToMany(Car2).joinColumns('user2_first_name', 'user2_last_name').inverseJoinColumns('car2_name', 'car2_year'),
+    sandwiches: () => p.manyToMany(Sandwich).joinColumns('user2_first_name', 'user2_last_name').inverseJoinColumn('sandwich_id'),
+  },
+});
 ",
 ]
 `;

--- a/tests/features/entity-generator/__snapshots__/TypesForScalarDecorators.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/TypesForScalarDecorators.mysql.test.ts.snap
@@ -2,29 +2,27 @@
 
 exports[`TypesForScalarDecorators > dump 1`] = `
 [
-  "import { Entity, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { type Opt, PrimaryKeyProp, defineEntity, p } from '@mikro-orm/core';
 
-@Entity()
 export class Users {
-
   [PrimaryKeyProp]?: 'userId';
-
-  @PrimaryKey({ type: 'integer' })
   userId!: number;
-
-  @Property({ type: 'string' })
   username!: string;
-
-  @Property({ type: 'bigint', unsigned: true })
   views!: bigint;
-
-  @Property({ type: 'boolean' })
   enabled!: boolean;
-
-  @Property({ type: 'datetime', defaultRaw: \`CURRENT_TIMESTAMP\` })
   createdAt!: Date & Opt;
-
 }
+
+export const UsersSchema = defineEntity({
+  class: Users,
+  properties: {
+    userId: p.integer().primary(),
+    username: p.string(),
+    views: p.bigint().unsigned(),
+    enabled: p.boolean(),
+    createdAt: p.datetime().defaultRaw(\`CURRENT_TIMESTAMP\`),
+  },
+});
 ",
 ]
 `;

--- a/tests/features/entity-generator/__snapshots__/UnknownType.mssql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/UnknownType.mssql.test.ts.snap
@@ -2,21 +2,22 @@
 
 exports[`unknown-types 1`] = `
 [
-  "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { defineEntity, p } from '@mikro-orm/core';
 
-@Entity()
 export class Test {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property({ columnType: 'xml', nullable: true, defaultRaw: \`<root>Test</root>\` })
   doc?: unknown;
-
-  @Property({ columnType: 'geometry', nullable: true })
   poly?: unknown;
-
 }
+
+export const TestSchema = defineEntity({
+  class: Test,
+  properties: {
+    id: p.integer().primary(),
+    doc: p.unknown().columnType('xml').nullable().defaultRaw(\`<root>Test</root>\`),
+    poly: p.unknown().columnType('geometry').nullable(),
+  },
+});
 ",
 ]
 `;

--- a/tests/features/entity-generator/__snapshots__/UnknownType.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/UnknownType.mysql.test.ts.snap
@@ -2,21 +2,22 @@
 
 exports[`unknown-types 1`] = `
 [
-  "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { defineEntity, p } from '@mikro-orm/core';
 
-@Entity()
 export class Test {
-
-  @PrimaryKey()
   id!: bigint;
-
-  @Property({ columnType: 'polygon', nullable: true })
   poly?: unknown;
-
-  @Property({ columnType: 'bit(8)', nullable: true, defaultRaw: \`b'1'\` })
   r?: unknown;
-
 }
+
+export const TestSchema = defineEntity({
+  class: Test,
+  properties: {
+    id: p.bigint().primary(),
+    poly: p.unknown().columnType('polygon').nullable(),
+    r: p.unknown().columnType('bit(8)').nullable().defaultRaw(\`b'1'\`),
+  },
+});
 ",
 ]
 `;

--- a/tests/features/entity-generator/__snapshots__/UnknownType.postgre.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/UnknownType.postgre.test.ts.snap
@@ -2,24 +2,24 @@
 
 exports[`unknown-types 1`] = `
 [
-  "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { defineEntity, p } from '@mikro-orm/core';
 
-@Entity()
 export class Test {
-
-  @PrimaryKey({ autoincrement: false })
   id!: bigint;
-
-  @Property({ type: 'unknown', columnType: 'cidr', nullable: true, default: '127.0.0.0/8' })
   cidr?: unknown;
-
-  @Property({ type: 'unknown', columnType: 'polygon', nullable: true, default: '((0,0),(1,0),(1,1),(0,1))' })
   poly?: unknown;
-
-  @Property({ type: 'unknown', columnType: 'varbit(8)', nullable: true, default: '1', ignoreSchemaChanges: ['type'] })
   r?: unknown;
-
 }
+
+export const TestSchema = defineEntity({
+  class: Test,
+  properties: {
+    id: p.bigint().primary().autoincrement(false),
+    cidr: p.unknown().columnType('cidr').nullable().default('127.0.0.0/8'),
+    poly: p.unknown().columnType('polygon').nullable().default('((0,0),(1,0),(1,1),(0,1))'),
+    r: p.unknown().columnType('varbit(8)').nullable().default('1').ignoreSchemaChanges('type'),
+  },
+});
 ",
 ]
 `;

--- a/tests/features/entity-generator/__snapshots__/character-types.mssql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/character-types.mssql.test.ts.snap
@@ -2,63 +2,50 @@
 
 exports[`character-types 1`] = `
 [
-  "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { defineEntity, p } from '@mikro-orm/core';
 
-@Entity()
 export class Test {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property({ type: 'string', columnType: 'varchar(max)', nullable: true })
   firstName?: string;
-
-  @Property({ type: 'string', columnType: 'char(1)', nullable: true })
   middleInitial?: string;
-
-  @Property({ type: 'string', columnType: 'varchar(255)', nullable: true })
   lastName?: string;
-
-  @Property({ type: 'character', nullable: true })
   gender?: string;
-
-  @Property({ type: 'character', length: 2, nullable: true })
   currency?: string;
-
-  @Property({ type: 'string', columnType: 'varchar(45)', nullable: true })
   locale?: string;
-
-  @Property({ type: 'string', columnType: 'char(2)', nullable: true })
   bloodType?: string;
-
-  @Property({ type: 'string', columnType: 'char(1)', nullable: true })
   motherInitial?: string;
-
-  @Property({ type: 'string', columnType: 'varchar(1)', nullable: true })
   spouceInitial?: string;
-
-  @Property({ length: -1, nullable: true })
   notes?: string;
-
-  @Property({ length: 1, nullable: true })
   favoriteLetter?: string;
-
-  @Property({ length: 10, nullable: true })
   governmentId?: string;
-
-  @Property({ nullable: true })
   descr?: string;
-
-  @Property({ type: 'character', nullable: true })
   fatherInitial?: string;
-
-  @Property({ type: 'string', columnType: 'varchar(1)', nullable: true })
   fatherInGroup?: string;
-
-  @Property({ length: 1, nullable: true })
   memberInGroup?: string;
-
 }
+
+export const TestSchema = defineEntity({
+  class: Test,
+  properties: {
+    id: p.integer().primary(),
+    firstName: p.string().columnType('varchar(max)').nullable(),
+    middleInitial: p.string().columnType('char(1)').nullable(),
+    lastName: p.string().columnType('varchar(255)').nullable(),
+    gender: p.character().nullable(),
+    currency: p.character().length(2).nullable(),
+    locale: p.string().columnType('varchar(45)').nullable(),
+    bloodType: p.string().columnType('char(2)').nullable(),
+    motherInitial: p.string().columnType('char(1)').nullable(),
+    spouceInitial: p.string().columnType('varchar(1)').nullable(),
+    notes: p.string().length(-1).nullable(),
+    favoriteLetter: p.string().length(1).nullable(),
+    governmentId: p.string().length(10).nullable(),
+    descr: p.string().nullable(),
+    fatherInitial: p.character().nullable(),
+    fatherInGroup: p.string().columnType('varchar(1)').nullable(),
+    memberInGroup: p.string().length(1).nullable(),
+  },
+});
 ",
 ]
 `;

--- a/tests/features/entity-generator/__snapshots__/character-types.postgres.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/character-types.postgres.test.ts.snap
@@ -2,54 +2,44 @@
 
 exports[`character-types 1`] = `
 [
-  "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { defineEntity, p } from '@mikro-orm/core';
 
-@Entity()
 export class Test {
-
-  @PrimaryKey({ autoincrement: false })
   id!: bigint;
-
-  @Property({ length: -1, nullable: true })
   firstName?: string;
-
-  @Property({ type: 'character', nullable: true })
   middleInitial?: string;
-
-  @Property({ nullable: true })
   lastName?: string;
-
-  @Property({ type: 'character', nullable: true })
   gender?: string;
-
-  @Property({ type: 'character', length: 2, nullable: true })
   currency?: string;
-
-  @Property({ length: 45, nullable: true })
   locale?: string;
-
-  @Property({ type: 'character', length: 2, nullable: true })
   bloodType?: string;
-
-  @Property({ type: 'character', nullable: true })
   motherInitial?: string;
-
-  @Property({ length: 1, nullable: true })
   spouceInitial?: string;
-
-  @Property({ type: 'character', length: -1, nullable: true })
   notes?: string;
-
-  @Property({ type: 'character', nullable: true })
   favoriteLetter?: string;
-
-  @Property({ type: 'character', length: 10, nullable: true })
   governmentId?: string;
-
-  @Property({ type: 'character', nullable: true })
   description?: string;
-
 }
+
+export const TestSchema = defineEntity({
+  class: Test,
+  properties: {
+    id: p.bigint().primary().autoincrement(false),
+    firstName: p.string().length(-1).nullable(),
+    middleInitial: p.character().nullable(),
+    lastName: p.string().nullable(),
+    gender: p.character().nullable(),
+    currency: p.character().length(2).nullable(),
+    locale: p.string().length(45).nullable(),
+    bloodType: p.character().length(2).nullable(),
+    motherInitial: p.character().nullable(),
+    spouceInitial: p.string().length(1).nullable(),
+    notes: p.character().length(-1).nullable(),
+    favoriteLetter: p.character().nullable(),
+    governmentId: p.character().length(10).nullable(),
+    description: p.character().nullable(),
+  },
+});
 ",
 ]
 `;

--- a/tests/features/entity-generator/__snapshots__/index-expressions.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/index-expressions.mysql.test.ts.snap
@@ -2,85 +2,80 @@
 
 exports[`4911 1`] = `
 [
-  "import { Entity, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { defineEntity, p } from '@mikro-orm/core';
 
-@Entity()
-@Unique({ name: 'dcim_device_unique_name_site', expression: 'alter table \`dcim_device\` add unique \`dcim_device_unique_name_site\` ((case when (\`tenant_id\` is null) then lower(\`name\`) end))' })
-@Unique({ name: 'dcim_device_unique_name_site_tenant', expression: 'alter table \`dcim_device\` add unique \`dcim_device_unique_name_site_tenant\` (lower(\`name\`))' })
-@Unique({ name: 'dcim_device_unique_rack_position_face', properties: ['rackId', 'position', 'face'] })
-@Unique({ name: 'dcim_device_unique_virtual_chassis_vc_position', properties: ['virtualChassisId', 'vcPosition'] })
 export class DcimDevice {
-
-  @Property({ columnType: 'timestamp', nullable: true })
   created?: Date;
-
-  @PrimaryKey({ unsigned: false, autoincrement: false })
   id!: bigint;
-
-  @Property({ nullable: true })
   name?: string;
-
-  @Property({ nullable: true })
   _name?: string;
-
-  @Property({ nullable: true, index: 'dcim_device_asset_tag_8dac1079_like', unique: 'dcim_device_asset_tag_key' })
   assetTag?: string;
-
-  @Property({ type: 'decimal', precision: 10, scale: 0, nullable: true })
   position?: string;
-
-  @Property()
   face!: string;
-
-  @Property({ type: 'smallint', nullable: true })
   vcPosition?: number;
-
-  @Property({ type: 'smallint', nullable: true })
   vcPriority?: number;
-
-  @Property({ nullable: true, index: 'dcim_device_cluster_id_cf852f78' })
   clusterId?: bigint;
-
-  @Property({ index: 'dcim_device_device_role_id_682e8188' })
   roleId!: bigint;
-
-  @Property({ index: 'dcim_device_device_type_id_d61b4086' })
   deviceTypeId!: bigint;
-
-  @Property({ nullable: true, index: 'dcim_device_location_id_11a7bedb' })
   locationId?: bigint;
-
-  @Property({ nullable: true, index: 'dcim_device_platform_id_468138f1' })
   platformId?: bigint;
-
-  @Property({ fieldName: 'primary_ip4_id', nullable: true, unique: 'dcim_device_primary_ip4_id_key' })
   primaryIp4Id?: bigint;
-
-  @Property({ fieldName: 'primary_ip6_id', nullable: true, unique: 'dcim_device_primary_ip6_id_key' })
   primaryIp6Id?: bigint;
-
-  @Property({ nullable: true, index: 'dcim_device_rack_id_23bde71f' })
   rackId?: bigint;
-
-  @Property({ index: 'dcim_device_site_id_ff897cf6' })
   siteId!: bigint;
-
-  @Property({ nullable: true, index: 'dcim_device_tenant_id_dcea7969' })
   tenantId?: bigint;
-
-  @Property({ nullable: true, index: 'dcim_device_virtual_chassis_id_aed51693' })
   virtualChassisId?: bigint;
-
-  @Property()
   airflow!: string;
-
-  @Property({ nullable: true, index: 'dcim_device_config_template_id_316328c4' })
   configTemplateId?: bigint;
-
-  @Property({ nullable: true, index: 'dcim_device_oob_ip_id_key' })
   oobIpId?: bigint;
-
 }
+
+export const DcimDeviceSchema = defineEntity({
+  class: DcimDevice,
+  uniques: [
+    {
+      name: 'dcim_device_unique_name_site',
+      expression: 'alter table \`dcim_device\` add unique \`dcim_device_unique_name_site\` ((case when (\`tenant_id\` is null) then lower(\`name\`) end))',
+    },
+    {
+      name: 'dcim_device_unique_name_site_tenant',
+      expression: 'alter table \`dcim_device\` add unique \`dcim_device_unique_name_site_tenant\` (lower(\`name\`))',
+    },
+    {
+      name: 'dcim_device_unique_rack_position_face',
+      properties: ['rackId', 'position', 'face'],
+    },
+    {
+      name: 'dcim_device_unique_virtual_chassis_vc_position',
+      properties: ['virtualChassisId', 'vcPosition'],
+    },
+  ],
+  properties: {
+    created: p.datetime().columnType('timestamp').nullable(),
+    id: p.bigint().primary().unsigned(false).autoincrement(false),
+    name: p.string().nullable(),
+    _name: p.string().nullable(),
+    assetTag: p.string().nullable().index('dcim_device_asset_tag_8dac1079_like').unique('dcim_device_asset_tag_key'),
+    position: p.decimal().precision(10).scale(0).nullable(),
+    face: p.string(),
+    vcPosition: p.smallint().nullable(),
+    vcPriority: p.smallint().nullable(),
+    clusterId: p.bigint().nullable().index('dcim_device_cluster_id_cf852f78'),
+    roleId: p.bigint().index('dcim_device_device_role_id_682e8188'),
+    deviceTypeId: p.bigint().index('dcim_device_device_type_id_d61b4086'),
+    locationId: p.bigint().nullable().index('dcim_device_location_id_11a7bedb'),
+    platformId: p.bigint().nullable().index('dcim_device_platform_id_468138f1'),
+    primaryIp4Id: p.bigint().name('primary_ip4_id').nullable().unique('dcim_device_primary_ip4_id_key'),
+    primaryIp6Id: p.bigint().name('primary_ip6_id').nullable().unique('dcim_device_primary_ip6_id_key'),
+    rackId: p.bigint().nullable().index('dcim_device_rack_id_23bde71f'),
+    siteId: p.bigint().index('dcim_device_site_id_ff897cf6'),
+    tenantId: p.bigint().nullable().index('dcim_device_tenant_id_dcea7969'),
+    virtualChassisId: p.bigint().nullable().index('dcim_device_virtual_chassis_id_aed51693'),
+    airflow: p.string(),
+    configTemplateId: p.bigint().nullable().index('dcim_device_config_template_id_316328c4'),
+    oobIpId: p.bigint().nullable().index('dcim_device_oob_ip_id_key'),
+  },
+});
 ",
 ]
 `;

--- a/tests/features/entity-generator/__snapshots__/index-expressions.postgres.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/index-expressions.postgres.test.ts.snap
@@ -2,85 +2,81 @@
 
 exports[`4911 1`] = `
 [
-  "import { Entity, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { defineEntity, p } from '@mikro-orm/core';
 
-@Entity()
-@Unique({ name: 'dcim_device_unique_name_site', expression: 'CREATE UNIQUE INDEX dcim_device_unique_name_site ON public.dcim_device USING btree (lower((name)::text), site_id) WHERE (tenant_id IS NULL)' })
-@Unique({ name: 'dcim_device_unique_name_site_tenant', expression: 'CREATE UNIQUE INDEX dcim_device_unique_name_site_tenant ON public.dcim_device USING btree (lower((name)::text), site_id, tenant_id)' })
-@Unique({ name: 'dcim_device_unique_rack_position_face', expression: 'CREATE UNIQUE INDEX dcim_device_unique_rack_position_face ON public.dcim_device USING btree (rack_id, "position", face)', properties: ['rackId', 'position', 'face'] })
-@Unique({ name: 'dcim_device_unique_virtual_chassis_vc_position', properties: ['virtualChassisId', 'vcPosition'] })
 export class DcimDevice {
-
-  @Property({ nullable: true })
   created?: Date;
-
-  @PrimaryKey({ autoincrement: false })
   id!: bigint;
-
-  @Property({ length: -1, nullable: true })
   name?: string;
-
-  @Property({ length: -1, nullable: true })
   _name?: string;
-
-  @Property({ length: -1, nullable: true, index: 'dcim_device_asset_tag_8dac1079_like', unique: 'dcim_device_asset_tag_key' })
   assetTag?: string;
-
-  @Property({ type: 'decimal', nullable: true })
   position?: string;
-
-  @Property({ length: -1 })
   face!: string;
-
-  @Property({ type: 'smallint', nullable: true })
   vcPosition?: number;
-
-  @Property({ type: 'smallint', nullable: true })
   vcPriority?: number;
-
-  @Property({ nullable: true, index: 'dcim_device_cluster_id_cf852f78' })
   clusterId?: bigint;
-
-  @Property({ index: 'dcim_device_device_role_id_682e8188' })
   roleId!: bigint;
-
-  @Property({ index: 'dcim_device_device_type_id_d61b4086' })
   deviceTypeId!: bigint;
-
-  @Property({ nullable: true, index: 'dcim_device_location_id_11a7bedb' })
   locationId?: bigint;
-
-  @Property({ nullable: true, index: 'dcim_device_platform_id_468138f1' })
   platformId?: bigint;
-
-  @Property({ fieldName: 'primary_ip4_id', nullable: true, unique: 'dcim_device_primary_ip4_id_key' })
   primaryIp4Id?: bigint;
-
-  @Property({ fieldName: 'primary_ip6_id', nullable: true, unique: 'dcim_device_primary_ip6_id_key' })
   primaryIp6Id?: bigint;
-
-  @Property({ nullable: true, index: 'dcim_device_rack_id_23bde71f' })
   rackId?: bigint;
-
-  @Property({ index: 'dcim_device_site_id_ff897cf6' })
   siteId!: bigint;
-
-  @Property({ nullable: true, index: 'dcim_device_tenant_id_dcea7969' })
   tenantId?: bigint;
-
-  @Property({ nullable: true, index: 'dcim_device_virtual_chassis_id_aed51693' })
   virtualChassisId?: bigint;
-
-  @Property({ length: -1 })
   airflow!: string;
-
-  @Property({ nullable: true, index: 'dcim_device_config_template_id_316328c4' })
   configTemplateId?: bigint;
-
-  @Property({ nullable: true, index: 'dcim_device_oob_ip_id_key' })
   oobIpId?: bigint;
-
 }
+
+export const DcimDeviceSchema = defineEntity({
+  class: DcimDevice,
+  uniques: [
+    {
+      name: 'dcim_device_unique_name_site',
+      expression: 'CREATE UNIQUE INDEX dcim_device_unique_name_site ON public.dcim_device USING btree (lower((name)::text), site_id) WHERE (tenant_id IS NULL)',
+    },
+    {
+      name: 'dcim_device_unique_name_site_tenant',
+      expression: 'CREATE UNIQUE INDEX dcim_device_unique_name_site_tenant ON public.dcim_device USING btree (lower((name)::text), site_id, tenant_id)',
+    },
+    {
+      name: 'dcim_device_unique_rack_position_face',
+      expression: 'CREATE UNIQUE INDEX dcim_device_unique_rack_position_face ON public.dcim_device USING btree (rack_id, "position", face)',
+      properties: ['rackId', 'position', 'face'],
+    },
+    {
+      name: 'dcim_device_unique_virtual_chassis_vc_position',
+      properties: ['virtualChassisId', 'vcPosition'],
+    },
+  ],
+  properties: {
+    created: p.datetime().nullable(),
+    id: p.bigint().primary().autoincrement(false),
+    name: p.string().length(-1).nullable(),
+    _name: p.string().length(-1).nullable(),
+    assetTag: p.string().length(-1).nullable().index('dcim_device_asset_tag_8dac1079_like').unique('dcim_device_asset_tag_key'),
+    position: p.decimal().nullable(),
+    face: p.string().length(-1),
+    vcPosition: p.smallint().nullable(),
+    vcPriority: p.smallint().nullable(),
+    clusterId: p.bigint().nullable().index('dcim_device_cluster_id_cf852f78'),
+    roleId: p.bigint().index('dcim_device_device_role_id_682e8188'),
+    deviceTypeId: p.bigint().index('dcim_device_device_type_id_d61b4086'),
+    locationId: p.bigint().nullable().index('dcim_device_location_id_11a7bedb'),
+    platformId: p.bigint().nullable().index('dcim_device_platform_id_468138f1'),
+    primaryIp4Id: p.bigint().name('primary_ip4_id').nullable().unique('dcim_device_primary_ip4_id_key'),
+    primaryIp6Id: p.bigint().name('primary_ip6_id').nullable().unique('dcim_device_primary_ip6_id_key'),
+    rackId: p.bigint().nullable().index('dcim_device_rack_id_23bde71f'),
+    siteId: p.bigint().index('dcim_device_site_id_ff897cf6'),
+    tenantId: p.bigint().nullable().index('dcim_device_tenant_id_dcea7969'),
+    virtualChassisId: p.bigint().nullable().index('dcim_device_virtual_chassis_id_aed51693'),
+    airflow: p.string().length(-1),
+    configTemplateId: p.bigint().nullable().index('dcim_device_config_template_id_316328c4'),
+    oobIpId: p.bigint().nullable().index('dcim_device_oob_ip_id_key'),
+  },
+});
 ",
 ]
 `;

--- a/tests/features/entity-generator/__snapshots__/index-expressions.sqlite.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/index-expressions.sqlite.test.ts.snap
@@ -2,83 +2,72 @@
 
 exports[`4911 1`] = `
 [
-  "import { Entity, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { defineEntity, p } from '@mikro-orm/core';
 
-@Entity()
-@Unique({ name: 'dcim_device_unique_rack_position_face', properties: ['rackId', 'position', 'face'] })
-@Unique({ name: 'dcim_device_unique_virtual_chassis_vc_position', properties: ['virtualChassisId', 'vcPosition'] })
 export class DcimDevice {
-
-  @Property({ columnType: 'timestamptz', nullable: true })
   created?: unknown;
-
-  @PrimaryKey({ columnType: 'int8' })
   id!: unknown;
-
-  @Property({ nullable: true })
   name?: string;
-
-  @Property({ nullable: true })
   _name?: string;
-
-  @Property({ nullable: true, index: 'dcim_device_asset_tag_8dac1079_like', unique: 'dcim_device_asset_tag_key' })
   assetTag?: string;
-
-  @Property({ type: 'decimal', nullable: true })
   position?: string;
-
-  @Property()
   face!: string;
-
-  @Property({ columnType: 'int2', nullable: true })
   vcPosition?: unknown;
-
-  @Property({ columnType: 'int2', nullable: true })
   vcPriority?: unknown;
-
-  @Property({ columnType: 'int8', nullable: true, index: 'dcim_device_cluster_id_cf852f78' })
   clusterId?: unknown;
-
-  @Property({ columnType: 'int8', index: 'dcim_device_device_role_id_682e8188' })
   roleId!: unknown;
-
-  @Property({ columnType: 'int8', index: 'dcim_device_device_type_id_d61b4086' })
   deviceTypeId!: unknown;
-
-  @Property({ columnType: 'int8', nullable: true, index: 'dcim_device_location_id_11a7bedb' })
   locationId?: unknown;
-
-  @Property({ columnType: 'int8', nullable: true, index: 'dcim_device_platform_id_468138f1' })
   platformId?: unknown;
-
-  @Property({ fieldName: 'primary_ip4_id', columnType: 'int8', nullable: true, unique: 'dcim_device_primary_ip4_id_key' })
   primaryIp4Id?: unknown;
-
-  @Property({ fieldName: 'primary_ip6_id', columnType: 'int8', nullable: true, unique: 'dcim_device_primary_ip6_id_key' })
   primaryIp6Id?: unknown;
-
-  @Property({ columnType: 'int8', nullable: true, index: 'dcim_device_rack_id_23bde71f' })
   rackId?: unknown;
-
-  @Property({ columnType: 'int8', index: 'dcim_device_site_id_ff897cf6' })
   siteId!: unknown;
-
-  @Property({ columnType: 'int8', nullable: true, index: 'dcim_device_tenant_id_dcea7969' })
   tenantId?: unknown;
-
-  @Property({ columnType: 'int8', nullable: true, index: 'dcim_device_virtual_chassis_id_aed51693' })
   virtualChassisId?: unknown;
-
-  @Property()
   airflow!: string;
-
-  @Property({ columnType: 'int8', nullable: true, index: 'dcim_device_config_template_id_316328c4' })
   configTemplateId?: unknown;
-
-  @Property({ columnType: 'int8', nullable: true, index: 'dcim_device_oob_ip_id_key' })
   oobIpId?: unknown;
-
 }
+
+export const DcimDeviceSchema = defineEntity({
+  class: DcimDevice,
+  uniques: [
+    {
+      name: 'dcim_device_unique_rack_position_face',
+      properties: ['rackId', 'position', 'face'],
+    },
+    {
+      name: 'dcim_device_unique_virtual_chassis_vc_position',
+      properties: ['virtualChassisId', 'vcPosition'],
+    },
+  ],
+  properties: {
+    created: p.unknown().columnType('timestamptz').nullable(),
+    id: p.unknown().primary().columnType('int8'),
+    name: p.string().nullable(),
+    _name: p.string().nullable(),
+    assetTag: p.string().nullable().index('dcim_device_asset_tag_8dac1079_like').unique('dcim_device_asset_tag_key'),
+    position: p.decimal().nullable(),
+    face: p.string(),
+    vcPosition: p.unknown().columnType('int2').nullable(),
+    vcPriority: p.unknown().columnType('int2').nullable(),
+    clusterId: p.unknown().columnType('int8').nullable().index('dcim_device_cluster_id_cf852f78'),
+    roleId: p.unknown().columnType('int8').index('dcim_device_device_role_id_682e8188'),
+    deviceTypeId: p.unknown().columnType('int8').index('dcim_device_device_type_id_d61b4086'),
+    locationId: p.unknown().columnType('int8').nullable().index('dcim_device_location_id_11a7bedb'),
+    platformId: p.unknown().columnType('int8').nullable().index('dcim_device_platform_id_468138f1'),
+    primaryIp4Id: p.unknown().name('primary_ip4_id').columnType('int8').nullable().unique('dcim_device_primary_ip4_id_key'),
+    primaryIp6Id: p.unknown().name('primary_ip6_id').columnType('int8').nullable().unique('dcim_device_primary_ip6_id_key'),
+    rackId: p.unknown().columnType('int8').nullable().index('dcim_device_rack_id_23bde71f'),
+    siteId: p.unknown().columnType('int8').index('dcim_device_site_id_ff897cf6'),
+    tenantId: p.unknown().columnType('int8').nullable().index('dcim_device_tenant_id_dcea7969'),
+    virtualChassisId: p.unknown().columnType('int8').nullable().index('dcim_device_virtual_chassis_id_aed51693'),
+    airflow: p.string(),
+    configTemplateId: p.unknown().columnType('int8').nullable().index('dcim_device_config_template_id_316328c4'),
+    oobIpId: p.unknown().columnType('int8').nullable().index('dcim_device_oob_ip_id_key'),
+  },
+});
 ",
 ]
 `;

--- a/tests/features/entity-generator/__snapshots__/multple-schemas.postgres.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/multple-schemas.postgres.test.ts.snap
@@ -2,124 +2,145 @@
 
 exports[`multiple schemas with same table name 1 1`] = `
 [
-  "import { Entity, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, type Ref, defineEntity, p } from '@mikro-orm/core';
 
-@Entity()
 export class Test {
-
-  @PrimaryKey({ autoincrement: false })
   id!: bigint;
-
-  @Property({ length: -1, nullable: true })
   name?: string;
-
-  @Property({ nullable: true })
   created?: Date;
-
-  @ManyToOne({ entity: () => Test, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  test?: Test;
-
+  test?: Ref<Test>;
+  testCollection = new Collection<Test>(this);
 }
-",
-  "import { Entity, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
 
-@Entity({ tableName: 'test', schema: 'schema1' })
+export const TestSchema = defineEntity({
+  class: Test,
+  properties: {
+    id: p.bigint().primary().autoincrement(false),
+    name: p.string().length(-1).nullable(),
+    created: p.datetime().nullable(),
+    test: () => p.manyToOne(Test).ref().updateRule('cascade').deleteRule('set null').nullable(),
+    testCollection: () => p.oneToMany(Test).mappedBy('test'),
+  },
+});
+",
+  "import { Collection, type Ref, defineEntity, p } from '@mikro-orm/core';
+
 export class Schema1Test {
-
-  @PrimaryKey({ autoincrement: false })
   id!: bigint;
-
-  @Property({ length: -1, nullable: true })
   name?: string;
-
-  @Property({ nullable: true })
   created?: Date;
-
-  @ManyToOne({ entity: () => Schema1Test, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  test?: Schema1Test;
-
+  test?: Ref<Schema1Test>;
+  schema1TestCollection = new Collection<Schema1Test>(this);
 }
+
+export const Schema1TestSchema = defineEntity({
+  class: Schema1Test,
+  tableName: 'test',
+  schema: 'schema1',
+  properties: {
+    id: p.bigint().primary().autoincrement(false),
+    name: p.string().length(-1).nullable(),
+    created: p.datetime().nullable(),
+    test: () => p.manyToOne(Schema1Test).ref().updateRule('cascade').deleteRule('set null').nullable(),
+    schema1TestCollection: () => p.oneToMany(Schema1Test).mappedBy('test'),
+  },
+});
 ",
-  "import { Entity, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, type Ref, defineEntity, p } from '@mikro-orm/core';
 
-@Entity({ tableName: 'test', schema: 'schema2' })
 export class Schema2Test {
-
-  @PrimaryKey({ autoincrement: false })
   id!: bigint;
-
-  @Property({ length: -1, nullable: true })
   name?: string;
-
-  @Property({ nullable: true })
   created?: Date;
-
-  @ManyToOne({ entity: () => Schema2Test, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  test?: Schema2Test;
-
+  test?: Ref<Schema2Test>;
+  schema2TestCollection = new Collection<Schema2Test>(this);
 }
+
+export const Schema2TestSchema = defineEntity({
+  class: Schema2Test,
+  tableName: 'test',
+  schema: 'schema2',
+  properties: {
+    id: p.bigint().primary().autoincrement(false),
+    name: p.string().length(-1).nullable(),
+    created: p.datetime().nullable(),
+    test: () => p.manyToOne(Schema2Test).ref().updateRule('cascade').deleteRule('set null').nullable(),
+    schema2TestCollection: () => p.oneToMany(Schema2Test).mappedBy('test'),
+  },
+});
 ",
 ]
 `;
 
 exports[`multiple schemas with same table name 2 1`] = `
 [
-  "import { Entity, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, type Ref, defineEntity, p } from '@mikro-orm/core';
 
-@Entity({ tableName: 'test' })
 export class PublicTest {
-
-  @PrimaryKey({ autoincrement: false })
   id!: bigint;
-
-  @Property({ length: -1, nullable: true })
   name?: string;
-
-  @Property({ nullable: true })
   created?: Date;
-
-  @ManyToOne({ entity: () => PublicTest, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  test?: PublicTest;
-
+  test?: Ref<PublicTest>;
+  publicTestCollection = new Collection<PublicTest>(this);
 }
-",
-  "import { Entity, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
 
-@Entity({ tableName: 'test', schema: 'schema1' })
+export const PublicTestSchema = defineEntity({
+  class: PublicTest,
+  tableName: 'test',
+  properties: {
+    id: p.bigint().primary().autoincrement(false),
+    name: p.string().length(-1).nullable(),
+    created: p.datetime().nullable(),
+    test: () => p.manyToOne(PublicTest).ref().updateRule('cascade').deleteRule('set null').nullable(),
+    publicTestCollection: () => p.oneToMany(PublicTest).mappedBy('test'),
+  },
+});
+",
+  "import { Collection, type Ref, defineEntity, p } from '@mikro-orm/core';
+
 export class Schema1Test {
-
-  @PrimaryKey({ autoincrement: false })
   id!: bigint;
-
-  @Property({ length: -1, nullable: true })
   name?: string;
-
-  @Property({ nullable: true })
   created?: Date;
-
-  @ManyToOne({ entity: () => Schema1Test, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  test?: Schema1Test;
-
+  test?: Ref<Schema1Test>;
+  schema1TestCollection = new Collection<Schema1Test>(this);
 }
+
+export const Schema1TestSchema = defineEntity({
+  class: Schema1Test,
+  tableName: 'test',
+  schema: 'schema1',
+  properties: {
+    id: p.bigint().primary().autoincrement(false),
+    name: p.string().length(-1).nullable(),
+    created: p.datetime().nullable(),
+    test: () => p.manyToOne(Schema1Test).ref().updateRule('cascade').deleteRule('set null').nullable(),
+    schema1TestCollection: () => p.oneToMany(Schema1Test).mappedBy('test'),
+  },
+});
 ",
-  "import { Entity, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, type Ref, defineEntity, p } from '@mikro-orm/core';
 
-@Entity({ tableName: 'test', schema: 'schema2' })
 export class Schema2Test {
-
-  @PrimaryKey({ autoincrement: false })
   id!: bigint;
-
-  @Property({ length: -1, nullable: true })
   name?: string;
-
-  @Property({ nullable: true })
   created?: Date;
-
-  @ManyToOne({ entity: () => Schema2Test, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  test?: Schema2Test;
-
+  test?: Ref<Schema2Test>;
+  schema2TestCollection = new Collection<Schema2Test>(this);
 }
+
+export const Schema2TestSchema = defineEntity({
+  class: Schema2Test,
+  tableName: 'test',
+  schema: 'schema2',
+  properties: {
+    id: p.bigint().primary().autoincrement(false),
+    name: p.string().length(-1).nullable(),
+    created: p.datetime().nullable(),
+    test: () => p.manyToOne(Schema2Test).ref().updateRule('cascade').deleteRule('set null').nullable(),
+    schema2TestCollection: () => p.oneToMany(Schema2Test).mappedBy('test'),
+  },
+});
 ",
 ]
 `;

--- a/tests/features/entity-generator/__snapshots__/shared-native-enum.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/shared-native-enum.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`shared native enums [dictionary] > [decorators] > shared native enum 1`] = `
 [
   "import { Collection, Entity, Enum, OneToMany, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
-import { DbRowStatus, TDbRowStatus } from './DbRowStatus';
+import { TDbRowStatus, TDbRowStatus } from './TDbRowStatus';
 import { UserRoles } from './UserRoles';
 
 @Entity()
@@ -32,7 +32,7 @@ export class Domains {
 }
 ",
   "import { Collection, Entity, Enum, OneToMany, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
-import { DbRowStatus, TDbRowStatus } from './DbRowStatus';
+import { TDbRowStatus, TDbRowStatus } from './TDbRowStatus';
 import { UserRoles } from './UserRoles';
 
 @Entity()
@@ -61,9 +61,9 @@ export class Roles {
 }
 ",
   "import { Entity, Enum, ManyToOne, type Opt, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
-import { DbRowStatus, TDbRowStatus } from './DbRowStatus';
 import { Domains } from './Domains';
 import { Roles } from './Roles';
+import { TDbRowStatus, TDbRowStatus } from './TDbRowStatus';
 import { Users } from './Users';
 
 @Entity()
@@ -101,7 +101,7 @@ export class UserRoles {
 }
 ",
   "import { Collection, Entity, Enum, OneToMany, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
-import { DbRowStatus, TDbRowStatus } from './DbRowStatus';
+import { TDbRowStatus, TDbRowStatus } from './TDbRowStatus';
 import { UserRoles } from './UserRoles';
 
 @Entity()
@@ -142,7 +142,7 @@ export type TDbRowStatus = (typeof DbRowStatus)[keyof typeof DbRowStatus];
 exports[`shared native enums [dictionary] > [defineEntity+types] > shared native enum 1`] = `
 [
   "import { InferEntity, defineEntity, p } from '@mikro-orm/core';
-import { DbRowStatus } from './DbRowStatus';
+import { TDbRowStatus } from './TDbRowStatus';
 import { UserRoles } from './UserRoles';
 
 export const Domains = defineEntity({
@@ -160,7 +160,7 @@ export const Domains = defineEntity({
 export interface IDomains extends InferEntity<typeof Domains> {}
 ",
   "import { InferEntity, defineEntity, p } from '@mikro-orm/core';
-import { DbRowStatus } from './DbRowStatus';
+import { TDbRowStatus } from './TDbRowStatus';
 import { UserRoles } from './UserRoles';
 
 export const Roles = defineEntity({
@@ -178,9 +178,9 @@ export const Roles = defineEntity({
 export interface IRoles extends InferEntity<typeof Roles> {}
 ",
   "import { InferEntity, defineEntity, p } from '@mikro-orm/core';
-import { DbRowStatus } from './DbRowStatus';
 import { Domains } from './Domains';
 import { Roles } from './Roles';
+import { TDbRowStatus } from './TDbRowStatus';
 import { Users } from './Users';
 
 export const UserRoles = defineEntity({
@@ -202,7 +202,7 @@ export const UserRoles = defineEntity({
 export interface IUserRoles extends InferEntity<typeof UserRoles> {}
 ",
   "import { InferEntity, defineEntity, p } from '@mikro-orm/core';
-import { DbRowStatus } from './DbRowStatus';
+import { TDbRowStatus } from './TDbRowStatus';
 import { UserRoles } from './UserRoles';
 
 export const Users = defineEntity({
@@ -234,7 +234,7 @@ export type TDbRowStatus = (typeof DbRowStatus)[keyof typeof DbRowStatus];
 exports[`shared native enums [dictionary] > [defineEntity] > shared native enum 1`] = `
 [
   "import { Collection, type Opt, PrimaryKeyProp, defineEntity, p } from '@mikro-orm/core';
-import { DbRowStatus, TDbRowStatus } from './DbRowStatus';
+import { TDbRowStatus, TDbRowStatus } from './TDbRowStatus';
 import { UserRoles } from './UserRoles';
 
 export class Domains {
@@ -260,7 +260,7 @@ export const DomainsSchema = defineEntity({
 });
 ",
   "import { Collection, type Opt, PrimaryKeyProp, defineEntity, p } from '@mikro-orm/core';
-import { DbRowStatus, TDbRowStatus } from './DbRowStatus';
+import { TDbRowStatus, TDbRowStatus } from './TDbRowStatus';
 import { UserRoles } from './UserRoles';
 
 export class Roles {
@@ -286,9 +286,9 @@ export const RolesSchema = defineEntity({
 });
 ",
   "import { type Opt, PrimaryKeyProp, type Ref, defineEntity, p } from '@mikro-orm/core';
-import { DbRowStatus, TDbRowStatus } from './DbRowStatus';
 import { Domains } from './Domains';
 import { Roles } from './Roles';
+import { TDbRowStatus, TDbRowStatus } from './TDbRowStatus';
 import { Users } from './Users';
 
 export class UserRoles {
@@ -320,7 +320,7 @@ export const UserRolesSchema = defineEntity({
 });
 ",
   "import { Collection, type Opt, defineEntity, p } from '@mikro-orm/core';
-import { DbRowStatus, TDbRowStatus } from './DbRowStatus';
+import { TDbRowStatus, TDbRowStatus } from './TDbRowStatus';
 import { UserRoles } from './UserRoles';
 
 export class Users {
@@ -359,7 +359,7 @@ export type TDbRowStatus = (typeof DbRowStatus)[keyof typeof DbRowStatus];
 exports[`shared native enums [dictionary] > [entitySchema] > shared native enum 1`] = `
 [
   "import { Collection, EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
-import { DbRowStatus, TDbRowStatus } from './DbRowStatus';
+import { TDbRowStatus, TDbRowStatus } from './TDbRowStatus';
 import { UserRoles } from './UserRoles';
 
 export class Domains {
@@ -393,7 +393,7 @@ export const DomainsSchema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
-import { DbRowStatus, TDbRowStatus } from './DbRowStatus';
+import { TDbRowStatus, TDbRowStatus } from './TDbRowStatus';
 import { UserRoles } from './UserRoles';
 
 export class Roles {
@@ -427,9 +427,9 @@ export const RolesSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
-import { DbRowStatus, TDbRowStatus } from './DbRowStatus';
 import { Domains } from './Domains';
 import { Roles } from './Roles';
+import { TDbRowStatus, TDbRowStatus } from './TDbRowStatus';
 import { Users } from './Users';
 
 export class UserRoles {
@@ -477,7 +477,7 @@ export const UserRolesSchema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, type Opt } from '@mikro-orm/core';
-import { DbRowStatus, TDbRowStatus } from './DbRowStatus';
+import { TDbRowStatus, TDbRowStatus } from './TDbRowStatus';
 import { UserRoles } from './UserRoles';
 
 export class Users {
@@ -524,7 +524,7 @@ export type TDbRowStatus = (typeof DbRowStatus)[keyof typeof DbRowStatus];
 exports[`shared native enums [ts-enum] > [decorators] > shared native enum 1`] = `
 [
   "import { Collection, Entity, Enum, OneToMany, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
-import { DbRowStatus } from './DbRowStatus';
+import { TDbRowStatus } from './TDbRowStatus';
 import { UserRoles } from './UserRoles';
 
 @Entity()
@@ -553,7 +553,7 @@ export class Domains {
 }
 ",
   "import { Collection, Entity, Enum, OneToMany, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
-import { DbRowStatus } from './DbRowStatus';
+import { TDbRowStatus } from './TDbRowStatus';
 import { UserRoles } from './UserRoles';
 
 @Entity()
@@ -582,9 +582,9 @@ export class Roles {
 }
 ",
   "import { Entity, Enum, ManyToOne, type Opt, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
-import { DbRowStatus } from './DbRowStatus';
 import { Domains } from './Domains';
 import { Roles } from './Roles';
+import { TDbRowStatus } from './TDbRowStatus';
 import { Users } from './Users';
 
 @Entity()
@@ -622,7 +622,7 @@ export class UserRoles {
 }
 ",
   "import { Collection, Entity, Enum, OneToMany, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
-import { DbRowStatus } from './DbRowStatus';
+import { TDbRowStatus } from './TDbRowStatus';
 import { UserRoles } from './UserRoles';
 
 @Entity()
@@ -661,7 +661,7 @@ export class Users {
 exports[`shared native enums [ts-enum] > [defineEntity+types] > shared native enum 1`] = `
 [
   "import { InferEntity, defineEntity, p } from '@mikro-orm/core';
-import { DbRowStatus } from './DbRowStatus';
+import { TDbRowStatus } from './TDbRowStatus';
 import { UserRoles } from './UserRoles';
 
 export const Domains = defineEntity({
@@ -679,7 +679,7 @@ export const Domains = defineEntity({
 export interface IDomains extends InferEntity<typeof Domains> {}
 ",
   "import { InferEntity, defineEntity, p } from '@mikro-orm/core';
-import { DbRowStatus } from './DbRowStatus';
+import { TDbRowStatus } from './TDbRowStatus';
 import { UserRoles } from './UserRoles';
 
 export const Roles = defineEntity({
@@ -697,9 +697,9 @@ export const Roles = defineEntity({
 export interface IRoles extends InferEntity<typeof Roles> {}
 ",
   "import { InferEntity, defineEntity, p } from '@mikro-orm/core';
-import { DbRowStatus } from './DbRowStatus';
 import { Domains } from './Domains';
 import { Roles } from './Roles';
+import { TDbRowStatus } from './TDbRowStatus';
 import { Users } from './Users';
 
 export const UserRoles = defineEntity({
@@ -721,7 +721,7 @@ export const UserRoles = defineEntity({
 export interface IUserRoles extends InferEntity<typeof UserRoles> {}
 ",
   "import { InferEntity, defineEntity, p } from '@mikro-orm/core';
-import { DbRowStatus } from './DbRowStatus';
+import { TDbRowStatus } from './TDbRowStatus';
 import { UserRoles } from './UserRoles';
 
 export const Users = defineEntity({
@@ -751,7 +751,7 @@ export interface IUsers extends InferEntity<typeof Users> {}
 exports[`shared native enums [ts-enum] > [defineEntity] > shared native enum 1`] = `
 [
   "import { Collection, type Opt, PrimaryKeyProp, defineEntity, p } from '@mikro-orm/core';
-import { DbRowStatus } from './DbRowStatus';
+import { TDbRowStatus } from './TDbRowStatus';
 import { UserRoles } from './UserRoles';
 
 export class Domains {
@@ -777,7 +777,7 @@ export const DomainsSchema = defineEntity({
 });
 ",
   "import { Collection, type Opt, PrimaryKeyProp, defineEntity, p } from '@mikro-orm/core';
-import { DbRowStatus } from './DbRowStatus';
+import { TDbRowStatus } from './TDbRowStatus';
 import { UserRoles } from './UserRoles';
 
 export class Roles {
@@ -803,9 +803,9 @@ export const RolesSchema = defineEntity({
 });
 ",
   "import { type Opt, PrimaryKeyProp, type Ref, defineEntity, p } from '@mikro-orm/core';
-import { DbRowStatus } from './DbRowStatus';
 import { Domains } from './Domains';
 import { Roles } from './Roles';
+import { TDbRowStatus } from './TDbRowStatus';
 import { Users } from './Users';
 
 export class UserRoles {
@@ -837,7 +837,7 @@ export const UserRolesSchema = defineEntity({
 });
 ",
   "import { Collection, type Opt, defineEntity, p } from '@mikro-orm/core';
-import { DbRowStatus } from './DbRowStatus';
+import { TDbRowStatus } from './TDbRowStatus';
 import { UserRoles } from './UserRoles';
 
 export class Users {
@@ -874,7 +874,7 @@ export const UsersSchema = defineEntity({
 exports[`shared native enums [ts-enum] > [entitySchema] > shared native enum 1`] = `
 [
   "import { Collection, EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
-import { DbRowStatus } from './DbRowStatus';
+import { TDbRowStatus } from './TDbRowStatus';
 import { UserRoles } from './UserRoles';
 
 export class Domains {
@@ -908,7 +908,7 @@ export const DomainsSchema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
-import { DbRowStatus } from './DbRowStatus';
+import { TDbRowStatus } from './TDbRowStatus';
 import { UserRoles } from './UserRoles';
 
 export class Roles {
@@ -942,9 +942,9 @@ export const RolesSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
-import { DbRowStatus } from './DbRowStatus';
 import { Domains } from './Domains';
 import { Roles } from './Roles';
+import { TDbRowStatus } from './TDbRowStatus';
 import { Users } from './Users';
 
 export class UserRoles {
@@ -992,7 +992,7 @@ export const UserRolesSchema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, type Opt } from '@mikro-orm/core';
-import { DbRowStatus } from './DbRowStatus';
+import { TDbRowStatus } from './TDbRowStatus';
 import { UserRoles } from './UserRoles';
 
 export class Users {
@@ -1037,7 +1037,7 @@ export const UsersSchema = new EntitySchema({
 exports[`shared native enums [union-type] > [decorators] > shared native enum 1`] = `
 [
   "import { Collection, Entity, Enum, OneToMany, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
-import { TDbRowStatus } from './DbRowStatus';
+import { TDbRowStatus } from './TDbRowStatus';
 import { UserRoles } from './UserRoles';
 
 @Entity()
@@ -1066,7 +1066,7 @@ export class Domains {
 }
 ",
   "import { Collection, Entity, Enum, OneToMany, type Opt, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
-import { TDbRowStatus } from './DbRowStatus';
+import { TDbRowStatus } from './TDbRowStatus';
 import { UserRoles } from './UserRoles';
 
 @Entity()
@@ -1095,9 +1095,9 @@ export class Roles {
 }
 ",
   "import { Entity, Enum, ManyToOne, type Opt, PrimaryKeyProp, Property, type Ref } from '@mikro-orm/core';
-import { TDbRowStatus } from './DbRowStatus';
 import { Domains } from './Domains';
 import { Roles } from './Roles';
+import { TDbRowStatus } from './TDbRowStatus';
 import { Users } from './Users';
 
 @Entity()
@@ -1135,7 +1135,7 @@ export class UserRoles {
 }
 ",
   "import { Collection, Entity, Enum, OneToMany, type Opt, PrimaryKey, Property } from '@mikro-orm/core';
-import { TDbRowStatus } from './DbRowStatus';
+import { TDbRowStatus } from './TDbRowStatus';
 import { UserRoles } from './UserRoles';
 
 @Entity()
@@ -1169,7 +1169,7 @@ export class Users {
 exports[`shared native enums [union-type] > [defineEntity+types] > shared native enum 1`] = `
 [
   "import { InferEntity, defineEntity, p } from '@mikro-orm/core';
-import {  } from './DbRowStatus';
+import {  } from './TDbRowStatus';
 import { UserRoles } from './UserRoles';
 
 export const Domains = defineEntity({
@@ -1187,7 +1187,7 @@ export const Domains = defineEntity({
 export interface IDomains extends InferEntity<typeof Domains> {}
 ",
   "import { InferEntity, defineEntity, p } from '@mikro-orm/core';
-import {  } from './DbRowStatus';
+import {  } from './TDbRowStatus';
 import { UserRoles } from './UserRoles';
 
 export const Roles = defineEntity({
@@ -1205,9 +1205,9 @@ export const Roles = defineEntity({
 export interface IRoles extends InferEntity<typeof Roles> {}
 ",
   "import { InferEntity, defineEntity, p } from '@mikro-orm/core';
-import {  } from './DbRowStatus';
 import { Domains } from './Domains';
 import { Roles } from './Roles';
+import {  } from './TDbRowStatus';
 import { Users } from './Users';
 
 export const UserRoles = defineEntity({
@@ -1229,7 +1229,7 @@ export const UserRoles = defineEntity({
 export interface IUserRoles extends InferEntity<typeof UserRoles> {}
 ",
   "import { InferEntity, defineEntity, p } from '@mikro-orm/core';
-import {  } from './DbRowStatus';
+import {  } from './TDbRowStatus';
 import { UserRoles } from './UserRoles';
 
 export const Users = defineEntity({
@@ -1254,7 +1254,7 @@ export interface IUsers extends InferEntity<typeof Users> {}
 exports[`shared native enums [union-type] > [defineEntity] > shared native enum 1`] = `
 [
   "import { Collection, type Opt, PrimaryKeyProp, defineEntity, p } from '@mikro-orm/core';
-import { TDbRowStatus } from './DbRowStatus';
+import { TDbRowStatus } from './TDbRowStatus';
 import { UserRoles } from './UserRoles';
 
 export class Domains {
@@ -1280,7 +1280,7 @@ export const DomainsSchema = defineEntity({
 });
 ",
   "import { Collection, type Opt, PrimaryKeyProp, defineEntity, p } from '@mikro-orm/core';
-import { TDbRowStatus } from './DbRowStatus';
+import { TDbRowStatus } from './TDbRowStatus';
 import { UserRoles } from './UserRoles';
 
 export class Roles {
@@ -1306,9 +1306,9 @@ export const RolesSchema = defineEntity({
 });
 ",
   "import { type Opt, PrimaryKeyProp, type Ref, defineEntity, p } from '@mikro-orm/core';
-import { TDbRowStatus } from './DbRowStatus';
 import { Domains } from './Domains';
 import { Roles } from './Roles';
+import { TDbRowStatus } from './TDbRowStatus';
 import { Users } from './Users';
 
 export class UserRoles {
@@ -1340,7 +1340,7 @@ export const UserRolesSchema = defineEntity({
 });
 ",
   "import { Collection, type Opt, defineEntity, p } from '@mikro-orm/core';
-import { TDbRowStatus } from './DbRowStatus';
+import { TDbRowStatus } from './TDbRowStatus';
 import { UserRoles } from './UserRoles';
 
 export class Users {
@@ -1372,7 +1372,7 @@ export const UsersSchema = defineEntity({
 exports[`shared native enums [union-type] > [entitySchema] > shared native enum 1`] = `
 [
   "import { Collection, EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
-import { TDbRowStatus } from './DbRowStatus';
+import { TDbRowStatus } from './TDbRowStatus';
 import { UserRoles } from './UserRoles';
 
 export class Domains {
@@ -1405,7 +1405,7 @@ export const DomainsSchema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, type Opt, PrimaryKeyProp } from '@mikro-orm/core';
-import { TDbRowStatus } from './DbRowStatus';
+import { TDbRowStatus } from './TDbRowStatus';
 import { UserRoles } from './UserRoles';
 
 export class Roles {
@@ -1438,9 +1438,9 @@ export const RolesSchema = new EntitySchema({
 });
 ",
   "import { EntitySchema, type Opt, PrimaryKeyProp, type Ref } from '@mikro-orm/core';
-import { TDbRowStatus } from './DbRowStatus';
 import { Domains } from './Domains';
 import { Roles } from './Roles';
+import { TDbRowStatus } from './TDbRowStatus';
 import { Users } from './Users';
 
 export class UserRoles {
@@ -1487,7 +1487,7 @@ export const UserRolesSchema = new EntitySchema({
 });
 ",
   "import { Collection, EntitySchema, type Opt } from '@mikro-orm/core';
-import { TDbRowStatus } from './DbRowStatus';
+import { TDbRowStatus } from './TDbRowStatus';
 import { UserRoles } from './UserRoles';
 
 export class Users {

--- a/tests/features/entity-generator/__snapshots__/smalldatetime.mssql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/smalldatetime.mssql.test.ts.snap
@@ -2,21 +2,22 @@
 
 exports[`small-date-time-type 1`] = `
 [
-  "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { defineEntity, p } from '@mikro-orm/core';
 
-@Entity()
 export class Test {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property({ columnType: 'smalldatetime', nullable: true, defaultRaw: \`current_timestamp\` })
   at?: Date;
-
-  @Property({ nullable: true, defaultRaw: \`current_timestamp\` })
   at2?: Date;
-
 }
+
+export const TestSchema = defineEntity({
+  class: Test,
+  properties: {
+    id: p.integer().primary(),
+    at: p.datetime().columnType('smalldatetime').nullable().defaultRaw(\`current_timestamp\`),
+    at2: p.datetime().nullable().defaultRaw(\`current_timestamp\`),
+  },
+});
 ",
 ]
 `;

--- a/tests/features/entity-generator/__snapshots__/timestamp.postgres.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/timestamp.postgres.test.ts.snap
@@ -2,23 +2,23 @@
 
 exports[`5918 > dump 1`] = `
 [
-  "import { BaseEntity, Entity, PrimaryKey, PrimaryKeyProp, Property } from '@mikro-orm/core';
+  "import { BaseEntity, PrimaryKeyProp, defineEntity, p } from '@mikro-orm/core';
 
-@Entity()
 export class Test extends BaseEntity {
-
   [PrimaryKeyProp]?: 'testId';
-
-  @PrimaryKey({ type: 'integer' })
   testId!: number;
-
-  @Property({ type: 'datetime', columnType: 'timestamp(6)' })
   testDataCadastro!: Date;
-
-  @Property({ type: 'datetime', columnType: 'timestamp(6)' })
   testDataAlteracao!: Date;
-
 }
+
+export const TestSchema = defineEntity({
+  class: Test,
+  properties: {
+    testId: p.integer().primary(),
+    testDataCadastro: p.datetime().columnType('timestamp(6)'),
+    testDataAlteracao: p.datetime().columnType('timestamp(6)'),
+  },
+});
 ",
 ]
 `;

--- a/tests/features/multiple-schemas/__snapshots__/multiple-schemas.mssql.test.ts.snap
+++ b/tests/features/multiple-schemas/__snapshots__/multiple-schemas.mssql.test.ts.snap
@@ -2,211 +2,281 @@
 
 exports[`generate entities for all schemas 1`] = `
 [
-  "import { Entity, OneToOne, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, type Ref, defineEntity, p } from '@mikro-orm/core';
+import { N2Book } from './N2Book';
+import { N3Book } from './N3Book';
+import { N4Book } from './N4Book';
+import { N5Book } from './N5Book';
 
-@Entity({ schema: 'n1' })
 export class Author {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property()
   name!: string;
-
-  @Unique({ name: 'author_mentor_id_unique', expression: 'create unique index [author_mentor_id_unique] on [author] (where ([mentor_id] IS NOT NULL))' })
-  @OneToOne({ entity: () => Author, nullable: true })
-  mentor?: Author;
-
+  mentor?: Ref<Author>;
+  author?: Ref<Author>;
+  n2BookCollection = new Collection<N2Book>(this);
+  n3BookCollection = new Collection<N3Book>(this);
+  n4BookCollection = new Collection<N4Book>(this);
+  n5BookCollection = new Collection<N5Book>(this);
 }
+
+export const AuthorSchema = defineEntity({
+  class: Author,
+  schema: 'n1',
+  uniques: [
+    {
+      name: 'author_mentor_id_unique',
+      expression: 'create unique index [author_mentor_id_unique] on [author] (where ([mentor_id] IS NOT NULL))',
+      properties: ['mentor'],
+    },
+  ],
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+    mentor: () => p.oneToOne(Author).ref().nullable(),
+    author: () => p.oneToOne(Author).ref().mappedBy('mentor'),
+    n2BookCollection: () => p.oneToMany(N2Book).mappedBy('author'),
+    n3BookCollection: () => p.oneToMany(N3Book).mappedBy('author'),
+    n4BookCollection: () => p.oneToMany(N4Book).mappedBy('author'),
+    n5BookCollection: () => p.oneToMany(N5Book).mappedBy('author'),
+  },
+});
 ",
-  "import { Collection, Entity, ManyToMany, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Author } from './Author';
 import { N2BookTag } from './N2BookTag';
 
-@Entity({ tableName: 'book', schema: 'n2' })
 export class N2Book {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property({ nullable: true })
   name?: string;
-
-  @ManyToOne({ entity: () => Author, updateRule: 'cascade', deleteRule: 'cascade', nullable: true })
-  author?: Author;
-
-  @ManyToOne({ entity: () => N2Book, nullable: true })
-  basedOn?: N2Book;
-
-  @ManyToMany({ entity: () => N2BookTag, joinColumn: 'book_id', inverseJoinColumn: 'book_tag_id' })
+  author?: Ref<Author>;
+  basedOn?: Ref<N2Book>;
   tags = new Collection<N2BookTag>(this);
-
+  n2BookCollection = new Collection<N2Book>(this);
 }
-",
-  "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
 
-@Entity({ tableName: 'book_tag', schema: 'n2' })
+export const N2BookSchema = defineEntity({
+  class: N2Book,
+  tableName: 'book',
+  schema: 'n2',
+  properties: {
+    id: p.integer().primary(),
+    name: p.string().nullable(),
+    author: () => p.manyToOne(Author).ref().updateRule('cascade').deleteRule('cascade').nullable(),
+    basedOn: () => p.manyToOne(N2Book).ref().nullable(),
+    tags: () => p.manyToMany(N2BookTag).joinColumn('book_id').inverseJoinColumn('book_tag_id'),
+    n2BookCollection: () => p.oneToMany(N2Book).mappedBy('basedOn'),
+  },
+});
+",
+  "import { Collection, defineEntity, p } from '@mikro-orm/core';
+import { N2Book } from './N2Book';
+
 export class N2BookTag {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property({ nullable: true })
   name?: string;
-
+  tagsInverse = new Collection<N2Book>(this);
 }
+
+export const N2BookTagSchema = defineEntity({
+  class: N2BookTag,
+  tableName: 'book_tag',
+  schema: 'n2',
+  properties: {
+    id: p.integer().primary(),
+    name: p.string().nullable(),
+    tagsInverse: () => p.manyToMany(N2Book).mappedBy('tags'),
+  },
+});
 ",
-  "import { Collection, Entity, ManyToMany, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Author } from './Author';
 import { N3BookTag } from './N3BookTag';
 
-@Entity({ tableName: 'book', schema: 'n3' })
 export class N3Book {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property({ nullable: true })
   name?: string;
-
-  @ManyToOne({ entity: () => Author, updateRule: 'cascade', deleteRule: 'cascade', nullable: true })
-  author?: Author;
-
-  @ManyToOne({ entity: () => N3Book, nullable: true })
-  basedOn?: N3Book;
-
-  @ManyToMany({ entity: () => N3BookTag, joinColumn: 'book_id', inverseJoinColumn: 'book_tag_id' })
+  author?: Ref<Author>;
+  basedOn?: Ref<N3Book>;
   tags = new Collection<N3BookTag>(this);
-
+  n3BookCollection = new Collection<N3Book>(this);
 }
-",
-  "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
 
-@Entity({ tableName: 'book_tag', schema: 'n3' })
+export const N3BookSchema = defineEntity({
+  class: N3Book,
+  tableName: 'book',
+  schema: 'n3',
+  properties: {
+    id: p.integer().primary(),
+    name: p.string().nullable(),
+    author: () => p.manyToOne(Author).ref().updateRule('cascade').deleteRule('cascade').nullable(),
+    basedOn: () => p.manyToOne(N3Book).ref().nullable(),
+    tags: () => p.manyToMany(N3BookTag).joinColumn('book_id').inverseJoinColumn('book_tag_id'),
+    n3BookCollection: () => p.oneToMany(N3Book).mappedBy('basedOn'),
+  },
+});
+",
+  "import { Collection, defineEntity, p } from '@mikro-orm/core';
+import { N3Book } from './N3Book';
+
 export class N3BookTag {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property({ nullable: true })
   name?: string;
-
+  tagsInverse = new Collection<N3Book>(this);
 }
+
+export const N3BookTagSchema = defineEntity({
+  class: N3BookTag,
+  tableName: 'book_tag',
+  schema: 'n3',
+  properties: {
+    id: p.integer().primary(),
+    name: p.string().nullable(),
+    tagsInverse: () => p.manyToMany(N3Book).mappedBy('tags'),
+  },
+});
 ",
-  "import { Collection, Entity, ManyToMany, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Author } from './Author';
 import { N4BookTag } from './N4BookTag';
 
-@Entity({ tableName: 'book', schema: 'n4' })
 export class N4Book {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property({ nullable: true })
   name?: string;
-
-  @ManyToOne({ entity: () => Author, updateRule: 'cascade', deleteRule: 'cascade', nullable: true })
-  author?: Author;
-
-  @ManyToOne({ entity: () => N4Book, nullable: true })
-  basedOn?: N4Book;
-
-  @ManyToMany({ entity: () => N4BookTag, joinColumn: 'book_id', inverseJoinColumn: 'book_tag_id' })
+  author?: Ref<Author>;
+  basedOn?: Ref<N4Book>;
   tags = new Collection<N4BookTag>(this);
-
+  n4BookCollection = new Collection<N4Book>(this);
 }
-",
-  "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
 
-@Entity({ tableName: 'book_tag', schema: 'n4' })
+export const N4BookSchema = defineEntity({
+  class: N4Book,
+  tableName: 'book',
+  schema: 'n4',
+  properties: {
+    id: p.integer().primary(),
+    name: p.string().nullable(),
+    author: () => p.manyToOne(Author).ref().updateRule('cascade').deleteRule('cascade').nullable(),
+    basedOn: () => p.manyToOne(N4Book).ref().nullable(),
+    tags: () => p.manyToMany(N4BookTag).joinColumn('book_id').inverseJoinColumn('book_tag_id'),
+    n4BookCollection: () => p.oneToMany(N4Book).mappedBy('basedOn'),
+  },
+});
+",
+  "import { Collection, defineEntity, p } from '@mikro-orm/core';
+import { N4Book } from './N4Book';
+
 export class N4BookTag {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property({ nullable: true })
   name?: string;
-
+  tagsInverse = new Collection<N4Book>(this);
 }
+
+export const N4BookTagSchema = defineEntity({
+  class: N4BookTag,
+  tableName: 'book_tag',
+  schema: 'n4',
+  properties: {
+    id: p.integer().primary(),
+    name: p.string().nullable(),
+    tagsInverse: () => p.manyToMany(N4Book).mappedBy('tags'),
+  },
+});
 ",
-  "import { Collection, Entity, ManyToMany, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Author } from './Author';
 import { N5BookTag } from './N5BookTag';
 
-@Entity({ tableName: 'book', schema: 'n5' })
 export class N5Book {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property({ nullable: true })
   name?: string;
-
-  @ManyToOne({ entity: () => Author, updateRule: 'cascade', deleteRule: 'cascade', nullable: true })
-  author?: Author;
-
-  @ManyToOne({ entity: () => N5Book, nullable: true })
-  basedOn?: N5Book;
-
-  @ManyToMany({ entity: () => N5BookTag, joinColumn: 'book_id', inverseJoinColumn: 'book_tag_id' })
+  author?: Ref<Author>;
+  basedOn?: Ref<N5Book>;
   tags = new Collection<N5BookTag>(this);
-
+  n5BookCollection = new Collection<N5Book>(this);
 }
+
+export const N5BookSchema = defineEntity({
+  class: N5Book,
+  tableName: 'book',
+  schema: 'n5',
+  properties: {
+    id: p.integer().primary(),
+    name: p.string().nullable(),
+    author: () => p.manyToOne(Author).ref().updateRule('cascade').deleteRule('cascade').nullable(),
+    basedOn: () => p.manyToOne(N5Book).ref().nullable(),
+    tags: () => p.manyToMany(N5BookTag).joinColumn('book_id').inverseJoinColumn('book_tag_id'),
+    n5BookCollection: () => p.oneToMany(N5Book).mappedBy('basedOn'),
+  },
+});
 ",
-  "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, defineEntity, p } from '@mikro-orm/core';
+import { N5Book } from './N5Book';
 
-@Entity({ tableName: 'book_tag', schema: 'n5' })
 export class N5BookTag {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property({ nullable: true })
   name?: string;
-
+  tagsInverse = new Collection<N5Book>(this);
 }
+
+export const N5BookTagSchema = defineEntity({
+  class: N5BookTag,
+  tableName: 'book_tag',
+  schema: 'n5',
+  properties: {
+    id: p.integer().primary(),
+    name: p.string().nullable(),
+    tagsInverse: () => p.manyToMany(N5Book).mappedBy('tags'),
+  },
+});
 ",
 ]
 `;
 
 exports[`multiple connected schemas in mssql > generate entities for given schema only 1`] = `
 [
-  "import { Collection, Entity, ManyToMany, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { BookTag } from './BookTag';
 
-@Entity({ schema: 'n2' })
 export class Book {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property({ nullable: true })
   name?: string;
-
-  @Property({ fieldName: 'author_id', nullable: true })
   author?: number;
-
-  @ManyToOne({ entity: () => Book, nullable: true })
-  basedOn?: Book;
-
-  @ManyToMany({ entity: () => BookTag, joinColumn: 'book_id', inverseJoinColumn: 'book_tag_id' })
+  basedOn?: Ref<Book>;
   tags = new Collection<BookTag>(this);
-
+  bookCollection = new Collection<Book>(this);
 }
+
+export const BookSchema = defineEntity({
+  class: Book,
+  schema: 'n2',
+  properties: {
+    id: p.integer().primary(),
+    name: p.string().nullable(),
+    author: p.integer().name('author_id').nullable(),
+    basedOn: () => p.manyToOne(Book).ref().nullable(),
+    tags: () => p.manyToMany(BookTag).joinColumn('book_id').inverseJoinColumn('book_tag_id'),
+    bookCollection: () => p.oneToMany(Book).mappedBy('basedOn'),
+  },
+});
 ",
-  "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, defineEntity, p } from '@mikro-orm/core';
+import { Book } from './Book';
 
-@Entity({ schema: 'n2' })
 export class BookTag {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property({ nullable: true })
   name?: string;
-
+  tagsInverse = new Collection<Book>(this);
 }
+
+export const BookTagSchema = defineEntity({
+  class: BookTag,
+  schema: 'n2',
+  properties: {
+    id: p.integer().primary(),
+    name: p.string().nullable(),
+    tagsInverse: () => p.manyToMany(Book).mappedBy('tags'),
+  },
+});
 ",
 ]
 `;

--- a/tests/features/multiple-schemas/__snapshots__/multiple-schemas.postgres.test.ts.snap
+++ b/tests/features/multiple-schemas/__snapshots__/multiple-schemas.postgres.test.ts.snap
@@ -2,211 +2,274 @@
 
 exports[`multiple connected schemas in postgres > generate entities for all schemas 1`] = `
 [
-  "import { Entity, OneToOne, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+  "import { Collection, type Ref, defineEntity, p } from '@mikro-orm/core';
+import { N2Book } from './N2Book';
+import { N3Book } from './N3Book';
+import { N4Book } from './N4Book';
+import { N5Book } from './N5Book';
 
-@Entity({ schema: 'n1' })
 export class Author {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property()
   name!: string;
-
-  @Unique({ name: 'author_mentor_id_unique' })
-  @OneToOne({ entity: () => Author, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  mentor?: Author;
-
+  mentor?: Ref<Author>;
+  author?: Ref<Author>;
+  n2BookCollection = new Collection<N2Book>(this);
+  n3BookCollection = new Collection<N3Book>(this);
+  n4BookCollection = new Collection<N4Book>(this);
+  n5BookCollection = new Collection<N5Book>(this);
 }
+
+export const AuthorSchema = defineEntity({
+  class: Author,
+  schema: 'n1',
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+    mentor: () => p.oneToOne(Author).ref().updateRule('cascade').deleteRule('set null').nullable(),
+    author: () => p.oneToOne(Author).ref().mappedBy('mentor'),
+    n2BookCollection: () => p.oneToMany(N2Book).mappedBy('author'),
+    n3BookCollection: () => p.oneToMany(N3Book).mappedBy('author'),
+    n4BookCollection: () => p.oneToMany(N4Book).mappedBy('author'),
+    n5BookCollection: () => p.oneToMany(N5Book).mappedBy('author'),
+  },
+});
 ",
-  "import { Collection, Entity, ManyToMany, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Author } from './Author';
 import { N2BookTag } from './N2BookTag';
 
-@Entity({ tableName: 'book', schema: 'n2' })
 export class N2Book {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property({ nullable: true })
   name?: string;
-
-  @ManyToOne({ entity: () => Author, updateRule: 'cascade', deleteRule: 'cascade', nullable: true })
-  author?: Author;
-
-  @ManyToOne({ entity: () => N2Book, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  basedOn?: N2Book;
-
-  @ManyToMany({ entity: () => N2BookTag, joinColumn: 'book_id', inverseJoinColumn: 'book_tag_id' })
+  author?: Ref<Author>;
+  basedOn?: Ref<N2Book>;
   tags = new Collection<N2BookTag>(this);
-
+  n2BookCollection = new Collection<N2Book>(this);
 }
-",
-  "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
 
-@Entity({ tableName: 'book_tag', schema: 'n2' })
+export const N2BookSchema = defineEntity({
+  class: N2Book,
+  tableName: 'book',
+  schema: 'n2',
+  properties: {
+    id: p.integer().primary(),
+    name: p.string().nullable(),
+    author: () => p.manyToOne(Author).ref().updateRule('cascade').deleteRule('cascade').nullable(),
+    basedOn: () => p.manyToOne(N2Book).ref().updateRule('cascade').deleteRule('set null').nullable(),
+    tags: () => p.manyToMany(N2BookTag).joinColumn('book_id').inverseJoinColumn('book_tag_id'),
+    n2BookCollection: () => p.oneToMany(N2Book).mappedBy('basedOn'),
+  },
+});
+",
+  "import { Collection, defineEntity, p } from '@mikro-orm/core';
+import { N2Book } from './N2Book';
+
 export class N2BookTag {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property({ nullable: true })
   name?: string;
-
+  tagsInverse = new Collection<N2Book>(this);
 }
+
+export const N2BookTagSchema = defineEntity({
+  class: N2BookTag,
+  tableName: 'book_tag',
+  schema: 'n2',
+  properties: {
+    id: p.integer().primary(),
+    name: p.string().nullable(),
+    tagsInverse: () => p.manyToMany(N2Book).mappedBy('tags'),
+  },
+});
 ",
-  "import { Collection, Entity, ManyToMany, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Author } from './Author';
 import { N3BookTag } from './N3BookTag';
 
-@Entity({ tableName: 'book', schema: 'n3' })
 export class N3Book {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property({ nullable: true })
   name?: string;
-
-  @ManyToOne({ entity: () => Author, updateRule: 'cascade', deleteRule: 'cascade', nullable: true })
-  author?: Author;
-
-  @ManyToOne({ entity: () => N3Book, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  basedOn?: N3Book;
-
-  @ManyToMany({ entity: () => N3BookTag, joinColumn: 'book_id', inverseJoinColumn: 'book_tag_id' })
+  author?: Ref<Author>;
+  basedOn?: Ref<N3Book>;
   tags = new Collection<N3BookTag>(this);
-
+  n3BookCollection = new Collection<N3Book>(this);
 }
-",
-  "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
 
-@Entity({ tableName: 'book_tag', schema: 'n3' })
+export const N3BookSchema = defineEntity({
+  class: N3Book,
+  tableName: 'book',
+  schema: 'n3',
+  properties: {
+    id: p.integer().primary(),
+    name: p.string().nullable(),
+    author: () => p.manyToOne(Author).ref().updateRule('cascade').deleteRule('cascade').nullable(),
+    basedOn: () => p.manyToOne(N3Book).ref().updateRule('cascade').deleteRule('set null').nullable(),
+    tags: () => p.manyToMany(N3BookTag).joinColumn('book_id').inverseJoinColumn('book_tag_id'),
+    n3BookCollection: () => p.oneToMany(N3Book).mappedBy('basedOn'),
+  },
+});
+",
+  "import { Collection, defineEntity, p } from '@mikro-orm/core';
+import { N3Book } from './N3Book';
+
 export class N3BookTag {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property({ nullable: true })
   name?: string;
-
+  tagsInverse = new Collection<N3Book>(this);
 }
+
+export const N3BookTagSchema = defineEntity({
+  class: N3BookTag,
+  tableName: 'book_tag',
+  schema: 'n3',
+  properties: {
+    id: p.integer().primary(),
+    name: p.string().nullable(),
+    tagsInverse: () => p.manyToMany(N3Book).mappedBy('tags'),
+  },
+});
 ",
-  "import { Collection, Entity, ManyToMany, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Author } from './Author';
 import { N4BookTag } from './N4BookTag';
 
-@Entity({ tableName: 'book', schema: 'n4' })
 export class N4Book {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property({ nullable: true })
   name?: string;
-
-  @ManyToOne({ entity: () => Author, updateRule: 'cascade', deleteRule: 'cascade', nullable: true })
-  author?: Author;
-
-  @ManyToOne({ entity: () => N4Book, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  basedOn?: N4Book;
-
-  @ManyToMany({ entity: () => N4BookTag, joinColumn: 'book_id', inverseJoinColumn: 'book_tag_id' })
+  author?: Ref<Author>;
+  basedOn?: Ref<N4Book>;
   tags = new Collection<N4BookTag>(this);
-
+  n4BookCollection = new Collection<N4Book>(this);
 }
-",
-  "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
 
-@Entity({ tableName: 'book_tag', schema: 'n4' })
+export const N4BookSchema = defineEntity({
+  class: N4Book,
+  tableName: 'book',
+  schema: 'n4',
+  properties: {
+    id: p.integer().primary(),
+    name: p.string().nullable(),
+    author: () => p.manyToOne(Author).ref().updateRule('cascade').deleteRule('cascade').nullable(),
+    basedOn: () => p.manyToOne(N4Book).ref().updateRule('cascade').deleteRule('set null').nullable(),
+    tags: () => p.manyToMany(N4BookTag).joinColumn('book_id').inverseJoinColumn('book_tag_id'),
+    n4BookCollection: () => p.oneToMany(N4Book).mappedBy('basedOn'),
+  },
+});
+",
+  "import { Collection, defineEntity, p } from '@mikro-orm/core';
+import { N4Book } from './N4Book';
+
 export class N4BookTag {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property({ nullable: true })
   name?: string;
-
+  tagsInverse = new Collection<N4Book>(this);
 }
+
+export const N4BookTagSchema = defineEntity({
+  class: N4BookTag,
+  tableName: 'book_tag',
+  schema: 'n4',
+  properties: {
+    id: p.integer().primary(),
+    name: p.string().nullable(),
+    tagsInverse: () => p.manyToMany(N4Book).mappedBy('tags'),
+  },
+});
 ",
-  "import { Collection, Entity, ManyToMany, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Author } from './Author';
 import { N5BookTag } from './N5BookTag';
 
-@Entity({ tableName: 'book', schema: 'n5' })
 export class N5Book {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property({ nullable: true })
   name?: string;
-
-  @ManyToOne({ entity: () => Author, updateRule: 'cascade', deleteRule: 'cascade', nullable: true })
-  author?: Author;
-
-  @ManyToOne({ entity: () => N5Book, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  basedOn?: N5Book;
-
-  @ManyToMany({ entity: () => N5BookTag, joinColumn: 'book_id', inverseJoinColumn: 'book_tag_id' })
+  author?: Ref<Author>;
+  basedOn?: Ref<N5Book>;
   tags = new Collection<N5BookTag>(this);
-
+  n5BookCollection = new Collection<N5Book>(this);
 }
+
+export const N5BookSchema = defineEntity({
+  class: N5Book,
+  tableName: 'book',
+  schema: 'n5',
+  properties: {
+    id: p.integer().primary(),
+    name: p.string().nullable(),
+    author: () => p.manyToOne(Author).ref().updateRule('cascade').deleteRule('cascade').nullable(),
+    basedOn: () => p.manyToOne(N5Book).ref().updateRule('cascade').deleteRule('set null').nullable(),
+    tags: () => p.manyToMany(N5BookTag).joinColumn('book_id').inverseJoinColumn('book_tag_id'),
+    n5BookCollection: () => p.oneToMany(N5Book).mappedBy('basedOn'),
+  },
+});
 ",
-  "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, defineEntity, p } from '@mikro-orm/core';
+import { N5Book } from './N5Book';
 
-@Entity({ tableName: 'book_tag', schema: 'n5' })
 export class N5BookTag {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property({ nullable: true })
   name?: string;
-
+  tagsInverse = new Collection<N5Book>(this);
 }
+
+export const N5BookTagSchema = defineEntity({
+  class: N5BookTag,
+  tableName: 'book_tag',
+  schema: 'n5',
+  properties: {
+    id: p.integer().primary(),
+    name: p.string().nullable(),
+    tagsInverse: () => p.manyToMany(N5Book).mappedBy('tags'),
+  },
+});
 ",
 ]
 `;
 
 exports[`multiple connected schemas in postgres > generate entities for given schema only 1`] = `
 [
-  "import { Collection, Entity, ManyToMany, ManyToOne, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, type Ref, defineEntity, p } from '@mikro-orm/core';
 import { BookTag } from './BookTag';
 
-@Entity({ schema: 'n2' })
 export class Book {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property({ nullable: true })
   name?: string;
-
-  @Property({ fieldName: 'author_id', nullable: true })
   author?: number;
-
-  @ManyToOne({ entity: () => Book, updateRule: 'cascade', deleteRule: 'set null', nullable: true })
-  basedOn?: Book;
-
-  @ManyToMany({ entity: () => BookTag, joinColumn: 'book_id', inverseJoinColumn: 'book_tag_id' })
+  basedOn?: Ref<Book>;
   tags = new Collection<BookTag>(this);
-
+  bookCollection = new Collection<Book>(this);
 }
+
+export const BookSchema = defineEntity({
+  class: Book,
+  schema: 'n2',
+  properties: {
+    id: p.integer().primary(),
+    name: p.string().nullable(),
+    author: p.integer().name('author_id').nullable(),
+    basedOn: () => p.manyToOne(Book).ref().updateRule('cascade').deleteRule('set null').nullable(),
+    tags: () => p.manyToMany(BookTag).joinColumn('book_id').inverseJoinColumn('book_tag_id'),
+    bookCollection: () => p.oneToMany(Book).mappedBy('basedOn'),
+  },
+});
 ",
-  "import { Entity, PrimaryKey, Property } from '@mikro-orm/core';
+  "import { Collection, defineEntity, p } from '@mikro-orm/core';
+import { Book } from './Book';
 
-@Entity({ schema: 'n2' })
 export class BookTag {
-
-  @PrimaryKey()
   id!: number;
-
-  @Property({ nullable: true })
   name?: string;
-
+  tagsInverse = new Collection<Book>(this);
 }
+
+export const BookTagSchema = defineEntity({
+  class: BookTag,
+  schema: 'n2',
+  properties: {
+    id: p.integer().primary(),
+    name: p.string().nullable(),
+    tagsInverse: () => p.manyToMany(Book).mappedBy('tags'),
+  },
+});
 ",
 ]
 `;

--- a/tests/features/schema-generator/__snapshots__/GH6323.test.ts.snap
+++ b/tests/features/schema-generator/__snapshots__/GH6323.test.ts.snap
@@ -2,49 +2,63 @@
 
 exports[`entity generator 1`] = `
 [
-  "import { Entity, PrimaryKey } from '@mikro-orm/core';
+  "import { Collection, type Ref, defineEntity, p } from '@mikro-orm/core';
+import { QuoteSettings } from './QuoteSettings';
+import { UserGroup } from './UserGroup';
 
-@Entity()
 export class Org {
-
-  @PrimaryKey()
   id!: number;
-
+  quoteSettings?: Ref<QuoteSettings>;
+  userGroupCollection = new Collection<UserGroup>(this);
 }
+
+export const OrgSchema = defineEntity({
+  class: Org,
+  properties: {
+    id: p.integer().primary(),
+    quoteSettings: () => p.oneToOne(QuoteSettings).ref().mappedBy('org'),
+    userGroupCollection: () => p.oneToMany(UserGroup).mappedBy('org'),
+  },
+});
 ",
-  "import { Entity, OneToOne, PrimaryKey, Unique } from '@mikro-orm/core';
+  "import { type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Org } from './Org';
 import { UserGroup } from './UserGroup';
 
-@Entity()
 export class QuoteSettings {
-
-  @PrimaryKey()
   id!: number;
-
-  @Unique({ name: 'quote_settings_org_id_unique' })
-  @OneToOne({ entity: () => Org, updateRule: 'cascade', deleteRule: 'cascade' })
-  org!: Org;
-
-  @OneToOne({ entity: () => UserGroup, fieldNames: ['user_group_id', 'org_id'], referencedColumnNames: ['id', 'org_id'], updateRule: 'cascade', deleteRule: 'cascade', nullable: true, unique: 'quote_settings_user_group_id_key' })
-  userGroup?: UserGroup;
-
+  org!: Ref<Org>;
+  userGroup?: Ref<UserGroup>;
 }
+
+export const QuoteSettingsSchema = defineEntity({
+  class: QuoteSettings,
+  properties: {
+    id: p.integer().primary(),
+    org: () => p.oneToOne(Org).ref().updateRule('cascade').deleteRule('cascade'),
+    userGroup: () => p.oneToOne(UserGroup).ref().fieldNames('user_group_id','org_id').referencedColumnNames('id','org_id').updateRule('cascade').deleteRule('cascade').nullable().unique('quote_settings_user_group_id_key'),
+  },
+});
 ",
-  "import { Entity, ManyToOne, PrimaryKey, Unique } from '@mikro-orm/core';
+  "import { type Ref, defineEntity, p } from '@mikro-orm/core';
 import { Org } from './Org';
+import { QuoteSettings } from './QuoteSettings';
 
-@Entity()
-@Unique({ name: 'user_group_id_org_id_key', properties: ['id', 'org'] })
 export class UserGroup {
-
-  @PrimaryKey()
   id!: number;
-
-  @ManyToOne({ entity: () => Org, updateRule: 'cascade' })
-  org!: Org;
-
+  org!: Ref<Org>;
+  quoteSettings?: Ref<QuoteSettings>;
 }
+
+export const UserGroupSchema = defineEntity({
+  class: UserGroup,
+  uniques: [{ name: 'user_group_id_org_id_key', properties: ['id', 'org'] }],
+  properties: {
+    id: p.integer().primary(),
+    org: () => p.manyToOne(Org).ref().updateRule('cascade'),
+    quoteSettings: () => p.oneToOne(QuoteSettings).ref().mappedBy('userGroup'),
+  },
+});
 ",
 ]
 `;


### PR DESCRIPTION
BREAKING CHANGE:

The `EntityGenerator` now emits entity definitions with the new `defineEntity` helper by default, and uses JS dictionaries for enums. Also, bidirectional relations are always defined and owning sides use the `Ref` wrapper.

Changed defaults:

- `entityDefinition`: `defineEntity` (used to be `decorators`)
- `enumMode`: `dictionary` (used to be `ts-enum`)
- `bidirectionalRelations`: `true` (used to be false)
- `identifiedReferences`: `true` (used to be false)

The `entitySchema` option is now removed in favor of `entityDefinition: 'entitySchema'`.