### PR TITLE
refactor: remove `Connection.loadFile` method

### DIFF
--- a/docs/docs/upgrading-v6-to-v7.md
+++ b/docs/docs/upgrading-v6-to-v7.md
@@ -299,3 +299,14 @@ The `processOnCreateHooksEarly` option is now enabled by default. `onCreate` hoo
 ## `validate` and `strict` options removed
 
 Both are now enabled by default, and the auto-fixing mechanism is removed. This means that if you try to map a raw result from the database, it needs to be correctly typed. One example where this can happen is when you use some aggregation function like `sum`, in some dialects like postgres, it produces strings by default, which are no longer mappable to a `number` property by default.
+
+## `Connection.loadFile` method removed
+
+A new method is introduced to execute a schema dump called `Connection.executeDump`. Loading of the dump from a file is now the user's responsibility.
+
+```diff
+-await orm.driver.getConnection().loadFile('schema.sql');
++import { readFile } from 'node:fs/promises';
++const buf = await readFile('schema.sql');
++await orm.driver.getConnection().executeDump(buf.toString());`
+```

--- a/packages/cli/src/commands/ImportCommand.ts
+++ b/packages/cli/src/commands/ImportCommand.ts
@@ -1,3 +1,4 @@
+import { readFile } from 'node:fs/promises';
 import { colors } from '@mikro-orm/core';
 import type { ArgumentsCamelCase } from 'yargs';
 import type { BaseArgs, BaseCommand } from '../CLIConfigurator.js';
@@ -15,7 +16,8 @@ export class ImportCommand implements BaseCommand<ImportArgs> {
    */
   async handler(args: ArgumentsCamelCase<ImportArgs>) {
     const orm = await CLIHelper.getORM(args.contextName, args.config, { multipleStatements: true });
-    await orm.em.getConnection().loadFile(args.file);
+    const buf = await readFile(args.file);
+    await orm.em.getConnection().executeDump(buf.toString());
     CLIHelper.dump(colors.green(`File ${args.file} successfully imported`));
     await orm.close(true);
   }

--- a/packages/core/src/connections/Connection.ts
+++ b/packages/core/src/connections/Connection.ts
@@ -66,10 +66,11 @@ export abstract class Connection {
   }
 
   /**
-   * Load schema dump from file and execute it. Not supported by MongoDB driver.
+   * Execute raw SQL queries, handy from running schema dump loaded from a file.
+   * This method doesn't support transactions, as opposed to `orm.schema.execute()`, which is used internally.
    */
-  async loadFile(path: string): Promise<void> {
-    throw new Error(`Loading SQL files is not supported by current driver`);
+  async executeDump(dump: string): Promise<void> {
+    throw new Error(`Executing SQL dumps is not supported by current driver`);
   }
 
   protected async onConnect(): Promise<void> {

--- a/packages/libsql/src/LibSqlConnection.ts
+++ b/packages/libsql/src/LibSqlConnection.ts
@@ -9,7 +9,6 @@ export class LibSqlConnection extends BaseSqliteConnection {
   override createKyselyDialect(options: Dictionary & Options) {
     const dbName = options.url ?? this.config.get('dbName');
     options.authToken ??= this.config.get('password');
-
     return new LibSqlDialect({
       database: async () => {
         return this.database = new Database(dbName, options);
@@ -18,11 +17,10 @@ export class LibSqlConnection extends BaseSqliteConnection {
     });
   }
 
-  /* v8 ignore next */
-  override async loadFile(path: string): Promise<void> {
+  /** @inheritDoc */
+  override async executeDump(source: string): Promise<void> {
     await this.ensureConnection();
-    const { readFile } = globalThis.process.getBuiltinModule('node:fs/promises');
-    this.database.exec((await readFile(path)).toString());
+    this.database.exec(source);
   }
 
 }

--- a/packages/sql/src/AbstractSqlConnection.ts
+++ b/packages/sql/src/AbstractSqlConnection.ts
@@ -249,16 +249,12 @@ export abstract class AbstractSqlConnection extends Connection {
     }
   }
 
-  /**
-   * Execute raw SQL queries from file
-   */
-  override async loadFile(path: string): Promise<void> {
+  /** @inheritDoc */
+  override async executeDump(dump: string): Promise<void> {
     await this.ensureConnection();
-    const { readFile } = globalThis.process.getBuiltinModule('node:fs/promises');
-    const buf = await readFile(path);
 
     try {
-      const raw = CompiledQuery.raw(buf.toString());
+      const raw = CompiledQuery.raw(dump);
       await this.getClient().executeQuery(raw);
     } catch (e) {
       /* v8 ignore next */

--- a/packages/sqlite/src/SqliteConnection.ts
+++ b/packages/sqlite/src/SqliteConnection.ts
@@ -15,10 +15,10 @@ export class SqliteConnection extends BaseSqliteConnection {
     });
   }
 
-  override async loadFile(path: string): Promise<void> {
+  /** @inheritDoc */
+  override async executeDump(dump: string): Promise<void> {
     await this.ensureConnection();
-    const { readFile } = globalThis.process.getBuiltinModule('node:fs/promises');
-    this.database.exec((await readFile(path)).toString());
+    this.database.exec(dump);
   }
 
 }

--- a/tests/Connection.test.ts
+++ b/tests/Connection.test.ts
@@ -37,7 +37,7 @@ describe('Connection', () => {
     await expect(conn.begin()).rejects.toThrow('Transactions are not supported by current driver');
     await expect(conn.commit({} as any)).rejects.toThrow('Transactions are not supported by current driver');
     await expect(conn.rollback({} as any)).rejects.toThrow('Transactions are not supported by current driver');
-    await expect(conn.loadFile('...')).rejects.toThrow('Loading SQL files is not supported by current driver');
+    await expect(conn.executeDump('...')).rejects.toThrow('Executing SQL dumps is not supported by current driver');
   });
 
   test('special characters in username and password', async () => {

--- a/tests/features/cli/ImportCommand.test.ts
+++ b/tests/features/cli/ImportCommand.test.ts
@@ -9,7 +9,7 @@ describe('ImportDatabaseCommand', () => {
   test('handler', async () => {
     const close = vi.fn();
     const config = new Configuration({ driver: MongoDriver } as any, false);
-    const connection = { loadFile: vi.fn() };
+    const connection = { executeDump: vi.fn() };
     const em = { getConnection: () => connection };
     const showHelpMock = vi.spyOn(CLIHelper, 'showHelp');
     showHelpMock.mockImplementation(() => void 0);
@@ -20,9 +20,9 @@ describe('ImportDatabaseCommand', () => {
 
     const cmd = new ImportCommand();
 
-    await expect(cmd.handler({} as any)).resolves.toBeUndefined();
+    await expect(cmd.handler({ file: `${process.cwd()}/tests/sqlite-schema.sql` } as any)).resolves.toBeUndefined();
     expect(close).toHaveBeenCalledTimes(1);
-    expect(connection.loadFile.mock.calls.length).toBe(1);
+    expect(connection.executeDump.mock.calls.length).toBe(1);
   });
 
 });

--- a/tests/mysql-schema.sql
+++ b/tests/mysql-schema.sql
@@ -39,7 +39,12 @@ create table `sandwich` (`id` int(10) unsigned not null auto_increment primary k
 
 create table `publisher2` (`id` int(10) unsigned not null auto_increment primary key, `name` varchar(255) not null default 'asd', `type` enum('local', 'global') not null default 'local', `type2` enum('LOCAL', 'GLOBAL') not null default 'LOCAL', `enum1` tinyint null, `enum2` tinyint null, `enum3` tinyint null, `enum4` enum('a', 'b', 'c') null, `enum5` enum('a') null) default character set utf8mb4 engine = InnoDB;
 
-create table `foo_baz2` (`id` int(10) unsigned not null auto_increment primary key, `name` varchar(255) not null, `code` varchar(255) not null, `version` datetime(3) not null default current_timestamp(3)) default character set utf8mb4 engine = InnoDB;
+create table `foo_baz2` (
+  `id` int(10) unsigned not null auto_increment primary key,
+  `name` varchar(255) not null,
+  `code` varchar(255) not null,
+  `version` datetime(3) not null default current_timestamp(3)
+) default character set utf8mb4 engine = InnoDB;
 
 create table `foo_bar2` (`id` int(10) unsigned not null auto_increment primary key, `name` varchar(255) not null, `name with space` varchar(255) null, `baz_id` int(10) unsigned null, `foo_bar_id` int(10) unsigned null, `version` datetime not null default current_timestamp, `blob` blob null, `blob2` blob null, `array` text null, `object_property` json null) default character set utf8mb4 engine = InnoDB;
 alter table `foo_bar2` add unique `foo_bar2_baz_id_unique`(`baz_id`);

--- a/tests/postgre-schema.sql
+++ b/tests/postgre-schema.sql
@@ -31,7 +31,12 @@ create schema if not exists "label_schema";
 create table "label2" ("uuid" uuid not null, "name" varchar(255) not null);
 alter table "label2" add constraint "label2_pkey" primary key ("uuid");
 
-create table "foo_baz2" ("id" serial primary key, "name" varchar(255) not null, "code" varchar(255) not null, "version" timestamptz(3) not null default current_timestamp(3));
+create table "foo_baz2" (
+  "id" serial primary key,
+  "name" varchar(255) not null,
+  "code" varchar(255) not null,
+  "version" timestamptz(3) not null default current_timestamp(3)
+);
 
 create table "foo_bar2" ("id" serial primary key, "name" varchar(255) not null, "name with space" varchar(255) null, "baz_id" int4 null, "foo_bar_id" int4 null, "version" timestamptz(0) not null default current_timestamp(0), "blob" bytea null, "blob2" bytea null, "array" text[] null, "object_property" jsonb null);
 alter table "foo_bar2" add constraint "foo_bar2_baz_id_unique" unique ("baz_id");

--- a/tests/sqlite-schema.sql
+++ b/tests/sqlite-schema.sql
@@ -11,7 +11,11 @@ drop table if exists `test3`;
 drop table if exists `book3_to_book_tag3`;
 drop table if exists `publisher3_to_test3`;
 
-create table `test3` (`id` integer not null primary key autoincrement, `name` text null, `version` integer not null default 1);
+create table `test3` (
+  `id` integer not null primary key autoincrement,
+  `name` text null,
+  `version` integer not null default 1
+);
 
 create table `publisher3` (`id` integer not null primary key autoincrement, `name` text not null, `type` text not null);
 


### PR DESCRIPTION
BREAKING CHANGE:
A new method is introduced to execute a schema dump called `Connection.executeDump`. Loading of the dump from a file is now the user's responsibility.

```diff
-await orm.driver.getConnection().loadFile('schema.sql');
+import { readFile } from 'node:fs/promises';
+const buf = await readFile('schema.sql');
+await orm.driver.getConnection().executeDump(buf.toString());`
```