### PR TITLE
refactor(core): use native glob instead of tinyglobby

### DIFF
--- a/docs/docs/upgrading-v6-to-v7.md
+++ b/docs/docs/upgrading-v6-to-v7.md
@@ -8,7 +8,7 @@ title: Upgrading from v6 to v7
 
 MikroORM v7 is a native ESM package now. It can be still consumed from a CJS project, as long as you use TypeScript and Node.js version that supports `require(esm)`.
 
-## Node 22.11+ required
+## Node 22.17+ required
 
 Support for older node versions was dropped.
 
@@ -192,3 +192,14 @@ The dependency on `dataloader` package is now defined as optional peer dependenc
 ```bash npm2yarn
 npm install dataloader
 ```
+
+## Native Node.js glob
+
+The ORM now uses native Node.js glob implementation for file discovery instead of the `globby` package. This means that some features provided by the `globby` package are no longer available, the main one being support for brace expansion patterns (e.g. `src/{entities,modules}/*.ts`). If you rely on those, use `tinyglobby` directly:
+
+```diff
+-entities: ['src/{entities,modules}/*.ts'],
++entities: await tinyglobby(['src/{entities,modules}/*.ts']),
+```
+
+> Migrations and seeders still support brace expansion in their `glob` option.

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "@types/node": "24.10.0",
     "@types/pg": "8.15.6",
     "@types/pg-cursor": "2.7.2",
+    "@types/picomatch": "4.0.2",
     "@types/semver": "7.7.1",
     "@types/sqlstring": "2.3.2",
     "@types/uuid": "11.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,7 +41,7 @@
     "mikro-orm": "./dist/cli"
   },
   "engines": {
-    "node": ">= 22.11.0"
+    "node": ">= 22.17.0"
   },
   "scripts": {
     "build": "yarn clean && yarn compile && yarn copy",

--- a/packages/cli/src/CLIHelper.ts
+++ b/packages/cli/src/CLIHelper.ts
@@ -86,7 +86,7 @@ export class CLIHelper {
     CLIHelper.dump(`   - mikro-orm ${colors.green(version)}`);
     CLIHelper.dump(`   - node ${colors.green(CLIHelper.getNodeVersion())}`);
 
-    if (Utils.pathExistsSync(process.cwd() + '/package.json')) {
+    if (Utils.pathExists(process.cwd() + '/package.json')) {
       /* v8 ignore next 3 */
       if (process.versions.bun) {
         CLIHelper.dump(`   - typescript via bun`);

--- a/packages/cli/src/commands/DebugCommand.ts
+++ b/packages/cli/src/commands/DebugCommand.ts
@@ -1,5 +1,5 @@
 import type { ArgumentsCamelCase } from 'yargs';
-import { ConfigurationLoader, Utils, colors } from '@mikro-orm/core';
+import { colors, ConfigurationLoader, Utils } from '@mikro-orm/core';
 import type { BaseArgs, BaseCommand } from '../CLIConfigurator.js';
 import { CLIHelper } from '../CLIHelper.js';
 
@@ -86,9 +86,8 @@ export class DebugCommand implements BaseCommand {
     for (let path of paths) {
       path = Utils.absolutePath(path, baseDir);
       path = Utils.normalizePath(path);
-      const found = await Utils.pathExists(path);
 
-      if (found) {
+      if (Utils.pathExists(path)) {
         CLIHelper.dump(`   - ${path} (${colors.green('found')})`);
       } else {
         CLIHelper.dump(`   - ${path} (${colors[failedColor]('not found')})`);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -40,7 +40,7 @@
   },
   "homepage": "https://mikro-orm.io",
   "engines": {
-    "node": ">= 22.11.0"
+    "node": ">= 22.17.0"
   },
   "scripts": {
     "build": "yarn clean && yarn compile && yarn copy",
@@ -55,8 +55,7 @@
     "dotenv": "17.2.3",
     "esprima": "4.0.1",
     "mikro-orm": "6.6.1",
-    "reflect-metadata": "0.2.2",
-    "tinyglobby": "0.2.13"
+    "reflect-metadata": "0.2.2"
   },
   "peerDependencies": {
     "dataloader": "2.2.3"

--- a/packages/core/src/cache/FileCacheAdapter.ts
+++ b/packages/core/src/cache/FileCacheAdapter.ts
@@ -1,4 +1,3 @@
-import { globSync } from 'tinyglobby';
 import { existsSync, readFileSync, writeFileSync, unlinkSync } from 'node:fs';
 
 import type { SyncCacheAdapter } from './CacheAdapter.js';
@@ -62,7 +61,7 @@ export class FileCacheAdapter implements SyncCacheAdapter {
    */
   clear(): void {
     const path = this.path('*');
-    const files = globSync(path);
+    const files = Utils.glob(path);
     files.forEach(file => unlinkSync(file));
     this.cache = {};
   }

--- a/packages/core/src/metadata/discover-entities.ts
+++ b/packages/core/src/metadata/discover-entities.ts
@@ -1,5 +1,4 @@
 import { basename } from 'node:path';
-import { glob } from 'tinyglobby';
 
 import { type Constructor } from '../typings.js';
 import { Utils } from '../utils/Utils.js';
@@ -34,7 +33,7 @@ async function getEntityClassOrSchema(filepath: string, allTargets: Map<Construc
 export async function discoverEntities(paths: string | string[], options?: { baseDir?: string }): Promise<Iterable<EntitySchema | Constructor>> {
   paths = Utils.asArray(paths).map(path => Utils.normalizePath(path));
   const baseDir = options?.baseDir ?? process.cwd();
-  const files = await glob(paths, { cwd: Utils.normalizePath(baseDir) });
+  const files = Utils.glob(paths, Utils.normalizePath(baseDir));
   const found = new Map<Constructor | EntitySchema, string>();
 
   for (const filepath of files) {

--- a/packages/core/src/utils/Configuration.ts
+++ b/packages/core/src/utils/Configuration.ts
@@ -436,14 +436,14 @@ export class Configuration<D extends IDatabaseDriver = IDatabaseDriver, EM exten
    * break existing projects, only help with the new ones.
    */
   private detectSourceFolder(options: Options): void {
-    if (!Utils.pathExistsSync(this.options.baseDir + '/src')) {
+    if (!Utils.pathExists(this.options.baseDir + '/src')) {
       return;
     }
 
-    const migrationsPathExists = Utils.pathExistsSync(this.options.baseDir + '/' + this.options.migrations.path);
-    const seedersPathExists = Utils.pathExistsSync(this.options.baseDir + '/' + this.options.seeder.path);
-    const distDir = Utils.pathExistsSync(this.options.baseDir + '/dist');
-    const buildDir = Utils.pathExistsSync(this.options.baseDir + '/build');
+    const migrationsPathExists = Utils.pathExists(this.options.baseDir + '/' + this.options.migrations.path);
+    const seedersPathExists = Utils.pathExists(this.options.baseDir + '/' + this.options.seeder.path);
+    const distDir = Utils.pathExists(this.options.baseDir + '/dist');
+    const buildDir = Utils.pathExists(this.options.baseDir + '/build');
     // if neither `dist` nor `build` exist, we use the `src` folder as it might be a JS project without building, but with `src` folder
     const path = distDir ? './dist' : (buildDir ? './build' : './src');
 

--- a/packages/core/src/utils/ConfigurationLoader.ts
+++ b/packages/core/src/utils/ConfigurationLoader.ts
@@ -95,7 +95,7 @@ export class ConfigurationLoader {
       path = Utils.absolutePath(path);
       path = Utils.normalizePath(path);
 
-      if (Utils.pathExistsSync(path)) {
+      if (Utils.pathExists(path)) {
         const config = await Utils.dynamicImport(path);
         /* v8 ignore next */
         return [path, await (config.default ?? config)];
@@ -105,7 +105,7 @@ export class ConfigurationLoader {
   }
 
   static getPackageConfig(basePath = process.cwd()): Dictionary {
-    if (Utils.pathExistsSync(`${basePath}/package.json`)) {
+    if (Utils.pathExists(`${basePath}/package.json`)) {
       /* v8 ignore next 5 */
       try {
         return Utils.readJSONSync(`${basePath}/package.json`);
@@ -156,8 +156,8 @@ export class ConfigurationLoader {
       paths.push('./mikro-orm.config.ts');
     }
 
-    const distDir = Utils.pathExistsSync(process.cwd() + '/dist');
-    const buildDir = Utils.pathExistsSync(process.cwd() + '/build');
+    const distDir = Utils.pathExists(process.cwd() + '/dist');
+    const buildDir = Utils.pathExists(process.cwd() + '/build');
     /* v8 ignore next */
     const path = distDir ? 'dist' : (buildDir ? 'build' : 'src');
     paths.push(`./${path}/mikro-orm.config.js`);

--- a/packages/entity-generator/package.json
+++ b/packages/entity-generator/package.json
@@ -38,7 +38,7 @@
   },
   "homepage": "https://mikro-orm.io",
   "engines": {
-    "node": ">= 22.11.0"
+    "node": ">= 22.17.0"
   },
   "scripts": {
     "build": "yarn clean && yarn compile && yarn copy",

--- a/packages/knex/package.json
+++ b/packages/knex/package.json
@@ -38,7 +38,7 @@
   },
   "homepage": "https://mikro-orm.io",
   "engines": {
-    "node": ">= 22.11.0"
+    "node": ">= 22.17.0"
   },
   "scripts": {
     "build": "yarn clean && yarn compile && yarn copy",

--- a/packages/libsql/package.json
+++ b/packages/libsql/package.json
@@ -38,7 +38,7 @@
   },
   "homepage": "https://mikro-orm.io",
   "engines": {
-    "node": ">= 22.11.0"
+    "node": ">= 22.17.0"
   },
   "scripts": {
     "build": "yarn clean && yarn compile && yarn copy",

--- a/packages/mariadb/package.json
+++ b/packages/mariadb/package.json
@@ -38,7 +38,7 @@
   },
   "homepage": "https://mikro-orm.io",
   "engines": {
-    "node": ">= 22.11.0"
+    "node": ">= 22.17.0"
   },
   "scripts": {
     "build": "yarn clean && yarn compile && yarn copy",

--- a/packages/migrations-mongodb/package.json
+++ b/packages/migrations-mongodb/package.json
@@ -38,7 +38,7 @@
   },
   "homepage": "https://mikro-orm.io",
   "engines": {
-    "node": ">= 22.11.0"
+    "node": ">= 22.17.0"
   },
   "scripts": {
     "build": "yarn clean && yarn compile && yarn copy",

--- a/packages/migrations/package.json
+++ b/packages/migrations/package.json
@@ -38,7 +38,7 @@
   },
   "homepage": "https://mikro-orm.io",
   "engines": {
-    "node": ">= 22.11.0"
+    "node": ">= 22.17.0"
   },
   "scripts": {
     "build": "yarn clean && yarn compile && yarn copy",

--- a/packages/mikro-orm/package.json
+++ b/packages/mikro-orm/package.json
@@ -38,7 +38,7 @@
   },
   "homepage": "https://mikro-orm.io",
   "engines": {
-    "node": ">= 22.11.0"
+    "node": ">= 22.17.0"
   },
   "scripts": {
     "build": "yarn clean && yarn compile && yarn copy",

--- a/packages/mongodb/package.json
+++ b/packages/mongodb/package.json
@@ -38,7 +38,7 @@
   },
   "homepage": "https://mikro-orm.io",
   "engines": {
-    "node": ">= 22.11.0"
+    "node": ">= 22.17.0"
   },
   "scripts": {
     "build": "yarn clean && yarn compile && yarn copy",

--- a/packages/mssql/package.json
+++ b/packages/mssql/package.json
@@ -38,7 +38,7 @@
   },
   "homepage": "https://mikro-orm.io",
   "engines": {
-    "node": ">= 22.11.0"
+    "node": ">= 22.17.0"
   },
   "scripts": {
     "build": "yarn clean && yarn compile && yarn copy",

--- a/packages/mysql/package.json
+++ b/packages/mysql/package.json
@@ -38,7 +38,7 @@
   },
   "homepage": "https://mikro-orm.io",
   "engines": {
-    "node": ">= 22.11.0"
+    "node": ">= 22.17.0"
   },
   "scripts": {
     "build": "yarn clean && yarn compile && yarn copy",

--- a/packages/postgresql/package.json
+++ b/packages/postgresql/package.json
@@ -38,7 +38,7 @@
   },
   "homepage": "https://mikro-orm.io",
   "engines": {
-    "node": ">= 22.11.0"
+    "node": ">= 22.17.0"
   },
   "scripts": {
     "build": "yarn clean && yarn compile && yarn copy",

--- a/packages/reflection/package.json
+++ b/packages/reflection/package.json
@@ -38,7 +38,7 @@
   },
   "homepage": "https://mikro-orm.io",
   "engines": {
-    "node": ">= 22.11.0"
+    "node": ">= 22.17.0"
   },
   "scripts": {
     "build": "yarn clean && yarn compile && yarn copy",

--- a/packages/seeder/package.json
+++ b/packages/seeder/package.json
@@ -39,7 +39,7 @@
   },
   "homepage": "https://mikro-orm.io",
   "engines": {
-    "node": ">= 22.11.0"
+    "node": ">= 22.17.0"
   },
   "scripts": {
     "build": "yarn clean && yarn compile && yarn copy",
@@ -51,7 +51,7 @@
     "access": "public"
   },
   "dependencies": {
-    "tinyglobby": "0.2.13"
+    "tinyglobby": "0.2.15"
   },
   "devDependencies": {
     "@mikro-orm/core": "^6.6.1"

--- a/packages/sqlite/package.json
+++ b/packages/sqlite/package.json
@@ -38,7 +38,7 @@
   },
   "homepage": "https://mikro-orm.io",
   "engines": {
-    "node": ">= 22.11.0"
+    "node": ">= 22.17.0"
   },
   "scripts": {
     "build": "yarn clean && yarn compile && yarn copy",

--- a/tests/MikroORM.test.ts
+++ b/tests/MikroORM.test.ts
@@ -22,7 +22,7 @@ describe('MikroORM', () => {
   });
 
   test('source folder detection', async () => {
-    const pathExistsMock = vi.spyOn(Utils, 'pathExistsSync');
+    const pathExistsMock = vi.spyOn(Utils, 'pathExists');
 
     pathExistsMock.mockImplementation(path => !!path.match(/src$/));
     const orm1 = await MikroORM.init({ driver: MongoDriver, dbName: 'test', baseDir: import.meta.dirname + '/../packages/core', entities: [import.meta.dirname + '/entities'], clientUrl: 'test' });

--- a/tests/Utils.test.ts
+++ b/tests/Utils.test.ts
@@ -311,10 +311,9 @@ describe('Utils', () => {
   });
 
   test('pathExists wrapper', async () => {
-    await expect(Utils.pathExists('LIC*')).resolves.toEqual(true);
-    await expect(Utils.pathExists('tests')).resolves.toEqual(true);
-    await expect(Utils.pathExists('tests/**/*.ts')).resolves.toEqual(true);
-    await expect(Utils.pathExists('**/tests', { onlyDirectories: true })).resolves.toEqual(true);
+    expect(Utils.pathExists('LIC*')).toBe(true);
+    expect(Utils.pathExists('tests')).toBe(true);
+    expect(Utils.pathExists('tests/**/*.ts')).toBe(true);
   });
 
   test('isPlainObject', async () => {

--- a/tests/features/cli/CLIHelper.test.ts
+++ b/tests/features/cli/CLIHelper.test.ts
@@ -34,7 +34,7 @@ describe('CLIHelper', () => {
   beforeEach(() => {
     delete process.env.MIKRO_ORM_CLI_TS_CONFIG_PATH;
     const config = { driver: MongoDriver, dbName: 'foo_bar', entities: ['tests/foo'] } satisfies Options;
-    pathExistsMock = vi.spyOn(Utils, 'pathExistsSync');
+    pathExistsMock = vi.spyOn(Utils, 'pathExists');
     const resolve = (path: any) => {
       switch (path.substring(path.lastIndexOf('/') + 1)) {
         case 'package.json': return pkg;

--- a/tests/features/cli/DebugCommand.test.ts
+++ b/tests/features/cli/DebugCommand.test.ts
@@ -22,7 +22,7 @@ describe('DebugCommand', () => {
     const cmd = new DebugCommand();
 
     const globbyMock = vi.spyOn(Utils, 'pathExists');
-    globbyMock.mockResolvedValue(true);
+    globbyMock.mockReturnValue(true);
     getSettings.mockReturnValue({});
     getConfiguration.mockResolvedValue(new Configuration(defineConfig({}), false));
     getConfigPaths.mockReturnValue(['./path/orm-config.ts']);
@@ -41,7 +41,7 @@ describe('DebugCommand', () => {
     ]);
 
     getSettings.mockReturnValue({ preferTs: true });
-    globbyMock.mockImplementation(async (path: string) => path.endsWith('entities-1') || path.endsWith('orm-config.ts'));
+    globbyMock.mockImplementation(path => path.endsWith('entities-1') || path.endsWith('orm-config.ts'));
     getConfiguration.mockResolvedValue(new Configuration(defineConfig({ preferTs: true, entities: ['./dist/entities-1', './dist/entities-2'], entitiesTs: ['./src/entities-1', './src/entities-2'] }), false));
     dump.mock.calls.length = 0;
     await expect(cmd.handler({ contextName: 'default' } as any)).resolves.toBeUndefined();
@@ -97,7 +97,7 @@ describe('DebugCommand', () => {
       ['- configuration not found (test error message)'],
     ]);
 
-    globbyMock.mockResolvedValue(false);
+    globbyMock.mockReturnValue(false);
     dump.mock.calls.length = 0;
     await expect(cmd.handler({ contextName: 'default' } as any)).resolves.toBeUndefined();
     expect(dumpDependencies).toHaveBeenCalledTimes(5);
@@ -115,7 +115,7 @@ describe('DebugCommand', () => {
       [' - will use `entities` array (contains 2 references and 0 paths)'],
     ]);
 
-    globbyMock.mockResolvedValue(false);
+    globbyMock.mockReturnValue(false);
     dump.mock.calls.length = 0;
     getSettings.mockReturnValue({});
     getConfiguration.mockResolvedValue(new Configuration(defineConfig({}), false));

--- a/yarn.lock
+++ b/yarn.lock
@@ -1398,7 +1398,6 @@ __metadata:
     esprima: "npm:4.0.1"
     mikro-orm: "npm:6.6.1"
     reflect-metadata: "npm:0.2.2"
-    tinyglobby: "npm:0.2.13"
   peerDependencies:
     dataloader: 2.2.3
   peerDependenciesMeta:
@@ -1581,6 +1580,7 @@ __metadata:
     "@types/node": "npm:24.10.0"
     "@types/pg": "npm:8.15.6"
     "@types/pg-cursor": "npm:2.7.2"
+    "@types/picomatch": "npm:4.0.2"
     "@types/semver": "npm:7.7.1"
     "@types/sqlstring": "npm:2.3.2"
     "@types/uuid": "npm:11.0.0"
@@ -1616,7 +1616,7 @@ __metadata:
   resolution: "@mikro-orm/seeder@workspace:packages/seeder"
   dependencies:
     "@mikro-orm/core": "npm:^6.6.1"
-    tinyglobby: "npm:0.2.13"
+    tinyglobby: "npm:0.2.15"
   peerDependencies:
     "@mikro-orm/core": ^6.0.0
   languageName: unknown
@@ -3072,6 +3072,13 @@ __metadata:
     pg-protocol: "npm:*"
     pg-types: "npm:^2.2.0"
   checksum: 10/4bc1bb274e0fc105be93e3a9cc8c9aa57fc50b78ed78a56348468157332daaecd71fcab762ee620c766510ffbc7018b56ca394787d6d41ff1726b152770aa532
+  languageName: node
+  linkType: hard
+
+"@types/picomatch@npm:4.0.2":
+  version: 4.0.2
+  resolution: "@types/picomatch@npm:4.0.2"
+  checksum: 10/7b74f860c4c2bf30f7952254717df2dd78441b0add79858dffe7f6a30c9dd6da6c3d7769d2a9f0c499bc5ffe820c629bffc7c5128948febfc2b935800169b1c3
   languageName: node
   linkType: hard
 
@@ -5701,7 +5708,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fdir@npm:^6.4.3, fdir@npm:^6.4.4, fdir@npm:^6.5.0":
+"fdir@npm:^6.4.3, fdir@npm:^6.5.0":
   version: 6.5.0
   resolution: "fdir@npm:6.5.0"
   peerDependencies:
@@ -11237,17 +11244,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tinyglobby@npm:0.2.13":
-  version: 0.2.13
-  resolution: "tinyglobby@npm:0.2.13"
-  dependencies:
-    fdir: "npm:^6.4.4"
-    picomatch: "npm:^4.0.2"
-  checksum: 10/b04557ee58ad2be5f2d2cbb4b441476436c92bb45ba2e1fc464d686b793392b305ed0bcb8b877429e9b5036bdd46770c161a08384c0720b6682b7cd6ac80e403
-  languageName: node
-  linkType: hard
-
-"tinyglobby@npm:^0.2.12, tinyglobby@npm:^0.2.14, tinyglobby@npm:^0.2.15":
+"tinyglobby@npm:0.2.15, tinyglobby@npm:^0.2.12, tinyglobby@npm:^0.2.14, tinyglobby@npm:^0.2.15":
   version: 0.2.15
   resolution: "tinyglobby@npm:0.2.15"
   dependencies:


### PR DESCRIPTION
BREAKING CHANGE:

The ORM now uses native Node.js glob implementation for file discovery instead of the `globby` package. This means that some features provided by the `globby` package are no longer available, the main one being support for brace expansion patterns (e.g. `src/{entities,modules}/*.ts`). If you rely on those, use `tinyglobby` directly:

```diff
-entities: ['src/{entities,modules}/*.ts'],
+entities: await tinyglobby(['src/{entities,modules}/*.ts']),
```

> Migrations and seeders still support brace expansion in their `glob` option.