### PR TITLE
refactor(core): make dataloader an optional peer dependency

### DIFF
--- a/docs/docs/dataloaders.md
+++ b/docs/docs/dataloaders.md
@@ -9,6 +9,16 @@ In the current version, MikroORM is able to automatically batch [references](./g
 
 ## Usage
 
+:::info
+
+Since v7, you need to install the `dataloader` dependency explicitly:
+
+```bash npm2yarn
+npm install dataloader
+```
+
+:::
+
 Dataloaders are disabled by default, but they can be easily enabled globally:
 
 ```ts

--- a/docs/docs/upgrading-v6-to-v7.md
+++ b/docs/docs/upgrading-v6-to-v7.md
@@ -184,3 +184,11 @@ The mechanism for processing serialized primary keys in MongoDB driver has chang
 ## Default propagation in `@Transactional` is `REQUIRED`
 
 The default propagation mode of the `@Transactional` decorator is now `REQUIRED`, which means that if there is an ongoing transaction, the decorated method will join it; otherwise, a new transaction will be started. The previous default was `REQUIRES_NEW`, which always started a new transaction. `REQUIRES_NEW` remains the default for the `em.transactional` method.
+
+## `dataloader` dependency
+
+The dependency on `dataloader` package is now defined as optional peer dependency. You need to install it explicitly.
+
+```bash npm2yarn
+npm install dataloader
+```

--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "@types/yargs": "17.0.33",
     "@vitest/coverage-v8": "3.2.4",
     "conditional-type-checks": "1.0.6",
+    "dataloader": "2.2.3",
     "eslint": "9.39.1",
     "eslint-plugin-import": "2.32.0",
     "eslint-plugin-unicorn": "62.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -52,11 +52,18 @@
     "access": "public"
   },
   "dependencies": {
-    "dataloader": "2.2.3",
     "dotenv": "17.2.3",
     "esprima": "4.0.1",
     "mikro-orm": "6.6.1",
     "reflect-metadata": "0.2.2",
     "tinyglobby": "0.2.13"
+  },
+  "peerDependencies": {
+    "dataloader": "2.2.3"
+  },
+  "peerDependenciesMeta": {
+    "dataloader": {
+      "optional": true
+    }
   }
 }

--- a/packages/core/src/entity/Collection.ts
+++ b/packages/core/src/entity/Collection.ts
@@ -311,11 +311,8 @@ export class Collection<T extends object, O extends object = object> extends Arr
       const orderBy = this.createOrderBy(options.orderBy);
       const customOrder = orderBy.length > 0;
       const pivotTable = this.property.kind === ReferenceKind.MANY_TO_MANY && em.getPlatform().usesPivotTable();
-      const loader = pivotTable ? 'colLoaderMtoN' : 'colLoader';
-      const items: TT[] = await em[loader].load([
-        this,
-        { ...options, orderBy },
-      ]);
+      const loader = await em.getDataLoader(pivotTable ? 'm:n' : '1:m');
+      const items: TT[] = await loader.load([this, { ...options, orderBy }]);
 
       if (this.property.kind === ReferenceKind.MANY_TO_MANY) {
         this.initialized = true;

--- a/packages/core/src/entity/Reference.ts
+++ b/packages/core/src/entity/Reference.ts
@@ -130,8 +130,8 @@ export class Reference<T extends object> {
 
     if (!this.isInitialized() || options.refresh) {
       if (options.dataloader ?? [DataloaderType.ALL, DataloaderType.REFERENCE].includes(wrapped.__em.config.getDataloaderType())) {
-        // eslint-disable-next-line dot-notation
-        return wrapped.__em!['refLoader'].load([this, options as any]);
+        const dataLoader = await wrapped.__em.getDataLoader('ref');
+        return dataLoader.load([this, options]);
       }
 
       return wrapped.init(options);

--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -204,7 +204,7 @@ export class MetadataDiscovery {
           throw new Error(`[requireEntitiesArray] Explicit list of entities is required, please use the 'entities' option.`);
         }
 
-        const { discoverEntities } = await Utils.dynamicImport('@mikro-orm/core/file-discovery');
+        const { discoverEntities } = await import('@mikro-orm/core/file-discovery' + '');
         processed.push(...await discoverEntities(entity, { baseDir }));
       } else {
         processed.push(entity);

--- a/packages/core/src/utils/Configuration.ts
+++ b/packages/core/src/utils/Configuration.ts
@@ -1,25 +1,25 @@
 import type { NamingStrategy } from '../naming-strategy/NamingStrategy.js';
 import { FileCacheAdapter } from '../cache/FileCacheAdapter.js';
 import { NullCacheAdapter } from '../cache/NullCacheAdapter.js';
-import { type SyncCacheAdapter, type CacheAdapter } from '../cache/CacheAdapter.js';
+import { type CacheAdapter, type SyncCacheAdapter } from '../cache/CacheAdapter.js';
 import type { EntityRepository } from '../entity/EntityRepository.js';
 import type {
   AnyEntity,
   Constructor,
   Dictionary,
+  EnsureDatabaseOptions,
   EntityClass,
+  EntityMetadata,
   FilterDef,
+  GenerateOptions,
   Highlighter,
   HydratorConstructor,
   IHydrator,
   IMigrationGenerator,
   IPrimaryKey,
   MaybePromise,
-  MigrationObject,
-  EntityMetadata,
-  EnsureDatabaseOptions,
-  GenerateOptions,
   Migration,
+  MigrationObject,
 } from '../typings.js';
 import { ObjectHydrator } from '../hydration/ObjectHydrator.js';
 import { NullHighlighter } from '../utils/NullHighlighter.js';
@@ -357,8 +357,7 @@ export class Configuration<D extends IDatabaseDriver = IDatabaseDriver, EM exten
    */
   getCachedService<T extends { new(...args: any[]): InstanceType<T> }>(cls: T, ...args: ConstructorParameters<T>): InstanceType<T> {
     if (!this.cache.has(cls.name)) {
-      const Class = cls as { new(...args: any[]): T };
-      this.cache.set(cls.name, new Class(...args));
+      this.cache.set(cls.name, new cls(...args));
     }
 
     return this.cache.get(cls.name);

--- a/packages/core/src/utils/DataloaderUtils.ts
+++ b/packages/core/src/utils/DataloaderUtils.ts
@@ -1,12 +1,15 @@
-import type DataLoader from 'dataloader';
-import type { Dictionary, Primary, Ref } from '../typings.js';
+import type { Constructor, Dictionary, Primary, Ref } from '../typings.js';
 import { Collection, type InitCollectionOptions } from '../entity/Collection.js';
 import { helper } from '../entity/wrap.js';
 import { type EntityManager } from '../EntityManager.js';
 import { type LoadReferenceOptions, Reference } from '../entity/Reference.js';
 import { Utils } from './Utils.js';
 
+type BatchLoadFn<K, V> = (keys: readonly K[]) => PromiseLike<ArrayLike<V | Error>>;
+
 export class DataloaderUtils {
+
+  static DataLoader?: Constructor<{ load: (...args: unknown[]) => Promise<unknown> }>;
 
   /**
    * Groups identified references by entity and returns a Map with the
@@ -45,7 +48,7 @@ export class DataloaderUtils {
    * Returns the reference dataloader batchLoadFn, which aggregates references by entity,
    * makes one query per entity and maps each input reference to the corresponding result.
    */
-  static getRefBatchLoadFn(em: EntityManager): DataLoader.BatchLoadFn<[Ref<any>, Omit<LoadReferenceOptions<any, any>, 'dataloader'>?], any> {
+  static getRefBatchLoadFn(em: EntityManager): BatchLoadFn<[Ref<any>, Omit<LoadReferenceOptions<any, any>, 'dataloader'>?], any> {
     return async (refsWithOpts: readonly [Ref<any>, Omit<LoadReferenceOptions<any, any>, 'dataloader'>?][]): Promise<ArrayLike<any | Error>> => {
       const groupedIdsMap = DataloaderUtils.groupPrimaryKeysByEntityAndOpts(refsWithOpts);
       const promises = Array.from(groupedIdsMap).map(
@@ -179,7 +182,7 @@ export class DataloaderUtils {
    * Returns the 1:M collection dataloader batchLoadFn, which aggregates collections by entity,
    * makes one query per entity and maps each input collection to the corresponding result.
    */
-  static getColBatchLoadFn(em: EntityManager): DataLoader.BatchLoadFn<[Collection<any>, Omit<InitCollectionOptions<any, any>, 'dataloader'>?], any> {
+  static getColBatchLoadFn(em: EntityManager): BatchLoadFn<[Collection<any>, Omit<InitCollectionOptions<any, any>, 'dataloader'>?], any> {
     return async (collsWithOpts: readonly [Collection<any>, Omit<InitCollectionOptions<any, any>, 'dataloader'>?][]) => {
       const entitiesAndOptsMap = DataloaderUtils.groupInversedOrMappedKeysByEntityAndOpts(collsWithOpts);
       const promises = DataloaderUtils.entitiesAndOptsMapToQueries(entitiesAndOptsMap, em);
@@ -203,7 +206,7 @@ export class DataloaderUtils {
    * Returns the M:N collection dataloader batchLoadFn, which aggregates collections by entity,
    * makes one query per entity and maps each input collection to the corresponding result.
    */
-  static getManyToManyColBatchLoadFn(em: EntityManager): DataLoader.BatchLoadFn<[Collection<any>, Omit<InitCollectionOptions<any, any>, 'dataloader'>?], any> {
+  static getManyToManyColBatchLoadFn(em: EntityManager): BatchLoadFn<[Collection<any>, Omit<InitCollectionOptions<any, any>, 'dataloader'>?], any> {
     return async (collsWithOpts: readonly [Collection<any>, Omit<InitCollectionOptions<any, any>, 'dataloader'>?][]) => {
       const groups = new Map<string, [Collection<any>, Omit<InitCollectionOptions<any, any>, 'dataloader'>?][]>();
 
@@ -242,6 +245,22 @@ export class DataloaderUtils {
 
       return ret;
     };
+  }
+
+  static async getDataLoader(): Promise<Constructor<{ load: (...args: unknown[]) => Promise<unknown> }>> {
+    if (this.DataLoader) {
+      return this.DataLoader;
+    }
+
+    try {
+      const mod = await import('dataloader' + '');
+      const DataLoader = mod.default;
+
+      return (this.DataLoader ??= DataLoader);
+    } catch {
+      /* v8 ignore next 2 */
+      throw new Error('DataLoader is not found, make sure `dataloader` package is installed in your project\'s dependencies.');
+    }
   }
 
 }

--- a/tests/features/schema-generator/GH6978.test.ts
+++ b/tests/features/schema-generator/GH6978.test.ts
@@ -34,7 +34,7 @@ test('GH #6978', async () => {
   const mock = mockLogger(orm);
   await orm.schema.ensureIndexes();
 
-  const calls = mock.mock.calls;
-  expect(calls[0][0]).toMatch(`db.getCollection('user').createIndex({ Name: 1 }, { unique: false });`);
-  expect(calls[1][0]).toMatch(`db.getCollection('user').createIndex({ Email: 1 }, { unique: true });`);
+  const calls = mock.mock.calls.sort((a, b) => a[0].localeCompare(b[0]));
+  expect(calls[0][0]).toMatch(`db.getCollection('user').createIndex({ Email: 1 }, { unique: true });`);
+  expect(calls[1][0]).toMatch(`db.getCollection('user').createIndex({ Name: 1 }, { unique: false });`);
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1394,12 +1394,16 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@mikro-orm/core@workspace:packages/core"
   dependencies:
-    dataloader: "npm:2.2.3"
     dotenv: "npm:17.2.3"
     esprima: "npm:4.0.1"
     mikro-orm: "npm:6.6.1"
     reflect-metadata: "npm:0.2.2"
     tinyglobby: "npm:0.2.13"
+  peerDependencies:
+    dataloader: 2.2.3
+  peerDependenciesMeta:
+    dataloader:
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -1583,6 +1587,7 @@ __metadata:
     "@types/yargs": "npm:17.0.33"
     "@vitest/coverage-v8": "npm:3.2.4"
     conditional-type-checks: "npm:1.0.6"
+    dataloader: "npm:2.2.3"
     eslint: "npm:9.39.1"
     eslint-plugin-import: "npm:2.32.0"
     eslint-plugin-unicorn: "npm:62.0.0"


### PR DESCRIPTION
BREAKING CHANGE:

The dependency on `dataloader` package is now defined as optional peer dependency. You need to install it explicitly.