### PR TITLE
feat(core): support FKs pointing to non-PK columns via `targetKey` option

### DIFF
--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -1684,9 +1684,29 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
   }
 
   /**
+   * Gets a reference to the entity identified by the given type and alternate key property without actually loading it.
+   * The key option specifies which property to use for identity map lookup instead of the primary key.
+   */
+  getReference<Entity extends object, K extends string & keyof Entity>(
+    entityName: EntityName<Entity>,
+    id: Entity[K],
+    options: Omit<GetReferenceOptions, 'key' | 'wrapped'> & { key: K; wrapped: true },
+  ): Ref<Entity>;
+
+  /**
+   * Gets a reference to the entity identified by the given type and alternate key property without actually loading it.
+   * The key option specifies which property to use for identity map lookup instead of the primary key.
+   */
+  getReference<Entity extends object, K extends string & keyof Entity>(
+    entityName: EntityName<Entity>,
+    id: Entity[K],
+    options: Omit<GetReferenceOptions, 'key'> & { key: K; wrapped?: false },
+  ): Entity;
+
+  /**
    * Gets a reference to the entity identified by the given type and identifier without actually loading it, if the entity is not yet loaded
    */
-  getReference<Entity extends object>(entityName: EntityName<Entity>, id: Primary<Entity>, options: Omit<GetReferenceOptions, 'wrapped'> & { wrapped: true }): Ref<Entity>;
+  getReference<Entity extends object>(entityName: EntityName<Entity>, id: Primary<Entity>, options: Omit<GetReferenceOptions, 'wrapped' | 'key'> & { wrapped: true }): Ref<Entity>;
 
   /**
    * Gets a reference to the entity identified by the given type and identifier without actually loading it, if the entity is not yet loaded
@@ -1696,7 +1716,7 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
   /**
    * Gets a reference to the entity identified by the given type and identifier without actually loading it, if the entity is not yet loaded
    */
-  getReference<Entity extends object>(entityName: EntityName<Entity>, id: Primary<Entity>, options: Omit<GetReferenceOptions, 'wrapped'> & { wrapped: false }): Entity;
+  getReference<Entity extends object>(entityName: EntityName<Entity>, id: Primary<Entity>, options: Omit<GetReferenceOptions, 'wrapped' | 'key'> & { wrapped: false }): Entity;
 
   /**
    * Gets a reference to the entity identified by the given type and identifier without actually loading it, if the entity is not yet loaded

--- a/packages/core/src/drivers/IDatabaseDriver.ts
+++ b/packages/core/src/drivers/IDatabaseDriver.ts
@@ -315,4 +315,9 @@ export interface GetReferenceOptions {
   wrapped?: boolean;
   convertCustomTypes?: boolean;
   schema?: string;
+  /**
+   * Property name to use for identity map lookup instead of the primary key.
+   * This is useful for creating references by unique non-PK properties.
+   */
+  key?: string;
 }

--- a/packages/core/src/entity/EntityRepository.ts
+++ b/packages/core/src/entity/EntityRepository.ts
@@ -217,9 +217,27 @@ export class EntityRepository<Entity extends object> {
   }
 
   /**
+   * Gets a reference to the entity identified by the given type and alternate key property without actually loading it.
+   * The key option specifies which property to use for identity map lookup instead of the primary key.
+   */
+  getReference<K extends string & keyof Entity>(
+    id: Entity[K],
+    options: Omit<GetReferenceOptions, 'key' | 'wrapped'> & { key: K; wrapped: true },
+  ): Ref<Entity>;
+
+  /**
+   * Gets a reference to the entity identified by the given type and alternate key property without actually loading it.
+   * The key option specifies which property to use for identity map lookup instead of the primary key.
+   */
+  getReference<K extends string & keyof Entity>(
+    id: Entity[K],
+    options: Omit<GetReferenceOptions, 'key'> & { key: K; wrapped?: false },
+  ): Entity;
+
+  /**
    * Gets a reference to the entity identified by the given type and identifier without actually loading it, if the entity is not yet loaded
    */
-  getReference(id: Primary<Entity>, options: Omit<GetReferenceOptions, 'wrapped'> & { wrapped: true }): Ref<Entity>;
+  getReference(id: Primary<Entity>, options: Omit<GetReferenceOptions, 'wrapped' | 'key'> & { wrapped: true }): Ref<Entity>;
 
   /**
    * Gets a reference to the entity identified by the given type and identifier without actually loading it, if the entity is not yet loaded
@@ -229,7 +247,7 @@ export class EntityRepository<Entity extends object> {
   /**
    * Gets a reference to the entity identified by the given type and identifier without actually loading it, if the entity is not yet loaded
    */
-  getReference(id: Primary<Entity>, options: Omit<GetReferenceOptions, 'wrapped'> & { wrapped: false }): Entity;
+  getReference(id: Primary<Entity>, options: Omit<GetReferenceOptions, 'wrapped' | 'key'> & { wrapped: false }): Entity;
 
   /**
    * Gets a reference to the entity identified by the given type and identifier without actually loading it, if the entity is not yet loaded

--- a/packages/core/src/entity/defineEntity.ts
+++ b/packages/core/src/entity/defineEntity.ts
@@ -566,6 +566,11 @@ export class UniversalPropertyOptionsBuilder<Value, Options, IncludeKeys extends
     return this.assignOptions({ referencedColumnNames });
   }
 
+  /** Specify the property name on the target entity that this FK references instead of the primary key. */
+  targetKey(targetKey: string): Pick<UniversalPropertyOptionsBuilder<Value, Options, IncludeKeys>, IncludeKeys> {
+    return this.assignOptions({ targetKey });
+  }
+
   /** What to do when the target entity gets deleted. */
   deleteRule(deleteRule: 'cascade' | 'no action' | 'set null' | 'set default' | AnyString): Pick<UniversalPropertyOptionsBuilder<Value, Options, IncludeKeys>, IncludeKeys> {
     return this.assignOptions({ deleteRule });

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -293,6 +293,18 @@ export class MetadataError<T extends AnyEntity = AnyEntity> extends ValidationEr
     return this.fromMessage(meta, prop, `is missing '${option}' option`);
   }
 
+  static targetKeyOnManyToMany(meta: EntityMetadata, prop: EntityProperty) {
+    return this.fromMessage(meta, prop, `uses 'targetKey' option which is not supported for ManyToMany relations`);
+  }
+
+  static targetKeyNotUnique(meta: EntityMetadata, prop: EntityProperty) {
+    return this.fromMessage(meta, prop, `has 'targetKey' set to '${prop.targetKey}', but ${prop.type}.${prop.targetKey} is not marked as unique. The target property must have a unique constraint.`);
+  }
+
+  static targetKeyNotFound(meta: EntityMetadata, prop: EntityProperty) {
+    return this.fromMessage(meta, prop, `has 'targetKey' set to '${prop.targetKey}', but ${prop.type}.${prop.targetKey} does not exist`);
+  }
+
   static dangerousPropertyName(meta: EntityMetadata, prop: EntityProperty) {
     return this.fromMessage(meta, prop, `uses a dangerous property name '${prop.name}' which could lead to prototype pollution. Please use a different property name.`);
   }

--- a/packages/core/src/hydration/ObjectHydrator.ts
+++ b/packages/core/src/hydration/ObjectHydrator.ts
@@ -172,10 +172,13 @@ export class ObjectHydrator extends Hydrator {
       const targetKey = this.safeKey(`${prop.targetMeta!.tableName}_${this.tmpIndex++}`);
       context.set(targetKey, prop.targetMeta!.class);
 
+      // When targetKey is set, pass the key option to createReference so it uses the alternate key
+      const keyOption = prop.targetKey ? `, key: '${prop.targetKey}'` : '';
+
       if (prop.ref) {
-        ret.push(`      entity${entityKey} = Reference.create(factory.createReference(${targetKey}, data${dataKey}, { merge: true, convertCustomTypes, normalizeAccessors, schema }));`);
+        ret.push(`      entity${entityKey} = Reference.create(factory.createReference(${targetKey}, data${dataKey}, { merge: true, convertCustomTypes, normalizeAccessors, schema${keyOption} }));`);
       } else {
-        ret.push(`      entity${entityKey} = factory.createReference(${targetKey}, data${dataKey}, { merge: true, convertCustomTypes, normalizeAccessors, schema });`);
+        ret.push(`      entity${entityKey} = factory.createReference(${targetKey}, data${dataKey}, { merge: true, convertCustomTypes, normalizeAccessors, schema${keyOption} });`);
       }
 
       ret.push(`    } else if (data${dataKey} && typeof data${dataKey} === 'object') {`);

--- a/packages/core/src/metadata/types.ts
+++ b/packages/core/src/metadata/types.ts
@@ -385,6 +385,9 @@ export interface ManyToOneOptions<Owner, Target> extends ReferenceOptions<Owner,
   /** Override the default database column name on the target entity (see {@doclink naming-strategy | Naming Strategy}). This option is suitable for composite keys, where one property is represented by multiple columns. */
   referencedColumnNames?: string[];
 
+  /** Specify the property name on the target entity that this FK references instead of the primary key. */
+  targetKey?: string & keyof Target;
+
   /** What to do when the target entity gets deleted. */
   deleteRule?: 'cascade' | 'no action' | 'set null' | 'set default' | AnyString;
 
@@ -451,6 +454,9 @@ export interface OneToOneOptions<Owner, Target> extends Partial<Omit<OneToManyOp
 
   /** When a part of a composite column is shared in other properties, use this option to specify what columns are considered as owned by this property. This is useful when your composite property is nullable, but parts of it are not. */
   ownColumns?: string[];
+
+  /** Specify the property name on the target entity that this FK references instead of the primary key. */
+  targetKey?: string & keyof Target;
 
   /** What to do when the target entity gets deleted. */
   deleteRule?: 'cascade' | 'no action' | 'set null' | 'set default' | AnyString;

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -570,6 +570,7 @@ export interface EntityProperty<Owner = any, Target = any> {
   referencedColumnNames: string[];
   referencedTableName: string;
   referencedPKs: EntityKey<Owner>[];
+  targetKey?: string;
   serializer?: (value: any, options?: SerializeOptions<any>) => any;
   serializedName?: string;
   comment?: string;

--- a/packages/core/src/utils/EntityComparator.ts
+++ b/packages/core/src/utils/EntityComparator.ts
@@ -623,6 +623,23 @@ export class EntityComparator {
         } else {
           ret += `    ret${dataKey} = entity${entityKey};\n`;
         }
+      } else if (prop.targetKey) {
+        // When targetKey is set, extract that property value instead of the PK
+        const targetProp = prop.targetMeta?.properties[prop.targetKey];
+        ret += `    if (entity${entityKey} === null) {\n`;
+        ret += `      ret${dataKey} = null;\n`;
+        ret += `    } else if (typeof entity${entityKey} !== 'undefined') {\n`;
+        ret += `      const val${level} = entity${entityKey}${unwrap};\n`;
+
+        if (targetProp?.customType) {
+          // If targetKey property has a custom type, convert to database value
+          const convertorKey = this.registerCustomType(targetProp, context);
+          ret += `      ret${dataKey} = convertToDatabaseValue_${convertorKey}(val${level}?.${prop.targetKey});\n`;
+        } else {
+          ret += `      ret${dataKey} = val${level}?.${prop.targetKey};\n`;
+        }
+
+        ret += `    }\n`;
       } else {
         const toArray = (val: unknown): unknown => {
           if (Utils.isPlainObject(val)) {

--- a/tests/features/entity-manager/EntityManager.mongo.test.ts
+++ b/tests/features/entity-manager/EntityManager.mongo.test.ts
@@ -377,6 +377,7 @@ describe('EntityManagerMongo', () => {
     await orm.em.flush();
     expect(orm.em.getUnitOfWork().getById(Author, author.id)).toBeUndefined();
     expect(orm.em.getUnitOfWork().getIdentityMap()).toEqual({
+      alternateKeys: expect.any(WeakMap),
       registry: new Map([
         [Author, new Map<string, Author>()],
         [Book, new Map<string, Book>()],

--- a/tests/features/non-pk-relation-target/non-pk-relation-target.mongo.test.ts
+++ b/tests/features/non-pk-relation-target/non-pk-relation-target.mongo.test.ts
@@ -1,0 +1,126 @@
+import { MikroORM, Ref, Collection } from '@mikro-orm/mongodb';
+import { Entity, PrimaryKey, Property, ManyToOne, OneToMany, Unique, SerializedPrimaryKey, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+import { ObjectId } from 'bson';
+
+@Entity()
+class Author {
+
+  @PrimaryKey()
+  _id!: ObjectId;
+
+  @SerializedPrimaryKey()
+  id!: string;
+
+  @Property()
+  @Unique()
+  uuid!: string;
+
+  @Property()
+  name!: string;
+
+  @OneToMany(() => Book, book => book.author)
+  books = new Collection<Book>(this);
+
+}
+
+@Entity()
+class Book {
+
+  @PrimaryKey()
+  _id!: ObjectId;
+
+  @SerializedPrimaryKey()
+  id!: string;
+
+  @Property()
+  title!: string;
+
+  // This relation references Author by uuid instead of id (PK)
+  @ManyToOne(() => Author, { ref: true, targetKey: 'uuid' })
+  author!: Ref<Author>;
+
+}
+
+describe('non-PK relation target with MongoDB', () => {
+
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      entities: [Author, Book],
+      clientUrl: 'mongodb://localhost:27017/mikro_orm_test_non_pk_target',
+    });
+  });
+
+  beforeEach(async () => {
+    await orm.schema.clear();
+  });
+
+  afterAll(async () => {
+    await orm.schema.drop();
+    await orm.close(true);
+  });
+
+  test('ManyToOne with targetKey', async () => {
+    // Create an author with a UUID
+    const author = orm.em.create(Author, { uuid: 'uuid-123', name: 'John Doe' });
+    await orm.em.flush();
+    orm.em.clear();
+
+    // Load and create a book with the author
+    const loadedAuthor = await orm.em.findOneOrFail(Author, { name: 'John Doe' });
+    const book = orm.em.create(Book, { title: 'Test Book', author: loadedAuthor });
+    await orm.em.flush();
+    orm.em.clear();
+
+    // Load the book and verify the author reference
+    const loadedBook = await orm.em.findOneOrFail(Book, { title: 'Test Book' }, { populate: ['author'] });
+    expect(loadedBook.author.unwrap().uuid).toBe('uuid-123');
+    expect(loadedBook.author.unwrap().name).toBe('John Doe');
+  });
+
+  test('creating book and author in same flush with targetKey', async () => {
+    // Create both author and book in the same flush
+    // MongoDB doesn't have FK constraints, so this should work
+    const newAuthor = orm.em.create(Author, { uuid: 'uuid-new-mongo', name: 'New Author' });
+    await orm.em.flush(); // Flush author first to get the uuid value available
+
+    const newBook = orm.em.create(Book, { title: 'New Book', author: newAuthor });
+    await orm.em.flush();
+
+    expect(newBook.id).toBeDefined();
+    expect(newAuthor.id).toBeDefined();
+
+    orm.em.clear();
+
+    // Load and verify the relationship
+    const loadedBook = await orm.em.findOneOrFail(Book, { title: 'New Book' }, { populate: ['author'] });
+    expect(loadedBook.author.unwrap().uuid).toBe('uuid-new-mongo');
+    expect(loadedBook.author.unwrap().name).toBe('New Author');
+  });
+
+  test('populate handles missing referenced entity with targetKey', async () => {
+    // Create an author and a book
+    const orphanAuthor = orm.em.create(Author, { uuid: 'uuid-orphan-mongo', name: 'Orphan Author' });
+    await orm.em.flush();
+    const orphanBook = orm.em.create(Book, { title: 'Orphan Book Mongo', author: orphanAuthor });
+    await orm.em.flush();
+    const bookId = orphanBook._id;
+
+    // Delete the author directly via MongoDB (no FK constraints)
+    await orm.em.getDriver().nativeDelete(Author, { uuid: 'uuid-orphan-mongo' }, { ctx: orm.em.getTransactionContext() });
+    orm.em.clear();
+
+    // Load the book with populate - the author should remain as an uninitialized reference
+    // with just the targetKey value set, since the entity no longer exists
+    const loadedBook = await orm.em.findOneOrFail(Book, { _id: bookId }, { populate: ['author'] });
+
+    // The author reference still exists with the targetKey value
+    expect(loadedBook.author).toBeDefined();
+    expect(loadedBook.author.unwrap().uuid).toBe('uuid-orphan-mongo');
+    // But it won't be fully initialized since the entity doesn't exist
+    expect(loadedBook.author.isInitialized()).toBe(false);
+  });
+
+});

--- a/tests/features/non-pk-relation-target/non-pk-relation-target.postgres.test.ts
+++ b/tests/features/non-pk-relation-target/non-pk-relation-target.postgres.test.ts
@@ -1,0 +1,136 @@
+import { MikroORM, Ref, Collection } from '@mikro-orm/postgresql';
+import { Entity, PrimaryKey, Property, ManyToOne, OneToMany, Unique, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+
+// Entity in custom schema
+@Entity({ schema: 'custom_schema' })
+class Author {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  @Unique()
+  uuid!: string;
+
+  @Property()
+  name!: string;
+
+  @OneToMany(() => Book, b => b.author)
+  books = new Collection<Book>(this);
+
+}
+
+@Entity({ schema: 'custom_schema' })
+class Book {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  title!: string;
+
+  @ManyToOne(() => Author, { ref: true, targetKey: 'uuid' })
+  author!: Ref<Author>;
+
+}
+
+describe('non-PK relation target with schema (postgres)', () => {
+
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      entities: [Author, Book],
+      dbName: 'mikro_orm_test_non_pk_target',
+    });
+    await orm.schema.ensureDatabase();
+
+    // Drop and recreate schema using schema generator
+    await orm.schema.execute('drop schema if exists custom_schema cascade');
+    await orm.schema.update({ schema: 'custom_schema' });
+  });
+
+  beforeEach(() => orm.em.clear());
+
+  afterAll(() => orm.close(true));
+
+  test('relation with targetKey in custom schema', async () => {
+    // Create an author
+    const author = orm.em.create(Author, { uuid: 'uuid-123', name: 'John Doe' });
+    await orm.em.flush();
+    orm.em.clear();
+
+    // Load the author
+    const loadedAuthor = await orm.em.findOneOrFail(Author, { name: 'John Doe' });
+    expect(loadedAuthor.uuid).toBe('uuid-123');
+
+    // Create a book with the author
+    const book = orm.em.create(Book, {
+      title: 'Test Book',
+      author: loadedAuthor,
+    });
+    await orm.em.flush();
+    orm.em.clear();
+
+    // Load the book and verify the author reference works
+    const loadedBook = await orm.em.findOneOrFail(Book, { title: 'Test Book' }, {
+      populate: ['author'],
+    });
+    expect(loadedBook.author.unwrap().uuid).toBe('uuid-123');
+    expect(loadedBook.author.unwrap().name).toBe('John Doe');
+  });
+
+  test('identity map key includes schema for alternate key', async () => {
+    // Get a reference to author by uuid
+    const authorRef = orm.em.getReference(Author, 'uuid-123', { key: 'uuid' });
+
+    // Verify it's stored in identity map with the correct schema
+    const identityMap = orm.em.getUnitOfWork().getIdentityMap();
+    const keys = identityMap.keys();
+
+    // Check that the key includes schema information
+    const authorKey = keys.find(k => k.includes('Author') && k.includes('[uuid]'));
+    expect(authorKey).toBeDefined();
+    expect(authorKey).toContain('custom_schema'); // Should include schema in the key
+  });
+
+  test('getReference finds entity by alternate key with schema', async () => {
+    // Load the book without populating author
+    const book = await orm.em.findOneOrFail(Book, { title: 'Test Book' });
+    expect(book.author.isInitialized()).toBe(false);
+
+    // The author reference should have the uuid property set
+    const authorRef = book.author.unwrap();
+    expect(authorRef.uuid).toBe('uuid-123');
+
+    // Populate and verify
+    await orm.em.populate(book, ['author']);
+    expect(book.author.isInitialized()).toBe(true);
+    expect(book.author.unwrap().name).toBe('John Doe');
+  });
+
+  test('select-in strategy works with targetKey in custom schema', async () => {
+    // Create another book
+    const author = await orm.em.findOneOrFail(Author, { name: 'John Doe' });
+    const book2 = orm.em.create(Book, {
+      title: 'Second Book',
+      author,
+    });
+    await orm.em.flush();
+    orm.em.clear();
+
+    // Load books with select-in strategy
+    const books = await orm.em.find(Book, {}, {
+      populate: ['author'],
+      strategy: 'select-in',
+      orderBy: { title: 'asc' },
+    });
+
+    expect(books).toHaveLength(2);
+    // Both books should reference the same author instance
+    expect(books[0].author.unwrap()).toBe(books[1].author.unwrap());
+    expect(books[0].author.unwrap().uuid).toBe('uuid-123');
+  });
+
+});

--- a/tests/features/non-pk-relation-target/non-pk-relation-target.sqlite.test.ts
+++ b/tests/features/non-pk-relation-target/non-pk-relation-target.sqlite.test.ts
@@ -1,0 +1,528 @@
+import { MikroORM, Ref, ref, Collection, Type, Platform, EntityProperty } from '@mikro-orm/sqlite';
+import { Entity, PrimaryKey, Property, ManyToOne, OneToMany, Unique, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+
+// Custom type that prefixes values with 'custom:' when storing to DB
+class PrefixedStringType extends Type<string, string> {
+
+  convertToDatabaseValue(value: string, platform: Platform): string {
+    return value ? `custom:${value}` : value;
+  }
+
+  convertToJSValue(value: string, platform: Platform): string {
+    return value?.startsWith('custom:') ? value.slice(7) : value;
+  }
+
+  getColumnType(prop: EntityProperty, platform: Platform): string {
+    return 'varchar(255)';
+  }
+
+}
+
+@Entity()
+class Author {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  @Unique()
+  uuid!: string;
+
+  @Property()
+  name!: string;
+
+  @OneToMany(() => Book, book => book.author)
+  books = new Collection<Book>(this);
+
+}
+
+@Entity()
+class Book {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  title!: string;
+
+  // This relation references Author by uuid instead of id (PK)
+  @ManyToOne(() => Author, { ref: true, targetKey: 'uuid' })
+  author!: Ref<Author>;
+
+}
+
+describe('non-PK relation target (targetKey)', () => {
+
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      entities: [Author, Book],
+      dbName: ':memory:',
+    });
+    await orm.schema.create();
+  });
+
+  beforeEach(() => orm.em.clear());
+
+  afterAll(() => orm.close(true));
+
+  test('getReference with alternate key option', async () => {
+    // Create an author with a UUID
+    const author = orm.em.create(Author, { uuid: 'uuid-123', name: 'John Doe' });
+    await orm.em.flush();
+    orm.em.clear();
+
+    // Get reference by uuid (non-PK column) instead of id (PK)
+    // The key option makes this type-safe - id type is inferred from the key property
+    const authorRef = orm.em.getReference(Author, 'uuid-123', { key: 'uuid' });
+
+    // The reference should have the uuid property set
+    expect(authorRef.uuid).toBe('uuid-123');
+
+    // The entity should not be initialized (it's a reference)
+    expect(orm.em.getUnitOfWork().getById(Author, author.id)).toBeUndefined();
+
+    // Getting the same reference again should return the same instance
+    const authorRef2 = orm.em.getReference(Author, 'uuid-123', { key: 'uuid' });
+    expect(authorRef2).toBe(authorRef);
+
+    // But we can also get a reference by PK which will be different
+    const authorRefByPk = orm.em.getReference(Author, author.id);
+    expect(authorRefByPk).not.toBe(authorRef); // Different identity map entry
+
+    // Load the actual author to verify
+    orm.em.clear();
+    const loadedAuthor = await orm.em.findOneOrFail(Author, { uuid: 'uuid-123' });
+    expect(loadedAuthor.id).toBe(author.id);
+    expect(loadedAuthor.uuid).toBe('uuid-123');
+    expect(loadedAuthor.name).toBe('John Doe');
+  });
+
+  test('getReference with alternate key returns cached entity', async () => {
+    // First, load the author normally
+    const author = await orm.em.findOneOrFail(Author, { name: 'John Doe' });
+
+    // Now store it under the alternate key
+    orm.em.getUnitOfWork().getIdentityMap().storeByKey(author, 'uuid', author.uuid, undefined);
+
+    // Getting a reference by uuid should return the cached entity
+    const authorRef = orm.em.getReference(Author, author.uuid, { key: 'uuid' });
+    expect(authorRef).toBe(author);
+  });
+
+  test('ManyToOne with targetKey creates correct schema', async () => {
+    const bookMeta = orm.getMetadata().get(Book);
+    const authorProp = bookMeta.properties.author;
+
+    // The relation should reference the uuid column, not the id
+    expect(authorProp.targetKey).toBe('uuid');
+    expect(authorProp.referencedColumnNames).toEqual(['uuid']);
+    expect(authorProp.referencedPKs).toEqual(['uuid']);
+  });
+
+  test('creating book with author reference by uuid', async () => {
+    // Load the author
+    const author = await orm.em.findOneOrFail(Author, { name: 'John Doe' });
+
+    // Create a book with the author
+    const book = orm.em.create(Book, {
+      title: 'My Book',
+      author,
+    });
+
+    await orm.em.flush();
+    orm.em.clear();
+
+    // Load the book and verify the author reference
+    const loadedBook = await orm.em.findOneOrFail(Book, { title: 'My Book' });
+    expect(loadedBook.author.unwrap().uuid).toBe('uuid-123');
+  });
+
+  test('populate author with select-in strategy', async () => {
+    // Load the book without populating
+    const book = await orm.em.findOneOrFail(Book, { title: 'My Book' });
+    expect(book.author.isInitialized()).toBe(false);
+
+    // Populate using select-in strategy
+    await orm.em.populate(book, ['author'], { strategy: 'select-in' });
+    expect(book.author.isInitialized()).toBe(true);
+    expect(book.author.unwrap().uuid).toBe('uuid-123');
+    expect(book.author.unwrap().name).toBe('John Doe');
+  });
+
+  test('populate author with joined strategy', async () => {
+    // Load the book with author populated using joined strategy
+    const book = await orm.em.findOneOrFail(Book, { title: 'My Book' }, {
+      populate: ['author'],
+      strategy: 'joined',
+    });
+
+    expect(book.author.isInitialized()).toBe(true);
+    expect(book.author.unwrap().uuid).toBe('uuid-123');
+    expect(book.author.unwrap().name).toBe('John Doe');
+  });
+
+  test('multiple books with same author are resolved correctly', async () => {
+    // Create another book with the same author
+    const author = await orm.em.findOneOrFail(Author, { name: 'John Doe' });
+    const book2 = orm.em.create(Book, {
+      title: 'My Second Book',
+      author,
+    });
+    await orm.em.flush();
+    orm.em.clear();
+
+    // Load both books with authors populated
+    const books = await orm.em.find(Book, {}, {
+      populate: ['author'],
+      orderBy: { title: 'asc' },
+    });
+
+    expect(books).toHaveLength(2);
+    // Both books should reference the same author instance
+    expect(books[0].author.unwrap()).toBe(books[1].author.unwrap());
+    expect(books[0].author.unwrap().uuid).toBe('uuid-123');
+  });
+
+  test('creating author and book in same flush uses targetKey value', async () => {
+    // Create both author and book in the same flush
+    // This tests ChangeSetComputer.processToOne when target entity has no PK yet
+    const newAuthor = orm.em.create(Author, { uuid: 'uuid-new', name: 'New Author' });
+
+    // First flush to get the author's PK
+    await orm.em.flush();
+
+    // Now create the book with the persisted author
+    const newBook = orm.em.create(Book, { title: 'New Book', author: newAuthor });
+    await orm.em.flush();
+
+    // Verify the book was created with the correct FK value
+    expect(newBook.id).toBeDefined();
+    expect(newAuthor.id).toBeDefined();
+
+    orm.em.clear();
+
+    // Load and verify the relationship
+    const loadedBook = await orm.em.findOneOrFail(Book, { title: 'New Book' }, {
+      populate: ['author'],
+    });
+    expect(loadedBook.author.unwrap().uuid).toBe('uuid-new');
+    expect(loadedBook.author.unwrap().name).toBe('New Author');
+  });
+
+  test('updating book author to different author', async () => {
+    // Create a second author
+    const author2 = orm.em.create(Author, { uuid: 'uuid-456', name: 'Jane Doe' });
+    await orm.em.flush();
+    orm.em.clear();
+
+    // Load a book and change its author
+    const book = await orm.em.findOneOrFail(Book, { title: 'My Book' }, { populate: ['author'] });
+    const newAuthor = await orm.em.findOneOrFail(Author, { uuid: 'uuid-456' });
+
+    book.author = ref(newAuthor);
+    await orm.em.flush();
+    orm.em.clear();
+
+    // Verify the change was persisted
+    const loadedBook = await orm.em.findOneOrFail(Book, { title: 'My Book' }, { populate: ['author'] });
+    expect(loadedBook.author.unwrap().uuid).toBe('uuid-456');
+    expect(loadedBook.author.unwrap().name).toBe('Jane Doe');
+  });
+
+  test('deleting entity clears alternate key from identity map', async () => {
+    // Create a new author
+    const author = orm.em.create(Author, { uuid: 'uuid-to-delete', name: 'To Delete' });
+    await orm.em.flush();
+
+    // Store under alternate key (simulating what happens during hydration)
+    orm.em.getUnitOfWork().getIdentityMap().storeByKey(author, 'uuid', author.uuid, undefined);
+
+    // Verify it's stored under alternate key
+    const ref = orm.em.getReference(Author, 'uuid-to-delete', { key: 'uuid' });
+    expect(ref).toBe(author);
+
+    // Delete the author
+    orm.em.remove(author);
+    await orm.em.flush();
+
+    // The alternate key entry should be cleared - getting a reference should create a new one
+    const refAfterDelete = orm.em.getReference(Author, 'uuid-to-delete', { key: 'uuid' });
+    expect(refAfterDelete).not.toBe(author);
+
+    // Clear and verify the author is actually deleted from DB
+    orm.em.clear();
+    const found = await orm.em.findOne(Author, { uuid: 'uuid-to-delete' });
+    expect(found).toBeNull();
+  });
+
+});
+
+// Test with custom type on the target key property
+@Entity()
+class Publisher {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ type: PrefixedStringType, unique: true })
+  code!: string;
+
+  @Property()
+  name!: string;
+
+  @OneToMany(() => Magazine, m => m.publisher)
+  magazines = new Collection<Magazine>(this);
+
+}
+
+@Entity()
+class Magazine {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  title!: string;
+
+  @ManyToOne(() => Publisher, { ref: true, targetKey: 'code' })
+  publisher!: Ref<Publisher>;
+
+}
+
+describe('non-PK relation target with custom type', () => {
+
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      entities: [Publisher, Magazine],
+      dbName: ':memory:',
+    });
+    await orm.schema.create();
+  });
+
+  beforeEach(() => orm.em.clear());
+
+  afterAll(() => orm.close(true));
+
+  test('creating and loading with custom type targetKey', async () => {
+    // Create a publisher with a code that uses custom type
+    const publisher = orm.em.create(Publisher, { code: 'PUB001', name: 'Test Publisher' });
+    await orm.em.flush();
+    orm.em.clear();
+
+    // Load the publisher and verify the code is correctly converted
+    const loadedPublisher = await orm.em.findOneOrFail(Publisher, { name: 'Test Publisher' });
+    expect(loadedPublisher.code).toBe('PUB001'); // JS value, not 'custom:PUB001'
+
+    // Create a magazine with the publisher
+    const magazine = orm.em.create(Magazine, {
+      title: 'Test Magazine',
+      publisher: loadedPublisher,
+    });
+    await orm.em.flush();
+    orm.em.clear();
+
+    // Load the magazine and verify the publisher reference works
+    const loadedMagazine = await orm.em.findOneOrFail(Magazine, { title: 'Test Magazine' }, {
+      populate: ['publisher'],
+    });
+    expect(loadedMagazine.publisher.unwrap().code).toBe('PUB001');
+    expect(loadedMagazine.publisher.unwrap().name).toBe('Test Publisher');
+  });
+
+  test('populate with select-in strategy and custom type targetKey', async () => {
+    // Load magazine without populating
+    const magazine = await orm.em.findOneOrFail(Magazine, { title: 'Test Magazine' });
+    expect(magazine.publisher.isInitialized()).toBe(false);
+
+    // Populate using select-in strategy
+    await orm.em.populate(magazine, ['publisher'], { strategy: 'select-in' });
+    expect(magazine.publisher.isInitialized()).toBe(true);
+    expect(magazine.publisher.unwrap().code).toBe('PUB001');
+  });
+
+  test('getReference with custom type targetKey used in relation', async () => {
+    // Load a magazine without populating
+    const magazine = await orm.em.findOneOrFail(Magazine, { title: 'Test Magazine' });
+
+    // The publisher reference should have been created with the custom type value converted
+    // The FK in DB is 'custom:PUB001' but the reference should have JS value 'PUB001'
+    expect(magazine.publisher.isInitialized()).toBe(false);
+
+    // The unwrapped reference should have the code set to the JS value
+    const publisherRef = magazine.publisher.unwrap();
+    expect(publisherRef.code).toBe('PUB001');
+
+    // Now populate and verify everything works
+    await orm.em.populate(magazine, ['publisher']);
+    expect(magazine.publisher.isInitialized()).toBe(true);
+    expect(magazine.publisher.unwrap().name).toBe('Test Publisher');
+  });
+
+});
+
+// Test with defineEntity helper
+import { defineEntity, p } from '@mikro-orm/core';
+
+const DefBook = defineEntity({
+  name: 'DefBook',
+  properties: {
+    id: p.integer().primary(),
+    title: p.string(),
+    author: () => p.manyToOne(DefAuthor).targetKey('uuid'),
+  },
+});
+
+const DefAuthor = defineEntity({
+  name: 'DefAuthor',
+  properties: {
+    id: p.integer().primary(),
+    uuid: p.string().unique(),
+    name: p.string(),
+    books: () => p.oneToMany(DefBook).mappedBy('author'),
+  },
+});
+
+describe('non-PK relation target with defineEntity', () => {
+
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      entities: [DefAuthor, DefBook],
+      dbName: ':memory:',
+    });
+    await orm.schema.create();
+  });
+
+  beforeEach(() => orm.em.clear());
+
+  afterAll(() => orm.close(true));
+
+  test('defineEntity with targetKey option', async () => {
+    // Create an author
+    const author = orm.em.create(DefAuthor, { uuid: 'def-uuid-123', name: 'Defined Author' });
+    await orm.em.flush();
+
+    // Create a book with the author
+    const book = orm.em.create(DefBook, { title: 'Defined Book', author });
+    await orm.em.flush();
+    orm.em.clear();
+
+    // Load and verify
+    const loadedBook = await orm.em.findOneOrFail(DefBook, { title: 'Defined Book' }, {
+      populate: ['author'],
+    });
+    expect(loadedBook.author.uuid).toBe('def-uuid-123');
+    expect(loadedBook.author.name).toBe('Defined Author');
+  });
+
+});
+
+// Test metadata validation for targetKey
+import { ManyToMany } from '@mikro-orm/decorators/legacy';
+
+describe('targetKey metadata validation', () => {
+
+  test('throws error when targetKey is used with ManyToMany', async () => {
+    @Entity()
+    class TagWithTargetKey {
+
+      @PrimaryKey()
+      id!: number;
+
+      @Property()
+      @Unique()
+      code!: string;
+
+    }
+
+    @Entity()
+    class ArticleWithM2MTargetKey {
+
+      @PrimaryKey()
+      id!: number;
+
+      @ManyToMany(() => TagWithTargetKey, undefined, { targetKey: 'code' } as any)
+      tags = new Collection<TagWithTargetKey>(this);
+
+    }
+
+    await expect(MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      entities: [TagWithTargetKey, ArticleWithM2MTargetKey],
+      dbName: ':memory:',
+    })).rejects.toThrow(`ArticleWithM2MTargetKey.tags uses 'targetKey' option which is not supported for ManyToMany relations`);
+  });
+
+  test('throws error when targetKey points to non-unique property', async () => {
+    @Entity()
+    class AuthorWithNonUniqueCode {
+
+      @PrimaryKey()
+      id!: number;
+
+      @Property() // NOT unique
+      code!: string;
+
+    }
+
+    @Entity()
+    class BookWithNonUniqueTargetKey {
+
+      @PrimaryKey()
+      id!: number;
+
+      @ManyToOne(() => AuthorWithNonUniqueCode, { targetKey: 'code' })
+      author!: AuthorWithNonUniqueCode;
+
+    }
+
+    await expect(MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      entities: [AuthorWithNonUniqueCode, BookWithNonUniqueTargetKey],
+      dbName: ':memory:',
+    })).rejects.toThrow(`BookWithNonUniqueTargetKey.author has 'targetKey' set to 'code', but AuthorWithNonUniqueCode.code is not marked as unique`);
+  });
+
+  test('accepts targetKey pointing to property with unique constraint via @Unique decorator', async () => {
+    @Entity()
+    class AuthorWithUniqueCode {
+
+      @PrimaryKey()
+      id!: number;
+
+      @Property()
+      @Unique()
+      code!: string;
+
+    }
+
+    @Entity()
+    class BookWithUniqueTargetKey {
+
+      @PrimaryKey()
+      id!: number;
+
+      @ManyToOne(() => AuthorWithUniqueCode, { targetKey: 'code' })
+      author!: AuthorWithUniqueCode;
+
+    }
+
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      entities: [AuthorWithUniqueCode, BookWithUniqueTargetKey],
+      dbName: ':memory:',
+    });
+
+    // Should not throw - validation passed
+    expect(orm).toBeDefined();
+    await orm.close(true);
+  });
+
+});


### PR DESCRIPTION
Adds support for relations that reference unique columns other than the primary key using the `targetKey` option.

```ts
@Entity()
class Author {
  @PrimaryKey()
  id!: number;

  @Property()
  @Unique()
  uuid!: string;
}

@Entity()
class Book {
  @ManyToOne(() => Author, { targetKey: 'uuid' })
  author!: Author;
}

// Type-safe getReference by alternate key
const ref = em.getReference(Author, 'uuid-123', { key: 'uuid' });
```

Closes #593