### PR TITLE
fix(core): only respect `Hidden` type on scalar properties

### DIFF
--- a/docs/docs/serializing.md
+++ b/docs/docs/serializing.md
@@ -30,7 +30,7 @@ console.log(wrap(book).toObject().hiddenField); // undefined
 console.log(wrap(book).toJSON().hiddenField); // undefined
 ```
 
-Alternatively, you can use the `Hidden` type. It works the same as the `Opt` type (an alternative for `OptionalProps` symbol), and can be used in two ways:
+Alternatively, you can use the `Hidden` type for **primitive property types** (`string`, `number`, `boolean`, `bigint`, `symbol`). It works the same as the `Opt` type (an alternative for `OptionalProps` symbol), and can be used in two ways:
 
 - with generics: `hiddenField?: Hidden<string>;`
 - with intersections: `hiddenField?: string & Hidden;`
@@ -42,13 +42,30 @@ Both will work the same, and can be combined with the `HiddenProps` symbol appro
 class Book {
 
   @Property({ hidden: true })
-  hiddenField: Hidden<Date> = Date.now();
+  hiddenField: Hidden<number> = Date.now();
 
   @Property({ hidden: true, nullable: true })
   otherHiddenField?: string & Hidden;
 
 }
 ```
+
+> **Note:** The `Hidden` type brand only works for primitive types. For object-type properties like `Date`, `Record<string, unknown>`, or JSON properties, you must use the `HiddenProps` symbol approach instead:
+>
+> ```ts
+> @Entity()
+> class User {
+>
+>   [HiddenProps]?: 'secretData' | 'hiddenDate';
+>
+>   @Property({ type: JsonType, hidden: true })
+>   secretData!: Record<string, unknown>;
+>
+>   @Property({ hidden: true })
+>   hiddenDate!: Date;
+>
+> }
+> ```
 
 ## Shadow Properties
 

--- a/docs/docs/upgrading-v6-to-v7.md
+++ b/docs/docs/upgrading-v6-to-v7.md
@@ -382,6 +382,33 @@ Previosly, it was possible to prefix the alias with target entity name. This is 
 +qb.as(User, 'fullName');
 ```
 
+## `Hidden` type brand only works for primitive types
+
+The `Hidden` type brand now only works for primitive property types (`string`, `number`, `boolean`, `bigint`, `symbol`). For object-type properties like `Date`, `Record<string, unknown>`, or JSON properties, you need to use the `HiddenProps` symbol instead.
+
+This change fixes an issue where object-type properties (including JSON and Date) were incorrectly detected as hidden in the `EntityDTO` type.
+
+```diff
+@Entity()
+class User {
+
++  // For object-type hidden properties, use HiddenProps symbol
++  [HiddenProps]?: 'secretData' | 'hiddenDate';
+
+   @Property({ hidden: true })
+   password!: Hidden<string>; // still works for primitives
+
+   @Property({ type: JsonType, hidden: true })
+-  secretData!: Hidden<Record<string, unknown>>; // no longer works
++  secretData!: Record<string, unknown>; // use HiddenProps instead
+
+   @Property({ hidden: true })
+-  hiddenDate!: Hidden<Date>; // no longer works
++  hiddenDate!: Date; // use HiddenProps instead
+
+}
+```
+
 ## Private constructors no longer allowed with `defineEntity`/`EntitySchema`
 
 To be able to infer constructor parameters, we need the constructor to be public. The ORM will use the constructor internally (e.g. in `em.create`), so this was partially a lie. If you need to use a private constructor, please cast the `class` parameter to `any` and use the first generict parameter:

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -166,6 +166,9 @@ export type IPrimaryKey<T extends IPrimaryKeyValue = IPrimaryKeyValue> = T;
 
 export type Scalar = boolean | number | string | bigint | symbol | Date | RegExp | Uint8Array | { toHexString(): string };
 
+// Primitive types that don't extend object - used for Hidden brand detection
+type Primitive = boolean | number | string | bigint | symbol;
+
 export type ExpandScalar<T> = null | (T extends string
   ? T | RegExp
   : T extends Date
@@ -417,7 +420,7 @@ export type Ref<T> = T extends any // we need this to get around `Ref<boolean>` 
       : EntityRef<T & object>
   : never;
 
-type ExtractHiddenProps<T> = (T extends { [HiddenProps]?: infer K } ? K : never) | ({ [K in keyof T]: T[K] extends Hidden ? K : never }[keyof T] & {});
+type ExtractHiddenProps<T> = (T extends { [HiddenProps]?: infer K } ? K : never) | ({ [K in keyof T]: T[K] extends Primitive ? (T[K] extends Hidden ? K : never) : never }[keyof T] & {});
 type ExcludeHidden<T, K extends keyof T> = K extends ExtractHiddenProps<T> ? never : K;
 type ExtractConfig<T> = T extends { [Config]?: infer K } ? (K & TypeConfig) : TypeConfig;
 type PreferExplicitConfig<E, I> = IsNever<E, I, E>;

--- a/tests/issues/GH7062.test.ts
+++ b/tests/issues/GH7062.test.ts
@@ -1,0 +1,85 @@
+import { Hidden, HiddenProps, JsonType, MikroORM, Opt, serialize } from '@mikro-orm/sqlite';
+import { Entity, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+
+@Entity()
+export class User {
+
+  // For object-type hidden props, use HiddenProps symbol
+  [HiddenProps]?: 'secretData' | 'hiddenDate';
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  // JSON property should be present in EntityDTO
+  @Property({ type: JsonType })
+  data!: Record<string, string>;
+
+  // Date property should be present in EntityDTO (not incorrectly detected as hidden)
+  @Property()
+  createdAt!: Opt<Date>;
+
+  // Hidden scalar property should be excluded from EntityDTO
+  @Property({ hidden: true })
+  password!: Hidden<string>;
+
+  // Hidden object property - uses HiddenProps symbol above
+  @Property({ type: JsonType, hidden: true })
+  secretData!: Record<string, unknown>;
+
+  // Hidden Date property - uses HiddenProps symbol above
+  @Property({ hidden: true })
+  hiddenDate!: Date;
+
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    metadataProvider: ReflectMetadataProvider,
+    dbName: ':memory:',
+    entities: [User],
+  });
+  await orm.schema.create();
+});
+
+afterAll(async () => {
+  await orm.close();
+});
+
+test('GH7062 - JsonType properties should be present in EntityDTO', async () => {
+  const now = new Date();
+  const user = orm.em.create(User, {
+    name: 'John',
+    data: { foo: 'bar', baz: 'qux' },
+    createdAt: now,
+    password: 'secret123',
+    secretData: { key: 'value' },
+    hiddenDate: now,
+  });
+  await orm.em.persist(user).flush();
+
+  // Type test: data property should be accessible on EntityDTO
+  const dto = serialize(user);
+  expect(dto.data).toEqual({ foo: 'bar', baz: 'qux' });
+  expect(dto.name).toBe('John');
+  expect(dto.id).toBe(1);
+
+  // Date property should be present in EntityDTO (not incorrectly detected as hidden)
+  expect(dto.createdAt).toBeDefined();
+
+  // Hidden scalar property should not be in serialized output
+  // @ts-expect-error - password is hidden
+  expect(dto.password).toBeUndefined();
+
+  // Hidden object property (via HiddenProps) should not be in serialized output
+  // @ts-expect-error - secretData is hidden via HiddenProps
+  expect(dto.secretData).toBeUndefined();
+
+  // Hidden Date property (via HiddenProps) should not be in serialized output
+  // @ts-expect-error - hiddenDate is hidden via HiddenProps
+  expect(dto.hiddenDate).toBeUndefined();
+});


### PR DESCRIPTION
BREAKING CHANGE:

The `Hidden` type brand now only works for primitive property types (`string`, `number`, `boolean`, `bigint`, `symbol`). For object-type properties like `Date`, `Record<string, unknown>`, or JSON properties, you need to use the `HiddenProps` symbol instead.

This change fixes an issue where object-type properties (including JSON and Date) were incorrectly detected as hidden in the `EntityDTO` type.

```diff
@Entity()
class User {

+  // For object-type hidden properties, use HiddenProps symbol
+  [HiddenProps]?: 'secretData' | 'hiddenDate';

   @Property({ hidden: true })
   password!: Hidden<string>; // still works for primitives

   @Property({ type: JsonType, hidden: true })
-  secretData!: Hidden<Record<string, unknown>>; // no longer works
+  secretData!: Record<string, unknown>; // use HiddenProps instead

   @Property({ hidden: true })
-  hiddenDate!: Hidden<Date>; // no longer works
+  hiddenDate!: Date; // use HiddenProps instead

}
```

Closes #7062