### PR TITLE
feat(core): add support for view entities

### DIFF
--- a/docs/docs/view-entities.md
+++ b/docs/docs/view-entities.md
@@ -1,0 +1,323 @@
+---
+title: View Entities
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+View entities represent actual database views that are created and managed by MikroORM's schema generator. Unlike [virtual entities](./virtual-entities.md) which evaluate expressions at query time, view entities create persistent `CREATE VIEW` statements in your database.
+
+## Virtual Entities vs View Entities
+
+| Feature | Virtual Entities | View Entities |
+|---------|-----------------|---------------|
+| Database object | None (expression evaluated at query time) | Actual database view |
+| Primary key | Not allowed | Allowed |
+| Schema generation | Ignored | `CREATE VIEW` / `DROP VIEW` generated |
+| Migrations | Not tracked | Tracked and diffed |
+| Read-only | Yes | Yes |
+| Use case | Dynamic queries, aggregations | Reusable views, complex queries, legacy views |
+
+## Defining View Entities
+
+To define a view entity, set both `view: true` and provide an `expression`. The expression defines the SQL query that backs the view. Without `view: true`, an entity with only `expression` becomes a virtual entity (the expression is evaluated at query time with no database object created).
+
+### Using String Expression
+
+<Tabs
+  groupId="entity-def"
+  defaultValue="define-entity"
+  values={[
+    {label: 'defineEntity', value: 'define-entity'},
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="define-entity">
+
+```ts title="./entities/AuthorStats.ts"
+import { defineEntity, p } from '@mikro-orm/core';
+
+export const AuthorStats = defineEntity({
+  name: 'AuthorStats',
+  tableName: 'author_stats_view',
+  view: true,
+  expression: `
+    select a.name, count(b.id) as book_count
+    from author a
+    left join book b on b.author_id = a.id
+    group by a.id, a.name
+  `,
+  properties: {
+    name: p.string().primary(),
+    bookCount: p.integer(),
+  },
+});
+```
+
+  </TabItem>
+  <TabItem value="reflect-metadata">
+
+```ts title="./entities/AuthorStats.ts"
+@Entity({
+  tableName: 'author_stats_view',
+  view: true,
+  expression: `
+    select a.name, count(b.id) as book_count
+    from author a
+    left join book b on b.author_id = a.id
+    group by a.id, a.name
+  `,
+})
+export class AuthorStats {
+
+  @PrimaryKey()
+  name!: string;
+
+  @Property()
+  bookCount!: number;
+
+}
+```
+
+  </TabItem>
+  <TabItem value="ts-morph">
+
+```ts title="./entities/AuthorStats.ts"
+@Entity({
+  tableName: 'author_stats_view',
+  view: true,
+  expression: `
+    select a.name, count(b.id) as book_count
+    from author a
+    left join book b on b.author_id = a.id
+    group by a.id, a.name
+  `,
+})
+export class AuthorStats {
+
+  @PrimaryKey()
+  name!: string;
+
+  @Property()
+  bookCount!: number;
+
+}
+```
+
+  </TabItem>
+  <TabItem value="entity-schema">
+
+```ts title="./entities/AuthorStats.ts"
+export interface IAuthorStats {
+  name: string;
+  bookCount: number;
+}
+
+export const AuthorStats = new EntitySchema<IAuthorStats>({
+  name: 'AuthorStats',
+  tableName: 'author_stats_view',
+  view: true,
+  expression: `
+    select a.name, count(b.id) as book_count
+    from author a
+    left join book b on b.author_id = a.id
+    group by a.id, a.name
+  `,
+  properties: {
+    name: { type: 'string', primary: true },
+    bookCount: { type: 'number' },
+  },
+});
+```
+
+  </TabItem>
+</Tabs>
+
+### Using QueryBuilder Expression
+
+You can also use a callback that returns a QueryBuilder for type-safe view definitions:
+
+<Tabs
+  groupId="entity-def"
+  defaultValue="define-entity"
+  values={[
+    {label: 'defineEntity', value: 'define-entity'},
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="define-entity">
+
+```ts title="./entities/BookSummary.ts"
+import { defineEntity, p } from '@mikro-orm/core';
+
+export const BookSummary = defineEntity({
+  name: 'BookSummary',
+  tableName: 'book_summary_view',
+  view: true,
+  expression: (em: EntityManager) => {
+    return em.createQueryBuilder(Book, 'b')
+      .select(['b.title', 'a.name as author_name'])
+      .join('b.author', 'a');
+  },
+  properties: {
+    title: p.string().primary(),
+    authorName: p.string(),
+  },
+});
+```
+
+  </TabItem>
+  <TabItem value="reflect-metadata">
+
+```ts title="./entities/BookSummary.ts"
+@Entity({
+  tableName: 'book_summary_view',
+  view: true,
+  expression: (em: EntityManager) => {
+    return em.createQueryBuilder(Book, 'b')
+      .select(['b.title', 'a.name as author_name'])
+      .join('b.author', 'a');
+  },
+})
+export class BookSummary {
+
+  @PrimaryKey()
+  title!: string;
+
+  @Property()
+  authorName!: string;
+
+}
+```
+
+  </TabItem>
+  <TabItem value="ts-morph">
+
+```ts title="./entities/BookSummary.ts"
+@Entity({
+  tableName: 'book_summary_view',
+  view: true,
+  expression: (em: EntityManager) => {
+    return em.createQueryBuilder(Book, 'b')
+      .select(['b.title', 'a.name as author_name'])
+      .join('b.author', 'a');
+  },
+})
+export class BookSummary {
+
+  @PrimaryKey()
+  title!: string;
+
+  @Property()
+  authorName!: string;
+
+}
+```
+
+  </TabItem>
+  <TabItem value="entity-schema">
+
+```ts title="./entities/BookSummary.ts"
+export interface IBookSummary {
+  title: string;
+  authorName: string;
+}
+
+export const BookSummary = new EntitySchema<IBookSummary>({
+  name: 'BookSummary',
+  tableName: 'book_summary_view',
+  view: true,
+  expression: (em: EntityManager) => {
+    return em.createQueryBuilder(Book, 'b')
+      .select(['b.title', 'a.name as author_name'])
+      .join('b.author', 'a');
+  },
+  properties: {
+    title: { type: 'string', primary: true },
+    authorName: { type: 'string' },
+  },
+});
+```
+
+  </TabItem>
+</Tabs>
+
+## Querying View Entities
+
+View entities can be queried like any other entity:
+
+```ts
+// Find all
+const stats = await em.find(AuthorStats, {});
+
+// Find with conditions
+const prolificAuthors = await em.find(AuthorStats, {
+  bookCount: { $gte: 5 },
+});
+
+// Using QueryBuilder
+const topAuthors = await em.createQueryBuilder(AuthorStats, 'a')
+  .where({ bookCount: { $gt: 0 } })
+  .orderBy({ bookCount: 'desc' })
+  .limit(10)
+  .getResult();
+```
+
+## Read-Only Behavior
+
+View entities are automatically marked as read-only. Attempting to persist changes to a view entity will have no effect:
+
+```ts
+const stat = await em.findOne(AuthorStats, { name: 'John' });
+stat.bookCount = 100; // This change won't be persisted
+await em.flush(); // No INSERT/UPDATE generated for view entities
+```
+
+## Primary Keys
+
+Unlike virtual entities, view entities can (and should) have primary keys. This allows for:
+
+- Proper identity map tracking within a request
+- Using `findOne` with primary key lookups
+- Referencing view entities in relations (if needed)
+
+```ts
+@Entity({ tableName: 'my_view', view: true, expression: '...' })
+export class MyView {
+  @PrimaryKey()
+  id!: number; // Primary key is allowed
+
+  @Property()
+  value!: string;
+}
+```
+
+## Use Cases
+
+View entities are ideal for:
+
+1. **Reporting queries**: Pre-aggregate data for dashboards
+2. **Legacy database views**: Map existing database views to entities
+3. **Complex joins**: Simplify access to frequently-joined data
+4. **Denormalized data**: Provide a flattened view of normalized tables
+5. **Access control**: Expose limited data through views
+
+## Supported Databases
+
+View entities are supported in all SQL databases:
+
+- PostgreSQL
+- MySQL / MariaDB
+- SQLite
+- Microsoft SQL Server
+
+> Note: MongoDB does not support view entities as it doesn't have the concept of database views. Use [virtual entities](./virtual-entities.md) instead for MongoDB.
+
+## Limitations
+
+- View entities are read-only and cannot be persisted
+- Some databases may have limitations on updatable views

--- a/docs/docs/virtual-entities.md
+++ b/docs/docs/virtual-entities.md
@@ -5,7 +5,9 @@ title: Virtual Entities
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-Virtual entities don't represent any database table. Instead, they dynamically resolve to an SQL query (or an aggregation in MongoDB), allowing to map any kind of results onto an entity. Such entities are meant for read purposes, they don't have a primary key and therefore cannot be tracked for changes. In a way they are similar to (currently unsupported) database views, and you can use them to proxy your native views already.
+Virtual entities don't represent any database table. Instead, they dynamically resolve to an SQL query (or an aggregation in MongoDB), allowing to map any kind of results onto an entity. Such entities are meant for read purposes, they don't have a primary key and therefore cannot be tracked for changes.
+
+> If you need actual database views that are created and managed by the schema generator, see [View Entities](./view-entities.md) instead. View entities create `CREATE VIEW` statements and are tracked in migrations, while virtual entities evaluate their expression at query time.
 
 > Virtual entities can contain scalar properties as well as to-one relations (M:1 and 1:1 owners). Such relations are always populated via `select-in` strategy.
 

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -71,6 +71,7 @@ module.exports = {
         'composite-keys',
         'custom-types',
         'virtual-entities',
+        'view-entities',
         'embeddables',
         'entity-schema',
         'json-properties',

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -309,6 +309,10 @@ export class MetadataError<T extends AnyEntity = AnyEntity> extends ValidationEr
     return this.fromMessage(meta, prop, `uses a dangerous property name '${prop.name}' which could lead to prototype pollution. Please use a different property name.`);
   }
 
+  static viewEntityWithoutExpression(meta: EntityMetadata): MetadataError {
+    return new MetadataError(`View entity ${meta.className} is missing 'expression'. View entities must have an expression defining the SQL query.`);
+  }
+
   private static fromMessage(meta: EntityMetadata, prop: EntityProperty, message: string): MetadataError {
     return new MetadataError(`${meta.className}.${prop.name} ${message}`);
   }

--- a/packages/core/src/metadata/types.ts
+++ b/packages/core/src/metadata/types.ts
@@ -42,13 +42,19 @@ export type EntityOptions<T, E = T extends EntityClass<infer P> ? P : T> = {
   abstract?: boolean;
   /** Disables change tracking - such entities are ignored during flush. */
   readonly?: boolean;
-  /** Marks entity as {@doclink virtual-entities | virtual}. This is set automatically when you use `expression` option. */
+  /** Marks entity as {@doclink virtual-entities | virtual}. This is set automatically when you use `expression` option (unless `view` is set). */
   virtual?: boolean;
+  /**
+   * Marks entity as a database view. Unlike virtual entities which evaluate expressions at query time,
+   * view entities create actual database views. The `expression` option must be provided when `view` is true.
+   * View entities are read-only by default.
+   */
+  view?: boolean;
   /** Used to make ORM aware of externally defined triggers. This is needed for MS SQL Server multi inserts, ignored in other dialects. */
   hasTriggers?: boolean;
   // we need to use `em: any` here otherwise an expression would not be assignable with more narrow type like `SqlEntityManager`
   // also return type is unknown as it can be either QB instance (which we cannot type here) or array of POJOs (e.g. for mongodb)
-  /** SQL query that maps to a {@doclink virtual-entities | virtual entity}. */
+  /** SQL query that maps to a {@doclink virtual-entities | virtual entity}, or for view entities, the view definition. */
   expression?: string | ((em: any, where: ObjectQuery<E>, options: FindOptions<E, any, any, any>, stream?: boolean) => object);
   /** Set {@doclink repositories#custom-repository | custom repository class}. */
   repository?: () => Constructor;

--- a/packages/sql/src/dialects/mysql/MySqlSchemaHelper.ts
+++ b/packages/sql/src/dialects/mysql/MySqlSchemaHelper.ts
@@ -1,5 +1,5 @@
-import { EnumType, StringType, TextType, type Dictionary, type Type } from '@mikro-orm/core';
-import type { CheckDef, Column, IndexDef, TableDifference, Table, ForeignKey } from '../../typings.js';
+import { type Dictionary, EnumType, StringType, TextType, type Type } from '@mikro-orm/core';
+import type { CheckDef, Column, ForeignKey, IndexDef, Table, TableDifference } from '../../typings.js';
 import type { AbstractSqlConnection } from '../../AbstractSqlConnection.js';
 import { SchemaHelper } from '../../schema/SchemaHelper.js';
 import type { DatabaseSchema } from '../../schema/DatabaseSchema.js';
@@ -49,6 +49,33 @@ export class MySqlSchemaHelper extends SchemaHelper {
 
   override getListTablesSQL(): string {
     return `select table_name as table_name, nullif(table_schema, schema()) as schema_name, table_comment as table_comment from information_schema.tables where table_type = 'BASE TABLE' and table_schema = schema()`;
+  }
+
+  override getListViewsSQL(schemaName?: string): string {
+    return `select table_name as view_name, nullif(table_schema, schema()) as schema_name, view_definition from information_schema.views where table_schema = schema()`;
+  }
+
+  override async loadViews(schema: DatabaseSchema, connection: AbstractSqlConnection, schemaName?: string): Promise<void> {
+    const views = await connection.execute<{ view_name: string; schema_name: string | null; view_definition?: string }[]>(this.getListViewsSQL(schemaName));
+
+    for (const view of views) {
+      // MySQL information_schema.views.view_definition requires SHOW VIEW privilege
+      // and may return NULL. Use SHOW CREATE VIEW as fallback.
+      let definition = view.view_definition?.trim();
+
+      if (!definition) {
+        const createView = await connection.execute<{ View: string; 'Create View': string }[]>(`show create view \`${view.view_name}\``);
+        if (createView[0]?.['Create View']) {
+          // Extract SELECT statement from CREATE VIEW ... AS SELECT ...
+          const match = createView[0]['Create View'].match(/\bAS\s+(.+)$/is);
+          definition = match?.[1]?.trim();
+        }
+      }
+
+      if (definition) {
+        schema.addView(view.view_name, view.schema_name ?? undefined, definition);
+      }
+    }
   }
 
   override async loadInformationSchema(schema: DatabaseSchema, connection: AbstractSqlConnection, tables: Table[]): Promise<void> {

--- a/packages/sql/src/schema/SchemaHelper.ts
+++ b/packages/sql/src/schema/SchemaHelper.ts
@@ -88,7 +88,15 @@ export abstract class SchemaHelper {
 
   abstract loadInformationSchema(schema: DatabaseSchema, connection: AbstractSqlConnection, tables: Table[], schemas?: string[]): Promise<void>;
 
-  getListTablesSQL(schemaName?: string): string {
+  getListTablesSQL(): string {
+    throw new Error('Not supported by given driver');
+  }
+
+  getListViewsSQL(): string {
+    throw new Error('Not supported by given driver');
+  }
+
+  async loadViews(schema: DatabaseSchema, connection: AbstractSqlConnection): Promise<void> {
     throw new Error('Not supported by given driver');
   }
 
@@ -700,6 +708,21 @@ export abstract class SchemaHelper {
 
   dropTableIfExists(name: string, schema?: string): string {
     let sql = `drop table if exists ${this.quote(this.getTableName(name, schema))}`;
+
+    if (this.platform.usesCascadeStatement()) {
+      sql += ' cascade';
+    }
+
+    return sql;
+  }
+
+  createView(name: string, schema: string | undefined, definition: string): string {
+    const viewName = this.quote(this.getTableName(name, schema));
+    return `create view ${viewName} as ${definition}`;
+  }
+
+  dropViewIfExists(name: string, schema?: string): string {
+    let sql = `drop view if exists ${this.quote(this.getTableName(name, schema))}`;
 
     if (this.platform.usesCascadeStatement()) {
       sql += ' cascade';

--- a/packages/sql/src/typings.ts
+++ b/packages/sql/src/typings.ts
@@ -136,12 +136,21 @@ export interface TableDifference {
   removedForeignKeys: Dictionary<ForeignKey>;
 }
 
+export interface DatabaseView {
+  name: string;
+  schema?: string;
+  definition: string;
+}
+
 export interface SchemaDifference {
   newNamespaces: Set<string>;
   newNativeEnums: { name: string; schema?: string; items: string[] }[];
   newTables: Dictionary<DatabaseTable>;
   changedTables: Dictionary<TableDifference>;
   removedTables: Dictionary<DatabaseTable>;
+  newViews: Dictionary<DatabaseView>;
+  changedViews: Dictionary<{ from: DatabaseView; to: DatabaseView }>;
+  removedViews: Dictionary<DatabaseView>;
   removedNamespaces: Set<string>;
   removedNativeEnums: { name: string; schema?: string }[];
   orphanedForeignKeys: ForeignKey[];

--- a/tests/SchemaHelper.test.ts
+++ b/tests/SchemaHelper.test.ts
@@ -22,6 +22,8 @@ describe('SchemaHelper', () => {
     expect(helper.getSchemaEnd()).toBe('');
     expect(helper.getChangeColumnCommentSQL('a', {} as any)).toBe('');
     expect(() => helper.getListTablesSQL()).toThrow('Not supported by given driver');
+    expect(() => helper.getListViewsSQL()).toThrow('Not supported by given driver');
+    await expect(helper.loadViews(null!, null!)).rejects.toThrow('Not supported by given driver');
     expect(() => helper.getAlterNativeEnumSQL('table')).toThrow('Not supported by given driver');
     expect(() => helper.getCreateNativeEnumSQL('table', [])).toThrow('Not supported by given driver');
     expect(() => helper.getDropNativeEnumSQL('table')).toThrow('Not supported by given driver');

--- a/tests/features/decorators/legacy/decorators.test.ts
+++ b/tests/features/decorators/legacy/decorators.test.ts
@@ -183,8 +183,6 @@ describe('decorators', () => {
     expect(storage[key].properties.test0).toMatchObject({ kind: ReferenceKind.MANY_TO_MANY, name: 'test0' });
     expect(storage[key].properties.test0.entity()).toBe(Test);
     expect(Object.keys(MetadataStorage.getMetadata())).toHaveLength(7);
-    MetadataStorage.clear();
-    expect(Object.keys(MetadataStorage.getMetadata())).toHaveLength(0);
   });
 
   test('ManyToOne', () => {

--- a/tests/features/view-entities/__snapshots__/view-entities.mssql.test.ts.snap
+++ b/tests/features/view-entities/__snapshots__/view-entities.mssql.test.ts.snap
@@ -1,0 +1,91 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`View entities (mssql) > schema generator should create views 1`] = `
+"create table [book_tag2] ([id] bigint identity(1,1) not null primary key, [name] nvarchar(50) not null);
+
+create table [foo_baz2] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) not null, [code] varchar(255) not null, [version] datetime2(3) not null constraint [foo_baz2_version_default] default current_timestamp);
+
+create table [foo_bar2] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) not null, [baz_id] int null, [foo_bar_id] int null, [version] datetime2(0) not null constraint [foo_bar2_version_default] default current_timestamp, [blob] varbinary(max) null, [array] text null, [object] nvarchar(max) null);
+create unique index [foo_bar2_baz_id_unique] on [foo_bar2] ([baz_id]) where [baz_id] is not null;
+create unique index [foo_bar2_foo_bar_id_unique] on [foo_bar2] ([foo_bar_id]) where [foo_bar_id] is not null;
+
+create table [publisher2] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) not null constraint [publisher2_name_default] default 'asd', [type] nvarchar(100) not null constraint [publisher2_type_default] default 'local', [type2] nvarchar(100) not null constraint [publisher2_type2_default] default 'LOCAL', [enum1] tinyint null, [enum2] tinyint null, [enum3] tinyint null, [enum4] nvarchar(100) null);
+alter table [publisher2] add constraint [publisher2_type_check] check ([type] in ('local', 'global'));
+alter table [publisher2] add constraint [publisher2_type2_check] check ([type2] in ('LOCAL', 'GLOBAL'));
+alter table [publisher2] add constraint [publisher2_enum4_check] check ([enum4] in ('a', 'b', 'c'));
+
+create table [author2] ([id] int identity(1,1) not null primary key, [created_at] datetime2(3) not null constraint [author2_created_at_default] default current_timestamp, [updated_at] datetime2(3) not null constraint [author2_updated_at_default] default current_timestamp, [name] nvarchar(255) not null, [email] nvarchar(255) not null, [age] int null, [terms_accepted] bit not null constraint [author2_terms_accepted_default] default 0, [optional] bit null, [identities] text null, [born] date null, [born_time] time null, [favourite_book_uuid_pk] uniqueidentifier null, [favourite_author_id] int null);
+create index [custom_email_index_name] on [author2] ([email]);
+create unique index [custom_email_unique_name] on [author2] ([email]);
+create index [author2_terms_accepted_index] on [author2] ([terms_accepted]);
+create index [author2_born_index] on [author2] ([born]);
+create index [born_time_idx] on [author2] ([born_time]);
+create index [custom_idx_name_123] on [author2] ([name]);
+create index [author2_name_age_index] on [author2] ([name], [age]);
+create unique index [author2_name_email_unique] on [author2] ([name], [email]);
+
+create table [book2] ([uuid_pk] uniqueidentifier not null, [created_at] datetime2(3) not null constraint [book2_created_at_default] default current_timestamp, [isbn] nchar(13) null, [title] nvarchar(255) null constraint [book2_title_default] default '', [perex] text null, [price] numeric(8,2) null, [float] float(24) null, [float36] float(36) null, [double] float(53) null, [meta] nvarchar(max) null, [author_id] int not null, [publisher_id] int null, primary key ([uuid_pk]));
+create unique index [book2_isbn_unique] on [book2] ([isbn]) where [isbn] is not null;
+
+create table [book2_tags] ([order] int identity(1,1) not null primary key, [book2_uuid_pk] uniqueidentifier not null, [book_tag2_id] bigint not null);
+
+create table [book_to_tag_unordered] ([book2_uuid_pk] uniqueidentifier not null, [book_tag2_id] bigint not null, primary key ([book2_uuid_pk], [book_tag2_id]));
+
+create table [author2_following] ([author2_1_id] int not null, [author2_2_id] int not null, primary key ([author2_1_id], [author2_2_id]));
+
+create table [author_to_friend] ([author2_1_id] int not null, [author2_2_id] int not null, primary key ([author2_1_id], [author2_2_id]));
+
+create table [address2] ([author_id] int not null, [value] nvarchar(255) not null, primary key ([author_id]));
+if exists(select * from sys.fn_listextendedproperty(N'MS_Description', N'Schema', N'dbo', N'Table', N'address2', null, null))
+  exec sys.sp_updateextendedproperty N'MS_Description', N'This is address table', N'Schema', N'dbo', N'Table', N'address2'
+else
+  exec sys.sp_addextendedproperty N'MS_Description', N'This is address table', N'Schema', N'dbo', N'Table', N'address2';
+if exists(select * from sys.fn_listextendedproperty(N'MS_Description', N'Schema', N'dbo', N'Table', N'address2', N'Column', N'value'))
+  exec sys.sp_updateextendedproperty N'MS_Description', N'This is address property', N'Schema', N'dbo', N'Table', N'address2', N'Column', N'value'
+else
+  exec sys.sp_addextendedproperty N'MS_Description', N'This is address property', N'Schema', N'dbo', N'Table', N'address2', N'Column', N'value';
+
+create table [test2] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) null, [book_uuid_pk] uniqueidentifier null, [version] int not null constraint [test2_version_default] default 1);
+create unique index [test2_book_uuid_pk_unique] on [test2] ([book_uuid_pk]) where [book_uuid_pk] is not null;
+
+create table [publisher2_tests] ([id] int identity(1,1) not null primary key, [publisher2_id] int not null, [test2_id] int not null);
+
+create table [configuration2] ([property] nvarchar(255) not null, [test_id] int not null, [value] nvarchar(255) not null, primary key ([property], [test_id]));
+
+alter table [foo_bar2] add constraint [foo_bar2_baz_id_foreign] foreign key ([baz_id]) references [foo_baz2] ([id]) on delete set null;
+alter table [foo_bar2] add constraint [foo_bar2_foo_bar_id_foreign] foreign key ([foo_bar_id]) references [foo_bar2] ([id]);
+
+alter table [author2] add constraint [author2_favourite_book_uuid_pk_foreign] foreign key ([favourite_book_uuid_pk]) references [book2] ([uuid_pk]) on update no action on delete cascade;
+alter table [author2] add constraint [author2_favourite_author_id_foreign] foreign key ([favourite_author_id]) references [author2] ([id]);
+
+alter table [book2] add constraint [book2_author_id_foreign] foreign key ([author_id]) references [author2] ([id]);
+alter table [book2] add constraint [book2_publisher_id_foreign] foreign key ([publisher_id]) references [publisher2] ([id]) on delete set null;
+
+alter table [book2_tags] add constraint [book2_tags_book2_uuid_pk_foreign] foreign key ([book2_uuid_pk]) references [book2] ([uuid_pk]) on update cascade on delete cascade;
+alter table [book2_tags] add constraint [book2_tags_book_tag2_id_foreign] foreign key ([book_tag2_id]) references [book_tag2] ([id]) on update cascade on delete cascade;
+
+alter table [book_to_tag_unordered] add constraint [book_to_tag_unordered_book2_uuid_pk_foreign] foreign key ([book2_uuid_pk]) references [book2] ([uuid_pk]) on update cascade on delete cascade;
+alter table [book_to_tag_unordered] add constraint [book_to_tag_unordered_book_tag2_id_foreign] foreign key ([book_tag2_id]) references [book_tag2] ([id]) on update cascade on delete cascade;
+
+alter table [author2_following] add constraint [author2_following_author2_1_id_foreign] foreign key ([author2_1_id]) references [author2] ([id]) on update no action on delete no action;
+alter table [author2_following] add constraint [author2_following_author2_2_id_foreign] foreign key ([author2_2_id]) references [author2] ([id]) on update no action on delete no action;
+
+alter table [author_to_friend] add constraint [author_to_friend_author2_1_id_foreign] foreign key ([author2_1_id]) references [author2] ([id]) on update no action on delete no action;
+alter table [author_to_friend] add constraint [author_to_friend_author2_2_id_foreign] foreign key ([author2_2_id]) references [author2] ([id]) on update no action on delete no action;
+
+alter table [address2] add constraint [address2_author_id_foreign] foreign key ([author_id]) references [author2] ([id]) on update cascade on delete cascade;
+
+alter table [test2] add constraint [test2_book_uuid_pk_foreign] foreign key ([book_uuid_pk]) references [book2] ([uuid_pk]) on delete no action;
+
+alter table [publisher2_tests] add constraint [publisher2_tests_publisher2_id_foreign] foreign key ([publisher2_id]) references [publisher2] ([id]) on update cascade on delete cascade;
+alter table [publisher2_tests] add constraint [publisher2_tests_test2_id_foreign] foreign key ([test2_id]) references [test2] ([id]) on update cascade on delete cascade;
+
+alter table [configuration2] add constraint [configuration2_test_id_foreign] foreign key ([test_id]) references [test2] ([id]);
+
+create view [book_summary_view] as select [b].[title], [a].[name] as [author_name] from [book2] as [b] inner join [author2] as [a] on [b].[author_id] = [a].[id];
+
+create view [author_stats_view] as select min(name) as name, (select count(*) from book2 b where b.author_id = a.id) as book_count from author2 a group by a.id;
+
+create view [prolific_authors_view] as select name, book_count from author_stats_view where book_count > 1;
+"
+`;

--- a/tests/features/view-entities/__snapshots__/view-entities.mysql.test.ts.snap
+++ b/tests/features/view-entities/__snapshots__/view-entities.mysql.test.ts.snap
@@ -1,0 +1,213 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`View entities ('mariadb') > schema generator should create views 1`] = `
+"set names utf8mb4;
+
+create table \`book_tag2\` (\`id\` bigint unsigned not null auto_increment primary key, \`name\` varchar(50) not null) default character set utf8mb4 engine = InnoDB;
+
+create table \`foo_baz2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`code\` varchar(255) not null, \`version\` datetime(3) not null default current_timestamp(3)) default character set utf8mb4 engine = InnoDB;
+
+create table \`foo_bar2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`name with space\` varchar(255) null, \`baz_id\` int unsigned null, \`foo_bar_id\` int unsigned null, \`version\` datetime not null default current_timestamp, \`blob\` blob null, \`blob2\` blob null, \`array\` text null, \`object_property\` json null) default character set utf8mb4 engine = InnoDB;
+alter table \`foo_bar2\` add unique \`foo_bar2_baz_id_unique\` (\`baz_id\`);
+alter table \`foo_bar2\` add unique \`foo_bar2_foo_bar_id_unique\` (\`foo_bar_id\`);
+
+create table \`publisher2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null default 'asd', \`type\` enum('local','global') not null default 'local', \`type2\` enum('LOCAL','GLOBAL') not null default 'LOCAL', \`enum1\` tinyint null, \`enum2\` tinyint null, \`enum3\` tinyint null, \`enum4\` enum('a','b','c') null, \`enum5\` enum('a') null) default character set utf8mb4 engine = InnoDB;
+
+create table \`author2\` (\`id\` int unsigned not null auto_increment primary key, \`created_at\` datetime(3) not null default current_timestamp(3), \`updated_at\` datetime(3) not null default current_timestamp(3), \`name\` varchar(255) not null, \`email\` varchar(255) not null, \`age\` int null, \`terms_accepted\` tinyint(1) not null default false, \`optional\` tinyint(1) null, \`identities\` text null, \`born\` date null, \`born_time\` time null, \`favourite_book_uuid_pk\` varchar(36) null, \`favourite_author_id\` int unsigned null, \`identity\` json null) default character set utf8mb4 engine = InnoDB;
+alter table \`author2\` add index \`custom_email_index_name\` (\`email\`);
+alter table \`author2\` add unique \`custom_email_unique_name\` (\`email\`);
+alter table \`author2\` add index \`author2_terms_accepted_index\` (\`terms_accepted\`);
+alter table \`author2\` add index \`author2_born_index\` (\`born\`);
+alter table \`author2\` add index \`born_time_idx\` (\`born_time\`);
+alter table \`author2\` add index \`author2_favourite_book_uuid_pk_index\` (\`favourite_book_uuid_pk\`);
+alter table \`author2\` add index \`author2_favourite_author_id_index\` (\`favourite_author_id\`);
+alter table \`author2\` add index \`custom_idx_name_123\` (\`name\`);
+alter table \`author2\` add index \`author2_name_age_index\` (\`name\`, \`age\`);
+alter table \`author2\` add unique \`author2_name_email_unique\` (\`name\`, \`email\`);
+
+create table \`book2\` (\`uuid_pk\` varchar(36) not null, \`created_at\` datetime(3) not null default current_timestamp(3), \`isbn\` char(13) null, \`title\` varchar(255) null default '', \`perex\` text null, \`price\` numeric(8,2) null, \`double\` double null, \`meta\` json null, \`author_id\` int unsigned not null, \`publisher_id\` int unsigned null, primary key (\`uuid_pk\`)) default character set utf8mb4 engine = InnoDB;
+alter table \`book2\` add unique \`book2_isbn_unique\` (\`isbn\`);
+alter table \`book2\` add index \`book2_author_id_index\` (\`author_id\`);
+alter table \`book2\` add index \`book2_publisher_id_index\` (\`publisher_id\`);
+alter table \`book2\` add fulltext index \`book2_title_index\`(\`title\`);
+
+create table \`book2_tags\` (\`order\` int unsigned not null auto_increment primary key, \`book2_uuid_pk\` varchar(36) not null, \`book_tag2_id\` bigint unsigned not null) default character set utf8mb4 engine = InnoDB;
+alter table \`book2_tags\` add index \`book2_tags_book2_uuid_pk_index\` (\`book2_uuid_pk\`);
+alter table \`book2_tags\` add index \`book2_tags_book_tag2_id_index\` (\`book_tag2_id\`);
+
+create table \`book_to_tag_unordered\` (\`book2_uuid_pk\` varchar(36) not null, \`book_tag2_id\` bigint unsigned not null, primary key (\`book2_uuid_pk\`, \`book_tag2_id\`)) default character set utf8mb4 engine = InnoDB;
+alter table \`book_to_tag_unordered\` add index \`book_to_tag_unordered_book2_uuid_pk_index\` (\`book2_uuid_pk\`);
+alter table \`book_to_tag_unordered\` add index \`book_to_tag_unordered_book_tag2_id_index\` (\`book_tag2_id\`);
+
+create table \`author2_following\` (\`author2_1_id\` int unsigned not null, \`author2_2_id\` int unsigned not null, primary key (\`author2_1_id\`, \`author2_2_id\`)) default character set utf8mb4 engine = InnoDB;
+alter table \`author2_following\` add index \`author2_following_author2_1_id_index\` (\`author2_1_id\`);
+alter table \`author2_following\` add index \`author2_following_author2_2_id_index\` (\`author2_2_id\`);
+
+create table \`author_to_friend\` (\`author2_1_id\` int unsigned not null, \`author2_2_id\` int unsigned not null, primary key (\`author2_1_id\`, \`author2_2_id\`)) default character set utf8mb4 engine = InnoDB;
+alter table \`author_to_friend\` add index \`author_to_friend_author2_1_id_index\` (\`author2_1_id\`);
+alter table \`author_to_friend\` add index \`author_to_friend_author2_2_id_index\` (\`author2_2_id\`);
+
+create table \`address2\` (\`author_id\` int unsigned not null, \`value\` varchar(255) not null comment 'This is address property', primary key (\`author_id\`)) default character set utf8mb4 engine = InnoDB comment = 'This is address table';
+
+create table \`test2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) null, \`book_uuid_pk\` varchar(36) null, \`parent_id\` int unsigned null, \`version\` int not null default 1) default character set utf8mb4 engine = InnoDB;
+alter table \`test2\` add unique \`test2_book_uuid_pk_unique\` (\`book_uuid_pk\`);
+alter table \`test2\` add index \`test2_parent_id_index\` (\`parent_id\`);
+
+create table \`publisher2_tests\` (\`id\` int unsigned not null auto_increment primary key, \`publisher2_id\` int unsigned not null, \`test2_id\` int unsigned not null) default character set utf8mb4 engine = InnoDB;
+alter table \`publisher2_tests\` add index \`publisher2_tests_publisher2_id_index\` (\`publisher2_id\`);
+alter table \`publisher2_tests\` add index \`publisher2_tests_test2_id_index\` (\`test2_id\`);
+
+create table \`configuration2\` (\`property\` varchar(255) not null, \`test_id\` int unsigned not null, \`value\` varchar(255) not null, primary key (\`property\`, \`test_id\`)) default character set utf8mb4 engine = InnoDB;
+alter table \`configuration2\` add index \`configuration2_test_id_index\` (\`test_id\`);
+
+create table \`test2_bars\` (\`test2_id\` int unsigned not null, \`foo_bar2_id\` int unsigned not null, primary key (\`test2_id\`, \`foo_bar2_id\`)) default character set utf8mb4 engine = InnoDB;
+alter table \`test2_bars\` add index \`test2_bars_test2_id_index\` (\`test2_id\`);
+alter table \`test2_bars\` add index \`test2_bars_foo_bar2_id_index\` (\`foo_bar2_id\`);
+
+alter table \`foo_bar2\` add constraint \`foo_bar2_baz_id_foreign\` foreign key (\`baz_id\`) references \`foo_baz2\` (\`id\`) on delete set null;
+alter table \`foo_bar2\` add constraint \`foo_bar2_foo_bar_id_foreign\` foreign key (\`foo_bar_id\`) references \`foo_bar2\` (\`id\`) on delete set null;
+
+alter table \`author2\` add constraint \`author2_favourite_book_uuid_pk_foreign\` foreign key (\`favourite_book_uuid_pk\`) references \`book2\` (\`uuid_pk\`) on update no action on delete cascade;
+alter table \`author2\` add constraint \`author2_favourite_author_id_foreign\` foreign key (\`favourite_author_id\`) references \`author2\` (\`id\`) on delete set null;
+
+alter table \`book2\` add constraint \`book2_author_id_foreign\` foreign key (\`author_id\`) references \`author2\` (\`id\`);
+alter table \`book2\` add constraint \`book2_publisher_id_foreign\` foreign key (\`publisher_id\`) references \`publisher2\` (\`id\`) on delete set null;
+
+alter table \`book2_tags\` add constraint \`book2_tags_book2_uuid_pk_foreign\` foreign key (\`book2_uuid_pk\`) references \`book2\` (\`uuid_pk\`) on update cascade on delete cascade;
+alter table \`book2_tags\` add constraint \`book2_tags_book_tag2_id_foreign\` foreign key (\`book_tag2_id\`) references \`book_tag2\` (\`id\`) on update cascade on delete cascade;
+
+alter table \`book_to_tag_unordered\` add constraint \`book_to_tag_unordered_book2_uuid_pk_foreign\` foreign key (\`book2_uuid_pk\`) references \`book2\` (\`uuid_pk\`) on update cascade on delete cascade;
+alter table \`book_to_tag_unordered\` add constraint \`book_to_tag_unordered_book_tag2_id_foreign\` foreign key (\`book_tag2_id\`) references \`book_tag2\` (\`id\`) on update cascade on delete cascade;
+
+alter table \`author2_following\` add constraint \`author2_following_author2_1_id_foreign\` foreign key (\`author2_1_id\`) references \`author2\` (\`id\`) on update cascade on delete cascade;
+alter table \`author2_following\` add constraint \`author2_following_author2_2_id_foreign\` foreign key (\`author2_2_id\`) references \`author2\` (\`id\`) on update cascade on delete cascade;
+
+alter table \`author_to_friend\` add constraint \`author_to_friend_author2_1_id_foreign\` foreign key (\`author2_1_id\`) references \`author2\` (\`id\`) on update cascade on delete cascade;
+alter table \`author_to_friend\` add constraint \`author_to_friend_author2_2_id_foreign\` foreign key (\`author2_2_id\`) references \`author2\` (\`id\`) on update cascade on delete cascade;
+
+alter table \`address2\` add constraint \`address2_author_id_foreign\` foreign key (\`author_id\`) references \`author2\` (\`id\`) on update cascade on delete cascade;
+
+alter table \`test2\` add constraint \`test2_book_uuid_pk_foreign\` foreign key (\`book_uuid_pk\`) references \`book2\` (\`uuid_pk\`) on delete set null;
+alter table \`test2\` add constraint \`test2_parent_id_foreign\` foreign key (\`parent_id\`) references \`test2\` (\`id\`) on delete set null;
+
+alter table \`publisher2_tests\` add constraint \`publisher2_tests_publisher2_id_foreign\` foreign key (\`publisher2_id\`) references \`publisher2\` (\`id\`) on update cascade on delete cascade;
+alter table \`publisher2_tests\` add constraint \`publisher2_tests_test2_id_foreign\` foreign key (\`test2_id\`) references \`test2\` (\`id\`) on update cascade on delete cascade;
+
+alter table \`configuration2\` add constraint \`configuration2_test_id_foreign\` foreign key (\`test_id\`) references \`test2\` (\`id\`);
+
+alter table \`test2_bars\` add constraint \`test2_bars_test2_id_foreign\` foreign key (\`test2_id\`) references \`test2\` (\`id\`) on update cascade on delete cascade;
+alter table \`test2_bars\` add constraint \`test2_bars_foo_bar2_id_foreign\` foreign key (\`foo_bar2_id\`) references \`foo_bar2\` (\`id\`) on update cascade on delete cascade;
+
+create view \`book_summary_view\` as select \`b\`.\`title\`, \`a\`.\`name\` as \`author_name\` from \`book2\` as \`b\` inner join \`author2\` as \`a\` on \`b\`.\`author_id\` = \`a\`.\`id\`;
+
+create view \`author_stats_view\` as select min(name) as name, (select count(*) from book2 b where b.author_id = a.id) as book_count from author2 a group by a.id;
+
+create view \`prolific_authors_view\` as select name, book_count from author_stats_view where book_count > 1;
+"
+`;
+
+exports[`View entities ('mysql') > schema generator should create views 1`] = `
+"set names utf8mb4;
+
+create table \`book_tag2\` (\`id\` bigint unsigned not null auto_increment primary key, \`name\` varchar(50) not null) default character set utf8mb4 engine = InnoDB;
+
+create table \`foo_baz2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`code\` varchar(255) not null, \`version\` datetime(3) not null default current_timestamp(3)) default character set utf8mb4 engine = InnoDB;
+
+create table \`foo_bar2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`name with space\` varchar(255) null, \`baz_id\` int unsigned null, \`foo_bar_id\` int unsigned null, \`version\` datetime not null default current_timestamp, \`blob\` blob null, \`blob2\` blob null, \`array\` text null, \`object_property\` json null) default character set utf8mb4 engine = InnoDB;
+alter table \`foo_bar2\` add unique \`foo_bar2_baz_id_unique\` (\`baz_id\`);
+alter table \`foo_bar2\` add unique \`foo_bar2_foo_bar_id_unique\` (\`foo_bar_id\`);
+
+create table \`publisher2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null default 'asd', \`type\` enum('local','global') not null default 'local', \`type2\` enum('LOCAL','GLOBAL') not null default 'LOCAL', \`enum1\` tinyint null, \`enum2\` tinyint null, \`enum3\` tinyint null, \`enum4\` enum('a','b','c') null, \`enum5\` enum('a') null) default character set utf8mb4 engine = InnoDB;
+
+create table \`author2\` (\`id\` int unsigned not null auto_increment primary key, \`created_at\` datetime(3) not null default current_timestamp(3), \`updated_at\` datetime(3) not null default current_timestamp(3), \`name\` varchar(255) not null, \`email\` varchar(255) not null, \`age\` int null, \`terms_accepted\` tinyint(1) not null default false, \`optional\` tinyint(1) null, \`identities\` text null, \`born\` date null, \`born_time\` time null, \`favourite_book_uuid_pk\` varchar(36) null, \`favourite_author_id\` int unsigned null, \`identity\` json null) default character set utf8mb4 engine = InnoDB;
+alter table \`author2\` add index \`custom_email_index_name\` (\`email\`);
+alter table \`author2\` add unique \`custom_email_unique_name\` (\`email\`);
+alter table \`author2\` add index \`author2_terms_accepted_index\` (\`terms_accepted\`);
+alter table \`author2\` add index \`author2_born_index\` (\`born\`);
+alter table \`author2\` add index \`born_time_idx\` (\`born_time\`);
+alter table \`author2\` add index \`author2_favourite_book_uuid_pk_index\` (\`favourite_book_uuid_pk\`);
+alter table \`author2\` add index \`author2_favourite_author_id_index\` (\`favourite_author_id\`);
+alter table \`author2\` add index \`custom_idx_name_123\` (\`name\`);
+alter table \`author2\` add index \`author2_name_age_index\` (\`name\`, \`age\`);
+alter table \`author2\` add unique \`author2_name_email_unique\` (\`name\`, \`email\`);
+
+create table \`book2\` (\`uuid_pk\` varchar(36) not null, \`created_at\` datetime(3) not null default current_timestamp(3), \`isbn\` char(13) null, \`title\` varchar(255) null default '', \`perex\` text null, \`price\` numeric(8,2) null, \`double\` double null, \`meta\` json null, \`author_id\` int unsigned not null, \`publisher_id\` int unsigned null, primary key (\`uuid_pk\`)) default character set utf8mb4 engine = InnoDB;
+alter table \`book2\` add unique \`book2_isbn_unique\` (\`isbn\`);
+alter table \`book2\` add index \`book2_author_id_index\` (\`author_id\`);
+alter table \`book2\` add index \`book2_publisher_id_index\` (\`publisher_id\`);
+alter table \`book2\` add fulltext index \`book2_title_index\`(\`title\`);
+
+create table \`book2_tags\` (\`order\` int unsigned not null auto_increment primary key, \`book2_uuid_pk\` varchar(36) not null, \`book_tag2_id\` bigint unsigned not null) default character set utf8mb4 engine = InnoDB;
+alter table \`book2_tags\` add index \`book2_tags_book2_uuid_pk_index\` (\`book2_uuid_pk\`);
+alter table \`book2_tags\` add index \`book2_tags_book_tag2_id_index\` (\`book_tag2_id\`);
+
+create table \`book_to_tag_unordered\` (\`book2_uuid_pk\` varchar(36) not null, \`book_tag2_id\` bigint unsigned not null, primary key (\`book2_uuid_pk\`, \`book_tag2_id\`)) default character set utf8mb4 engine = InnoDB;
+alter table \`book_to_tag_unordered\` add index \`book_to_tag_unordered_book2_uuid_pk_index\` (\`book2_uuid_pk\`);
+alter table \`book_to_tag_unordered\` add index \`book_to_tag_unordered_book_tag2_id_index\` (\`book_tag2_id\`);
+
+create table \`author2_following\` (\`author2_1_id\` int unsigned not null, \`author2_2_id\` int unsigned not null, primary key (\`author2_1_id\`, \`author2_2_id\`)) default character set utf8mb4 engine = InnoDB;
+alter table \`author2_following\` add index \`author2_following_author2_1_id_index\` (\`author2_1_id\`);
+alter table \`author2_following\` add index \`author2_following_author2_2_id_index\` (\`author2_2_id\`);
+
+create table \`author_to_friend\` (\`author2_1_id\` int unsigned not null, \`author2_2_id\` int unsigned not null, primary key (\`author2_1_id\`, \`author2_2_id\`)) default character set utf8mb4 engine = InnoDB;
+alter table \`author_to_friend\` add index \`author_to_friend_author2_1_id_index\` (\`author2_1_id\`);
+alter table \`author_to_friend\` add index \`author_to_friend_author2_2_id_index\` (\`author2_2_id\`);
+
+create table \`address2\` (\`author_id\` int unsigned not null, \`value\` varchar(255) not null comment 'This is address property', primary key (\`author_id\`)) default character set utf8mb4 engine = InnoDB comment = 'This is address table';
+
+create table \`test2\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) null, \`book_uuid_pk\` varchar(36) null, \`parent_id\` int unsigned null, \`version\` int not null default 1) default character set utf8mb4 engine = InnoDB;
+alter table \`test2\` add unique \`test2_book_uuid_pk_unique\` (\`book_uuid_pk\`);
+alter table \`test2\` add index \`test2_parent_id_index\` (\`parent_id\`);
+
+create table \`publisher2_tests\` (\`id\` int unsigned not null auto_increment primary key, \`publisher2_id\` int unsigned not null, \`test2_id\` int unsigned not null) default character set utf8mb4 engine = InnoDB;
+alter table \`publisher2_tests\` add index \`publisher2_tests_publisher2_id_index\` (\`publisher2_id\`);
+alter table \`publisher2_tests\` add index \`publisher2_tests_test2_id_index\` (\`test2_id\`);
+
+create table \`configuration2\` (\`property\` varchar(255) not null, \`test_id\` int unsigned not null, \`value\` varchar(255) not null, primary key (\`property\`, \`test_id\`)) default character set utf8mb4 engine = InnoDB;
+alter table \`configuration2\` add index \`configuration2_test_id_index\` (\`test_id\`);
+
+create table \`test2_bars\` (\`test2_id\` int unsigned not null, \`foo_bar2_id\` int unsigned not null, primary key (\`test2_id\`, \`foo_bar2_id\`)) default character set utf8mb4 engine = InnoDB;
+alter table \`test2_bars\` add index \`test2_bars_test2_id_index\` (\`test2_id\`);
+alter table \`test2_bars\` add index \`test2_bars_foo_bar2_id_index\` (\`foo_bar2_id\`);
+
+alter table \`foo_bar2\` add constraint \`foo_bar2_baz_id_foreign\` foreign key (\`baz_id\`) references \`foo_baz2\` (\`id\`) on delete set null;
+alter table \`foo_bar2\` add constraint \`foo_bar2_foo_bar_id_foreign\` foreign key (\`foo_bar_id\`) references \`foo_bar2\` (\`id\`) on delete set null;
+
+alter table \`author2\` add constraint \`author2_favourite_book_uuid_pk_foreign\` foreign key (\`favourite_book_uuid_pk\`) references \`book2\` (\`uuid_pk\`) on update no action on delete cascade;
+alter table \`author2\` add constraint \`author2_favourite_author_id_foreign\` foreign key (\`favourite_author_id\`) references \`author2\` (\`id\`) on delete set null;
+
+alter table \`book2\` add constraint \`book2_author_id_foreign\` foreign key (\`author_id\`) references \`author2\` (\`id\`);
+alter table \`book2\` add constraint \`book2_publisher_id_foreign\` foreign key (\`publisher_id\`) references \`publisher2\` (\`id\`) on delete set null;
+
+alter table \`book2_tags\` add constraint \`book2_tags_book2_uuid_pk_foreign\` foreign key (\`book2_uuid_pk\`) references \`book2\` (\`uuid_pk\`) on update cascade on delete cascade;
+alter table \`book2_tags\` add constraint \`book2_tags_book_tag2_id_foreign\` foreign key (\`book_tag2_id\`) references \`book_tag2\` (\`id\`) on update cascade on delete cascade;
+
+alter table \`book_to_tag_unordered\` add constraint \`book_to_tag_unordered_book2_uuid_pk_foreign\` foreign key (\`book2_uuid_pk\`) references \`book2\` (\`uuid_pk\`) on update cascade on delete cascade;
+alter table \`book_to_tag_unordered\` add constraint \`book_to_tag_unordered_book_tag2_id_foreign\` foreign key (\`book_tag2_id\`) references \`book_tag2\` (\`id\`) on update cascade on delete cascade;
+
+alter table \`author2_following\` add constraint \`author2_following_author2_1_id_foreign\` foreign key (\`author2_1_id\`) references \`author2\` (\`id\`) on update cascade on delete cascade;
+alter table \`author2_following\` add constraint \`author2_following_author2_2_id_foreign\` foreign key (\`author2_2_id\`) references \`author2\` (\`id\`) on update cascade on delete cascade;
+
+alter table \`author_to_friend\` add constraint \`author_to_friend_author2_1_id_foreign\` foreign key (\`author2_1_id\`) references \`author2\` (\`id\`) on update cascade on delete cascade;
+alter table \`author_to_friend\` add constraint \`author_to_friend_author2_2_id_foreign\` foreign key (\`author2_2_id\`) references \`author2\` (\`id\`) on update cascade on delete cascade;
+
+alter table \`address2\` add constraint \`address2_author_id_foreign\` foreign key (\`author_id\`) references \`author2\` (\`id\`) on update cascade on delete cascade;
+
+alter table \`test2\` add constraint \`test2_book_uuid_pk_foreign\` foreign key (\`book_uuid_pk\`) references \`book2\` (\`uuid_pk\`) on delete set null;
+alter table \`test2\` add constraint \`test2_parent_id_foreign\` foreign key (\`parent_id\`) references \`test2\` (\`id\`) on delete set null;
+
+alter table \`publisher2_tests\` add constraint \`publisher2_tests_publisher2_id_foreign\` foreign key (\`publisher2_id\`) references \`publisher2\` (\`id\`) on update cascade on delete cascade;
+alter table \`publisher2_tests\` add constraint \`publisher2_tests_test2_id_foreign\` foreign key (\`test2_id\`) references \`test2\` (\`id\`) on update cascade on delete cascade;
+
+alter table \`configuration2\` add constraint \`configuration2_test_id_foreign\` foreign key (\`test_id\`) references \`test2\` (\`id\`);
+
+alter table \`test2_bars\` add constraint \`test2_bars_test2_id_foreign\` foreign key (\`test2_id\`) references \`test2\` (\`id\`) on update cascade on delete cascade;
+alter table \`test2_bars\` add constraint \`test2_bars_foo_bar2_id_foreign\` foreign key (\`foo_bar2_id\`) references \`foo_bar2\` (\`id\`) on update cascade on delete cascade;
+
+create view \`book_summary_view\` as select \`b\`.\`title\`, \`a\`.\`name\` as \`author_name\` from \`book2\` as \`b\` inner join \`author2\` as \`a\` on \`b\`.\`author_id\` = \`a\`.\`id\`;
+
+create view \`author_stats_view\` as select min(name) as name, (select count(*) from book2 b where b.author_id = a.id) as book_count from author2 a group by a.id;
+
+create view \`prolific_authors_view\` as select name, book_count from author_stats_view where book_count > 1;
+"
+`;

--- a/tests/features/view-entities/__snapshots__/view-entities.postgres.test.ts.snap
+++ b/tests/features/view-entities/__snapshots__/view-entities.postgres.test.ts.snap
@@ -1,0 +1,95 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`View entities (postgres) > schema generator should create views 1`] = `
+"set names 'utf8';
+
+create table "book_tag2" ("id" bigserial primary key, "name" varchar(50) not null);
+
+create table "foo_baz2" ("id" serial primary key, "name" varchar(255) not null, "code" varchar(255) not null, "version" timestamptz(3) not null default current_timestamp(3));
+
+create table "foo_bar2" ("id" serial primary key, "name" varchar(255) not null, "name with space" varchar(255) null, "baz_id" int null, "foo_bar_id" int null, "version" timestamptz(0) not null default current_timestamp(0), "blob" bytea null, "blob2" bytea null, "array" text[] null, "object_property" jsonb null);
+alter table "foo_bar2" add constraint "foo_bar2_baz_id_unique" unique ("baz_id");
+alter table "foo_bar2" add constraint "foo_bar2_foo_bar_id_unique" unique ("foo_bar_id");
+
+create table "publisher2" ("id" serial primary key, "name" varchar(255) not null default 'asd', "type" text not null default 'local', "type2" text not null default 'LOCAL', "enum1" smallint null, "enum2" smallint null, "enum3" smallint null, "enum4" text null, "enum5" text null);
+alter table "publisher2" add constraint "publisher2_type_check" check ("type" in ('local', 'global'));
+alter table "publisher2" add constraint "publisher2_type2_check" check ("type2" in ('LOCAL', 'GLOBAL'));
+alter table "publisher2" add constraint "publisher2_enum4_check" check ("enum4" in ('a', 'b', 'c'));
+alter table "publisher2" add constraint "publisher2_enum5_check" check ("enum5" in ('a'));
+
+create table "author2" ("id" serial primary key, "created_at" timestamptz(3) not null default current_timestamp(3), "updated_at" timestamptz(3) not null default current_timestamp(3), "name" varchar(255) not null, "email" varchar(255) not null, "age" int null, "terms_accepted" boolean not null default false, "optional" boolean null, "identities" text[] null, "born" date null, "born_time" time(0) null, "favourite_book_uuid_pk" uuid null, "favourite_author_id" int null, "identity" jsonb null);
+create index "custom_email_index_name" on "author2" ("email");
+alter table "author2" add constraint "custom_email_unique_name" unique ("email");
+create index "author2_terms_accepted_index" on "author2" ("terms_accepted");
+create index "author2_born_index" on "author2" ("born");
+create index "born_time_idx" on "author2" ("born_time");
+create index "custom_idx_name_123" on "author2" ("name");
+create index "author2_name_age_index" on "author2" ("name", "age");
+alter table "author2" add constraint "author2_name_email_unique" unique ("name", "email");
+
+create table "book2" ("uuid_pk" uuid not null, "created_at" timestamptz(3) not null default current_timestamp(3), "isbn" char(13) null, "title" varchar(255) null default '', "perex" text null, "price" numeric(8,2) null, "double" double precision null, "meta" jsonb null, "author_id" int not null, "publisher_id" int null, primary key ("uuid_pk"));
+alter table "book2" add constraint "book2_isbn_unique" unique ("isbn");
+create index "book2_title_index" on "public"."book2" using gin(to_tsvector('simple', "title"));
+
+create table "book2_tags" ("order" serial primary key, "book2_uuid_pk" uuid not null, "book_tag2_id" bigint not null);
+
+create table "book_to_tag_unordered" ("book2_uuid_pk" uuid not null, "book_tag2_id" bigint not null, primary key ("book2_uuid_pk", "book_tag2_id"));
+
+create table "author2_following" ("author2_1_id" int not null, "author2_2_id" int not null, primary key ("author2_1_id", "author2_2_id"));
+
+create table "author_to_friend" ("author2_1_id" int not null, "author2_2_id" int not null, primary key ("author2_1_id", "author2_2_id"));
+
+create table "address2" ("author_id" int not null, "value" varchar(255) not null, primary key ("author_id"));
+comment on table "address2" is 'This is address table';
+comment on column "address2"."value" is 'This is address property';
+
+create table "test2" ("id" serial primary key, "name" varchar(255) null, "book_uuid_pk" uuid null, "parent_id" int null, "version" int not null default 1);
+alter table "test2" add constraint "test2_book_uuid_pk_unique" unique ("book_uuid_pk");
+
+create table "publisher2_tests" ("id" serial primary key, "publisher2_id" int not null, "test2_id" int not null);
+
+create table "configuration2" ("property" varchar(255) not null, "test_id" int not null, "value" varchar(255) not null, primary key ("property", "test_id"));
+
+create table "test2_bars" ("test2_id" int not null, "foo_bar2_id" int not null, primary key ("test2_id", "foo_bar2_id"));
+
+alter table "foo_bar2" add constraint "foo_bar2_baz_id_foreign" foreign key ("baz_id") references "foo_baz2" ("id") on delete set null;
+alter table "foo_bar2" add constraint "foo_bar2_foo_bar_id_foreign" foreign key ("foo_bar_id") references "foo_bar2" ("id") on delete set null;
+
+alter table "author2" add constraint "author2_favourite_book_uuid_pk_foreign" foreign key ("favourite_book_uuid_pk") references "book2" ("uuid_pk") on update no action on delete cascade;
+alter table "author2" add constraint "author2_favourite_author_id_foreign" foreign key ("favourite_author_id") references "author2" ("id") on delete set null;
+
+alter table "book2" add constraint "book2_author_id_foreign" foreign key ("author_id") references "author2" ("id");
+alter table "book2" add constraint "book2_publisher_id_foreign" foreign key ("publisher_id") references "publisher2" ("id") on delete set null;
+
+alter table "book2_tags" add constraint "book2_tags_book2_uuid_pk_foreign" foreign key ("book2_uuid_pk") references "book2" ("uuid_pk") on update cascade on delete cascade;
+alter table "book2_tags" add constraint "book2_tags_book_tag2_id_foreign" foreign key ("book_tag2_id") references "book_tag2" ("id") on update cascade on delete cascade;
+
+alter table "book_to_tag_unordered" add constraint "book_to_tag_unordered_book2_uuid_pk_foreign" foreign key ("book2_uuid_pk") references "book2" ("uuid_pk") on update cascade on delete cascade;
+alter table "book_to_tag_unordered" add constraint "book_to_tag_unordered_book_tag2_id_foreign" foreign key ("book_tag2_id") references "book_tag2" ("id") on update cascade on delete cascade;
+
+alter table "author2_following" add constraint "author2_following_author2_1_id_foreign" foreign key ("author2_1_id") references "author2" ("id") on update cascade on delete cascade;
+alter table "author2_following" add constraint "author2_following_author2_2_id_foreign" foreign key ("author2_2_id") references "author2" ("id") on update cascade on delete cascade;
+
+alter table "author_to_friend" add constraint "author_to_friend_author2_1_id_foreign" foreign key ("author2_1_id") references "author2" ("id") on update cascade on delete cascade;
+alter table "author_to_friend" add constraint "author_to_friend_author2_2_id_foreign" foreign key ("author2_2_id") references "author2" ("id") on update cascade on delete cascade;
+
+alter table "address2" add constraint "address2_author_id_foreign" foreign key ("author_id") references "author2" ("id") on update cascade on delete cascade;
+
+alter table "test2" add constraint "test2_book_uuid_pk_foreign" foreign key ("book_uuid_pk") references "book2" ("uuid_pk") on delete set null;
+alter table "test2" add constraint "test2_parent_id_foreign" foreign key ("parent_id") references "test2" ("id") on delete set null;
+
+alter table "publisher2_tests" add constraint "publisher2_tests_publisher2_id_foreign" foreign key ("publisher2_id") references "publisher2" ("id") on update cascade on delete cascade;
+alter table "publisher2_tests" add constraint "publisher2_tests_test2_id_foreign" foreign key ("test2_id") references "test2" ("id") on update cascade on delete cascade;
+
+alter table "configuration2" add constraint "configuration2_test_id_foreign" foreign key ("test_id") references "test2" ("id");
+
+alter table "test2_bars" add constraint "test2_bars_test2_id_foreign" foreign key ("test2_id") references "test2" ("id") on update cascade on delete cascade;
+alter table "test2_bars" add constraint "test2_bars_foo_bar2_id_foreign" foreign key ("foo_bar2_id") references "foo_bar2" ("id") on update cascade on delete cascade;
+
+create view "book_summary_view" as select min(b.title) as "title", min(a.name) as "author_name" from "book2" as "b" inner join "author2" as "a" on "b"."author_id" = "a"."id" group by "b"."uuid_pk";
+
+create view "author_stats_view" as select min(name) as name, (select count(*)::int from book2 b where b.author_id = a.id) as book_count from author2 a group by a.id;
+
+create view "prolific_authors_view" as select name, book_count from author_stats_view where book_count > 1;
+"
+`;

--- a/tests/features/view-entities/__snapshots__/view-entities.sqlite.test.ts.snap
+++ b/tests/features/view-entities/__snapshots__/view-entities.sqlite.test.ts.snap
@@ -1,0 +1,42 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`View entities (sqlite) > schema generator should create views 1`] = `
+"create table \`book_tag4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` text not null, \`version\` datetime not null default current_timestamp);
+
+create table \`foo_baz4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` text not null, \`version\` datetime not null default current_timestamp);
+
+create table \`foo_bar4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` text not null default 'asd', \`baz_id\` integer null, \`foo_bar_id\` integer null, \`version\` integer not null default 1, \`blob\` blob null, \`blob2\` blob null, \`array\` text null, \`object\` json null, constraint \`foo_bar4_baz_id_foreign\` foreign key (\`baz_id\`) references \`foo_baz4\` (\`id\`) on delete set null, constraint \`foo_bar4_foo_bar_id_foreign\` foreign key (\`foo_bar_id\`) references \`foo_bar4\` (\`id\`) on delete set null);
+create unique index \`foo_bar4_baz_id_unique\` on \`foo_bar4\` (\`baz_id\`);
+create unique index \`foo_bar4_foo_bar_id_unique\` on \`foo_bar4\` (\`foo_bar_id\`);
+
+create table \`publisher4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` text not null default 'asd', \`type\` text check (\`type\` in ('local', 'global')) not null default 'local', \`enum3\` integer null);
+
+create table \`book4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`title\` text not null, \`price\` real null, \`author_id\` integer null, \`publisher_id\` integer null, \`meta\` json null, constraint \`book4_author_id_foreign\` foreign key (\`author_id\`) references \`author4\` (\`id\`) on delete set null, constraint \`book4_publisher_id_foreign\` foreign key (\`publisher_id\`) references \`publisher4\` (\`id\`) on delete set null);
+create index \`book4_author_id_index\` on \`book4\` (\`author_id\`);
+create index \`book4_publisher_id_index\` on \`book4\` (\`publisher_id\`);
+
+create table \`author4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` text not null, \`email\` text not null, \`age\` integer null, \`terms_accepted\` integer not null default 0, \`identities\` text null, \`born\` date null, \`born_time\` time(3) null, \`favourite_book_id\` integer null, \`identity\` json null, constraint \`author4_favourite_book_id_foreign\` foreign key (\`favourite_book_id\`) references \`book4\` (\`id\`) on delete set null);
+create unique index \`author4_email_unique\` on \`author4\` (\`email\`);
+create index \`author4_favourite_book_id_index\` on \`author4\` (\`favourite_book_id\`);
+
+create table \`tags_ordered\` (\`id\` integer not null primary key autoincrement, \`book4_id\` integer not null, \`book_tag4_id\` integer not null, constraint \`tags_ordered_book4_id_foreign\` foreign key (\`book4_id\`) references \`book4\` (\`id\`) on update cascade on delete cascade, constraint \`tags_ordered_book_tag4_id_foreign\` foreign key (\`book_tag4_id\`) references \`book_tag4\` (\`id\`) on update cascade on delete cascade);
+create index \`tags_ordered_book4_id_index\` on \`tags_ordered\` (\`book4_id\`);
+create index \`tags_ordered_book_tag4_id_index\` on \`tags_ordered\` (\`book_tag4_id\`);
+
+create table \`tags_unordered\` (\`book4_id\` integer not null, \`book_tag4_id\` integer not null, primary key (\`book4_id\`, \`book_tag4_id\`), constraint \`tags_unordered_book4_id_foreign\` foreign key (\`book4_id\`) references \`book4\` (\`id\`) on update cascade on delete cascade, constraint \`tags_unordered_book_tag4_id_foreign\` foreign key (\`book_tag4_id\`) references \`book_tag4\` (\`id\`) on update cascade on delete cascade);
+create index \`tags_unordered_book4_id_index\` on \`tags_unordered\` (\`book4_id\`);
+create index \`tags_unordered_book_tag4_id_index\` on \`tags_unordered\` (\`book_tag4_id\`);
+
+create table \`test4\` (\`id\` integer not null primary key autoincrement, \`created_at\` datetime null, \`updated_at\` datetime null, \`name\` text null, \`version\` integer not null default 1);
+
+create table \`publisher4_tests\` (\`id\` integer not null primary key autoincrement, \`publisher4_id\` integer not null, \`test4_id\` integer not null, constraint \`publisher4_tests_publisher4_id_foreign\` foreign key (\`publisher4_id\`) references \`publisher4\` (\`id\`) on update cascade on delete cascade, constraint \`publisher4_tests_test4_id_foreign\` foreign key (\`test4_id\`) references \`test4\` (\`id\`) on update cascade on delete cascade);
+create index \`publisher4_tests_publisher4_id_index\` on \`publisher4_tests\` (\`publisher4_id\`);
+create index \`publisher4_tests_test4_id_index\` on \`publisher4_tests\` (\`test4_id\`);
+
+create view \`book_summary_view\` as select \`b\`.\`title\`, \`a\`.\`name\` as \`author_name\` from \`book4\` as \`b\` inner join \`author4\` as \`a\` on \`b\`.\`author_id\` = \`a\`.\`id\`;
+
+create view \`author_stats_view\` as select name, (select count(*) from book4 b where b.author_id = a.id) as book_count from author4 a;
+
+create view \`prolific_authors_view\` as select name, book_count from author_stats_view where book_count > 1;
+"
+`;

--- a/tests/features/view-entities/view-entities.mssql.test.ts
+++ b/tests/features/view-entities/view-entities.mssql.test.ts
@@ -1,0 +1,138 @@
+import { defineEntity, p } from '@mikro-orm/core';
+import { ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+import { EntityManager, MikroORM } from '@mikro-orm/mssql';
+import { Author2, Book2, BookTag2, FooBar2, FooBaz2, Publisher2, Test2, Address2, Configuration2 } from '../../entities-mssql/index.js';
+
+// View entity with string expression
+const authorStatsSQL = `select min(name) as name, (select count(*) from book2 b where b.author_id = a.id) as book_count from author2 a group by a.id`;
+
+const AuthorStats = defineEntity({
+  name: 'AuthorStats',
+  tableName: 'author_stats_view',
+  view: true,
+  expression: authorStatsSQL,
+  properties: {
+    name: p.string().primary(),
+    bookCount: p.integer(),
+  },
+});
+
+// View entity with QueryBuilder expression
+const BookSummary = defineEntity({
+  name: 'BookSummary',
+  tableName: 'book_summary_view',
+  view: true,
+  expression: (em: EntityManager) => {
+    return em.createQueryBuilder(Book2, 'b')
+      .select(['b.title', 'a.name as author_name'])
+      .join('b.author', 'a');
+  },
+  properties: {
+    title: p.string().primary(),
+    authorName: p.string(),
+  },
+});
+
+// View depending on another view (for testing dependency ordering)
+const ProlificAuthors = defineEntity({
+  name: 'ProlificAuthors',
+  tableName: 'prolific_authors_view',
+  view: true,
+  expression: `select name, book_count from author_stats_view where book_count > 1`,
+  properties: {
+    name: p.string().primary(),
+    bookCount: p.integer(),
+  },
+});
+
+describe('View entities (mssql)', () => {
+
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      entities: [Author2, Book2, BookTag2, Publisher2, Test2, FooBar2, FooBaz2, Address2, Configuration2, AuthorStats, BookSummary, ProlificAuthors],
+      dbName: 'mikro_orm_test_views',
+      password: 'Root.Root',
+    });
+
+    await orm.schema.refresh();
+
+    // Create test data once for all tests
+    const em = orm.em.fork();
+    const author = em.create(Author2, { name: 'Jon Snow', email: 'snow@wall.st' });
+    em.create(Book2, { title: 'Book 1', author });
+    em.create(Book2, { title: 'Book 2', author });
+    await em.flush();
+  });
+
+  afterAll(async () => {
+    await orm.close(true);
+  });
+
+  test('schema generator should create views', async () => {
+    const sql = await orm.schema.getCreateSchemaSQL();
+    expect(sql).toMatchSnapshot();
+  });
+
+  test('schema generator should drop views before tables', async () => {
+    const sql = await orm.schema.getDropSchemaSQL();
+    expect(sql).toContain('drop view');
+  });
+
+  test('can query view entity with string expression', async () => {
+    const em = orm.em.fork();
+
+    const stats = await em.find(AuthorStats, {});
+    expect(stats.length).toBe(1);
+    expect(stats[0].name).toBe('Jon Snow');
+    expect(stats[0].bookCount).toBe(2);
+  });
+
+  test('can query view entity with QueryBuilder expression', async () => {
+    const em = orm.em.fork();
+
+    const summaries = await em.find(BookSummary, {});
+    expect(summaries.length).toBe(2);
+    expect(summaries.every(s => s.authorName === 'Jon Snow')).toBe(true);
+    expect(summaries.map(s => s.title).sort()).toEqual(['Book 1', 'Book 2']);
+  });
+
+  test('views depending on other views are created in correct order', async () => {
+    const sql = await orm.schema.getCreateSchemaSQL();
+
+    const authorStatsPos = sql.indexOf('author_stats_view');
+    const prolificAuthorsPos = sql.indexOf('prolific_authors_view');
+
+    expect(authorStatsPos).toBeGreaterThan(-1);
+    expect(prolificAuthorsPos).toBeGreaterThan(-1);
+    expect(authorStatsPos).toBeLessThan(prolificAuthorsPos);
+  });
+
+  test('views depending on other views are dropped in correct order', async () => {
+    const sql = await orm.schema.getDropSchemaSQL();
+
+    const authorStatsPos = sql.indexOf('author_stats_view');
+    const prolificAuthorsPos = sql.indexOf('prolific_authors_view');
+
+    expect(authorStatsPos).toBeGreaterThan(-1);
+    expect(prolificAuthorsPos).toBeGreaterThan(-1);
+    expect(prolificAuthorsPos).toBeLessThan(authorStatsPos);
+  });
+
+  test('can query view depending on another view', async () => {
+    const em = orm.em.fork();
+
+    const prolificAuthors = await em.find(ProlificAuthors, {});
+    expect(prolificAuthors.length).toBe(1);
+    expect(prolificAuthors[0].name).toBe('Jon Snow');
+    expect(prolificAuthors[0].bookCount).toBe(2);
+  });
+
+  test('updateSchema detects no changes for unchanged views', async () => {
+    const sql = await orm.schema.getUpdateSchemaSQL();
+    expect(sql).toBe('');
+  });
+
+});

--- a/tests/features/view-entities/view-entities.mysql.test.ts
+++ b/tests/features/view-entities/view-entities.mysql.test.ts
@@ -1,0 +1,144 @@
+import { defineEntity, p, type EntityManager as EM } from '@mikro-orm/core';
+import { ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+import { MikroORM as MySqlORM, EntityManager as MySqlEM } from '@mikro-orm/mysql';
+import { MikroORM as MariaDbORM, EntityManager as MariaDbEM } from '@mikro-orm/mariadb';
+import { Author2, Book2, BookTag2, FooBar2, FooBaz2, Publisher2, Test2, Address2, Configuration2 } from '../../entities-sql/index.js';
+
+// View entity with string expression
+const authorStatsSQL = `select min(name) as name, (select count(*) from book2 b where b.author_id = a.id) as book_count from author2 a group by a.id`;
+
+const AuthorStats = defineEntity({
+  name: 'AuthorStats',
+  tableName: 'author_stats_view',
+  view: true,
+  expression: authorStatsSQL,
+  properties: {
+    name: p.string().primary(),
+    bookCount: p.integer(),
+  },
+});
+
+// View entity with QueryBuilder expression
+const BookSummary = defineEntity({
+  name: 'BookSummary',
+  tableName: 'book_summary_view',
+  view: true,
+  expression: (em: EM) => {
+    return (em as MySqlEM | MariaDbEM).createQueryBuilder(Book2, 'b')
+      .select(['b.title', 'a.name as author_name'])
+      .join('b.author', 'a');
+  },
+  properties: {
+    title: p.string().primary(),
+    authorName: p.string(),
+  },
+});
+
+// View depending on another view (for testing dependency ordering)
+const ProlificAuthors = defineEntity({
+  name: 'ProlificAuthors',
+  tableName: 'prolific_authors_view',
+  view: true,
+  expression: `select name, book_count from author_stats_view where book_count > 1`,
+  properties: {
+    name: p.string().primary(),
+    bookCount: p.integer(),
+  },
+});
+
+const drivers = [
+  { name: 'mysql', ORM: MySqlORM, port: 3308 },
+  { name: 'mariadb', ORM: MariaDbORM, port: 3309 },
+] as const;
+
+describe.each(drivers)('View entities ($name)', ({ name, ORM, port }) => {
+
+  let orm: MySqlORM | MariaDbORM;
+
+  beforeAll(async () => {
+    orm = await ORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      entities: [Author2, Book2, BookTag2, Publisher2, Test2, FooBar2, FooBaz2, Address2, Configuration2, AuthorStats, BookSummary, ProlificAuthors],
+      dbName: 'mikro_orm_test_views',
+      port,
+    });
+
+    await orm.schema.refresh();
+
+    // Create test data once for all tests
+    const em = orm.em.fork();
+    const author = em.create(Author2, { name: 'Jon Snow', email: 'snow@wall.st' });
+    em.create(Book2, { title: 'Book 1', author });
+    em.create(Book2, { title: 'Book 2', author });
+    await em.flush();
+  });
+
+  afterAll(async () => {
+    await orm.close(true);
+  });
+
+  test('schema generator should create views', async () => {
+    const sql = await orm.schema.getCreateSchemaSQL();
+    expect(sql).toMatchSnapshot();
+  });
+
+  test('schema generator should drop views before tables', async () => {
+    const sql = await orm.schema.getDropSchemaSQL();
+    expect(sql).toContain('drop view');
+  });
+
+  test('can query view entity with string expression', async () => {
+    const em = orm.em.fork();
+
+    const stats = await em.find(AuthorStats, {});
+    expect(stats.length).toBe(1);
+    expect(stats[0].name).toBe('Jon Snow');
+    expect(stats[0].bookCount).toBe(2);
+  });
+
+  test('can query view entity with QueryBuilder expression', async () => {
+    const em = orm.em.fork();
+
+    const summaries = await em.find(BookSummary, {});
+    expect(summaries.length).toBe(2);
+    expect(summaries.every(s => s.authorName === 'Jon Snow')).toBe(true);
+    expect(summaries.map(s => s.title).sort()).toEqual(['Book 1', 'Book 2']);
+  });
+
+  test('views depending on other views are created in correct order', async () => {
+    const sql = await orm.schema.getCreateSchemaSQL();
+
+    const authorStatsPos = sql.indexOf('author_stats_view');
+    const prolificAuthorsPos = sql.indexOf('prolific_authors_view');
+
+    expect(authorStatsPos).toBeGreaterThan(-1);
+    expect(prolificAuthorsPos).toBeGreaterThan(-1);
+    expect(authorStatsPos).toBeLessThan(prolificAuthorsPos);
+  });
+
+  test('views depending on other views are dropped in correct order', async () => {
+    const sql = await orm.schema.getDropSchemaSQL();
+
+    const authorStatsPos = sql.indexOf('author_stats_view');
+    const prolificAuthorsPos = sql.indexOf('prolific_authors_view');
+
+    expect(authorStatsPos).toBeGreaterThan(-1);
+    expect(prolificAuthorsPos).toBeGreaterThan(-1);
+    expect(prolificAuthorsPos).toBeLessThan(authorStatsPos);
+  });
+
+  test('can query view depending on another view', async () => {
+    const em = orm.em.fork();
+
+    const prolificAuthors = await em.find(ProlificAuthors, {});
+    expect(prolificAuthors.length).toBe(1);
+    expect(prolificAuthors[0].name).toBe('Jon Snow');
+    expect(prolificAuthors[0].bookCount).toBe(2);
+  });
+
+  test('updateSchema detects no changes for unchanged views', async () => {
+    const sql = await orm.schema.getUpdateSchemaSQL();
+    expect(sql).toBe('');
+  });
+
+});

--- a/tests/features/view-entities/view-entities.postgres.test.ts
+++ b/tests/features/view-entities/view-entities.postgres.test.ts
@@ -1,0 +1,318 @@
+import { defineEntity, p, sql } from '@mikro-orm/core';
+import { Entity, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+import { EntityManager, MikroORM } from '@mikro-orm/postgresql';
+import { Author2, Book2, BookTag2, Publisher2, Test2, FooBar2, FooBaz2, Address2, Configuration2 } from '../../entities-sql/index.js';
+
+// View entity with string expression using decorator
+const authorStatsSQL = `select min(name) as name, (select count(*)::int from book2 b where b.author_id = a.id) as book_count from author2 a group by a.id`;
+
+@Entity({ tableName: 'author_stats_view', view: true, expression: authorStatsSQL })
+class AuthorStats {
+
+  @PrimaryKey()
+  name!: string;
+
+  @Property()
+  bookCount!: number;
+
+}
+
+// View entity with QueryBuilder expression using defineEntity
+const BookSummary = defineEntity({
+  name: 'BookSummary',
+  tableName: 'book_summary_view',
+  view: true,
+  expression: (em: EntityManager) => {
+    return em.createQueryBuilder(Book2, 'b')
+      .select([sql`min(b.title)`.as('title'), sql`min(a.name)`.as('author_name')])
+      .join('b.author', 'a')
+      .groupBy('b.uuid_pk');
+  },
+  properties: {
+    title: p.string().primary(),
+    authorName: p.string(),
+  },
+});
+
+// View depending on another view (for testing dependency ordering)
+// This view references author_stats_view
+const ProlificAuthors = defineEntity({
+  name: 'ProlificAuthors',
+  tableName: 'prolific_authors_view',
+  view: true,
+  expression: `select name, book_count from author_stats_view where book_count > 1`,
+  properties: {
+    name: p.string().primary(),
+    bookCount: p.integer(),
+  },
+});
+
+describe('View entities (postgres)', () => {
+
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      entities: [Author2, Book2, BookTag2, Publisher2, Test2, FooBar2, FooBaz2, Address2, Configuration2, AuthorStats, BookSummary, ProlificAuthors],
+      dbName: 'mikro_orm_test_views',
+    });
+
+    await orm.schema.refresh();
+
+    // Create test data once for all tests
+    const em = orm.em.fork();
+    const author = em.create(Author2, { name: 'Jon Snow', email: 'snow@wall.st' });
+    em.create(Book2, { title: 'Book 1', author });
+    em.create(Book2, { title: 'Book 2', author });
+    await em.flush();
+  });
+
+  afterAll(async () => {
+    await orm.close(true);
+  });
+
+  test('schema generator should create views', async () => {
+    const sql = await orm.schema.getCreateSchemaSQL();
+    expect(sql).toMatchSnapshot();
+  });
+
+  test('schema generator should drop views before tables', async () => {
+    const sql = await orm.schema.getDropSchemaSQL();
+    expect(sql).toContain('drop view');
+    expect(sql).toContain('cascade'); // PostgreSQL uses cascade
+  });
+
+  test('can query view entity with string expression', async () => {
+    const em = orm.em.fork();
+
+    const stats = await em.find(AuthorStats, {});
+    expect(stats.length).toBe(1);
+    expect(stats[0].name).toBe('Jon Snow');
+    expect(stats[0].bookCount).toBe(2);
+  });
+
+  test('can query view entity with QueryBuilder expression', async () => {
+    const em = orm.em.fork();
+
+    const summaries = await em.find(BookSummary, {});
+    expect(summaries.length).toBe(2);
+    expect(summaries.every(s => s.authorName === 'Jon Snow')).toBe(true);
+    expect(summaries.map(s => s.title).sort()).toEqual(['Book 1', 'Book 2']);
+  });
+
+  test('updateSchema detects no changes for unchanged views', async () => {
+    const sql = await orm.schema.getUpdateSchemaSQL();
+    expect(sql).toBe('');
+  });
+
+  test('views depending on other views are created in correct order', async () => {
+    const sql = await orm.schema.getCreateSchemaSQL();
+
+    const authorStatsPos = sql.indexOf('author_stats_view');
+    const prolificAuthorsPos = sql.indexOf('prolific_authors_view');
+
+    expect(authorStatsPos).toBeGreaterThan(-1);
+    expect(prolificAuthorsPos).toBeGreaterThan(-1);
+    expect(authorStatsPos).toBeLessThan(prolificAuthorsPos);
+  });
+
+  test('views depending on other views are dropped in correct order', async () => {
+    const sql = await orm.schema.getDropSchemaSQL();
+
+    const authorStatsPos = sql.indexOf('author_stats_view');
+    const prolificAuthorsPos = sql.indexOf('prolific_authors_view');
+
+    expect(authorStatsPos).toBeGreaterThan(-1);
+    expect(prolificAuthorsPos).toBeGreaterThan(-1);
+    expect(prolificAuthorsPos).toBeLessThan(authorStatsPos);
+  });
+
+  test('can query view depending on another view', async () => {
+    const em = orm.em.fork();
+
+    const prolificAuthors = await em.find(ProlificAuthors, {});
+    expect(prolificAuthors.length).toBe(1);
+    expect(prolificAuthors[0].name).toBe('Jon Snow');
+    expect(prolificAuthors[0].bookCount).toBe(2);
+  });
+
+  test('updateSchema detects changed view definitions', async () => {
+    const ModifiedAuthorStats = defineEntity({
+      name: 'ModifiedAuthorStats',
+      tableName: 'author_stats_view',
+      view: true,
+      expression: `select min(name) as name, (select count(*)::int * 2 from book2 b where b.author_id = a.id) as book_count from author2 a group by a.id`,
+      properties: {
+        name: p.string().primary(),
+        bookCount: p.integer(),
+      },
+    });
+
+    const orm2 = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      entities: [Author2, Book2, BookTag2, Publisher2, Test2, FooBar2, FooBaz2, ModifiedAuthorStats, BookSummary, ProlificAuthors],
+      dbName: 'mikro_orm_test_views',
+    });
+
+    try {
+      const sql = await orm2.schema.getUpdateSchemaSQL();
+      expect(typeof sql).toBe('string');
+    } finally {
+      await orm2.close();
+    }
+  });
+
+  test('updateSchema detects new views', async () => {
+    const NewView = defineEntity({
+      name: 'NewView',
+      tableName: 'new_test_view',
+      view: true,
+      expression: `select 1 as id`,
+      properties: {
+        id: p.integer().primary(),
+      },
+    });
+
+    const orm2 = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      entities: [Author2, Book2, BookTag2, Publisher2, Test2, FooBar2, FooBaz2, AuthorStats, BookSummary, ProlificAuthors, NewView],
+      dbName: 'mikro_orm_test_views',
+    });
+
+    try {
+      const sql = await orm2.schema.getUpdateSchemaSQL();
+      expect(sql).toContain('new_test_view');
+      expect(sql).toContain('create view');
+    } finally {
+      await orm2.close();
+    }
+  });
+
+  test('updateSchema detects removed views', async () => {
+    await orm.em.execute(`create or replace view extra_view as select 1 as id`);
+
+    try {
+      const sql = await orm.schema.getUpdateSchemaSQL();
+      expect(sql).toContain('extra_view');
+      expect(sql).toContain('drop view');
+    } finally {
+      await orm.em.execute(`drop view if exists extra_view`);
+    }
+  });
+
+  test('view in custom schema', async () => {
+    // Create a schema for testing
+    await orm.em.execute(`create schema if not exists custom_schema`);
+
+    const SchemaView = defineEntity({
+      name: 'SchemaView',
+      tableName: 'schema_test_view',
+      schema: 'custom_schema',
+      view: true,
+      expression: `select 1 as id`,
+      properties: {
+        id: p.integer().primary(),
+      },
+    });
+
+    const orm2 = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      entities: [SchemaView],
+      dbName: 'mikro_orm_test_views',
+    });
+
+    try {
+      await orm2.schema.refresh();
+
+      // Verify view was created in schema
+      const createSql = await orm2.schema.getCreateSchemaSQL();
+      expect(createSql).toContain('custom_schema');
+      expect(createSql).toContain('schema_test_view');
+
+      // Query the view
+      const em = orm2.em.fork();
+      const results = await em.find(SchemaView, {});
+      expect(results.length).toBe(1);
+      expect(results[0].id).toBe(1);
+
+      // Verify updateSchema can find the view by schema-qualified name
+      const updateSql = await orm2.schema.getUpdateSchemaSQL();
+      expect(typeof updateSql).toBe('string');
+    } finally {
+      await orm2.schema.drop();
+      await orm2.close();
+      await orm.em.execute(`drop schema if exists custom_schema cascade`);
+    }
+  });
+
+  test('circular view dependencies are handled', async () => {
+    // Create two views that reference each other (circular dependency)
+    // In practice this would be a bad design, but we should handle it gracefully
+    const CircularViewA = defineEntity({
+      name: 'CircularViewA',
+      tableName: 'circular_view_a',
+      view: true,
+      // This references circular_view_b
+      expression: `select 1 as id, (select count(*) from circular_view_b) as b_count`,
+      properties: {
+        id: p.integer().primary(),
+        bCount: p.integer(),
+      },
+    });
+
+    const CircularViewB = defineEntity({
+      name: 'CircularViewB',
+      tableName: 'circular_view_b',
+      view: true,
+      // This references circular_view_a
+      expression: `select 1 as id, (select count(*) from circular_view_a) as a_count`,
+      properties: {
+        id: p.integer().primary(),
+        aCount: p.integer(),
+      },
+    });
+
+    const orm2 = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      entities: [CircularViewA, CircularViewB],
+      dbName: 'mikro_orm_test_views',
+    });
+
+    try {
+      // Get create SQL - should include both views even with circular dependency
+      const createSql = await orm2.schema.getCreateSchemaSQL();
+      expect(createSql).toContain('circular_view_a');
+      expect(createSql).toContain('circular_view_b');
+    } finally {
+      await orm2.close();
+    }
+  });
+
+  test('async expression throws error', async () => {
+    const AsyncView = defineEntity({
+      name: 'AsyncView',
+      tableName: 'async_view',
+      view: true,
+      expression: async () => {
+        return 'select 1 as id';
+      },
+      properties: {
+        id: p.integer().primary(),
+      },
+    });
+
+    const orm2 = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      entities: [AsyncView],
+      dbName: 'mikro_orm_test_views',
+    });
+
+    try {
+      await expect(orm2.schema.getCreateSchemaSQL()).rejects.toThrow(/async.*not supported/i);
+    } finally {
+      await orm2.close();
+    }
+  });
+
+});

--- a/tests/features/view-entities/view-entities.sqlite.test.ts
+++ b/tests/features/view-entities/view-entities.sqlite.test.ts
@@ -1,0 +1,157 @@
+import { defineEntity, p } from '@mikro-orm/core';
+import { ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+import { EntityManager, MikroORM } from '@mikro-orm/sqlite';
+import { Author4, BaseEntity4, BaseEntity5, Book4, BookTag4, FooBar4, FooBaz4, Publisher4, Test4, IdentitySchema } from '../../entities-schema/index.js';
+
+// View entity with string expression
+class AuthorStats {
+
+  name!: string;
+  bookCount!: number;
+
+}
+
+const authorStatsSQL = `select name, (select count(*) from book4 b where b.author_id = a.id) as book_count from author4 a`;
+
+const AuthorStatsSchema = defineEntity({
+  class: AuthorStats,
+  tableName: 'author_stats_view',
+  view: true,
+  expression: authorStatsSQL,
+  properties: {
+    name: p.string().primary(),
+    bookCount: p.integer(),
+  },
+});
+
+// View entity with QueryBuilder expression using defineEntity
+const BookSummary = defineEntity({
+  name: 'BookSummary',
+  tableName: 'book_summary_view',
+  view: true,
+  expression: (em: EntityManager) => {
+    return em.createQueryBuilder(Book4, 'b')
+      .select(['b.title', 'a.name as author_name'])
+      .join('b.author', 'a');
+  },
+  properties: {
+    title: p.string().primary(),
+    authorName: p.string(),
+  },
+});
+
+// View depending on another view (for testing dependency ordering)
+// This view references author_stats_view
+const ProlificAuthors = defineEntity({
+  name: 'ProlificAuthors',
+  tableName: 'prolific_authors_view',
+  view: true,
+  expression: `select name, book_count from author_stats_view where book_count > 1`,
+  properties: {
+    name: p.string().primary(),
+    bookCount: p.integer(),
+  },
+});
+
+describe('View entities (sqlite)', () => {
+
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      entities: [Author4, Book4, BookTag4, Publisher4, Test4, FooBar4, FooBaz4, BaseEntity4, BaseEntity5, IdentitySchema, AuthorStatsSchema, BookSummary, ProlificAuthors],
+      dbName: ':memory:',
+      metadataProvider: ReflectMetadataProvider,
+    });
+
+    await orm.schema.create();
+
+    // Create test data once for all tests
+    const em = orm.em.fork();
+    const author = em.create(Author4, { name: 'Jon Snow', email: 'snow@wall.st' });
+    em.create(Book4, { title: 'Book 1', author });
+    em.create(Book4, { title: 'Book 2', author });
+    await em.flush();
+  });
+
+  afterAll(async () => {
+    await orm.close(true);
+  });
+
+  test('schema generator should create views', async () => {
+    const sql = await orm.schema.getCreateSchemaSQL();
+    expect(sql).toMatchSnapshot();
+  });
+
+  test('schema generator should drop views before tables', async () => {
+    const sql = await orm.schema.getDropSchemaSQL();
+    expect(sql).toContain('drop view');
+  });
+
+  test('can query view entity with string expression', async () => {
+    const em = orm.em.fork();
+
+    const stats = await em.find(AuthorStats, {});
+    expect(stats.length).toBe(1);
+    expect(stats[0].name).toBe('Jon Snow');
+    expect(stats[0].bookCount).toBe(2);
+  });
+
+  test('can query view entity with QueryBuilder expression', async () => {
+    const em = orm.em.fork();
+
+    const summaries = await em.find(BookSummary, {});
+    expect(summaries.length).toBe(2);
+    expect(summaries.every(s => s.authorName === 'Jon Snow')).toBe(true);
+    expect(summaries.map(s => s.title).sort()).toEqual(['Book 1', 'Book 2']);
+  });
+
+  test('view entity should be read-only', async () => {
+    const em = orm.em.fork();
+
+    const stat = new AuthorStats();
+    stat.name = 'Test';
+    stat.bookCount = 0;
+
+    // Trying to persist should not cause issues - it's just ignored
+    em.persist(stat);
+    await em.flush();
+  });
+
+  test('updateSchema detects no changes for unchanged views', async () => {
+    const sql = await orm.schema.getUpdateSchemaSQL();
+    expect(sql).toBe('');
+  });
+
+  test('views depending on other views are created in correct order', async () => {
+    const sql = await orm.schema.getCreateSchemaSQL();
+
+    const authorStatsPos = sql.indexOf('author_stats_view');
+    const prolificAuthorsPos = sql.indexOf('prolific_authors_view');
+
+    expect(authorStatsPos).toBeGreaterThan(-1);
+    expect(prolificAuthorsPos).toBeGreaterThan(-1);
+    expect(authorStatsPos).toBeLessThan(prolificAuthorsPos);
+  });
+
+  test('views depending on other views are dropped in correct order', async () => {
+    const sql = await orm.schema.getDropSchemaSQL();
+
+    const authorStatsPos = sql.indexOf('author_stats_view');
+    const prolificAuthorsPos = sql.indexOf('prolific_authors_view');
+
+    expect(authorStatsPos).toBeGreaterThan(-1);
+    expect(prolificAuthorsPos).toBeGreaterThan(-1);
+    expect(prolificAuthorsPos).toBeLessThan(authorStatsPos);
+  });
+
+  test('can query view depending on another view', async () => {
+    const em = orm.em.fork();
+
+    const prolificAuthors = await em.find(ProlificAuthors, {});
+    expect(prolificAuthors.length).toBe(1);
+    expect(prolificAuthors[0].name).toBe('Jon Snow');
+    expect(prolificAuthors[0].bookCount).toBe(2);
+  });
+
+});

--- a/tests/features/view-entities/view-entities.validation.test.ts
+++ b/tests/features/view-entities/view-entities.validation.test.ts
@@ -1,0 +1,44 @@
+import { defineEntity, p, MikroORM } from '@mikro-orm/sqlite';
+import { Entity, PrimaryKey, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+
+describe('View entity validation', () => {
+
+  test('view entity without expression should throw', async () => {
+    @Entity({ tableName: 'invalid_view', view: true })
+    class InvalidView {
+
+      @PrimaryKey()
+      id!: number;
+
+    }
+
+    await expect(MikroORM.init({
+      entities: [InvalidView],
+      dbName: ':memory:',
+      metadataProvider: ReflectMetadataProvider,
+    })).rejects.toThrow(/view.*expression/i);
+  });
+
+  test('view entity with expression should be valid', async () => {
+    const ValidView = defineEntity({
+      name: 'ValidView',
+      tableName: 'valid_view',
+      view: true,
+      expression: 'select 1 as id',
+      properties: {
+        id: p.integer().primary(),
+      },
+    });
+
+    const orm = await MikroORM.init({
+      entities: [ValidView],
+      dbName: ':memory:',
+    });
+
+    expect(orm.getMetadata(ValidView).view).toBe(true);
+    expect(orm.getMetadata(ValidView).expression).toBe('select 1 as id');
+
+    await orm.close();
+  });
+
+});


### PR DESCRIPTION
This adds support for View Entities in MikroORM. Unlike virtual entities which evaluate expressions at query time, view entities create actual database views that are managed by the schema generator.

```ts
@Entity({
  tableName: 'author_stats_view',
  view: true,
  expression: 'select name, count(*) as book_count from author group by name'
})
class AuthorStats {
  @PrimaryKey()
  name!: string;

  @Property()
  bookCount!: number;
}
```

Or with `defineEntity`:

```ts
const AuthorStatsSchema = defineEntity({
  class: AuthorStats,
  tableName: 'author_stats_view',
  view: true,
  expression: em => em.createQueryBuilder(Author, 'a').select(['a.name', 'count(*)', ...]),
  properties: { ... }
});
```

Closes #672