### PR TITLE
refactor: support extends on type level with `defineEntity`

### DIFF
--- a/docs/docs/defining-entities.md
+++ b/docs/docs/defining-entities.md
@@ -53,7 +53,7 @@ export class Book extends CustomBaseEntity {
   @ManyToOne(() => Publisher, { ref: true, nullable: true })
   publisher?: Ref<Publisher>;
 
-  @ManyToMany({ entity: 'BookTag', fixedOrder: true })
+  @ManyToMany(() => BookTag, { fixedOrder: true })
   tags = new Collection<BookTag>(this);
 
 }
@@ -89,8 +89,8 @@ import { type InferEntity, defineEntity } from '@mikro-orm/core';
 
 export const Book = defineEntity({
   name: 'Book',
+  extends: CustomBaseEntity,
   properties: p => ({
-    ...CustomBaseProperties,
     title: p.string(),
     author: () => p.manyToOne(Author),
     publisher: () => p.manyToOne(Publisher)
@@ -108,21 +108,21 @@ export interface IBook extends InferEntity<typeof Book> {}
   <TabItem value="entity-schema">
 
 ```ts title="./entities/Book.ts"
-export interface IBook extends CustomBaseEntity {
+export interface IBook extends ICustomBaseEntity {
   title: string;
   author: Author;
   publisher?: Ref<Publisher>;
   tags: Collection<BookTag>;
 }
 
-export const Book = new EntitySchema<IBook, CustomBaseEntity>({
+export const Book = new EntitySchema<IBook>({
   name: 'Book',
-  extends: 'CustomBaseEntity',
+  extends: CustomBaseEntity,
   properties: {
     title: { type: 'string' },
-    author: { kind: 'm:1', entity: 'Author' },
-    publisher: { kind: 'm:1', entity: 'Publisher', ref: true, nullable: true },
-    tags: { kind: 'm:n', entity: 'BookTag', fixedOrder: true },
+    author: { kind: 'm:1', entity: () => Author },
+    publisher: { kind: 'm:1', entity: () => Publisher, ref: true, nullable: true },
+    tags: { kind: 'm:n', entity: () => BookTag, fixedOrder: true },
   },
 });
 ```
@@ -2304,8 +2304,8 @@ export const BookSchema = new EntitySchema<Book>({
   properties: {
     id: { type: Number, primary: true },
     title: { type: String },
-    author: { kind: 'm:1', entity: 'Author' },
-    publisher: { kind: 'm:1', entity: 'Publisher', ref: true, nullable: true },
+    author: { kind: 'm:1', entity: () => Author },
+    publisher: { kind: 'm:1', entity: () => Publisher, ref: true, nullable: true },
   },
 });
 ```

--- a/packages/core/src/metadata/EntitySchema.ts
+++ b/packages/core/src/metadata/EntitySchema.ts
@@ -44,13 +44,13 @@ export type EntitySchemaProperty<Target, Owner> =
   | ({ enum: true } & EnumOptions<Owner>)
   | (TypeDef<Target> & PropertyOptions<Owner>);
 type OmitBaseProps<Entity, Base> = IsNever<Base> extends true ? Entity : Omit<Entity, keyof Base>;
-export type EntitySchemaMetadata<Entity, Base = never, Class extends EntityCtor = any> =
+export type EntitySchemaMetadata<Entity, Base = never, Class extends EntityCtor = EntityCtor<Entity>> =
   & Omit<Partial<EntityMetadata<Entity>>, 'name' | 'properties' | 'extends'>
   & ({ name: string } | { class: Class; name?: string })
   & { extends?: EntityName<Base> }
   & { properties?: { [Key in keyof OmitBaseProps<Entity, Base> as CleanKeys<OmitBaseProps<Entity, Base>, Key>]-?: EntitySchemaProperty<ExpandProperty<NonNullable<Entity[Key]>>, Entity> } };
 
-export class EntitySchema<Entity = any, Base = never, Class extends EntityCtor = any> {
+export class EntitySchema<Entity = any, Base = never, Class extends EntityCtor = EntityCtor<Entity>> {
 
   /**
    * When schema links the entity class via `class` option, this registry allows the lookup from opposite side,

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -30,6 +30,7 @@ import { EntityComparator } from './utils/EntityComparator.js';
 import type { EntityManager } from './EntityManager.js';
 import type { EventSubscriber } from './events/EventSubscriber.js';
 import type { FilterOptions, FindOneOptions, FindOptions, LoadHint } from './drivers/IDatabaseDriver.js';
+import { BaseEntity } from './entity/BaseEntity.js';
 
 export type Constructor<T = unknown> = new (...args: any[]) => T;
 export type Dictionary<T = any> = { [k: string]: T };
@@ -594,7 +595,10 @@ export class EntityMetadata<Entity = any, Class extends EntityCtor<Entity> = Ent
     const name = meta.className ?? meta.name;
 
     if (!this.class && name) {
-      this.class = ({ [name]: class {} })[name] as any;
+      const Class = this.extends === BaseEntity
+        ? ({ [name]: class extends BaseEntity {} })[name]
+        : ({ [name]: class {} })[name];
+      this.class = Class as any;
     }
   }
 
@@ -1352,7 +1356,7 @@ export type MetadataProcessor = (metadata: EntityMetadata[], platform: Platform)
 
 export type MaybeReturnType<T> = T extends (...args: any[]) => infer R ? R : T;
 
-export interface EntitySchemaWithMeta<TName extends string = string, TTableName extends string = string, TEntity = any, TBase = never, TProperties extends Record<string, any> = Record<string, any>, TClass extends EntityCtor = any> extends EntitySchema<TEntity, TBase, TClass> {
+export interface EntitySchemaWithMeta<TName extends string = string, TTableName extends string = string, TEntity = any, TBase = never, TProperties extends Record<string, any> = Record<string, any>, TClass extends EntityCtor = EntityCtor<TEntity>> extends EntitySchema<TEntity, TBase, TClass> {
   readonly name: TName;
   readonly properties: TProperties;
   readonly tableName: TTableName;

--- a/tests/entities-schema/Book4.ts
+++ b/tests/entities-schema/Book4.ts
@@ -1,5 +1,5 @@
 import { p, defineEntity, InferEntity } from '@mikro-orm/core';
-import { BaseProperties } from './BaseEntity5.js';
+import { BaseEntity5 } from './BaseEntity5.js';
 import { Author4 } from './Author4.js';
 import { Publisher4 } from './Publisher4.js';
 import { BookTag4 } from './BookTag4.js';
@@ -13,8 +13,8 @@ export interface Book4Meta {
 
 export const Book4 = defineEntity({
   name: 'Book4',
+  extends: BaseEntity5,
   properties: {
-    ...BaseProperties,
     title: p.string(),
     price: p.float().nullable(),
     priceTaxed: p.float().formula(a => `${a}.price * 1.19`).persist(false),

--- a/tests/entities-schema/BookTag4.ts
+++ b/tests/entities-schema/BookTag4.ts
@@ -1,11 +1,11 @@
 import { p, InferEntity, defineEntity } from '@mikro-orm/core';
 import { Book4 } from './Book4.js';
-import { BaseProperties } from './BaseEntity5.js';
+import { BaseEntity5 } from './BaseEntity5.js';
 
 export const BookTag4 = defineEntity({
   name: 'BookTag4',
+  extends: BaseEntity5,
   properties: {
-    ...BaseProperties,
     name: p.string(),
     books: () => p.manyToMany(Book4).mappedBy('tags'),
     version: p.datetime().version(),

--- a/tests/entities-schema/FooBar4.ts
+++ b/tests/entities-schema/FooBar4.ts
@@ -1,8 +1,9 @@
-import { defineEntity, InferEntity, p } from '@mikro-orm/core';
+import { defineEntity, InferEntity, BaseEntity, p } from '@mikro-orm/core';
 import { FooBaz4, BaseProperties } from './index.js';
 
 export const FooBar4 = defineEntity({
   name: 'FooBar4',
+  extends: BaseEntity,
   properties: {
     ...BaseProperties,
     name: p.string().default('asd'),

--- a/tests/features/entity-manager/EntityManager.sqlite.test.ts
+++ b/tests/features/entity-manager/EntityManager.sqlite.test.ts
@@ -1049,6 +1049,15 @@ describe.each(['sqlite', 'libsql'] as const)('EntityManager (%s)', driver => {
     const b1 = await orm.em.findOneOrFail(FooBar4, { name: 'b1' });
     expect(b1.virtual).toBeUndefined();
 
+    // test `defineEntity` with `extends: BaseEntity`
+    expect(b1.toObject()).toEqual({
+      id: b1.id,
+      createdAt: b1.createdAt,
+      updatedAt: b1.updatedAt,
+      name: 'b1',
+      version: 1,
+    });
+
     await orm.em.createQueryBuilder(FooBar4).select(raw(`id, '123' as virtual`)).getResultList();
     expect(b1.virtual).toBe('123');
   });

--- a/tests/features/filters/control-filters-on-relation-props.test.ts
+++ b/tests/features/filters/control-filters-on-relation-props.test.ts
@@ -1,6 +1,5 @@
 import { defineEntity, MikroORM, p } from '@mikro-orm/sqlite';
 
-import { ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
 const BenefitDetail = defineEntity({
   name: 'BenefitDetail',
   properties: {
@@ -42,8 +41,6 @@ const Benefit = defineEntity({
   name: 'Benefit',
   extends: BaseBenefit,
   properties: {
-    // FIXME this is required for `InferEntity` with `extends`
-    ...BaseBenefitProps,
     name: p.string(),
     details: () => p.oneToMany(BenefitDetail).mappedBy('benefit').filters({ isActive: { active: true } }),
   },
@@ -64,7 +61,6 @@ describe('control filters on relation props [sqlite]', () => {
 
   beforeAll(async () => {
     orm = await MikroORM.init({
-      metadataProvider: ReflectMetadataProvider,
       entities: [Employee, Benefit],
       dbName: ':memory:',
     });


### PR DESCRIPTION
```ts
export const Book = defineEntity({
  name: 'Book',
  extends: CustomBaseEntity, // this is now supported on type level correctly, also accepts the ORM BaseEntity
  properties: p => ({
    title: p.string(),
    author: () => p.manyToOne(Author),
    publisher: () => p.manyToOne(Publisher)
      .ref()
      .nullable(),
    tags: () => p.manyToMany(BookTag)
      .fixedOrder(),
  }),
});

export interface IBook extends InferEntity<typeof Book> {}
```