### PR TITLE
feat(core): improve formula callback to provide more information about the table and column mapping

### DIFF
--- a/docs/docs/defining-entities.md
+++ b/docs/docs/defining-entities.md
@@ -1133,6 +1133,24 @@ properties: {
   </TabItem>
 </Tabs>
 
+For more complex scenarios, you can use an enhanced callback signature that provides access to table metadata and column name mappings. This is useful when you need to construct sub-selects with proper schema qualification:
+
+```ts
+@Formula((table, columns) => {
+  return `(select count(*) from other_table where other_table.ref_id = ${table.qualifiedName}.${columns.id})`;
+})
+relatedCount?: number;
+```
+
+The `table` parameter provides:
+- `alias`: The quoted table alias (same as the simple callback parameter)
+- `name`: The table name
+- `schema`: The schema name (if applicable)
+- `qualifiedName`: The schema-qualified table name (`schema.table` or just `table`)
+- `toString()`: Returns the alias for convenience in template literals
+
+The `columns` parameter is a dictionary mapping property names to their database column names.
+
 ## Indexes
 
 We can define indexes via `@Index()` decorator, for unique indexes, we can use `@Unique()` decorator. We can use it either on entity class, or on entity property.

--- a/packages/core/src/entity/defineEntity.ts
+++ b/packages/core/src/entity/defineEntity.ts
@@ -29,6 +29,7 @@ import type {
   MaybeReturnType,
   Ref,
   IndexCallback,
+  FormulaCallback,
   EntityCtor,
   IsNever,
 } from '../typings.js';
@@ -238,7 +239,7 @@ export class UniversalPropertyOptionsBuilder<Value, Options, IncludeKeys extends
    *
    * @see https://mikro-orm.io/docs/defining-entities#formulas Formulas
    */
-  formula<T extends string | ((alias: string) => string)>(formula: T): Pick<UniversalPropertyOptionsBuilder<Value, Omit<Options, 'formula'> & { formula: T }, IncludeKeys>, IncludeKeys> {
+  formula<T extends string | FormulaCallback<any>>(formula: T): Pick<UniversalPropertyOptionsBuilder<Value, Omit<Options, 'formula'> & { formula: T }, IncludeKeys>, IncludeKeys> {
     return this.assignOptions({ formula }) as any;
   }
 
@@ -649,7 +650,7 @@ const propertyBuilders = {
 
   json: <T>() => new UniversalPropertyOptionsBuilder<T, EmptyOptions, IncludeKeysForProperty>({ type: types.json }),
 
-  formula: <T>(formula: string | ((alias: string) => string)) =>
+  formula: <T>(formula: string | FormulaCallback<any>) =>
     new UniversalPropertyOptionsBuilder<T, EmptyOptions, IncludeKeysForProperty>({ formula }),
 
   datetime: (length?: number) => new UniversalPropertyOptionsBuilder<InferPropertyValueType<typeof types.datetime>, EmptyOptions, IncludeKeysForProperty>({ type: types.datetime, length }),
@@ -891,7 +892,7 @@ type MaybeOpt<Value, Options> =
   Options extends { defaultRaw: string } ? Opt<Value> :
   Options extends { persist: false } ? Opt<Value> :
   Options extends { version: true } ? Opt<Value> :
-  Options extends { formula: string | (() => string) } ? Opt<Value> :
+  Options extends { formula: string | ((...args: any[]) => string) } ? Opt<Value> :
     Value;
 
 type MaybeHidden<Value, Options> = Options extends { hidden: true } ? Hidden<Value> : Value;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,7 +7,7 @@ export type {
   Constructor, ConnectionType, Dictionary, Primary, IPrimaryKey, ObjectQuery, FilterQuery, IWrappedEntity, EntityName, EntityData, Highlighter, MaybePromise,
   AnyEntity, EntityClass, EntityProperty, QBFilterQuery, PopulateOptions, Populate, Loaded, New, LoadedReference, LoadedCollection, IMigrator, IMigrationGenerator, MigratorEvent,
   GetRepository, MigrationObject, DeepPartial, PrimaryProperty, Cast, IsUnknown, EntityDictionary, EntityDTO, MigrationDiff, GenerateOptions, FilterObject,
-  IEntityGenerator, ISeedManager, RequiredEntityData, CheckCallback, IndexCallback, SimpleColumnMeta, Rel, Ref, ScalarRef, EntityRef, ISchemaGenerator,
+  IEntityGenerator, ISeedManager, RequiredEntityData, CheckCallback, IndexCallback, FormulaCallback, FormulaTable, SimpleColumnMeta, Rel, Ref, ScalarRef, EntityRef, ISchemaGenerator,
   UmzugMigration, MigrateOptions, MigrationResult, MigrationRow, EntityKey, EntityValue, EntityDataValue, FilterKey, EntityType, FromEntityType, Selected, IsSubset, NoInfer,
   EntityProps, ExpandProperty, ExpandScalar, FilterItemValue, ExpandQuery, Scalar, ExpandHint, FilterValue, MergeLoaded, MergeSelected, TypeConfig, AnyString,
   ClearDatabaseOptions, CreateSchemaOptions, EnsureDatabaseOptions, UpdateSchemaOptions, DropSchemaOptions, RefreshDatabaseOptions, AutoPath, UnboxArray, MetadataProcessor, ImportsResolver,

--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -1495,7 +1495,7 @@ export class MetadataDiscovery {
     prop.targetMeta = meta2;
 
     if (!prop.formula && prop.persist === false && [ReferenceKind.MANY_TO_ONE, ReferenceKind.ONE_TO_ONE].includes(prop.kind) && !prop.embedded) {
-      prop.formula = a => `${a}.${this.platform.quoteIdentifier(prop.fieldNames[0])}`;
+      prop.formula = table => `${table}.${this.platform.quoteIdentifier(prop.fieldNames[0])}`;
     }
   }
 

--- a/packages/core/src/metadata/types.ts
+++ b/packages/core/src/metadata/types.ts
@@ -5,6 +5,7 @@ import type {
   AnyString,
   CheckCallback,
   GeneratedColumnCallback,
+  FormulaCallback,
   FilterQuery,
   Dictionary,
   AutoPath,
@@ -136,7 +137,7 @@ export interface PropertyOptions<Owner> {
    *
    * @see https://mikro-orm.io/docs/defining-entities#formulas Formulas
    */
-  formula?: string | ((alias: string) => string);
+  formula?: string | FormulaCallback<Owner>;
   /**
    * For generated columns. This will be appended to the column type after the `generated always` clause.
    */

--- a/packages/decorators/src/es/Formula.ts
+++ b/packages/decorators/src/es/Formula.ts
@@ -1,12 +1,13 @@
 import {
   type EntityKey,
   type EntityProperty,
+  type FormulaCallback,
   type PropertyOptions,
   ReferenceKind,
 } from '@mikro-orm/core';
 import { prepareMetadataContext } from '../utils.js';
 
-export function Formula<Owner extends object>(formula: string | ((alias: string) => string), options: PropertyOptions<Owner> = {}) {
+export function Formula<Owner extends object>(formula: string | FormulaCallback<Owner>, options: PropertyOptions<Owner> = {}) {
   return function (value: unknown, context: ClassFieldDecoratorContext<Owner>) {
     const meta = prepareMetadataContext(context);
     meta.properties![context.name as EntityKey<Owner>] = {

--- a/packages/decorators/src/legacy/Formula.ts
+++ b/packages/decorators/src/legacy/Formula.ts
@@ -1,7 +1,7 @@
-import { type EntityKey, type EntityProperty, type PropertyOptions, ReferenceKind } from '@mikro-orm/core';
+import { type EntityKey, type EntityProperty, type FormulaCallback, type PropertyOptions, ReferenceKind } from '@mikro-orm/core';
 import { getMetadataFromDecorator } from '../utils.js';
 
-export function Formula<T extends object>(formula: string | ((alias: string) => string), options: PropertyOptions<T> = {}) {
+export function Formula<T extends object>(formula: string | FormulaCallback<T>, options: PropertyOptions<T> = {}) {
   return function (target: T, propertyName: string) {
     const meta = getMetadataFromDecorator(target.constructor as T);
     meta.properties[propertyName as EntityKey<T>] = {


### PR DESCRIPTION
For more complex scenarios, you can use an enhanced callback signature that provides access to table metadata and column name mappings. This is useful when you need to construct sub-selects with proper schema qualification:

```ts
@Formula((table, columns) => {
  return `(select count(*) from other_table where other_table.ref_id = ${table.qualifiedName}.${columns.id})`;
})
relatedCount?: number;
```

The `table` parameter provides:
- `alias`: The quoted table alias (same as the simple callback parameter)
- `name`: The table name
- `schema`: The schema name (if applicable)
- `qualifiedName`: The schema-qualified table name (`schema.table` or just `table`)
- `toString()`: Returns the alias for convenience in template literals

The `columns` parameter is a dictionary mapping property names to their database column names.

Closes #7102