### PR TITLE
refactor: create kysely/mongodb client lazily

### DIFF
--- a/packages/core/src/utils/Configuration.ts
+++ b/packages/core/src/utils/Configuration.ts
@@ -431,6 +431,10 @@ export class Configuration<D extends IDatabaseDriver = IDatabaseDriver, EM exten
     if (this.options.entities.length === 0 && this.options.discovery.warnWhenNoEntities) {
       throw new Error('No entities found, please use `entities` option');
     }
+
+    if (typeof this.options.driverOptions === 'function' && this.options.driverOptions.constructor.name === 'AsyncFunction') {
+      throw new Error('`driverOptions` callback cannot be async');
+    }
   }
 
 }

--- a/packages/sql/src/dialects/sqlite/BaseSqliteConnection.ts
+++ b/packages/sql/src/dialects/sqlite/BaseSqliteConnection.ts
@@ -5,7 +5,7 @@ export abstract class BaseSqliteConnection extends AbstractSqlConnection {
 
   override async connect(options?: { skipOnConnect?: boolean }): Promise<void> {
     await super.connect(options);
-    await this.client.executeQuery(CompiledQuery.raw('pragma foreign_keys = on'));
+    await this.getClient().executeQuery(CompiledQuery.raw('pragma foreign_keys = on'));
   }
 
 }

--- a/tests/MikroORM.test.ts
+++ b/tests/MikroORM.test.ts
@@ -172,6 +172,22 @@ describe('MikroORM', () => {
     })).rejects.toThrow(err);
   });
 
+  test('should throw when async callback provided in `driverOptions`', async () => {
+    const err = '`driverOptions` callback cannot be async';
+    await expect(MikroORM.init({
+      driver: SqliteDriver, dbName: ':memory:', entities: [Author2, BaseEntity2],
+      driverOptions: async () => ({}),
+    })).rejects.toThrow(err);
+  });
+
+  test('should throw when async callback provided in `driverOptions`', async () => {
+    const err = '`driverOptions` callback cannot be async';
+    await expect(MikroORM.init({
+      driver: MongoDriver, dbName: 'dbname', entities: [Author2, BaseEntity2],
+      driverOptions: async () => ({}),
+    })).rejects.toThrow(err);
+  });
+
   test('folder based discover with multiple entities in single file', async () => {
     const orm = await MikroORM.init({
       metadataProvider: ReflectMetadataProvider,

--- a/tests/features/entity-manager/EntityManager.mysql.test.ts
+++ b/tests/features/entity-manager/EntityManager.mysql.test.ts
@@ -2360,27 +2360,6 @@ describe('EntityManagerMySql', () => {
     expect(authors2[4].name).toBe('God 30');
   });
 
-  test('colors: false', async () => {
-    const mock = mockLogger(orm, ['query']);
-
-    const author = new Author2('Jon Snow', 'snow@wall.st');
-    await orm.em.persist(author).flush();
-
-    expect(mock.mock.calls.length).toBe(3);
-    expect(mock.mock.calls[0][0]).toMatch("\x1B[90m[query] \x1B[39mbegin\x1B[36m (via write connection '127.0.0.1')\x1B[39m");
-    expect(mock.mock.calls[1][0]).toMatch(/\x1B\[90m\[query] \x1B\[39minsert into `author2` \(`created_at`, `updated_at`, `name`, `email`, `terms_accepted`\) values \(\?, \?, \?, \?, \?\)\x1B\[90m \[took \d+ ms, 1 row affected]\x1B\[39m\x1B\[36m \(via write connection '127\.0\.0\.1'\)\x1B\[39m/);
-    expect(mock.mock.calls[2][0]).toMatch("\x1B[90m[query] \x1B[39mcommit\x1B[36m (via write connection '127.0.0.1')\x1B[39m");
-
-    orm.config.set('colors', false);
-    mock.mockReset();
-    await orm.em.remove(author).flush();
-
-    expect(mock.mock.calls.length).toBe(3);
-    expect(mock.mock.calls[0][0]).toMatch("[query] begin (via write connection '127.0.0.1')");
-    expect(mock.mock.calls[1][0]).toMatch(/\[query] delete from `author2` where `id` in \(\?\) \[took \d+ ms, 1 row affected] \(via write connection '127\.0\.0\.1'\)/);
-    expect(mock.mock.calls[2][0]).toMatch("[query] commit (via write connection '127.0.0.1')");
-  });
-
   test('datetime is stored in correct timezone', async () => {
     const author = new Author2('n', 'e');
     author.createdAt = new Date('2000-01-01T00:00:00Z');

--- a/tests/features/reusing-kysely-client.test.ts
+++ b/tests/features/reusing-kysely-client.test.ts
@@ -8,8 +8,9 @@ test('should allow reusing kysely connection', async () => {
     dbName: ':memory:',
     entities: [Car2, CarOwner2, User2, Sandwich],
   });
-  await orm.connect();
   const kysely = orm.em.getKysely();
+  expect(kysely).toBeDefined();
+  await orm.connect();
 
   const orm2 = await MikroORM.init({
     metadataProvider: ReflectMetadataProvider,
@@ -23,7 +24,7 @@ test('should allow reusing kysely connection', async () => {
     metadataProvider: ReflectMetadataProvider,
     dbName: ':memory:',
     entities: [Car2, CarOwner2, User2, Sandwich],
-    driverOptions: async () => kysely,
+    driverOptions: () => kysely,
   });
   await orm3.connect();
 
@@ -31,7 +32,7 @@ test('should allow reusing kysely connection', async () => {
     metadataProvider: ReflectMetadataProvider,
     dbName: ':memory:',
     entities: [Car2, CarOwner2, User2, Sandwich],
-    driverOptions: async () => orm3.driver.getConnection().createKyselyDialect({}),
+    driverOptions: () => orm3.driver.getConnection().createKyselyDialect({}),
   });
   await orm4.connect();
 

--- a/tests/features/reusing-mongo-client.test.ts
+++ b/tests/features/reusing-mongo-client.test.ts
@@ -10,8 +10,8 @@ test('should allow reusing mongo connection', async () => {
     dbName: 'mikro_orm_test',
     entities: [Author, schema],
   });
-  await orm.connect();
   const mongo = orm.em.getConnection().getClient();
+  await orm.connect();
 
   const orm2 = await MikroORM.init({
     metadataProvider: ReflectMetadataProvider,
@@ -27,7 +27,7 @@ test('should allow reusing mongo connection', async () => {
     driver: MongoDriver,
     dbName: 'mikro_orm_test',
     entities: [Author, schema],
-    driverOptions: async () => mongo,
+    driverOptions: () => mongo,
   });
   await orm3.connect();
 


### PR DESCRIPTION
This fixes `em.getKysely()` returning `undefined` when used before any query is fired.

This reverts #6599, we need to be able to create the kysely/mongodb instance synchronously, since we no longer connect eagerly.