### PR TITLE
fix(defineEntity): avoid circular type inference in meta

### DIFF
--- a/packages/core/src/entity/defineEntity.ts
+++ b/packages/core/src/entity/defineEntity.ts
@@ -717,7 +717,8 @@ export interface EntityMetadataWithProperties<
   serializedPrimaryKey?: keyof TProperties;
   indexes?: {
     properties?: keyof TProperties | (keyof TProperties)[];
-    name?: string; type?: string;
+    name?: string;
+    type?: string;
     options?: Dictionary;
     expression?: string | IndexCallback<InferEntityFromProperties<TProperties, TPK>>;
   }[];
@@ -726,6 +727,7 @@ export interface EntityMetadataWithProperties<
     name?: string;
     options?: Dictionary;
     expression?: string | IndexCallback<InferEntityFromProperties<TProperties, TPK>>;
+    deferMode?: DeferMode | `${DeferMode}`;
   }[];
 }
 

--- a/tests/defineEntity.test.ts
+++ b/tests/defineEntity.test.ts
@@ -826,7 +826,14 @@ describe('defineEntity', () => {
     const Category = defineEntity({
       name: 'Category',
       uniques: [
-        { properties: ['name', 'children'], expression:() => `` },
+        { properties: ['name', 'children'] },
+      ],
+      indexes: [
+        {
+          name: 'unique_name_children',
+          expression: (table, columns) =>
+            `create unique index ${table.name}_${columns.name}_${columns.children} on ${table.name} (${columns.name}, ${columns.children})`,
+        },
       ],
       properties: {
         id: p.integer().primary(),


### PR DESCRIPTION
This PR fixes the type circular error that occurs when using `defineEntity` to define a circular entity, for properties such as `indexes`, `uniques`:

```ts
const Category = defineEntity({
  name: 'Category',
  uniques: [
    { properties: ['name', 'children'] },
  ],
  properties: {
    id: p.integer().primary(),
    name: p.string(),
    description: p.string().length(2048).nullable(),
    metadata: p.json<Record<string, any>>().default('{}'),
    isShopEnabled: p.boolean(),
    parentCategory: () => p.manyToOne(Category).nullable(),
    children: () => p.oneToMany(Category).mappedBy('parentCategory'),
  },
});
```

The cause of this problem is that `EntityKey<T>` reads the property values of the circular entity type, and TypeScript starts to compute the specific values of the circular entity type.
The solution is to use `keyof TProperties` instead of `EntityKey<T>` in `defineEntity`.