### PR TITLE
feat(core): add support for polymorphic relations

### DIFF
--- a/docs/docs/inheritance-mapping.md
+++ b/docs/docs/inheritance-mapping.md
@@ -549,3 +549,15 @@ This strategy is very efficient for querying across all types in the hierarchy o
 For Single-Table-Inheritance to work in scenarios where you are using either a legacy database schema or a self-written database schema, you have to make sure that all columns that are not in the root entity but in any of the different sub-entities has to allow null values. Columns that have NOT NULL constraints have to be on the root entity of the single-table inheritance hierarchy.
 
 > This part of documentation is highly inspired by [doctrine docs](https://www.doctrine-project.org/projects/doctrine-orm/en/latest/reference/inheritance-mapping.html) as the behaviour here is pretty much the same.
+
+## See also: Polymorphic Relations
+
+If you need a relationship that can point to multiple unrelated entity types (each with their own table), consider using [Polymorphic Relations](./relationships.md#polymorphic-relations) instead of inheritance.
+
+| Feature      | Single Table Inheritance                         | Polymorphic Relations                           |
+|--------------|--------------------------------------------------|-------------------------------------------------|
+| Storage      | Single table for all types                       | Each type has its own table                     |
+| Use case     | Entities share common fields/behavior            | Flexible FK to unrelated entities               |
+| Inheritance  | Required (common base class)                     | Not required                                    |
+| Foreign keys | Native FK constraints with referential integrity | No FK constraints (no database-level integrity) |
+| Example      | `Cat`, `Dog` extending `Animal`                  | `Like` pointing to `Post` or `Comment`          |

--- a/docs/docs/naming-strategy.md
+++ b/docs/docs/naming-strategy.md
@@ -146,3 +146,9 @@ Returns the property name for a many-to-many relation. Used in the `EntityGenera
 For example, with a pivot table `author_books` and owner table `author`, the default implementation returns `books`.
 
 ---
+
+#### `NamingStrategy.discriminatorColumnName(baseName: string): string`
+
+Returns the discriminator column name for polymorphic relations. The `baseName` is the discriminator property base name (e.g., `likeable`), and the default implementation appends `Type` and converts to column format (e.g., `likeable_type`).
+
+---

--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -466,8 +466,11 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
   }
 
   protected async getJoinedFilters<Entity extends object>(meta: EntityMetadata<Entity>, options: FindOptions<Entity, any, any, any> | FindOneOptions<Entity, any, any, any>): Promise<ObjectQuery<Entity> | undefined> {
+    // If user provided populateFilter, merge it with computed filters
+    const userFilter = options.populateFilter;
+
     if (!this.config.get('filtersOnRelations') || !options.populate) {
-      return undefined;
+      return userFilter;
     }
 
     const ret = {} as ObjectQuery<Entity>;
@@ -507,7 +510,12 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
       }
     }
 
-    return ret;
+    // Merge user-provided populateFilter with computed filters
+    if (userFilter) {
+      Utils.merge(ret, userFilter);
+    }
+
+    return Utils.hasObjectKeys(ret) ? ret : undefined;
   }
 
   /**

--- a/packages/core/src/cache/FileCacheAdapter.ts
+++ b/packages/core/src/cache/FileCacheAdapter.ts
@@ -66,7 +66,16 @@ export class FileCacheAdapter implements SyncCacheAdapter {
   clear(): void {
     const path = this.path('*');
     const files = fs.glob(path);
-    files.forEach(file => unlinkSync(file));
+
+    for (const file of files) {
+      /* v8 ignore next */
+      try {
+        unlinkSync(file);
+      } catch {
+        // ignore if file is already gone
+      }
+    }
+
     this.cache = {};
   }
 

--- a/packages/core/src/entity/EntityHelper.ts
+++ b/packages/core/src/entity/EntityHelper.ts
@@ -217,7 +217,20 @@ export class EntityHelper {
   }
 
   static propagate<T extends object>(meta: EntityMetadata<T>, entity: T, owner: T, prop: EntityProperty<T>, value?: T[keyof T & string], old?: T): void {
-    for (const prop2 of prop.targetMeta!.bidirectionalRelations) {
+    // For polymorphic relations, get bidirectional relations from the actual entity's metadata
+    let bidirectionalRelations: EntityProperty<T>[];
+    if (prop.polymorphic && prop.polymorphTargets?.length) {
+      // For polymorphic relations, we need to get the bidirectional relations from the actual value's metadata
+      if (!value) {
+        return; // No value means no propagation needed
+      }
+
+      bidirectionalRelations = helper(value).__meta.bidirectionalRelations as EntityProperty<T>[];
+    } else {
+      bidirectionalRelations = prop.targetMeta!.bidirectionalRelations;
+    }
+
+    for (const prop2 of bidirectionalRelations) {
       if ((prop2.inversedBy || prop2.mappedBy) !== prop.name) {
         continue;
       }

--- a/packages/core/src/entity/PolymorphicRef.ts
+++ b/packages/core/src/entity/PolymorphicRef.ts
@@ -1,0 +1,20 @@
+import { Utils } from '../utils/Utils.js';
+
+/**
+ * Wrapper class for polymorphic relation reference data.
+ * Holds the discriminator value (type identifier) and the primary key value(s).
+ * Used internally to track polymorphic FK values before hydration.
+ */
+export class PolymorphicRef {
+
+  constructor(
+    public readonly discriminator: string,
+    public id: unknown,
+  ) {}
+
+  /** Returns `[discriminator, ...idValues]` tuple suitable for column-level expansion. */
+  toTuple(): unknown[] {
+    return [this.discriminator, ...Utils.asArray(this.id)];
+  }
+
+}

--- a/packages/core/src/entity/defineEntity.ts
+++ b/packages/core/src/entity/defineEntity.ts
@@ -498,6 +498,16 @@ export class UniversalPropertyOptionsBuilder<Value, Options, IncludeKeys extends
     return this.assignOptions({ owner });
   }
 
+  /** For polymorphic relations. Specifies the property name that stores the entity type discriminator. Defaults to the property name. */
+  discriminator(discriminator: string): Pick<UniversalPropertyOptionsBuilder<Value, Options, IncludeKeys>, IncludeKeys> {
+    return this.assignOptions({ discriminator });
+  }
+
+  /** For polymorphic relations. Custom mapping of discriminator values to entity class names. */
+  discriminatorMap(discriminatorMap: Dictionary<string>): Pick<UniversalPropertyOptionsBuilder<Value, Options, IncludeKeys>, IncludeKeys> {
+    return this.assignOptions({ discriminatorMap });
+  }
+
   /** Point to the inverse side property name. */
   inversedBy(inversedBy: keyof Value | ((e: Value) => any)): Pick<UniversalPropertyOptionsBuilder<Value, Options, IncludeKeys>, IncludeKeys> {
     return this.assignOptions({ inversedBy });
@@ -688,8 +698,8 @@ const propertyBuilders = {
       kind: 'm:n',
     }),
 
-  manyToOne: <Target extends EntityTarget>(target: Target) =>
-    new UniversalPropertyOptionsBuilder<InferEntity<Target>, EmptyOptions & { kind: 'm:1' }, IncludeKeysForManyToOneOptions>({
+  manyToOne: <Target extends EntityTarget | EntityTarget[]>(target: Target) =>
+    new UniversalPropertyOptionsBuilder<InferEntity<Target extends (infer T)[] ? T : Target>, EmptyOptions & { kind: 'm:1' }, IncludeKeysForManyToOneOptions>({
       entity: () => target as any,
       kind: 'm:1',
     }),
@@ -700,8 +710,8 @@ const propertyBuilders = {
       kind: '1:m',
     }),
 
-  oneToOne: <Target extends EntityTarget>(target: Target) =>
-    new UniversalPropertyOptionsBuilder<InferEntity<Target>, EmptyOptions & { kind: '1:1' }, IncludeKeysForOneToOneOptions>({
+  oneToOne: <Target extends EntityTarget | EntityTarget[]>(target: Target) =>
+    new UniversalPropertyOptionsBuilder<InferEntity<Target extends (infer T)[] ? T : Target>, EmptyOptions & { kind: '1:1' }, IncludeKeysForOneToOneOptions>({
       entity: () => target as any,
       kind: '1:1',
     }),

--- a/packages/core/src/entity/index.ts
+++ b/packages/core/src/entity/index.ts
@@ -1,5 +1,6 @@
 export * from './EntityRepository.js';
 export * from './EntityIdentifier.js';
+export * from './PolymorphicRef.js';
 export * from './EntityAssigner.js';
 export * from './EntityHelper.js';
 export * from './EntityFactory.js';

--- a/packages/core/src/entity/utils.ts
+++ b/packages/core/src/entity/utils.ts
@@ -6,7 +6,7 @@ import { Utils } from '../utils/Utils.js';
  * Expands `books.perex` like populate to use `children` array instead of the dot syntax
  */
 function expandNestedPopulate<Entity>(parentProp: EntityProperty, parts: string[], strategy?: LoadStrategy, all?: boolean): PopulateOptions<Entity> {
-  const meta = parentProp.targetMeta! as EntityMetadata<Entity>;
+  const meta = parentProp.targetMeta as EntityMetadata<Entity>;
   const field = parts.shift()! as EntityKey<Entity>;
   const prop = meta.properties[field];
   const ret = { field, strategy, all } as PopulateOptions<Entity>;

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -297,12 +297,18 @@ export class MetadataError<T extends AnyEntity = AnyEntity> extends ValidationEr
     return this.fromMessage(meta, prop, `uses 'targetKey' option which is not supported for ManyToMany relations`);
   }
 
-  static targetKeyNotUnique(meta: EntityMetadata, prop: EntityProperty) {
-    return this.fromMessage(meta, prop, `has 'targetKey' set to '${prop.targetKey}', but ${prop.type}.${prop.targetKey} is not marked as unique. The target property must have a unique constraint.`);
+  static targetKeyNotUnique(meta: EntityMetadata, prop: EntityProperty, target?: EntityMetadata) {
+    const targetName = target?.className ?? prop.type;
+    return this.fromMessage(meta, prop, `has 'targetKey' set to '${prop.targetKey}', but ${targetName}.${prop.targetKey} is not marked as unique`);
   }
 
-  static targetKeyNotFound(meta: EntityMetadata, prop: EntityProperty) {
-    return this.fromMessage(meta, prop, `has 'targetKey' set to '${prop.targetKey}', but ${prop.type}.${prop.targetKey} does not exist`);
+  static targetKeyNotFound(meta: EntityMetadata, prop: EntityProperty, target?: EntityMetadata) {
+    const targetName = target?.className ?? prop.type;
+    return this.fromMessage(meta, prop, `has 'targetKey' set to '${prop.targetKey}', but ${targetName}.${prop.targetKey} does not exist`);
+  }
+
+  static incompatiblePolymorphicTargets(meta: EntityMetadata, prop: EntityProperty, target1: EntityMetadata, target2: EntityMetadata, reason: string) {
+    return this.fromMessage(meta, prop, `has incompatible polymorphic targets ${target1.className} and ${target2.className}: ${reason}`);
   }
 
   static dangerousPropertyName(meta: EntityMetadata, prop: EntityProperty) {

--- a/packages/core/src/metadata/EntitySchema.ts
+++ b/packages/core/src/metadata/EntitySchema.ts
@@ -34,7 +34,7 @@ import type {
 } from './types.js';
 
 type TypeType = string | NumberConstructor | StringConstructor | BooleanConstructor | DateConstructor | ArrayConstructor | Constructor<Type<any>> | Type<any>;
-type TypeDef<Target> = { type: TypeType } | { entity: () => EntityName<Target> };
+type TypeDef<Target> = { type: TypeType } | { entity: () => EntityName<Target> | EntityName[] };
 type EmbeddedTypeDef<Target> = { type: TypeType } | { entity: () => EntityName<Target> | EntityName[] };
 export type EntitySchemaProperty<Target, Owner> =
   | ({ kind: ReferenceKind.MANY_TO_ONE | 'm:1' } & TypeDef<Target> & ManyToOneOptions<Owner, Target>)
@@ -340,13 +340,13 @@ export class EntitySchema<Entity = any, Base = never, Class extends EntityCtor =
 
       switch (options.kind) {
         case ReferenceKind.ONE_TO_ONE:
-          this.addOneToOne<any>(name, options.type, options);
+          this.addOneToOne<any>(name, options.type, options as unknown as OneToOneOptions<any, any>);
           break;
         case ReferenceKind.ONE_TO_MANY:
           this.addOneToMany<any>(name, options.type, options);
           break;
         case ReferenceKind.MANY_TO_ONE:
-          this.addManyToOne<any>(name, options.type, options);
+          this.addManyToOne<any>(name, options.type, options as unknown as ManyToOneOptions<any, any>);
           break;
         case ReferenceKind.MANY_TO_MANY:
           this.addManyToMany<any>(name, options.type, options as unknown as ManyToManyOptions<any, any>);

--- a/packages/core/src/naming-strategy/AbstractNamingStrategy.ts
+++ b/packages/core/src/naming-strategy/AbstractNamingStrategy.ts
@@ -117,6 +117,13 @@ export abstract class AbstractNamingStrategy implements NamingStrategy {
     return this.columnNameToProperty(pivotTableName.replace(new RegExp('^' + ownerTableName + '_'), ''));
   }
 
+  /**
+   * @inheritDoc
+   */
+  discriminatorColumnName(baseName: string): string {
+    return this.propertyToColumnName(baseName + 'Type');
+  }
+
   abstract classToTableName(entityName: string, tableName?: string): string;
 
   abstract joinColumnName(propertyName: string): string;

--- a/packages/core/src/naming-strategy/NamingStrategy.ts
+++ b/packages/core/src/naming-strategy/NamingStrategy.ts
@@ -120,4 +120,9 @@ export interface NamingStrategy {
     schemaName?: string,
   ): string;
 
+  /**
+   * Returns the discriminator column name for polymorphic relations.
+   */
+  discriminatorColumnName(baseName: string): string;
+
 }

--- a/packages/core/src/unit-of-work/ChangeSetPersister.ts
+++ b/packages/core/src/unit-of-work/ChangeSetPersister.ts
@@ -1,6 +1,7 @@
 import type { MetadataStorage } from '../metadata/MetadataStorage.js';
 import type { AnyEntity, Dictionary, EntityData, EntityDictionary, EntityMetadata, EntityProperty, EntityKey, FilterQuery, IHydrator, IPrimaryKey } from '../typings.js';
 import { EntityIdentifier } from '../entity/EntityIdentifier.js';
+import { PolymorphicRef } from '../entity/PolymorphicRef.js';
 import { type Collection } from '../entity/Collection.js';
 import { type EntityFactory } from '../entity/EntityFactory.js';
 import { helper } from '../entity/wrap.js';
@@ -468,6 +469,13 @@ export class ChangeSetPersister {
 
     if (value instanceof EntityIdentifier) {
       changeSet.payload[prop.name] = value.getValue();
+      return;
+    }
+
+    if (value instanceof PolymorphicRef) {
+      if (value.id instanceof EntityIdentifier) {
+        value.id = value.id.getValue();
+      }
       return;
     }
 

--- a/packages/core/src/utils/Utils.ts
+++ b/packages/core/src/utils/Utils.ts
@@ -14,7 +14,7 @@ import { GroupOperator, PlainObject, QueryOperator, ReferenceKind } from '../enu
 import type { Collection } from '../entity/Collection.js';
 import type { Platform } from '../platforms/Platform.js';
 import { helper } from '../entity/wrap.js';
-import type { ScalarReference } from '../entity/Reference.js';
+import { Reference, type ScalarReference } from '../entity/Reference.js';
 import { Raw, type RawQueryFragmentSymbol } from './RawQueryFragment.js';
 
 function compareConstructors(a: any, b: any) {

--- a/packages/decorators/src/es/ManyToOne.ts
+++ b/packages/decorators/src/es/ManyToOne.ts
@@ -10,7 +10,7 @@ import {
 import { prepareMetadataContext, processDecoratorParameters } from '../utils.js';
 
 export function ManyToOne<Target extends object, Owner extends object>(
-  entity: ManyToOneOptions<Owner, Target> | ((e?: Owner) => EntityName<Target>) = {},
+  entity: ManyToOneOptions<Owner, Target> | ((e?: Owner) => EntityName<Target> | EntityName[]) = {},
   options: Partial<ManyToOneOptions<Owner, Target>> = {},
 ) {
   return function (_: unknown, context: ClassFieldDecoratorContext<Owner, Target | undefined | null | Ref<Target>>) {

--- a/packages/decorators/src/es/OneToOne.ts
+++ b/packages/decorators/src/es/OneToOne.ts
@@ -10,7 +10,7 @@ import {
 import { prepareMetadataContext, processDecoratorParameters } from '../utils.js';
 
 export function OneToOne<Target extends object, Owner extends object>(
-  entity?: OneToOneOptions<Owner, Target> | string | ((e: Owner) => EntityName<Target>),
+  entity?: OneToOneOptions<Owner, Target> | string | ((e: Owner) => EntityName<Target> | EntityName[]),
   mappedByOrOptions?: (string & keyof Target) | ((e: Target) => any) | Partial<OneToOneOptions<Owner, Target>>,
   options: Partial<OneToOneOptions<Owner, Target>> = {},
 ) {

--- a/packages/decorators/src/legacy/ManyToOne.ts
+++ b/packages/decorators/src/legacy/ManyToOne.ts
@@ -8,7 +8,7 @@ import {
 import { processDecoratorParameters, validateSingleDecorator, getMetadataFromDecorator } from '../utils.js';
 
 export function ManyToOne<Target extends object, Owner extends object>(
-  entity: (e?: any) => EntityName<Target>,
+  entity: (e?: any) => EntityName<Target> | EntityName[],
   options?: Partial<ManyToOneOptions<Owner, Target>>,
 ): (target: Owner, propertyName: string) => void;
 export function ManyToOne<Target extends object, Owner extends object>(
@@ -19,7 +19,7 @@ export function ManyToOne<Target extends object, Owner extends object>(
   options?: ManyToOneOptions<Owner, Target>,
 ): (target: Owner, propertyName: string) => void;
 export function ManyToOne<Target extends object, Owner extends object>(
-  entity: ManyToOneOptions<Owner, Target> | ((e?: any) => EntityName<Target>) = {},
+  entity: ManyToOneOptions<Owner, Target> | ((e?: any) => EntityName<Target> | EntityName[]) = {},
   options: Partial<ManyToOneOptions<Owner, Target>> = {},
 ) {
   return function (target: Owner, propertyName: keyof Owner) {

--- a/packages/decorators/src/legacy/OneToOne.ts
+++ b/packages/decorators/src/legacy/OneToOne.ts
@@ -9,7 +9,7 @@ import {
 import { processDecoratorParameters, validateSingleDecorator, getMetadataFromDecorator } from '../utils.js';
 
 export function OneToOne<Target, Owner>(
-  entity: ((e: Owner) => EntityName<Target>),
+  entity: ((e: Owner) => EntityName<Target> | EntityName[]),
   mappedByOrOptions?: (string & keyof Target) | ((e: Target) => any) | Partial<OneToOneOptions<Owner, Target>>,
   options?: Partial<OneToOneOptions<Owner, Target>>,
 ): (target: Owner, propertyName: string) => void;
@@ -17,7 +17,7 @@ export function OneToOne<Target, Owner>(
   entity?: OneToOneOptions<Owner, Target>,
 ): (target: Owner, propertyName: string) => void;
 export function OneToOne<Target, Owner>(
-  entity?: OneToOneOptions<Owner, Target> | ((e: Owner) => EntityName<Target>),
+  entity?: OneToOneOptions<Owner, Target> | ((e: Owner) => EntityName<Target> | EntityName[]),
   mappedByOrOptions?: (string & keyof Target) | ((e: Target) => any) | Partial<OneToOneOptions<Owner, Target>>,
   options: Partial<OneToOneOptions<Owner, Target>> = {},
 ) {

--- a/packages/sql/src/schema/DatabaseTable.ts
+++ b/packages/sql/src/schema/DatabaseTable.ts
@@ -141,7 +141,7 @@ export class DatabaseTable {
       this.columns[field].default = defaultValue as string;
     });
 
-    if ([ReferenceKind.MANY_TO_ONE, ReferenceKind.ONE_TO_ONE].includes(prop.kind)) {
+    if ([ReferenceKind.MANY_TO_ONE, ReferenceKind.ONE_TO_ONE].includes(prop.kind) && !prop.polymorphic) {
       const constraintName = this.getIndexName(prop.foreignKeyName ?? true, prop.fieldNames, 'foreign');
       let schema = prop.targetMeta!.root.schema === '*' ? this.schema : (prop.targetMeta!.root.schema ?? config.get('schema', this.platform.getDefaultSchemaName()));
 

--- a/tests/features/cli/__snapshots__/CompileCommand.test.ts.snap
+++ b/tests/features/cli/__snapshots__/CompileCommand.test.ts.snap
@@ -4,7 +4,7 @@ exports[`CompileCommand > handler generates CJS output 1`] = `
 "'use strict';
 module.exports = {
   __version: '[[MIKRO_ORM_VERSION]]',
-  'hydrator-user_0-full-false': function(isPrimaryKey, Collection, Reference) {
+  'hydrator-user_0-full-false': function(isPrimaryKey, Collection, Reference, PolymorphicRef, ValidationError) {
     // compiled hydrator for entity User ( normalized)
     return function(entity, data, factory, newEntity, convertCustomTypes, schema, parentSchema, normalizeAccessors) {
       if (data.id === null) {
@@ -19,7 +19,7 @@ module.exports = {
       }
     }
   },
-  'hydrator-user_0-full-true': function(isPrimaryKey, Collection, Reference) {
+  'hydrator-user_0-full-true': function(isPrimaryKey, Collection, Reference, PolymorphicRef, ValidationError) {
     // compiled hydrator for entity User ( normalized)
     return function(entity, data, factory, newEntity, convertCustomTypes, schema, parentSchema, normalizeAccessors) {
       if (data.id === null) {
@@ -77,7 +77,7 @@ module.exports = {
       return ret;
     }
   },
-  'resultMapper-user_0': function() {
+  'resultMapper-user_0': function(PolymorphicRef) {
     // compiled mapper for entity User
     return function(result) {
       const ret = {};
@@ -94,7 +94,7 @@ module.exports = {
       return ret;
     }
   },
-  'hydrator-user_0-reference-false': function(isPrimaryKey, Collection, Reference) {
+  'hydrator-user_0-reference-false': function(isPrimaryKey, Collection, Reference, PolymorphicRef, ValidationError) {
     // compiled hydrator for entity User ( normalized)
     return function(entity, data, factory, newEntity, convertCustomTypes, schema, parentSchema, normalizeAccessors) {
       if (data.id === null) {
@@ -104,7 +104,7 @@ module.exports = {
       }
     }
   },
-  'hydrator-user_0-reference-true': function(isPrimaryKey, Collection, Reference) {
+  'hydrator-user_0-reference-true': function(isPrimaryKey, Collection, Reference, PolymorphicRef, ValidationError) {
     // compiled hydrator for entity User ( normalized)
     return function(entity, data, factory, newEntity, convertCustomTypes, schema, parentSchema, normalizeAccessors) {
       if (data.id === null) {
@@ -132,7 +132,7 @@ module.exports = {
       return '' + entity.id;
     }
   },
-  'hydrator-undefined_1000-full-false': function(isPrimaryKey, Collection, Reference) {
+  'hydrator-undefined_1000-full-false': function(isPrimaryKey, Collection, Reference, PolymorphicRef, ValidationError) {
     // compiled hydrator for entity Address ( normalized)
     return function(entity, data, factory, newEntity, convertCustomTypes, schema, parentSchema, normalizeAccessors) {
       if (data.street === null) {
@@ -142,7 +142,7 @@ module.exports = {
       }
     }
   },
-  'hydrator-undefined_1000-full-true': function(isPrimaryKey, Collection, Reference) {
+  'hydrator-undefined_1000-full-true': function(isPrimaryKey, Collection, Reference, PolymorphicRef, ValidationError) {
     // compiled hydrator for entity Address ( normalized)
     return function(entity, data, factory, newEntity, convertCustomTypes, schema, parentSchema, normalizeAccessors) {
       if (data.street === null) {
@@ -181,7 +181,7 @@ module.exports = {
       return ret;
     }
   },
-  'resultMapper-undefined_1000': function() {
+  'resultMapper-undefined_1000': function(PolymorphicRef) {
     // compiled mapper for entity Address
     return function(result) {
       const ret = {};
@@ -201,7 +201,7 @@ module.exports = {
 exports[`CompileCommand > handler generates ESM output when project uses type=module 1`] = `
 "export default {
   __version: '[[MIKRO_ORM_VERSION]]',
-  'hydrator-user_2000-full-false': function(isPrimaryKey, Collection, Reference) {
+  'hydrator-user_2000-full-false': function(isPrimaryKey, Collection, Reference, PolymorphicRef, ValidationError) {
     // compiled hydrator for entity User ( normalized)
     return function(entity, data, factory, newEntity, convertCustomTypes, schema, parentSchema, normalizeAccessors) {
       if (data.id === null) {
@@ -216,7 +216,7 @@ exports[`CompileCommand > handler generates ESM output when project uses type=mo
       }
     }
   },
-  'hydrator-user_2000-full-true': function(isPrimaryKey, Collection, Reference) {
+  'hydrator-user_2000-full-true': function(isPrimaryKey, Collection, Reference, PolymorphicRef, ValidationError) {
     // compiled hydrator for entity User ( normalized)
     return function(entity, data, factory, newEntity, convertCustomTypes, schema, parentSchema, normalizeAccessors) {
       if (data.id === null) {
@@ -274,7 +274,7 @@ exports[`CompileCommand > handler generates ESM output when project uses type=mo
       return ret;
     }
   },
-  'resultMapper-user_2000': function() {
+  'resultMapper-user_2000': function(PolymorphicRef) {
     // compiled mapper for entity User
     return function(result) {
       const ret = {};
@@ -291,7 +291,7 @@ exports[`CompileCommand > handler generates ESM output when project uses type=mo
       return ret;
     }
   },
-  'hydrator-user_2000-reference-false': function(isPrimaryKey, Collection, Reference) {
+  'hydrator-user_2000-reference-false': function(isPrimaryKey, Collection, Reference, PolymorphicRef, ValidationError) {
     // compiled hydrator for entity User ( normalized)
     return function(entity, data, factory, newEntity, convertCustomTypes, schema, parentSchema, normalizeAccessors) {
       if (data.id === null) {
@@ -301,7 +301,7 @@ exports[`CompileCommand > handler generates ESM output when project uses type=mo
       }
     }
   },
-  'hydrator-user_2000-reference-true': function(isPrimaryKey, Collection, Reference) {
+  'hydrator-user_2000-reference-true': function(isPrimaryKey, Collection, Reference, PolymorphicRef, ValidationError) {
     // compiled hydrator for entity User ( normalized)
     return function(entity, data, factory, newEntity, convertCustomTypes, schema, parentSchema, normalizeAccessors) {
       if (data.id === null) {
@@ -329,7 +329,7 @@ exports[`CompileCommand > handler generates ESM output when project uses type=mo
       return '' + entity.id;
     }
   },
-  'hydrator-undefined_3000-full-false': function(isPrimaryKey, Collection, Reference) {
+  'hydrator-undefined_3000-full-false': function(isPrimaryKey, Collection, Reference, PolymorphicRef, ValidationError) {
     // compiled hydrator for entity Address ( normalized)
     return function(entity, data, factory, newEntity, convertCustomTypes, schema, parentSchema, normalizeAccessors) {
       if (data.street === null) {
@@ -339,7 +339,7 @@ exports[`CompileCommand > handler generates ESM output when project uses type=mo
       }
     }
   },
-  'hydrator-undefined_3000-full-true': function(isPrimaryKey, Collection, Reference) {
+  'hydrator-undefined_3000-full-true': function(isPrimaryKey, Collection, Reference, PolymorphicRef, ValidationError) {
     // compiled hydrator for entity Address ( normalized)
     return function(entity, data, factory, newEntity, convertCustomTypes, schema, parentSchema, normalizeAccessors) {
       if (data.street === null) {
@@ -378,7 +378,7 @@ exports[`CompileCommand > handler generates ESM output when project uses type=mo
       return ret;
     }
   },
-  'resultMapper-undefined_3000': function() {
+  'resultMapper-undefined_3000': function(PolymorphicRef) {
     // compiled mapper for entity Address
     return function(result) {
       const ret = {};

--- a/tests/features/embeddables/__snapshots__/entities-in-embeddables.mongo.test.ts.snap
+++ b/tests/features/embeddables/__snapshots__/entities-in-embeddables.mongo.test.ts.snap
@@ -323,7 +323,7 @@ exports[`embedded entities in mongo > diffing 2`] = `
           if (isPrimaryKey(data.profile1_identity_meta_source, true)) {
             entity.profile1.identity.meta.source = factory.createReference(source_9, data.profile1_identity_meta_source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
           } else if (data.profile1_identity_meta_source && typeof data.profile1_identity_meta_source === 'object') {
-            entity.profile1.identity.meta.source = factory.create(source_9, data.profile1_identity_meta_source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
+            entity.profile1.identity.meta.source = factory.create(source_10, data.profile1_identity_meta_source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
           }
         }
       } else if (data.profile1_identity_meta_foo === null && data.profile1_identity_meta_bar === null && data.profile1_identity_meta_source === null) {
@@ -332,7 +332,7 @@ exports[`embedded entities in mongo > diffing 2`] = `
       if (data.profile1_identity_meta != null) {
         const embeddedData = data.profile1_identity_meta;
         if (entity.profile1.identity.meta == null) {
-          entity.profile1.identity.meta = factory.createEmbeddable(identity_meta_10, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+          entity.profile1.identity.meta = factory.createEmbeddable(identity_meta_11, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
         }
         if (data.profile1_identity_meta.foo === null) {
           entity.profile1.identity.meta.foo = null;
@@ -348,9 +348,9 @@ exports[`embedded entities in mongo > diffing 2`] = `
     entity.profile1.identity.meta.source = null;
         } else if (typeof data.profile1_identity_meta.source !== 'undefined') {
           if (isPrimaryKey(data.profile1_identity_meta.source, true)) {
-            entity.profile1.identity.meta.source = factory.createReference(source_13, data.profile1_identity_meta.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
+            entity.profile1.identity.meta.source = factory.createReference(source_14, data.profile1_identity_meta.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
           } else if (data.profile1_identity_meta.source && typeof data.profile1_identity_meta.source === 'object') {
-            entity.profile1.identity.meta.source = factory.create(source_13, data.profile1_identity_meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
+            entity.profile1.identity.meta.source = factory.create(source_15, data.profile1_identity_meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
           }
         }
       } else if (data.profile1_identity_meta === null) {
@@ -358,98 +358,98 @@ exports[`embedded entities in mongo > diffing 2`] = `
       }
       if (Array.isArray(data.profile1_identity_links)) {
         entity.profile1.identity.links = [];
-        data.profile1_identity_links.forEach((_, idx_14) => {
-          if (data.profile1_identity_links[idx_14] != null) {
-            const embeddedData = data.profile1_identity_links[idx_14];
-            if (entity.profile1.identity.links[idx_14] == null) {
-              entity.profile1.identity.links[idx_14] = factory.createEmbeddable(identity_link_15, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+        data.profile1_identity_links.forEach((_, idx_16) => {
+          if (data.profile1_identity_links[idx_16] != null) {
+            const embeddedData = data.profile1_identity_links[idx_16];
+            if (entity.profile1.identity.links[idx_16] == null) {
+              entity.profile1.identity.links[idx_16] = factory.createEmbeddable(identity_link_17, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
             }
-            if (data.profile1_identity_links[idx_14].url === null) {
-              entity.profile1.identity.links[idx_14].url = null;
-            } else if (typeof data.profile1_identity_links[idx_14].url !== 'undefined') {
-              entity.profile1.identity.links[idx_14].url = data.profile1_identity_links[idx_14].url;
+            if (data.profile1_identity_links[idx_16].url === null) {
+              entity.profile1.identity.links[idx_16].url = null;
+            } else if (typeof data.profile1_identity_links[idx_16].url !== 'undefined') {
+              entity.profile1.identity.links[idx_16].url = data.profile1_identity_links[idx_16].url;
             }
-            if (data.profile1_identity_links[idx_14].createdAt === null) {
-              entity.profile1.identity.links[idx_14].createdAt = null;
-            } else if (typeof data.profile1_identity_links[idx_14].createdAt !== 'undefined') {
-              if (data.profile1_identity_links[idx_14].createdAt instanceof Date) {
-                entity.profile1.identity.links[idx_14].createdAt = data.profile1_identity_links[idx_14].createdAt;
-              } else if (typeof data.profile1_identity_links[idx_14].createdAt === 'number' || data.profile1_identity_links[idx_14].createdAt.includes('+') || data.profile1_identity_links[idx_14].createdAt.lastIndexOf('-') > 10 || data.profile1_identity_links[idx_14].createdAt.endsWith('Z')) {
-                entity.profile1.identity.links[idx_14].createdAt = new Date(data.profile1_identity_links[idx_14].createdAt);
+            if (data.profile1_identity_links[idx_16].createdAt === null) {
+              entity.profile1.identity.links[idx_16].createdAt = null;
+            } else if (typeof data.profile1_identity_links[idx_16].createdAt !== 'undefined') {
+              if (data.profile1_identity_links[idx_16].createdAt instanceof Date) {
+                entity.profile1.identity.links[idx_16].createdAt = data.profile1_identity_links[idx_16].createdAt;
+              } else if (typeof data.profile1_identity_links[idx_16].createdAt === 'number' || data.profile1_identity_links[idx_16].createdAt.includes('+') || data.profile1_identity_links[idx_16].createdAt.lastIndexOf('-') > 10 || data.profile1_identity_links[idx_16].createdAt.endsWith('Z')) {
+                entity.profile1.identity.links[idx_16].createdAt = new Date(data.profile1_identity_links[idx_16].createdAt);
               } else {
-                entity.profile1.identity.links[idx_14].createdAt = new Date(data.profile1_identity_links[idx_14].createdAt + 'Z');
+                entity.profile1.identity.links[idx_16].createdAt = new Date(data.profile1_identity_links[idx_16].createdAt + 'Z');
               }
             }
-            if (data.profile1_identity_links[idx_14].meta != null) {
-              const embeddedData = data.profile1_identity_links[idx_14].meta;
-              if (entity.profile1.identity.links[idx_14].meta == null) {
-                entity.profile1.identity.links[idx_14].meta = factory.createEmbeddable(identity_meta_18, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+            if (data.profile1_identity_links[idx_16].meta != null) {
+              const embeddedData = data.profile1_identity_links[idx_16].meta;
+              if (entity.profile1.identity.links[idx_16].meta == null) {
+                entity.profile1.identity.links[idx_16].meta = factory.createEmbeddable(identity_meta_20, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
               }
-              if (data.profile1_identity_links[idx_14].meta.foo === null) {
-                entity.profile1.identity.links[idx_14].meta.foo = null;
-              } else if (typeof data.profile1_identity_links[idx_14].meta.foo !== 'undefined') {
-                entity.profile1.identity.links[idx_14].meta.foo = data.profile1_identity_links[idx_14].meta.foo;
+              if (data.profile1_identity_links[idx_16].meta.foo === null) {
+                entity.profile1.identity.links[idx_16].meta.foo = null;
+              } else if (typeof data.profile1_identity_links[idx_16].meta.foo !== 'undefined') {
+                entity.profile1.identity.links[idx_16].meta.foo = data.profile1_identity_links[idx_16].meta.foo;
               }
-              if (data.profile1_identity_links[idx_14].meta.bar === null) {
-                entity.profile1.identity.links[idx_14].meta.bar = null;
-              } else if (typeof data.profile1_identity_links[idx_14].meta.bar !== 'undefined') {
-                entity.profile1.identity.links[idx_14].meta.bar = data.profile1_identity_links[idx_14].meta.bar;
+              if (data.profile1_identity_links[idx_16].meta.bar === null) {
+                entity.profile1.identity.links[idx_16].meta.bar = null;
+              } else if (typeof data.profile1_identity_links[idx_16].meta.bar !== 'undefined') {
+                entity.profile1.identity.links[idx_16].meta.bar = data.profile1_identity_links[idx_16].meta.bar;
               }
-              if (data.profile1_identity_links[idx_14].meta.source === null) {
-    entity.profile1.identity.links[idx_14].meta.source = null;
-              } else if (typeof data.profile1_identity_links[idx_14].meta.source !== 'undefined') {
-                if (isPrimaryKey(data.profile1_identity_links[idx_14].meta.source, true)) {
-                  entity.profile1.identity.links[idx_14].meta.source = factory.createReference(source_21, data.profile1_identity_links[idx_14].meta.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
-                } else if (data.profile1_identity_links[idx_14].meta.source && typeof data.profile1_identity_links[idx_14].meta.source === 'object') {
-                  entity.profile1.identity.links[idx_14].meta.source = factory.create(source_21, data.profile1_identity_links[idx_14].meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
+              if (data.profile1_identity_links[idx_16].meta.source === null) {
+    entity.profile1.identity.links[idx_16].meta.source = null;
+              } else if (typeof data.profile1_identity_links[idx_16].meta.source !== 'undefined') {
+                if (isPrimaryKey(data.profile1_identity_links[idx_16].meta.source, true)) {
+                  entity.profile1.identity.links[idx_16].meta.source = factory.createReference(source_23, data.profile1_identity_links[idx_16].meta.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
+                } else if (data.profile1_identity_links[idx_16].meta.source && typeof data.profile1_identity_links[idx_16].meta.source === 'object') {
+                  entity.profile1.identity.links[idx_16].meta.source = factory.create(source_24, data.profile1_identity_links[idx_16].meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
                 }
               }
-            } else if (data.profile1_identity_links[idx_14].meta === null) {
-              entity.profile1.identity.links[idx_14].meta = null;
+            } else if (data.profile1_identity_links[idx_16].meta === null) {
+              entity.profile1.identity.links[idx_16].meta = null;
             }
-            if (Array.isArray(data.profile1_identity_links[idx_14].metas)) {
-              entity.profile1.identity.links[idx_14].metas = [];
-              data.profile1_identity_links[idx_14].metas.forEach((_, idx_22) => {
-                if (data.profile1_identity_links[idx_14].metas[idx_22] != null) {
-                  const embeddedData = data.profile1_identity_links[idx_14].metas[idx_22];
-                  if (entity.profile1.identity.links[idx_14].metas[idx_22] == null) {
-                    entity.profile1.identity.links[idx_14].metas[idx_22] = factory.createEmbeddable(identity_meta_23, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+            if (Array.isArray(data.profile1_identity_links[idx_16].metas)) {
+              entity.profile1.identity.links[idx_16].metas = [];
+              data.profile1_identity_links[idx_16].metas.forEach((_, idx_25) => {
+                if (data.profile1_identity_links[idx_16].metas[idx_25] != null) {
+                  const embeddedData = data.profile1_identity_links[idx_16].metas[idx_25];
+                  if (entity.profile1.identity.links[idx_16].metas[idx_25] == null) {
+                    entity.profile1.identity.links[idx_16].metas[idx_25] = factory.createEmbeddable(identity_meta_26, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
                   }
-                  if (data.profile1_identity_links[idx_14].metas[idx_22].foo === null) {
-                    entity.profile1.identity.links[idx_14].metas[idx_22].foo = null;
-                  } else if (typeof data.profile1_identity_links[idx_14].metas[idx_22].foo !== 'undefined') {
-                    entity.profile1.identity.links[idx_14].metas[idx_22].foo = data.profile1_identity_links[idx_14].metas[idx_22].foo;
+                  if (data.profile1_identity_links[idx_16].metas[idx_25].foo === null) {
+                    entity.profile1.identity.links[idx_16].metas[idx_25].foo = null;
+                  } else if (typeof data.profile1_identity_links[idx_16].metas[idx_25].foo !== 'undefined') {
+                    entity.profile1.identity.links[idx_16].metas[idx_25].foo = data.profile1_identity_links[idx_16].metas[idx_25].foo;
                   }
-                  if (data.profile1_identity_links[idx_14].metas[idx_22].bar === null) {
-                    entity.profile1.identity.links[idx_14].metas[idx_22].bar = null;
-                  } else if (typeof data.profile1_identity_links[idx_14].metas[idx_22].bar !== 'undefined') {
-                    entity.profile1.identity.links[idx_14].metas[idx_22].bar = data.profile1_identity_links[idx_14].metas[idx_22].bar;
+                  if (data.profile1_identity_links[idx_16].metas[idx_25].bar === null) {
+                    entity.profile1.identity.links[idx_16].metas[idx_25].bar = null;
+                  } else if (typeof data.profile1_identity_links[idx_16].metas[idx_25].bar !== 'undefined') {
+                    entity.profile1.identity.links[idx_16].metas[idx_25].bar = data.profile1_identity_links[idx_16].metas[idx_25].bar;
                   }
-                  if (data.profile1_identity_links[idx_14].metas[idx_22].source === null) {
-    entity.profile1.identity.links[idx_14].metas[idx_22].source = null;
-                  } else if (typeof data.profile1_identity_links[idx_14].metas[idx_22].source !== 'undefined') {
-                    if (isPrimaryKey(data.profile1_identity_links[idx_14].metas[idx_22].source, true)) {
-                      entity.profile1.identity.links[idx_14].metas[idx_22].source = factory.createReference(source_26, data.profile1_identity_links[idx_14].metas[idx_22].source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
-                    } else if (data.profile1_identity_links[idx_14].metas[idx_22].source && typeof data.profile1_identity_links[idx_14].metas[idx_22].source === 'object') {
-                      entity.profile1.identity.links[idx_14].metas[idx_22].source = factory.create(source_26, data.profile1_identity_links[idx_14].metas[idx_22].source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
+                  if (data.profile1_identity_links[idx_16].metas[idx_25].source === null) {
+    entity.profile1.identity.links[idx_16].metas[idx_25].source = null;
+                  } else if (typeof data.profile1_identity_links[idx_16].metas[idx_25].source !== 'undefined') {
+                    if (isPrimaryKey(data.profile1_identity_links[idx_16].metas[idx_25].source, true)) {
+                      entity.profile1.identity.links[idx_16].metas[idx_25].source = factory.createReference(source_29, data.profile1_identity_links[idx_16].metas[idx_25].source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
+                    } else if (data.profile1_identity_links[idx_16].metas[idx_25].source && typeof data.profile1_identity_links[idx_16].metas[idx_25].source === 'object') {
+                      entity.profile1.identity.links[idx_16].metas[idx_25].source = factory.create(source_30, data.profile1_identity_links[idx_16].metas[idx_25].source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
                     }
                   }
-                } else if (data.profile1_identity_links[idx_14].metas[idx_22] === null) {
-                  entity.profile1.identity.links[idx_14].metas[idx_22] = null;
+                } else if (data.profile1_identity_links[idx_16].metas[idx_25] === null) {
+                  entity.profile1.identity.links[idx_16].metas[idx_25] = null;
                 }
               });
             }
-            if (data.profile1_identity_links[idx_14].source === null) {
-    entity.profile1.identity.links[idx_14].source = null;
-            } else if (typeof data.profile1_identity_links[idx_14].source !== 'undefined') {
-              if (isPrimaryKey(data.profile1_identity_links[idx_14].source, true)) {
-                entity.profile1.identity.links[idx_14].source = factory.createReference(source_27, data.profile1_identity_links[idx_14].source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
-              } else if (data.profile1_identity_links[idx_14].source && typeof data.profile1_identity_links[idx_14].source === 'object') {
-                entity.profile1.identity.links[idx_14].source = factory.create(source_27, data.profile1_identity_links[idx_14].source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
+            if (data.profile1_identity_links[idx_16].source === null) {
+    entity.profile1.identity.links[idx_16].source = null;
+            } else if (typeof data.profile1_identity_links[idx_16].source !== 'undefined') {
+              if (isPrimaryKey(data.profile1_identity_links[idx_16].source, true)) {
+                entity.profile1.identity.links[idx_16].source = factory.createReference(source_31, data.profile1_identity_links[idx_16].source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
+              } else if (data.profile1_identity_links[idx_16].source && typeof data.profile1_identity_links[idx_16].source === 'object') {
+                entity.profile1.identity.links[idx_16].source = factory.create(source_32, data.profile1_identity_links[idx_16].source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
               }
             }
-          } else if (data.profile1_identity_links[idx_14] === null) {
-            entity.profile1.identity.links[idx_14] = null;
+          } else if (data.profile1_identity_links[idx_16] === null) {
+            entity.profile1.identity.links[idx_16] = null;
           }
         });
       }
@@ -457,9 +457,9 @@ exports[`embedded entities in mongo > diffing 2`] = `
     entity.profile1.identity.source = null;
       } else if (typeof data.profile1_identity_source !== 'undefined') {
         if (isPrimaryKey(data.profile1_identity_source, true)) {
-          entity.profile1.identity.source = factory.createReference(source_28, data.profile1_identity_source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
+          entity.profile1.identity.source = factory.createReference(source_33, data.profile1_identity_source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
         } else if (data.profile1_identity_source && typeof data.profile1_identity_source === 'object') {
-          entity.profile1.identity.source = factory.create(source_28, data.profile1_identity_source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
+          entity.profile1.identity.source = factory.create(source_34, data.profile1_identity_source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
         }
       }
     } else if (data.profile1_identity_email === null && data.profile1_identity_meta_foo === null && data.profile1_identity_meta_bar === null && data.profile1_identity_meta_source === null && data.profile1_identity_links === null && data.profile1_identity_source === null) {
@@ -468,7 +468,7 @@ exports[`embedded entities in mongo > diffing 2`] = `
     if (data.profile1_identity != null) {
       const embeddedData = data.profile1_identity;
       if (entity.profile1.identity == null) {
-        entity.profile1.identity = factory.createEmbeddable(identity_29, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+        entity.profile1.identity = factory.createEmbeddable(identity_35, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
       }
       if (data.profile1_identity.email === null) {
         entity.profile1.identity.email = null;
@@ -482,7 +482,7 @@ exports[`embedded entities in mongo > diffing 2`] = `
           source: data.profile1_identity_meta_source,
         };
         if (entity.profile1.identity.meta == null) {
-          entity.profile1.identity.meta = factory.createEmbeddable(identity_meta_31, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+          entity.profile1.identity.meta = factory.createEmbeddable(identity_meta_37, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
         }
         if (data.profile1_identity_meta_foo === null) {
           entity.profile1.identity.meta.foo = null;
@@ -498,9 +498,9 @@ exports[`embedded entities in mongo > diffing 2`] = `
     entity.profile1.identity.meta.source = null;
         } else if (typeof data.profile1_identity_meta_source !== 'undefined') {
           if (isPrimaryKey(data.profile1_identity_meta_source, true)) {
-            entity.profile1.identity.meta.source = factory.createReference(source_34, data.profile1_identity_meta_source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
+            entity.profile1.identity.meta.source = factory.createReference(source_40, data.profile1_identity_meta_source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
           } else if (data.profile1_identity_meta_source && typeof data.profile1_identity_meta_source === 'object') {
-            entity.profile1.identity.meta.source = factory.create(source_34, data.profile1_identity_meta_source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
+            entity.profile1.identity.meta.source = factory.create(source_41, data.profile1_identity_meta_source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
           }
         }
       } else if (data.profile1_identity_meta_foo === null && data.profile1_identity_meta_bar === null && data.profile1_identity_meta_source === null) {
@@ -509,7 +509,7 @@ exports[`embedded entities in mongo > diffing 2`] = `
       if (data.profile1_identity.meta != null) {
         const embeddedData = data.profile1_identity.meta;
         if (entity.profile1.identity.meta == null) {
-          entity.profile1.identity.meta = factory.createEmbeddable(identity_meta_35, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+          entity.profile1.identity.meta = factory.createEmbeddable(identity_meta_42, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
         }
         if (data.profile1_identity.meta.foo === null) {
           entity.profile1.identity.meta.foo = null;
@@ -525,9 +525,9 @@ exports[`embedded entities in mongo > diffing 2`] = `
     entity.profile1.identity.meta.source = null;
         } else if (typeof data.profile1_identity.meta.source !== 'undefined') {
           if (isPrimaryKey(data.profile1_identity.meta.source, true)) {
-            entity.profile1.identity.meta.source = factory.createReference(source_38, data.profile1_identity.meta.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
+            entity.profile1.identity.meta.source = factory.createReference(source_45, data.profile1_identity.meta.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
           } else if (data.profile1_identity.meta.source && typeof data.profile1_identity.meta.source === 'object') {
-            entity.profile1.identity.meta.source = factory.create(source_38, data.profile1_identity.meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
+            entity.profile1.identity.meta.source = factory.create(source_46, data.profile1_identity.meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
           }
         }
       } else if (data.profile1_identity.meta === null) {
@@ -535,98 +535,98 @@ exports[`embedded entities in mongo > diffing 2`] = `
       }
       if (Array.isArray(data.profile1_identity.links)) {
         entity.profile1.identity.links = [];
-        data.profile1_identity.links.forEach((_, idx_39) => {
-          if (data.profile1_identity.links[idx_39] != null) {
-            const embeddedData = data.profile1_identity.links[idx_39];
-            if (entity.profile1.identity.links[idx_39] == null) {
-              entity.profile1.identity.links[idx_39] = factory.createEmbeddable(identity_link_40, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+        data.profile1_identity.links.forEach((_, idx_47) => {
+          if (data.profile1_identity.links[idx_47] != null) {
+            const embeddedData = data.profile1_identity.links[idx_47];
+            if (entity.profile1.identity.links[idx_47] == null) {
+              entity.profile1.identity.links[idx_47] = factory.createEmbeddable(identity_link_48, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
             }
-            if (data.profile1_identity.links[idx_39].url === null) {
-              entity.profile1.identity.links[idx_39].url = null;
-            } else if (typeof data.profile1_identity.links[idx_39].url !== 'undefined') {
-              entity.profile1.identity.links[idx_39].url = data.profile1_identity.links[idx_39].url;
+            if (data.profile1_identity.links[idx_47].url === null) {
+              entity.profile1.identity.links[idx_47].url = null;
+            } else if (typeof data.profile1_identity.links[idx_47].url !== 'undefined') {
+              entity.profile1.identity.links[idx_47].url = data.profile1_identity.links[idx_47].url;
             }
-            if (data.profile1_identity.links[idx_39].createdAt === null) {
-              entity.profile1.identity.links[idx_39].createdAt = null;
-            } else if (typeof data.profile1_identity.links[idx_39].createdAt !== 'undefined') {
-              if (data.profile1_identity.links[idx_39].createdAt instanceof Date) {
-                entity.profile1.identity.links[idx_39].createdAt = data.profile1_identity.links[idx_39].createdAt;
-              } else if (typeof data.profile1_identity.links[idx_39].createdAt === 'number' || data.profile1_identity.links[idx_39].createdAt.includes('+') || data.profile1_identity.links[idx_39].createdAt.lastIndexOf('-') > 10 || data.profile1_identity.links[idx_39].createdAt.endsWith('Z')) {
-                entity.profile1.identity.links[idx_39].createdAt = new Date(data.profile1_identity.links[idx_39].createdAt);
+            if (data.profile1_identity.links[idx_47].createdAt === null) {
+              entity.profile1.identity.links[idx_47].createdAt = null;
+            } else if (typeof data.profile1_identity.links[idx_47].createdAt !== 'undefined') {
+              if (data.profile1_identity.links[idx_47].createdAt instanceof Date) {
+                entity.profile1.identity.links[idx_47].createdAt = data.profile1_identity.links[idx_47].createdAt;
+              } else if (typeof data.profile1_identity.links[idx_47].createdAt === 'number' || data.profile1_identity.links[idx_47].createdAt.includes('+') || data.profile1_identity.links[idx_47].createdAt.lastIndexOf('-') > 10 || data.profile1_identity.links[idx_47].createdAt.endsWith('Z')) {
+                entity.profile1.identity.links[idx_47].createdAt = new Date(data.profile1_identity.links[idx_47].createdAt);
               } else {
-                entity.profile1.identity.links[idx_39].createdAt = new Date(data.profile1_identity.links[idx_39].createdAt + 'Z');
+                entity.profile1.identity.links[idx_47].createdAt = new Date(data.profile1_identity.links[idx_47].createdAt + 'Z');
               }
             }
-            if (data.profile1_identity.links[idx_39].meta != null) {
-              const embeddedData = data.profile1_identity.links[idx_39].meta;
-              if (entity.profile1.identity.links[idx_39].meta == null) {
-                entity.profile1.identity.links[idx_39].meta = factory.createEmbeddable(identity_meta_43, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+            if (data.profile1_identity.links[idx_47].meta != null) {
+              const embeddedData = data.profile1_identity.links[idx_47].meta;
+              if (entity.profile1.identity.links[idx_47].meta == null) {
+                entity.profile1.identity.links[idx_47].meta = factory.createEmbeddable(identity_meta_51, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
               }
-              if (data.profile1_identity.links[idx_39].meta.foo === null) {
-                entity.profile1.identity.links[idx_39].meta.foo = null;
-              } else if (typeof data.profile1_identity.links[idx_39].meta.foo !== 'undefined') {
-                entity.profile1.identity.links[idx_39].meta.foo = data.profile1_identity.links[idx_39].meta.foo;
+              if (data.profile1_identity.links[idx_47].meta.foo === null) {
+                entity.profile1.identity.links[idx_47].meta.foo = null;
+              } else if (typeof data.profile1_identity.links[idx_47].meta.foo !== 'undefined') {
+                entity.profile1.identity.links[idx_47].meta.foo = data.profile1_identity.links[idx_47].meta.foo;
               }
-              if (data.profile1_identity.links[idx_39].meta.bar === null) {
-                entity.profile1.identity.links[idx_39].meta.bar = null;
-              } else if (typeof data.profile1_identity.links[idx_39].meta.bar !== 'undefined') {
-                entity.profile1.identity.links[idx_39].meta.bar = data.profile1_identity.links[idx_39].meta.bar;
+              if (data.profile1_identity.links[idx_47].meta.bar === null) {
+                entity.profile1.identity.links[idx_47].meta.bar = null;
+              } else if (typeof data.profile1_identity.links[idx_47].meta.bar !== 'undefined') {
+                entity.profile1.identity.links[idx_47].meta.bar = data.profile1_identity.links[idx_47].meta.bar;
               }
-              if (data.profile1_identity.links[idx_39].meta.source === null) {
-    entity.profile1.identity.links[idx_39].meta.source = null;
-              } else if (typeof data.profile1_identity.links[idx_39].meta.source !== 'undefined') {
-                if (isPrimaryKey(data.profile1_identity.links[idx_39].meta.source, true)) {
-                  entity.profile1.identity.links[idx_39].meta.source = factory.createReference(source_46, data.profile1_identity.links[idx_39].meta.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
-                } else if (data.profile1_identity.links[idx_39].meta.source && typeof data.profile1_identity.links[idx_39].meta.source === 'object') {
-                  entity.profile1.identity.links[idx_39].meta.source = factory.create(source_46, data.profile1_identity.links[idx_39].meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
+              if (data.profile1_identity.links[idx_47].meta.source === null) {
+    entity.profile1.identity.links[idx_47].meta.source = null;
+              } else if (typeof data.profile1_identity.links[idx_47].meta.source !== 'undefined') {
+                if (isPrimaryKey(data.profile1_identity.links[idx_47].meta.source, true)) {
+                  entity.profile1.identity.links[idx_47].meta.source = factory.createReference(source_54, data.profile1_identity.links[idx_47].meta.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
+                } else if (data.profile1_identity.links[idx_47].meta.source && typeof data.profile1_identity.links[idx_47].meta.source === 'object') {
+                  entity.profile1.identity.links[idx_47].meta.source = factory.create(source_55, data.profile1_identity.links[idx_47].meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
                 }
               }
-            } else if (data.profile1_identity.links[idx_39].meta === null) {
-              entity.profile1.identity.links[idx_39].meta = null;
+            } else if (data.profile1_identity.links[idx_47].meta === null) {
+              entity.profile1.identity.links[idx_47].meta = null;
             }
-            if (Array.isArray(data.profile1_identity.links[idx_39].metas)) {
-              entity.profile1.identity.links[idx_39].metas = [];
-              data.profile1_identity.links[idx_39].metas.forEach((_, idx_47) => {
-                if (data.profile1_identity.links[idx_39].metas[idx_47] != null) {
-                  const embeddedData = data.profile1_identity.links[idx_39].metas[idx_47];
-                  if (entity.profile1.identity.links[idx_39].metas[idx_47] == null) {
-                    entity.profile1.identity.links[idx_39].metas[idx_47] = factory.createEmbeddable(identity_meta_48, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+            if (Array.isArray(data.profile1_identity.links[idx_47].metas)) {
+              entity.profile1.identity.links[idx_47].metas = [];
+              data.profile1_identity.links[idx_47].metas.forEach((_, idx_56) => {
+                if (data.profile1_identity.links[idx_47].metas[idx_56] != null) {
+                  const embeddedData = data.profile1_identity.links[idx_47].metas[idx_56];
+                  if (entity.profile1.identity.links[idx_47].metas[idx_56] == null) {
+                    entity.profile1.identity.links[idx_47].metas[idx_56] = factory.createEmbeddable(identity_meta_57, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
                   }
-                  if (data.profile1_identity.links[idx_39].metas[idx_47].foo === null) {
-                    entity.profile1.identity.links[idx_39].metas[idx_47].foo = null;
-                  } else if (typeof data.profile1_identity.links[idx_39].metas[idx_47].foo !== 'undefined') {
-                    entity.profile1.identity.links[idx_39].metas[idx_47].foo = data.profile1_identity.links[idx_39].metas[idx_47].foo;
+                  if (data.profile1_identity.links[idx_47].metas[idx_56].foo === null) {
+                    entity.profile1.identity.links[idx_47].metas[idx_56].foo = null;
+                  } else if (typeof data.profile1_identity.links[idx_47].metas[idx_56].foo !== 'undefined') {
+                    entity.profile1.identity.links[idx_47].metas[idx_56].foo = data.profile1_identity.links[idx_47].metas[idx_56].foo;
                   }
-                  if (data.profile1_identity.links[idx_39].metas[idx_47].bar === null) {
-                    entity.profile1.identity.links[idx_39].metas[idx_47].bar = null;
-                  } else if (typeof data.profile1_identity.links[idx_39].metas[idx_47].bar !== 'undefined') {
-                    entity.profile1.identity.links[idx_39].metas[idx_47].bar = data.profile1_identity.links[idx_39].metas[idx_47].bar;
+                  if (data.profile1_identity.links[idx_47].metas[idx_56].bar === null) {
+                    entity.profile1.identity.links[idx_47].metas[idx_56].bar = null;
+                  } else if (typeof data.profile1_identity.links[idx_47].metas[idx_56].bar !== 'undefined') {
+                    entity.profile1.identity.links[idx_47].metas[idx_56].bar = data.profile1_identity.links[idx_47].metas[idx_56].bar;
                   }
-                  if (data.profile1_identity.links[idx_39].metas[idx_47].source === null) {
-    entity.profile1.identity.links[idx_39].metas[idx_47].source = null;
-                  } else if (typeof data.profile1_identity.links[idx_39].metas[idx_47].source !== 'undefined') {
-                    if (isPrimaryKey(data.profile1_identity.links[idx_39].metas[idx_47].source, true)) {
-                      entity.profile1.identity.links[idx_39].metas[idx_47].source = factory.createReference(source_51, data.profile1_identity.links[idx_39].metas[idx_47].source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
-                    } else if (data.profile1_identity.links[idx_39].metas[idx_47].source && typeof data.profile1_identity.links[idx_39].metas[idx_47].source === 'object') {
-                      entity.profile1.identity.links[idx_39].metas[idx_47].source = factory.create(source_51, data.profile1_identity.links[idx_39].metas[idx_47].source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
+                  if (data.profile1_identity.links[idx_47].metas[idx_56].source === null) {
+    entity.profile1.identity.links[idx_47].metas[idx_56].source = null;
+                  } else if (typeof data.profile1_identity.links[idx_47].metas[idx_56].source !== 'undefined') {
+                    if (isPrimaryKey(data.profile1_identity.links[idx_47].metas[idx_56].source, true)) {
+                      entity.profile1.identity.links[idx_47].metas[idx_56].source = factory.createReference(source_60, data.profile1_identity.links[idx_47].metas[idx_56].source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
+                    } else if (data.profile1_identity.links[idx_47].metas[idx_56].source && typeof data.profile1_identity.links[idx_47].metas[idx_56].source === 'object') {
+                      entity.profile1.identity.links[idx_47].metas[idx_56].source = factory.create(source_61, data.profile1_identity.links[idx_47].metas[idx_56].source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
                     }
                   }
-                } else if (data.profile1_identity.links[idx_39].metas[idx_47] === null) {
-                  entity.profile1.identity.links[idx_39].metas[idx_47] = null;
+                } else if (data.profile1_identity.links[idx_47].metas[idx_56] === null) {
+                  entity.profile1.identity.links[idx_47].metas[idx_56] = null;
                 }
               });
             }
-            if (data.profile1_identity.links[idx_39].source === null) {
-    entity.profile1.identity.links[idx_39].source = null;
-            } else if (typeof data.profile1_identity.links[idx_39].source !== 'undefined') {
-              if (isPrimaryKey(data.profile1_identity.links[idx_39].source, true)) {
-                entity.profile1.identity.links[idx_39].source = factory.createReference(source_52, data.profile1_identity.links[idx_39].source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
-              } else if (data.profile1_identity.links[idx_39].source && typeof data.profile1_identity.links[idx_39].source === 'object') {
-                entity.profile1.identity.links[idx_39].source = factory.create(source_52, data.profile1_identity.links[idx_39].source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
+            if (data.profile1_identity.links[idx_47].source === null) {
+    entity.profile1.identity.links[idx_47].source = null;
+            } else if (typeof data.profile1_identity.links[idx_47].source !== 'undefined') {
+              if (isPrimaryKey(data.profile1_identity.links[idx_47].source, true)) {
+                entity.profile1.identity.links[idx_47].source = factory.createReference(source_62, data.profile1_identity.links[idx_47].source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
+              } else if (data.profile1_identity.links[idx_47].source && typeof data.profile1_identity.links[idx_47].source === 'object') {
+                entity.profile1.identity.links[idx_47].source = factory.create(source_63, data.profile1_identity.links[idx_47].source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
               }
             }
-          } else if (data.profile1_identity.links[idx_39] === null) {
-            entity.profile1.identity.links[idx_39] = null;
+          } else if (data.profile1_identity.links[idx_47] === null) {
+            entity.profile1.identity.links[idx_47] = null;
           }
         });
       }
@@ -634,9 +634,9 @@ exports[`embedded entities in mongo > diffing 2`] = `
     entity.profile1.identity.source = null;
       } else if (typeof data.profile1_identity.source !== 'undefined') {
         if (isPrimaryKey(data.profile1_identity.source, true)) {
-          entity.profile1.identity.source = factory.createReference(source_53, data.profile1_identity.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
+          entity.profile1.identity.source = factory.createReference(source_64, data.profile1_identity.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
         } else if (data.profile1_identity.source && typeof data.profile1_identity.source === 'object') {
-          entity.profile1.identity.source = factory.create(source_53, data.profile1_identity.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
+          entity.profile1.identity.source = factory.create(source_65, data.profile1_identity.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
         }
       }
     } else if (data.profile1_identity === null) {
@@ -646,9 +646,9 @@ exports[`embedded entities in mongo > diffing 2`] = `
     entity.profile1.source = null;
     } else if (typeof data.profile1_source !== 'undefined') {
       if (isPrimaryKey(data.profile1_source, true)) {
-        entity.profile1.source = factory.createReference(source_54, data.profile1_source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
+        entity.profile1.source = factory.createReference(source_66, data.profile1_source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
       } else if (data.profile1_source && typeof data.profile1_source === 'object') {
-        entity.profile1.source = factory.create(source_54, data.profile1_source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
+        entity.profile1.source = factory.create(source_67, data.profile1_source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
       }
     }
   } else if (data.profile1_username === null && data.profile1_identity_email === null && data.profile1_identity_meta_foo === null && data.profile1_identity_meta_bar === null && data.profile1_identity_meta_source === null && data.profile1_identity_links === null && data.profile1_identity_source === null && data.profile1_source === null) {
@@ -657,7 +657,7 @@ exports[`embedded entities in mongo > diffing 2`] = `
   if (data.profile1 != null) {
     const embeddedData = data.profile1;
     if (entity.profile1 == null) {
-      entity.profile1 = factory.createEmbeddable(profile_55, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+      entity.profile1 = factory.createEmbeddable(profile_68, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
     }
     if (data.profile1.username === null) {
       entity.profile1.username = null;
@@ -672,7 +672,7 @@ exports[`embedded entities in mongo > diffing 2`] = `
         source: data.profile1_identity_source,
       };
       if (entity.profile1.identity == null) {
-        entity.profile1.identity = factory.createEmbeddable(identity_57, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+        entity.profile1.identity = factory.createEmbeddable(identity_70, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
       }
       if (data.profile1_identity_email === null) {
         entity.profile1.identity.email = null;
@@ -686,7 +686,7 @@ exports[`embedded entities in mongo > diffing 2`] = `
           source: data.profile1_identity_meta_source,
         };
         if (entity.profile1.identity.meta == null) {
-          entity.profile1.identity.meta = factory.createEmbeddable(identity_meta_59, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+          entity.profile1.identity.meta = factory.createEmbeddable(identity_meta_72, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
         }
         if (data.profile1_identity_meta_foo === null) {
           entity.profile1.identity.meta.foo = null;
@@ -702,9 +702,9 @@ exports[`embedded entities in mongo > diffing 2`] = `
     entity.profile1.identity.meta.source = null;
         } else if (typeof data.profile1_identity_meta_source !== 'undefined') {
           if (isPrimaryKey(data.profile1_identity_meta_source, true)) {
-            entity.profile1.identity.meta.source = factory.createReference(source_62, data.profile1_identity_meta_source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
+            entity.profile1.identity.meta.source = factory.createReference(source_75, data.profile1_identity_meta_source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
           } else if (data.profile1_identity_meta_source && typeof data.profile1_identity_meta_source === 'object') {
-            entity.profile1.identity.meta.source = factory.create(source_62, data.profile1_identity_meta_source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
+            entity.profile1.identity.meta.source = factory.create(source_76, data.profile1_identity_meta_source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
           }
         }
       } else if (data.profile1_identity_meta_foo === null && data.profile1_identity_meta_bar === null && data.profile1_identity_meta_source === null) {
@@ -713,7 +713,7 @@ exports[`embedded entities in mongo > diffing 2`] = `
       if (data.profile1_identity_meta != null) {
         const embeddedData = data.profile1_identity_meta;
         if (entity.profile1.identity.meta == null) {
-          entity.profile1.identity.meta = factory.createEmbeddable(identity_meta_63, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+          entity.profile1.identity.meta = factory.createEmbeddable(identity_meta_77, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
         }
         if (data.profile1_identity_meta.foo === null) {
           entity.profile1.identity.meta.foo = null;
@@ -729,9 +729,9 @@ exports[`embedded entities in mongo > diffing 2`] = `
     entity.profile1.identity.meta.source = null;
         } else if (typeof data.profile1_identity_meta.source !== 'undefined') {
           if (isPrimaryKey(data.profile1_identity_meta.source, true)) {
-            entity.profile1.identity.meta.source = factory.createReference(source_66, data.profile1_identity_meta.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
+            entity.profile1.identity.meta.source = factory.createReference(source_80, data.profile1_identity_meta.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
           } else if (data.profile1_identity_meta.source && typeof data.profile1_identity_meta.source === 'object') {
-            entity.profile1.identity.meta.source = factory.create(source_66, data.profile1_identity_meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
+            entity.profile1.identity.meta.source = factory.create(source_81, data.profile1_identity_meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
           }
         }
       } else if (data.profile1_identity_meta === null) {
@@ -739,98 +739,98 @@ exports[`embedded entities in mongo > diffing 2`] = `
       }
       if (Array.isArray(data.profile1_identity_links)) {
         entity.profile1.identity.links = [];
-        data.profile1_identity_links.forEach((_, idx_67) => {
-          if (data.profile1_identity_links[idx_67] != null) {
-            const embeddedData = data.profile1_identity_links[idx_67];
-            if (entity.profile1.identity.links[idx_67] == null) {
-              entity.profile1.identity.links[idx_67] = factory.createEmbeddable(identity_link_68, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+        data.profile1_identity_links.forEach((_, idx_82) => {
+          if (data.profile1_identity_links[idx_82] != null) {
+            const embeddedData = data.profile1_identity_links[idx_82];
+            if (entity.profile1.identity.links[idx_82] == null) {
+              entity.profile1.identity.links[idx_82] = factory.createEmbeddable(identity_link_83, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
             }
-            if (data.profile1_identity_links[idx_67].url === null) {
-              entity.profile1.identity.links[idx_67].url = null;
-            } else if (typeof data.profile1_identity_links[idx_67].url !== 'undefined') {
-              entity.profile1.identity.links[idx_67].url = data.profile1_identity_links[idx_67].url;
+            if (data.profile1_identity_links[idx_82].url === null) {
+              entity.profile1.identity.links[idx_82].url = null;
+            } else if (typeof data.profile1_identity_links[idx_82].url !== 'undefined') {
+              entity.profile1.identity.links[idx_82].url = data.profile1_identity_links[idx_82].url;
             }
-            if (data.profile1_identity_links[idx_67].createdAt === null) {
-              entity.profile1.identity.links[idx_67].createdAt = null;
-            } else if (typeof data.profile1_identity_links[idx_67].createdAt !== 'undefined') {
-              if (data.profile1_identity_links[idx_67].createdAt instanceof Date) {
-                entity.profile1.identity.links[idx_67].createdAt = data.profile1_identity_links[idx_67].createdAt;
-              } else if (typeof data.profile1_identity_links[idx_67].createdAt === 'number' || data.profile1_identity_links[idx_67].createdAt.includes('+') || data.profile1_identity_links[idx_67].createdAt.lastIndexOf('-') > 10 || data.profile1_identity_links[idx_67].createdAt.endsWith('Z')) {
-                entity.profile1.identity.links[idx_67].createdAt = new Date(data.profile1_identity_links[idx_67].createdAt);
+            if (data.profile1_identity_links[idx_82].createdAt === null) {
+              entity.profile1.identity.links[idx_82].createdAt = null;
+            } else if (typeof data.profile1_identity_links[idx_82].createdAt !== 'undefined') {
+              if (data.profile1_identity_links[idx_82].createdAt instanceof Date) {
+                entity.profile1.identity.links[idx_82].createdAt = data.profile1_identity_links[idx_82].createdAt;
+              } else if (typeof data.profile1_identity_links[idx_82].createdAt === 'number' || data.profile1_identity_links[idx_82].createdAt.includes('+') || data.profile1_identity_links[idx_82].createdAt.lastIndexOf('-') > 10 || data.profile1_identity_links[idx_82].createdAt.endsWith('Z')) {
+                entity.profile1.identity.links[idx_82].createdAt = new Date(data.profile1_identity_links[idx_82].createdAt);
               } else {
-                entity.profile1.identity.links[idx_67].createdAt = new Date(data.profile1_identity_links[idx_67].createdAt + 'Z');
+                entity.profile1.identity.links[idx_82].createdAt = new Date(data.profile1_identity_links[idx_82].createdAt + 'Z');
               }
             }
-            if (data.profile1_identity_links[idx_67].meta != null) {
-              const embeddedData = data.profile1_identity_links[idx_67].meta;
-              if (entity.profile1.identity.links[idx_67].meta == null) {
-                entity.profile1.identity.links[idx_67].meta = factory.createEmbeddable(identity_meta_71, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+            if (data.profile1_identity_links[idx_82].meta != null) {
+              const embeddedData = data.profile1_identity_links[idx_82].meta;
+              if (entity.profile1.identity.links[idx_82].meta == null) {
+                entity.profile1.identity.links[idx_82].meta = factory.createEmbeddable(identity_meta_86, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
               }
-              if (data.profile1_identity_links[idx_67].meta.foo === null) {
-                entity.profile1.identity.links[idx_67].meta.foo = null;
-              } else if (typeof data.profile1_identity_links[idx_67].meta.foo !== 'undefined') {
-                entity.profile1.identity.links[idx_67].meta.foo = data.profile1_identity_links[idx_67].meta.foo;
+              if (data.profile1_identity_links[idx_82].meta.foo === null) {
+                entity.profile1.identity.links[idx_82].meta.foo = null;
+              } else if (typeof data.profile1_identity_links[idx_82].meta.foo !== 'undefined') {
+                entity.profile1.identity.links[idx_82].meta.foo = data.profile1_identity_links[idx_82].meta.foo;
               }
-              if (data.profile1_identity_links[idx_67].meta.bar === null) {
-                entity.profile1.identity.links[idx_67].meta.bar = null;
-              } else if (typeof data.profile1_identity_links[idx_67].meta.bar !== 'undefined') {
-                entity.profile1.identity.links[idx_67].meta.bar = data.profile1_identity_links[idx_67].meta.bar;
+              if (data.profile1_identity_links[idx_82].meta.bar === null) {
+                entity.profile1.identity.links[idx_82].meta.bar = null;
+              } else if (typeof data.profile1_identity_links[idx_82].meta.bar !== 'undefined') {
+                entity.profile1.identity.links[idx_82].meta.bar = data.profile1_identity_links[idx_82].meta.bar;
               }
-              if (data.profile1_identity_links[idx_67].meta.source === null) {
-    entity.profile1.identity.links[idx_67].meta.source = null;
-              } else if (typeof data.profile1_identity_links[idx_67].meta.source !== 'undefined') {
-                if (isPrimaryKey(data.profile1_identity_links[idx_67].meta.source, true)) {
-                  entity.profile1.identity.links[idx_67].meta.source = factory.createReference(source_74, data.profile1_identity_links[idx_67].meta.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
-                } else if (data.profile1_identity_links[idx_67].meta.source && typeof data.profile1_identity_links[idx_67].meta.source === 'object') {
-                  entity.profile1.identity.links[idx_67].meta.source = factory.create(source_74, data.profile1_identity_links[idx_67].meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
+              if (data.profile1_identity_links[idx_82].meta.source === null) {
+    entity.profile1.identity.links[idx_82].meta.source = null;
+              } else if (typeof data.profile1_identity_links[idx_82].meta.source !== 'undefined') {
+                if (isPrimaryKey(data.profile1_identity_links[idx_82].meta.source, true)) {
+                  entity.profile1.identity.links[idx_82].meta.source = factory.createReference(source_89, data.profile1_identity_links[idx_82].meta.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
+                } else if (data.profile1_identity_links[idx_82].meta.source && typeof data.profile1_identity_links[idx_82].meta.source === 'object') {
+                  entity.profile1.identity.links[idx_82].meta.source = factory.create(source_90, data.profile1_identity_links[idx_82].meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
                 }
               }
-            } else if (data.profile1_identity_links[idx_67].meta === null) {
-              entity.profile1.identity.links[idx_67].meta = null;
+            } else if (data.profile1_identity_links[idx_82].meta === null) {
+              entity.profile1.identity.links[idx_82].meta = null;
             }
-            if (Array.isArray(data.profile1_identity_links[idx_67].metas)) {
-              entity.profile1.identity.links[idx_67].metas = [];
-              data.profile1_identity_links[idx_67].metas.forEach((_, idx_75) => {
-                if (data.profile1_identity_links[idx_67].metas[idx_75] != null) {
-                  const embeddedData = data.profile1_identity_links[idx_67].metas[idx_75];
-                  if (entity.profile1.identity.links[idx_67].metas[idx_75] == null) {
-                    entity.profile1.identity.links[idx_67].metas[idx_75] = factory.createEmbeddable(identity_meta_76, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+            if (Array.isArray(data.profile1_identity_links[idx_82].metas)) {
+              entity.profile1.identity.links[idx_82].metas = [];
+              data.profile1_identity_links[idx_82].metas.forEach((_, idx_91) => {
+                if (data.profile1_identity_links[idx_82].metas[idx_91] != null) {
+                  const embeddedData = data.profile1_identity_links[idx_82].metas[idx_91];
+                  if (entity.profile1.identity.links[idx_82].metas[idx_91] == null) {
+                    entity.profile1.identity.links[idx_82].metas[idx_91] = factory.createEmbeddable(identity_meta_92, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
                   }
-                  if (data.profile1_identity_links[idx_67].metas[idx_75].foo === null) {
-                    entity.profile1.identity.links[idx_67].metas[idx_75].foo = null;
-                  } else if (typeof data.profile1_identity_links[idx_67].metas[idx_75].foo !== 'undefined') {
-                    entity.profile1.identity.links[idx_67].metas[idx_75].foo = data.profile1_identity_links[idx_67].metas[idx_75].foo;
+                  if (data.profile1_identity_links[idx_82].metas[idx_91].foo === null) {
+                    entity.profile1.identity.links[idx_82].metas[idx_91].foo = null;
+                  } else if (typeof data.profile1_identity_links[idx_82].metas[idx_91].foo !== 'undefined') {
+                    entity.profile1.identity.links[idx_82].metas[idx_91].foo = data.profile1_identity_links[idx_82].metas[idx_91].foo;
                   }
-                  if (data.profile1_identity_links[idx_67].metas[idx_75].bar === null) {
-                    entity.profile1.identity.links[idx_67].metas[idx_75].bar = null;
-                  } else if (typeof data.profile1_identity_links[idx_67].metas[idx_75].bar !== 'undefined') {
-                    entity.profile1.identity.links[idx_67].metas[idx_75].bar = data.profile1_identity_links[idx_67].metas[idx_75].bar;
+                  if (data.profile1_identity_links[idx_82].metas[idx_91].bar === null) {
+                    entity.profile1.identity.links[idx_82].metas[idx_91].bar = null;
+                  } else if (typeof data.profile1_identity_links[idx_82].metas[idx_91].bar !== 'undefined') {
+                    entity.profile1.identity.links[idx_82].metas[idx_91].bar = data.profile1_identity_links[idx_82].metas[idx_91].bar;
                   }
-                  if (data.profile1_identity_links[idx_67].metas[idx_75].source === null) {
-    entity.profile1.identity.links[idx_67].metas[idx_75].source = null;
-                  } else if (typeof data.profile1_identity_links[idx_67].metas[idx_75].source !== 'undefined') {
-                    if (isPrimaryKey(data.profile1_identity_links[idx_67].metas[idx_75].source, true)) {
-                      entity.profile1.identity.links[idx_67].metas[idx_75].source = factory.createReference(source_79, data.profile1_identity_links[idx_67].metas[idx_75].source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
-                    } else if (data.profile1_identity_links[idx_67].metas[idx_75].source && typeof data.profile1_identity_links[idx_67].metas[idx_75].source === 'object') {
-                      entity.profile1.identity.links[idx_67].metas[idx_75].source = factory.create(source_79, data.profile1_identity_links[idx_67].metas[idx_75].source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
+                  if (data.profile1_identity_links[idx_82].metas[idx_91].source === null) {
+    entity.profile1.identity.links[idx_82].metas[idx_91].source = null;
+                  } else if (typeof data.profile1_identity_links[idx_82].metas[idx_91].source !== 'undefined') {
+                    if (isPrimaryKey(data.profile1_identity_links[idx_82].metas[idx_91].source, true)) {
+                      entity.profile1.identity.links[idx_82].metas[idx_91].source = factory.createReference(source_95, data.profile1_identity_links[idx_82].metas[idx_91].source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
+                    } else if (data.profile1_identity_links[idx_82].metas[idx_91].source && typeof data.profile1_identity_links[idx_82].metas[idx_91].source === 'object') {
+                      entity.profile1.identity.links[idx_82].metas[idx_91].source = factory.create(source_96, data.profile1_identity_links[idx_82].metas[idx_91].source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
                     }
                   }
-                } else if (data.profile1_identity_links[idx_67].metas[idx_75] === null) {
-                  entity.profile1.identity.links[idx_67].metas[idx_75] = null;
+                } else if (data.profile1_identity_links[idx_82].metas[idx_91] === null) {
+                  entity.profile1.identity.links[idx_82].metas[idx_91] = null;
                 }
               });
             }
-            if (data.profile1_identity_links[idx_67].source === null) {
-    entity.profile1.identity.links[idx_67].source = null;
-            } else if (typeof data.profile1_identity_links[idx_67].source !== 'undefined') {
-              if (isPrimaryKey(data.profile1_identity_links[idx_67].source, true)) {
-                entity.profile1.identity.links[idx_67].source = factory.createReference(source_80, data.profile1_identity_links[idx_67].source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
-              } else if (data.profile1_identity_links[idx_67].source && typeof data.profile1_identity_links[idx_67].source === 'object') {
-                entity.profile1.identity.links[idx_67].source = factory.create(source_80, data.profile1_identity_links[idx_67].source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
+            if (data.profile1_identity_links[idx_82].source === null) {
+    entity.profile1.identity.links[idx_82].source = null;
+            } else if (typeof data.profile1_identity_links[idx_82].source !== 'undefined') {
+              if (isPrimaryKey(data.profile1_identity_links[idx_82].source, true)) {
+                entity.profile1.identity.links[idx_82].source = factory.createReference(source_97, data.profile1_identity_links[idx_82].source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
+              } else if (data.profile1_identity_links[idx_82].source && typeof data.profile1_identity_links[idx_82].source === 'object') {
+                entity.profile1.identity.links[idx_82].source = factory.create(source_98, data.profile1_identity_links[idx_82].source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
               }
             }
-          } else if (data.profile1_identity_links[idx_67] === null) {
-            entity.profile1.identity.links[idx_67] = null;
+          } else if (data.profile1_identity_links[idx_82] === null) {
+            entity.profile1.identity.links[idx_82] = null;
           }
         });
       }
@@ -838,9 +838,9 @@ exports[`embedded entities in mongo > diffing 2`] = `
     entity.profile1.identity.source = null;
       } else if (typeof data.profile1_identity_source !== 'undefined') {
         if (isPrimaryKey(data.profile1_identity_source, true)) {
-          entity.profile1.identity.source = factory.createReference(source_81, data.profile1_identity_source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
+          entity.profile1.identity.source = factory.createReference(source_99, data.profile1_identity_source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
         } else if (data.profile1_identity_source && typeof data.profile1_identity_source === 'object') {
-          entity.profile1.identity.source = factory.create(source_81, data.profile1_identity_source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
+          entity.profile1.identity.source = factory.create(source_100, data.profile1_identity_source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
         }
       }
     } else if (data.profile1_identity_email === null && data.profile1_identity_meta_foo === null && data.profile1_identity_meta_bar === null && data.profile1_identity_meta_source === null && data.profile1_identity_links === null && data.profile1_identity_source === null) {
@@ -849,7 +849,7 @@ exports[`embedded entities in mongo > diffing 2`] = `
     if (data.profile1.identity != null) {
       const embeddedData = data.profile1.identity;
       if (entity.profile1.identity == null) {
-        entity.profile1.identity = factory.createEmbeddable(identity_82, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+        entity.profile1.identity = factory.createEmbeddable(identity_101, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
       }
       if (data.profile1.identity.email === null) {
         entity.profile1.identity.email = null;
@@ -863,7 +863,7 @@ exports[`embedded entities in mongo > diffing 2`] = `
           source: data.profile1_identity_meta_source,
         };
         if (entity.profile1.identity.meta == null) {
-          entity.profile1.identity.meta = factory.createEmbeddable(identity_meta_84, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+          entity.profile1.identity.meta = factory.createEmbeddable(identity_meta_103, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
         }
         if (data.profile1_identity_meta_foo === null) {
           entity.profile1.identity.meta.foo = null;
@@ -879,9 +879,9 @@ exports[`embedded entities in mongo > diffing 2`] = `
     entity.profile1.identity.meta.source = null;
         } else if (typeof data.profile1_identity_meta_source !== 'undefined') {
           if (isPrimaryKey(data.profile1_identity_meta_source, true)) {
-            entity.profile1.identity.meta.source = factory.createReference(source_87, data.profile1_identity_meta_source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
+            entity.profile1.identity.meta.source = factory.createReference(source_106, data.profile1_identity_meta_source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
           } else if (data.profile1_identity_meta_source && typeof data.profile1_identity_meta_source === 'object') {
-            entity.profile1.identity.meta.source = factory.create(source_87, data.profile1_identity_meta_source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
+            entity.profile1.identity.meta.source = factory.create(source_107, data.profile1_identity_meta_source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
           }
         }
       } else if (data.profile1_identity_meta_foo === null && data.profile1_identity_meta_bar === null && data.profile1_identity_meta_source === null) {
@@ -890,7 +890,7 @@ exports[`embedded entities in mongo > diffing 2`] = `
       if (data.profile1.identity.meta != null) {
         const embeddedData = data.profile1.identity.meta;
         if (entity.profile1.identity.meta == null) {
-          entity.profile1.identity.meta = factory.createEmbeddable(identity_meta_88, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+          entity.profile1.identity.meta = factory.createEmbeddable(identity_meta_108, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
         }
         if (data.profile1.identity.meta.foo === null) {
           entity.profile1.identity.meta.foo = null;
@@ -906,9 +906,9 @@ exports[`embedded entities in mongo > diffing 2`] = `
     entity.profile1.identity.meta.source = null;
         } else if (typeof data.profile1.identity.meta.source !== 'undefined') {
           if (isPrimaryKey(data.profile1.identity.meta.source, true)) {
-            entity.profile1.identity.meta.source = factory.createReference(source_91, data.profile1.identity.meta.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
+            entity.profile1.identity.meta.source = factory.createReference(source_111, data.profile1.identity.meta.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
           } else if (data.profile1.identity.meta.source && typeof data.profile1.identity.meta.source === 'object') {
-            entity.profile1.identity.meta.source = factory.create(source_91, data.profile1.identity.meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
+            entity.profile1.identity.meta.source = factory.create(source_112, data.profile1.identity.meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
           }
         }
       } else if (data.profile1.identity.meta === null) {
@@ -916,98 +916,98 @@ exports[`embedded entities in mongo > diffing 2`] = `
       }
       if (Array.isArray(data.profile1.identity.links)) {
         entity.profile1.identity.links = [];
-        data.profile1.identity.links.forEach((_, idx_92) => {
-          if (data.profile1.identity.links[idx_92] != null) {
-            const embeddedData = data.profile1.identity.links[idx_92];
-            if (entity.profile1.identity.links[idx_92] == null) {
-              entity.profile1.identity.links[idx_92] = factory.createEmbeddable(identity_link_93, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+        data.profile1.identity.links.forEach((_, idx_113) => {
+          if (data.profile1.identity.links[idx_113] != null) {
+            const embeddedData = data.profile1.identity.links[idx_113];
+            if (entity.profile1.identity.links[idx_113] == null) {
+              entity.profile1.identity.links[idx_113] = factory.createEmbeddable(identity_link_114, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
             }
-            if (data.profile1.identity.links[idx_92].url === null) {
-              entity.profile1.identity.links[idx_92].url = null;
-            } else if (typeof data.profile1.identity.links[idx_92].url !== 'undefined') {
-              entity.profile1.identity.links[idx_92].url = data.profile1.identity.links[idx_92].url;
+            if (data.profile1.identity.links[idx_113].url === null) {
+              entity.profile1.identity.links[idx_113].url = null;
+            } else if (typeof data.profile1.identity.links[idx_113].url !== 'undefined') {
+              entity.profile1.identity.links[idx_113].url = data.profile1.identity.links[idx_113].url;
             }
-            if (data.profile1.identity.links[idx_92].createdAt === null) {
-              entity.profile1.identity.links[idx_92].createdAt = null;
-            } else if (typeof data.profile1.identity.links[idx_92].createdAt !== 'undefined') {
-              if (data.profile1.identity.links[idx_92].createdAt instanceof Date) {
-                entity.profile1.identity.links[idx_92].createdAt = data.profile1.identity.links[idx_92].createdAt;
-              } else if (typeof data.profile1.identity.links[idx_92].createdAt === 'number' || data.profile1.identity.links[idx_92].createdAt.includes('+') || data.profile1.identity.links[idx_92].createdAt.lastIndexOf('-') > 10 || data.profile1.identity.links[idx_92].createdAt.endsWith('Z')) {
-                entity.profile1.identity.links[idx_92].createdAt = new Date(data.profile1.identity.links[idx_92].createdAt);
+            if (data.profile1.identity.links[idx_113].createdAt === null) {
+              entity.profile1.identity.links[idx_113].createdAt = null;
+            } else if (typeof data.profile1.identity.links[idx_113].createdAt !== 'undefined') {
+              if (data.profile1.identity.links[idx_113].createdAt instanceof Date) {
+                entity.profile1.identity.links[idx_113].createdAt = data.profile1.identity.links[idx_113].createdAt;
+              } else if (typeof data.profile1.identity.links[idx_113].createdAt === 'number' || data.profile1.identity.links[idx_113].createdAt.includes('+') || data.profile1.identity.links[idx_113].createdAt.lastIndexOf('-') > 10 || data.profile1.identity.links[idx_113].createdAt.endsWith('Z')) {
+                entity.profile1.identity.links[idx_113].createdAt = new Date(data.profile1.identity.links[idx_113].createdAt);
               } else {
-                entity.profile1.identity.links[idx_92].createdAt = new Date(data.profile1.identity.links[idx_92].createdAt + 'Z');
+                entity.profile1.identity.links[idx_113].createdAt = new Date(data.profile1.identity.links[idx_113].createdAt + 'Z');
               }
             }
-            if (data.profile1.identity.links[idx_92].meta != null) {
-              const embeddedData = data.profile1.identity.links[idx_92].meta;
-              if (entity.profile1.identity.links[idx_92].meta == null) {
-                entity.profile1.identity.links[idx_92].meta = factory.createEmbeddable(identity_meta_96, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+            if (data.profile1.identity.links[idx_113].meta != null) {
+              const embeddedData = data.profile1.identity.links[idx_113].meta;
+              if (entity.profile1.identity.links[idx_113].meta == null) {
+                entity.profile1.identity.links[idx_113].meta = factory.createEmbeddable(identity_meta_117, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
               }
-              if (data.profile1.identity.links[idx_92].meta.foo === null) {
-                entity.profile1.identity.links[idx_92].meta.foo = null;
-              } else if (typeof data.profile1.identity.links[idx_92].meta.foo !== 'undefined') {
-                entity.profile1.identity.links[idx_92].meta.foo = data.profile1.identity.links[idx_92].meta.foo;
+              if (data.profile1.identity.links[idx_113].meta.foo === null) {
+                entity.profile1.identity.links[idx_113].meta.foo = null;
+              } else if (typeof data.profile1.identity.links[idx_113].meta.foo !== 'undefined') {
+                entity.profile1.identity.links[idx_113].meta.foo = data.profile1.identity.links[idx_113].meta.foo;
               }
-              if (data.profile1.identity.links[idx_92].meta.bar === null) {
-                entity.profile1.identity.links[idx_92].meta.bar = null;
-              } else if (typeof data.profile1.identity.links[idx_92].meta.bar !== 'undefined') {
-                entity.profile1.identity.links[idx_92].meta.bar = data.profile1.identity.links[idx_92].meta.bar;
+              if (data.profile1.identity.links[idx_113].meta.bar === null) {
+                entity.profile1.identity.links[idx_113].meta.bar = null;
+              } else if (typeof data.profile1.identity.links[idx_113].meta.bar !== 'undefined') {
+                entity.profile1.identity.links[idx_113].meta.bar = data.profile1.identity.links[idx_113].meta.bar;
               }
-              if (data.profile1.identity.links[idx_92].meta.source === null) {
-    entity.profile1.identity.links[idx_92].meta.source = null;
-              } else if (typeof data.profile1.identity.links[idx_92].meta.source !== 'undefined') {
-                if (isPrimaryKey(data.profile1.identity.links[idx_92].meta.source, true)) {
-                  entity.profile1.identity.links[idx_92].meta.source = factory.createReference(source_99, data.profile1.identity.links[idx_92].meta.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
-                } else if (data.profile1.identity.links[idx_92].meta.source && typeof data.profile1.identity.links[idx_92].meta.source === 'object') {
-                  entity.profile1.identity.links[idx_92].meta.source = factory.create(source_99, data.profile1.identity.links[idx_92].meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
+              if (data.profile1.identity.links[idx_113].meta.source === null) {
+    entity.profile1.identity.links[idx_113].meta.source = null;
+              } else if (typeof data.profile1.identity.links[idx_113].meta.source !== 'undefined') {
+                if (isPrimaryKey(data.profile1.identity.links[idx_113].meta.source, true)) {
+                  entity.profile1.identity.links[idx_113].meta.source = factory.createReference(source_120, data.profile1.identity.links[idx_113].meta.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
+                } else if (data.profile1.identity.links[idx_113].meta.source && typeof data.profile1.identity.links[idx_113].meta.source === 'object') {
+                  entity.profile1.identity.links[idx_113].meta.source = factory.create(source_121, data.profile1.identity.links[idx_113].meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
                 }
               }
-            } else if (data.profile1.identity.links[idx_92].meta === null) {
-              entity.profile1.identity.links[idx_92].meta = null;
+            } else if (data.profile1.identity.links[idx_113].meta === null) {
+              entity.profile1.identity.links[idx_113].meta = null;
             }
-            if (Array.isArray(data.profile1.identity.links[idx_92].metas)) {
-              entity.profile1.identity.links[idx_92].metas = [];
-              data.profile1.identity.links[idx_92].metas.forEach((_, idx_100) => {
-                if (data.profile1.identity.links[idx_92].metas[idx_100] != null) {
-                  const embeddedData = data.profile1.identity.links[idx_92].metas[idx_100];
-                  if (entity.profile1.identity.links[idx_92].metas[idx_100] == null) {
-                    entity.profile1.identity.links[idx_92].metas[idx_100] = factory.createEmbeddable(identity_meta_101, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+            if (Array.isArray(data.profile1.identity.links[idx_113].metas)) {
+              entity.profile1.identity.links[idx_113].metas = [];
+              data.profile1.identity.links[idx_113].metas.forEach((_, idx_122) => {
+                if (data.profile1.identity.links[idx_113].metas[idx_122] != null) {
+                  const embeddedData = data.profile1.identity.links[idx_113].metas[idx_122];
+                  if (entity.profile1.identity.links[idx_113].metas[idx_122] == null) {
+                    entity.profile1.identity.links[idx_113].metas[idx_122] = factory.createEmbeddable(identity_meta_123, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
                   }
-                  if (data.profile1.identity.links[idx_92].metas[idx_100].foo === null) {
-                    entity.profile1.identity.links[idx_92].metas[idx_100].foo = null;
-                  } else if (typeof data.profile1.identity.links[idx_92].metas[idx_100].foo !== 'undefined') {
-                    entity.profile1.identity.links[idx_92].metas[idx_100].foo = data.profile1.identity.links[idx_92].metas[idx_100].foo;
+                  if (data.profile1.identity.links[idx_113].metas[idx_122].foo === null) {
+                    entity.profile1.identity.links[idx_113].metas[idx_122].foo = null;
+                  } else if (typeof data.profile1.identity.links[idx_113].metas[idx_122].foo !== 'undefined') {
+                    entity.profile1.identity.links[idx_113].metas[idx_122].foo = data.profile1.identity.links[idx_113].metas[idx_122].foo;
                   }
-                  if (data.profile1.identity.links[idx_92].metas[idx_100].bar === null) {
-                    entity.profile1.identity.links[idx_92].metas[idx_100].bar = null;
-                  } else if (typeof data.profile1.identity.links[idx_92].metas[idx_100].bar !== 'undefined') {
-                    entity.profile1.identity.links[idx_92].metas[idx_100].bar = data.profile1.identity.links[idx_92].metas[idx_100].bar;
+                  if (data.profile1.identity.links[idx_113].metas[idx_122].bar === null) {
+                    entity.profile1.identity.links[idx_113].metas[idx_122].bar = null;
+                  } else if (typeof data.profile1.identity.links[idx_113].metas[idx_122].bar !== 'undefined') {
+                    entity.profile1.identity.links[idx_113].metas[idx_122].bar = data.profile1.identity.links[idx_113].metas[idx_122].bar;
                   }
-                  if (data.profile1.identity.links[idx_92].metas[idx_100].source === null) {
-    entity.profile1.identity.links[idx_92].metas[idx_100].source = null;
-                  } else if (typeof data.profile1.identity.links[idx_92].metas[idx_100].source !== 'undefined') {
-                    if (isPrimaryKey(data.profile1.identity.links[idx_92].metas[idx_100].source, true)) {
-                      entity.profile1.identity.links[idx_92].metas[idx_100].source = factory.createReference(source_104, data.profile1.identity.links[idx_92].metas[idx_100].source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
-                    } else if (data.profile1.identity.links[idx_92].metas[idx_100].source && typeof data.profile1.identity.links[idx_92].metas[idx_100].source === 'object') {
-                      entity.profile1.identity.links[idx_92].metas[idx_100].source = factory.create(source_104, data.profile1.identity.links[idx_92].metas[idx_100].source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
+                  if (data.profile1.identity.links[idx_113].metas[idx_122].source === null) {
+    entity.profile1.identity.links[idx_113].metas[idx_122].source = null;
+                  } else if (typeof data.profile1.identity.links[idx_113].metas[idx_122].source !== 'undefined') {
+                    if (isPrimaryKey(data.profile1.identity.links[idx_113].metas[idx_122].source, true)) {
+                      entity.profile1.identity.links[idx_113].metas[idx_122].source = factory.createReference(source_126, data.profile1.identity.links[idx_113].metas[idx_122].source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
+                    } else if (data.profile1.identity.links[idx_113].metas[idx_122].source && typeof data.profile1.identity.links[idx_113].metas[idx_122].source === 'object') {
+                      entity.profile1.identity.links[idx_113].metas[idx_122].source = factory.create(source_127, data.profile1.identity.links[idx_113].metas[idx_122].source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
                     }
                   }
-                } else if (data.profile1.identity.links[idx_92].metas[idx_100] === null) {
-                  entity.profile1.identity.links[idx_92].metas[idx_100] = null;
+                } else if (data.profile1.identity.links[idx_113].metas[idx_122] === null) {
+                  entity.profile1.identity.links[idx_113].metas[idx_122] = null;
                 }
               });
             }
-            if (data.profile1.identity.links[idx_92].source === null) {
-    entity.profile1.identity.links[idx_92].source = null;
-            } else if (typeof data.profile1.identity.links[idx_92].source !== 'undefined') {
-              if (isPrimaryKey(data.profile1.identity.links[idx_92].source, true)) {
-                entity.profile1.identity.links[idx_92].source = factory.createReference(source_105, data.profile1.identity.links[idx_92].source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
-              } else if (data.profile1.identity.links[idx_92].source && typeof data.profile1.identity.links[idx_92].source === 'object') {
-                entity.profile1.identity.links[idx_92].source = factory.create(source_105, data.profile1.identity.links[idx_92].source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
+            if (data.profile1.identity.links[idx_113].source === null) {
+    entity.profile1.identity.links[idx_113].source = null;
+            } else if (typeof data.profile1.identity.links[idx_113].source !== 'undefined') {
+              if (isPrimaryKey(data.profile1.identity.links[idx_113].source, true)) {
+                entity.profile1.identity.links[idx_113].source = factory.createReference(source_128, data.profile1.identity.links[idx_113].source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
+              } else if (data.profile1.identity.links[idx_113].source && typeof data.profile1.identity.links[idx_113].source === 'object') {
+                entity.profile1.identity.links[idx_113].source = factory.create(source_129, data.profile1.identity.links[idx_113].source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
               }
             }
-          } else if (data.profile1.identity.links[idx_92] === null) {
-            entity.profile1.identity.links[idx_92] = null;
+          } else if (data.profile1.identity.links[idx_113] === null) {
+            entity.profile1.identity.links[idx_113] = null;
           }
         });
       }
@@ -1015,9 +1015,9 @@ exports[`embedded entities in mongo > diffing 2`] = `
     entity.profile1.identity.source = null;
       } else if (typeof data.profile1.identity.source !== 'undefined') {
         if (isPrimaryKey(data.profile1.identity.source, true)) {
-          entity.profile1.identity.source = factory.createReference(source_106, data.profile1.identity.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
+          entity.profile1.identity.source = factory.createReference(source_130, data.profile1.identity.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
         } else if (data.profile1.identity.source && typeof data.profile1.identity.source === 'object') {
-          entity.profile1.identity.source = factory.create(source_106, data.profile1.identity.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
+          entity.profile1.identity.source = factory.create(source_131, data.profile1.identity.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
         }
       }
     } else if (data.profile1.identity === null) {
@@ -1027,9 +1027,9 @@ exports[`embedded entities in mongo > diffing 2`] = `
     entity.profile1.source = null;
     } else if (typeof data.profile1.source !== 'undefined') {
       if (isPrimaryKey(data.profile1.source, true)) {
-        entity.profile1.source = factory.createReference(source_107, data.profile1.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
+        entity.profile1.source = factory.createReference(source_132, data.profile1.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
       } else if (data.profile1.source && typeof data.profile1.source === 'object') {
-        entity.profile1.source = factory.create(source_107, data.profile1.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
+        entity.profile1.source = factory.create(source_133, data.profile1.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
       }
     }
   } else if (data.profile1 === null) {
@@ -1038,7 +1038,7 @@ exports[`embedded entities in mongo > diffing 2`] = `
   if (data.profile2 != null) {
     const embeddedData = data.profile2;
     if (entity.profile2 == null) {
-      entity.profile2 = factory.createEmbeddable(profile_108, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+      entity.profile2 = factory.createEmbeddable(profile_134, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
     }
     if (data.profile2.username === null) {
       entity.profile2.username = null;
@@ -1048,7 +1048,7 @@ exports[`embedded entities in mongo > diffing 2`] = `
     if (data.profile2.identity != null) {
       const embeddedData = data.profile2.identity;
       if (entity.profile2.identity == null) {
-        entity.profile2.identity = factory.createEmbeddable(identity_110, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+        entity.profile2.identity = factory.createEmbeddable(identity_136, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
       }
       if (data.profile2.identity.email === null) {
         entity.profile2.identity.email = null;
@@ -1058,7 +1058,7 @@ exports[`embedded entities in mongo > diffing 2`] = `
       if (data.profile2.identity.meta != null) {
         const embeddedData = data.profile2.identity.meta;
         if (entity.profile2.identity.meta == null) {
-          entity.profile2.identity.meta = factory.createEmbeddable(identity_meta_112, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+          entity.profile2.identity.meta = factory.createEmbeddable(identity_meta_138, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
         }
         if (data.profile2.identity.meta.foo === null) {
           entity.profile2.identity.meta.foo = null;
@@ -1074,9 +1074,9 @@ exports[`embedded entities in mongo > diffing 2`] = `
     entity.profile2.identity.meta.source = null;
         } else if (typeof data.profile2.identity.meta.source !== 'undefined') {
           if (isPrimaryKey(data.profile2.identity.meta.source, true)) {
-            entity.profile2.identity.meta.source = factory.createReference(source_115, data.profile2.identity.meta.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
+            entity.profile2.identity.meta.source = factory.createReference(source_141, data.profile2.identity.meta.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
           } else if (data.profile2.identity.meta.source && typeof data.profile2.identity.meta.source === 'object') {
-            entity.profile2.identity.meta.source = factory.create(source_115, data.profile2.identity.meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
+            entity.profile2.identity.meta.source = factory.create(source_142, data.profile2.identity.meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
           }
         }
       } else if (data.profile2.identity.meta === null) {
@@ -1084,98 +1084,98 @@ exports[`embedded entities in mongo > diffing 2`] = `
       }
       if (Array.isArray(data.profile2.identity.links)) {
         entity.profile2.identity.links = [];
-        data.profile2.identity.links.forEach((_, idx_116) => {
-          if (data.profile2.identity.links[idx_116] != null) {
-            const embeddedData = data.profile2.identity.links[idx_116];
-            if (entity.profile2.identity.links[idx_116] == null) {
-              entity.profile2.identity.links[idx_116] = factory.createEmbeddable(identity_link_117, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+        data.profile2.identity.links.forEach((_, idx_143) => {
+          if (data.profile2.identity.links[idx_143] != null) {
+            const embeddedData = data.profile2.identity.links[idx_143];
+            if (entity.profile2.identity.links[idx_143] == null) {
+              entity.profile2.identity.links[idx_143] = factory.createEmbeddable(identity_link_144, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
             }
-            if (data.profile2.identity.links[idx_116].url === null) {
-              entity.profile2.identity.links[idx_116].url = null;
-            } else if (typeof data.profile2.identity.links[idx_116].url !== 'undefined') {
-              entity.profile2.identity.links[idx_116].url = data.profile2.identity.links[idx_116].url;
+            if (data.profile2.identity.links[idx_143].url === null) {
+              entity.profile2.identity.links[idx_143].url = null;
+            } else if (typeof data.profile2.identity.links[idx_143].url !== 'undefined') {
+              entity.profile2.identity.links[idx_143].url = data.profile2.identity.links[idx_143].url;
             }
-            if (data.profile2.identity.links[idx_116].createdAt === null) {
-              entity.profile2.identity.links[idx_116].createdAt = null;
-            } else if (typeof data.profile2.identity.links[idx_116].createdAt !== 'undefined') {
-              if (data.profile2.identity.links[idx_116].createdAt instanceof Date) {
-                entity.profile2.identity.links[idx_116].createdAt = data.profile2.identity.links[idx_116].createdAt;
-              } else if (typeof data.profile2.identity.links[idx_116].createdAt === 'number' || data.profile2.identity.links[idx_116].createdAt.includes('+') || data.profile2.identity.links[idx_116].createdAt.lastIndexOf('-') > 10 || data.profile2.identity.links[idx_116].createdAt.endsWith('Z')) {
-                entity.profile2.identity.links[idx_116].createdAt = new Date(data.profile2.identity.links[idx_116].createdAt);
+            if (data.profile2.identity.links[idx_143].createdAt === null) {
+              entity.profile2.identity.links[idx_143].createdAt = null;
+            } else if (typeof data.profile2.identity.links[idx_143].createdAt !== 'undefined') {
+              if (data.profile2.identity.links[idx_143].createdAt instanceof Date) {
+                entity.profile2.identity.links[idx_143].createdAt = data.profile2.identity.links[idx_143].createdAt;
+              } else if (typeof data.profile2.identity.links[idx_143].createdAt === 'number' || data.profile2.identity.links[idx_143].createdAt.includes('+') || data.profile2.identity.links[idx_143].createdAt.lastIndexOf('-') > 10 || data.profile2.identity.links[idx_143].createdAt.endsWith('Z')) {
+                entity.profile2.identity.links[idx_143].createdAt = new Date(data.profile2.identity.links[idx_143].createdAt);
               } else {
-                entity.profile2.identity.links[idx_116].createdAt = new Date(data.profile2.identity.links[idx_116].createdAt + 'Z');
+                entity.profile2.identity.links[idx_143].createdAt = new Date(data.profile2.identity.links[idx_143].createdAt + 'Z');
               }
             }
-            if (data.profile2.identity.links[idx_116].meta != null) {
-              const embeddedData = data.profile2.identity.links[idx_116].meta;
-              if (entity.profile2.identity.links[idx_116].meta == null) {
-                entity.profile2.identity.links[idx_116].meta = factory.createEmbeddable(identity_meta_120, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+            if (data.profile2.identity.links[idx_143].meta != null) {
+              const embeddedData = data.profile2.identity.links[idx_143].meta;
+              if (entity.profile2.identity.links[idx_143].meta == null) {
+                entity.profile2.identity.links[idx_143].meta = factory.createEmbeddable(identity_meta_147, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
               }
-              if (data.profile2.identity.links[idx_116].meta.foo === null) {
-                entity.profile2.identity.links[idx_116].meta.foo = null;
-              } else if (typeof data.profile2.identity.links[idx_116].meta.foo !== 'undefined') {
-                entity.profile2.identity.links[idx_116].meta.foo = data.profile2.identity.links[idx_116].meta.foo;
+              if (data.profile2.identity.links[idx_143].meta.foo === null) {
+                entity.profile2.identity.links[idx_143].meta.foo = null;
+              } else if (typeof data.profile2.identity.links[idx_143].meta.foo !== 'undefined') {
+                entity.profile2.identity.links[idx_143].meta.foo = data.profile2.identity.links[idx_143].meta.foo;
               }
-              if (data.profile2.identity.links[idx_116].meta.bar === null) {
-                entity.profile2.identity.links[idx_116].meta.bar = null;
-              } else if (typeof data.profile2.identity.links[idx_116].meta.bar !== 'undefined') {
-                entity.profile2.identity.links[idx_116].meta.bar = data.profile2.identity.links[idx_116].meta.bar;
+              if (data.profile2.identity.links[idx_143].meta.bar === null) {
+                entity.profile2.identity.links[idx_143].meta.bar = null;
+              } else if (typeof data.profile2.identity.links[idx_143].meta.bar !== 'undefined') {
+                entity.profile2.identity.links[idx_143].meta.bar = data.profile2.identity.links[idx_143].meta.bar;
               }
-              if (data.profile2.identity.links[idx_116].meta.source === null) {
-    entity.profile2.identity.links[idx_116].meta.source = null;
-              } else if (typeof data.profile2.identity.links[idx_116].meta.source !== 'undefined') {
-                if (isPrimaryKey(data.profile2.identity.links[idx_116].meta.source, true)) {
-                  entity.profile2.identity.links[idx_116].meta.source = factory.createReference(source_123, data.profile2.identity.links[idx_116].meta.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
-                } else if (data.profile2.identity.links[idx_116].meta.source && typeof data.profile2.identity.links[idx_116].meta.source === 'object') {
-                  entity.profile2.identity.links[idx_116].meta.source = factory.create(source_123, data.profile2.identity.links[idx_116].meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
+              if (data.profile2.identity.links[idx_143].meta.source === null) {
+    entity.profile2.identity.links[idx_143].meta.source = null;
+              } else if (typeof data.profile2.identity.links[idx_143].meta.source !== 'undefined') {
+                if (isPrimaryKey(data.profile2.identity.links[idx_143].meta.source, true)) {
+                  entity.profile2.identity.links[idx_143].meta.source = factory.createReference(source_150, data.profile2.identity.links[idx_143].meta.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
+                } else if (data.profile2.identity.links[idx_143].meta.source && typeof data.profile2.identity.links[idx_143].meta.source === 'object') {
+                  entity.profile2.identity.links[idx_143].meta.source = factory.create(source_151, data.profile2.identity.links[idx_143].meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
                 }
               }
-            } else if (data.profile2.identity.links[idx_116].meta === null) {
-              entity.profile2.identity.links[idx_116].meta = null;
+            } else if (data.profile2.identity.links[idx_143].meta === null) {
+              entity.profile2.identity.links[idx_143].meta = null;
             }
-            if (Array.isArray(data.profile2.identity.links[idx_116].metas)) {
-              entity.profile2.identity.links[idx_116].metas = [];
-              data.profile2.identity.links[idx_116].metas.forEach((_, idx_124) => {
-                if (data.profile2.identity.links[idx_116].metas[idx_124] != null) {
-                  const embeddedData = data.profile2.identity.links[idx_116].metas[idx_124];
-                  if (entity.profile2.identity.links[idx_116].metas[idx_124] == null) {
-                    entity.profile2.identity.links[idx_116].metas[idx_124] = factory.createEmbeddable(identity_meta_125, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+            if (Array.isArray(data.profile2.identity.links[idx_143].metas)) {
+              entity.profile2.identity.links[idx_143].metas = [];
+              data.profile2.identity.links[idx_143].metas.forEach((_, idx_152) => {
+                if (data.profile2.identity.links[idx_143].metas[idx_152] != null) {
+                  const embeddedData = data.profile2.identity.links[idx_143].metas[idx_152];
+                  if (entity.profile2.identity.links[idx_143].metas[idx_152] == null) {
+                    entity.profile2.identity.links[idx_143].metas[idx_152] = factory.createEmbeddable(identity_meta_153, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
                   }
-                  if (data.profile2.identity.links[idx_116].metas[idx_124].foo === null) {
-                    entity.profile2.identity.links[idx_116].metas[idx_124].foo = null;
-                  } else if (typeof data.profile2.identity.links[idx_116].metas[idx_124].foo !== 'undefined') {
-                    entity.profile2.identity.links[idx_116].metas[idx_124].foo = data.profile2.identity.links[idx_116].metas[idx_124].foo;
+                  if (data.profile2.identity.links[idx_143].metas[idx_152].foo === null) {
+                    entity.profile2.identity.links[idx_143].metas[idx_152].foo = null;
+                  } else if (typeof data.profile2.identity.links[idx_143].metas[idx_152].foo !== 'undefined') {
+                    entity.profile2.identity.links[idx_143].metas[idx_152].foo = data.profile2.identity.links[idx_143].metas[idx_152].foo;
                   }
-                  if (data.profile2.identity.links[idx_116].metas[idx_124].bar === null) {
-                    entity.profile2.identity.links[idx_116].metas[idx_124].bar = null;
-                  } else if (typeof data.profile2.identity.links[idx_116].metas[idx_124].bar !== 'undefined') {
-                    entity.profile2.identity.links[idx_116].metas[idx_124].bar = data.profile2.identity.links[idx_116].metas[idx_124].bar;
+                  if (data.profile2.identity.links[idx_143].metas[idx_152].bar === null) {
+                    entity.profile2.identity.links[idx_143].metas[idx_152].bar = null;
+                  } else if (typeof data.profile2.identity.links[idx_143].metas[idx_152].bar !== 'undefined') {
+                    entity.profile2.identity.links[idx_143].metas[idx_152].bar = data.profile2.identity.links[idx_143].metas[idx_152].bar;
                   }
-                  if (data.profile2.identity.links[idx_116].metas[idx_124].source === null) {
-    entity.profile2.identity.links[idx_116].metas[idx_124].source = null;
-                  } else if (typeof data.profile2.identity.links[idx_116].metas[idx_124].source !== 'undefined') {
-                    if (isPrimaryKey(data.profile2.identity.links[idx_116].metas[idx_124].source, true)) {
-                      entity.profile2.identity.links[idx_116].metas[idx_124].source = factory.createReference(source_128, data.profile2.identity.links[idx_116].metas[idx_124].source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
-                    } else if (data.profile2.identity.links[idx_116].metas[idx_124].source && typeof data.profile2.identity.links[idx_116].metas[idx_124].source === 'object') {
-                      entity.profile2.identity.links[idx_116].metas[idx_124].source = factory.create(source_128, data.profile2.identity.links[idx_116].metas[idx_124].source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
+                  if (data.profile2.identity.links[idx_143].metas[idx_152].source === null) {
+    entity.profile2.identity.links[idx_143].metas[idx_152].source = null;
+                  } else if (typeof data.profile2.identity.links[idx_143].metas[idx_152].source !== 'undefined') {
+                    if (isPrimaryKey(data.profile2.identity.links[idx_143].metas[idx_152].source, true)) {
+                      entity.profile2.identity.links[idx_143].metas[idx_152].source = factory.createReference(source_156, data.profile2.identity.links[idx_143].metas[idx_152].source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
+                    } else if (data.profile2.identity.links[idx_143].metas[idx_152].source && typeof data.profile2.identity.links[idx_143].metas[idx_152].source === 'object') {
+                      entity.profile2.identity.links[idx_143].metas[idx_152].source = factory.create(source_157, data.profile2.identity.links[idx_143].metas[idx_152].source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
                     }
                   }
-                } else if (data.profile2.identity.links[idx_116].metas[idx_124] === null) {
-                  entity.profile2.identity.links[idx_116].metas[idx_124] = null;
+                } else if (data.profile2.identity.links[idx_143].metas[idx_152] === null) {
+                  entity.profile2.identity.links[idx_143].metas[idx_152] = null;
                 }
               });
             }
-            if (data.profile2.identity.links[idx_116].source === null) {
-    entity.profile2.identity.links[idx_116].source = null;
-            } else if (typeof data.profile2.identity.links[idx_116].source !== 'undefined') {
-              if (isPrimaryKey(data.profile2.identity.links[idx_116].source, true)) {
-                entity.profile2.identity.links[idx_116].source = factory.createReference(source_129, data.profile2.identity.links[idx_116].source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
-              } else if (data.profile2.identity.links[idx_116].source && typeof data.profile2.identity.links[idx_116].source === 'object') {
-                entity.profile2.identity.links[idx_116].source = factory.create(source_129, data.profile2.identity.links[idx_116].source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
+            if (data.profile2.identity.links[idx_143].source === null) {
+    entity.profile2.identity.links[idx_143].source = null;
+            } else if (typeof data.profile2.identity.links[idx_143].source !== 'undefined') {
+              if (isPrimaryKey(data.profile2.identity.links[idx_143].source, true)) {
+                entity.profile2.identity.links[idx_143].source = factory.createReference(source_158, data.profile2.identity.links[idx_143].source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
+              } else if (data.profile2.identity.links[idx_143].source && typeof data.profile2.identity.links[idx_143].source === 'object') {
+                entity.profile2.identity.links[idx_143].source = factory.create(source_159, data.profile2.identity.links[idx_143].source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
               }
             }
-          } else if (data.profile2.identity.links[idx_116] === null) {
-            entity.profile2.identity.links[idx_116] = null;
+          } else if (data.profile2.identity.links[idx_143] === null) {
+            entity.profile2.identity.links[idx_143] = null;
           }
         });
       }
@@ -1183,9 +1183,9 @@ exports[`embedded entities in mongo > diffing 2`] = `
     entity.profile2.identity.source = null;
       } else if (typeof data.profile2.identity.source !== 'undefined') {
         if (isPrimaryKey(data.profile2.identity.source, true)) {
-          entity.profile2.identity.source = factory.createReference(source_130, data.profile2.identity.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
+          entity.profile2.identity.source = factory.createReference(source_160, data.profile2.identity.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
         } else if (data.profile2.identity.source && typeof data.profile2.identity.source === 'object') {
-          entity.profile2.identity.source = factory.create(source_130, data.profile2.identity.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
+          entity.profile2.identity.source = factory.create(source_161, data.profile2.identity.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
         }
       }
     } else if (data.profile2.identity === null) {
@@ -1195,9 +1195,9 @@ exports[`embedded entities in mongo > diffing 2`] = `
     entity.profile2.source = null;
     } else if (typeof data.profile2.source !== 'undefined') {
       if (isPrimaryKey(data.profile2.source, true)) {
-        entity.profile2.source = factory.createReference(source_131, data.profile2.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
+        entity.profile2.source = factory.createReference(source_162, data.profile2.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
       } else if (data.profile2.source && typeof data.profile2.source === 'object') {
-        entity.profile2.source = factory.create(source_131, data.profile2.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
+        entity.profile2.source = factory.create(source_163, data.profile2.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
       }
     }
   } else if (data.profile2 === null) {

--- a/tests/features/embeddables/__snapshots__/entities-in-embeddables.postgres.test.ts.snap
+++ b/tests/features/embeddables/__snapshots__/entities-in-embeddables.postgres.test.ts.snap
@@ -323,7 +323,7 @@ exports[`embedded entities in postgres > diffing 2`] = `
           if (isPrimaryKey(data.profile1_identity_meta_source, true)) {
             entity.profile1.identity.meta.source = factory.createReference(source_9, data.profile1_identity_meta_source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
           } else if (data.profile1_identity_meta_source && typeof data.profile1_identity_meta_source === 'object') {
-            entity.profile1.identity.meta.source = factory.create(source_9, data.profile1_identity_meta_source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
+            entity.profile1.identity.meta.source = factory.create(source_10, data.profile1_identity_meta_source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
           }
         }
       } else if (data.profile1_identity_meta_foo === null && data.profile1_identity_meta_bar === null && data.profile1_identity_meta_source === null) {
@@ -332,7 +332,7 @@ exports[`embedded entities in postgres > diffing 2`] = `
       if (data.profile1_identity_meta != null) {
         const embeddedData = data.profile1_identity_meta;
         if (entity.profile1.identity.meta == null) {
-          entity.profile1.identity.meta = factory.createEmbeddable(identity_meta_10, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+          entity.profile1.identity.meta = factory.createEmbeddable(identity_meta_11, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
         }
         if (data.profile1_identity_meta.foo === null) {
           entity.profile1.identity.meta.foo = null;
@@ -348,9 +348,9 @@ exports[`embedded entities in postgres > diffing 2`] = `
     entity.profile1.identity.meta.source = null;
         } else if (typeof data.profile1_identity_meta.source !== 'undefined') {
           if (isPrimaryKey(data.profile1_identity_meta.source, true)) {
-            entity.profile1.identity.meta.source = factory.createReference(source_13, data.profile1_identity_meta.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
+            entity.profile1.identity.meta.source = factory.createReference(source_14, data.profile1_identity_meta.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
           } else if (data.profile1_identity_meta.source && typeof data.profile1_identity_meta.source === 'object') {
-            entity.profile1.identity.meta.source = factory.create(source_13, data.profile1_identity_meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
+            entity.profile1.identity.meta.source = factory.create(source_15, data.profile1_identity_meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
           }
         }
       } else if (data.profile1_identity_meta === null) {
@@ -358,98 +358,98 @@ exports[`embedded entities in postgres > diffing 2`] = `
       }
       if (Array.isArray(data.profile1_identity_links)) {
         entity.profile1.identity.links = [];
-        data.profile1_identity_links.forEach((_, idx_14) => {
-          if (data.profile1_identity_links[idx_14] != null) {
-            const embeddedData = data.profile1_identity_links[idx_14];
-            if (entity.profile1.identity.links[idx_14] == null) {
-              entity.profile1.identity.links[idx_14] = factory.createEmbeddable(identity_link_15, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+        data.profile1_identity_links.forEach((_, idx_16) => {
+          if (data.profile1_identity_links[idx_16] != null) {
+            const embeddedData = data.profile1_identity_links[idx_16];
+            if (entity.profile1.identity.links[idx_16] == null) {
+              entity.profile1.identity.links[idx_16] = factory.createEmbeddable(identity_link_17, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
             }
-            if (data.profile1_identity_links[idx_14].url === null) {
-              entity.profile1.identity.links[idx_14].url = null;
-            } else if (typeof data.profile1_identity_links[idx_14].url !== 'undefined') {
-              entity.profile1.identity.links[idx_14].url = data.profile1_identity_links[idx_14].url;
+            if (data.profile1_identity_links[idx_16].url === null) {
+              entity.profile1.identity.links[idx_16].url = null;
+            } else if (typeof data.profile1_identity_links[idx_16].url !== 'undefined') {
+              entity.profile1.identity.links[idx_16].url = data.profile1_identity_links[idx_16].url;
             }
-            if (data.profile1_identity_links[idx_14].createdAt === null) {
-              entity.profile1.identity.links[idx_14].createdAt = null;
-            } else if (typeof data.profile1_identity_links[idx_14].createdAt !== 'undefined') {
-              if (data.profile1_identity_links[idx_14].createdAt instanceof Date) {
-                entity.profile1.identity.links[idx_14].createdAt = data.profile1_identity_links[idx_14].createdAt;
-              } else if (typeof data.profile1_identity_links[idx_14].createdAt === 'number' || data.profile1_identity_links[idx_14].createdAt.includes('+') || data.profile1_identity_links[idx_14].createdAt.lastIndexOf('-') > 10 || data.profile1_identity_links[idx_14].createdAt.endsWith('Z')) {
-                entity.profile1.identity.links[idx_14].createdAt = new Date(data.profile1_identity_links[idx_14].createdAt);
+            if (data.profile1_identity_links[idx_16].createdAt === null) {
+              entity.profile1.identity.links[idx_16].createdAt = null;
+            } else if (typeof data.profile1_identity_links[idx_16].createdAt !== 'undefined') {
+              if (data.profile1_identity_links[idx_16].createdAt instanceof Date) {
+                entity.profile1.identity.links[idx_16].createdAt = data.profile1_identity_links[idx_16].createdAt;
+              } else if (typeof data.profile1_identity_links[idx_16].createdAt === 'number' || data.profile1_identity_links[idx_16].createdAt.includes('+') || data.profile1_identity_links[idx_16].createdAt.lastIndexOf('-') > 10 || data.profile1_identity_links[idx_16].createdAt.endsWith('Z')) {
+                entity.profile1.identity.links[idx_16].createdAt = new Date(data.profile1_identity_links[idx_16].createdAt);
               } else {
-                entity.profile1.identity.links[idx_14].createdAt = new Date(data.profile1_identity_links[idx_14].createdAt + 'Z');
+                entity.profile1.identity.links[idx_16].createdAt = new Date(data.profile1_identity_links[idx_16].createdAt + 'Z');
               }
             }
-            if (data.profile1_identity_links[idx_14].meta != null) {
-              const embeddedData = data.profile1_identity_links[idx_14].meta;
-              if (entity.profile1.identity.links[idx_14].meta == null) {
-                entity.profile1.identity.links[idx_14].meta = factory.createEmbeddable(identity_meta_18, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+            if (data.profile1_identity_links[idx_16].meta != null) {
+              const embeddedData = data.profile1_identity_links[idx_16].meta;
+              if (entity.profile1.identity.links[idx_16].meta == null) {
+                entity.profile1.identity.links[idx_16].meta = factory.createEmbeddable(identity_meta_20, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
               }
-              if (data.profile1_identity_links[idx_14].meta.foo === null) {
-                entity.profile1.identity.links[idx_14].meta.foo = null;
-              } else if (typeof data.profile1_identity_links[idx_14].meta.foo !== 'undefined') {
-                entity.profile1.identity.links[idx_14].meta.foo = data.profile1_identity_links[idx_14].meta.foo;
+              if (data.profile1_identity_links[idx_16].meta.foo === null) {
+                entity.profile1.identity.links[idx_16].meta.foo = null;
+              } else if (typeof data.profile1_identity_links[idx_16].meta.foo !== 'undefined') {
+                entity.profile1.identity.links[idx_16].meta.foo = data.profile1_identity_links[idx_16].meta.foo;
               }
-              if (data.profile1_identity_links[idx_14].meta.bar === null) {
-                entity.profile1.identity.links[idx_14].meta.bar = null;
-              } else if (typeof data.profile1_identity_links[idx_14].meta.bar !== 'undefined') {
-                entity.profile1.identity.links[idx_14].meta.bar = data.profile1_identity_links[idx_14].meta.bar;
+              if (data.profile1_identity_links[idx_16].meta.bar === null) {
+                entity.profile1.identity.links[idx_16].meta.bar = null;
+              } else if (typeof data.profile1_identity_links[idx_16].meta.bar !== 'undefined') {
+                entity.profile1.identity.links[idx_16].meta.bar = data.profile1_identity_links[idx_16].meta.bar;
               }
-              if (data.profile1_identity_links[idx_14].meta.source === null) {
-    entity.profile1.identity.links[idx_14].meta.source = null;
-              } else if (typeof data.profile1_identity_links[idx_14].meta.source !== 'undefined') {
-                if (isPrimaryKey(data.profile1_identity_links[idx_14].meta.source, true)) {
-                  entity.profile1.identity.links[idx_14].meta.source = factory.createReference(source_21, data.profile1_identity_links[idx_14].meta.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
-                } else if (data.profile1_identity_links[idx_14].meta.source && typeof data.profile1_identity_links[idx_14].meta.source === 'object') {
-                  entity.profile1.identity.links[idx_14].meta.source = factory.create(source_21, data.profile1_identity_links[idx_14].meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
+              if (data.profile1_identity_links[idx_16].meta.source === null) {
+    entity.profile1.identity.links[idx_16].meta.source = null;
+              } else if (typeof data.profile1_identity_links[idx_16].meta.source !== 'undefined') {
+                if (isPrimaryKey(data.profile1_identity_links[idx_16].meta.source, true)) {
+                  entity.profile1.identity.links[idx_16].meta.source = factory.createReference(source_23, data.profile1_identity_links[idx_16].meta.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
+                } else if (data.profile1_identity_links[idx_16].meta.source && typeof data.profile1_identity_links[idx_16].meta.source === 'object') {
+                  entity.profile1.identity.links[idx_16].meta.source = factory.create(source_24, data.profile1_identity_links[idx_16].meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
                 }
               }
-            } else if (data.profile1_identity_links[idx_14].meta === null) {
-              entity.profile1.identity.links[idx_14].meta = null;
+            } else if (data.profile1_identity_links[idx_16].meta === null) {
+              entity.profile1.identity.links[idx_16].meta = null;
             }
-            if (Array.isArray(data.profile1_identity_links[idx_14].metas)) {
-              entity.profile1.identity.links[idx_14].metas = [];
-              data.profile1_identity_links[idx_14].metas.forEach((_, idx_22) => {
-                if (data.profile1_identity_links[idx_14].metas[idx_22] != null) {
-                  const embeddedData = data.profile1_identity_links[idx_14].metas[idx_22];
-                  if (entity.profile1.identity.links[idx_14].metas[idx_22] == null) {
-                    entity.profile1.identity.links[idx_14].metas[idx_22] = factory.createEmbeddable(identity_meta_23, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+            if (Array.isArray(data.profile1_identity_links[idx_16].metas)) {
+              entity.profile1.identity.links[idx_16].metas = [];
+              data.profile1_identity_links[idx_16].metas.forEach((_, idx_25) => {
+                if (data.profile1_identity_links[idx_16].metas[idx_25] != null) {
+                  const embeddedData = data.profile1_identity_links[idx_16].metas[idx_25];
+                  if (entity.profile1.identity.links[idx_16].metas[idx_25] == null) {
+                    entity.profile1.identity.links[idx_16].metas[idx_25] = factory.createEmbeddable(identity_meta_26, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
                   }
-                  if (data.profile1_identity_links[idx_14].metas[idx_22].foo === null) {
-                    entity.profile1.identity.links[idx_14].metas[idx_22].foo = null;
-                  } else if (typeof data.profile1_identity_links[idx_14].metas[idx_22].foo !== 'undefined') {
-                    entity.profile1.identity.links[idx_14].metas[idx_22].foo = data.profile1_identity_links[idx_14].metas[idx_22].foo;
+                  if (data.profile1_identity_links[idx_16].metas[idx_25].foo === null) {
+                    entity.profile1.identity.links[idx_16].metas[idx_25].foo = null;
+                  } else if (typeof data.profile1_identity_links[idx_16].metas[idx_25].foo !== 'undefined') {
+                    entity.profile1.identity.links[idx_16].metas[idx_25].foo = data.profile1_identity_links[idx_16].metas[idx_25].foo;
                   }
-                  if (data.profile1_identity_links[idx_14].metas[idx_22].bar === null) {
-                    entity.profile1.identity.links[idx_14].metas[idx_22].bar = null;
-                  } else if (typeof data.profile1_identity_links[idx_14].metas[idx_22].bar !== 'undefined') {
-                    entity.profile1.identity.links[idx_14].metas[idx_22].bar = data.profile1_identity_links[idx_14].metas[idx_22].bar;
+                  if (data.profile1_identity_links[idx_16].metas[idx_25].bar === null) {
+                    entity.profile1.identity.links[idx_16].metas[idx_25].bar = null;
+                  } else if (typeof data.profile1_identity_links[idx_16].metas[idx_25].bar !== 'undefined') {
+                    entity.profile1.identity.links[idx_16].metas[idx_25].bar = data.profile1_identity_links[idx_16].metas[idx_25].bar;
                   }
-                  if (data.profile1_identity_links[idx_14].metas[idx_22].source === null) {
-    entity.profile1.identity.links[idx_14].metas[idx_22].source = null;
-                  } else if (typeof data.profile1_identity_links[idx_14].metas[idx_22].source !== 'undefined') {
-                    if (isPrimaryKey(data.profile1_identity_links[idx_14].metas[idx_22].source, true)) {
-                      entity.profile1.identity.links[idx_14].metas[idx_22].source = factory.createReference(source_26, data.profile1_identity_links[idx_14].metas[idx_22].source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
-                    } else if (data.profile1_identity_links[idx_14].metas[idx_22].source && typeof data.profile1_identity_links[idx_14].metas[idx_22].source === 'object') {
-                      entity.profile1.identity.links[idx_14].metas[idx_22].source = factory.create(source_26, data.profile1_identity_links[idx_14].metas[idx_22].source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
+                  if (data.profile1_identity_links[idx_16].metas[idx_25].source === null) {
+    entity.profile1.identity.links[idx_16].metas[idx_25].source = null;
+                  } else if (typeof data.profile1_identity_links[idx_16].metas[idx_25].source !== 'undefined') {
+                    if (isPrimaryKey(data.profile1_identity_links[idx_16].metas[idx_25].source, true)) {
+                      entity.profile1.identity.links[idx_16].metas[idx_25].source = factory.createReference(source_29, data.profile1_identity_links[idx_16].metas[idx_25].source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
+                    } else if (data.profile1_identity_links[idx_16].metas[idx_25].source && typeof data.profile1_identity_links[idx_16].metas[idx_25].source === 'object') {
+                      entity.profile1.identity.links[idx_16].metas[idx_25].source = factory.create(source_30, data.profile1_identity_links[idx_16].metas[idx_25].source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
                     }
                   }
-                } else if (data.profile1_identity_links[idx_14].metas[idx_22] === null) {
-                  entity.profile1.identity.links[idx_14].metas[idx_22] = null;
+                } else if (data.profile1_identity_links[idx_16].metas[idx_25] === null) {
+                  entity.profile1.identity.links[idx_16].metas[idx_25] = null;
                 }
               });
             }
-            if (data.profile1_identity_links[idx_14].source === null) {
-    entity.profile1.identity.links[idx_14].source = null;
-            } else if (typeof data.profile1_identity_links[idx_14].source !== 'undefined') {
-              if (isPrimaryKey(data.profile1_identity_links[idx_14].source, true)) {
-                entity.profile1.identity.links[idx_14].source = factory.createReference(source_27, data.profile1_identity_links[idx_14].source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
-              } else if (data.profile1_identity_links[idx_14].source && typeof data.profile1_identity_links[idx_14].source === 'object') {
-                entity.profile1.identity.links[idx_14].source = factory.create(source_27, data.profile1_identity_links[idx_14].source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
+            if (data.profile1_identity_links[idx_16].source === null) {
+    entity.profile1.identity.links[idx_16].source = null;
+            } else if (typeof data.profile1_identity_links[idx_16].source !== 'undefined') {
+              if (isPrimaryKey(data.profile1_identity_links[idx_16].source, true)) {
+                entity.profile1.identity.links[idx_16].source = factory.createReference(source_31, data.profile1_identity_links[idx_16].source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
+              } else if (data.profile1_identity_links[idx_16].source && typeof data.profile1_identity_links[idx_16].source === 'object') {
+                entity.profile1.identity.links[idx_16].source = factory.create(source_32, data.profile1_identity_links[idx_16].source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
               }
             }
-          } else if (data.profile1_identity_links[idx_14] === null) {
-            entity.profile1.identity.links[idx_14] = null;
+          } else if (data.profile1_identity_links[idx_16] === null) {
+            entity.profile1.identity.links[idx_16] = null;
           }
         });
       }
@@ -457,9 +457,9 @@ exports[`embedded entities in postgres > diffing 2`] = `
     entity.profile1.identity.source = null;
       } else if (typeof data.profile1_identity_source !== 'undefined') {
         if (isPrimaryKey(data.profile1_identity_source, true)) {
-          entity.profile1.identity.source = factory.createReference(source_28, data.profile1_identity_source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
+          entity.profile1.identity.source = factory.createReference(source_33, data.profile1_identity_source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
         } else if (data.profile1_identity_source && typeof data.profile1_identity_source === 'object') {
-          entity.profile1.identity.source = factory.create(source_28, data.profile1_identity_source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
+          entity.profile1.identity.source = factory.create(source_34, data.profile1_identity_source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
         }
       }
     } else if (data.profile1_identity_email === null && data.profile1_identity_meta_foo === null && data.profile1_identity_meta_bar === null && data.profile1_identity_meta_source === null && data.profile1_identity_links === null && data.profile1_identity_source === null) {
@@ -468,7 +468,7 @@ exports[`embedded entities in postgres > diffing 2`] = `
     if (data.profile1_identity != null) {
       const embeddedData = data.profile1_identity;
       if (entity.profile1.identity == null) {
-        entity.profile1.identity = factory.createEmbeddable(identity_29, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+        entity.profile1.identity = factory.createEmbeddable(identity_35, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
       }
       if (data.profile1_identity.email === null) {
         entity.profile1.identity.email = null;
@@ -482,7 +482,7 @@ exports[`embedded entities in postgres > diffing 2`] = `
           source: data.profile1_identity_meta_source,
         };
         if (entity.profile1.identity.meta == null) {
-          entity.profile1.identity.meta = factory.createEmbeddable(identity_meta_31, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+          entity.profile1.identity.meta = factory.createEmbeddable(identity_meta_37, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
         }
         if (data.profile1_identity_meta_foo === null) {
           entity.profile1.identity.meta.foo = null;
@@ -498,9 +498,9 @@ exports[`embedded entities in postgres > diffing 2`] = `
     entity.profile1.identity.meta.source = null;
         } else if (typeof data.profile1_identity_meta_source !== 'undefined') {
           if (isPrimaryKey(data.profile1_identity_meta_source, true)) {
-            entity.profile1.identity.meta.source = factory.createReference(source_34, data.profile1_identity_meta_source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
+            entity.profile1.identity.meta.source = factory.createReference(source_40, data.profile1_identity_meta_source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
           } else if (data.profile1_identity_meta_source && typeof data.profile1_identity_meta_source === 'object') {
-            entity.profile1.identity.meta.source = factory.create(source_34, data.profile1_identity_meta_source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
+            entity.profile1.identity.meta.source = factory.create(source_41, data.profile1_identity_meta_source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
           }
         }
       } else if (data.profile1_identity_meta_foo === null && data.profile1_identity_meta_bar === null && data.profile1_identity_meta_source === null) {
@@ -509,7 +509,7 @@ exports[`embedded entities in postgres > diffing 2`] = `
       if (data.profile1_identity.meta != null) {
         const embeddedData = data.profile1_identity.meta;
         if (entity.profile1.identity.meta == null) {
-          entity.profile1.identity.meta = factory.createEmbeddable(identity_meta_35, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+          entity.profile1.identity.meta = factory.createEmbeddable(identity_meta_42, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
         }
         if (data.profile1_identity.meta.foo === null) {
           entity.profile1.identity.meta.foo = null;
@@ -525,9 +525,9 @@ exports[`embedded entities in postgres > diffing 2`] = `
     entity.profile1.identity.meta.source = null;
         } else if (typeof data.profile1_identity.meta.source !== 'undefined') {
           if (isPrimaryKey(data.profile1_identity.meta.source, true)) {
-            entity.profile1.identity.meta.source = factory.createReference(source_38, data.profile1_identity.meta.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
+            entity.profile1.identity.meta.source = factory.createReference(source_45, data.profile1_identity.meta.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
           } else if (data.profile1_identity.meta.source && typeof data.profile1_identity.meta.source === 'object') {
-            entity.profile1.identity.meta.source = factory.create(source_38, data.profile1_identity.meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
+            entity.profile1.identity.meta.source = factory.create(source_46, data.profile1_identity.meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
           }
         }
       } else if (data.profile1_identity.meta === null) {
@@ -535,98 +535,98 @@ exports[`embedded entities in postgres > diffing 2`] = `
       }
       if (Array.isArray(data.profile1_identity.links)) {
         entity.profile1.identity.links = [];
-        data.profile1_identity.links.forEach((_, idx_39) => {
-          if (data.profile1_identity.links[idx_39] != null) {
-            const embeddedData = data.profile1_identity.links[idx_39];
-            if (entity.profile1.identity.links[idx_39] == null) {
-              entity.profile1.identity.links[idx_39] = factory.createEmbeddable(identity_link_40, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+        data.profile1_identity.links.forEach((_, idx_47) => {
+          if (data.profile1_identity.links[idx_47] != null) {
+            const embeddedData = data.profile1_identity.links[idx_47];
+            if (entity.profile1.identity.links[idx_47] == null) {
+              entity.profile1.identity.links[idx_47] = factory.createEmbeddable(identity_link_48, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
             }
-            if (data.profile1_identity.links[idx_39].url === null) {
-              entity.profile1.identity.links[idx_39].url = null;
-            } else if (typeof data.profile1_identity.links[idx_39].url !== 'undefined') {
-              entity.profile1.identity.links[idx_39].url = data.profile1_identity.links[idx_39].url;
+            if (data.profile1_identity.links[idx_47].url === null) {
+              entity.profile1.identity.links[idx_47].url = null;
+            } else if (typeof data.profile1_identity.links[idx_47].url !== 'undefined') {
+              entity.profile1.identity.links[idx_47].url = data.profile1_identity.links[idx_47].url;
             }
-            if (data.profile1_identity.links[idx_39].createdAt === null) {
-              entity.profile1.identity.links[idx_39].createdAt = null;
-            } else if (typeof data.profile1_identity.links[idx_39].createdAt !== 'undefined') {
-              if (data.profile1_identity.links[idx_39].createdAt instanceof Date) {
-                entity.profile1.identity.links[idx_39].createdAt = data.profile1_identity.links[idx_39].createdAt;
-              } else if (typeof data.profile1_identity.links[idx_39].createdAt === 'number' || data.profile1_identity.links[idx_39].createdAt.includes('+') || data.profile1_identity.links[idx_39].createdAt.lastIndexOf('-') > 10 || data.profile1_identity.links[idx_39].createdAt.endsWith('Z')) {
-                entity.profile1.identity.links[idx_39].createdAt = new Date(data.profile1_identity.links[idx_39].createdAt);
+            if (data.profile1_identity.links[idx_47].createdAt === null) {
+              entity.profile1.identity.links[idx_47].createdAt = null;
+            } else if (typeof data.profile1_identity.links[idx_47].createdAt !== 'undefined') {
+              if (data.profile1_identity.links[idx_47].createdAt instanceof Date) {
+                entity.profile1.identity.links[idx_47].createdAt = data.profile1_identity.links[idx_47].createdAt;
+              } else if (typeof data.profile1_identity.links[idx_47].createdAt === 'number' || data.profile1_identity.links[idx_47].createdAt.includes('+') || data.profile1_identity.links[idx_47].createdAt.lastIndexOf('-') > 10 || data.profile1_identity.links[idx_47].createdAt.endsWith('Z')) {
+                entity.profile1.identity.links[idx_47].createdAt = new Date(data.profile1_identity.links[idx_47].createdAt);
               } else {
-                entity.profile1.identity.links[idx_39].createdAt = new Date(data.profile1_identity.links[idx_39].createdAt + 'Z');
+                entity.profile1.identity.links[idx_47].createdAt = new Date(data.profile1_identity.links[idx_47].createdAt + 'Z');
               }
             }
-            if (data.profile1_identity.links[idx_39].meta != null) {
-              const embeddedData = data.profile1_identity.links[idx_39].meta;
-              if (entity.profile1.identity.links[idx_39].meta == null) {
-                entity.profile1.identity.links[idx_39].meta = factory.createEmbeddable(identity_meta_43, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+            if (data.profile1_identity.links[idx_47].meta != null) {
+              const embeddedData = data.profile1_identity.links[idx_47].meta;
+              if (entity.profile1.identity.links[idx_47].meta == null) {
+                entity.profile1.identity.links[idx_47].meta = factory.createEmbeddable(identity_meta_51, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
               }
-              if (data.profile1_identity.links[idx_39].meta.foo === null) {
-                entity.profile1.identity.links[idx_39].meta.foo = null;
-              } else if (typeof data.profile1_identity.links[idx_39].meta.foo !== 'undefined') {
-                entity.profile1.identity.links[idx_39].meta.foo = data.profile1_identity.links[idx_39].meta.foo;
+              if (data.profile1_identity.links[idx_47].meta.foo === null) {
+                entity.profile1.identity.links[idx_47].meta.foo = null;
+              } else if (typeof data.profile1_identity.links[idx_47].meta.foo !== 'undefined') {
+                entity.profile1.identity.links[idx_47].meta.foo = data.profile1_identity.links[idx_47].meta.foo;
               }
-              if (data.profile1_identity.links[idx_39].meta.bar === null) {
-                entity.profile1.identity.links[idx_39].meta.bar = null;
-              } else if (typeof data.profile1_identity.links[idx_39].meta.bar !== 'undefined') {
-                entity.profile1.identity.links[idx_39].meta.bar = data.profile1_identity.links[idx_39].meta.bar;
+              if (data.profile1_identity.links[idx_47].meta.bar === null) {
+                entity.profile1.identity.links[idx_47].meta.bar = null;
+              } else if (typeof data.profile1_identity.links[idx_47].meta.bar !== 'undefined') {
+                entity.profile1.identity.links[idx_47].meta.bar = data.profile1_identity.links[idx_47].meta.bar;
               }
-              if (data.profile1_identity.links[idx_39].meta.source === null) {
-    entity.profile1.identity.links[idx_39].meta.source = null;
-              } else if (typeof data.profile1_identity.links[idx_39].meta.source !== 'undefined') {
-                if (isPrimaryKey(data.profile1_identity.links[idx_39].meta.source, true)) {
-                  entity.profile1.identity.links[idx_39].meta.source = factory.createReference(source_46, data.profile1_identity.links[idx_39].meta.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
-                } else if (data.profile1_identity.links[idx_39].meta.source && typeof data.profile1_identity.links[idx_39].meta.source === 'object') {
-                  entity.profile1.identity.links[idx_39].meta.source = factory.create(source_46, data.profile1_identity.links[idx_39].meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
+              if (data.profile1_identity.links[idx_47].meta.source === null) {
+    entity.profile1.identity.links[idx_47].meta.source = null;
+              } else if (typeof data.profile1_identity.links[idx_47].meta.source !== 'undefined') {
+                if (isPrimaryKey(data.profile1_identity.links[idx_47].meta.source, true)) {
+                  entity.profile1.identity.links[idx_47].meta.source = factory.createReference(source_54, data.profile1_identity.links[idx_47].meta.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
+                } else if (data.profile1_identity.links[idx_47].meta.source && typeof data.profile1_identity.links[idx_47].meta.source === 'object') {
+                  entity.profile1.identity.links[idx_47].meta.source = factory.create(source_55, data.profile1_identity.links[idx_47].meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
                 }
               }
-            } else if (data.profile1_identity.links[idx_39].meta === null) {
-              entity.profile1.identity.links[idx_39].meta = null;
+            } else if (data.profile1_identity.links[idx_47].meta === null) {
+              entity.profile1.identity.links[idx_47].meta = null;
             }
-            if (Array.isArray(data.profile1_identity.links[idx_39].metas)) {
-              entity.profile1.identity.links[idx_39].metas = [];
-              data.profile1_identity.links[idx_39].metas.forEach((_, idx_47) => {
-                if (data.profile1_identity.links[idx_39].metas[idx_47] != null) {
-                  const embeddedData = data.profile1_identity.links[idx_39].metas[idx_47];
-                  if (entity.profile1.identity.links[idx_39].metas[idx_47] == null) {
-                    entity.profile1.identity.links[idx_39].metas[idx_47] = factory.createEmbeddable(identity_meta_48, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+            if (Array.isArray(data.profile1_identity.links[idx_47].metas)) {
+              entity.profile1.identity.links[idx_47].metas = [];
+              data.profile1_identity.links[idx_47].metas.forEach((_, idx_56) => {
+                if (data.profile1_identity.links[idx_47].metas[idx_56] != null) {
+                  const embeddedData = data.profile1_identity.links[idx_47].metas[idx_56];
+                  if (entity.profile1.identity.links[idx_47].metas[idx_56] == null) {
+                    entity.profile1.identity.links[idx_47].metas[idx_56] = factory.createEmbeddable(identity_meta_57, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
                   }
-                  if (data.profile1_identity.links[idx_39].metas[idx_47].foo === null) {
-                    entity.profile1.identity.links[idx_39].metas[idx_47].foo = null;
-                  } else if (typeof data.profile1_identity.links[idx_39].metas[idx_47].foo !== 'undefined') {
-                    entity.profile1.identity.links[idx_39].metas[idx_47].foo = data.profile1_identity.links[idx_39].metas[idx_47].foo;
+                  if (data.profile1_identity.links[idx_47].metas[idx_56].foo === null) {
+                    entity.profile1.identity.links[idx_47].metas[idx_56].foo = null;
+                  } else if (typeof data.profile1_identity.links[idx_47].metas[idx_56].foo !== 'undefined') {
+                    entity.profile1.identity.links[idx_47].metas[idx_56].foo = data.profile1_identity.links[idx_47].metas[idx_56].foo;
                   }
-                  if (data.profile1_identity.links[idx_39].metas[idx_47].bar === null) {
-                    entity.profile1.identity.links[idx_39].metas[idx_47].bar = null;
-                  } else if (typeof data.profile1_identity.links[idx_39].metas[idx_47].bar !== 'undefined') {
-                    entity.profile1.identity.links[idx_39].metas[idx_47].bar = data.profile1_identity.links[idx_39].metas[idx_47].bar;
+                  if (data.profile1_identity.links[idx_47].metas[idx_56].bar === null) {
+                    entity.profile1.identity.links[idx_47].metas[idx_56].bar = null;
+                  } else if (typeof data.profile1_identity.links[idx_47].metas[idx_56].bar !== 'undefined') {
+                    entity.profile1.identity.links[idx_47].metas[idx_56].bar = data.profile1_identity.links[idx_47].metas[idx_56].bar;
                   }
-                  if (data.profile1_identity.links[idx_39].metas[idx_47].source === null) {
-    entity.profile1.identity.links[idx_39].metas[idx_47].source = null;
-                  } else if (typeof data.profile1_identity.links[idx_39].metas[idx_47].source !== 'undefined') {
-                    if (isPrimaryKey(data.profile1_identity.links[idx_39].metas[idx_47].source, true)) {
-                      entity.profile1.identity.links[idx_39].metas[idx_47].source = factory.createReference(source_51, data.profile1_identity.links[idx_39].metas[idx_47].source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
-                    } else if (data.profile1_identity.links[idx_39].metas[idx_47].source && typeof data.profile1_identity.links[idx_39].metas[idx_47].source === 'object') {
-                      entity.profile1.identity.links[idx_39].metas[idx_47].source = factory.create(source_51, data.profile1_identity.links[idx_39].metas[idx_47].source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
+                  if (data.profile1_identity.links[idx_47].metas[idx_56].source === null) {
+    entity.profile1.identity.links[idx_47].metas[idx_56].source = null;
+                  } else if (typeof data.profile1_identity.links[idx_47].metas[idx_56].source !== 'undefined') {
+                    if (isPrimaryKey(data.profile1_identity.links[idx_47].metas[idx_56].source, true)) {
+                      entity.profile1.identity.links[idx_47].metas[idx_56].source = factory.createReference(source_60, data.profile1_identity.links[idx_47].metas[idx_56].source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
+                    } else if (data.profile1_identity.links[idx_47].metas[idx_56].source && typeof data.profile1_identity.links[idx_47].metas[idx_56].source === 'object') {
+                      entity.profile1.identity.links[idx_47].metas[idx_56].source = factory.create(source_61, data.profile1_identity.links[idx_47].metas[idx_56].source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
                     }
                   }
-                } else if (data.profile1_identity.links[idx_39].metas[idx_47] === null) {
-                  entity.profile1.identity.links[idx_39].metas[idx_47] = null;
+                } else if (data.profile1_identity.links[idx_47].metas[idx_56] === null) {
+                  entity.profile1.identity.links[idx_47].metas[idx_56] = null;
                 }
               });
             }
-            if (data.profile1_identity.links[idx_39].source === null) {
-    entity.profile1.identity.links[idx_39].source = null;
-            } else if (typeof data.profile1_identity.links[idx_39].source !== 'undefined') {
-              if (isPrimaryKey(data.profile1_identity.links[idx_39].source, true)) {
-                entity.profile1.identity.links[idx_39].source = factory.createReference(source_52, data.profile1_identity.links[idx_39].source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
-              } else if (data.profile1_identity.links[idx_39].source && typeof data.profile1_identity.links[idx_39].source === 'object') {
-                entity.profile1.identity.links[idx_39].source = factory.create(source_52, data.profile1_identity.links[idx_39].source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
+            if (data.profile1_identity.links[idx_47].source === null) {
+    entity.profile1.identity.links[idx_47].source = null;
+            } else if (typeof data.profile1_identity.links[idx_47].source !== 'undefined') {
+              if (isPrimaryKey(data.profile1_identity.links[idx_47].source, true)) {
+                entity.profile1.identity.links[idx_47].source = factory.createReference(source_62, data.profile1_identity.links[idx_47].source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
+              } else if (data.profile1_identity.links[idx_47].source && typeof data.profile1_identity.links[idx_47].source === 'object') {
+                entity.profile1.identity.links[idx_47].source = factory.create(source_63, data.profile1_identity.links[idx_47].source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
               }
             }
-          } else if (data.profile1_identity.links[idx_39] === null) {
-            entity.profile1.identity.links[idx_39] = null;
+          } else if (data.profile1_identity.links[idx_47] === null) {
+            entity.profile1.identity.links[idx_47] = null;
           }
         });
       }
@@ -634,9 +634,9 @@ exports[`embedded entities in postgres > diffing 2`] = `
     entity.profile1.identity.source = null;
       } else if (typeof data.profile1_identity.source !== 'undefined') {
         if (isPrimaryKey(data.profile1_identity.source, true)) {
-          entity.profile1.identity.source = factory.createReference(source_53, data.profile1_identity.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
+          entity.profile1.identity.source = factory.createReference(source_64, data.profile1_identity.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
         } else if (data.profile1_identity.source && typeof data.profile1_identity.source === 'object') {
-          entity.profile1.identity.source = factory.create(source_53, data.profile1_identity.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
+          entity.profile1.identity.source = factory.create(source_65, data.profile1_identity.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
         }
       }
     } else if (data.profile1_identity === null) {
@@ -646,9 +646,9 @@ exports[`embedded entities in postgres > diffing 2`] = `
     entity.profile1.source = null;
     } else if (typeof data.profile1_source !== 'undefined') {
       if (isPrimaryKey(data.profile1_source, true)) {
-        entity.profile1.source = factory.createReference(source_54, data.profile1_source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
+        entity.profile1.source = factory.createReference(source_66, data.profile1_source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
       } else if (data.profile1_source && typeof data.profile1_source === 'object') {
-        entity.profile1.source = factory.create(source_54, data.profile1_source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
+        entity.profile1.source = factory.create(source_67, data.profile1_source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
       }
     }
   } else if (data.profile1_username === null && data.profile1_identity_email === null && data.profile1_identity_meta_foo === null && data.profile1_identity_meta_bar === null && data.profile1_identity_meta_source === null && data.profile1_identity_links === null && data.profile1_identity_source === null && data.profile1_source === null) {
@@ -657,7 +657,7 @@ exports[`embedded entities in postgres > diffing 2`] = `
   if (data.profile1 != null) {
     const embeddedData = data.profile1;
     if (entity.profile1 == null) {
-      entity.profile1 = factory.createEmbeddable(profile_55, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+      entity.profile1 = factory.createEmbeddable(profile_68, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
     }
     if (data.profile1.username === null) {
       entity.profile1.username = null;
@@ -672,7 +672,7 @@ exports[`embedded entities in postgres > diffing 2`] = `
         source: data.profile1_identity_source,
       };
       if (entity.profile1.identity == null) {
-        entity.profile1.identity = factory.createEmbeddable(identity_57, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+        entity.profile1.identity = factory.createEmbeddable(identity_70, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
       }
       if (data.profile1_identity_email === null) {
         entity.profile1.identity.email = null;
@@ -686,7 +686,7 @@ exports[`embedded entities in postgres > diffing 2`] = `
           source: data.profile1_identity_meta_source,
         };
         if (entity.profile1.identity.meta == null) {
-          entity.profile1.identity.meta = factory.createEmbeddable(identity_meta_59, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+          entity.profile1.identity.meta = factory.createEmbeddable(identity_meta_72, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
         }
         if (data.profile1_identity_meta_foo === null) {
           entity.profile1.identity.meta.foo = null;
@@ -702,9 +702,9 @@ exports[`embedded entities in postgres > diffing 2`] = `
     entity.profile1.identity.meta.source = null;
         } else if (typeof data.profile1_identity_meta_source !== 'undefined') {
           if (isPrimaryKey(data.profile1_identity_meta_source, true)) {
-            entity.profile1.identity.meta.source = factory.createReference(source_62, data.profile1_identity_meta_source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
+            entity.profile1.identity.meta.source = factory.createReference(source_75, data.profile1_identity_meta_source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
           } else if (data.profile1_identity_meta_source && typeof data.profile1_identity_meta_source === 'object') {
-            entity.profile1.identity.meta.source = factory.create(source_62, data.profile1_identity_meta_source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
+            entity.profile1.identity.meta.source = factory.create(source_76, data.profile1_identity_meta_source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
           }
         }
       } else if (data.profile1_identity_meta_foo === null && data.profile1_identity_meta_bar === null && data.profile1_identity_meta_source === null) {
@@ -713,7 +713,7 @@ exports[`embedded entities in postgres > diffing 2`] = `
       if (data.profile1_identity_meta != null) {
         const embeddedData = data.profile1_identity_meta;
         if (entity.profile1.identity.meta == null) {
-          entity.profile1.identity.meta = factory.createEmbeddable(identity_meta_63, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+          entity.profile1.identity.meta = factory.createEmbeddable(identity_meta_77, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
         }
         if (data.profile1_identity_meta.foo === null) {
           entity.profile1.identity.meta.foo = null;
@@ -729,9 +729,9 @@ exports[`embedded entities in postgres > diffing 2`] = `
     entity.profile1.identity.meta.source = null;
         } else if (typeof data.profile1_identity_meta.source !== 'undefined') {
           if (isPrimaryKey(data.profile1_identity_meta.source, true)) {
-            entity.profile1.identity.meta.source = factory.createReference(source_66, data.profile1_identity_meta.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
+            entity.profile1.identity.meta.source = factory.createReference(source_80, data.profile1_identity_meta.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
           } else if (data.profile1_identity_meta.source && typeof data.profile1_identity_meta.source === 'object') {
-            entity.profile1.identity.meta.source = factory.create(source_66, data.profile1_identity_meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
+            entity.profile1.identity.meta.source = factory.create(source_81, data.profile1_identity_meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
           }
         }
       } else if (data.profile1_identity_meta === null) {
@@ -739,98 +739,98 @@ exports[`embedded entities in postgres > diffing 2`] = `
       }
       if (Array.isArray(data.profile1_identity_links)) {
         entity.profile1.identity.links = [];
-        data.profile1_identity_links.forEach((_, idx_67) => {
-          if (data.profile1_identity_links[idx_67] != null) {
-            const embeddedData = data.profile1_identity_links[idx_67];
-            if (entity.profile1.identity.links[idx_67] == null) {
-              entity.profile1.identity.links[idx_67] = factory.createEmbeddable(identity_link_68, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+        data.profile1_identity_links.forEach((_, idx_82) => {
+          if (data.profile1_identity_links[idx_82] != null) {
+            const embeddedData = data.profile1_identity_links[idx_82];
+            if (entity.profile1.identity.links[idx_82] == null) {
+              entity.profile1.identity.links[idx_82] = factory.createEmbeddable(identity_link_83, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
             }
-            if (data.profile1_identity_links[idx_67].url === null) {
-              entity.profile1.identity.links[idx_67].url = null;
-            } else if (typeof data.profile1_identity_links[idx_67].url !== 'undefined') {
-              entity.profile1.identity.links[idx_67].url = data.profile1_identity_links[idx_67].url;
+            if (data.profile1_identity_links[idx_82].url === null) {
+              entity.profile1.identity.links[idx_82].url = null;
+            } else if (typeof data.profile1_identity_links[idx_82].url !== 'undefined') {
+              entity.profile1.identity.links[idx_82].url = data.profile1_identity_links[idx_82].url;
             }
-            if (data.profile1_identity_links[idx_67].createdAt === null) {
-              entity.profile1.identity.links[idx_67].createdAt = null;
-            } else if (typeof data.profile1_identity_links[idx_67].createdAt !== 'undefined') {
-              if (data.profile1_identity_links[idx_67].createdAt instanceof Date) {
-                entity.profile1.identity.links[idx_67].createdAt = data.profile1_identity_links[idx_67].createdAt;
-              } else if (typeof data.profile1_identity_links[idx_67].createdAt === 'number' || data.profile1_identity_links[idx_67].createdAt.includes('+') || data.profile1_identity_links[idx_67].createdAt.lastIndexOf('-') > 10 || data.profile1_identity_links[idx_67].createdAt.endsWith('Z')) {
-                entity.profile1.identity.links[idx_67].createdAt = new Date(data.profile1_identity_links[idx_67].createdAt);
+            if (data.profile1_identity_links[idx_82].createdAt === null) {
+              entity.profile1.identity.links[idx_82].createdAt = null;
+            } else if (typeof data.profile1_identity_links[idx_82].createdAt !== 'undefined') {
+              if (data.profile1_identity_links[idx_82].createdAt instanceof Date) {
+                entity.profile1.identity.links[idx_82].createdAt = data.profile1_identity_links[idx_82].createdAt;
+              } else if (typeof data.profile1_identity_links[idx_82].createdAt === 'number' || data.profile1_identity_links[idx_82].createdAt.includes('+') || data.profile1_identity_links[idx_82].createdAt.lastIndexOf('-') > 10 || data.profile1_identity_links[idx_82].createdAt.endsWith('Z')) {
+                entity.profile1.identity.links[idx_82].createdAt = new Date(data.profile1_identity_links[idx_82].createdAt);
               } else {
-                entity.profile1.identity.links[idx_67].createdAt = new Date(data.profile1_identity_links[idx_67].createdAt + 'Z');
+                entity.profile1.identity.links[idx_82].createdAt = new Date(data.profile1_identity_links[idx_82].createdAt + 'Z');
               }
             }
-            if (data.profile1_identity_links[idx_67].meta != null) {
-              const embeddedData = data.profile1_identity_links[idx_67].meta;
-              if (entity.profile1.identity.links[idx_67].meta == null) {
-                entity.profile1.identity.links[idx_67].meta = factory.createEmbeddable(identity_meta_71, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+            if (data.profile1_identity_links[idx_82].meta != null) {
+              const embeddedData = data.profile1_identity_links[idx_82].meta;
+              if (entity.profile1.identity.links[idx_82].meta == null) {
+                entity.profile1.identity.links[idx_82].meta = factory.createEmbeddable(identity_meta_86, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
               }
-              if (data.profile1_identity_links[idx_67].meta.foo === null) {
-                entity.profile1.identity.links[idx_67].meta.foo = null;
-              } else if (typeof data.profile1_identity_links[idx_67].meta.foo !== 'undefined') {
-                entity.profile1.identity.links[idx_67].meta.foo = data.profile1_identity_links[idx_67].meta.foo;
+              if (data.profile1_identity_links[idx_82].meta.foo === null) {
+                entity.profile1.identity.links[idx_82].meta.foo = null;
+              } else if (typeof data.profile1_identity_links[idx_82].meta.foo !== 'undefined') {
+                entity.profile1.identity.links[idx_82].meta.foo = data.profile1_identity_links[idx_82].meta.foo;
               }
-              if (data.profile1_identity_links[idx_67].meta.bar === null) {
-                entity.profile1.identity.links[idx_67].meta.bar = null;
-              } else if (typeof data.profile1_identity_links[idx_67].meta.bar !== 'undefined') {
-                entity.profile1.identity.links[idx_67].meta.bar = data.profile1_identity_links[idx_67].meta.bar;
+              if (data.profile1_identity_links[idx_82].meta.bar === null) {
+                entity.profile1.identity.links[idx_82].meta.bar = null;
+              } else if (typeof data.profile1_identity_links[idx_82].meta.bar !== 'undefined') {
+                entity.profile1.identity.links[idx_82].meta.bar = data.profile1_identity_links[idx_82].meta.bar;
               }
-              if (data.profile1_identity_links[idx_67].meta.source === null) {
-    entity.profile1.identity.links[idx_67].meta.source = null;
-              } else if (typeof data.profile1_identity_links[idx_67].meta.source !== 'undefined') {
-                if (isPrimaryKey(data.profile1_identity_links[idx_67].meta.source, true)) {
-                  entity.profile1.identity.links[idx_67].meta.source = factory.createReference(source_74, data.profile1_identity_links[idx_67].meta.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
-                } else if (data.profile1_identity_links[idx_67].meta.source && typeof data.profile1_identity_links[idx_67].meta.source === 'object') {
-                  entity.profile1.identity.links[idx_67].meta.source = factory.create(source_74, data.profile1_identity_links[idx_67].meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
+              if (data.profile1_identity_links[idx_82].meta.source === null) {
+    entity.profile1.identity.links[idx_82].meta.source = null;
+              } else if (typeof data.profile1_identity_links[idx_82].meta.source !== 'undefined') {
+                if (isPrimaryKey(data.profile1_identity_links[idx_82].meta.source, true)) {
+                  entity.profile1.identity.links[idx_82].meta.source = factory.createReference(source_89, data.profile1_identity_links[idx_82].meta.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
+                } else if (data.profile1_identity_links[idx_82].meta.source && typeof data.profile1_identity_links[idx_82].meta.source === 'object') {
+                  entity.profile1.identity.links[idx_82].meta.source = factory.create(source_90, data.profile1_identity_links[idx_82].meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
                 }
               }
-            } else if (data.profile1_identity_links[idx_67].meta === null) {
-              entity.profile1.identity.links[idx_67].meta = null;
+            } else if (data.profile1_identity_links[idx_82].meta === null) {
+              entity.profile1.identity.links[idx_82].meta = null;
             }
-            if (Array.isArray(data.profile1_identity_links[idx_67].metas)) {
-              entity.profile1.identity.links[idx_67].metas = [];
-              data.profile1_identity_links[idx_67].metas.forEach((_, idx_75) => {
-                if (data.profile1_identity_links[idx_67].metas[idx_75] != null) {
-                  const embeddedData = data.profile1_identity_links[idx_67].metas[idx_75];
-                  if (entity.profile1.identity.links[idx_67].metas[idx_75] == null) {
-                    entity.profile1.identity.links[idx_67].metas[idx_75] = factory.createEmbeddable(identity_meta_76, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+            if (Array.isArray(data.profile1_identity_links[idx_82].metas)) {
+              entity.profile1.identity.links[idx_82].metas = [];
+              data.profile1_identity_links[idx_82].metas.forEach((_, idx_91) => {
+                if (data.profile1_identity_links[idx_82].metas[idx_91] != null) {
+                  const embeddedData = data.profile1_identity_links[idx_82].metas[idx_91];
+                  if (entity.profile1.identity.links[idx_82].metas[idx_91] == null) {
+                    entity.profile1.identity.links[idx_82].metas[idx_91] = factory.createEmbeddable(identity_meta_92, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
                   }
-                  if (data.profile1_identity_links[idx_67].metas[idx_75].foo === null) {
-                    entity.profile1.identity.links[idx_67].metas[idx_75].foo = null;
-                  } else if (typeof data.profile1_identity_links[idx_67].metas[idx_75].foo !== 'undefined') {
-                    entity.profile1.identity.links[idx_67].metas[idx_75].foo = data.profile1_identity_links[idx_67].metas[idx_75].foo;
+                  if (data.profile1_identity_links[idx_82].metas[idx_91].foo === null) {
+                    entity.profile1.identity.links[idx_82].metas[idx_91].foo = null;
+                  } else if (typeof data.profile1_identity_links[idx_82].metas[idx_91].foo !== 'undefined') {
+                    entity.profile1.identity.links[idx_82].metas[idx_91].foo = data.profile1_identity_links[idx_82].metas[idx_91].foo;
                   }
-                  if (data.profile1_identity_links[idx_67].metas[idx_75].bar === null) {
-                    entity.profile1.identity.links[idx_67].metas[idx_75].bar = null;
-                  } else if (typeof data.profile1_identity_links[idx_67].metas[idx_75].bar !== 'undefined') {
-                    entity.profile1.identity.links[idx_67].metas[idx_75].bar = data.profile1_identity_links[idx_67].metas[idx_75].bar;
+                  if (data.profile1_identity_links[idx_82].metas[idx_91].bar === null) {
+                    entity.profile1.identity.links[idx_82].metas[idx_91].bar = null;
+                  } else if (typeof data.profile1_identity_links[idx_82].metas[idx_91].bar !== 'undefined') {
+                    entity.profile1.identity.links[idx_82].metas[idx_91].bar = data.profile1_identity_links[idx_82].metas[idx_91].bar;
                   }
-                  if (data.profile1_identity_links[idx_67].metas[idx_75].source === null) {
-    entity.profile1.identity.links[idx_67].metas[idx_75].source = null;
-                  } else if (typeof data.profile1_identity_links[idx_67].metas[idx_75].source !== 'undefined') {
-                    if (isPrimaryKey(data.profile1_identity_links[idx_67].metas[idx_75].source, true)) {
-                      entity.profile1.identity.links[idx_67].metas[idx_75].source = factory.createReference(source_79, data.profile1_identity_links[idx_67].metas[idx_75].source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
-                    } else if (data.profile1_identity_links[idx_67].metas[idx_75].source && typeof data.profile1_identity_links[idx_67].metas[idx_75].source === 'object') {
-                      entity.profile1.identity.links[idx_67].metas[idx_75].source = factory.create(source_79, data.profile1_identity_links[idx_67].metas[idx_75].source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
+                  if (data.profile1_identity_links[idx_82].metas[idx_91].source === null) {
+    entity.profile1.identity.links[idx_82].metas[idx_91].source = null;
+                  } else if (typeof data.profile1_identity_links[idx_82].metas[idx_91].source !== 'undefined') {
+                    if (isPrimaryKey(data.profile1_identity_links[idx_82].metas[idx_91].source, true)) {
+                      entity.profile1.identity.links[idx_82].metas[idx_91].source = factory.createReference(source_95, data.profile1_identity_links[idx_82].metas[idx_91].source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
+                    } else if (data.profile1_identity_links[idx_82].metas[idx_91].source && typeof data.profile1_identity_links[idx_82].metas[idx_91].source === 'object') {
+                      entity.profile1.identity.links[idx_82].metas[idx_91].source = factory.create(source_96, data.profile1_identity_links[idx_82].metas[idx_91].source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
                     }
                   }
-                } else if (data.profile1_identity_links[idx_67].metas[idx_75] === null) {
-                  entity.profile1.identity.links[idx_67].metas[idx_75] = null;
+                } else if (data.profile1_identity_links[idx_82].metas[idx_91] === null) {
+                  entity.profile1.identity.links[idx_82].metas[idx_91] = null;
                 }
               });
             }
-            if (data.profile1_identity_links[idx_67].source === null) {
-    entity.profile1.identity.links[idx_67].source = null;
-            } else if (typeof data.profile1_identity_links[idx_67].source !== 'undefined') {
-              if (isPrimaryKey(data.profile1_identity_links[idx_67].source, true)) {
-                entity.profile1.identity.links[idx_67].source = factory.createReference(source_80, data.profile1_identity_links[idx_67].source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
-              } else if (data.profile1_identity_links[idx_67].source && typeof data.profile1_identity_links[idx_67].source === 'object') {
-                entity.profile1.identity.links[idx_67].source = factory.create(source_80, data.profile1_identity_links[idx_67].source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
+            if (data.profile1_identity_links[idx_82].source === null) {
+    entity.profile1.identity.links[idx_82].source = null;
+            } else if (typeof data.profile1_identity_links[idx_82].source !== 'undefined') {
+              if (isPrimaryKey(data.profile1_identity_links[idx_82].source, true)) {
+                entity.profile1.identity.links[idx_82].source = factory.createReference(source_97, data.profile1_identity_links[idx_82].source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
+              } else if (data.profile1_identity_links[idx_82].source && typeof data.profile1_identity_links[idx_82].source === 'object') {
+                entity.profile1.identity.links[idx_82].source = factory.create(source_98, data.profile1_identity_links[idx_82].source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
               }
             }
-          } else if (data.profile1_identity_links[idx_67] === null) {
-            entity.profile1.identity.links[idx_67] = null;
+          } else if (data.profile1_identity_links[idx_82] === null) {
+            entity.profile1.identity.links[idx_82] = null;
           }
         });
       }
@@ -838,9 +838,9 @@ exports[`embedded entities in postgres > diffing 2`] = `
     entity.profile1.identity.source = null;
       } else if (typeof data.profile1_identity_source !== 'undefined') {
         if (isPrimaryKey(data.profile1_identity_source, true)) {
-          entity.profile1.identity.source = factory.createReference(source_81, data.profile1_identity_source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
+          entity.profile1.identity.source = factory.createReference(source_99, data.profile1_identity_source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
         } else if (data.profile1_identity_source && typeof data.profile1_identity_source === 'object') {
-          entity.profile1.identity.source = factory.create(source_81, data.profile1_identity_source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
+          entity.profile1.identity.source = factory.create(source_100, data.profile1_identity_source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
         }
       }
     } else if (data.profile1_identity_email === null && data.profile1_identity_meta_foo === null && data.profile1_identity_meta_bar === null && data.profile1_identity_meta_source === null && data.profile1_identity_links === null && data.profile1_identity_source === null) {
@@ -849,7 +849,7 @@ exports[`embedded entities in postgres > diffing 2`] = `
     if (data.profile1.identity != null) {
       const embeddedData = data.profile1.identity;
       if (entity.profile1.identity == null) {
-        entity.profile1.identity = factory.createEmbeddable(identity_82, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+        entity.profile1.identity = factory.createEmbeddable(identity_101, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
       }
       if (data.profile1.identity.email === null) {
         entity.profile1.identity.email = null;
@@ -863,7 +863,7 @@ exports[`embedded entities in postgres > diffing 2`] = `
           source: data.profile1_identity_meta_source,
         };
         if (entity.profile1.identity.meta == null) {
-          entity.profile1.identity.meta = factory.createEmbeddable(identity_meta_84, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+          entity.profile1.identity.meta = factory.createEmbeddable(identity_meta_103, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
         }
         if (data.profile1_identity_meta_foo === null) {
           entity.profile1.identity.meta.foo = null;
@@ -879,9 +879,9 @@ exports[`embedded entities in postgres > diffing 2`] = `
     entity.profile1.identity.meta.source = null;
         } else if (typeof data.profile1_identity_meta_source !== 'undefined') {
           if (isPrimaryKey(data.profile1_identity_meta_source, true)) {
-            entity.profile1.identity.meta.source = factory.createReference(source_87, data.profile1_identity_meta_source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
+            entity.profile1.identity.meta.source = factory.createReference(source_106, data.profile1_identity_meta_source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
           } else if (data.profile1_identity_meta_source && typeof data.profile1_identity_meta_source === 'object') {
-            entity.profile1.identity.meta.source = factory.create(source_87, data.profile1_identity_meta_source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
+            entity.profile1.identity.meta.source = factory.create(source_107, data.profile1_identity_meta_source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
           }
         }
       } else if (data.profile1_identity_meta_foo === null && data.profile1_identity_meta_bar === null && data.profile1_identity_meta_source === null) {
@@ -890,7 +890,7 @@ exports[`embedded entities in postgres > diffing 2`] = `
       if (data.profile1.identity.meta != null) {
         const embeddedData = data.profile1.identity.meta;
         if (entity.profile1.identity.meta == null) {
-          entity.profile1.identity.meta = factory.createEmbeddable(identity_meta_88, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+          entity.profile1.identity.meta = factory.createEmbeddable(identity_meta_108, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
         }
         if (data.profile1.identity.meta.foo === null) {
           entity.profile1.identity.meta.foo = null;
@@ -906,9 +906,9 @@ exports[`embedded entities in postgres > diffing 2`] = `
     entity.profile1.identity.meta.source = null;
         } else if (typeof data.profile1.identity.meta.source !== 'undefined') {
           if (isPrimaryKey(data.profile1.identity.meta.source, true)) {
-            entity.profile1.identity.meta.source = factory.createReference(source_91, data.profile1.identity.meta.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
+            entity.profile1.identity.meta.source = factory.createReference(source_111, data.profile1.identity.meta.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
           } else if (data.profile1.identity.meta.source && typeof data.profile1.identity.meta.source === 'object') {
-            entity.profile1.identity.meta.source = factory.create(source_91, data.profile1.identity.meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
+            entity.profile1.identity.meta.source = factory.create(source_112, data.profile1.identity.meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
           }
         }
       } else if (data.profile1.identity.meta === null) {
@@ -916,98 +916,98 @@ exports[`embedded entities in postgres > diffing 2`] = `
       }
       if (Array.isArray(data.profile1.identity.links)) {
         entity.profile1.identity.links = [];
-        data.profile1.identity.links.forEach((_, idx_92) => {
-          if (data.profile1.identity.links[idx_92] != null) {
-            const embeddedData = data.profile1.identity.links[idx_92];
-            if (entity.profile1.identity.links[idx_92] == null) {
-              entity.profile1.identity.links[idx_92] = factory.createEmbeddable(identity_link_93, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+        data.profile1.identity.links.forEach((_, idx_113) => {
+          if (data.profile1.identity.links[idx_113] != null) {
+            const embeddedData = data.profile1.identity.links[idx_113];
+            if (entity.profile1.identity.links[idx_113] == null) {
+              entity.profile1.identity.links[idx_113] = factory.createEmbeddable(identity_link_114, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
             }
-            if (data.profile1.identity.links[idx_92].url === null) {
-              entity.profile1.identity.links[idx_92].url = null;
-            } else if (typeof data.profile1.identity.links[idx_92].url !== 'undefined') {
-              entity.profile1.identity.links[idx_92].url = data.profile1.identity.links[idx_92].url;
+            if (data.profile1.identity.links[idx_113].url === null) {
+              entity.profile1.identity.links[idx_113].url = null;
+            } else if (typeof data.profile1.identity.links[idx_113].url !== 'undefined') {
+              entity.profile1.identity.links[idx_113].url = data.profile1.identity.links[idx_113].url;
             }
-            if (data.profile1.identity.links[idx_92].createdAt === null) {
-              entity.profile1.identity.links[idx_92].createdAt = null;
-            } else if (typeof data.profile1.identity.links[idx_92].createdAt !== 'undefined') {
-              if (data.profile1.identity.links[idx_92].createdAt instanceof Date) {
-                entity.profile1.identity.links[idx_92].createdAt = data.profile1.identity.links[idx_92].createdAt;
-              } else if (typeof data.profile1.identity.links[idx_92].createdAt === 'number' || data.profile1.identity.links[idx_92].createdAt.includes('+') || data.profile1.identity.links[idx_92].createdAt.lastIndexOf('-') > 10 || data.profile1.identity.links[idx_92].createdAt.endsWith('Z')) {
-                entity.profile1.identity.links[idx_92].createdAt = new Date(data.profile1.identity.links[idx_92].createdAt);
+            if (data.profile1.identity.links[idx_113].createdAt === null) {
+              entity.profile1.identity.links[idx_113].createdAt = null;
+            } else if (typeof data.profile1.identity.links[idx_113].createdAt !== 'undefined') {
+              if (data.profile1.identity.links[idx_113].createdAt instanceof Date) {
+                entity.profile1.identity.links[idx_113].createdAt = data.profile1.identity.links[idx_113].createdAt;
+              } else if (typeof data.profile1.identity.links[idx_113].createdAt === 'number' || data.profile1.identity.links[idx_113].createdAt.includes('+') || data.profile1.identity.links[idx_113].createdAt.lastIndexOf('-') > 10 || data.profile1.identity.links[idx_113].createdAt.endsWith('Z')) {
+                entity.profile1.identity.links[idx_113].createdAt = new Date(data.profile1.identity.links[idx_113].createdAt);
               } else {
-                entity.profile1.identity.links[idx_92].createdAt = new Date(data.profile1.identity.links[idx_92].createdAt + 'Z');
+                entity.profile1.identity.links[idx_113].createdAt = new Date(data.profile1.identity.links[idx_113].createdAt + 'Z');
               }
             }
-            if (data.profile1.identity.links[idx_92].meta != null) {
-              const embeddedData = data.profile1.identity.links[idx_92].meta;
-              if (entity.profile1.identity.links[idx_92].meta == null) {
-                entity.profile1.identity.links[idx_92].meta = factory.createEmbeddable(identity_meta_96, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+            if (data.profile1.identity.links[idx_113].meta != null) {
+              const embeddedData = data.profile1.identity.links[idx_113].meta;
+              if (entity.profile1.identity.links[idx_113].meta == null) {
+                entity.profile1.identity.links[idx_113].meta = factory.createEmbeddable(identity_meta_117, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
               }
-              if (data.profile1.identity.links[idx_92].meta.foo === null) {
-                entity.profile1.identity.links[idx_92].meta.foo = null;
-              } else if (typeof data.profile1.identity.links[idx_92].meta.foo !== 'undefined') {
-                entity.profile1.identity.links[idx_92].meta.foo = data.profile1.identity.links[idx_92].meta.foo;
+              if (data.profile1.identity.links[idx_113].meta.foo === null) {
+                entity.profile1.identity.links[idx_113].meta.foo = null;
+              } else if (typeof data.profile1.identity.links[idx_113].meta.foo !== 'undefined') {
+                entity.profile1.identity.links[idx_113].meta.foo = data.profile1.identity.links[idx_113].meta.foo;
               }
-              if (data.profile1.identity.links[idx_92].meta.bar === null) {
-                entity.profile1.identity.links[idx_92].meta.bar = null;
-              } else if (typeof data.profile1.identity.links[idx_92].meta.bar !== 'undefined') {
-                entity.profile1.identity.links[idx_92].meta.bar = data.profile1.identity.links[idx_92].meta.bar;
+              if (data.profile1.identity.links[idx_113].meta.bar === null) {
+                entity.profile1.identity.links[idx_113].meta.bar = null;
+              } else if (typeof data.profile1.identity.links[idx_113].meta.bar !== 'undefined') {
+                entity.profile1.identity.links[idx_113].meta.bar = data.profile1.identity.links[idx_113].meta.bar;
               }
-              if (data.profile1.identity.links[idx_92].meta.source === null) {
-    entity.profile1.identity.links[idx_92].meta.source = null;
-              } else if (typeof data.profile1.identity.links[idx_92].meta.source !== 'undefined') {
-                if (isPrimaryKey(data.profile1.identity.links[idx_92].meta.source, true)) {
-                  entity.profile1.identity.links[idx_92].meta.source = factory.createReference(source_99, data.profile1.identity.links[idx_92].meta.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
-                } else if (data.profile1.identity.links[idx_92].meta.source && typeof data.profile1.identity.links[idx_92].meta.source === 'object') {
-                  entity.profile1.identity.links[idx_92].meta.source = factory.create(source_99, data.profile1.identity.links[idx_92].meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
+              if (data.profile1.identity.links[idx_113].meta.source === null) {
+    entity.profile1.identity.links[idx_113].meta.source = null;
+              } else if (typeof data.profile1.identity.links[idx_113].meta.source !== 'undefined') {
+                if (isPrimaryKey(data.profile1.identity.links[idx_113].meta.source, true)) {
+                  entity.profile1.identity.links[idx_113].meta.source = factory.createReference(source_120, data.profile1.identity.links[idx_113].meta.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
+                } else if (data.profile1.identity.links[idx_113].meta.source && typeof data.profile1.identity.links[idx_113].meta.source === 'object') {
+                  entity.profile1.identity.links[idx_113].meta.source = factory.create(source_121, data.profile1.identity.links[idx_113].meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
                 }
               }
-            } else if (data.profile1.identity.links[idx_92].meta === null) {
-              entity.profile1.identity.links[idx_92].meta = null;
+            } else if (data.profile1.identity.links[idx_113].meta === null) {
+              entity.profile1.identity.links[idx_113].meta = null;
             }
-            if (Array.isArray(data.profile1.identity.links[idx_92].metas)) {
-              entity.profile1.identity.links[idx_92].metas = [];
-              data.profile1.identity.links[idx_92].metas.forEach((_, idx_100) => {
-                if (data.profile1.identity.links[idx_92].metas[idx_100] != null) {
-                  const embeddedData = data.profile1.identity.links[idx_92].metas[idx_100];
-                  if (entity.profile1.identity.links[idx_92].metas[idx_100] == null) {
-                    entity.profile1.identity.links[idx_92].metas[idx_100] = factory.createEmbeddable(identity_meta_101, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+            if (Array.isArray(data.profile1.identity.links[idx_113].metas)) {
+              entity.profile1.identity.links[idx_113].metas = [];
+              data.profile1.identity.links[idx_113].metas.forEach((_, idx_122) => {
+                if (data.profile1.identity.links[idx_113].metas[idx_122] != null) {
+                  const embeddedData = data.profile1.identity.links[idx_113].metas[idx_122];
+                  if (entity.profile1.identity.links[idx_113].metas[idx_122] == null) {
+                    entity.profile1.identity.links[idx_113].metas[idx_122] = factory.createEmbeddable(identity_meta_123, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
                   }
-                  if (data.profile1.identity.links[idx_92].metas[idx_100].foo === null) {
-                    entity.profile1.identity.links[idx_92].metas[idx_100].foo = null;
-                  } else if (typeof data.profile1.identity.links[idx_92].metas[idx_100].foo !== 'undefined') {
-                    entity.profile1.identity.links[idx_92].metas[idx_100].foo = data.profile1.identity.links[idx_92].metas[idx_100].foo;
+                  if (data.profile1.identity.links[idx_113].metas[idx_122].foo === null) {
+                    entity.profile1.identity.links[idx_113].metas[idx_122].foo = null;
+                  } else if (typeof data.profile1.identity.links[idx_113].metas[idx_122].foo !== 'undefined') {
+                    entity.profile1.identity.links[idx_113].metas[idx_122].foo = data.profile1.identity.links[idx_113].metas[idx_122].foo;
                   }
-                  if (data.profile1.identity.links[idx_92].metas[idx_100].bar === null) {
-                    entity.profile1.identity.links[idx_92].metas[idx_100].bar = null;
-                  } else if (typeof data.profile1.identity.links[idx_92].metas[idx_100].bar !== 'undefined') {
-                    entity.profile1.identity.links[idx_92].metas[idx_100].bar = data.profile1.identity.links[idx_92].metas[idx_100].bar;
+                  if (data.profile1.identity.links[idx_113].metas[idx_122].bar === null) {
+                    entity.profile1.identity.links[idx_113].metas[idx_122].bar = null;
+                  } else if (typeof data.profile1.identity.links[idx_113].metas[idx_122].bar !== 'undefined') {
+                    entity.profile1.identity.links[idx_113].metas[idx_122].bar = data.profile1.identity.links[idx_113].metas[idx_122].bar;
                   }
-                  if (data.profile1.identity.links[idx_92].metas[idx_100].source === null) {
-    entity.profile1.identity.links[idx_92].metas[idx_100].source = null;
-                  } else if (typeof data.profile1.identity.links[idx_92].metas[idx_100].source !== 'undefined') {
-                    if (isPrimaryKey(data.profile1.identity.links[idx_92].metas[idx_100].source, true)) {
-                      entity.profile1.identity.links[idx_92].metas[idx_100].source = factory.createReference(source_104, data.profile1.identity.links[idx_92].metas[idx_100].source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
-                    } else if (data.profile1.identity.links[idx_92].metas[idx_100].source && typeof data.profile1.identity.links[idx_92].metas[idx_100].source === 'object') {
-                      entity.profile1.identity.links[idx_92].metas[idx_100].source = factory.create(source_104, data.profile1.identity.links[idx_92].metas[idx_100].source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
+                  if (data.profile1.identity.links[idx_113].metas[idx_122].source === null) {
+    entity.profile1.identity.links[idx_113].metas[idx_122].source = null;
+                  } else if (typeof data.profile1.identity.links[idx_113].metas[idx_122].source !== 'undefined') {
+                    if (isPrimaryKey(data.profile1.identity.links[idx_113].metas[idx_122].source, true)) {
+                      entity.profile1.identity.links[idx_113].metas[idx_122].source = factory.createReference(source_126, data.profile1.identity.links[idx_113].metas[idx_122].source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
+                    } else if (data.profile1.identity.links[idx_113].metas[idx_122].source && typeof data.profile1.identity.links[idx_113].metas[idx_122].source === 'object') {
+                      entity.profile1.identity.links[idx_113].metas[idx_122].source = factory.create(source_127, data.profile1.identity.links[idx_113].metas[idx_122].source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
                     }
                   }
-                } else if (data.profile1.identity.links[idx_92].metas[idx_100] === null) {
-                  entity.profile1.identity.links[idx_92].metas[idx_100] = null;
+                } else if (data.profile1.identity.links[idx_113].metas[idx_122] === null) {
+                  entity.profile1.identity.links[idx_113].metas[idx_122] = null;
                 }
               });
             }
-            if (data.profile1.identity.links[idx_92].source === null) {
-    entity.profile1.identity.links[idx_92].source = null;
-            } else if (typeof data.profile1.identity.links[idx_92].source !== 'undefined') {
-              if (isPrimaryKey(data.profile1.identity.links[idx_92].source, true)) {
-                entity.profile1.identity.links[idx_92].source = factory.createReference(source_105, data.profile1.identity.links[idx_92].source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
-              } else if (data.profile1.identity.links[idx_92].source && typeof data.profile1.identity.links[idx_92].source === 'object') {
-                entity.profile1.identity.links[idx_92].source = factory.create(source_105, data.profile1.identity.links[idx_92].source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
+            if (data.profile1.identity.links[idx_113].source === null) {
+    entity.profile1.identity.links[idx_113].source = null;
+            } else if (typeof data.profile1.identity.links[idx_113].source !== 'undefined') {
+              if (isPrimaryKey(data.profile1.identity.links[idx_113].source, true)) {
+                entity.profile1.identity.links[idx_113].source = factory.createReference(source_128, data.profile1.identity.links[idx_113].source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
+              } else if (data.profile1.identity.links[idx_113].source && typeof data.profile1.identity.links[idx_113].source === 'object') {
+                entity.profile1.identity.links[idx_113].source = factory.create(source_129, data.profile1.identity.links[idx_113].source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
               }
             }
-          } else if (data.profile1.identity.links[idx_92] === null) {
-            entity.profile1.identity.links[idx_92] = null;
+          } else if (data.profile1.identity.links[idx_113] === null) {
+            entity.profile1.identity.links[idx_113] = null;
           }
         });
       }
@@ -1015,9 +1015,9 @@ exports[`embedded entities in postgres > diffing 2`] = `
     entity.profile1.identity.source = null;
       } else if (typeof data.profile1.identity.source !== 'undefined') {
         if (isPrimaryKey(data.profile1.identity.source, true)) {
-          entity.profile1.identity.source = factory.createReference(source_106, data.profile1.identity.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
+          entity.profile1.identity.source = factory.createReference(source_130, data.profile1.identity.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
         } else if (data.profile1.identity.source && typeof data.profile1.identity.source === 'object') {
-          entity.profile1.identity.source = factory.create(source_106, data.profile1.identity.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
+          entity.profile1.identity.source = factory.create(source_131, data.profile1.identity.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
         }
       }
     } else if (data.profile1.identity === null) {
@@ -1027,9 +1027,9 @@ exports[`embedded entities in postgres > diffing 2`] = `
     entity.profile1.source = null;
     } else if (typeof data.profile1.source !== 'undefined') {
       if (isPrimaryKey(data.profile1.source, true)) {
-        entity.profile1.source = factory.createReference(source_107, data.profile1.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
+        entity.profile1.source = factory.createReference(source_132, data.profile1.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
       } else if (data.profile1.source && typeof data.profile1.source === 'object') {
-        entity.profile1.source = factory.create(source_107, data.profile1.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
+        entity.profile1.source = factory.create(source_133, data.profile1.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
       }
     }
   } else if (data.profile1 === null) {
@@ -1038,7 +1038,7 @@ exports[`embedded entities in postgres > diffing 2`] = `
   if (data.profile2 != null) {
     const embeddedData = data.profile2;
     if (entity.profile2 == null) {
-      entity.profile2 = factory.createEmbeddable(profile_108, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+      entity.profile2 = factory.createEmbeddable(profile_134, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
     }
     if (data.profile2.username === null) {
       entity.profile2.username = null;
@@ -1048,7 +1048,7 @@ exports[`embedded entities in postgres > diffing 2`] = `
     if (data.profile2.identity != null) {
       const embeddedData = data.profile2.identity;
       if (entity.profile2.identity == null) {
-        entity.profile2.identity = factory.createEmbeddable(identity_110, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+        entity.profile2.identity = factory.createEmbeddable(identity_136, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
       }
       if (data.profile2.identity.email === null) {
         entity.profile2.identity.email = null;
@@ -1058,7 +1058,7 @@ exports[`embedded entities in postgres > diffing 2`] = `
       if (data.profile2.identity.meta != null) {
         const embeddedData = data.profile2.identity.meta;
         if (entity.profile2.identity.meta == null) {
-          entity.profile2.identity.meta = factory.createEmbeddable(identity_meta_112, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+          entity.profile2.identity.meta = factory.createEmbeddable(identity_meta_138, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
         }
         if (data.profile2.identity.meta.foo === null) {
           entity.profile2.identity.meta.foo = null;
@@ -1074,9 +1074,9 @@ exports[`embedded entities in postgres > diffing 2`] = `
     entity.profile2.identity.meta.source = null;
         } else if (typeof data.profile2.identity.meta.source !== 'undefined') {
           if (isPrimaryKey(data.profile2.identity.meta.source, true)) {
-            entity.profile2.identity.meta.source = factory.createReference(source_115, data.profile2.identity.meta.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
+            entity.profile2.identity.meta.source = factory.createReference(source_141, data.profile2.identity.meta.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
           } else if (data.profile2.identity.meta.source && typeof data.profile2.identity.meta.source === 'object') {
-            entity.profile2.identity.meta.source = factory.create(source_115, data.profile2.identity.meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
+            entity.profile2.identity.meta.source = factory.create(source_142, data.profile2.identity.meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
           }
         }
       } else if (data.profile2.identity.meta === null) {
@@ -1084,98 +1084,98 @@ exports[`embedded entities in postgres > diffing 2`] = `
       }
       if (Array.isArray(data.profile2.identity.links)) {
         entity.profile2.identity.links = [];
-        data.profile2.identity.links.forEach((_, idx_116) => {
-          if (data.profile2.identity.links[idx_116] != null) {
-            const embeddedData = data.profile2.identity.links[idx_116];
-            if (entity.profile2.identity.links[idx_116] == null) {
-              entity.profile2.identity.links[idx_116] = factory.createEmbeddable(identity_link_117, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+        data.profile2.identity.links.forEach((_, idx_143) => {
+          if (data.profile2.identity.links[idx_143] != null) {
+            const embeddedData = data.profile2.identity.links[idx_143];
+            if (entity.profile2.identity.links[idx_143] == null) {
+              entity.profile2.identity.links[idx_143] = factory.createEmbeddable(identity_link_144, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
             }
-            if (data.profile2.identity.links[idx_116].url === null) {
-              entity.profile2.identity.links[idx_116].url = null;
-            } else if (typeof data.profile2.identity.links[idx_116].url !== 'undefined') {
-              entity.profile2.identity.links[idx_116].url = data.profile2.identity.links[idx_116].url;
+            if (data.profile2.identity.links[idx_143].url === null) {
+              entity.profile2.identity.links[idx_143].url = null;
+            } else if (typeof data.profile2.identity.links[idx_143].url !== 'undefined') {
+              entity.profile2.identity.links[idx_143].url = data.profile2.identity.links[idx_143].url;
             }
-            if (data.profile2.identity.links[idx_116].createdAt === null) {
-              entity.profile2.identity.links[idx_116].createdAt = null;
-            } else if (typeof data.profile2.identity.links[idx_116].createdAt !== 'undefined') {
-              if (data.profile2.identity.links[idx_116].createdAt instanceof Date) {
-                entity.profile2.identity.links[idx_116].createdAt = data.profile2.identity.links[idx_116].createdAt;
-              } else if (typeof data.profile2.identity.links[idx_116].createdAt === 'number' || data.profile2.identity.links[idx_116].createdAt.includes('+') || data.profile2.identity.links[idx_116].createdAt.lastIndexOf('-') > 10 || data.profile2.identity.links[idx_116].createdAt.endsWith('Z')) {
-                entity.profile2.identity.links[idx_116].createdAt = new Date(data.profile2.identity.links[idx_116].createdAt);
+            if (data.profile2.identity.links[idx_143].createdAt === null) {
+              entity.profile2.identity.links[idx_143].createdAt = null;
+            } else if (typeof data.profile2.identity.links[idx_143].createdAt !== 'undefined') {
+              if (data.profile2.identity.links[idx_143].createdAt instanceof Date) {
+                entity.profile2.identity.links[idx_143].createdAt = data.profile2.identity.links[idx_143].createdAt;
+              } else if (typeof data.profile2.identity.links[idx_143].createdAt === 'number' || data.profile2.identity.links[idx_143].createdAt.includes('+') || data.profile2.identity.links[idx_143].createdAt.lastIndexOf('-') > 10 || data.profile2.identity.links[idx_143].createdAt.endsWith('Z')) {
+                entity.profile2.identity.links[idx_143].createdAt = new Date(data.profile2.identity.links[idx_143].createdAt);
               } else {
-                entity.profile2.identity.links[idx_116].createdAt = new Date(data.profile2.identity.links[idx_116].createdAt + 'Z');
+                entity.profile2.identity.links[idx_143].createdAt = new Date(data.profile2.identity.links[idx_143].createdAt + 'Z');
               }
             }
-            if (data.profile2.identity.links[idx_116].meta != null) {
-              const embeddedData = data.profile2.identity.links[idx_116].meta;
-              if (entity.profile2.identity.links[idx_116].meta == null) {
-                entity.profile2.identity.links[idx_116].meta = factory.createEmbeddable(identity_meta_120, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+            if (data.profile2.identity.links[idx_143].meta != null) {
+              const embeddedData = data.profile2.identity.links[idx_143].meta;
+              if (entity.profile2.identity.links[idx_143].meta == null) {
+                entity.profile2.identity.links[idx_143].meta = factory.createEmbeddable(identity_meta_147, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
               }
-              if (data.profile2.identity.links[idx_116].meta.foo === null) {
-                entity.profile2.identity.links[idx_116].meta.foo = null;
-              } else if (typeof data.profile2.identity.links[idx_116].meta.foo !== 'undefined') {
-                entity.profile2.identity.links[idx_116].meta.foo = data.profile2.identity.links[idx_116].meta.foo;
+              if (data.profile2.identity.links[idx_143].meta.foo === null) {
+                entity.profile2.identity.links[idx_143].meta.foo = null;
+              } else if (typeof data.profile2.identity.links[idx_143].meta.foo !== 'undefined') {
+                entity.profile2.identity.links[idx_143].meta.foo = data.profile2.identity.links[idx_143].meta.foo;
               }
-              if (data.profile2.identity.links[idx_116].meta.bar === null) {
-                entity.profile2.identity.links[idx_116].meta.bar = null;
-              } else if (typeof data.profile2.identity.links[idx_116].meta.bar !== 'undefined') {
-                entity.profile2.identity.links[idx_116].meta.bar = data.profile2.identity.links[idx_116].meta.bar;
+              if (data.profile2.identity.links[idx_143].meta.bar === null) {
+                entity.profile2.identity.links[idx_143].meta.bar = null;
+              } else if (typeof data.profile2.identity.links[idx_143].meta.bar !== 'undefined') {
+                entity.profile2.identity.links[idx_143].meta.bar = data.profile2.identity.links[idx_143].meta.bar;
               }
-              if (data.profile2.identity.links[idx_116].meta.source === null) {
-    entity.profile2.identity.links[idx_116].meta.source = null;
-              } else if (typeof data.profile2.identity.links[idx_116].meta.source !== 'undefined') {
-                if (isPrimaryKey(data.profile2.identity.links[idx_116].meta.source, true)) {
-                  entity.profile2.identity.links[idx_116].meta.source = factory.createReference(source_123, data.profile2.identity.links[idx_116].meta.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
-                } else if (data.profile2.identity.links[idx_116].meta.source && typeof data.profile2.identity.links[idx_116].meta.source === 'object') {
-                  entity.profile2.identity.links[idx_116].meta.source = factory.create(source_123, data.profile2.identity.links[idx_116].meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
+              if (data.profile2.identity.links[idx_143].meta.source === null) {
+    entity.profile2.identity.links[idx_143].meta.source = null;
+              } else if (typeof data.profile2.identity.links[idx_143].meta.source !== 'undefined') {
+                if (isPrimaryKey(data.profile2.identity.links[idx_143].meta.source, true)) {
+                  entity.profile2.identity.links[idx_143].meta.source = factory.createReference(source_150, data.profile2.identity.links[idx_143].meta.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
+                } else if (data.profile2.identity.links[idx_143].meta.source && typeof data.profile2.identity.links[idx_143].meta.source === 'object') {
+                  entity.profile2.identity.links[idx_143].meta.source = factory.create(source_151, data.profile2.identity.links[idx_143].meta.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
                 }
               }
-            } else if (data.profile2.identity.links[idx_116].meta === null) {
-              entity.profile2.identity.links[idx_116].meta = null;
+            } else if (data.profile2.identity.links[idx_143].meta === null) {
+              entity.profile2.identity.links[idx_143].meta = null;
             }
-            if (Array.isArray(data.profile2.identity.links[idx_116].metas)) {
-              entity.profile2.identity.links[idx_116].metas = [];
-              data.profile2.identity.links[idx_116].metas.forEach((_, idx_124) => {
-                if (data.profile2.identity.links[idx_116].metas[idx_124] != null) {
-                  const embeddedData = data.profile2.identity.links[idx_116].metas[idx_124];
-                  if (entity.profile2.identity.links[idx_116].metas[idx_124] == null) {
-                    entity.profile2.identity.links[idx_116].metas[idx_124] = factory.createEmbeddable(identity_meta_125, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+            if (Array.isArray(data.profile2.identity.links[idx_143].metas)) {
+              entity.profile2.identity.links[idx_143].metas = [];
+              data.profile2.identity.links[idx_143].metas.forEach((_, idx_152) => {
+                if (data.profile2.identity.links[idx_143].metas[idx_152] != null) {
+                  const embeddedData = data.profile2.identity.links[idx_143].metas[idx_152];
+                  if (entity.profile2.identity.links[idx_143].metas[idx_152] == null) {
+                    entity.profile2.identity.links[idx_143].metas[idx_152] = factory.createEmbeddable(identity_meta_153, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
                   }
-                  if (data.profile2.identity.links[idx_116].metas[idx_124].foo === null) {
-                    entity.profile2.identity.links[idx_116].metas[idx_124].foo = null;
-                  } else if (typeof data.profile2.identity.links[idx_116].metas[idx_124].foo !== 'undefined') {
-                    entity.profile2.identity.links[idx_116].metas[idx_124].foo = data.profile2.identity.links[idx_116].metas[idx_124].foo;
+                  if (data.profile2.identity.links[idx_143].metas[idx_152].foo === null) {
+                    entity.profile2.identity.links[idx_143].metas[idx_152].foo = null;
+                  } else if (typeof data.profile2.identity.links[idx_143].metas[idx_152].foo !== 'undefined') {
+                    entity.profile2.identity.links[idx_143].metas[idx_152].foo = data.profile2.identity.links[idx_143].metas[idx_152].foo;
                   }
-                  if (data.profile2.identity.links[idx_116].metas[idx_124].bar === null) {
-                    entity.profile2.identity.links[idx_116].metas[idx_124].bar = null;
-                  } else if (typeof data.profile2.identity.links[idx_116].metas[idx_124].bar !== 'undefined') {
-                    entity.profile2.identity.links[idx_116].metas[idx_124].bar = data.profile2.identity.links[idx_116].metas[idx_124].bar;
+                  if (data.profile2.identity.links[idx_143].metas[idx_152].bar === null) {
+                    entity.profile2.identity.links[idx_143].metas[idx_152].bar = null;
+                  } else if (typeof data.profile2.identity.links[idx_143].metas[idx_152].bar !== 'undefined') {
+                    entity.profile2.identity.links[idx_143].metas[idx_152].bar = data.profile2.identity.links[idx_143].metas[idx_152].bar;
                   }
-                  if (data.profile2.identity.links[idx_116].metas[idx_124].source === null) {
-    entity.profile2.identity.links[idx_116].metas[idx_124].source = null;
-                  } else if (typeof data.profile2.identity.links[idx_116].metas[idx_124].source !== 'undefined') {
-                    if (isPrimaryKey(data.profile2.identity.links[idx_116].metas[idx_124].source, true)) {
-                      entity.profile2.identity.links[idx_116].metas[idx_124].source = factory.createReference(source_128, data.profile2.identity.links[idx_116].metas[idx_124].source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
-                    } else if (data.profile2.identity.links[idx_116].metas[idx_124].source && typeof data.profile2.identity.links[idx_116].metas[idx_124].source === 'object') {
-                      entity.profile2.identity.links[idx_116].metas[idx_124].source = factory.create(source_128, data.profile2.identity.links[idx_116].metas[idx_124].source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
+                  if (data.profile2.identity.links[idx_143].metas[idx_152].source === null) {
+    entity.profile2.identity.links[idx_143].metas[idx_152].source = null;
+                  } else if (typeof data.profile2.identity.links[idx_143].metas[idx_152].source !== 'undefined') {
+                    if (isPrimaryKey(data.profile2.identity.links[idx_143].metas[idx_152].source, true)) {
+                      entity.profile2.identity.links[idx_143].metas[idx_152].source = factory.createReference(source_156, data.profile2.identity.links[idx_143].metas[idx_152].source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
+                    } else if (data.profile2.identity.links[idx_143].metas[idx_152].source && typeof data.profile2.identity.links[idx_143].metas[idx_152].source === 'object') {
+                      entity.profile2.identity.links[idx_143].metas[idx_152].source = factory.create(source_157, data.profile2.identity.links[idx_143].metas[idx_152].source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
                     }
                   }
-                } else if (data.profile2.identity.links[idx_116].metas[idx_124] === null) {
-                  entity.profile2.identity.links[idx_116].metas[idx_124] = null;
+                } else if (data.profile2.identity.links[idx_143].metas[idx_152] === null) {
+                  entity.profile2.identity.links[idx_143].metas[idx_152] = null;
                 }
               });
             }
-            if (data.profile2.identity.links[idx_116].source === null) {
-    entity.profile2.identity.links[idx_116].source = null;
-            } else if (typeof data.profile2.identity.links[idx_116].source !== 'undefined') {
-              if (isPrimaryKey(data.profile2.identity.links[idx_116].source, true)) {
-                entity.profile2.identity.links[idx_116].source = factory.createReference(source_129, data.profile2.identity.links[idx_116].source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
-              } else if (data.profile2.identity.links[idx_116].source && typeof data.profile2.identity.links[idx_116].source === 'object') {
-                entity.profile2.identity.links[idx_116].source = factory.create(source_129, data.profile2.identity.links[idx_116].source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
+            if (data.profile2.identity.links[idx_143].source === null) {
+    entity.profile2.identity.links[idx_143].source = null;
+            } else if (typeof data.profile2.identity.links[idx_143].source !== 'undefined') {
+              if (isPrimaryKey(data.profile2.identity.links[idx_143].source, true)) {
+                entity.profile2.identity.links[idx_143].source = factory.createReference(source_158, data.profile2.identity.links[idx_143].source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
+              } else if (data.profile2.identity.links[idx_143].source && typeof data.profile2.identity.links[idx_143].source === 'object') {
+                entity.profile2.identity.links[idx_143].source = factory.create(source_159, data.profile2.identity.links[idx_143].source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
               }
             }
-          } else if (data.profile2.identity.links[idx_116] === null) {
-            entity.profile2.identity.links[idx_116] = null;
+          } else if (data.profile2.identity.links[idx_143] === null) {
+            entity.profile2.identity.links[idx_143] = null;
           }
         });
       }
@@ -1183,9 +1183,9 @@ exports[`embedded entities in postgres > diffing 2`] = `
     entity.profile2.identity.source = null;
       } else if (typeof data.profile2.identity.source !== 'undefined') {
         if (isPrimaryKey(data.profile2.identity.source, true)) {
-          entity.profile2.identity.source = factory.createReference(source_130, data.profile2.identity.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
+          entity.profile2.identity.source = factory.createReference(source_160, data.profile2.identity.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
         } else if (data.profile2.identity.source && typeof data.profile2.identity.source === 'object') {
-          entity.profile2.identity.source = factory.create(source_130, data.profile2.identity.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
+          entity.profile2.identity.source = factory.create(source_161, data.profile2.identity.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
         }
       }
     } else if (data.profile2.identity === null) {
@@ -1195,9 +1195,9 @@ exports[`embedded entities in postgres > diffing 2`] = `
     entity.profile2.source = null;
     } else if (typeof data.profile2.source !== 'undefined') {
       if (isPrimaryKey(data.profile2.source, true)) {
-        entity.profile2.source = factory.createReference(source_131, data.profile2.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
+        entity.profile2.source = factory.createReference(source_162, data.profile2.source, { merge: true, convertCustomTypes, normalizeAccessors, schema });
       } else if (data.profile2.source && typeof data.profile2.source === 'object') {
-        entity.profile2.source = factory.create(source_131, data.profile2.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
+        entity.profile2.source = factory.create(source_163, data.profile2.source, { initialized: true, merge: true, newEntity, convertCustomTypes, normalizeAccessors, schema });
       }
     }
   } else if (data.profile2 === null) {

--- a/tests/features/polymorphic-relations/polymorphic-composite-keys.sqlite.test.ts
+++ b/tests/features/polymorphic-relations/polymorphic-composite-keys.sqlite.test.ts
@@ -1,0 +1,398 @@
+import { Collection, MikroORM, PolymorphicRef, PrimaryKeyProp } from '@mikro-orm/sqlite';
+import { Entity, ManyToOne, OneToMany, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+
+@Entity()
+class Organization {
+
+  [PrimaryKeyProp]?: ['tenantId', 'orgId'];
+
+  @PrimaryKey()
+  tenantId!: number;
+
+  @PrimaryKey()
+  orgId!: number;
+
+  @Property()
+  name!: string;
+
+  @OneToMany(() => Notification, n => n.recipient)
+  notifications = new Collection<Notification>(this);
+
+  constructor(tenantId: number, orgId: number, name: string) {
+    this.tenantId = tenantId;
+    this.orgId = orgId;
+    this.name = name;
+  }
+
+}
+
+@Entity()
+class User {
+
+  [PrimaryKeyProp]?: ['tenantId', 'userId'];
+
+  @PrimaryKey()
+  tenantId!: number;
+
+  @PrimaryKey()
+  userId!: number;
+
+  @Property()
+  email!: string;
+
+  @OneToMany(() => Notification, n => n.recipient)
+  notifications = new Collection<Notification>(this);
+
+  constructor(tenantId: number, userId: number, email: string) {
+    this.tenantId = tenantId;
+    this.userId = userId;
+    this.email = email;
+  }
+
+}
+
+@Entity()
+class Notification {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  message!: string;
+
+  // Polymorphic relation to entities with composite PKs
+  @ManyToOne(() => [Organization, User])
+  recipient!: Organization | User;
+
+  constructor(message: string) {
+    this.message = message;
+  }
+
+}
+
+describe('polymorphic relations with composite primary keys', () => {
+
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      entities: [Organization, User, Notification],
+      dbName: ':memory:',
+      metadataProvider: ReflectMetadataProvider,
+    });
+    await orm.schema.create();
+  });
+
+  afterAll(async () => {
+    await orm.close(true);
+  });
+
+  beforeEach(async () => {
+    await orm.em.nativeDelete(Notification, {});
+    await orm.em.nativeDelete(Organization, {});
+    await orm.em.nativeDelete(User, {});
+    orm.em.clear();
+  });
+
+  test('metadata correctly handles composite keys', async () => {
+    const meta = orm.getMetadata().get(Notification);
+    const recipientProp = meta.properties.recipient;
+
+    expect(recipientProp.polymorphic).toBe(true);
+    expect(recipientProp.fieldNames).toHaveLength(3); // discriminator + 2 PK columns
+    expect(recipientProp.fieldNames).toContain('recipient_type');
+    expect(recipientProp.referencedColumnNames).toHaveLength(2); // Both composite PK columns
+    // Discriminator map uses table names as keys
+    expect(Object.keys(recipientProp.discriminatorMap!)).toEqual(['organization', 'user']);
+  });
+
+  test('schema creates columns for all composite key parts', async () => {
+    const sql = await orm.schema.getCreateSchemaSQL();
+    const notifTable = sql.split('\n').find(s => s.toLowerCase().includes('notification'));
+
+    expect(notifTable).toBeDefined();
+    expect(notifTable).toContain('recipient_type');
+    // Should have columns for both parts of the composite key
+    expect(notifTable).toMatch(/recipient_tenant_id|recipient_id_0/);
+    expect(notifTable).toMatch(/recipient_org_id|recipient_user_id|recipient_id_1/);
+  });
+
+  test('can persist and load polymorphic relation to Organization with composite PK', async () => {
+    const org = new Organization(1, 100, 'Acme Corp');
+    const notif = orm.em.create(Notification, {
+      message: 'Hello organization',
+      recipient: org,
+    });
+
+    await orm.em.flush();
+    orm.em.clear();
+
+    const loaded = await orm.em.findOneOrFail(Notification, { id: notif.id });
+    expect(loaded.recipient).toBeInstanceOf(Organization);
+
+    await orm.em.populate(loaded, ['recipient']);
+    const loadedOrg = loaded.recipient as Organization;
+    expect(loadedOrg.tenantId).toBe(1);
+    expect(loadedOrg.orgId).toBe(100);
+    expect(loadedOrg.name).toBe('Acme Corp');
+  });
+
+  test('can persist and load polymorphic relation to User with composite PK', async () => {
+    const user = new User(1, 42, 'user@example.com');
+    const notif = orm.em.create(Notification, {
+      message: 'Hello user',
+      recipient: user,
+    });
+
+    await orm.em.flush();
+    orm.em.clear();
+
+    const loaded = await orm.em.findOneOrFail(Notification, { id: notif.id });
+    expect(loaded.recipient).toBeInstanceOf(User);
+
+    await orm.em.populate(loaded, ['recipient']);
+    const loadedUser = loaded.recipient as User;
+    expect(loadedUser.tenantId).toBe(1);
+    expect(loadedUser.userId).toBe(42);
+    expect(loadedUser.email).toBe('user@example.com');
+  });
+
+  test('can update from one entity to another with composite keys', async () => {
+    const org = new Organization(1, 100, 'Org');
+    const user = new User(1, 42, 'user@test.com');
+    const notif = orm.em.create(Notification, {
+      message: 'Test',
+      recipient: org,
+    });
+    orm.em.persist(user);
+
+    await orm.em.flush();
+    orm.em.clear();
+
+    const loadedNotif = await orm.em.findOneOrFail(Notification, { id: notif.id });
+    const loadedUser = await orm.em.findOneOrFail(User, { tenantId: 1, userId: 42 });
+    loadedNotif.recipient = loadedUser;
+
+    await orm.em.flush();
+    orm.em.clear();
+
+    const reloaded = await orm.em.findOneOrFail(Notification, { id: notif.id });
+    expect(reloaded.recipient).toBeInstanceOf(User);
+    await orm.em.populate(reloaded, ['recipient']);
+    expect((reloaded.recipient as User).email).toBe('user@test.com');
+  });
+
+  test('inverse side works with composite keys', async () => {
+    const org = new Organization(1, 100, 'Test Org');
+    const n1 = orm.em.create(Notification, { message: 'N1', recipient: org });
+    const n2 = orm.em.create(Notification, { message: 'N2', recipient: org });
+
+    await orm.em.flush();
+    orm.em.clear();
+
+    const loadedOrg = await orm.em.findOneOrFail(
+      Organization,
+      { tenantId: 1, orgId: 100 },
+      { populate: ['notifications'] },
+    );
+
+    expect(loadedOrg.notifications).toHaveLength(2);
+    expect(loadedOrg.notifications.getItems().map(n => n.message).sort()).toEqual(['N1', 'N2']);
+  });
+
+  test('handles same composite key values in different tables', async () => {
+    // Both entities with same composite key values
+    const org = new Organization(1, 100, 'Organization');
+    const user = new User(1, 100, 'user@test.com');
+
+    const orgNotif = orm.em.create(Notification, { message: 'To org', recipient: org });
+    const userNotif = orm.em.create(Notification, { message: 'To user', recipient: user });
+
+    await orm.em.flush();
+    orm.em.clear();
+
+    const notifications = await orm.em.find(Notification, {}, { populate: ['recipient'] });
+    expect(notifications).toHaveLength(2);
+
+    const orgN = notifications.find(n => n.message === 'To org')!;
+    const userN = notifications.find(n => n.message === 'To user')!;
+
+    expect(orgN.recipient).toBeInstanceOf(Organization);
+    expect(userN.recipient).toBeInstanceOf(User);
+  });
+
+  test('batch loads polymorphic relations with composite keys', async () => {
+    const org1 = new Organization(1, 100, 'Org 1');
+    const org2 = new Organization(1, 200, 'Org 2');
+    const user1 = new User(1, 100, 'user1@test.com');
+
+    const n1 = orm.em.create(Notification, { message: 'N1', recipient: org1 });
+    const n2 = orm.em.create(Notification, { message: 'N2', recipient: org2 });
+    const n3 = orm.em.create(Notification, { message: 'N3', recipient: user1 });
+
+    await orm.em.flush();
+    orm.em.clear();
+
+    // Load all notifications with populated recipients
+    const notifications = await orm.em.find(Notification, {}, {
+      populate: ['recipient'],
+      orderBy: { message: 'ASC' },
+    });
+
+    expect(notifications).toHaveLength(3);
+    expect(notifications[0].recipient).toBeInstanceOf(Organization);
+    expect((notifications[0].recipient as Organization).name).toBe('Org 1');
+    expect(notifications[1].recipient).toBeInstanceOf(Organization);
+    expect((notifications[1].recipient as Organization).name).toBe('Org 2');
+    expect(notifications[2].recipient).toBeInstanceOf(User);
+  });
+
+  test('multiple inverse side loads with composite keys', async () => {
+    const org1 = new Organization(1, 100, 'Org 1');
+    const org2 = new Organization(1, 200, 'Org 2');
+    const user = new User(1, 100, 'user@test.com');
+
+    orm.em.create(Notification, { message: 'N1', recipient: org1 });
+    orm.em.create(Notification, { message: 'N2', recipient: org1 });
+    orm.em.create(Notification, { message: 'N3', recipient: org2 });
+    orm.em.create(Notification, { message: 'N4', recipient: user });
+
+    await orm.em.flush();
+    orm.em.clear();
+
+    // Load multiple organizations with their notifications
+    const orgs = await orm.em.find(Organization, {}, { populate: ['notifications'] });
+
+    expect(orgs).toHaveLength(2);
+    const org1Loaded = orgs.find(o => o.name === 'Org 1')!;
+    const org2Loaded = orgs.find(o => o.name === 'Org 2')!;
+
+    expect(org1Loaded.notifications).toHaveLength(2);
+    expect(org2Loaded.notifications).toHaveLength(1);
+  });
+
+  test('batch updates with polymorphic composite keys', async () => {
+    const org = new Organization(1, 100, 'Org');
+    const user1 = new User(1, 42, 'user1@test.com');
+    const user2 = new User(1, 43, 'user2@test.com');
+    orm.em.persist([user1, user2]);
+
+    orm.em.create(Notification, { message: 'N1', recipient: org });
+    orm.em.create(Notification, { message: 'N2', recipient: org });
+    orm.em.create(Notification, { message: 'N3', recipient: org });
+
+    await orm.em.flush();
+    orm.em.clear();
+
+    // Load all notifications and change their recipients
+    const notifications = await orm.em.find(Notification, {}, {
+      orderBy: { id: 'ASC' },
+    });
+
+    // Change recipients to different users (batch update)
+    notifications[0].recipient = await orm.em.findOneOrFail(User, { tenantId: 1, userId: 42 });
+    notifications[1].recipient = await orm.em.findOneOrFail(User, { tenantId: 1, userId: 43 });
+    notifications[2].message = 'Updated message'; // Also update a non-polymorphic field
+
+    await orm.em.flush();
+    orm.em.clear();
+
+    // Verify updates
+    const reloaded = await orm.em.find(Notification, {}, {
+      populate: ['recipient'],
+      orderBy: { id: 'ASC' },
+    });
+
+    expect(reloaded[0].recipient).toBeInstanceOf(User);
+    expect((reloaded[0].recipient as User).email).toBe('user1@test.com');
+    expect(reloaded[1].recipient).toBeInstanceOf(User);
+    expect((reloaded[1].recipient as User).email).toBe('user2@test.com');
+    expect(reloaded[2].recipient).toBeInstanceOf(Organization);
+    expect(reloaded[2].message).toBe('Updated message');
+  });
+
+  test('insert via QueryBuilder with tuple format for composite key', async () => {
+    // Create target entities first
+    const org = new Organization(1, 100, 'Tuple Org');
+    const user = new User(1, 42, 'tuple@test.com');
+    orm.em.persist([org, user]);
+    await orm.em.flush();
+    orm.em.clear();
+
+    // Insert notification using QueryBuilder with tuple format: ['discriminator', ...ids]
+    const qb = orm.em.createQueryBuilder(Notification);
+    await qb.insert({
+      message: 'Via QB with tuple',
+      recipient: ['organization', 1, 100] as const,
+    }).execute();
+
+    orm.em.clear();
+
+    // Verify it was inserted correctly
+    const loaded = await orm.em.findOneOrFail(Notification, { message: 'Via QB with tuple' }, { populate: ['recipient'] });
+    expect(loaded.recipient).toBeInstanceOf(Organization);
+    expect((loaded.recipient as Organization).tenantId).toBe(1);
+    expect((loaded.recipient as Organization).orgId).toBe(100);
+    expect((loaded.recipient as Organization).name).toBe('Tuple Org');
+  });
+
+  test('batch insert with tuple format for composite keys', async () => {
+    // Create target entities
+    const org1 = new Organization(1, 100, 'Batch Org 1');
+    const org2 = new Organization(1, 200, 'Batch Org 2');
+    const user1 = new User(1, 50, 'batch1@test.com');
+    orm.em.persist([org1, org2, user1]);
+    await orm.em.flush();
+    orm.em.clear();
+
+    // Batch insert notifications using tuple format: ['discriminator', ...ids]
+    await orm.em.insertMany(Notification, [
+      { message: 'Batch N1', recipient: ['organization', 1, 100] as const },
+      { message: 'Batch N2', recipient: ['organization', 1, 200] as const },
+      { message: 'Batch N3', recipient: ['user', 1, 50] as const },
+    ]);
+
+    orm.em.clear();
+
+    // Verify
+    const notifications = await orm.em.find(Notification, { message: { $like: 'Batch N%' } }, {
+      populate: ['recipient'],
+      orderBy: { message: 'ASC' },
+    });
+
+    expect(notifications).toHaveLength(3);
+    expect(notifications[0].recipient).toBeInstanceOf(Organization);
+    expect((notifications[0].recipient as Organization).name).toBe('Batch Org 1');
+    expect(notifications[1].recipient).toBeInstanceOf(Organization);
+    expect((notifications[1].recipient as Organization).name).toBe('Batch Org 2');
+    expect(notifications[2].recipient).toBeInstanceOf(User);
+    expect((notifications[2].recipient as User).email).toBe('batch1@test.com');
+  });
+
+  test('insert with PolymorphicRef using object-style composite key', async () => {
+    // Create target entity
+    const org = new Organization(1, 100, 'Object PK Org');
+    orm.em.persist(org);
+    await orm.em.flush();
+    orm.em.clear();
+
+    // Insert using PolymorphicRef with object-style ID (not array)
+    const qb = orm.em.createQueryBuilder(Notification);
+    await qb.insert({
+      message: 'Via PolymorphicRef with object ID',
+      recipient: new PolymorphicRef('organization', { tenantId: 1, orgId: 100 }) as any,
+    }).execute();
+
+    orm.em.clear();
+
+    const loaded = await orm.em.findOneOrFail(
+      Notification,
+      { message: 'Via PolymorphicRef with object ID' },
+      { populate: ['recipient'] },
+    );
+    expect(loaded.recipient).toBeInstanceOf(Organization);
+    expect((loaded.recipient as Organization).tenantId).toBe(1);
+    expect((loaded.recipient as Organization).orgId).toBe(100);
+  });
+
+});

--- a/tests/features/polymorphic-relations/polymorphic-custom-discriminator.sqlite.test.ts
+++ b/tests/features/polymorphic-relations/polymorphic-custom-discriminator.sqlite.test.ts
@@ -1,0 +1,217 @@
+import { Collection, MikroORM } from '@mikro-orm/sqlite';
+import { Entity, ManyToOne, OneToMany, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+
+@Entity()
+class BlogPost {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  title!: string;
+
+  @OneToMany(() => Activity, a => a.subject)
+  activities = new Collection<Activity>(this);
+
+  constructor(title: string) {
+    this.title = title;
+  }
+
+}
+
+@Entity()
+class ForumPost {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  content!: string;
+
+  @OneToMany(() => Activity, a => a.subject)
+  activities = new Collection<Activity>(this);
+
+  constructor(content: string) {
+    this.content = content;
+  }
+
+}
+
+@Entity()
+class Activity {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  action!: string;
+
+  // Polymorphic relation with custom discriminator map
+  // Using custom values instead of table names
+  @ManyToOne(() => [BlogPost, ForumPost], {
+    discriminator: 'subject',
+    discriminatorMap: {
+      blog: 'BlogPost',
+      forum: 'ForumPost',
+    },
+    nullable: true,
+  })
+  subject!: BlogPost | ForumPost | null;
+
+  constructor(action: string) {
+    this.action = action;
+  }
+
+}
+
+describe('polymorphic relations with custom discriminator map', () => {
+
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      entities: [BlogPost, ForumPost, Activity],
+      dbName: ':memory:',
+      metadataProvider: ReflectMetadataProvider,
+    });
+    await orm.schema.create();
+  });
+
+  afterAll(async () => {
+    await orm.close(true);
+  });
+
+  beforeEach(async () => {
+    await orm.em.nativeDelete(Activity, {});
+    await orm.em.nativeDelete(BlogPost, {});
+    await orm.em.nativeDelete(ForumPost, {});
+    orm.em.clear();
+  });
+
+  test('metadata has custom discriminator map', async () => {
+    const meta = orm.getMetadata().get(Activity);
+    const subjectProp = meta.properties.subject;
+
+    expect(subjectProp.polymorphic).toBe(true);
+    expect(subjectProp.discriminatorMap).toBeDefined();
+    expect(subjectProp.discriminatorMap!.blog).toBe(BlogPost);
+    expect(subjectProp.discriminatorMap!.forum).toBe(ForumPost);
+  });
+
+  test('stores custom discriminator value for BlogPost', async () => {
+    const post = new BlogPost('My Blog Post');
+
+    const activity = orm.em.create(Activity, {
+      action: 'created',
+      subject: post,
+    });
+
+    await orm.em.flush();
+    orm.em.clear();
+
+    const connection = orm.em.getConnection();
+    const [row] = await connection.execute('SELECT * FROM activity WHERE id = ?', [activity.id]);
+
+    expect(row.subject_type).toBe('blog');
+    expect(row.subject_id).toBe(post.id);
+  });
+
+  test('stores custom discriminator value for ForumPost', async () => {
+    const post = new ForumPost('Forum discussion');
+    const activity = orm.em.create(Activity, {
+      action: 'commented',
+      subject: post,
+    });
+
+    await orm.em.flush();
+    orm.em.clear();
+
+    const connection = orm.em.getConnection();
+    const [row] = await connection.execute('SELECT * FROM activity WHERE id = ?', [activity.id]);
+
+    // Should use custom value 'forum' instead of table name 'forum_post'
+    expect(row.subject_type).toBe('forum');
+    expect(row.subject_id).toBe(post.id);
+  });
+
+  test('hydrates correctly using custom discriminator values', async () => {
+    const blogPost = new BlogPost('Blog');
+    const forumPost = new ForumPost('Forum');
+    const blogActivity = orm.em.create(Activity, { action: 'like', subject: blogPost });
+    const forumActivity = orm.em.create(Activity, { action: 'share', subject: forumPost });
+
+    await orm.em.flush();
+    orm.em.clear();
+
+    const loadedBlogActivity = await orm.em.findOneOrFail(Activity, { id: blogActivity.id });
+    const loadedForumActivity = await orm.em.findOneOrFail(Activity, { id: forumActivity.id });
+
+    expect(loadedBlogActivity.subject).toBeInstanceOf(BlogPost);
+    expect(loadedForumActivity.subject).toBeInstanceOf(ForumPost);
+
+    await orm.em.populate([loadedBlogActivity, loadedForumActivity], ['subject']);
+
+    expect((loadedBlogActivity.subject as BlogPost).title).toBe('Blog');
+    expect((loadedForumActivity.subject as ForumPost).content).toBe('Forum');
+  });
+
+  test('inverse collections work with custom discriminator', async () => {
+    const blogPost = new BlogPost('My Post');
+    const a1 = orm.em.create(Activity, { action: 'view', subject: blogPost });
+    const a2 = orm.em.create(Activity, { action: 'like', subject: blogPost });
+
+    await orm.em.flush();
+    orm.em.clear();
+
+    const loadedPost = await orm.em.findOneOrFail(
+      BlogPost,
+      { id: blogPost.id },
+      { populate: ['activities'] },
+    );
+
+    expect(loadedPost.activities).toHaveLength(2);
+    expect(loadedPost.activities.getItems().map(a => a.action).sort()).toEqual(['like', 'view']);
+  });
+
+  test('updating between different types with custom discriminator', async () => {
+    const blogPost = new BlogPost('Blog');
+    const forumPost = new ForumPost('Forum');
+    const activity = orm.em.create(Activity, { action: 'test', subject: blogPost });
+    orm.em.persist(forumPost);
+
+    await orm.em.flush();
+    orm.em.clear();
+
+    const loadedActivity = await orm.em.findOneOrFail(Activity, { id: activity.id });
+    const loadedForumPost = await orm.em.findOneOrFail(ForumPost, { id: forumPost.id });
+
+    loadedActivity.subject = loadedForumPost;
+
+    await orm.em.flush();
+    orm.em.clear();
+
+    const connection = orm.em.getConnection();
+    const [row] = await connection.execute('SELECT * FROM activity WHERE id = ?', [activity.id]);
+
+    expect(row.subject_type).toBe('forum');
+    expect(row.subject_id).toBe(forumPost.id);
+  });
+
+  test('discriminator map prevents using table names directly', async () => {
+    // Insert data with table name instead of custom value
+    const connection = orm.em.getConnection();
+    await connection.execute(
+      "INSERT INTO blog_post (id, title) VALUES (1, 'Test')",
+    );
+    await connection.execute(
+      "INSERT INTO activity (id, action, subject_type, subject_id) VALUES (1, 'test', 'blog_post', 1)",
+    );
+
+    // When we try to load, it should throw an error because
+    // 'blog_post' is not in the discriminator map (only 'blog' and 'forum' are valid)
+    await expect(
+      orm.em.findOne(Activity, { id: 1 }),
+    ).rejects.toThrow(/Unknown discriminator value 'blog_post' for polymorphic relation 'subject'/);
+  });
+
+});

--- a/tests/features/polymorphic-relations/polymorphic-define-entity.sqlite.test.ts
+++ b/tests/features/polymorphic-relations/polymorphic-define-entity.sqlite.test.ts
@@ -1,0 +1,204 @@
+import { defineEntity, InferEntity, MikroORM, p } from '@mikro-orm/sqlite';
+
+const Article = defineEntity({
+  name: 'Article',
+  properties: {
+    id: p.integer().primary().autoincrement(),
+    title: p.string(),
+    ratings: () => p.oneToMany(Rating).mappedBy('rateable'),
+  },
+});
+
+const Video = defineEntity({
+  name: 'Video',
+  properties: {
+    id: p.integer().primary().autoincrement(),
+    url: p.string(),
+    ratings: () => p.oneToMany(Rating).mappedBy('rateable'),
+  },
+});
+
+const Rating = defineEntity({
+  name: 'Rating',
+  properties: {
+    id: p.integer().primary().autoincrement(),
+    score: p.integer(),
+    rateable: () => p.manyToOne([Article, Video]).discriminatorMap({
+      art: 'Article',
+      vid: 'Video',
+    }),
+  },
+});
+
+const Category = defineEntity({
+  name: 'Category',
+  properties: {
+    id: p.integer().primary().autoincrement(),
+    name: p.string(),
+    posts: () => p.manyToMany(Post).mappedBy('categories'),
+    products: () => p.manyToMany(Product).mappedBy('categories'),
+  },
+});
+
+const Post = defineEntity({
+  name: 'Post',
+  properties: {
+    id: p.integer().primary().autoincrement(),
+    title: p.string(),
+    categories: () => p.manyToMany(Category)
+      .mappedBy('posts')
+      .pivotTable('categorizables')
+      .discriminator('categorizable')
+      .discriminatorMap({ post: 'Post', prod: 'Product' })
+      .owner(),
+  },
+});
+
+const Product = defineEntity({
+  name: 'Product',
+  properties: {
+    id: p.integer().primary().autoincrement(),
+    sku: p.string(),
+    categories: () => p.manyToMany(Category)
+      .mappedBy('products')
+      .pivotTable('categorizables')
+      .discriminator('categorizable')
+      .discriminatorMap({ post: 'Post', prod: 'Product' })
+      .owner(),
+  },
+});
+
+type Category = InferEntity<typeof Category>;
+type Post = InferEntity<typeof Post>;
+type Product = InferEntity<typeof Product>;
+
+describe('polymorphic M:1 via defineEntity', () => {
+
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      entities: [Article, Video, Rating],
+      dbName: ':memory:',
+    });
+    await orm.schema.create();
+  });
+
+  afterAll(() => orm.close(true));
+
+  beforeEach(async () => {
+    await orm.schema.clear();
+    orm.em.clear();
+  });
+
+  test('metadata has custom discriminator map', () => {
+    const meta = orm.getMetadata().get(Rating);
+    const prop = meta.properties.rateable;
+
+    expect(prop.polymorphic).toBe(true);
+    expect(prop.discriminatorMap).toBeDefined();
+    expect(prop.discriminatorMap!.art).toBe(Article.meta.class);
+    expect(prop.discriminatorMap!.vid).toBe(Video.meta.class);
+  });
+
+  test('persist and load with discriminatorMap', async () => {
+    const article = orm.em.create(Article, { title: 'Test Article' });
+    const video = orm.em.create(Video, { url: 'https://example.com/v' });
+    orm.em.create(Rating, { score: 5, rateable: article });
+    orm.em.create(Rating, { score: 4, rateable: video });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const ratings = await orm.em.find(Rating, {}, {
+      populate: ['rateable'],
+      orderBy: { id: 'ASC' },
+    });
+
+    expect(ratings).toHaveLength(2);
+    expect(ratings[0].rateable).toBeInstanceOf(Article.meta.class);
+    expect(ratings[1].rateable).toBeInstanceOf(Video.meta.class);
+  });
+
+  test('stores custom discriminator values', async () => {
+    const article = orm.em.create(Article, { title: 'A' });
+    const rating = orm.em.create(Rating, { score: 1, rateable: article });
+    await orm.em.flush();
+
+    const conn = orm.em.getConnection();
+    const [row] = await conn.execute('SELECT * FROM rating WHERE id = ?', [rating.id]);
+    expect(row.rateable_type).toBe('art');
+  });
+
+});
+
+describe('polymorphic M:N via defineEntity', () => {
+
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      entities: [Category, Post, Product],
+      dbName: ':memory:',
+    });
+    await orm.schema.create();
+  });
+
+  afterAll(() => orm.close(true));
+
+  beforeEach(async () => {
+    await orm.schema.clear();
+    orm.em.clear();
+  });
+
+  test('metadata has custom discriminator values', () => {
+    const postMeta = orm.getMetadata().get(Post);
+    const productMeta = orm.getMetadata().get(Product);
+
+    expect(postMeta.properties.categories.discriminatorValue).toBe('post');
+    expect(productMeta.properties.categories.discriminatorValue).toBe('prod');
+  });
+
+  test('persist and load from owner side', async () => {
+    const cat = orm.em.create(Category, { name: 'Tech' });
+    const post = orm.em.create(Post, { title: 'Post 1' });
+    const product = orm.em.create(Product, { sku: 'SKU-1' });
+    post.categories.add(cat);
+    product.categories.add(cat);
+    await orm.em.flush();
+    orm.em.clear();
+
+    const loadedPost = await orm.em.findOneOrFail(Post, post.id, { populate: ['categories'] });
+    expect(loadedPost.categories).toHaveLength(1);
+    expect(loadedPost.categories[0].name).toBe('Tech');
+  });
+
+  test('load from inverse side', async () => {
+    const cat = orm.em.create(Category, { name: 'Tech' });
+    const post = orm.em.create(Post, { title: 'P1' });
+    const product = orm.em.create(Product, { sku: 'S1' });
+    post.categories.add(cat);
+    product.categories.add(cat);
+    await orm.em.flush();
+    orm.em.clear();
+
+    const loadedCat = await orm.em.findOneOrFail(Category, cat.id, {
+      populate: ['posts', 'products'],
+    });
+
+    expect(loadedCat.posts).toHaveLength(1);
+    expect(loadedCat.products).toHaveLength(1);
+  });
+
+  test('stores custom discriminator values in pivot table', async () => {
+    const cat = orm.em.create(Category, { name: 'Cat' });
+    const post = orm.em.create(Post, { title: 'P' });
+    post.categories.add(cat);
+    await orm.em.flush();
+
+    const conn = orm.em.getConnection();
+    const rows = await conn.execute('SELECT * FROM categorizables');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].categorizable_type).toBe('post');
+  });
+
+});

--- a/tests/features/polymorphic-relations/polymorphic-issues.sqlite.test.ts
+++ b/tests/features/polymorphic-relations/polymorphic-issues.sqlite.test.ts
@@ -1,0 +1,510 @@
+import { Collection, LoadStrategy, MikroORM, Opt, QueryOrder } from '@mikro-orm/sqlite';
+import {
+  Embeddable,
+  Embedded,
+  Entity,
+  ManyToMany,
+  ManyToOne,
+  PrimaryKey,
+  Property,
+  ReflectMetadataProvider,
+} from '@mikro-orm/decorators/legacy';
+import { vi } from 'vitest';
+
+describe('polymorphic M:N with composite keys on owner side (fixed)', () => {
+
+  @Entity()
+  class Article {
+
+    @PrimaryKey()
+    tenantId!: number;
+
+    @PrimaryKey()
+    articleId!: number;
+
+    @Property()
+    title!: string;
+
+    @ManyToMany(() => Category, c => c.articles, {
+      pivotTable: 'categorizables',
+      discriminator: 'categorizable',
+      owner: true,
+    })
+    categories = new Collection<Category>(this);
+
+    constructor(tenantId: number, articleId: number, title: string) {
+      this.tenantId = tenantId;
+      this.articleId = articleId;
+      this.title = title;
+    }
+
+  }
+
+  @Entity()
+  class Product {
+
+    @PrimaryKey()
+    tenantId!: number;
+
+    @PrimaryKey()
+    productId!: number;
+
+    @Property()
+    name!: string;
+
+    @ManyToMany(() => Category, c => c.products, {
+      pivotTable: 'categorizables',
+      discriminator: 'categorizable',
+      owner: true,
+    })
+    categories = new Collection<Category>(this);
+
+    constructor(tenantId: number, productId: number, name: string) {
+      this.tenantId = tenantId;
+      this.productId = productId;
+      this.name = name;
+    }
+
+  }
+
+  @Entity()
+  class Category {
+
+    @PrimaryKey()
+    id!: number;
+
+    @Property()
+    name!: string;
+
+    @ManyToMany(() => Article, a => a.categories)
+    articles = new Collection<Article>(this);
+
+    @ManyToMany(() => Product, p => p.categories)
+    products = new Collection<Product>(this);
+
+    constructor(name: string) {
+      this.name = name;
+    }
+
+  }
+
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      entities: [Article, Product, Category],
+      dbName: ':memory:',
+      metadataProvider: ReflectMetadataProvider,
+    });
+    await orm.schema.create();
+  });
+
+  afterAll(() => orm.close(true));
+
+  beforeEach(async () => {
+    await orm.schema.clear();
+    orm.em.clear();
+  });
+
+  test('inverse side loading with composite PK owners', async () => {
+    const article1 = new Article(1, 100, 'Article 1');
+    const article2 = new Article(1, 200, 'Article 2');
+    const product1 = new Product(1, 100, 'Product 1');
+
+    const category = new Category('Tech');
+    category.articles.add(article1, article2);
+    category.products.add(product1);
+
+    orm.em.persist(category);
+    await orm.em.flush();
+    orm.em.clear();
+
+    const loaded = await orm.em.findOneOrFail(Category, { id: category.id }, {
+      populate: ['articles', 'products'],
+    });
+
+    expect(loaded.articles).toHaveLength(2);
+    expect(loaded.products).toHaveLength(1);
+
+    const loadedArticle1 = loaded.articles.getItems().find(a => a.articleId === 100);
+    expect(loadedArticle1).toBeDefined();
+    expect(loadedArticle1!.tenantId).toBe(1);
+    expect(loadedArticle1!.title).toBe('Article 1');
+  });
+
+});
+
+describe('polymorphic to-one with joined strategy', () => {
+
+  @Entity()
+  class Tag {
+
+    @PrimaryKey()
+    tenantId!: number;
+
+    @PrimaryKey()
+    tagId!: number;
+
+    @Property()
+    label!: string;
+
+  }
+
+  @Embeddable()
+  class Address {
+
+    @Property()
+    city!: string;
+
+    @Property()
+    country!: string;
+
+  }
+
+  @Entity()
+  class TargetA {
+
+    @PrimaryKey()
+    id!: number;
+
+    @Property()
+    valueA!: string;
+
+    @Property()
+    createdAt: Date & Opt = new Date('2024-01-15T12:00:00Z');
+
+    @ManyToOne(() => Tag, { nullable: true })
+    tag?: Tag;
+
+  }
+
+  @Entity()
+  class TargetB {
+
+    @PrimaryKey()
+    id!: number;
+
+    @Property()
+    valueB!: string;
+
+    @Embedded(() => Address, { object: true, nullable: true })
+    address?: Address;
+
+  }
+
+  @Entity()
+  class Owner {
+
+    @PrimaryKey()
+    id!: number;
+
+    @Property()
+    name!: string;
+
+    @ManyToOne(() => [TargetA, TargetB], { nullable: true })
+    target!: TargetA | TargetB | null;
+
+  }
+
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      entities: [Tag, TargetA, TargetB, Owner],
+      dbName: ':memory:',
+      metadataProvider: ReflectMetadataProvider,
+    });
+    await orm.schema.create();
+  });
+
+  afterAll(() => orm.close(true));
+
+  beforeEach(async () => {
+    await orm.schema.clear();
+    orm.em.clear();
+
+    const tag = orm.em.create(Tag, { tenantId: 1, tagId: 10, label: 'important' });
+    const targetA = orm.em.create(TargetA, { valueA: 'Value A', tag });
+    const targetB = orm.em.create(TargetB, { valueB: 'Value B', address: { city: 'London', country: 'UK' } });
+    orm.em.create(Owner, { name: 'Owner 1', target: targetA });
+    orm.em.create(Owner, { name: 'Owner 2', target: targetB });
+    orm.em.create(Owner, { name: 'Owner 3', target: null });
+
+    await orm.em.flush();
+    orm.em.clear();
+  });
+
+  test('SELECT_IN strategy fires multiple queries for polymorphic relation', async () => {
+    const mock = vi.fn();
+    const logger = orm.config.getLogger();
+    logger.setDebugMode(true);
+    logger.log = mock;
+
+    const owners = await orm.em.find(Owner, {}, {
+      populate: ['target'],
+      strategy: LoadStrategy.SELECT_IN,
+      orderBy: { id: QueryOrder.ASC },
+    });
+
+    logger.setDebugMode(false);
+
+    expect(owners).toHaveLength(3);
+    expect(owners[0].target).toBeInstanceOf(TargetA);
+    expect(owners[1].target).toBeInstanceOf(TargetB);
+    expect(owners[2].target).toBeNull();
+
+    // SELECT_IN: 1 query for owners + 2 queries (one per target type) = 3
+    // Note: There may be additional queries from commit or other operations
+    const selectQueries = mock.mock.calls.filter((c: any) => c[1]?.includes('select'));
+    expect(selectQueries.length).toBeGreaterThanOrEqual(3);
+  });
+
+  test('JOINED strategy uses LEFT JOINs per target type for polymorphic relations', async () => {
+    const mock = vi.fn();
+    const logger = orm.config.getLogger();
+    logger.setDebugMode(true);
+    logger.log = mock;
+
+    const owners = await orm.em.find(Owner, {}, {
+      populate: ['target'],
+      strategy: LoadStrategy.JOINED,
+      orderBy: { id: QueryOrder.ASC },
+    });
+
+    logger.setDebugMode(false);
+
+    expect(owners).toHaveLength(3);
+    expect(owners[0].target).toBeInstanceOf(TargetA);
+    expect(owners[1].target).toBeInstanceOf(TargetB);
+    expect(owners[2].target).toBeNull();
+
+    // Verify Date property on polymorphic target is correctly hydrated
+    expect((owners[0].target as TargetA).createdAt).toBeInstanceOf(Date);
+    // Verify composite FK on polymorphic target is hydrated as reference
+    expect((owners[0].target as TargetA).tag).toBeDefined();
+    // Verify embedded object on polymorphic target is correctly hydrated
+    expect((owners[1].target as TargetB).address).toEqual({ city: 'London', country: 'UK' });
+
+    // JOINED: single query with LEFT JOINs per target type
+    const selectQueries = mock.mock.calls.filter((c: any) => c[1]?.includes('select'));
+    expect(selectQueries[0][1]).toContain('left join');
+    expect(selectQueries[0][1]).toContain('target_type');
+    expect(selectQueries).toHaveLength(1);
+  });
+
+  test('JOINED strategy with timezone config parses dates correctly', async () => {
+    const tzOrm = await MikroORM.init({
+      entities: [Tag, TargetA, TargetB, Owner],
+      dbName: ':memory:',
+      metadataProvider: ReflectMetadataProvider,
+      timezone: '+02:00',
+    });
+    await tzOrm.schema.create();
+
+    const tag = tzOrm.em.create(Tag, { tenantId: 1, tagId: 10, label: 'tz' });
+    const targetA = tzOrm.em.create(TargetA, { valueA: 'TZ Value', tag });
+    tzOrm.em.create(Owner, { name: 'TZ Owner', target: targetA });
+    await tzOrm.em.flush();
+    tzOrm.em.clear();
+
+    const owners = await tzOrm.em.find(Owner, {}, {
+      populate: ['target'],
+      strategy: LoadStrategy.JOINED,
+    });
+
+    expect(owners).toHaveLength(1);
+    expect(owners[0].target).toBeInstanceOf(TargetA);
+    expect((owners[0].target as TargetA).createdAt).toBeInstanceOf(Date);
+
+    await tzOrm.close(true);
+  });
+
+});
+
+describe('polymorphic relation with STI target (fixed)', () => {
+
+  test('throws error when polymorphic targets share the same table (STI)', async () => {
+    @Entity({
+      discriminatorColumn: 'type',
+      discriminatorMap: { person: 'Person', employee: 'Employee' },
+    })
+    class Person {
+
+      @PrimaryKey()
+      id!: number;
+
+      @Property()
+      name!: string;
+
+    }
+
+    @Entity({ discriminatorValue: 'employee' })
+    class Employee extends Person {
+
+      @Property()
+      department!: string;
+
+    }
+
+    @Entity()
+    class Task {
+
+      @PrimaryKey()
+      id!: number;
+
+      @Property()
+      title!: string;
+
+      // This is disallowed: Person and Employee share the same table
+      // Use separate @ManyToOne(() => Person) properties instead
+      @ManyToOne(() => [Person, Employee], { nullable: true })
+      assignee!: Person | Employee | null;
+
+    }
+
+    await expect(
+      MikroORM.init({
+        entities: [Person, Employee, Task],
+        dbName: ':memory:',
+        metadataProvider: ReflectMetadataProvider,
+      }),
+    ).rejects.toThrow(/incompatible polymorphic targets.*both use table 'person'.*Use separate properties/i);
+  });
+
+});
+
+describe('invalid discriminator value handling (fixed)', () => {
+
+  @Entity()
+  class TypeA {
+
+    @PrimaryKey()
+    id!: number;
+
+    @Property()
+    value!: string;
+
+  }
+
+  @Entity()
+  class TypeB {
+
+    @PrimaryKey()
+    id!: number;
+
+    @Property()
+    value!: string;
+
+  }
+
+  @Entity()
+  class Container {
+
+    @PrimaryKey()
+    id!: number;
+
+    @ManyToOne(() => [TypeA, TypeB])
+    item!: TypeA | TypeB;
+
+  }
+
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      entities: [TypeA, TypeB, Container],
+      dbName: ':memory:',
+      metadataProvider: ReflectMetadataProvider,
+    });
+    await orm.schema.create();
+  });
+
+  afterAll(() => orm.close(true));
+
+  beforeEach(async () => {
+    await orm.schema.clear();
+    orm.em.clear();
+  });
+
+  test('throws error when hydrating invalid discriminator value', async () => {
+    const conn = orm.em.getConnection();
+    await conn.execute(`INSERT INTO type_a (id, value) VALUES (1, 'A')`);
+    await conn.execute(`INSERT INTO container (id, item_type, item_id) VALUES (1, 'invalid_type', 1)`);
+
+    await expect(
+      orm.em.findOneOrFail(Container, { id: 1 }),
+    ).rejects.toThrow(/discriminator|unknown|invalid/i);
+  });
+
+});
+
+describe('ChangeSetComputer with polymorphic relations (fixed)', () => {
+
+  @Entity()
+  class Target {
+
+    @PrimaryKey()
+    id!: number;
+
+    @Property()
+    name!: string;
+
+  }
+
+  @Entity()
+  class Target2 {
+
+    @PrimaryKey()
+    id!: number;
+
+    @Property()
+    name!: string;
+
+  }
+
+  @Entity()
+  class Parent {
+
+    @PrimaryKey()
+    id!: number;
+
+    @ManyToOne(() => [Target, Target2])
+    poly!: Target | Target2;
+
+  }
+
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      entities: [Target, Target2, Parent],
+      dbName: ':memory:',
+      metadataProvider: ReflectMetadataProvider,
+    });
+    await orm.schema.create();
+  });
+
+  afterAll(() => orm.close(true));
+
+  beforeEach(async () => {
+    await orm.schema.clear();
+    orm.em.clear();
+  });
+
+  test('updating to same target does not create unnecessary changeset', async () => {
+    const target = orm.em.create(Target, { name: 'Target' });
+    const parent = orm.em.create(Parent, { poly: target });
+    await orm.em.flush();
+
+    // Re-assign the same target - should not create a changeset
+    parent.poly = target;
+
+    const uow = orm.em.getUnitOfWork();
+    uow.computeChangeSets();
+    const changes = uow.getChangeSets();
+
+    const parentChanges = changes.filter(cs => cs.entity === parent);
+    expect(parentChanges).toHaveLength(0);
+  });
+
+});

--- a/tests/features/polymorphic-relations/polymorphic-loading-strategies.sqlite.test.ts
+++ b/tests/features/polymorphic-relations/polymorphic-loading-strategies.sqlite.test.ts
@@ -1,0 +1,713 @@
+import { Collection, helper, LoadStrategy, MikroORM, Ref, ref, wrap } from '@mikro-orm/sqlite';
+import { Entity, ManyToOne, OneToMany, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+
+@Entity()
+class Author {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @OneToMany(() => Article, a => a.author)
+  articles = new Collection<Article>(this);
+
+}
+
+@Entity()
+class Article {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  title!: string;
+
+  @ManyToOne(() => Author)
+  author!: Author;
+
+  @OneToMany(() => Reaction, r => r.target)
+  reactions = new Collection<Reaction>(this);
+
+}
+
+@Entity()
+class Video {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  url!: string;
+
+  @ManyToOne(() => Author)
+  author!: Author;
+
+  @OneToMany(() => Reaction, r => r.target)
+  reactions = new Collection<Reaction>(this);
+
+}
+
+@Entity()
+class Reaction {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  emoji!: string;
+
+  @ManyToOne(() => [Article, Video])
+  target!: Article | Video;
+
+  @ManyToOne(() => Author)
+  reactor!: Author;
+
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    metadataProvider: ReflectMetadataProvider,
+    dbName: ':memory:',
+    entities: [Author, Article, Video, Reaction],
+  });
+  await orm.schema.create();
+
+  const author1 = orm.em.create(Author, { name: 'Alice' });
+  const author2 = orm.em.create(Author, { name: 'Bob' });
+
+  const article1 = orm.em.create(Article, { title: 'Article 1', author: author1 });
+  const article2 = orm.em.create(Article, { title: 'Article 2', author: author1 });
+  const video1 = orm.em.create(Video, { url: 'https://example.com/video1', author: author2 });
+  const video2 = orm.em.create(Video, { url: 'https://example.com/video2', author: author2 });
+
+  orm.em.create(Reaction, { emoji: '👍', target: article1, reactor: author2 });
+  orm.em.create(Reaction, { emoji: '❤️', target: article1, reactor: author2 });
+  orm.em.create(Reaction, { emoji: '🎉', target: article2, reactor: author2 });
+  orm.em.create(Reaction, { emoji: '👍', target: video1, reactor: author1 });
+  orm.em.create(Reaction, { emoji: '😂', target: video2, reactor: author1 });
+
+  await orm.em.flush();
+  orm.em.clear();
+});
+
+afterAll(() => orm.close(true));
+
+describe.each(Object.values(LoadStrategy))('polymorphic relations with %s strategy', strategy => {
+
+  beforeEach(() => orm.em.clear());
+
+  test('loads polymorphic relation', async () => {
+    const reactions = await orm.em.find(Reaction, {}, {
+      populate: ['target'],
+      strategy,
+    });
+
+    expect(reactions).toHaveLength(5);
+    const articleReactions = reactions.filter(r => r.target instanceof Article);
+    const videoReactions = reactions.filter(r => r.target instanceof Video);
+    expect(articleReactions).toHaveLength(3);
+    expect(videoReactions).toHaveLength(2);
+  });
+
+  test('loads polymorphic relation alongside regular relation', async () => {
+    const reactions = await orm.em.find(Reaction, {}, {
+      populate: ['target', 'reactor'],
+      strategy,
+    });
+
+    expect(reactions).toHaveLength(5);
+    for (const reaction of reactions) {
+      expect(reaction.target).toBeDefined();
+      expect(reaction.reactor).toBeDefined();
+      expect(['Alice', 'Bob']).toContain(reaction.reactor.name);
+    }
+  });
+
+  test('loads nested relation through polymorphic relation', async () => {
+    const reactions = await orm.em.find(Reaction, {}, {
+      populate: ['target.author'],
+      strategy,
+    });
+
+    expect(reactions).toHaveLength(5);
+    for (const reaction of reactions) {
+      expect(reaction.target).toBeDefined();
+      if (reaction.target instanceof Article) {
+        expect(reaction.target.author.name).toBe('Alice');
+      } else {
+        expect(reaction.target.author.name).toBe('Bob');
+      }
+    }
+  });
+
+});
+
+describe.each(Object.values(LoadStrategy))('polymorphic inverse side with %s strategy', strategy => {
+
+  beforeEach(() => orm.em.clear());
+
+  test('loads inverse side of polymorphic relation', async () => {
+    const articles = await orm.em.find(Article, {}, {
+      populate: ['reactions'],
+      strategy,
+    });
+
+    expect(articles).toHaveLength(2);
+    expect(articles.find(a => a.title === 'Article 1')!.reactions).toHaveLength(2);
+    expect(articles.find(a => a.title === 'Article 2')!.reactions).toHaveLength(1);
+  });
+
+  test('loads inverse side with nested populate', async () => {
+    const articles = await orm.em.find(Article, {}, {
+      populate: ['reactions.reactor'],
+      strategy,
+    });
+
+    expect(articles).toHaveLength(2);
+    for (const article of articles) {
+      for (const reaction of article.reactions) {
+        expect(reaction.reactor.name).toBe('Bob');
+      }
+    }
+  });
+
+  test('loads complex graph: author -> articles -> reactions -> reactor', async () => {
+    const authors = await orm.em.find(Author, { name: 'Alice' }, {
+      populate: ['articles.reactions.reactor'],
+      strategy,
+    });
+
+    expect(authors).toHaveLength(1);
+    const alice = authors[0];
+    expect(alice.articles).toHaveLength(2);
+
+    const article1 = alice.articles.find(a => a.title === 'Article 1')!;
+    expect(article1.reactions).toHaveLength(2);
+    for (const reaction of article1.reactions) {
+      expect(reaction.reactor.name).toBe('Bob');
+    }
+  });
+
+});
+
+// Test Ref wrapper on polymorphic relations
+describe('polymorphic relations with Ref wrapper', () => {
+
+  @Entity()
+  class Post {
+
+    @PrimaryKey()
+    id!: number;
+
+    @Property()
+    title!: string;
+
+  }
+
+  @Entity()
+  class Image {
+
+    @PrimaryKey()
+    id!: number;
+
+    @Property()
+    url!: string;
+
+  }
+
+  @Entity()
+  class Comment {
+
+    @PrimaryKey()
+    id!: number;
+
+    @Property()
+    text!: string;
+
+    @ManyToOne(() => [Post, Image], { ref: true })
+    target!: Ref<Post> | Ref<Image>;
+
+  }
+
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      dbName: ':memory:',
+      entities: [Post, Image, Comment],
+    });
+    await orm.schema.create();
+  });
+
+  afterAll(() => orm.close(true));
+
+  beforeEach(() => orm.em.clear());
+
+  test('creates entity with Ref-wrapped polymorphic relation', async () => {
+    const post = orm.em.create(Post, { title: 'Test Post' });
+    const image = orm.em.create(Image, { url: 'https://example.com/image.png' });
+    const comment1 = orm.em.create(Comment, { text: 'Nice post!', target: ref(post) });
+    const comment2 = orm.em.create(Comment, { text: 'Nice image!', target: ref(image) });
+
+    await orm.em.flush();
+    orm.em.clear();
+
+    const comments = await orm.em.find(Comment, {}, { populate: ['target'] });
+    expect(comments).toHaveLength(2);
+
+    const postComment = comments.find(c => c.text === 'Nice post!')!;
+    const imageComment = comments.find(c => c.text === 'Nice image!')!;
+
+    expect(postComment.target.unwrap()).toBeInstanceOf(Post);
+    expect(imageComment.target.unwrap()).toBeInstanceOf(Image);
+    expect((postComment.target.unwrap() as Post).title).toBe('Test Post');
+    expect((imageComment.target.unwrap() as Image).url).toBe('https://example.com/image.png');
+  });
+
+  test('loads Ref-wrapped polymorphic relation without populate', async () => {
+    const post = orm.em.create(Post, { title: 'Another Post' });
+    orm.em.create(Comment, { text: 'Comment on post', target: ref(post) });
+
+    await orm.em.flush();
+    orm.em.clear();
+
+    const comment = await orm.em.findOneOrFail(Comment, { text: 'Comment on post' });
+
+    // Without populate, target should be a reference (not loaded)
+    expect(comment.target.isInitialized()).toBe(false);
+    expect(comment.target.id).toBeDefined();
+  });
+
+  test.each(Object.values(LoadStrategy))('loads Ref-wrapped polymorphic relation with %s strategy', async strategy => {
+    orm.em.clear();
+    const image = orm.em.create(Image, { url: 'https://example.com/test.png' });
+    orm.em.create(Comment, { text: 'Test comment', target: ref(image) });
+
+    await orm.em.flush();
+    orm.em.clear();
+
+    const comment = await orm.em.findOneOrFail(Comment, { text: 'Test comment' }, {
+      populate: ['target'],
+      strategy,
+    });
+
+    expect(comment.target.isInitialized()).toBe(true);
+    expect(comment.target.unwrap()).toBeInstanceOf(Image);
+    expect((comment.target.unwrap() as Image).url).toBe('https://example.com/test.png');
+  });
+
+  test('assigns entity directly to Ref-wrapped polymorphic relation', async () => {
+    const post = orm.em.create(Post, { title: 'Direct assign post' });
+    const comment = orm.em.create(Comment, { text: 'Direct assign comment', target: post });
+
+    await orm.em.flush();
+    orm.em.clear();
+
+    const loaded = await orm.em.findOneOrFail(Comment, { text: 'Direct assign comment' }, { populate: ['target'] });
+    expect(loaded.target.unwrap()).toBeInstanceOf(Post);
+    expect((loaded.target.unwrap() as Post).title).toBe('Direct assign post');
+  });
+
+});
+
+describe('lazy loading polymorphic relations', () => {
+
+  beforeEach(() => orm.em.clear());
+
+  test('polymorphic relation is a reference when not populated', async () => {
+    const reaction = await orm.em.findOneOrFail(Reaction, { emoji: '👍' });
+
+    // Should have a reference with the correct type, but not initialized
+    expect(reaction.target).toBeDefined();
+    expect(reaction.target).toBeInstanceOf(Article);
+    expect(wrap(reaction.target).isInitialized()).toBe(false);
+    expect(helper(reaction.target).hasPrimaryKey()).toBe(true);
+
+    // The reference should only have PK, not other properties
+    const article = reaction.target as Article;
+    expect(article.id).toBeDefined();
+    expect(article.title).toBeUndefined(); // Not loaded yet
+  });
+
+  test('lazy loads polymorphic relation via em.populate', async () => {
+    const reaction = await orm.em.findOneOrFail(Reaction, { emoji: '👍' });
+
+    // Should be a reference, not initialized
+    expect(wrap(reaction.target).isInitialized()).toBe(false);
+
+    await orm.em.populate(reaction, ['target']);
+
+    // Now should be initialized
+    expect(wrap(reaction.target).isInitialized()).toBe(true);
+    expect(reaction.target).toBeInstanceOf(Article);
+    expect((reaction.target as Article).title).toBe('Article 1');
+  });
+
+  test('skips already-initialized polymorphic relation without refresh', async () => {
+    // Load reaction with populated target
+    const reaction = await orm.em.findOneOrFail(Reaction, { emoji: '👍' }, {
+      populate: ['target'],
+    });
+
+    // Target should be initialized
+    expect(wrap(reaction.target).isInitialized()).toBe(true);
+    expect((reaction.target as Article).title).toBe('Article 1');
+
+    // Populate again without refresh - should be a no-op (covers line 275 in EntityLoader.ts)
+    await orm.em.populate(reaction, ['target']);
+
+    // Still initialized with same data
+    expect(wrap(reaction.target).isInitialized()).toBe(true);
+    expect((reaction.target as Article).title).toBe('Article 1');
+  });
+
+  test('lazy loads multiple polymorphic relations via em.populate', async () => {
+    const reactions = await orm.em.find(Reaction, {});
+
+    // All targets should be references (not initialized)
+    for (const reaction of reactions) {
+      expect(reaction.target).toBeDefined();
+      expect(wrap(reaction.target).isInitialized()).toBe(false);
+    }
+
+    // Populate should load all
+    await orm.em.populate(reactions, ['target']);
+
+    for (const reaction of reactions) {
+      expect(wrap(reaction.target).isInitialized()).toBe(true);
+    }
+
+    const articleReactions = reactions.filter(r => r.target instanceof Article);
+    const videoReactions = reactions.filter(r => r.target instanceof Video);
+    expect(articleReactions).toHaveLength(3);
+    expect(videoReactions).toHaveLength(2);
+  });
+
+  test('lazy loads second polymorphic target type (Video) via em.populate', async () => {
+    // Load only reaction pointing to Video (second target type)
+    const reaction = await orm.em.findOneOrFail(Reaction, { emoji: '😂' });
+
+    expect(reaction.target).toBeInstanceOf(Video);
+    expect(wrap(reaction.target).isInitialized()).toBe(false);
+
+    await orm.em.populate(reaction, ['target']);
+
+    expect(wrap(reaction.target).isInitialized()).toBe(true);
+    expect((reaction.target as Video).url).toBe('https://example.com/video2');
+  });
+
+  test('lazy loads nested relation through second polymorphic target type', async () => {
+    const reaction = await orm.em.findOneOrFail(Reaction, { emoji: '😂' });
+
+    expect(reaction.target).toBeInstanceOf(Video);
+    expect(wrap(reaction.target).isInitialized()).toBe(false);
+
+    await orm.em.populate(reaction, ['target.author']);
+
+    expect(wrap(reaction.target).isInitialized()).toBe(true);
+    expect((reaction.target as Video).author).toBeDefined();
+    expect((reaction.target as Video).author.name).toBe('Bob');
+  });
+
+  test('lazy loads Ref-wrapped polymorphic relation via ref.load()', async () => {
+    @Entity()
+    class LazyPost {
+
+      @PrimaryKey()
+      id!: number;
+
+      @Property()
+      title!: string;
+
+    }
+
+    @Entity()
+    class LazyImage {
+
+      @PrimaryKey()
+      id!: number;
+
+      @Property()
+      url!: string;
+
+    }
+
+    @Entity()
+    class LazyComment {
+
+      @PrimaryKey()
+      id!: number;
+
+      @Property()
+      text!: string;
+
+      @ManyToOne(() => [LazyPost, LazyImage], { ref: true })
+      target!: Ref<LazyPost> | Ref<LazyImage>;
+
+    }
+
+    const localOrm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      dbName: ':memory:',
+      entities: [LazyPost, LazyImage, LazyComment],
+    });
+    await localOrm.schema.create();
+
+    const post = localOrm.em.create(LazyPost, { title: 'Lazy load post' });
+    localOrm.em.create(LazyComment, { text: 'Lazy load comment', target: ref(post) });
+    await localOrm.em.flush();
+    localOrm.em.clear();
+
+    // Polymorphic relations are auto-loaded, but ref.load() should still work
+    const comment = await localOrm.em.findOneOrFail(LazyComment, { text: 'Lazy load comment' });
+
+    const loaded = await (comment.target as Ref<LazyPost>).load();
+    expect(comment.target.isInitialized()).toBe(true);
+    expect(loaded).toBeInstanceOf(LazyPost);
+    expect(loaded!.title).toBe('Lazy load post');
+
+    await localOrm.close(true);
+  });
+
+  test('lazy loads inverse side collection via collection.init()', async () => {
+    // Load article without populating reactions
+    const article = await orm.em.findOneOrFail(Article, { title: 'Article 1' });
+
+    // Collection should not be initialized
+    expect(article.reactions.isInitialized()).toBe(false);
+
+    // Lazy load the collection
+    await article.reactions.init();
+
+    expect(article.reactions.isInitialized()).toBe(true);
+    expect(article.reactions).toHaveLength(2);
+    expect(article.reactions.getItems().map(r => r.emoji).sort()).toEqual(['❤️', '👍']);
+  });
+
+  test('lazy loads nested relations through polymorphic relation via em.populate', async () => {
+    const reaction = await orm.em.findOneOrFail(Reaction, { emoji: '👍' });
+
+    // Polymorphic target is a reference (not initialized)
+    expect(reaction.target).toBeInstanceOf(Article);
+    expect(wrap(reaction.target).isInitialized()).toBe(false);
+
+    // Populate the nested author relation through the polymorphic relation
+    await orm.em.populate(reaction, ['target.author']);
+
+    // Now target should be initialized
+    expect(wrap(reaction.target).isInitialized()).toBe(true);
+
+    // And author should be populated
+    const article = reaction.target as Article;
+    expect(article.author).toBeDefined();
+    expect(wrap(article.author).isInitialized()).toBe(true);
+    expect(article.author.name).toBe('Alice');
+  });
+
+});
+
+describe(':ref populate hints for polymorphic relations', () => {
+
+  beforeEach(() => orm.em.clear());
+
+  test('polymorphic to-one with :ref hint is a no-op (already has FK and discriminator)', async () => {
+    // For polymorphic to-one relations, :ref should be a no-op since we already
+    // have the FK and discriminator columns in the row - no additional query needed
+    const reaction = await orm.em.findOneOrFail(Reaction, { emoji: '👍' }, {
+      populate: ['target:ref'],
+    });
+
+    expect(reaction.target).toBeInstanceOf(Article);
+    // :ref should NOT load the entity - we already have a reference from the FK columns
+    expect(wrap(reaction.target).isInitialized()).toBe(false);
+    expect(helper(reaction.target).hasPrimaryKey()).toBe(true);
+    expect((reaction.target as Article).id).toBeDefined();
+    expect((reaction.target as Article).title).toBeUndefined(); // Not loaded
+  });
+
+  test('polymorphic to-one without populate is already a reference', async () => {
+    // This test confirms that without populate, we already get a reference
+    const reaction = await orm.em.findOneOrFail(Reaction, { emoji: '👍' });
+
+    expect(reaction.target).toBeInstanceOf(Article);
+    expect(wrap(reaction.target).isInitialized()).toBe(false);
+    expect(helper(reaction.target).hasPrimaryKey()).toBe(true);
+    expect((reaction.target as Article).id).toBeDefined();
+    expect((reaction.target as Article).title).toBeUndefined();
+  });
+
+  test('inverse polymorphic collection with :ref hint populates with references', async () => {
+    // For to-many inverse side, :ref should populate the collection with entity references
+    // that have PKs but are not fully loaded
+    const article = await orm.em.findOneOrFail(Article, { title: 'Article 1' }, {
+      populate: ['reactions:ref'],
+    });
+
+    // Collection should be initialized (we know which items belong to it)
+    expect(article.reactions.isInitialized()).toBe(true);
+    expect(article.reactions).toHaveLength(2);
+
+    // But each item should be a reference (not fully loaded)
+    for (const reaction of article.reactions) {
+      expect(reaction.id).toBeDefined();
+      expect(wrap(reaction).isInitialized()).toBe(false);
+      expect(reaction.emoji).toBeUndefined(); // Not loaded yet
+    }
+  });
+
+  test('inverse polymorphic collection :ref can be fully loaded afterward', async () => {
+    const article = await orm.em.findOneOrFail(Article, { title: 'Article 1' }, {
+      populate: ['reactions:ref'],
+    });
+
+    // Collection has references
+    expect(article.reactions.isInitialized()).toBe(true);
+    expect(article.reactions).toHaveLength(2);
+    expect(wrap(article.reactions[0]).isInitialized()).toBe(false);
+
+    // Now fully populate the reactions
+    await orm.em.populate(article, ['reactions']);
+
+    // Now each reaction should be fully loaded
+    for (const reaction of article.reactions) {
+      expect(wrap(reaction).isInitialized()).toBe(true);
+      expect(reaction.emoji).toBeDefined();
+    }
+    expect(article.reactions.getItems().map(r => r.emoji).sort()).toEqual(['❤️', '👍']);
+  });
+
+  test('polymorphic to-one with :ref and partial loading (FK excluded) loads only FK', async () => {
+    // Load reaction without the polymorphic FK columns (partial loading)
+    const reaction = await orm.em.findOneOrFail(Reaction, { emoji: '👍' }, {
+      fields: ['id', 'emoji'], // Exclude target FK columns
+    });
+
+    // Target should be undefined since FK was not loaded
+    expect((reaction as Reaction).target).toBeUndefined();
+
+    // Now populate with :ref - should load only the FK columns, not the full target
+    await orm.em.populate(reaction, ['target:ref']);
+
+    // Target should now be a reference (not initialized) with PK set
+    expect((reaction as Reaction).target).toBeInstanceOf(Article);
+    expect(wrap((reaction as Reaction).target).isInitialized()).toBe(false);
+    expect(helper((reaction as Reaction).target).hasPrimaryKey()).toBe(true);
+    expect(((reaction as Reaction).target as Article).id).toBeDefined();
+    expect(((reaction as Reaction).target as Article).title).toBeUndefined(); // Not loaded
+  });
+
+  test('polymorphic to-one without :ref and partial loading loads full target', async () => {
+    // Load reaction without the polymorphic FK columns (partial loading)
+    const reaction = await orm.em.findOneOrFail(Reaction, { emoji: '❤️' }, {
+      fields: ['id', 'emoji'], // Exclude target FK columns
+    });
+
+    // Target should be undefined since FK was not loaded
+    expect((reaction as Reaction).target).toBeUndefined();
+
+    // Now populate without :ref - should load the full target entity
+    await orm.em.populate(reaction, ['target']);
+
+    // Target should be fully initialized
+    expect((reaction as Reaction).target).toBeInstanceOf(Article);
+    expect(wrap((reaction as Reaction).target).isInitialized()).toBe(true);
+    expect(((reaction as Reaction).target as Article).title).toBe('Article 1');
+  });
+
+});
+
+// Test for nullable polymorphic relation in nested joined loading
+// This exercises mapJoinedProps code path for polymorphic relations
+describe('nullable polymorphic relation in nested joined loading', () => {
+  @Entity()
+  class TargetA {
+
+    @PrimaryKey()
+    id!: number;
+
+    @Property()
+    name!: string;
+
+  }
+
+  @Entity()
+  class TargetB {
+
+    @PrimaryKey()
+    id!: number;
+
+    @Property()
+    label!: string;
+
+  }
+
+  @Entity()
+  class ChildEntity {
+
+    @PrimaryKey()
+    id!: number;
+
+    @Property()
+    title!: string;
+
+    @ManyToOne(() => [TargetA, TargetB], { nullable: true })
+    ref!: TargetA | TargetB | null;
+
+  }
+
+  @Entity()
+  class ParentEntity {
+
+    @PrimaryKey()
+    id!: number;
+
+    @Property()
+    name!: string;
+
+    @ManyToOne(() => ChildEntity)
+    child!: ChildEntity;
+
+  }
+
+  let orm2: MikroORM;
+
+  beforeAll(async () => {
+    orm2 = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      dbName: ':memory:',
+      entities: [TargetA, TargetB, ChildEntity, ParentEntity],
+    });
+    await orm2.schema.create();
+
+    const targetA = orm2.em.create(TargetA, { name: 'Target A' });
+    const child1 = orm2.em.create(ChildEntity, { title: 'Child with ref', ref: targetA });
+    const child2 = orm2.em.create(ChildEntity, { title: 'Child without ref', ref: null });
+    orm2.em.create(ParentEntity, { name: 'Parent 1', child: child1 });
+    orm2.em.create(ParentEntity, { name: 'Parent 2', child: child2 });
+
+    await orm2.em.flush();
+    orm2.em.clear();
+  });
+
+  afterAll(() => orm2.close(true));
+
+  test('joined loading with null polymorphic relation in nested entity', async () => {
+    const parents = await orm2.em.find(ParentEntity, {}, {
+      populate: ['child'],
+      strategy: LoadStrategy.JOINED,
+      orderBy: { id: 'ASC' },
+    });
+
+    expect(parents).toHaveLength(2);
+    expect(parents[0].child.title).toBe('Child with ref');
+    expect(parents[0].child.ref).toBeInstanceOf(TargetA);
+    expect(parents[1].child.title).toBe('Child without ref');
+    expect(parents[1].child.ref).toBeNull();
+  });
+
+});

--- a/tests/features/polymorphic-relations/polymorphic-many-to-many.sqlite.test.ts
+++ b/tests/features/polymorphic-relations/polymorphic-many-to-many.sqlite.test.ts
@@ -1,0 +1,624 @@
+import { Collection, MikroORM } from '@mikro-orm/sqlite';
+import {
+  Entity,
+  ManyToMany,
+  PrimaryKey,
+  Property,
+  ReflectMetadataProvider,
+} from '@mikro-orm/decorators/legacy';
+
+@Entity()
+class Tag {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  // Inverse sides - separate collections per entity type
+  @ManyToMany(() => Post, post => post.tags)
+  posts = new Collection<Post>(this);
+
+  @ManyToMany(() => Video, video => video.tags)
+  videos = new Collection<Video>(this);
+
+  constructor(name: string) {
+    this.name = name;
+  }
+
+}
+
+@Entity()
+class Post {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  title!: string;
+
+  // Owner side - polymorphic M:N to Tag via shared pivot table
+  @ManyToMany(() => Tag, tag => tag.posts, {
+    pivotTable: 'taggables',
+    discriminator: 'taggable',  // Column in pivot table storing 'post' or 'video'
+    owner: true,
+  })
+  tags = new Collection<Tag>(this);
+
+  constructor(title: string) {
+    this.title = title;
+  }
+
+}
+
+@Entity()
+class Video {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  url!: string;
+
+  // Owner side - polymorphic M:N to Tag via same shared pivot table
+  @ManyToMany(() => Tag, tag => tag.videos, {
+    pivotTable: 'taggables',
+    discriminator: 'taggable',  // Same discriminator column
+    owner: true,
+  })
+  tags = new Collection<Tag>(this);
+
+  constructor(url: string) {
+    this.url = url;
+  }
+
+}
+
+describe('polymorphic many-to-many relations', () => {
+
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      entities: [Tag, Post, Video],
+      dbName: ':memory:',
+      metadataProvider: ReflectMetadataProvider,
+    });
+    await orm.schema.create();
+  });
+
+  afterAll(async () => {
+    await orm.close(true);
+  });
+
+  beforeEach(async () => {
+    await orm.schema.clear();
+    orm.em.clear();
+  });
+
+  test('metadata is correctly initialized for polymorphic M:N relation', async () => {
+    const postMeta = orm.getMetadata().get(Post);
+    const tagsProp = postMeta.properties.tags;
+
+    expect(tagsProp.pivotTable).toBe('taggables');
+    expect(tagsProp.discriminatorColumn).toBe('taggable_type');
+  });
+
+  test('schema creates shared pivot table with discriminator column', async () => {
+    const sql = await orm.schema.getCreateSchemaSQL();
+
+    expect(sql).toContain('taggables');
+    expect(sql).toContain('taggable_type');
+    expect(sql).toContain('taggable_id');
+    expect(sql).toContain('tag_id');
+  });
+
+  test('can add tags to Post and Video using same pivot table', async () => {
+    const tag1 = new Tag('TypeScript');
+    const tag2 = new Tag('Testing');
+    const post = new Post('MikroORM Guide');
+    const video = new Video('https://example.com/video.mp4');
+
+    post.tags.add(tag1, tag2);
+    video.tags.add(tag1);
+
+    await orm.em.persist([post, video]).flush();
+    orm.em.clear();
+
+    const pivotData = await orm.em.execute('SELECT * FROM taggables ORDER BY taggable_type, tag_id');
+    expect(pivotData).toHaveLength(3);
+
+    const postEntries = pivotData.filter((r: any) => r.taggable_type === 'post');
+    const videoEntries = pivotData.filter((r: any) => r.taggable_type === 'video');
+
+    expect(postEntries).toHaveLength(2);
+    expect(videoEntries).toHaveLength(1);
+  });
+
+  test('can load tags for Post and Video independently', async () => {
+    const tag1 = new Tag('TypeScript');
+    const tag2 = new Tag('Testing');
+    const post = new Post('MikroORM Guide');
+    const video = new Video('https://example.com/video.mp4');
+
+    post.tags.add(tag1, tag2);
+    video.tags.add(tag1);
+
+    await orm.em.persist([post, video]).flush();
+    orm.em.clear();
+
+    const loadedPost = await orm.em.findOneOrFail(Post, { id: post.id }, { populate: ['tags'] });
+    expect(loadedPost.tags).toHaveLength(2);
+    expect(loadedPost.tags.getItems().map(t => t.name).sort()).toEqual(['Testing', 'TypeScript']);
+
+    orm.em.clear();
+
+    const loadedVideo = await orm.em.findOneOrFail(Video, { id: video.id }, { populate: ['tags'] });
+    expect(loadedVideo.tags).toHaveLength(1);
+    expect(loadedVideo.tags.getItems()[0].name).toBe('TypeScript');
+  });
+
+  test('inverse side returns correct entities per type', async () => {
+    const tag = new Tag('Shared Tag');
+    const post1 = new Post('Post 1');
+    const post2 = new Post('Post 2');
+    const video = new Video('https://example.com/video.mp4');
+
+    post1.tags.add(tag);
+    post2.tags.add(tag);
+    video.tags.add(tag);
+
+    await orm.em.persist([post1, post2, video]).flush();
+    orm.em.clear();
+
+    const loadedTag = await orm.em.findOneOrFail(Tag, { id: tag.id }, { populate: ['posts', 'videos'] });
+
+    expect(loadedTag.posts).toHaveLength(2);
+    expect(loadedTag.videos).toHaveLength(1);
+    expect(loadedTag.posts.getItems().map(p => p.title).sort()).toEqual(['Post 1', 'Post 2']);
+    expect(loadedTag.videos.getItems()[0].url).toBe('https://example.com/video.mp4');
+  });
+
+  test('can remove tags from polymorphic collection', async () => {
+    const tag1 = new Tag('TypeScript');
+    const tag2 = new Tag('Testing');
+    const post = new Post('MikroORM Guide');
+
+    post.tags.add(tag1, tag2);
+    await orm.em.persist(post).flush();
+
+    post.tags.remove(tag1);
+    await orm.em.flush();
+    orm.em.clear();
+
+    const loadedPost = await orm.em.findOneOrFail(Post, { id: post.id }, { populate: ['tags'] });
+    expect(loadedPost.tags).toHaveLength(1);
+    expect(loadedPost.tags.getItems()[0].name).toBe('Testing');
+  });
+
+  test('can clear all tags from polymorphic collection', async () => {
+    const tag1 = new Tag('Tag1');
+    const tag2 = new Tag('Tag2');
+    const post = new Post('Post with tags');
+
+    post.tags.add(tag1, tag2);
+    await orm.em.persist(post).flush();
+
+    post.tags.removeAll();
+    await orm.em.flush();
+    orm.em.clear();
+
+    const loadedPost = await orm.em.findOneOrFail(Post, { id: post.id }, { populate: ['tags'] });
+    expect(loadedPost.tags).toHaveLength(0);
+
+    const pivotData = await orm.em.execute('SELECT * FROM taggables WHERE taggable_type = ? AND taggable_id = ?', ['post', post.id]);
+    expect(pivotData).toHaveLength(0);
+  });
+
+  test('can load M:N with where condition on target', async () => {
+    const tag1 = new Tag('TypeScript');
+    const tag2 = new Tag('JavaScript');
+    const post = new Post('Programming');
+    post.tags.add(tag1, tag2);
+
+    await orm.em.persist(post).flush();
+    orm.em.clear();
+
+    const loadedPost = await orm.em.findOneOrFail(Post, post.id, {
+      populate: ['tags'],
+      populateWhere: { tags: { name: 'TypeScript' } },
+    });
+
+    expect(loadedPost.tags.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test('can load M:N with fields option', async () => {
+    const tag = new Tag('Testing');
+    const post = new Post('Test Post');
+    post.tags.add(tag);
+
+    await orm.em.persist(post).flush();
+    orm.em.clear();
+
+    const loadedPost = await orm.em.findOneOrFail(Post, post.id, {
+      populate: ['tags'],
+      fields: ['title', 'tags.name'],
+    });
+
+    expect(loadedPost.tags).toHaveLength(1);
+    expect(loadedPost.tags[0].name).toBe('Testing');
+  });
+
+  test('loads multiple owners with composite batch', async () => {
+    const tag = new Tag('Shared');
+    const post1 = new Post('Post 1');
+    const post2 = new Post('Post 2');
+    const video = new Video('https://example.com/v1.mp4');
+
+    post1.tags.add(tag);
+    post2.tags.add(tag);
+    video.tags.add(tag);
+
+    await orm.em.persist([post1, post2, video]).flush();
+    orm.em.clear();
+
+    const loadedTag = await orm.em.findOneOrFail(Tag, tag.id, {
+      populate: ['posts', 'videos'],
+    });
+
+    expect(loadedTag.posts).toHaveLength(2);
+    expect(loadedTag.videos).toHaveLength(1);
+  });
+
+  test('can set and clear M:N collection without initializing', async () => {
+    const tag = new Tag('ToRemove');
+    const post = new Post('Post to clear');
+    post.tags.add(tag);
+
+    await orm.em.persist(post).flush();
+    orm.em.clear();
+
+    const loadedPost = await orm.em.findOneOrFail(Post, post.id);
+
+    loadedPost.tags.removeAll();
+    await orm.em.flush();
+    orm.em.clear();
+
+    const reloadedPost = await orm.em.findOneOrFail(Post, post.id, { populate: ['tags'] });
+    expect(reloadedPost.tags).toHaveLength(0);
+  });
+
+  test('load M:N with exclude option', async () => {
+    const tag = new Tag('Full Tag');
+    const post = new Post('Post with Tag');
+    post.tags.add(tag);
+
+    await orm.em.persist(post).flush();
+    orm.em.clear();
+
+    const loadedPost = await orm.em.findOneOrFail(Post, post.id, {
+      populate: ['tags'],
+      exclude: ['tags.name'],
+    });
+
+    expect(loadedPost.tags).toHaveLength(1);
+    expect(loadedPost.tags[0].id).toBe(tag.id);
+  });
+
+  test('bidirectional propagation works with polymorphic M:N', async () => {
+    const tag = new Tag('Propagate Tag');
+    const post = new Post('Propagate Post');
+
+    post.tags.add(tag);
+    await orm.em.persist(post).flush();
+    orm.em.clear();
+
+    const loadedTag = await orm.em.findOneOrFail(Tag, tag.id, { populate: ['posts'] });
+    expect(loadedTag.posts).toHaveLength(1);
+    expect(loadedTag.posts[0].id).toBe(post.id);
+  });
+
+  test('load M:N with :ref populate hint (pivotJoin)', async () => {
+    const tag = new Tag('Ref Tag');
+    const post = new Post('Ref Post');
+    post.tags.add(tag);
+
+    await orm.em.persist(post).flush();
+    orm.em.clear();
+
+    const loadedPost = await orm.em.findOneOrFail(Post, post.id, {
+      populate: ['tags:ref'],
+    });
+
+    expect(loadedPost.tags).toHaveLength(1);
+    expect(loadedPost.tags[0].id).toBe(tag.id);
+  });
+
+  test('load inverse M:N with populateFilter', async () => {
+    const tag1 = new Tag('Common');
+    const tag2 = new Tag('Rare');
+    const post1 = new Post('Post A');
+    const post2 = new Post('Post B');
+
+    post1.tags.add(tag1, tag2);
+    post2.tags.add(tag1);
+
+    await orm.em.persist([post1, post2]).flush();
+    orm.em.clear();
+
+    const posts = await orm.em.find(Post, {}, {
+      populate: ['tags'],
+      populateFilter: { tags: { name: 'Common' } },
+    });
+
+    expect(posts).toHaveLength(2);
+    for (const p of posts) {
+      expect(p.tags.getItems().every(t => t.name === 'Common')).toBe(true);
+    }
+  });
+
+  test('load inverse M:N with populateWhere on inverse side', async () => {
+    const tag = new Tag('Shared');
+    const post1 = new Post('Post Alpha');
+    const post2 = new Post('Post Beta');
+
+    post1.tags.add(tag);
+    post2.tags.add(tag);
+
+    await orm.em.persist([post1, post2]).flush();
+    orm.em.clear();
+
+    // Load from inverse side (Tag -> Posts) with populateWhere filter
+    const loadedTag = await orm.em.findOneOrFail(Tag, tag.id, {
+      populate: ['posts'],
+      populateWhere: { posts: { title: { $like: '%Alpha%' } } },
+    });
+
+    // Only posts matching the filter should be populated
+    expect(loadedTag.posts).toHaveLength(1);
+    expect(loadedTag.posts[0].title).toBe('Post Alpha');
+  });
+
+});
+
+// Test for custom discriminator map in polymorphic M:N
+@Entity()
+class Category {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @ManyToMany(() => Article, article => article.categories)
+  articles = new Collection<Article>(this);
+
+  @ManyToMany(() => Product, product => product.categories)
+  products = new Collection<Product>(this);
+
+  constructor(name: string) {
+    this.name = name;
+  }
+
+}
+
+@Entity()
+class Article {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  title!: string;
+
+  @ManyToMany(() => Category, cat => cat.articles, {
+    pivotTable: 'categorizables',
+    discriminator: 'categorizable',
+    discriminatorMap: {
+      art: 'Article',
+      prod: 'Product',
+    },
+    owner: true,
+  })
+  categories = new Collection<Category>(this);
+
+  constructor(title: string) {
+    this.title = title;
+  }
+
+}
+
+@Entity()
+class Product {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  sku!: string;
+
+  @ManyToMany(() => Category, cat => cat.products, {
+    pivotTable: 'categorizables',
+    discriminator: 'categorizable',
+    discriminatorMap: {
+      art: 'Article',
+      prod: 'Product',
+    },
+    owner: true,
+  })
+  categories = new Collection<Category>(this);
+
+  constructor(sku: string) {
+    this.sku = sku;
+  }
+
+}
+
+describe('polymorphic M:N with custom discriminator map', () => {
+
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      entities: [Category, Article, Product],
+      dbName: ':memory:',
+      metadataProvider: ReflectMetadataProvider,
+    });
+    await orm.schema.create();
+  });
+
+  afterAll(async () => {
+    await orm.close(true);
+  });
+
+  beforeEach(async () => {
+    await orm.schema.clear();
+    orm.em.clear();
+  });
+
+  test('metadata has custom discriminator values', async () => {
+    const articleMeta = orm.getMetadata().get(Article);
+    const productMeta = orm.getMetadata().get(Product);
+
+    const articleTagsProp = articleMeta.properties.categories;
+    const productTagsProp = productMeta.properties.categories;
+
+    expect(articleTagsProp.discriminatorValue).toBe('art');
+    expect(productTagsProp.discriminatorValue).toBe('prod');
+
+    expect(articleTagsProp.discriminatorMap).toEqual({
+      art: Article,
+      prod: Product,
+    });
+    expect(productTagsProp.discriminatorMap).toEqual({
+      art: Article,
+      prod: Product,
+    });
+  });
+
+  test('pivot table uses custom discriminator values', async () => {
+    const category = new Category('Electronics');
+    const article = new Article('Best Electronics 2024');
+    const product = new Product('ELEC-001');
+
+    article.categories.add(category);
+    product.categories.add(category);
+
+    await orm.em.persist([article, product]).flush();
+
+    const pivotData = await orm.em.execute('SELECT * FROM categorizables ORDER BY categorizable_type, categorizable_id');
+
+    expect(pivotData).toHaveLength(2);
+    expect(pivotData[0].categorizable_type).toBe('art');
+    expect(pivotData[1].categorizable_type).toBe('prod');
+  });
+
+  test('loading from owner side with custom discriminator', async () => {
+    const category = new Category('Books');
+    const article = new Article('Top 10 Books');
+    article.categories.add(category);
+
+    await orm.em.persist(article).flush();
+    orm.em.clear();
+
+    const loadedArticle = await orm.em.findOneOrFail(Article, article.id, { populate: ['categories'] });
+    expect(loadedArticle.categories).toHaveLength(1);
+    expect(loadedArticle.categories[0].name).toBe('Books');
+  });
+
+  test('loading from inverse side with custom discriminator', async () => {
+    const category = new Category('Tech');
+    const article = new Article('Tech News');
+    const product = new Product('TECH-001');
+
+    article.categories.add(category);
+    product.categories.add(category);
+
+    await orm.em.persist([article, product]).flush();
+    orm.em.clear();
+
+    const loadedCategory = await orm.em.findOneOrFail(Category, category.id, {
+      populate: ['articles', 'products'],
+    });
+
+    expect(loadedCategory.articles).toHaveLength(1);
+    expect(loadedCategory.products).toHaveLength(1);
+    expect(loadedCategory.articles[0].title).toBe('Tech News');
+    expect(loadedCategory.products[0].sku).toBe('TECH-001');
+  });
+
+  test('loading multiple owners in batch', async () => {
+    const category1 = new Category('Cat1');
+    const category2 = new Category('Cat2');
+    const article1 = new Article('Article 1');
+    const article2 = new Article('Article 2');
+
+    article1.categories.add(category1, category2);
+    article2.categories.add(category1);
+
+    await orm.em.persist([article1, article2]).flush();
+    orm.em.clear();
+
+    const articles = await orm.em.find(Article, {}, { populate: ['categories'] });
+    expect(articles).toHaveLength(2);
+    expect(articles.find(a => a.title === 'Article 1')!.categories).toHaveLength(2);
+    expect(articles.find(a => a.title === 'Article 2')!.categories).toHaveLength(1);
+  });
+
+  test('inverse side returns empty collection when no relations exist', async () => {
+    const category = new Category('Empty Cat');
+    await orm.em.persist(category).flush();
+    orm.em.clear();
+
+    const loadedCategory = await orm.em.findOneOrFail(Category, category.id, {
+      populate: ['articles', 'products'],
+    });
+
+    expect(loadedCategory.articles).toHaveLength(0);
+    expect(loadedCategory.products).toHaveLength(0);
+  });
+
+  test('throws error for invalid class name in discriminatorMap', async () => {
+    @Entity()
+    class MyTag {
+
+      @PrimaryKey()
+      id!: number;
+
+      @Property()
+      name!: string;
+
+      @ManyToMany(() => MyPost, post => post.tags)
+      posts = new Collection<MyPost>(this);
+
+    }
+
+    @Entity()
+    class MyPost {
+
+      @PrimaryKey()
+      id!: number;
+
+      @ManyToMany(() => MyTag, tag => tag.posts, {
+        pivotTable: 'my_taggables',
+        discriminator: 'taggable',
+        discriminatorMap: {
+          post: 'MyPost',
+          invalid: 'NonExistentEntity', // This class doesn't exist
+        },
+        owner: true,
+      })
+      tags = new Collection<MyTag>(this);
+
+    }
+
+    await expect(MikroORM.init({
+      entities: [MyTag, MyPost],
+      dbName: ':memory:',
+      metadataProvider: ReflectMetadataProvider,
+    })).rejects.toThrow(/NonExistentEntity.*was not discovered.*MyPost\.tags discriminatorMap/);
+  });
+
+});

--- a/tests/features/polymorphic-relations/polymorphic-relations.mongo.test.ts
+++ b/tests/features/polymorphic-relations/polymorphic-relations.mongo.test.ts
@@ -1,0 +1,187 @@
+import { Collection } from '@mikro-orm/core';
+import {
+  Entity,
+  ManyToOne,
+  OneToMany,
+  PrimaryKey,
+  Property,
+  ReflectMetadataProvider,
+  SerializedPrimaryKey,
+} from '@mikro-orm/decorators/legacy';
+import { MikroORM, ObjectId } from '@mikro-orm/mongodb';
+
+@Entity()
+class Post {
+
+  @PrimaryKey()
+  _id!: ObjectId;
+
+  @SerializedPrimaryKey()
+  id!: string;
+
+  @Property()
+  title!: string;
+
+  @OneToMany(() => UserLike, like => like.likeable)
+  likes = new Collection<UserLike>(this);
+
+}
+
+@Entity()
+class Comment {
+
+  @PrimaryKey()
+  _id!: ObjectId;
+
+  @SerializedPrimaryKey()
+  id!: string;
+
+  @Property()
+  text!: string;
+
+  @OneToMany(() => UserLike, like => like.likeable)
+  likes = new Collection<UserLike>(this);
+
+}
+
+@Entity()
+class UserLike {
+
+  @PrimaryKey()
+  _id!: ObjectId;
+
+  @SerializedPrimaryKey()
+  id!: string;
+
+  @ManyToOne(() => [Post, Comment], { nullable: true })
+  likeable!: Post | Comment | null;
+
+}
+
+describe('polymorphic relations in mongodb', () => {
+
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      entities: [Post, Comment, UserLike],
+      clientUrl: 'mongodb://localhost:27017/mikro-orm-test-polymorphic',
+      metadataProvider: ReflectMetadataProvider,
+    });
+  });
+
+  beforeEach(async () => {
+    await orm.schema.clear();
+    orm.em.clear();
+  });
+
+  afterAll(async () => {
+    await orm.schema.drop();
+    await orm.close(true);
+  });
+
+
+  test('can persist and load polymorphic relation to Post', async () => {
+    const post = orm.em.create(Post, { title: 'Test Post' });
+    const like = orm.em.create(UserLike, { likeable: post });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const loaded = await orm.em.findOneOrFail(UserLike, like.id);
+    expect(loaded.likeable).toBeDefined();
+    expect(loaded.likeable!.constructor.name).toBe('Post');
+  });
+
+  test('can persist and load polymorphic relation to Comment', async () => {
+    const comment = orm.em.create(Comment, { text: 'Test Comment' });
+    const like = orm.em.create(UserLike, { likeable: comment });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const loaded = await orm.em.findOneOrFail(UserLike, like.id);
+    expect(loaded.likeable).toBeDefined();
+    expect(loaded.likeable!.constructor.name).toBe('Comment');
+  });
+
+  test('can populate polymorphic relation', async () => {
+    const post = orm.em.create(Post, { title: 'Populated Post' });
+    const comment = orm.em.create(Comment, { text: 'Populated Comment' });
+    const like1 = orm.em.create(UserLike, { likeable: post });
+    const like2 = orm.em.create(UserLike, { likeable: comment });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const likes = await orm.em.find(UserLike, {}, { populate: ['likeable'] });
+    expect(likes).toHaveLength(2);
+
+    const postLike = likes.find(l => l.id === like1.id)!;
+    const commentLike = likes.find(l => l.id === like2.id)!;
+
+    expect(postLike.likeable).toBeInstanceOf(Post);
+    expect((postLike.likeable as Post).title).toBe('Populated Post');
+
+    expect(commentLike.likeable).toBeInstanceOf(Comment);
+    expect((commentLike.likeable as Comment).text).toBe('Populated Comment');
+  });
+
+  test('inverse side loading works', async () => {
+    const post = orm.em.create(Post, { title: 'Post with likes' });
+    orm.em.create(UserLike, { likeable: post });
+    orm.em.create(UserLike, { likeable: post });
+    const comment = orm.em.create(Comment, { text: 'Comment' });
+    orm.em.create(UserLike, { likeable: comment });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const loaded = await orm.em.findOneOrFail(Post, post.id, { populate: ['likes'] });
+    expect(loaded.likes).toHaveLength(2);
+  });
+
+  test('null polymorphic relation', async () => {
+    const like = orm.em.create(UserLike, { likeable: null });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const loaded = await orm.em.findOneOrFail(UserLike, like.id);
+    expect(loaded.likeable).toBeNull();
+  });
+
+  test('tuple format in native insert', async () => {
+    const post = orm.em.create(Post, { title: 'Tuple test' });
+    await orm.em.flush();
+    orm.em.clear();
+
+    // Insert via em.insert with tuple format [discriminator, id]
+    await orm.em.insert(UserLike, {
+      likeable: ['post', post._id.toHexString()] as any,
+    });
+    orm.em.clear();
+
+    const likes = await orm.em.find(UserLike, {}, { populate: ['likeable'] });
+    const like = likes.find(l => l.likeable && (l.likeable as Post).title === 'Tuple test');
+    expect(like).toBeDefined();
+    expect(like!.likeable).toBeInstanceOf(Post);
+  });
+
+  test('can update polymorphic relation between types', async () => {
+    const post = orm.em.create(Post, { title: 'Original' });
+    const like = orm.em.create(UserLike, { likeable: post });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const loaded = await orm.em.findOneOrFail(UserLike, like.id, { populate: ['likeable'] });
+    expect(loaded.likeable).toBeInstanceOf(Post);
+
+    const comment = orm.em.create(Comment, { text: 'New target' });
+    loaded.likeable = comment;
+    await orm.em.flush();
+    orm.em.clear();
+
+    const updated = await orm.em.findOneOrFail(UserLike, like.id, { populate: ['likeable'] });
+    expect(updated.likeable).toBeInstanceOf(Comment);
+    expect((updated.likeable as Comment).text).toBe('New target');
+  });
+
+});
+
+

--- a/tests/features/polymorphic-relations/polymorphic-relations.mysql.test.ts
+++ b/tests/features/polymorphic-relations/polymorphic-relations.mysql.test.ts
@@ -1,0 +1,252 @@
+import { Collection, MikroORM } from '@mikro-orm/mysql';
+import { Entity, ManyToOne, OneToMany, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+
+@Entity()
+class Product {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @Property({ type: 'decimal', scale: 3 })
+  price!: number;
+
+  @OneToMany(() => Image, image => image.imageable)
+  images = new Collection<Image>(this);
+
+  constructor(name: string, price: number) {
+    this.name = name;
+    this.price = price;
+  }
+
+}
+
+@Entity()
+class Article {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  title!: string;
+
+  @OneToMany(() => Image, image => image.imageable)
+  images = new Collection<Image>(this);
+
+  constructor(title: string) {
+    this.title = title;
+  }
+
+}
+
+@Entity()
+class Image {
+
+  @PrimaryKey()
+  id!: number;
+
+  @ManyToOne(() => [Product, Article])
+  imageable!: Product | Article;
+
+  @Property()
+  url!: string;
+
+  @Property({ nullable: true })
+  altText?: string;
+
+}
+
+describe('polymorphic relations in MySQL', () => {
+
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      entities: [Product, Article, Image],
+      dbName: 'mikro_orm_test_polymorphic',
+      metadataProvider: ReflectMetadataProvider,
+      port: 3308,
+    });
+    await orm.schema.refresh();
+  });
+
+  afterAll(async () => {
+    await orm.close(true);
+  });
+
+  beforeEach(async () => {
+    await orm.schema.clear();
+  });
+
+  test('can persist and load polymorphic relation to Product', async () => {
+    const product = new Product('Laptop', 999.99);
+    const image = orm.em.create(Image, {
+      imageable: product,
+      url: 'https://example.com/laptop.jpg',
+      altText: 'Laptop image',
+    });
+
+    await orm.em.flush();
+    orm.em.clear();
+
+    const loadedImage = await orm.em.findOneOrFail(Image, { id: image.id });
+    expect(loadedImage.imageable).toBeInstanceOf(Product);
+
+    await orm.em.populate(loadedImage, ['imageable']);
+    expect((loadedImage.imageable as Product).name).toBe('Laptop');
+    expect((loadedImage.imageable as Product).price).toBe(999.99);
+  });
+
+  test('can persist and load polymorphic relation to Article', async () => {
+    const article = new Article('How to use MikroORM');
+    const image = orm.em.create(Image, {
+      imageable: article,
+      url: 'https://example.com/article.jpg',
+    });
+
+    await orm.em.flush();
+    orm.em.clear();
+
+    const loadedImage = await orm.em.findOneOrFail(Image, { id: image.id });
+    expect(loadedImage.imageable).toBeInstanceOf(Article);
+
+    await orm.em.populate(loadedImage, ['imageable']);
+    expect((loadedImage.imageable as Article).title).toBe('How to use MikroORM');
+  });
+
+  test('can query images by polymorphic target type', async () => {
+    const product = new Product('Phone', 599);
+    const article = new Article('Article');
+    const productImage = orm.em.create(Image, { imageable: product, url: 'phone.jpg' });
+    const articleImage = orm.em.create(Image, { imageable: article, url: 'article.jpg' });
+
+    await orm.em.flush();
+    orm.em.clear();
+
+    // Get all images - we can't easily filter by type directly
+    // but we can load and check the discriminator
+    const allImages = await orm.em.find(Image, {});
+    expect(allImages).toHaveLength(2);
+  });
+
+  test('cascade persist works with polymorphic relations', async () => {
+    const product = new Product('Monitor', 399);
+    // Note: cascade options need to be set on the relation
+    const image = new Image();
+    image.imageable = product;
+    image.url = 'monitor.jpg';
+
+    orm.em.persist(image);
+    await orm.em.flush();
+
+    expect(product.id).toBeDefined();
+    expect(image.id).toBeDefined();
+  });
+
+  test('can update polymorphic relation', async () => {
+    const product = new Product('Keyboard', 99);
+    const article = new Article('Article about keyboards');
+    const image = orm.em.create(Image, { imageable: product, url: 'keyboard.jpg' });
+    orm.em.persist(article);
+
+    await orm.em.flush();
+    orm.em.clear();
+
+    const loadedImage = await orm.em.findOneOrFail(Image, { id: image.id });
+    const loadedArticle = await orm.em.findOneOrFail(Article, { id: article.id });
+
+    loadedImage.imageable = loadedArticle;
+
+    await orm.em.flush();
+    orm.em.clear();
+
+    const reloadedImage = await orm.em.findOneOrFail(Image, { id: image.id });
+    expect(reloadedImage.imageable).toBeInstanceOf(Article);
+    await orm.em.populate(reloadedImage, ['imageable']);
+    expect((reloadedImage.imageable as Article).title).toBe('Article about keyboards');
+  });
+
+  test('populating inverse collection works correctly', async () => {
+    const product = new Product('Mouse', 29);
+    const img1 = orm.em.create(Image, { imageable: product, url: 'mouse1.jpg' });
+    const img2 = orm.em.create(Image, { imageable: product, url: 'mouse2.jpg' });
+    const img3 = orm.em.create(Image, { imageable: product, url: 'mouse3.jpg' });
+
+    await orm.em.flush();
+    orm.em.clear();
+
+    const loadedProduct = await orm.em.findOneOrFail(Product, { id: product.id }, {
+      populate: ['images'],
+    });
+
+    expect(loadedProduct.images).toHaveLength(3);
+    expect(loadedProduct.images.getItems().map(i => i.url).sort()).toEqual([
+      'mouse1.jpg',
+      'mouse2.jpg',
+      'mouse3.jpg',
+    ]);
+  });
+
+  test('removing entity with polymorphic relations', async () => {
+    const product = new Product('Test Product', 10);
+    const image = orm.em.create(Image, { imageable: product, url: 'test.jpg' });
+
+    await orm.em.flush();
+
+    orm.em.remove(image);
+    await orm.em.flush();
+
+    const count = await orm.em.count(Image, {});
+    expect(count).toBe(0);
+
+    // Product should still exist
+    const productCount = await orm.em.count(Product, {});
+    expect(productCount).toBe(1);
+  });
+
+  test('discriminator column stores correct value', async () => {
+    const product = new Product('Test', 1);
+    const image = orm.em.create(Image, { imageable: product, url: 'test.jpg' });
+
+    await orm.em.flush();
+    orm.em.clear();
+
+    // Check raw data in database
+    const connection = orm.em.getConnection();
+    const [row] = await connection.execute('SELECT * FROM image WHERE id = ?', [image.id]);
+
+    expect(row.imageable_type).toBe('product');
+    expect(row.imageable_id).toBe(product.id);
+  });
+
+  test('can handle entities with same ID in different tables', async () => {
+    // Both entities will have id = 1
+    const product = new Product('Product', 100);
+    const article = new Article('Article');
+
+    const productImage = orm.em.create(Image, { imageable: product, url: 'product.jpg' });
+    const articleImage = orm.em.create(Image, { imageable: article, url: 'article.jpg' });
+
+    await orm.em.flush();
+
+    // Both entities should have id = 1 after flush
+    expect(product.id).toBe(1);
+    expect(article.id).toBe(1);
+
+    orm.em.clear();
+
+    // Load images and verify they point to correct entities
+    const images = await orm.em.find(Image, {}, { populate: ['imageable'] });
+
+    const prodImg = images.find(i => (i.imageable as Product).name === 'Product');
+    const artImg = images.find(i => (i.imageable as Article).title === 'Article');
+
+    expect(prodImg).toBeDefined();
+    expect(artImg).toBeDefined();
+    expect(prodImg!.imageable).toBeInstanceOf(Product);
+    expect(artImg!.imageable).toBeInstanceOf(Article);
+  });
+
+});

--- a/tests/features/polymorphic-relations/polymorphic-relations.postgres.test.ts
+++ b/tests/features/polymorphic-relations/polymorphic-relations.postgres.test.ts
@@ -1,0 +1,228 @@
+import { Collection, MikroORM } from '@mikro-orm/postgresql';
+import {
+  Entity,
+  ManyToOne,
+  OneToMany,
+  PrimaryKey,
+  Property,
+  ReflectMetadataProvider,
+} from '@mikro-orm/decorators/legacy';
+
+@Entity()
+class Post {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  title!: string;
+
+  @Property()
+  content!: string;
+
+  @OneToMany(() => Like, like => like.likeable)
+  likes = new Collection<Like>(this);
+
+  constructor(title: string, content: string) {
+    this.title = title;
+    this.content = content;
+  }
+
+}
+
+@Entity()
+class Comment {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  text!: string;
+
+  @OneToMany(() => Like, like => like.likeable)
+  likes = new Collection<Like>(this);
+
+  constructor(text: string) {
+    this.text = text;
+  }
+
+}
+
+@Entity()
+class Like {
+
+  @PrimaryKey()
+  id!: number;
+
+  @ManyToOne(() => [Post, Comment])
+  likeable!: Post | Comment;
+
+  @Property({ nullable: true })
+  createdAt?: Date;
+
+}
+
+describe('polymorphic relations in PostgreSQL', () => {
+
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      entities: [Post, Comment, Like],
+      dbName: 'mikro_orm_test_polymorphic',
+      metadataProvider: ReflectMetadataProvider,
+    });
+    await orm.schema.refresh();
+  });
+
+  afterAll(async () => {
+    await orm.close(true);
+  });
+
+  beforeEach(async () => {
+    await orm.schema.clear();
+  });
+
+  test('can create and persist polymorphic relation to Post', async () => {
+    const post = new Post('Hello World', 'This is a test post');
+    const like = orm.em.create(Like, { likeable: post });
+
+    await orm.em.flush();
+    orm.em.clear();
+
+    const loadedLike = await orm.em.findOneOrFail(Like, { id: like.id });
+    expect(loadedLike.likeable).toBeInstanceOf(Post);
+    await orm.em.populate(loadedLike, ['likeable']);
+    expect((loadedLike.likeable as Post).title).toBe('Hello World');
+  });
+
+  test('can create and persist polymorphic relation to Comment', async () => {
+    const comment = new Comment('Great post!');
+    const like = orm.em.create(Like, { likeable: comment });
+
+    await orm.em.flush();
+    orm.em.clear();
+
+    const loadedLike = await orm.em.findOneOrFail(Like, { id: like.id });
+    expect(loadedLike.likeable).toBeInstanceOf(Comment);
+    await orm.em.populate(loadedLike, ['likeable']);
+    expect((loadedLike.likeable as Comment).text).toBe('Great post!');
+  });
+
+  test('can update polymorphic relation from Post to Comment', async () => {
+    const post = new Post('Post', 'Content');
+    const comment = new Comment('Comment');
+    const like = orm.em.create(Like, { likeable: post });
+    orm.em.persist(comment);
+
+    await orm.em.flush();
+    orm.em.clear();
+
+    const loadedLike = await orm.em.findOneOrFail(Like, { id: like.id });
+    const loadedComment = await orm.em.findOneOrFail(Comment, { id: comment.id });
+    loadedLike.likeable = loadedComment;
+
+    await orm.em.flush();
+    orm.em.clear();
+
+    const reloadedLike = await orm.em.findOneOrFail(Like, { id: like.id });
+    expect(reloadedLike.likeable).toBeInstanceOf(Comment);
+    await orm.em.populate(reloadedLike, ['likeable']);
+    expect((reloadedLike.likeable as Comment).text).toBe('Comment');
+  });
+
+  test('can populate inverse side (OneToMany) for Post', async () => {
+    const post = new Post('Post', 'Content');
+    const like1 = orm.em.create(Like, { likeable: post });
+    const like2 = orm.em.create(Like, { likeable: post });
+
+    await orm.em.flush();
+    orm.em.clear();
+
+    const loadedPost = await orm.em.findOneOrFail(Post, { id: post.id }, { populate: ['likes'] });
+    expect(loadedPost.likes).toHaveLength(2);
+    expect(loadedPost.likes.getItems().map(l => l.id).sort()).toEqual([like1.id, like2.id].sort());
+  });
+
+  test('can populate inverse side (OneToMany) for Comment', async () => {
+    const comment = new Comment('Comment');
+    const like1 = orm.em.create(Like, { likeable: comment });
+    const like2 = orm.em.create(Like, { likeable: comment });
+
+    await orm.em.flush();
+    orm.em.clear();
+
+    const loadedComment = await orm.em.findOneOrFail(Comment, { id: comment.id }, { populate: ['likes'] });
+    expect(loadedComment.likes).toHaveLength(2);
+  });
+
+  test('inverse side only includes likes for that specific entity type', async () => {
+    const post = new Post('Post', 'Content');
+    const comment = new Comment('Comment');
+    const postLike = orm.em.create(Like, { likeable: post });
+    const commentLike = orm.em.create(Like, { likeable: comment });
+
+    await orm.em.flush();
+    orm.em.clear();
+
+    const loadedPost = await orm.em.findOneOrFail(Post, { id: post.id }, { populate: ['likes'] });
+    const loadedComment = await orm.em.findOneOrFail(Comment, { id: comment.id }, { populate: ['likes'] });
+
+    expect(loadedPost.likes).toHaveLength(1);
+    expect(loadedPost.likes[0].id).toBe(postLike.id);
+
+    expect(loadedComment.likes).toHaveLength(1);
+    expect(loadedComment.likes[0].id).toBe(commentLike.id);
+  });
+
+  test('can remove entity with polymorphic relations', async () => {
+    const post = new Post('Post', 'Content');
+    const like = orm.em.create(Like, { likeable: post });
+
+    await orm.em.flush();
+    orm.em.clear();
+
+    const loadedLike = await orm.em.findOneOrFail(Like, { id: like.id });
+    orm.em.remove(loadedLike);
+
+    await orm.em.flush();
+
+    const count = await orm.em.count(Like, {});
+    expect(count).toBe(0);
+  });
+
+  test('metadata is correctly initialized', async () => {
+    const meta = orm.getMetadata().get(Like);
+    const likeableProp = meta.properties.likeable;
+
+    expect(likeableProp.polymorphic).toBe(true);
+    expect(likeableProp.polymorphTargets).toHaveLength(2);
+    expect(likeableProp.discriminator).toBe('likeable');
+    expect(likeableProp.discriminatorMap).toBeDefined();
+    expect(likeableProp.createForeignKeyConstraint).toBe(false);
+    expect(likeableProp.fieldNames).toContain('likeable_type');
+    expect(likeableProp.fieldNames).toContain('likeable_id');
+  });
+
+  test('schema has correct columns', async () => {
+    const sql = await orm.schema.getCreateSchemaSQL();
+    const likeTable = sql.split('\n').find(s => s.includes('create table "like"'));
+
+    expect(likeTable).toBeDefined();
+    expect(likeTable).toContain('likeable_type');
+  });
+
+  test('can handle multiple polymorphic relations to same target', async () => {
+    const post = new Post('Post', 'Content');
+    const like1 = orm.em.create(Like, { likeable: post });
+    const like2 = orm.em.create(Like, { likeable: post });
+    const like3 = orm.em.create(Like, { likeable: post });
+
+    await orm.em.flush();
+    orm.em.clear();
+
+    const loadedPost = await orm.em.findOneOrFail(Post, { id: post.id }, { populate: ['likes'] });
+    expect(loadedPost.likes).toHaveLength(3);
+  });
+
+});

--- a/tests/features/polymorphic-relations/polymorphic-relations.sqlite.test.ts
+++ b/tests/features/polymorphic-relations/polymorphic-relations.sqlite.test.ts
@@ -1,0 +1,1173 @@
+import { Collection, MikroORM } from '@mikro-orm/sqlite';
+import { Entity, ManyToOne, OneToMany, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+
+@Entity()
+class Post {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  title!: string;
+
+  @Property()
+  content!: string;
+
+  // Inverse side of polymorphic relation
+  @OneToMany(() => UserLike, like => like.likeable)
+  likes = new Collection<UserLike>(this);
+
+  constructor(title: string, content: string) {
+    this.title = title;
+    this.content = content;
+  }
+
+}
+
+@Entity()
+class Comment {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  text!: string;
+
+  // Inverse side of polymorphic relation
+  @OneToMany(() => UserLike, like => like.likeable)
+  likes = new Collection<UserLike>(this);
+
+  constructor(text: string) {
+    this.text = text;
+  }
+
+}
+
+@Entity()
+class UserLike {
+
+  @PrimaryKey()
+  id!: number;
+
+  // Expose discriminator for querying (persist: false since it's managed by the relation)
+  @Property({ persist: false })
+  likeableType?: string;
+
+  // Polymorphic relation - can point to either Post or Comment
+  @ManyToOne(() => [Post, Comment], { nullable: true })
+  likeable!: Post | Comment | null;
+
+}
+
+describe('polymorphic relations in sqlite', () => {
+
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      entities: [Post, Comment, UserLike],
+      dbName: ':memory:',
+      metadataProvider: ReflectMetadataProvider,
+    });
+    await orm.schema.create();
+  });
+
+  afterAll(async () => {
+    await orm.close(true);
+  });
+
+  beforeEach(async () => {
+    await orm.em.nativeDelete(UserLike, {});
+    await orm.em.nativeDelete(Post, {});
+    await orm.em.nativeDelete(Comment, {});
+    orm.em.clear();
+  });
+
+  test('metadata is correctly initialized for polymorphic relation', async () => {
+    const meta = orm.getMetadata().get(UserLike);
+    const likeableProp = meta.properties.likeable;
+
+    expect(likeableProp.polymorphic).toBe(true);
+    expect(likeableProp.polymorphTargets).toHaveLength(2);
+    expect(likeableProp.discriminator).toBe('likeable');
+    expect(likeableProp.discriminatorMap).toBeDefined();
+    expect(likeableProp.createForeignKeyConstraint).toBe(false);
+  });
+
+  test('schema has correct columns for polymorphic relation', async () => {
+    const sql = await orm.schema.getCreateSchemaSQL();
+
+    // Should have discriminator column and ID column
+    expect(sql).toContain('likeable_type');
+    expect(sql).toContain('likeable_id');
+  });
+
+  test('can hydrate polymorphic relation pointing to Post', async () => {
+    // Insert test data directly using raw queries
+    const connection = orm.em.getConnection();
+    await connection.execute("INSERT INTO post (id, title, content) VALUES (1, 'Test Post', 'Test Content')");
+    await connection.execute("INSERT INTO user_like (id, likeable_type, likeable_id) VALUES (1, 'post', 1)");
+
+    // Load the entity with the polymorphic relation
+    const like = await orm.em.findOne(UserLike, { id: 1 });
+
+    expect(like).toBeDefined();
+    expect(like!.likeable).toBeDefined();
+    // The relation should be a reference to Post
+    expect(like!.likeable!.constructor.name).toBe('Post');
+  });
+
+  test('can hydrate polymorphic relation pointing to Comment', async () => {
+    // Insert test data directly using raw queries
+    const connection = orm.em.getConnection();
+    await connection.execute("INSERT INTO comment (id, text) VALUES (1, 'Test Comment')");
+    await connection.execute("INSERT INTO user_like (id, likeable_type, likeable_id) VALUES (1, 'comment', 1)");
+
+    // Load the entity with the polymorphic relation
+    const like = await orm.em.findOne(UserLike, { id: 1 });
+
+    expect(like).toBeDefined();
+    expect(like!.likeable).toBeDefined();
+    // The relation should be a reference to Comment
+    expect(like!.likeable!.constructor.name).toBe('Comment');
+  });
+
+  test('can load polymorphic relation reference and initialize separately', async () => {
+    // Insert test data directly using raw queries
+    const connection = orm.em.getConnection();
+    await connection.execute("INSERT INTO post (id, title, content) VALUES (1, 'My Post', 'Post content here')");
+    await connection.execute("INSERT INTO user_like (id, likeable_type, likeable_id) VALUES (1, 'post', 1)");
+
+    // Load without populate - just get the reference
+    const like = await orm.em.findOne(UserLike, { id: 1 });
+
+    expect(like).toBeDefined();
+    expect(like!.likeable).toBeDefined();
+    expect(like!.likeable!.constructor.name).toBe('Post');
+
+    // Load the referenced entity separately to verify the ID is correct
+    const post = await orm.em.findOne(Post, { id: 1 });
+    expect(post).toBeDefined();
+    expect(post!.title).toBe('My Post');
+    expect(post!.content).toBe('Post content here');
+  });
+
+  test('can persist polymorphic relation pointing to Post', async () => {
+    const post = new Post('Persisted Post', 'Persisted Content');
+
+    // Create entity using new and directly assign the property
+    const like = new UserLike();
+    like.likeable = post;
+    orm.em.persist(like);
+
+    await orm.em.flush();
+    orm.em.clear();
+
+    // Verify the data was persisted correctly
+    const connection = orm.em.getConnection();
+    const rows = await connection.execute('SELECT * FROM user_like WHERE id = ?', [like.id]);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].likeable_type).toBe('post');
+    expect(rows[0].likeable_id).toBe(post.id);
+  });
+
+  test('can persist polymorphic relation pointing to Comment', async () => {
+    const comment = new Comment('Persisted Comment');
+    const like = orm.em.create(UserLike, { likeable: comment });
+    await orm.em.flush();
+    orm.em.clear();
+
+    // Verify the data was persisted correctly
+    const connection = orm.em.getConnection();
+    const rows = await connection.execute('SELECT * FROM user_like WHERE id = ?', [like.id]);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].likeable_type).toBe('comment');
+    expect(rows[0].likeable_id).toBe(comment.id);
+  });
+
+  test('can load inverse side (OneToMany) for Post', async () => {
+    // Insert test data directly using raw queries
+    const connection = orm.em.getConnection();
+    await connection.execute("INSERT INTO post (id, title, content) VALUES (1, 'Post 1', 'Content 1')");
+    await connection.execute("INSERT INTO comment (id, text) VALUES (1, 'Comment 1')");
+    await connection.execute("INSERT INTO user_like (id, likeable_type, likeable_id) VALUES (1, 'post', 1)");
+    await connection.execute("INSERT INTO user_like (id, likeable_type, likeable_id) VALUES (2, 'post', 1)");
+    await connection.execute("INSERT INTO user_like (id, likeable_type, likeable_id) VALUES (3, 'comment', 1)");
+
+    // Load Post with its likes collection
+    const post = await orm.em.findOne(Post, { id: 1 }, { populate: ['likes'] });
+
+    expect(post).toBeDefined();
+    expect(post!.likes).toBeDefined();
+    expect(post!.likes.length).toBe(2); // Only likes pointing to posts, not comments
+    expect(post!.likes[0].id).toBe(1);
+    expect(post!.likes[1].id).toBe(2);
+  });
+
+  test('can load inverse side (OneToMany) for Comment', async () => {
+    // Insert test data directly using raw queries
+    const connection = orm.em.getConnection();
+    await connection.execute("INSERT INTO post (id, title, content) VALUES (1, 'Post 1', 'Content 1')");
+    await connection.execute("INSERT INTO comment (id, text) VALUES (1, 'Comment 1')");
+    await connection.execute("INSERT INTO user_like (id, likeable_type, likeable_id) VALUES (1, 'post', 1)");
+    await connection.execute("INSERT INTO user_like (id, likeable_type, likeable_id) VALUES (2, 'comment', 1)");
+    await connection.execute("INSERT INTO user_like (id, likeable_type, likeable_id) VALUES (3, 'comment', 1)");
+
+    // Load Comment with its likes collection
+    const comment = await orm.em.findOne(Comment, { id: 1 }, { populate: ['likes'] });
+
+    expect(comment).toBeDefined();
+    expect(comment!.likes).toBeDefined();
+    expect(comment!.likes.length).toBe(2); // Only likes pointing to comments, not posts
+    expect(comment!.likes[0].id).toBe(2);
+    expect(comment!.likes[1].id).toBe(3);
+  });
+
+  test('can populate polymorphic relation', async () => {
+    // Insert test data
+    const connection = orm.em.getConnection();
+    await connection.execute("INSERT INTO post (id, title, content) VALUES (1, 'Post 1', 'Content 1')");
+    await connection.execute("INSERT INTO comment (id, text) VALUES (1, 'Comment 1')");
+    await connection.execute("INSERT INTO user_like (id, likeable_type, likeable_id) VALUES (1, 'post', 1)");
+    await connection.execute("INSERT INTO user_like (id, likeable_type, likeable_id) VALUES (2, 'comment', 1)");
+
+    // Load likes with populated likeable
+    const likes = await orm.em.find(UserLike, {}, { populate: ['likeable'] });
+
+    expect(likes).toHaveLength(2);
+    const postLike = likes.find(l => l.id === 1)!;
+    const commentLike = likes.find(l => l.id === 2)!;
+
+    expect(postLike.likeable).toBeDefined();
+    expect(postLike.likeable!.constructor.name).toBe('Post');
+    expect((postLike.likeable as Post).title).toBe('Post 1');
+
+    expect(commentLike.likeable).toBeDefined();
+    expect(commentLike.likeable!.constructor.name).toBe('Comment');
+    expect((commentLike.likeable as Comment).text).toBe('Comment 1');
+  });
+
+  test('can handle null polymorphic relation', async () => {
+    // Insert a like with null likeable directly via raw SQL
+    const connection = orm.em.getConnection();
+    await connection.execute('INSERT INTO user_like (id, likeable_type, likeable_id) VALUES (1, NULL, NULL)');
+    orm.em.clear();
+
+    const loadedLike = await orm.em.findOneOrFail(UserLike, 1);
+    expect(loadedLike.likeable).toBeNull();
+  });
+
+  test('can handle null polymorphic relation with joined loading', async () => {
+    // Insert a like with null likeable directly via raw SQL
+    const connection = orm.em.getConnection();
+    await connection.execute('INSERT INTO user_like (id, likeable_type, likeable_id) VALUES (1, NULL, NULL)');
+    orm.em.clear();
+
+    // Use joined loading strategy to trigger mapJoinedProps code path
+    const loadedLike = await orm.em.findOneOrFail(UserLike, 1, {
+      populate: ['likeable'],
+      strategy: 'joined',
+    });
+    expect(loadedLike.likeable).toBeNull();
+  });
+
+  test('handles mixed null and non-null polymorphic relations with joined loading', async () => {
+    // Create entities: some with polymorphic relation, some with null
+    const post = new Post('Mixed Test Post', 'Content');
+    const like1 = new UserLike();
+    like1.likeable = post;
+    await orm.em.persist(like1).flush();
+
+    // Insert a like with null likeable directly via raw SQL
+    const connection = orm.em.getConnection();
+    await connection.execute('INSERT INTO user_like (id, likeable_type, likeable_id) VALUES (999, NULL, NULL)');
+    orm.em.clear();
+
+    // Load all likes with joined strategy - this should trigger mapJoinedProps for both
+    const likes = await orm.em.find(UserLike, {}, {
+      populate: ['likeable'],
+      strategy: 'joined',
+      orderBy: { id: 'ASC' },
+    });
+
+    expect(likes).toHaveLength(2);
+    expect(likes[0].likeable).toBeInstanceOf(Post);
+    expect(likes[1].likeable).toBeNull();
+  });
+
+  test('batch loads multiple entities with polymorphic relations', async () => {
+    const post1 = new Post('Post 1', 'Content 1');
+    const post2 = new Post('Post 2', 'Content 2');
+    const comment1 = new Comment('Comment 1');
+
+    const like1 = new UserLike();
+    like1.likeable = post1;
+    const like2 = new UserLike();
+    like2.likeable = post2;
+    const like3 = new UserLike();
+    like3.likeable = comment1;
+
+    await orm.em.persist([like1, like2, like3]).flush();
+    orm.em.clear();
+
+    // Load all likes with populated likeables
+    const likes = await orm.em.find(UserLike, {}, { populate: ['likeable'] });
+
+    expect(likes).toHaveLength(3);
+    // Should have loaded 2 Posts and 1 Comment
+    const postLikes = likes.filter(l => l.likeable instanceof Post);
+    const commentLikes = likes.filter(l => l.likeable instanceof Comment);
+    expect(postLikes).toHaveLength(2);
+    expect(commentLikes).toHaveLength(1);
+  });
+
+  test('can populate already-loaded entity reference', async () => {
+    const post = new Post('My Post', 'Content');
+    const like = new UserLike();
+    like.likeable = post;
+    await orm.em.persist(like).flush();
+    orm.em.clear();
+
+    // Load without clearing - entity reference already exists
+    const loadedLike = await orm.em.findOneOrFail(UserLike, like.id);
+    // At this point likeable is already hydrated
+    expect(loadedLike.likeable).toBeInstanceOf(Post);
+
+    // Populate again - should hit the __meta branch
+    await orm.em.populate(loadedLike, ['likeable']);
+    expect((loadedLike.likeable as Post).title).toBe('My Post');
+  });
+
+  test('handles entities without polymorphic relation value', async () => {
+    // Insert a like with null values directly
+    const connection = orm.em.getConnection();
+    await connection.execute('INSERT INTO user_like (id, likeable_type, likeable_id) VALUES (99, NULL, NULL)');
+    orm.em.clear();
+
+    // Load without populate - should handle null gracefully
+    const like = await orm.em.findOne(UserLike, 99);
+    expect(like).toBeDefined();
+    expect(like!.likeable).toBeNull();
+  });
+
+  test('populate multiple entities with mixed reference states', async () => {
+    const post1 = new Post('Post 1', 'Content 1');
+    const post2 = new Post('Post 2', 'Content 2');
+    const comment = new Comment('Comment');
+
+    const like1 = new UserLike();
+    like1.likeable = post1;
+    const like2 = new UserLike();
+    like2.likeable = post2;
+    const like3 = new UserLike();
+    like3.likeable = comment;
+
+    await orm.em.persist([like1, like2, like3]).flush();
+    orm.em.clear();
+
+    // Load likes - they will have entity references already hydrated
+    const likes = await orm.em.find(UserLike, {});
+    expect(likes).toHaveLength(3);
+
+    // All should already have likeable as entity references
+    for (const like of likes) {
+      expect(like.likeable).toBeDefined();
+      expect('__meta' in (like.likeable as object)).toBe(true);
+    }
+
+    // Populate again - should handle already-loaded references via __meta branch
+    await orm.em.populate(likes, ['likeable']);
+
+    expect(likes.filter(l => l.likeable instanceof Post)).toHaveLength(2);
+    expect(likes.filter(l => l.likeable instanceof Comment)).toHaveLength(1);
+  });
+
+  test('can query polymorphic relation with $or conditions', async () => {
+    // This exercises QueryHelper.liftGroupOperators which skips polymorphic relations
+    const post1 = new Post('Post 1', 'Content 1');
+    const post2 = new Post('Post 2', 'Content 2');
+    const comment1 = new Comment('Comment 1');
+
+    const like1 = new UserLike();
+    like1.likeable = post1;
+    const like2 = new UserLike();
+    like2.likeable = post2;
+    const like3 = new UserLike();
+    like3.likeable = comment1;
+
+    await orm.em.persist([like1, like2, like3]).flush();
+    orm.em.clear();
+
+    // Query with $or on IDs - polymorphic relations should be skipped in liftGroupOperators
+    const likes = await orm.em.find(UserLike, {
+      $or: [{ id: like1.id }, { id: like2.id }],
+    });
+    expect(likes).toHaveLength(2);
+
+    // Query all likes for posts (using the discriminator column)
+    const postLikes = await orm.em.find(UserLike, {
+      likeableType: 'post',
+    });
+    expect(postLikes).toHaveLength(2);
+
+    // Query with nested condition on polymorphic relation
+    // This exercises the polymorphic skip branch in liftGroupOperators (line 103)
+    const specificLikes = await orm.em.find(UserLike, {
+      likeable: { $or: [{ id: post1.id }, { id: post2.id }] },
+    });
+    expect(specificLikes).toHaveLength(2);
+  });
+
+  test('insert via QueryBuilder with tuple format for simple PK', async () => {
+    const post = new Post('Tuple Post', 'Content');
+    orm.em.persist(post);
+    await orm.em.flush();
+    orm.em.clear();
+
+    // Insert using tuple format: ['discriminator', id]
+    const qb = orm.em.createQueryBuilder(UserLike);
+    await qb.insert({
+      likeable: ['post', post.id],
+    }).execute();
+
+    orm.em.clear();
+
+    const like = await orm.em.findOneOrFail(UserLike, { likeable: { $ne: null } }, { populate: ['likeable'] });
+    expect(like.likeable).toBeInstanceOf(Post);
+    expect((like.likeable as Post).title).toBe('Tuple Post');
+  });
+
+  test('batch insert with tuple format for simple PK', async () => {
+    const post1 = new Post('Batch Post 1', 'Content 1');
+    const post2 = new Post('Batch Post 2', 'Content 2');
+    const comment1 = new Comment('Batch Comment');
+    orm.em.persist([post1, post2, comment1]);
+    await orm.em.flush();
+    orm.em.clear();
+
+    // Batch insert using tuple format
+    await orm.em.insertMany(UserLike, [
+      { likeable: ['post', post1.id] },
+      { likeable: ['post', post2.id] },
+      { likeable: ['comment', comment1.id] },
+    ]);
+
+    orm.em.clear();
+
+    const likes = await orm.em.find(UserLike, { likeable: { $ne: null } }, {
+      populate: ['likeable'],
+      orderBy: { id: 'ASC' },
+    });
+
+    expect(likes).toHaveLength(3);
+    expect(likes[0].likeable).toBeInstanceOf(Post);
+    expect(likes[1].likeable).toBeInstanceOf(Post);
+    expect(likes[2].likeable).toBeInstanceOf(Comment);
+  });
+
+});
+
+// Test polymorphic with Ref wrapper
+import { Reference, ReferenceKind } from '@mikro-orm/core';
+
+@Entity()
+class BlogPost {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  title!: string;
+
+  constructor(title: string) {
+    this.title = title;
+  }
+
+}
+
+@Entity()
+class Podcast {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  url!: string;
+
+  constructor(url: string) {
+    this.url = url;
+  }
+
+}
+
+@Entity()
+class Bookmark {
+
+  @PrimaryKey()
+  id!: number;
+
+  @ManyToOne(() => [BlogPost, Podcast], { ref: true })
+  bookmarkable!: Reference<BlogPost | Podcast>;
+
+}
+
+describe('polymorphic relations with Ref wrapper', () => {
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      entities: [BlogPost, Podcast, Bookmark],
+      dbName: ':memory:',
+      metadataProvider: ReflectMetadataProvider,
+    });
+    await orm.schema.create();
+  });
+
+  afterAll(() => orm.close(true));
+
+  beforeEach(() => orm.em.clear());
+
+  test('can persist and load polymorphic Ref relation', async () => {
+    const blogPost = new BlogPost('Test Article');
+    const bookmark = new Bookmark();
+    bookmark.bookmarkable = Reference.create(blogPost);
+
+    await orm.em.persist(bookmark).flush();
+    orm.em.clear();
+
+    const loadedBookmark = await orm.em.findOneOrFail(Bookmark, bookmark.id);
+    expect(loadedBookmark.bookmarkable).toBeInstanceOf(Reference);
+    expect(loadedBookmark.bookmarkable.unwrap()).toBeInstanceOf(BlogPost);
+  });
+
+  test('can load and populate polymorphic Ref relation', async () => {
+    const podcast = new Podcast('https://example.com/podcast');
+    const bookmark = new Bookmark();
+    bookmark.bookmarkable = Reference.create(podcast);
+
+    await orm.em.persist(bookmark).flush();
+    orm.em.clear();
+
+    const loadedBookmark = await orm.em.findOneOrFail(Bookmark, bookmark.id, { populate: ['bookmarkable'] });
+    // After populate, the reference is unwrapped to the actual entity
+    expect(loadedBookmark.bookmarkable).toBeInstanceOf(Reference);
+    const unwrapped = (loadedBookmark.bookmarkable as unknown as Reference<Podcast>).unwrap();
+    expect(unwrapped.url).toBe('https://example.com/podcast');
+  });
+
+  test('refresh option works with polymorphic Ref relation', async () => {
+    const blogPost = new BlogPost('Refresh Test');
+    const bookmark = new Bookmark();
+    bookmark.bookmarkable = Reference.create(blogPost);
+
+    await orm.em.persist(bookmark).flush();
+    orm.em.clear();
+
+    // Load once
+    const loadedBookmark = await orm.em.findOneOrFail(Bookmark, bookmark.id, {
+      populate: ['bookmarkable'],
+    });
+    expect(loadedBookmark.bookmarkable).toBeInstanceOf(Reference);
+    expect((loadedBookmark.bookmarkable.unwrap() as BlogPost).title).toBe('Refresh Test');
+
+    // Re-load with refresh: true - this triggers the isEntity path in hydrator
+    // because the entity already has the relation as an entity reference
+    const refreshed = await orm.em.findOneOrFail(Bookmark, bookmark.id, {
+      populate: ['bookmarkable'],
+      refresh: true,
+    });
+    expect(refreshed.bookmarkable).toBeInstanceOf(Reference);
+    expect((refreshed.bookmarkable.unwrap() as BlogPost).title).toBe('Refresh Test');
+  });
+
+  test('batch updates with polymorphic simple keys', async () => {
+    const post = orm.em.create(BlogPost, { title: 'Original Post' });
+    const podcast = new Podcast('https://example.com/podcast');
+    orm.em.persist(podcast);
+
+    const bookmark1 = orm.em.create(Bookmark, { bookmarkable: post });
+    const bookmark2 = orm.em.create(Bookmark, { bookmarkable: post });
+    const bookmark3 = orm.em.create(Bookmark, { bookmarkable: post });
+
+    await orm.em.flush();
+    orm.em.clear();
+
+    // Load all bookmarks and change their bookmarkables
+    const bookmarks = await orm.em.find(Bookmark, {}, { orderBy: { id: 'ASC' } });
+
+    // Change bookmarkables to different entities (batch update with simple PKs)
+    const loadedPodcast = await orm.em.findOneOrFail(Podcast, { url: 'https://example.com/podcast' });
+    bookmarks[0].bookmarkable = Reference.create(loadedPodcast);
+    bookmarks[1].bookmarkable = Reference.create(loadedPodcast);
+
+    await orm.em.flush();
+    orm.em.clear();
+
+    // Verify updates
+    const reloaded = await orm.em.find(Bookmark, {}, {
+      populate: ['bookmarkable'],
+      orderBy: { id: 'ASC' },
+    });
+
+    expect(reloaded[0].bookmarkable.unwrap()).toBeInstanceOf(Podcast);
+    expect(reloaded[1].bookmarkable.unwrap()).toBeInstanceOf(Podcast);
+    expect(reloaded[2].bookmarkable.unwrap()).toBeInstanceOf(BlogPost);
+  });
+
+  test('discriminatorMap with class name strings', async () => {
+    @Entity()
+    class Article {
+
+      @PrimaryKey()
+      id!: number;
+
+      @Property()
+      title!: string;
+
+      @OneToMany(() => Rating, r => r.rateable)
+      ratings = new Collection<Rating>(this);
+
+    }
+
+    @Entity()
+    class Video {
+
+      @PrimaryKey()
+      id!: number;
+
+      @Property()
+      url!: string;
+
+      @OneToMany(() => Rating, r => r.rateable)
+      ratings = new Collection<Rating>(this);
+
+    }
+
+    @Entity()
+    class Rating {
+
+      @PrimaryKey()
+      id!: number;
+
+      @Property()
+      score!: number;
+
+      // Using class names (strings) in discriminatorMap
+      @ManyToOne(() => [Article, Video], {
+        discriminatorMap: {
+          art: Article.name,
+          vid: Video.name,
+        },
+      })
+      rateable!: Article | Video;
+
+    }
+
+    const orm2 = await MikroORM.init({
+      entities: [Article, Video, Rating],
+      dbName: ':memory:',
+      metadataProvider: ReflectMetadataProvider,
+    });
+
+    await orm2.schema.create();
+
+    const article = new Article();
+    article.title = 'Test Article';
+
+    const video = new Video();
+    video.url = 'https://example.com/video';
+
+    const rating1 = new Rating();
+    rating1.score = 5;
+    rating1.rateable = article;
+
+    const rating2 = new Rating();
+    rating2.score = 4;
+    rating2.rateable = video;
+
+    await orm2.em.persist([rating1, rating2]).flush();
+    orm2.em.clear();
+
+    const ratings = await orm2.em.find(Rating, {}, {
+      populate: ['rateable'],
+      orderBy: { id: 'ASC' },
+    });
+
+    expect(ratings).toHaveLength(2);
+    expect(ratings[0].rateable).toBeInstanceOf(Article);
+    expect(ratings[1].rateable).toBeInstanceOf(Video);
+
+    await orm2.close();
+  });
+
+  test('single target union type works as polymorphic', async () => {
+    @Entity()
+    class SingleTarget {
+
+      @PrimaryKey()
+      id!: number;
+
+      @Property()
+      name!: string;
+
+    }
+
+    @Entity()
+    class Reference {
+
+      @PrimaryKey()
+      id!: number;
+
+      // Union type with only one actual target - still works as polymorphic
+      @ManyToOne(() => [SingleTarget])
+      target!: SingleTarget;
+
+    }
+
+    const orm2 = await MikroORM.init({
+      entities: [SingleTarget, Reference],
+      dbName: ':memory:',
+      metadataProvider: ReflectMetadataProvider,
+    });
+
+    // Should be marked as polymorphic even with single target
+    const meta = orm2.getMetadata().getByClassName('Reference');
+    const prop = meta.properties.target;
+    expect(prop.polymorphic).toBe(true);
+    expect(prop.polymorphTargets).toHaveLength(1);
+
+    await orm2.close();
+  });
+
+  test('throws error for invalid class name in discriminatorMap', async () => {
+    @Entity()
+    class ValidTarget {
+
+      @PrimaryKey()
+      id!: number;
+
+    }
+
+    @Entity()
+    class AnotherTarget {
+
+      @PrimaryKey()
+      id!: number;
+
+    }
+
+    @Entity()
+    class Reference {
+
+      @PrimaryKey()
+      id!: number;
+
+      @ManyToOne(() => [ValidTarget, AnotherTarget], {
+        discriminatorMap: {
+          valid: 'ValidTarget',
+          invalid: 'NonExistentEntity', // This class doesn't exist
+        },
+      })
+      target!: ValidTarget | AnotherTarget;
+
+    }
+
+    await expect(MikroORM.init({
+      entities: [ValidTarget, AnotherTarget, Reference],
+      dbName: ':memory:',
+      metadataProvider: ReflectMetadataProvider,
+    })).rejects.toThrow(/NonExistentEntity.*was not discovered.*Reference\.target discriminatorMap/);
+  });
+
+  test('polymorphic relation with targetKey persists correctly', async () => {
+    @Entity()
+    class SlugArticle {
+
+      @PrimaryKey()
+      id!: number;
+
+      @Property({ unique: true })
+      slug!: string;
+
+      @Property()
+      title!: string;
+
+    }
+
+    @Entity()
+    class SlugVideo {
+
+      @PrimaryKey()
+      id!: number;
+
+      @Property({ unique: true })
+      slug!: string;
+
+      @Property()
+      url!: string;
+
+    }
+
+    @Entity()
+    class SlugBookmark {
+
+      @PrimaryKey()
+      id!: number;
+
+      @ManyToOne(() => [SlugArticle, SlugVideo], { targetKey: 'slug' })
+      bookmarkable!: SlugArticle | SlugVideo;
+
+    }
+
+    const orm2 = await MikroORM.init({
+      entities: [SlugArticle, SlugVideo, SlugBookmark],
+      dbName: ':memory:',
+      metadataProvider: ReflectMetadataProvider,
+    });
+    await orm2.schema.create();
+
+    // Create target entities
+    const article = orm2.em.create(SlugArticle, { slug: 'my-article', title: 'My Article' });
+    const video = orm2.em.create(SlugVideo, { slug: 'my-video', url: 'https://example.com/video' });
+    await orm2.em.flush();
+
+    // Create bookmarks pointing to each target using targetKey (slug)
+    // This exercises ChangeSetComputer line 186: target[prop.targetKey]
+    const bookmark1 = orm2.em.create(SlugBookmark, { bookmarkable: article });
+    const bookmark2 = orm2.em.create(SlugBookmark, { bookmarkable: video });
+    await orm2.em.flush();
+
+    // Verify the FK columns store the slug value (not the PK)
+    const connection = orm2.em.getConnection();
+    const rows = await connection.execute('SELECT * FROM slug_bookmark ORDER BY id');
+    expect(rows[0].bookmarkable_type).toBe('slug_article');
+    expect(rows[0].bookmarkable_id).toBe('my-article'); // stores slug value via targetKey
+    expect(rows[1].bookmarkable_type).toBe('slug_video');
+    expect(rows[1].bookmarkable_id).toBe('my-video'); // stores slug value via targetKey
+
+    await orm2.close(true);
+  });
+
+  test('throws on incompatible polymorphic target PK types', async () => {
+    @Entity()
+    class NumberPKEntity {
+
+      @PrimaryKey()
+      id!: number;
+
+    }
+
+    @Entity()
+    class StringPKEntity {
+
+      @PrimaryKey()
+      id!: string;
+
+    }
+
+    @Entity()
+    class IncompatibleRef {
+
+      @PrimaryKey()
+      id!: number;
+
+      @ManyToOne(() => [NumberPKEntity, StringPKEntity])
+      target!: NumberPKEntity | StringPKEntity;
+
+    }
+
+    await expect(MikroORM.init({
+      entities: [NumberPKEntity, StringPKEntity, IncompatibleRef],
+      dbName: ':memory:',
+      metadataProvider: ReflectMetadataProvider,
+    })).rejects.toThrow(/incompatible polymorphic targets.*incompatible primary key types/);
+  });
+
+  test('throws on incompatible polymorphic target PK count', async () => {
+    @Entity()
+    class SimplePKEntity {
+
+      @PrimaryKey()
+      id!: number;
+
+    }
+
+    @Entity()
+    class CompositePKEntity {
+
+      @PrimaryKey()
+      id1!: number;
+
+      @PrimaryKey()
+      id2!: number;
+
+    }
+
+    @Entity()
+    class IncompatibleRef {
+
+      @PrimaryKey()
+      id!: number;
+
+      @ManyToOne(() => [SimplePKEntity, CompositePKEntity])
+      target!: SimplePKEntity | CompositePKEntity;
+
+    }
+
+    await expect(MikroORM.init({
+      entities: [SimplePKEntity, CompositePKEntity, IncompatibleRef],
+      dbName: ':memory:',
+      metadataProvider: ReflectMetadataProvider,
+    })).rejects.toThrow(/incompatible polymorphic targets.*different number of primary keys/);
+  });
+
+  test('throws when targetKey is missing on polymorphic target', async () => {
+    @Entity()
+    class EntityWithSlug {
+
+      @PrimaryKey()
+      id!: number;
+
+      @Property({ unique: true })
+      slug!: string;
+
+    }
+
+    @Entity()
+    class EntityWithoutSlug {
+
+      @PrimaryKey()
+      id!: number;
+
+    }
+
+    @Entity()
+    class RefWithTargetKey {
+
+      @PrimaryKey()
+      id!: number;
+
+      @ManyToOne(() => [EntityWithSlug, EntityWithoutSlug], { targetKey: 'slug' })
+      target!: EntityWithSlug | EntityWithoutSlug;
+
+    }
+
+    await expect(MikroORM.init({
+      entities: [EntityWithSlug, EntityWithoutSlug, RefWithTargetKey],
+      dbName: ':memory:',
+      metadataProvider: ReflectMetadataProvider,
+    })).rejects.toThrow(/targetKey.*slug.*EntityWithoutSlug\.slug does not exist/);
+  });
+
+  test('throws when targetKey is not unique on polymorphic target', async () => {
+    @Entity()
+    class EntityWithUniqueSlug {
+
+      @PrimaryKey()
+      id!: number;
+
+      @Property({ unique: true })
+      slug!: string;
+
+    }
+
+    @Entity()
+    class EntityWithNonUniqueSlug {
+
+      @PrimaryKey()
+      id!: number;
+
+      @Property()
+      slug!: string;
+
+    }
+
+    @Entity()
+    class RefWithTargetKey {
+
+      @PrimaryKey()
+      id!: number;
+
+      @ManyToOne(() => [EntityWithUniqueSlug, EntityWithNonUniqueSlug], { targetKey: 'slug' })
+      target!: EntityWithUniqueSlug | EntityWithNonUniqueSlug;
+
+    }
+
+    await expect(MikroORM.init({
+      entities: [EntityWithUniqueSlug, EntityWithNonUniqueSlug, RefWithTargetKey],
+      dbName: ':memory:',
+      metadataProvider: ReflectMetadataProvider,
+    })).rejects.toThrow(/targetKey.*slug.*EntityWithNonUniqueSlug\.slug is not marked as unique/);
+  });
+
+  test('schema is up-to-date for polymorphic relations', async () => {
+    const sql = await orm.schema.getUpdateSchemaSQL();
+    expect(sql).toBe('');
+  });
+
+});
+
+// Test polymorphic with @OneToOne
+import { OneToOne } from '@mikro-orm/decorators/legacy';
+
+@Entity()
+class User {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  constructor(name: string) {
+    this.name = name;
+  }
+
+}
+
+@Entity()
+class Organization {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  title!: string;
+
+  constructor(title: string) {
+    this.title = title;
+  }
+
+}
+
+@Entity()
+class Profile {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  bio!: string;
+
+  @OneToOne(() => [User, Organization], { nullable: true, owner: true })
+  owner!: User | Organization | null;
+
+  constructor(bio: string) {
+    this.bio = bio;
+  }
+
+}
+
+describe('polymorphic @OneToOne relations', () => {
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      entities: [User, Organization, Profile],
+      dbName: ':memory:',
+      metadataProvider: ReflectMetadataProvider,
+    });
+    await orm.schema.create();
+  });
+
+  afterAll(() => orm.close(true));
+
+  beforeEach(async () => {
+    await orm.em.nativeDelete(Profile, {});
+    await orm.em.nativeDelete(User, {});
+    await orm.em.nativeDelete(Organization, {});
+    orm.em.clear();
+  });
+
+  test('metadata is correctly initialized for polymorphic OneToOne', () => {
+    const meta = orm.getMetadata().get(Profile);
+    const ownerProp = meta.properties.owner;
+
+    expect(ownerProp.polymorphic).toBe(true);
+    expect(ownerProp.polymorphTargets).toHaveLength(2);
+    expect(ownerProp.discriminator).toBe('owner');
+    expect(ownerProp.discriminatorMap).toBeDefined();
+    expect(ownerProp.kind).toBe(ReferenceKind.ONE_TO_ONE);
+    expect(ownerProp.createForeignKeyConstraint).toBe(false);
+  });
+
+  test('can persist and load polymorphic OneToOne pointing to User', async () => {
+    const user = new User('Alice');
+    const profile = new Profile('Alice bio');
+    profile.owner = user;
+
+    orm.em.persist(profile);
+    await orm.em.flush();
+    orm.em.clear();
+
+    const loaded = await orm.em.findOneOrFail(Profile, profile.id);
+    expect(loaded.owner).toBeDefined();
+    expect(loaded.owner!.constructor.name).toBe('User');
+  });
+
+  test('can persist and load polymorphic OneToOne pointing to Organization', async () => {
+    const org = new Organization('Acme Corp');
+    const profile = new Profile('Org bio');
+    profile.owner = org;
+
+    orm.em.persist(profile);
+    await orm.em.flush();
+    orm.em.clear();
+
+    const loaded = await orm.em.findOneOrFail(Profile, profile.id);
+    expect(loaded.owner).toBeDefined();
+    expect(loaded.owner!.constructor.name).toBe('Organization');
+  });
+
+  test('can populate polymorphic OneToOne', async () => {
+    const user = new User('Bob');
+    const org = new Organization('Corp Inc');
+
+    const profile1 = new Profile('Bob bio');
+    profile1.owner = user;
+    const profile2 = new Profile('Corp bio');
+    profile2.owner = org;
+
+    orm.em.persist([profile1, profile2]);
+    await orm.em.flush();
+    orm.em.clear();
+
+    const profiles = await orm.em.find(Profile, {}, {
+      populate: ['owner'],
+      orderBy: { id: 'ASC' },
+    });
+
+    expect(profiles).toHaveLength(2);
+    expect(profiles[0].owner).toBeInstanceOf(User);
+    expect((profiles[0].owner as User).name).toBe('Bob');
+    expect(profiles[1].owner).toBeInstanceOf(Organization);
+    expect((profiles[1].owner as Organization).title).toBe('Corp Inc');
+  });
+
+  test('can handle null polymorphic OneToOne', async () => {
+    const connection = orm.em.getConnection();
+    await connection.execute("INSERT INTO profile (id, bio, owner_type, owner_id) VALUES (1, 'No owner', NULL, NULL)");
+    orm.em.clear();
+
+    const loaded = await orm.em.findOneOrFail(Profile, 1);
+    expect(loaded.owner).toBeNull();
+  });
+
+  test('can handle null polymorphic OneToOne with joined loading', async () => {
+    const connection = orm.em.getConnection();
+    await connection.execute("INSERT INTO profile (id, bio, owner_type, owner_id) VALUES (1, 'No owner', NULL, NULL)");
+    orm.em.clear();
+
+    const loaded = await orm.em.findOneOrFail(Profile, 1, {
+      populate: ['owner'],
+      strategy: 'joined',
+    });
+    expect(loaded.owner).toBeNull();
+  });
+
+  test('schema is up-to-date for polymorphic OneToOne', async () => {
+    const sql = await orm.schema.getUpdateSchemaSQL();
+    expect(sql).toBe('');
+  });
+
+});

--- a/tests/features/polymorphic-relations/polymorphic-tsmorph.sqlite.test.ts
+++ b/tests/features/polymorphic-relations/polymorphic-tsmorph.sqlite.test.ts
@@ -1,0 +1,155 @@
+import { Collection, MikroORM } from '@mikro-orm/sqlite';
+import { Entity, ManyToOne, OneToMany, PrimaryKey, Property } from '@mikro-orm/decorators/legacy';
+import { TsMorphMetadataProvider } from '@mikro-orm/reflection';
+
+@Entity()
+class Video {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  title!: string;
+
+  @OneToMany(() => Comment, comment => comment.commentable)
+  comments = new Collection<Comment>(this);
+
+}
+
+@Entity()
+class Photo {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  caption!: string;
+
+  @OneToMany(() => Comment, comment => comment.commentable)
+  comments = new Collection<Comment>(this);
+
+}
+
+@Entity()
+class Comment {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  text!: string;
+
+  @ManyToOne(() => [Video, Photo])
+  commentable!: Video | Photo;
+
+}
+
+describe('polymorphic relations with ts-morph', () => {
+
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      entities: [Video, Photo, Comment],
+      dbName: ':memory:',
+      metadataProvider: TsMorphMetadataProvider,
+    });
+    await orm.schema.create();
+  });
+
+  afterAll(async () => {
+    await orm.close(true);
+  });
+
+  beforeEach(async () => {
+    await orm.em.nativeDelete(Comment, {});
+    await orm.em.nativeDelete(Video, {});
+    await orm.em.nativeDelete(Photo, {});
+    orm.em.clear();
+  });
+
+  test('metadata is correctly initialized', () => {
+    const meta = orm.getMetadata().get(Comment);
+    const commentableProp = meta.properties.commentable;
+
+    expect(commentableProp.polymorphic).toBe(true);
+    expect(commentableProp.discriminator).toBe('commentable');
+    expect(commentableProp.polymorphTargets).toHaveLength(2);
+    expect(commentableProp.fieldNames).toContain('commentable_type');
+    expect(commentableProp.fieldNames).toContain('commentable_id');
+  });
+
+  test('can create and persist comment to Video', async () => {
+    const video = orm.em.create(Video, { title: 'My Video' });
+    const comment = orm.em.create(Comment, {
+      text: 'Great video!',
+      commentable: video,
+    });
+
+    await orm.em.flush();
+    orm.em.clear();
+
+    const loaded = await orm.em.findOneOrFail(Comment, { id: comment.id });
+    expect(loaded.commentable).toBeInstanceOf(Video);
+
+    await orm.em.populate(loaded, ['commentable']);
+    expect((loaded.commentable as Video).title).toBe('My Video');
+  });
+
+
+  test('can create and persist comment to Photo', async () => {
+    const photo = orm.em.create(Photo, { caption: 'Beautiful sunset' });
+
+    const comment = orm.em.create(Comment, {
+      text: 'Stunning!',
+      commentable: photo,
+    });
+
+    await orm.em.flush();
+    orm.em.clear();
+
+    const loaded = await orm.em.findOneOrFail(Comment, { id: comment.id });
+    expect(loaded.commentable).toBeInstanceOf(Photo);
+
+    await orm.em.populate(loaded, ['commentable']);
+    expect((loaded.commentable as Photo).caption).toBe('Beautiful sunset');
+  });
+
+  test('inverse side collection works', async () => {
+    const video = orm.em.create(Video, { title: 'Video' });
+    const c1 = orm.em.create(Comment, { text: 'C1', commentable: video });
+    const c2 = orm.em.create(Comment, { text: 'C2', commentable: video });
+
+    await orm.em.flush();
+    orm.em.clear();
+
+    const loaded = await orm.em.findOneOrFail(Video, { id: video.id }, {
+      populate: ['comments'],
+    });
+
+    expect(loaded.comments).toHaveLength(2);
+    expect(loaded.comments.getItems().map(c => c.text).sort()).toEqual(['C1', 'C2']);
+  });
+
+  test('can update polymorphic relation', async () => {
+    const video = orm.em.create(Video, { title: 'Video' });
+    const photo = orm.em.create(Photo, { caption: 'Photo' });
+    const comment = orm.em.create(Comment, { text: 'Comment', commentable: video });
+
+    await orm.em.flush();
+    orm.em.clear();
+
+    const loadedComment = await orm.em.findOneOrFail(Comment, { id: comment.id });
+    const loadedPhoto = await orm.em.findOneOrFail(Photo, { id: photo.id });
+
+    loadedComment.commentable = loadedPhoto;
+
+    await orm.em.flush();
+    orm.em.clear();
+
+    const reloaded = await orm.em.findOneOrFail(Comment, { id: comment.id });
+    await orm.em.populate(reloaded, ['commentable']);
+    expect((reloaded.commentable as Photo).caption).toBe('Photo');
+  });
+
+});

--- a/tests/issues/__snapshots__/GH6865.test.ts.snap
+++ b/tests/issues/__snapshots__/GH6865.test.ts.snap
@@ -39,9 +39,9 @@ exports[`6865 1`] = `
     entity.password = data.password;
   }
   const createCollectionItem_allowedTokens = (value, entity) => {
-    if (isPrimaryKey(value, false)) return factory.createReference(allowed_token_19, value, { convertCustomTypes, schema, normalizeAccessors, merge: true });
+    if (isPrimaryKey(value, false)) return factory.createReference(allowed_token_20, value, { convertCustomTypes, schema, normalizeAccessors, merge: true });
     if (value && value.__entity) return value;
-    return factory.create(allowed_token_19, value, { newEntity, convertCustomTypes, schema, normalizeAccessors, merge: true });
+    return factory.create(allowed_token_20, value, { newEntity, convertCustomTypes, schema, normalizeAccessors, merge: true });
   }
   if (data.allowedTokens && !Array.isArray(data.allowedTokens) && typeof data.allowedTokens === 'object') {
     data.allowedTokens = [data.allowedTokens];


### PR DESCRIPTION
Polymorphic relations allow a property to reference entities of multiple different types. This is useful when you have a relationship that can point to various entity types, such as a "like" that can be associated with either a "post" or a "comment".

```ts
@Entity()
export class Post {

  @PrimaryKey()
  id!: number;

  @Property()
  title!: string;

  // Inverse side of polymorphic relation
  @OneToMany(() => UserLike, like => like.likeable)
  likes = new Collection<UserLike>(this);

}

@Entity()
export class Comment {

  @PrimaryKey()
  id!: number;

  @Property()
  text!: string;

  // Inverse side of polymorphic relation
  @OneToMany(() => UserLike, like => like.likeable)
  likes = new Collection<UserLike>(this);

}

@Entity()
export class UserLike {

  @PrimaryKey()
  id!: number;

  // Polymorphic relation - can point to either Post or Comment
  @ManyToOne(() => [Post, Comment])
  likeable!: Post | Comment;

}
```

Closes #706