### PR TITLE
refactor: move file discovery to separate file

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,7 +5,8 @@
   "description": "TypeScript ORM for Node.js based on Data Mapper, Unit of Work and Identity Map patterns. Supports MongoDB, MySQL, PostgreSQL and SQLite databases as well as usage with vanilla JavaScript.",
   "exports": {
     "./package.json": "./package.json",
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./file-discovery": "./src/metadata/discover-entities.ts"
   },
   "repository": {
     "type": "git",

--- a/packages/core/src/MikroORM.ts
+++ b/packages/core/src/MikroORM.ts
@@ -57,7 +57,7 @@ export class MikroORM<
    * - no loading of the `config` file, `options` parameter is mandatory
    * - no support for folder based discovery
    */
-  constructor(options: Options<Driver, EM>) {
+  constructor(options: Options<Driver, EM, Entities>) {
     ConfigurationLoader.registerDotenv(options);
     const env = ConfigurationLoader.loadEnvironmentVarsSync<Driver>();
     const coreVersion = ConfigurationLoader.checkPackageVersion();
@@ -97,7 +97,7 @@ export class MikroORM<
   /**
    * Reconnects, possibly to a different database.
    */
-  async reconnect(options: Options = {}): Promise<void> {
+  async reconnect(options: Partial<Options<Driver, EM, Entities>> = {}): Promise<void> {
     /* v8 ignore next 3 */
     for (const key of Utils.keys(options)) {
       this.config.set(key, options[key]!);

--- a/packages/core/src/metadata/discover-entities.ts
+++ b/packages/core/src/metadata/discover-entities.ts
@@ -1,0 +1,51 @@
+import { basename } from 'node:path';
+import { glob } from 'tinyglobby';
+
+import { type Constructor } from '../typings.js';
+import { Utils } from '../utils/Utils.js';
+import { MetadataStorage } from './MetadataStorage.js';
+import { EntitySchema } from './EntitySchema.js';
+
+async function getEntityClassOrSchema(filepath: string, allTargets: Map<Constructor | EntitySchema, string>, baseDir: string): Promise<void> {
+  const path = Utils.normalizePath(baseDir, filepath);
+  const exports = await Utils.dynamicImport(path);
+  const targets = Object.values<Constructor | EntitySchema>(exports);
+
+  // ignore class implementations that are linked from an EntitySchema
+  for (const item of targets) {
+    if (item instanceof EntitySchema) {
+      for (const item2 of targets) {
+        if (item.meta.class === item2) {
+          targets.splice(targets.indexOf(item2), 1);
+        }
+      }
+    }
+  }
+
+  for (const item of targets) {
+    const validTarget = item instanceof EntitySchema || (item instanceof Function && MetadataStorage.isKnownEntity(item.name));
+
+    if (validTarget && !allTargets.has(item)) {
+      allTargets.set(item, path);
+    }
+  }
+}
+
+export async function discoverEntities(paths: string | string[], options?: { baseDir?: string }): Promise<Iterable<EntitySchema | Constructor>> {
+  paths = Utils.asArray(paths).map(path => Utils.normalizePath(path));
+  const baseDir = options?.baseDir ?? process.cwd();
+  const files = await glob(paths, { cwd: Utils.normalizePath(baseDir) });
+  const found = new Map<Constructor | EntitySchema, string>();
+
+  for (const filepath of files) {
+    const filename = basename(filepath);
+
+    if (!filename.match(/\.[cm]?[jt]s$/) || filename.match(/\.d\.[cm]?ts/)) {
+      continue;
+    }
+
+    await getEntityClassOrSchema(filepath, found, baseDir);
+  }
+
+  return found.keys();
+}

--- a/packages/core/src/utils/Configuration.ts
+++ b/packages/core/src/utils/Configuration.ts
@@ -567,7 +567,7 @@ export interface Options<
   Entities extends (string | EntityClass<AnyEntity> | EntitySchema)[] = (string | EntityClass<AnyEntity> | EntitySchema)[],
 > extends ConnectionOptions {
   entities?: Entities;
-  entitiesTs?: (string | EntityClass<AnyEntity> | EntitySchema)[];
+  entitiesTs?: Entities;
   extensions?: { register: (orm: MikroORM) => void }[];
   subscribers?: (EventSubscriber | Constructor<EventSubscriber>)[];
   filters?: Dictionary<{ name?: string } & Omit<FilterDef, 'name'>>;

--- a/packages/libsql/src/LibSqlMikroORM.ts
+++ b/packages/libsql/src/LibSqlMikroORM.ts
@@ -46,7 +46,7 @@ export class LibSqlMikroORM<
   /**
    * @inheritDoc
    */
-  constructor(options: LibSqlOptions<EM, Entities>) {
+  constructor(options: Options<LibSqlDriver, EM, Entities>) {
     super(defineLibSqlConfig(options));
   }
 

--- a/packages/mariadb/src/MariaDbMikroORM.ts
+++ b/packages/mariadb/src/MariaDbMikroORM.ts
@@ -20,7 +20,7 @@ export type MariaDbOptions<
 export function defineMariaDbConfig<
   EM extends SqlEntityManager<MariaDbDriver> = SqlEntityManager<MariaDbDriver>,
   Entities extends (string | EntityClass<AnyEntity> | EntitySchema)[] = (string | EntityClass<AnyEntity> | EntitySchema)[],
->(options: MariaDbOptions<EM, Entities>) {
+>(options: Options<MariaDbDriver, EM, Entities>) {
   return defineConfig({ driver: MariaDbDriver, ...options });
 }
 
@@ -46,7 +46,7 @@ export class MariaDbMikroORM<
   /**
    * @inheritDoc
    */
-  constructor(options: Options<MariaDbDriver, EM>) {
+  constructor(options: Options<MariaDbDriver, EM, Entities>) {
     super(defineMariaDbConfig(options));
   }
 

--- a/packages/mongodb/src/MongoMikroORM.ts
+++ b/packages/mongodb/src/MongoMikroORM.ts
@@ -30,7 +30,7 @@ export function defineMongoConfig<
 export class MongoMikroORM<
   EM extends MongoEntityManager = MongoEntityManager,
   Entities extends (string | EntityClass<AnyEntity> | EntitySchema)[] = (string | EntityClass<AnyEntity> | EntitySchema)[],
-> extends MikroORM<MongoDriver, EM, any> {
+> extends MikroORM<MongoDriver, EM, Entities> {
 
   /**
    * @inheritDoc
@@ -46,7 +46,7 @@ export class MongoMikroORM<
   /**
    * @inheritDoc
    */
-  constructor(options: MongoOptions<EM, Entities>) {
+  constructor(options: Options<MongoDriver, EM, Entities>) {
     super(defineMongoConfig(options));
   }
 

--- a/packages/mssql/src/MsSqlMikroORM.ts
+++ b/packages/mssql/src/MsSqlMikroORM.ts
@@ -20,7 +20,7 @@ export type MsSqlOptions<
 export function defineMsSqlConfig<
   EM extends SqlEntityManager<MsSqlDriver> = SqlEntityManager<MsSqlDriver>,
   Entities extends (string | EntityClass<AnyEntity> | EntitySchema)[] = (string | EntityClass<AnyEntity> | EntitySchema)[],
->(options: MsSqlOptions<EM, Entities>) {
+>(options: Options<MsSqlDriver, EM, Entities>) {
   return defineConfig({ driver: MsSqlDriver, ...options });
 }
 
@@ -46,7 +46,7 @@ export class MsSqlMikroORM<
   /**
    * @inheritDoc
    */
-  constructor(options: MsSqlOptions<EM, Entities>) {
+  constructor(options: Options<MsSqlDriver, EM, Entities>) {
     super(defineMsSqlConfig(options));
   }
 

--- a/packages/mysql/src/MySqlMikroORM.ts
+++ b/packages/mysql/src/MySqlMikroORM.ts
@@ -20,7 +20,7 @@ export type MySqlOptions<
 export function defineMySqlConfig<
   EM extends SqlEntityManager<MySqlDriver> = SqlEntityManager<MySqlDriver>,
   Entities extends (string | EntityClass<AnyEntity> | EntitySchema)[] = (string | EntityClass<AnyEntity> | EntitySchema)[],
->(options: MySqlOptions<EM, Entities>) {
+>(options: Options<MySqlDriver, EM, Entities>) {
   return defineConfig({ driver: MySqlDriver, ...options });
 }
 
@@ -46,7 +46,7 @@ export class MySqlMikroORM<
   /**
    * @inheritDoc
    */
-  constructor(options: MySqlOptions<EM, Entities>) {
+  constructor(options: Options<MySqlDriver, EM, Entities>) {
     super(defineMySqlConfig(options));
   }
 

--- a/packages/postgresql/src/PostgreSqlMikroORM.ts
+++ b/packages/postgresql/src/PostgreSqlMikroORM.ts
@@ -20,7 +20,7 @@ export type PostgreSqlOptions<
 export function definePostgreSqlConfig<
   EM extends SqlEntityManager<PostgreSqlDriver> = SqlEntityManager<PostgreSqlDriver>,
   Entities extends (string | EntityClass<AnyEntity> | EntitySchema)[] = (string | EntityClass<AnyEntity> | EntitySchema)[],
->(options: PostgreSqlOptions<EM, Entities>) {
+>(options: Options<PostgreSqlDriver, EM, Entities>) {
   return defineConfig({ driver: PostgreSqlDriver, ...options });
 }
 
@@ -46,7 +46,7 @@ export class PostgreSqlMikroORM<
   /**
    * @inheritDoc
    */
-  constructor(options: PostgreSqlOptions<EM, Entities>) {
+  constructor(options: Options<PostgreSqlDriver, EM, Entities>) {
     super(definePostgreSqlConfig(options));
   }
 

--- a/packages/sqlite/src/SqliteMikroORM.ts
+++ b/packages/sqlite/src/SqliteMikroORM.ts
@@ -46,7 +46,7 @@ export class SqliteMikroORM<
   /**
    * @inheritDoc
    */
-  constructor(options: SqliteOptions<EM, Entities>) {
+  constructor(options: Options<SqliteDriver, EM, Entities>) {
     super(defineSqliteConfig(options));
   }
 

--- a/tests/MikroORM.test.ts
+++ b/tests/MikroORM.test.ts
@@ -14,9 +14,9 @@ describe('MikroORM', () => {
 
   test('should throw when not enough config provided', async () => {
     const err = `No driver specified, please fill in the \`driver\` option or use \`defineConfig\` helper (to define your ORM config) or \`MikroORM\` class (to call the \`init\` method) exported from the driver package (e.g. \`import { defineConfig } from '@mikro-orm/mysql'; export defineConfig({ ... })\`).`;
-    expect(() => new MikroORM({ entities: ['entities'], clientUrl: '' })).toThrow(err);
-    expect(() => new MikroORM({ driver: MongoDriver, entities: ['entities'], dbName: '' })).toThrow('No database specified, please fill in `dbName` or `clientUrl` option');
-    expect(() => new MikroORM({ driver: MongoDriver, entities: ['entities'], clientUrl: '...' })).toThrow("No database specified, `clientUrl` option provided but it's missing the pathname.");
+    expect(() => new MikroORM({ entities: [Author], clientUrl: '' })).toThrow(err);
+    expect(() => new MikroORM({ driver: MongoDriver, entities: [Author], dbName: '' })).toThrow('No database specified, please fill in `dbName` or `clientUrl` option');
+    expect(() => new MikroORM({ driver: MongoDriver, entities: [Author], clientUrl: '...' })).toThrow("No database specified, `clientUrl` option provided but it's missing the pathname.");
     expect(() => new MikroORM({ driver: MongoDriver, entities: [], dbName: 'test' })).toThrow('No entities found, please use `entities` option');
     expect(() => new MikroORM({ driver: MongoDriver, dbName: 'test', entities: [Author], clientUrl: 'test' })).not.toThrow();
   });

--- a/tests/Webpack.test.ts
+++ b/tests/Webpack.test.ts
@@ -47,4 +47,15 @@ describe('Webpack', () => {
     await expect(MikroORM.init(options)).rejects.toThrow(err);
   });
 
+  test('should throw error if entities is not defined', async () => {
+    const options = {
+      dbName: `mikro_orm_test`,
+      driver: MySqlDriver,
+      entities: ['not/existing'],
+      discovery: { disableDynamicFileAccess: true },
+    } as Options;
+    const err = 'Folder based discovery requires the async `MikroORM.init()` method.';
+    expect(() => new MikroORM(options)).toThrow(err);
+  });
+
 });

--- a/tests/features/cli/CLIHelper.test.ts
+++ b/tests/features/cli/CLIHelper.test.ts
@@ -83,6 +83,7 @@ describe('CLIHelper', () => {
           )),
         ];
         case 'mikro-orm-invalid.config.js': return 'Not a config';
+        case 'file-discovery': return ({ discoverEntities: () => [] });
         default: return undefined;
       }
     };

--- a/tests/features/reflection/TsMorphMetadataProvider.test.ts
+++ b/tests/features/reflection/TsMorphMetadataProvider.test.ts
@@ -1,5 +1,5 @@
-import { Configuration, MikroORM } from '@mikro-orm/mongodb';
-import type { Options, PrimaryProperty, EntityMetadata } from '@mikro-orm/core';
+import { Options, Configuration, MikroORM } from '@mikro-orm/mongodb';
+import type { PrimaryProperty, EntityMetadata } from '@mikro-orm/core';
 import { Collection as Collection_, Reference as Reference_, ReferenceKind, EnumArrayType } from '@mikro-orm/core';
 import { TsMorphMetadataProvider } from '@mikro-orm/reflection';
 import { Author, Book, Publisher, BaseEntity, BaseEntity3, BookTagSchema, Test, FooBaz } from './entities/index.js';

--- a/tests/features/single-table-inheritance/single-table-inheritance.mysql.test.ts
+++ b/tests/features/single-table-inheritance/single-table-inheritance.mysql.test.ts
@@ -185,7 +185,6 @@ describe('single table inheritance in mysql', () => {
     class B {}
     class C {}
     orm.config.set('entities', [A, B, C]);
-    orm.config.set('entitiesTs', [A, B, C]);
     const discovery = new MetadataDiscovery(storage, orm.em.getDriver().getPlatform(), orm.config);
     const discovered = await discovery.discover();
     expect(discovered.get('A').discriminatorMap).toEqual({ a: 'A', b: 'B', c: 'C' });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -38,6 +38,7 @@ export default defineConfig({
       { find: '@mikro-orm/mongo-highlighter', replacement: new URL('/node_modules/@mikro-orm/mongo-highlighter', import.meta.url).pathname },
       { find: '@mikro-orm/sql-highlighter', replacement: new URL('/node_modules/@mikro-orm/sql-highlighter', import.meta.url).pathname },
       { find: 'mikro-orm', replacement: new URL('./packages/mikro-orm/src', import.meta.url).pathname },
+      { find: /@mikro-orm\/core\/file-discovery/, replacement: new URL('/packages/core/src/metadata/discover-entities.ts', import.meta.url).pathname },
       { find: /^@mikro-orm\/(.*)$/, replacement: new URL('./packages/$1/src', import.meta.url).pathname },
     ],
     retry: process.env.RETRY_TESTS ? 3 : 0,


### PR DESCRIPTION
Folder-based discovery has been moved to its own export, which is dynamically imported if the `entities` option contains a path. Since this won't work in bundlers anyway, we use `Utils.dynamicImport` wrapper here, so when bundling, it won't end up in the bundle.

Builds on top of #6992 
Related: #6975