### PR TITLE
Documentation update: Update findOne call to use dynamic ID

### DIFF
--- a/docs/versioned_docs/version-6.6/unit-of-work.md
+++ b/docs/versioned_docs/version-6.6/unit-of-work.md
@@ -71,7 +71,7 @@ const jon = em.create(Author, {
 });
 
 // this will trigger auto flush and insert the entity, then query for it
-const jon2 = await em.findOne(Author, 1);
+const jon2 = await em.findOne(Author, jon.id);
 console.log(jon === jon2); // true
 await em.flush(); // this is a no-op
 ```


### PR DESCRIPTION
In the code provided we wouldn't actually know the ID of the entity so updating to a more realistic scenario