### PR TITLE
feat(postgres): add support for materialized views

### DIFF
--- a/docs/docs/materialized-views.md
+++ b/docs/docs/materialized-views.md
@@ -1,0 +1,284 @@
+---
+title: Materialized Views
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+Materialized views store the results of a query physically, providing faster read performance at the cost of data freshness. Unlike regular views, materialized views must be explicitly refreshed to reflect changes in the underlying data.
+
+## Defining a Materialized View Entity
+
+To create a materialized view entity, set both `view: true` and `materialized: true` in your entity options:
+
+<Tabs
+  groupId="entity-def"
+  defaultValue="define-entity"
+  values={[
+    {label: 'defineEntity', value: 'define-entity'},
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="define-entity">
+
+```ts title="./entities/AuthorStats.ts"
+import { defineEntity, p } from '@mikro-orm/postgresql';
+
+export const AuthorStats = defineEntity({
+  name: 'AuthorStats',
+  tableName: 'author_stats_matview',
+  view: true,
+  materialized: true,
+  expression: `
+    select
+      a.id,
+      a.name,
+      count(b.id)::int as book_count
+    from author a
+    left join book b on b.author_id = a.id
+    group by a.id
+  `,
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+    bookCount: p.integer(),
+  },
+});
+```
+
+  </TabItem>
+  <TabItem value="reflect-metadata">
+
+```ts title="./entities/AuthorStats.ts"
+import { Entity, Property, PrimaryKey } from '@mikro-orm/postgresql';
+
+@Entity({
+  tableName: 'author_stats_matview',
+  view: true,
+  materialized: true,
+  expression: `
+    select
+      a.id,
+      a.name,
+      count(b.id)::int as book_count
+    from author a
+    left join book b on b.author_id = a.id
+    group by a.id
+  `,
+})
+export class AuthorStats {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @Property()
+  bookCount!: number;
+
+}
+```
+
+  </TabItem>
+  <TabItem value="ts-morph">
+
+```ts title="./entities/AuthorStats.ts"
+import { Entity, Property, PrimaryKey } from '@mikro-orm/postgresql';
+
+@Entity({
+  tableName: 'author_stats_matview',
+  view: true,
+  materialized: true,
+  expression: `
+    select
+      a.id,
+      a.name,
+      count(b.id)::int as book_count
+    from author a
+    left join book b on b.author_id = a.id
+    group by a.id
+  `,
+})
+export class AuthorStats {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @Property()
+  bookCount!: number;
+
+}
+```
+
+  </TabItem>
+  <TabItem value="entity-schema">
+
+```ts title="./entities/AuthorStats.ts"
+import { EntitySchema } from '@mikro-orm/postgresql';
+
+export interface IAuthorStats {
+  id: number;
+  name: string;
+  bookCount: number;
+}
+
+export const AuthorStats = new EntitySchema<IAuthorStats>({
+  name: 'AuthorStats',
+  tableName: 'author_stats_matview',
+  view: true,
+  materialized: true,
+  expression: `
+    select
+      a.id,
+      a.name,
+      count(b.id)::int as book_count
+    from author a
+    left join book b on b.author_id = a.id
+    group by a.id
+  `,
+  properties: {
+    id: { type: 'number', primary: true },
+    name: { type: 'string' },
+    bookCount: { type: 'number' },
+  },
+});
+```
+
+  </TabItem>
+</Tabs>
+
+## Creating Materialized Views Without Data
+
+By default, materialized views are created with data populated immediately (`WITH DATA`). If you want to create an empty materialized view that will be populated later, set `withData: false`:
+
+```typescript
+const AuthorStats = defineEntity({
+  name: 'AuthorStats',
+  tableName: 'author_stats_matview',
+  view: true,
+  materialized: true,
+  withData: false, // Creates with "WITH NO DATA"
+  expression: `select ...`,
+  properties: { ... },
+});
+```
+
+This is useful when the underlying tables are empty during schema creation, or when you want to control exactly when the initial data population occurs.
+
+## Refreshing Materialized Views
+
+Since materialized views cache query results, you need to refresh them to see updated data. Use the `refreshMaterializedView` method on `PostgreSqlEntityManager`:
+
+```typescript
+import { MikroORM, EntityManager } from '@mikro-orm/postgresql';
+
+const orm = await MikroORM.init({ ... });
+const em = orm.em;
+
+// Refresh the materialized view
+await em.refreshMaterializedView(AuthorStats);
+
+// Now queries will return the updated data
+const stats = await em.find(AuthorStats, {});
+```
+
+### Concurrent Refresh
+
+PostgreSQL supports refreshing materialized views concurrently, which allows reads to continue during the refresh. This requires a unique index on the materialized view:
+
+```typescript
+// Refresh concurrently (requires unique index on the view)
+await em.refreshMaterializedView(AuthorStats, { concurrently: true });
+```
+
+> **Note:** Concurrent refresh requires at least one unique index on the materialized view. Without it, PostgreSQL will throw an error.
+
+## Querying Materialized Views
+
+Materialized views are queried like any other entity:
+
+```typescript
+// Find all
+const allStats = await em.find(AuthorStats, {});
+
+// Find with conditions
+const prolificAuthors = await em.find(AuthorStats, {
+  bookCount: { $gte: 5 },
+});
+
+// Find one
+const authorStats = await em.findOne(AuthorStats, { name: 'Jon Snow' });
+```
+
+## Read-Only Behavior
+
+Materialized view entities are automatically marked as read-only (`readonly: true`). Attempting to persist changes to a materialized view entity will result in an error:
+
+```typescript
+const stats = await em.findOne(AuthorStats, { id: 1 });
+stats.bookCount = 100; // This change won't be persisted
+await em.flush(); // No UPDATE will be generated for this entity
+```
+
+## Schema Generation
+
+The schema generator handles materialized views automatically:
+
+```typescript
+// Create schema (includes CREATE MATERIALIZED VIEW statements)
+await orm.schema.createSchema();
+
+// Drop schema (includes DROP MATERIALIZED VIEW statements)
+await orm.schema.dropSchema();
+
+// Update schema (detects changes to materialized views)
+await orm.schema.updateSchema();
+```
+
+### Generated SQL
+
+Creating a materialized view generates:
+
+```sql
+create materialized view "author_stats_matview" as
+  select a.id, a.name, count(b.id)::int as book_count
+  from author a
+  left join book b on b.author_id = a.id
+  group by a.id
+with data;
+```
+
+With `withData: false`:
+
+```sql
+create materialized view "author_stats_matview" as
+  select ...
+with no data;
+```
+
+## Limitations
+
+- **PostgreSQL only:** Materialized views are only supported on PostgreSQL. Other databases will throw an error if you try to use `materialized: true`.
+- **No automatic refresh:** MikroORM does not automatically refresh materialized views. You must call `refreshMaterializedView()` manually or set up a database-level refresh mechanism (triggers, cron jobs, etc.).
+
+## Best Practices
+
+1. **Choose appropriate refresh strategies:** For frequently changing data, consider regular views instead. Use materialized views for data that changes infrequently or where stale data is acceptable.
+
+2. **Add indexes:** Materialized views support indexes. Add them for columns you frequently query:
+   ```sql
+   CREATE UNIQUE INDEX author_stats_id_idx ON author_stats_matview (id);
+   CREATE INDEX author_stats_book_count_idx ON author_stats_matview (book_count);
+   ```
+
+3. **Schedule refreshes:** Use database schedulers (pg_cron) or application-level scheduling to refresh materialized views during low-traffic periods.
+
+4. **Use concurrent refresh in production:** If your application needs to read from the view while refreshing, always use `{ concurrently: true }` (requires a unique index).
+
+5. **Monitor view size:** Materialized views consume disk space. Monitor their size and consider partitioning strategies for large datasets.

--- a/docs/docs/view-entities.md
+++ b/docs/docs/view-entities.md
@@ -317,7 +317,36 @@ View entities are supported in all SQL databases:
 
 > Note: MongoDB does not support view entities as it doesn't have the concept of database views. Use [virtual entities](./virtual-entities.md) instead for MongoDB.
 
+## Materialized Views
+
+Materialized views are a database feature that allows you to pre-compute and store query results in a table.
+
+MikroORM supports materialized views in PostgreSQL through view entities by setting the `materialized: true` option:
+
+```ts
+@Entity({
+  tableName: 'author_stats_mat_view',
+  view: true,
+  materialized: true,
+  expression: `
+    select a.name, count(b.id) as book_count
+    from author a
+    left join book b on b.author_id = a.id
+    group by a.id, a.name
+  `,
+})
+export class AuthorStatsMatView {
+  @PrimaryKey()
+  name!: string;
+  
+  @Property()
+  bookCount!: number;
+}
+```
+
+Read more about materialized views [in their own section](./materialized-views.md). 
+
 ## Limitations
 
-- View entities are read-only and cannot be persisted
-- Some databases may have limitations on updatable views
+- View entities are read-only and cannot be persisted.
+- Some databases may have limitations on updatable views.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -72,6 +72,7 @@ module.exports = {
         'custom-types',
         'virtual-entities',
         'view-entities',
+        'materialized-views',
         'embeddables',
         'entity-schema',
         'json-properties',

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -313,6 +313,10 @@ export class MetadataError<T extends AnyEntity = AnyEntity> extends ValidationEr
     return new MetadataError(`View entity ${meta.className} is missing 'expression'. View entities must have an expression defining the SQL query.`);
   }
 
+  static materializedWithoutView(meta: EntityMetadata): MetadataError {
+    return new MetadataError(`Entity ${meta.className} has 'materialized: true' but is missing 'view: true'. Materialized views must also be marked as views.`);
+  }
+
   private static fromMessage(meta: EntityMetadata, prop: EntityProperty, message: string): MetadataError {
     return new MetadataError(`${meta.className}.${prop.name} ${message}`);
   }

--- a/packages/core/src/metadata/MetadataValidator.ts
+++ b/packages/core/src/metadata/MetadataValidator.ts
@@ -26,6 +26,10 @@ export class MetadataValidator {
   validateEntityDefinition<T>(metadata: MetadataStorage, name: EntityName<T>, options: MetadataDiscoveryOptions): void {
     const meta = metadata.get(name);
 
+    if (meta.materialized && !meta.view) {
+      throw MetadataError.materializedWithoutView(meta);
+    }
+
     // View entities (expression with view flag) behave like regular tables but are read-only
     // They can have primary keys and are created as actual database views
     if (meta.view) {

--- a/packages/core/src/metadata/types.ts
+++ b/packages/core/src/metadata/types.ts
@@ -50,6 +50,18 @@ export type EntityOptions<T, E = T extends EntityClass<infer P> ? P : T> = {
    * View entities are read-only by default.
    */
   view?: boolean;
+  /**
+   * Marks the view entity as a materialized view. Requires `view: true`.
+   * Materialized views store the query results and must be refreshed to update data.
+   * Only supported on PostgreSQL.
+   */
+  materialized?: boolean;
+  /**
+   * For materialized views, whether to populate data immediately on creation.
+   * Defaults to `true`. Set to `false` to create an unpopulated materialized view.
+   * Only applicable when `materialized: true`.
+   */
+  withData?: boolean;
   /** Used to make ORM aware of externally defined triggers. This is needed for MS SQL Server multi inserts, ignored in other dialects. */
   hasTriggers?: boolean;
   // we need to use `em: any` here otherwise an expression would not be assignable with more narrow type like `SqlEntityManager`

--- a/packages/core/src/platforms/Platform.ts
+++ b/packages/core/src/platforms/Platform.ts
@@ -95,6 +95,10 @@ export abstract class Platform {
     return false;
   }
 
+  supportsMaterializedViews(): boolean {
+    return false;
+  }
+
   getSchemaHelper(): unknown {
     return undefined;
   }

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -862,6 +862,10 @@ export interface EntityMetadata<Entity = any, Class extends EntityCtor<Entity> =
   virtual?: boolean;
   /** True if this entity represents a database view (not a virtual entity). */
   view?: boolean;
+  /** True if this is a materialized view (PostgreSQL only). Requires `view: true`. */
+  materialized?: boolean;
+  /** For materialized views, whether data is populated on creation. Defaults to true. */
+  withData?: boolean;
   // we need to use `em: any` here otherwise an expression would not be assignable with more narrow type like `SqlEntityManager`
   // also return type is unknown as it can be either QB instance (which we cannot type here) or array of POJOs (e.g. for mongodb)
   expression?: string | ((em: any, where: ObjectQuery<Entity>, options: FindOptions<Entity, any, any, any>, stream?: boolean) => MaybePromise<Raw | object | string>);

--- a/packages/postgresql/src/PostgreSqlDriver.ts
+++ b/packages/postgresql/src/PostgreSqlDriver.ts
@@ -1,13 +1,21 @@
-import type { Configuration, Constructor } from '@mikro-orm/core';
+import { type Configuration, type Constructor, EntityManagerType } from '@mikro-orm/core';
 import { AbstractSqlDriver } from '@mikro-orm/sql';
 import { PostgreSqlConnection } from './PostgreSqlConnection.js';
 import { PostgreSqlPlatform } from './PostgreSqlPlatform.js';
 import { PostgreSqlMikroORM } from './PostgreSqlMikroORM.js';
+import { PostgreSqlEntityManager } from './PostgreSqlEntityManager.js';
 
 export class PostgreSqlDriver extends AbstractSqlDriver<PostgreSqlConnection> {
 
+  override [EntityManagerType]!: PostgreSqlEntityManager<this>;
+
   constructor(config: Configuration) {
     super(config, new PostgreSqlPlatform(), PostgreSqlConnection, ['kysely', 'pg']);
+  }
+
+  override createEntityManager(useContext?: boolean): this[typeof EntityManagerType] {
+    const EntityManagerClass = this.config.get('entityManager', PostgreSqlEntityManager);
+    return new EntityManagerClass(this.config, this, this.metadata, useContext) as this[typeof EntityManagerType];
   }
 
   /** @inheritDoc */

--- a/packages/postgresql/src/PostgreSqlEntityManager.ts
+++ b/packages/postgresql/src/PostgreSqlEntityManager.ts
@@ -1,0 +1,34 @@
+import { type EntityName } from '@mikro-orm/core';
+import { SqlEntityManager } from '@mikro-orm/sql';
+import type { PostgreSqlDriver } from './PostgreSqlDriver.js';
+
+/**
+ * @inheritDoc
+ */
+export class PostgreSqlEntityManager<Driver extends PostgreSqlDriver = PostgreSqlDriver> extends SqlEntityManager<Driver> {
+
+  /**
+   * Refreshes a materialized view.
+   *
+   * @param entityName - The entity name or class of the materialized view
+   * @param options - Optional settings
+   * @param options.concurrently - If true, refreshes the view concurrently (requires a unique index on the view)
+   */
+  async refreshMaterializedView<Entity extends object>(
+    entityName: EntityName<Entity>,
+    options?: { concurrently?: boolean },
+  ): Promise<void> {
+    const meta = this.getMetadata(entityName);
+
+    if (!meta.view || !meta.materialized) {
+      throw new Error(`Entity ${meta.className} is not a materialized view`);
+    }
+
+    const helper = this.getDriver().getPlatform().getSchemaHelper()!;
+    const schema = meta.schema ?? this.config.get('schema');
+    const sql = helper.refreshMaterializedView(meta.tableName, schema, options?.concurrently);
+
+    await this.execute(sql);
+  }
+
+}

--- a/packages/postgresql/src/PostgreSqlMikroORM.ts
+++ b/packages/postgresql/src/PostgreSqlMikroORM.ts
@@ -9,16 +9,16 @@ import {
   type EntityManager,
   type EntityManagerType,
 } from '@mikro-orm/core';
-import type { SqlEntityManager } from '@mikro-orm/sql';
 import { PostgreSqlDriver } from './PostgreSqlDriver.js';
+import type { PostgreSqlEntityManager } from './PostgreSqlEntityManager.js';
 
 export type PostgreSqlOptions<
-  EM extends SqlEntityManager<PostgreSqlDriver> = SqlEntityManager<PostgreSqlDriver>,
+  EM extends PostgreSqlEntityManager = PostgreSqlEntityManager,
   Entities extends (string | EntityClass<AnyEntity> | EntitySchema)[] = (string | EntityClass<AnyEntity> | EntitySchema)[],
 > = Options<PostgreSqlDriver, EM, Entities>;
 
 export function definePostgreSqlConfig<
-  EM extends SqlEntityManager<PostgreSqlDriver> = SqlEntityManager<PostgreSqlDriver>,
+  EM extends PostgreSqlEntityManager = PostgreSqlEntityManager,
   Entities extends (string | EntityClass<AnyEntity> | EntitySchema)[] = (string | EntityClass<AnyEntity> | EntitySchema)[],
 >(options: Options<PostgreSqlDriver, EM, Entities>) {
   return defineConfig({ driver: PostgreSqlDriver, ...options });
@@ -28,7 +28,7 @@ export function definePostgreSqlConfig<
  * @inheritDoc
  */
 export class PostgreSqlMikroORM<
-  EM extends SqlEntityManager<PostgreSqlDriver> = SqlEntityManager<PostgreSqlDriver>,
+  EM extends PostgreSqlEntityManager = PostgreSqlEntityManager,
   Entities extends (string | EntityClass<AnyEntity> | EntitySchema)[] = (string | EntityClass<AnyEntity> | EntitySchema)[],
 > extends MikroORM<PostgreSqlDriver, EM, Entities> {
 

--- a/packages/postgresql/src/index.ts
+++ b/packages/postgresql/src/index.ts
@@ -2,6 +2,7 @@ export * from '@mikro-orm/sql';
 export * from './PostgreSqlConnection.js';
 export * from './PostgreSqlDriver.js';
 export * from './PostgreSqlPlatform.js';
+export { PostgreSqlEntityManager as EntityManager } from './PostgreSqlEntityManager.js';
 export {
   PostgreSqlMikroORM as MikroORM,
   type PostgreSqlOptions as Options,

--- a/packages/sql/src/dialects/postgresql/BasePostgreSqlPlatform.ts
+++ b/packages/sql/src/dialects/postgresql/BasePostgreSqlPlatform.ts
@@ -42,6 +42,10 @@ export class BasePostgreSqlPlatform extends AbstractSqlPlatform {
     return true;
   }
 
+  override supportsMaterializedViews(): boolean {
+    return true;
+  }
+
   override supportsCustomPrimaryKeyNames(): boolean {
     return true;
   }

--- a/packages/sql/src/schema/SchemaHelper.ts
+++ b/packages/sql/src/schema/SchemaHelper.ts
@@ -731,4 +731,24 @@ export abstract class SchemaHelper {
     return sql;
   }
 
+  createMaterializedView(name: string, schema: string | undefined, definition: string, withData = true): string {
+    throw new Error('Not supported by given driver');
+  }
+
+  dropMaterializedViewIfExists(name: string, schema?: string): string {
+    throw new Error('Not supported by given driver');
+  }
+
+  refreshMaterializedView(name: string, schema?: string, concurrently = false): string {
+    throw new Error('Not supported by given driver');
+  }
+
+  getListMaterializedViewsSQL(): string {
+    throw new Error('Not supported by given driver');
+  }
+
+  async loadMaterializedViews(schema: DatabaseSchema, connection: AbstractSqlConnection, schemaName?: string): Promise<void> {
+    throw new Error('Not supported by given driver');
+  }
+
 }

--- a/packages/sql/src/typings.ts
+++ b/packages/sql/src/typings.ts
@@ -140,6 +140,10 @@ export interface DatabaseView {
   name: string;
   schema?: string;
   definition: string;
+  /** True if this is a materialized view (PostgreSQL only). */
+  materialized?: boolean;
+  /** For materialized views, whether data was populated on creation. */
+  withData?: boolean;
 }
 
 export interface SchemaDifference {

--- a/tests/SchemaHelper.test.ts
+++ b/tests/SchemaHelper.test.ts
@@ -27,6 +27,11 @@ describe('SchemaHelper', () => {
     expect(() => helper.getAlterNativeEnumSQL('table')).toThrow('Not supported by given driver');
     expect(() => helper.getCreateNativeEnumSQL('table', [])).toThrow('Not supported by given driver');
     expect(() => helper.getDropNativeEnumSQL('table')).toThrow('Not supported by given driver');
+    expect(() => helper.createMaterializedView('table', undefined, '')).toThrow('Not supported by given driver');
+    expect(() => helper.dropMaterializedViewIfExists('table')).toThrow('Not supported by given driver');
+    expect(() => helper.refreshMaterializedView('table')).toThrow('Not supported by given driver');
+    expect(() => helper.getListMaterializedViewsSQL()).toThrow('Not supported by given driver');
+    await expect(helper.loadMaterializedViews({} as any, {} as any)).rejects.toThrow('Not supported by given driver');
   });
 
   test('mysql schema helper', async () => {

--- a/tests/features/schema-generator/__snapshots__/materialized-view-diffing.postgres.test.ts.snap
+++ b/tests/features/schema-generator/__snapshots__/materialized-view-diffing.postgres.test.ts.snap
@@ -1,0 +1,38 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`materialized view diffing in postgres > schema generator adds new materialized view 1`] = `
+"create materialized view "author_stats_matview" as select a.id, a.name, count(b.id)::int as book_count from author a left join book b on b.author_id = a.id group by a.id with data;
+"
+`;
+
+exports[`materialized view diffing in postgres > schema generator handles add, modify, and remove in sequence 1`] = `
+"create materialized view "author_stats_matview" as select a.id, a.name, count(b.id)::int as book_count from author a left join book b on b.author_id = a.id group by a.id with data;
+"
+`;
+
+exports[`materialized view diffing in postgres > schema generator handles add, modify, and remove in sequence 2`] = `
+"create materialized view "book_stats_matview" as select count(*)::int as total_books from book with data;
+"
+`;
+
+exports[`materialized view diffing in postgres > schema generator handles add, modify, and remove in sequence 3`] = `
+"drop materialized view if exists "author_stats_matview" cascade;
+create materialized view "author_stats_matview" as select a.id, a.name, a.email, count(b.id)::int as book_count from author a left join book b on b.author_id = a.id group by a.id with data;
+"
+`;
+
+exports[`materialized view diffing in postgres > schema generator handles add, modify, and remove in sequence 4`] = `
+"drop materialized view if exists "book_stats_matview" cascade;
+"
+`;
+
+exports[`materialized view diffing in postgres > schema generator modifies materialized view expression 1`] = `
+"drop materialized view if exists "author_stats_matview" cascade;
+create materialized view "author_stats_matview" as select a.id, a.name, a.email, count(b.id)::int as book_count from author a left join book b on b.author_id = a.id group by a.id with data;
+"
+`;
+
+exports[`materialized view diffing in postgres > schema generator removes materialized view 1`] = `
+"drop materialized view if exists "book_stats_matview" cascade;
+"
+`;

--- a/tests/features/schema-generator/materialized-view-diffing.postgres.test.ts
+++ b/tests/features/schema-generator/materialized-view-diffing.postgres.test.ts
@@ -1,0 +1,241 @@
+import { defineEntity, p, MikroORM } from '@mikro-orm/postgresql';
+import { ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+
+// Base table for the views
+const Author = defineEntity({
+  name: 'Author',
+  tableName: 'author',
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+    email: p.string(),
+  },
+});
+
+const Book = defineEntity({
+  name: 'Book',
+  tableName: 'book',
+  properties: {
+    id: p.integer().primary(),
+    title: p.string(),
+    authorId: p.integer(),
+  },
+});
+
+// Initial materialized view
+const AuthorStats0 = defineEntity({
+  name: 'AuthorStats',
+  tableName: 'author_stats_matview',
+  view: true,
+  materialized: true,
+  expression: `select a.id, a.name, count(b.id)::int as book_count from author a left join book b on b.author_id = a.id group by a.id`,
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+    bookCount: p.integer(),
+  },
+});
+
+// Modified materialized view (changed expression)
+const AuthorStats1 = defineEntity({
+  name: 'AuthorStats',
+  tableName: 'author_stats_matview',
+  view: true,
+  materialized: true,
+  expression: `select a.id, a.name, a.email, count(b.id)::int as book_count from author a left join book b on b.author_id = a.id group by a.id`,
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+    email: p.string(),
+    bookCount: p.integer(),
+  },
+});
+
+// Another materialized view for testing add/remove
+const BookStats0 = defineEntity({
+  name: 'BookStats',
+  tableName: 'book_stats_matview',
+  view: true,
+  materialized: true,
+  expression: `select count(*)::int as total_books from book`,
+  properties: {
+    totalBooks: p.integer().primary(),
+  },
+});
+
+// Materialized view with no data on creation
+const AuthorStatsNoData = defineEntity({
+  name: 'AuthorStatsNoData',
+  tableName: 'author_stats_nodata_matview',
+  view: true,
+  materialized: true,
+  withData: false,
+  expression: `select a.id, a.name from author a`,
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+  },
+});
+
+// Modified version with data
+const AuthorStatsWithData = defineEntity({
+  name: 'AuthorStatsWithData',
+  tableName: 'author_stats_nodata_matview',
+  view: true,
+  materialized: true,
+  withData: true,
+  expression: `select a.id, a.name from author a`,
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+  },
+});
+
+describe('materialized view diffing in postgres', () => {
+
+  test('schema generator adds new materialized view', async () => {
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      entities: [Author, Book],
+      dbName: 'mikro_orm_test_matview_diffing',
+    });
+    await orm.schema.ensureDatabase();
+    await orm.schema.execute('drop materialized view if exists author_stats_matview cascade');
+    await orm.schema.execute('drop materialized view if exists book_stats_matview cascade');
+    await orm.schema.execute('drop table if exists author cascade');
+    await orm.schema.execute('drop table if exists book cascade');
+    await orm.schema.create();
+
+    // Add a materialized view
+    orm.discoverEntity(AuthorStats0);
+    const diff1 = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(diff1).toMatchSnapshot();
+    await orm.schema.execute(diff1);
+
+    // Verify no diff after applying
+    await expect(orm.schema.getUpdateSchemaSQL({ wrap: false })).resolves.toBe('');
+
+    await orm.close(true);
+  });
+
+  test('schema generator modifies materialized view expression', async () => {
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      entities: [Author, Book, AuthorStats0],
+      dbName: 'mikro_orm_test_matview_diffing',
+    });
+    await orm.schema.ensureDatabase();
+    await orm.schema.execute('drop materialized view if exists author_stats_matview cascade');
+    await orm.schema.execute('drop table if exists author cascade');
+    await orm.schema.execute('drop table if exists book cascade');
+    await orm.schema.create();
+
+    // Modify the materialized view (add email column)
+    orm.discoverEntity(AuthorStats1, AuthorStats0);
+    const diff1 = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(diff1).toMatchSnapshot();
+    await orm.schema.execute(diff1);
+
+    // Verify no diff after applying
+    await expect(orm.schema.getUpdateSchemaSQL({ wrap: false })).resolves.toBe('');
+
+    await orm.close(true);
+  });
+
+  test('schema generator removes materialized view', async () => {
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      entities: [Author, Book, AuthorStats0, BookStats0],
+      dbName: 'mikro_orm_test_matview_diffing',
+    });
+    await orm.schema.ensureDatabase();
+    await orm.schema.execute('drop materialized view if exists author_stats_matview cascade');
+    await orm.schema.execute('drop materialized view if exists book_stats_matview cascade');
+    await orm.schema.execute('drop table if exists author cascade');
+    await orm.schema.execute('drop table if exists book cascade');
+    await orm.schema.create();
+
+    // Remove one materialized view (keep AuthorStats0, remove BookStats0)
+    orm.getMetadata().reset(BookStats0);
+    const diff1 = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(diff1).toMatchSnapshot();
+    await orm.schema.execute(diff1);
+
+    // Verify no diff after applying
+    await expect(orm.schema.getUpdateSchemaSQL({ wrap: false })).resolves.toBe('');
+
+    await orm.close(true);
+  });
+
+  test('schema generator handles add, modify, and remove in sequence', async () => {
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      entities: [Author, Book],
+      dbName: 'mikro_orm_test_matview_diffing',
+    });
+    await orm.schema.ensureDatabase();
+    await orm.schema.execute('drop materialized view if exists author_stats_matview cascade');
+    await orm.schema.execute('drop materialized view if exists book_stats_matview cascade');
+    await orm.schema.execute('drop table if exists author cascade');
+    await orm.schema.execute('drop table if exists book cascade');
+    await orm.schema.create();
+
+    // Step 1: Add first materialized view
+    orm.discoverEntity(AuthorStats0);
+    const diff1 = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(diff1).toMatchSnapshot();
+    await orm.schema.execute(diff1);
+    await expect(orm.schema.getUpdateSchemaSQL({ wrap: false })).resolves.toBe('');
+
+    // Step 2: Add second materialized view
+    orm.discoverEntity(BookStats0);
+    const diff2 = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(diff2).toMatchSnapshot();
+    await orm.schema.execute(diff2);
+    await expect(orm.schema.getUpdateSchemaSQL({ wrap: false })).resolves.toBe('');
+
+    // Step 3: Modify first materialized view
+    orm.discoverEntity(AuthorStats1, AuthorStats0);
+    const diff3 = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(diff3).toMatchSnapshot();
+    await orm.schema.execute(diff3);
+    await expect(orm.schema.getUpdateSchemaSQL({ wrap: false })).resolves.toBe('');
+
+    // Step 4: Remove second materialized view
+    orm.getMetadata().reset(BookStats0);
+    const diff4 = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(diff4).toMatchSnapshot();
+    await orm.schema.execute(diff4);
+    await expect(orm.schema.getUpdateSchemaSQL({ wrap: false })).resolves.toBe('');
+
+    await orm.close(true);
+  });
+
+  test('schema generator handles withData option change', async () => {
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      entities: [Author, Book, AuthorStatsNoData],
+      dbName: 'mikro_orm_test_matview_diffing',
+    });
+    await orm.schema.ensureDatabase();
+    await orm.schema.execute('drop materialized view if exists author_stats_nodata_matview cascade');
+    await orm.schema.execute('drop table if exists author cascade');
+    await orm.schema.execute('drop table if exists book cascade');
+    await orm.schema.create();
+
+    // The create SQL should contain WITH NO DATA
+    const createSql = await orm.schema.getCreateSchemaSQL();
+    expect(createSql).toContain('with no data');
+
+    // Change from withData: false to withData: true
+    // Note: withData is a creation-time option, not a view property that can be diffed.
+    // The view structure itself is the same, so no diff is expected.
+    // To populate a WITH NO DATA view, use REFRESH MATERIALIZED VIEW.
+    orm.discoverEntity(AuthorStatsWithData, AuthorStatsNoData);
+    const diff1 = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(diff1).toBe(''); // No diff expected since withData doesn't affect view structure
+
+    await orm.close(true);
+  });
+
+});

--- a/tests/features/view-entities/__snapshots__/view-entities.postgres.test.ts.snap
+++ b/tests/features/view-entities/__snapshots__/view-entities.postgres.test.ts.snap
@@ -1,5 +1,96 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`Materialized view entities (postgres) > schema generator should create materialized views 1`] = `
+"set names 'utf8';
+
+create table "book_tag2" ("id" bigserial primary key, "name" varchar(50) not null);
+
+create table "foo_baz2" ("id" serial primary key, "name" varchar(255) not null, "code" varchar(255) not null, "version" timestamptz(3) not null default current_timestamp(3));
+
+create table "foo_bar2" ("id" serial primary key, "name" varchar(255) not null, "name with space" varchar(255) null, "baz_id" int null, "foo_bar_id" int null, "version" timestamptz(0) not null default current_timestamp(0), "blob" bytea null, "blob2" bytea null, "array" text[] null, "object_property" jsonb null);
+alter table "foo_bar2" add constraint "foo_bar2_baz_id_unique" unique ("baz_id");
+alter table "foo_bar2" add constraint "foo_bar2_foo_bar_id_unique" unique ("foo_bar_id");
+
+create table "publisher2" ("id" serial primary key, "name" varchar(255) not null default 'asd', "type" text not null default 'local', "type2" text not null default 'LOCAL', "enum1" smallint null, "enum2" smallint null, "enum3" smallint null, "enum4" text null, "enum5" text null);
+alter table "publisher2" add constraint "publisher2_type_check" check ("type" in ('local', 'global'));
+alter table "publisher2" add constraint "publisher2_type2_check" check ("type2" in ('LOCAL', 'GLOBAL'));
+alter table "publisher2" add constraint "publisher2_enum4_check" check ("enum4" in ('a', 'b', 'c'));
+alter table "publisher2" add constraint "publisher2_enum5_check" check ("enum5" in ('a'));
+
+create table "author2" ("id" serial primary key, "created_at" timestamptz(3) not null default current_timestamp(3), "updated_at" timestamptz(3) not null default current_timestamp(3), "name" varchar(255) not null, "email" varchar(255) not null, "age" int null, "terms_accepted" boolean not null default false, "optional" boolean null, "identities" text[] null, "born" date null, "born_time" time(0) null, "favourite_book_uuid_pk" uuid null, "favourite_author_id" int null, "identity" jsonb null);
+create index "custom_email_index_name" on "author2" ("email");
+alter table "author2" add constraint "custom_email_unique_name" unique ("email");
+create index "author2_terms_accepted_index" on "author2" ("terms_accepted");
+create index "author2_born_index" on "author2" ("born");
+create index "born_time_idx" on "author2" ("born_time");
+create index "custom_idx_name_123" on "author2" ("name");
+create index "author2_name_age_index" on "author2" ("name", "age");
+alter table "author2" add constraint "author2_name_email_unique" unique ("name", "email");
+
+create table "book2" ("uuid_pk" uuid not null, "created_at" timestamptz(3) not null default current_timestamp(3), "isbn" char(13) null, "title" varchar(255) null default '', "perex" text null, "price" numeric(8,2) null, "double" double precision null, "meta" jsonb null, "author_id" int not null, "publisher_id" int null, primary key ("uuid_pk"));
+alter table "book2" add constraint "book2_isbn_unique" unique ("isbn");
+create index "book2_title_index" on "public"."book2" using gin(to_tsvector('simple', "title"));
+
+create table "book2_tags" ("order" serial primary key, "book2_uuid_pk" uuid not null, "book_tag2_id" bigint not null);
+
+create table "book_to_tag_unordered" ("book2_uuid_pk" uuid not null, "book_tag2_id" bigint not null, primary key ("book2_uuid_pk", "book_tag2_id"));
+
+create table "author2_following" ("author2_1_id" int not null, "author2_2_id" int not null, primary key ("author2_1_id", "author2_2_id"));
+
+create table "author_to_friend" ("author2_1_id" int not null, "author2_2_id" int not null, primary key ("author2_1_id", "author2_2_id"));
+
+create table "address2" ("author_id" int not null, "value" varchar(255) not null, primary key ("author_id"));
+comment on table "address2" is 'This is address table';
+comment on column "address2"."value" is 'This is address property';
+
+create table "test2" ("id" serial primary key, "name" varchar(255) null, "book_uuid_pk" uuid null, "parent_id" int null, "version" int not null default 1);
+alter table "test2" add constraint "test2_book_uuid_pk_unique" unique ("book_uuid_pk");
+
+create table "publisher2_tests" ("id" serial primary key, "publisher2_id" int not null, "test2_id" int not null);
+
+create table "configuration2" ("property" varchar(255) not null, "test_id" int not null, "value" varchar(255) not null, primary key ("property", "test_id"));
+
+create table "test2_bars" ("test2_id" int not null, "foo_bar2_id" int not null, primary key ("test2_id", "foo_bar2_id"));
+
+alter table "foo_bar2" add constraint "foo_bar2_baz_id_foreign" foreign key ("baz_id") references "foo_baz2" ("id") on delete set null;
+alter table "foo_bar2" add constraint "foo_bar2_foo_bar_id_foreign" foreign key ("foo_bar_id") references "foo_bar2" ("id") on delete set null;
+
+alter table "author2" add constraint "author2_favourite_book_uuid_pk_foreign" foreign key ("favourite_book_uuid_pk") references "book2" ("uuid_pk") on update no action on delete cascade;
+alter table "author2" add constraint "author2_favourite_author_id_foreign" foreign key ("favourite_author_id") references "author2" ("id") on delete set null;
+
+alter table "book2" add constraint "book2_author_id_foreign" foreign key ("author_id") references "author2" ("id");
+alter table "book2" add constraint "book2_publisher_id_foreign" foreign key ("publisher_id") references "publisher2" ("id") on delete set null;
+
+alter table "book2_tags" add constraint "book2_tags_book2_uuid_pk_foreign" foreign key ("book2_uuid_pk") references "book2" ("uuid_pk") on update cascade on delete cascade;
+alter table "book2_tags" add constraint "book2_tags_book_tag2_id_foreign" foreign key ("book_tag2_id") references "book_tag2" ("id") on update cascade on delete cascade;
+
+alter table "book_to_tag_unordered" add constraint "book_to_tag_unordered_book2_uuid_pk_foreign" foreign key ("book2_uuid_pk") references "book2" ("uuid_pk") on update cascade on delete cascade;
+alter table "book_to_tag_unordered" add constraint "book_to_tag_unordered_book_tag2_id_foreign" foreign key ("book_tag2_id") references "book_tag2" ("id") on update cascade on delete cascade;
+
+alter table "author2_following" add constraint "author2_following_author2_1_id_foreign" foreign key ("author2_1_id") references "author2" ("id") on update cascade on delete cascade;
+alter table "author2_following" add constraint "author2_following_author2_2_id_foreign" foreign key ("author2_2_id") references "author2" ("id") on update cascade on delete cascade;
+
+alter table "author_to_friend" add constraint "author_to_friend_author2_1_id_foreign" foreign key ("author2_1_id") references "author2" ("id") on update cascade on delete cascade;
+alter table "author_to_friend" add constraint "author_to_friend_author2_2_id_foreign" foreign key ("author2_2_id") references "author2" ("id") on update cascade on delete cascade;
+
+alter table "address2" add constraint "address2_author_id_foreign" foreign key ("author_id") references "author2" ("id") on update cascade on delete cascade;
+
+alter table "test2" add constraint "test2_book_uuid_pk_foreign" foreign key ("book_uuid_pk") references "book2" ("uuid_pk") on delete set null;
+alter table "test2" add constraint "test2_parent_id_foreign" foreign key ("parent_id") references "test2" ("id") on delete set null;
+
+alter table "publisher2_tests" add constraint "publisher2_tests_publisher2_id_foreign" foreign key ("publisher2_id") references "publisher2" ("id") on update cascade on delete cascade;
+alter table "publisher2_tests" add constraint "publisher2_tests_test2_id_foreign" foreign key ("test2_id") references "test2" ("id") on update cascade on delete cascade;
+
+alter table "configuration2" add constraint "configuration2_test_id_foreign" foreign key ("test_id") references "test2" ("id");
+
+alter table "test2_bars" add constraint "test2_bars_test2_id_foreign" foreign key ("test2_id") references "test2" ("id") on update cascade on delete cascade;
+alter table "test2_bars" add constraint "test2_bars_foo_bar2_id_foreign" foreign key ("foo_bar2_id") references "foo_bar2" ("id") on update cascade on delete cascade;
+
+create materialized view "author_stats_nodata_matview" as select min(name) as name, count(*)::int as book_count from author2 a group by a.id with no data;
+create materialized view "author_stats_matview" as select min(name) as name, (select count(*)::int from book2 b where b.author_id = a.id) as book_count from author2 a group by a.id with data;
+"
+`;
+
 exports[`View entities (postgres) > schema generator should create views 1`] = `
 "set names 'utf8';
 

--- a/tests/features/view-entities/view-entities.validation.test.ts
+++ b/tests/features/view-entities/view-entities.validation.test.ts
@@ -19,6 +19,22 @@ describe('View entity validation', () => {
     })).rejects.toThrow(/view.*expression/i);
   });
 
+  test('materialized view entity without `view: true` should throw', async () => {
+    @Entity({ tableName: 'invalid_view', materialized: true })
+    class InvalidView2 {
+
+      @PrimaryKey()
+      id!: number;
+
+    }
+
+    await expect(MikroORM.init({
+      entities: [InvalidView2],
+      dbName: ':memory:',
+      metadataProvider: ReflectMetadataProvider,
+    })).rejects.toThrow(`Entity InvalidView2 has 'materialized: true' but is missing 'view: true'. Materialized views must also be marked as views.`);
+  });
+
   test('view entity with expression should be valid', async () => {
     const ValidView = defineEntity({
       name: 'ValidView',


### PR DESCRIPTION
```ts
@Entity({
  tableName: 'author_stats_mat_view',
  view: true,
  materialized: true,
  expression: `
    select a.name, count(b.id) as book_count
    from author a
    left join book b on b.author_id = a.id
    group by a.id, a.name
  `,
})
export class AuthorStatsMatView {
  @PrimaryKey()
  name!: string;
  
  @Property()
  bookCount!: number;
}
```

Related: #672