### PR TITLE
fix(core): enable `forceUtcTimezone` by default for all SQL drivers

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -307,11 +307,13 @@ MikroORM.init({
 
 ## Forcing UTC Timezone
 
-Use `forceUtcTimezone` option to force the `Date`s to be saved in UTC in datetime columns without timezone. It works for MySQL (`datetime` type) and PostgreSQL (`timestamp` type). SQLite does this by default.
+The `forceUtcTimezone` option forces `Date` values to be stored in UTC for datetime columns without timezone. It works for MySQL (`datetime` type), PostgreSQL (`timestamp` type), and MSSQL (`datetime`/`datetime2` types). SQLite stores dates as numeric timestamps, which are inherently timezone-agnostic.
+
+This option is enabled by default since v7. To disable it and store dates in local timezone:
 
 ```ts
 MikroORM.init({
-  forceUtcTimezone: true,
+  forceUtcTimezone: false,
 });
 ```
 

--- a/docs/docs/upgrading-v6-to-v7.md
+++ b/docs/docs/upgrading-v6-to-v7.md
@@ -331,6 +331,20 @@ The following methods were renamed:
 
 Previously, we used `md5` hash algorithm in various places, mainly to compute a stable hash for a string value, e.g. for long index names. This was made configurable and sha256 was also allowed via `hashAlgorithm` option. The algorithm is now replaced with FNV-1a 64-bit, so we don't have to depend on `node:crypto`. The option `hashAlgorithm` is removed.
 
+## `forceUtcTimezone` enabled by default
+
+The `forceUtcTimezone` option is now enabled by default for all SQL drivers. This means datetime columns without timezone (`datetime` in MySQL/MSSQL, `timestamp` in PostgreSQL) will store and retrieve values in UTC.
+
+If your application relies on storing dates in local timezone, you can disable this by setting `forceUtcTimezone: false`:
+
+```ts
+MikroORM.init({
+  forceUtcTimezone: false,
+});
+```
+
+> Note: If you have existing data stored in local timezone and enable UTC mode, or vice versa, the timestamps will be interpreted incorrectly. Make sure to migrate your data accordingly, or keep the setting consistent with how your data was originally stored.
+
 ## `processOnCreateHooksEarly` enabled by default
 
 The `processOnCreateHooksEarly` option is now enabled by default. `onCreate` hooks are now executed inside `em.create` method if used explicitly.

--- a/packages/core/src/utils/Configuration.ts
+++ b/packages/core/src/utils/Configuration.ts
@@ -94,6 +94,7 @@ const DEFAULTS = {
   upsertManaged: true,
   forceEntityConstructor: false,
   forceUndefined: false,
+  forceUtcTimezone: true,
   processOnCreateHooksEarly: true,
   ensureDatabase: true,
   ensureIndexes: false,
@@ -864,9 +865,9 @@ export interface Options<
   processOnCreateHooksEarly?: boolean;
   /**
    * Force `Date` values to be stored in UTC for datetime columns without timezone.
-   * Works for MySQL (`datetime` type) and PostgreSQL (`timestamp` type).
+   * Works for MySQL (`datetime` type), PostgreSQL (`timestamp` type), and MSSQL (`datetime`/`datetime2` types).
    * SQLite does this by default.
-   * @default false
+   * @default true
    */
   forceUtcTimezone?: boolean;
   /**

--- a/packages/sql/src/dialects/postgresql/BasePostgreSqlPlatform.ts
+++ b/packages/sql/src/dialects/postgresql/BasePostgreSqlPlatform.ts
@@ -1,7 +1,6 @@
 import {
   ALIAS_REPLACEMENT,
   ARRAY_OPERATORS,
-  type Configuration,
   type Dictionary,
   type EntityProperty,
   type IsolationLevel,
@@ -22,14 +21,6 @@ export class BasePostgreSqlPlatform extends AbstractSqlPlatform {
 
   protected override readonly schemaHelper: PostgreSqlSchemaHelper = new PostgreSqlSchemaHelper(this);
   protected override readonly exceptionConverter = new PostgreSqlExceptionConverter();
-
-  override setConfig(config: Configuration) {
-    if (config.get('forceUtcTimezone') == null) {
-      config.set('forceUtcTimezone', true);
-    }
-
-    super.setConfig(config);
-  }
 
   override createNativeQueryBuilder(): PostgreSqlNativeQueryBuilder {
     return new PostgreSqlNativeQueryBuilder(this);

--- a/tests/features/embeddables/__snapshots__/GH2391-2.test.ts.snap
+++ b/tests/features/embeddables/__snapshots__/GH2391-2.test.ts.snap
@@ -13,8 +13,10 @@ exports[`onCreate and onUpdate in embeddables (GH 2283 and 2391) > result mapper
       ret.foo_audit1_archived = result.foo_audit1_archivedAt;
     } else if (typeof result.foo_audit1_archivedAt === 'bigint') {
       ret.foo_audit1_archived = parseDate(Number(result.foo_audit1_archivedAt));
-    } else {
+    } else if (typeof result.foo_audit1_archivedAt === 'number' || result.foo_audit1_archivedAt.includes('+') || result.foo_audit1_archivedAt.lastIndexOf('-') > 10 || result.foo_audit1_archivedAt.endsWith('Z')) {
       ret.foo_audit1_archived = parseDate(result.foo_audit1_archivedAt);
+    } else {
+      ret.foo_audit1_archived = parseDate(result.foo_audit1_archivedAt + 'Z');
     }
     mapped.foo_audit1_archivedAt = true;
   }
@@ -23,8 +25,10 @@ exports[`onCreate and onUpdate in embeddables (GH 2283 and 2391) > result mapper
       ret.foo_audit1_updatedAt = result.foo_audit1_updated_at;
     } else if (typeof result.foo_audit1_updated_at === 'bigint') {
       ret.foo_audit1_updatedAt = parseDate(Number(result.foo_audit1_updated_at));
-    } else {
+    } else if (typeof result.foo_audit1_updated_at === 'number' || result.foo_audit1_updated_at.includes('+') || result.foo_audit1_updated_at.lastIndexOf('-') > 10 || result.foo_audit1_updated_at.endsWith('Z')) {
       ret.foo_audit1_updatedAt = parseDate(result.foo_audit1_updated_at);
+    } else {
+      ret.foo_audit1_updatedAt = parseDate(result.foo_audit1_updated_at + 'Z');
     }
     mapped.foo_audit1_updated_at = true;
   }
@@ -33,8 +37,10 @@ exports[`onCreate and onUpdate in embeddables (GH 2283 and 2391) > result mapper
       ret.foo_audit1_created = result.foo_audit1_created;
     } else if (typeof result.foo_audit1_created === 'bigint') {
       ret.foo_audit1_created = parseDate(Number(result.foo_audit1_created));
-    } else {
+    } else if (typeof result.foo_audit1_created === 'number' || result.foo_audit1_created.includes('+') || result.foo_audit1_created.lastIndexOf('-') > 10 || result.foo_audit1_created.endsWith('Z')) {
       ret.foo_audit1_created = parseDate(result.foo_audit1_created);
+    } else {
+      ret.foo_audit1_created = parseDate(result.foo_audit1_created + 'Z');
     }
     mapped.foo_audit1_created = true;
   }
@@ -43,8 +49,10 @@ exports[`onCreate and onUpdate in embeddables (GH 2283 and 2391) > result mapper
       ret.foo_audit1_nested_audit1_archived = result.foo_audit1_nested_audit1_archivedAt;
     } else if (typeof result.foo_audit1_nested_audit1_archivedAt === 'bigint') {
       ret.foo_audit1_nested_audit1_archived = parseDate(Number(result.foo_audit1_nested_audit1_archivedAt));
-    } else {
+    } else if (typeof result.foo_audit1_nested_audit1_archivedAt === 'number' || result.foo_audit1_nested_audit1_archivedAt.includes('+') || result.foo_audit1_nested_audit1_archivedAt.lastIndexOf('-') > 10 || result.foo_audit1_nested_audit1_archivedAt.endsWith('Z')) {
       ret.foo_audit1_nested_audit1_archived = parseDate(result.foo_audit1_nested_audit1_archivedAt);
+    } else {
+      ret.foo_audit1_nested_audit1_archived = parseDate(result.foo_audit1_nested_audit1_archivedAt + 'Z');
     }
     mapped.foo_audit1_nested_audit1_archivedAt = true;
   }
@@ -53,8 +61,10 @@ exports[`onCreate and onUpdate in embeddables (GH 2283 and 2391) > result mapper
       ret.foo_audit1_nested_audit1_updatedAt = result.foo_audit1_nested_audit1_updated_at;
     } else if (typeof result.foo_audit1_nested_audit1_updated_at === 'bigint') {
       ret.foo_audit1_nested_audit1_updatedAt = parseDate(Number(result.foo_audit1_nested_audit1_updated_at));
-    } else {
+    } else if (typeof result.foo_audit1_nested_audit1_updated_at === 'number' || result.foo_audit1_nested_audit1_updated_at.includes('+') || result.foo_audit1_nested_audit1_updated_at.lastIndexOf('-') > 10 || result.foo_audit1_nested_audit1_updated_at.endsWith('Z')) {
       ret.foo_audit1_nested_audit1_updatedAt = parseDate(result.foo_audit1_nested_audit1_updated_at);
+    } else {
+      ret.foo_audit1_nested_audit1_updatedAt = parseDate(result.foo_audit1_nested_audit1_updated_at + 'Z');
     }
     mapped.foo_audit1_nested_audit1_updated_at = true;
   }
@@ -63,8 +73,10 @@ exports[`onCreate and onUpdate in embeddables (GH 2283 and 2391) > result mapper
       ret.foo_audit1_nested_audit1_created = result.foo_audit1_nested_audit1_created;
     } else if (typeof result.foo_audit1_nested_audit1_created === 'bigint') {
       ret.foo_audit1_nested_audit1_created = parseDate(Number(result.foo_audit1_nested_audit1_created));
-    } else {
+    } else if (typeof result.foo_audit1_nested_audit1_created === 'number' || result.foo_audit1_nested_audit1_created.includes('+') || result.foo_audit1_nested_audit1_created.lastIndexOf('-') > 10 || result.foo_audit1_nested_audit1_created.endsWith('Z')) {
       ret.foo_audit1_nested_audit1_created = parseDate(result.foo_audit1_nested_audit1_created);
+    } else {
+      ret.foo_audit1_nested_audit1_created = parseDate(result.foo_audit1_nested_audit1_created + 'Z');
     }
     mapped.foo_audit1_nested_audit1_created = true;
   }

--- a/tests/features/embeddables/__snapshots__/GH2391.test.ts.snap
+++ b/tests/features/embeddables/__snapshots__/GH2391.test.ts.snap
@@ -13,8 +13,10 @@ exports[`onCreate and onUpdate in embeddables (GH 2283 and 2391) > result mapper
       ret.audit1_archived = result.audit1_archived;
     } else if (typeof result.audit1_archived === 'bigint') {
       ret.audit1_archived = parseDate(Number(result.audit1_archived));
-    } else {
+    } else if (typeof result.audit1_archived === 'number' || result.audit1_archived.includes('+') || result.audit1_archived.lastIndexOf('-') > 10 || result.audit1_archived.endsWith('Z')) {
       ret.audit1_archived = parseDate(result.audit1_archived);
+    } else {
+      ret.audit1_archived = parseDate(result.audit1_archived + 'Z');
     }
     mapped.audit1_archived = true;
   }
@@ -23,8 +25,10 @@ exports[`onCreate and onUpdate in embeddables (GH 2283 and 2391) > result mapper
       ret.audit1_updated = result.audit1_updated;
     } else if (typeof result.audit1_updated === 'bigint') {
       ret.audit1_updated = parseDate(Number(result.audit1_updated));
-    } else {
+    } else if (typeof result.audit1_updated === 'number' || result.audit1_updated.includes('+') || result.audit1_updated.lastIndexOf('-') > 10 || result.audit1_updated.endsWith('Z')) {
       ret.audit1_updated = parseDate(result.audit1_updated);
+    } else {
+      ret.audit1_updated = parseDate(result.audit1_updated + 'Z');
     }
     mapped.audit1_updated = true;
   }
@@ -33,8 +37,10 @@ exports[`onCreate and onUpdate in embeddables (GH 2283 and 2391) > result mapper
       ret.audit1_created = result.audit1_created;
     } else if (typeof result.audit1_created === 'bigint') {
       ret.audit1_created = parseDate(Number(result.audit1_created));
-    } else {
+    } else if (typeof result.audit1_created === 'number' || result.audit1_created.includes('+') || result.audit1_created.lastIndexOf('-') > 10 || result.audit1_created.endsWith('Z')) {
       ret.audit1_created = parseDate(result.audit1_created);
+    } else {
+      ret.audit1_created = parseDate(result.audit1_created + 'Z');
     }
     mapped.audit1_created = true;
   }
@@ -43,8 +49,10 @@ exports[`onCreate and onUpdate in embeddables (GH 2283 and 2391) > result mapper
       ret.audit1_nested_audit1_archived = result.audit1_nested_audit1_archived;
     } else if (typeof result.audit1_nested_audit1_archived === 'bigint') {
       ret.audit1_nested_audit1_archived = parseDate(Number(result.audit1_nested_audit1_archived));
-    } else {
+    } else if (typeof result.audit1_nested_audit1_archived === 'number' || result.audit1_nested_audit1_archived.includes('+') || result.audit1_nested_audit1_archived.lastIndexOf('-') > 10 || result.audit1_nested_audit1_archived.endsWith('Z')) {
       ret.audit1_nested_audit1_archived = parseDate(result.audit1_nested_audit1_archived);
+    } else {
+      ret.audit1_nested_audit1_archived = parseDate(result.audit1_nested_audit1_archived + 'Z');
     }
     mapped.audit1_nested_audit1_archived = true;
   }
@@ -53,8 +61,10 @@ exports[`onCreate and onUpdate in embeddables (GH 2283 and 2391) > result mapper
       ret.audit1_nested_audit1_updated = result.audit1_nested_audit1_updated;
     } else if (typeof result.audit1_nested_audit1_updated === 'bigint') {
       ret.audit1_nested_audit1_updated = parseDate(Number(result.audit1_nested_audit1_updated));
-    } else {
+    } else if (typeof result.audit1_nested_audit1_updated === 'number' || result.audit1_nested_audit1_updated.includes('+') || result.audit1_nested_audit1_updated.lastIndexOf('-') > 10 || result.audit1_nested_audit1_updated.endsWith('Z')) {
       ret.audit1_nested_audit1_updated = parseDate(result.audit1_nested_audit1_updated);
+    } else {
+      ret.audit1_nested_audit1_updated = parseDate(result.audit1_nested_audit1_updated + 'Z');
     }
     mapped.audit1_nested_audit1_updated = true;
   }
@@ -63,8 +73,10 @@ exports[`onCreate and onUpdate in embeddables (GH 2283 and 2391) > result mapper
       ret.audit1_nested_audit1_created = result.audit1_nested_audit1_created;
     } else if (typeof result.audit1_nested_audit1_created === 'bigint') {
       ret.audit1_nested_audit1_created = parseDate(Number(result.audit1_nested_audit1_created));
-    } else {
+    } else if (typeof result.audit1_nested_audit1_created === 'number' || result.audit1_nested_audit1_created.includes('+') || result.audit1_nested_audit1_created.lastIndexOf('-') > 10 || result.audit1_nested_audit1_created.endsWith('Z')) {
       ret.audit1_nested_audit1_created = parseDate(result.audit1_nested_audit1_created);
+    } else {
+      ret.audit1_nested_audit1_created = parseDate(result.audit1_nested_audit1_created + 'Z');
     }
     mapped.audit1_nested_audit1_created = true;
   }

--- a/tests/features/embeddables/__snapshots__/entities-in-embeddables.mongo.test.ts.snap
+++ b/tests/features/embeddables/__snapshots__/entities-in-embeddables.mongo.test.ts.snap
@@ -374,8 +374,10 @@ exports[`embedded entities in mongo > diffing 2`] = `
             } else if (typeof data.profile1_identity_links[idx_14].createdAt !== 'undefined') {
               if (data.profile1_identity_links[idx_14].createdAt instanceof Date) {
                 entity.profile1.identity.links[idx_14].createdAt = data.profile1_identity_links[idx_14].createdAt;
-              } else {
+              } else if (typeof data.profile1_identity_links[idx_14].createdAt === 'number' || data.profile1_identity_links[idx_14].createdAt.includes('+') || data.profile1_identity_links[idx_14].createdAt.lastIndexOf('-') > 10 || data.profile1_identity_links[idx_14].createdAt.endsWith('Z')) {
                 entity.profile1.identity.links[idx_14].createdAt = new Date(data.profile1_identity_links[idx_14].createdAt);
+              } else {
+                entity.profile1.identity.links[idx_14].createdAt = new Date(data.profile1_identity_links[idx_14].createdAt + 'Z');
               }
             }
             if (data.profile1_identity_links[idx_14].meta != null) {
@@ -549,8 +551,10 @@ exports[`embedded entities in mongo > diffing 2`] = `
             } else if (typeof data.profile1_identity.links[idx_39].createdAt !== 'undefined') {
               if (data.profile1_identity.links[idx_39].createdAt instanceof Date) {
                 entity.profile1.identity.links[idx_39].createdAt = data.profile1_identity.links[idx_39].createdAt;
-              } else {
+              } else if (typeof data.profile1_identity.links[idx_39].createdAt === 'number' || data.profile1_identity.links[idx_39].createdAt.includes('+') || data.profile1_identity.links[idx_39].createdAt.lastIndexOf('-') > 10 || data.profile1_identity.links[idx_39].createdAt.endsWith('Z')) {
                 entity.profile1.identity.links[idx_39].createdAt = new Date(data.profile1_identity.links[idx_39].createdAt);
+              } else {
+                entity.profile1.identity.links[idx_39].createdAt = new Date(data.profile1_identity.links[idx_39].createdAt + 'Z');
               }
             }
             if (data.profile1_identity.links[idx_39].meta != null) {
@@ -751,8 +755,10 @@ exports[`embedded entities in mongo > diffing 2`] = `
             } else if (typeof data.profile1_identity_links[idx_67].createdAt !== 'undefined') {
               if (data.profile1_identity_links[idx_67].createdAt instanceof Date) {
                 entity.profile1.identity.links[idx_67].createdAt = data.profile1_identity_links[idx_67].createdAt;
-              } else {
+              } else if (typeof data.profile1_identity_links[idx_67].createdAt === 'number' || data.profile1_identity_links[idx_67].createdAt.includes('+') || data.profile1_identity_links[idx_67].createdAt.lastIndexOf('-') > 10 || data.profile1_identity_links[idx_67].createdAt.endsWith('Z')) {
                 entity.profile1.identity.links[idx_67].createdAt = new Date(data.profile1_identity_links[idx_67].createdAt);
+              } else {
+                entity.profile1.identity.links[idx_67].createdAt = new Date(data.profile1_identity_links[idx_67].createdAt + 'Z');
               }
             }
             if (data.profile1_identity_links[idx_67].meta != null) {
@@ -926,8 +932,10 @@ exports[`embedded entities in mongo > diffing 2`] = `
             } else if (typeof data.profile1.identity.links[idx_92].createdAt !== 'undefined') {
               if (data.profile1.identity.links[idx_92].createdAt instanceof Date) {
                 entity.profile1.identity.links[idx_92].createdAt = data.profile1.identity.links[idx_92].createdAt;
-              } else {
+              } else if (typeof data.profile1.identity.links[idx_92].createdAt === 'number' || data.profile1.identity.links[idx_92].createdAt.includes('+') || data.profile1.identity.links[idx_92].createdAt.lastIndexOf('-') > 10 || data.profile1.identity.links[idx_92].createdAt.endsWith('Z')) {
                 entity.profile1.identity.links[idx_92].createdAt = new Date(data.profile1.identity.links[idx_92].createdAt);
+              } else {
+                entity.profile1.identity.links[idx_92].createdAt = new Date(data.profile1.identity.links[idx_92].createdAt + 'Z');
               }
             }
             if (data.profile1.identity.links[idx_92].meta != null) {
@@ -1092,8 +1100,10 @@ exports[`embedded entities in mongo > diffing 2`] = `
             } else if (typeof data.profile2.identity.links[idx_116].createdAt !== 'undefined') {
               if (data.profile2.identity.links[idx_116].createdAt instanceof Date) {
                 entity.profile2.identity.links[idx_116].createdAt = data.profile2.identity.links[idx_116].createdAt;
-              } else {
+              } else if (typeof data.profile2.identity.links[idx_116].createdAt === 'number' || data.profile2.identity.links[idx_116].createdAt.includes('+') || data.profile2.identity.links[idx_116].createdAt.lastIndexOf('-') > 10 || data.profile2.identity.links[idx_116].createdAt.endsWith('Z')) {
                 entity.profile2.identity.links[idx_116].createdAt = new Date(data.profile2.identity.links[idx_116].createdAt);
+              } else {
+                entity.profile2.identity.links[idx_116].createdAt = new Date(data.profile2.identity.links[idx_116].createdAt + 'Z');
               }
             }
             if (data.profile2.identity.links[idx_116].meta != null) {

--- a/tests/features/entity-manager/EntityManager.mssql.test.ts
+++ b/tests/features/entity-manager/EntityManager.mssql.test.ts
@@ -1213,7 +1213,7 @@ describe('EntityManagerMsSql', () => {
 
   test('datetime is stored in correct timezone', async () => {
     const author = new Author2('n', 'e');
-    author.createdAt = new Date('2000-01-01T00:00:00');
+    author.createdAt = new Date('2000-01-01T00:00:00Z');
     await orm.em.persist(author).flush();
     orm.em.clear();
 

--- a/tests/features/upsert/GH6534.test.ts
+++ b/tests/features/upsert/GH6534.test.ts
@@ -43,7 +43,7 @@ test('6534', async () => {
     username: 'john',
     email: 'johndoe@nowhere.com',
     image: 'https://test.com',
-    created_at: new Date('2025-03-19 22:58:56.659'),
+    created_at: new Date('2025-03-19 22:58:56.659Z'),
   };
 
   const mock = mockLogger(orm);


### PR DESCRIPTION
The `forceUtcTimezone` option is now enabled by default for all SQL drivers. This means datetime columns without timezone (`datetime` in MySQL/MSSQL, `timestamp` in PostgreSQL) will store and retrieve values in UTC.

If your application relies on storing dates in local timezone, you can disable this by setting `forceUtcTimezone: false`:

```ts
MikroORM.init({
  forceUtcTimezone: false,
});
```

> Note: If you have existing data stored in local timezone and enable UTC mode, or vice versa, the timestamps will be interpreted incorrectly. Make sure to migrate your data accordingly, or keep the setting consistent with how your data was originally stored.

Closes #5591