### PR TITLE
perf(core): optimize `AutoPath` and `Loaded` type instantiation costs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -224,6 +224,38 @@ jobs:
       - name: Test
         run: yarn bench
 
+  bench-types:
+    name: Type Benchmarks
+    if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Source code
+        uses: actions/checkout@v6
+
+      - name: Use Node.js 24
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          package-manager-cache: false
+
+      - name: Enable corepack
+        run: |
+          corepack enable
+          corepack prepare yarn@stable --activate
+
+      # Yarn dependencies cannot be cached until yarn is installed
+      # WORKAROUND: https://github.com/actions/setup-node/issues/531
+      - name: Extract cached dependencies
+        uses: actions/setup-node@v6
+        with:
+          cache: yarn
+
+      - name: Install
+        run: yarn
+
+      - name: Type performance benchmarks
+        run: yarn bench:types
+
   test-windows:
     name: Tests (windows)
     if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "test:sqlite": "vitest --run **/*.sqlite.test.ts **/*.win.test.ts",
     "test:fast": "vitest --run --exclude='tests/features/schema-generator'",
     "bench": "tsx tests/bench/basic.bench.ts",
+    "bench:types": "bash -c 'for f in tests/bench/types/*.ts; do node --import=tsx \"$f\" || exit 1; done'",
     "clean-tests": "rimraf temp tests/generated-entities",
     "tsc-check-tests": "tsc --noEmit --project tests/tsconfig.json",
     "coverage": "yarn clean-tests && yarn test --coverage",

--- a/tests/bench/types/autopath-loaded-isolated.ts
+++ b/tests/bench/types/autopath-loaded-isolated.ts
@@ -1,0 +1,225 @@
+#!/usr/bin/env -S node --import=tsx
+
+/**
+ * Isolated benchmarks to identify bottlenecks in AutoPath and Loaded types.
+ * These tests use simple, linear entity structures without circular references
+ * to measure the true cost of the type computations.
+ *
+ * These tests helped identify a major performance issue: using `extends Collection<any, any>`
+ * in conditional types caused massive instantiation explosion (~133k instantiations).
+ * The fix was to use property-based checks instead: `extends { [k: number]: any; readonly owner: object }`.
+ */
+
+import { bench } from '@ark/attest';
+import {
+  type AutoPath,
+  type Loaded,
+  type Ref,
+  type Collection,
+  type PopulatePath,
+  PrimaryKeyProp,
+} from '@mikro-orm/core';
+
+// ============================================
+// LINEAR entity chain (no circular refs)
+// ============================================
+
+interface Country {
+  id: number;
+  name: string;
+  [PrimaryKeyProp]?: 'id';
+}
+
+interface City {
+  id: number;
+  name: string;
+  country: Ref<Country>;
+  [PrimaryKeyProp]?: 'id';
+}
+
+interface Address {
+  id: number;
+  street: string;
+  city: Ref<City>;
+  [PrimaryKeyProp]?: 'id';
+}
+
+interface Person {
+  id: number;
+  name: string;
+  address: Ref<Address>;
+  [PrimaryKeyProp]?: 'id';
+}
+
+// ============================================
+// AutoPath with LINEAR entities
+// ============================================
+
+// eslint-disable-next-line
+function validatePath<T, P extends string>(_path: AutoPath<T, P, PopulatePath.ALL>): void {}
+
+bench('AutoPath LINEAR - 1 level', () => {
+  validatePath<Person, 'address'>('address');
+}).types([2100, 'instantiations']);
+
+bench('AutoPath LINEAR - 2 levels', () => {
+  validatePath<Person, 'address.city'>('address.city');
+}).types([2400, 'instantiations']);
+
+bench('AutoPath LINEAR - 3 levels', () => {
+  validatePath<Person, 'address.city.country'>('address.city.country');
+}).types([2700, 'instantiations']);
+
+// ============================================
+// Loaded with LINEAR entities (Ref only)
+// ============================================
+
+// eslint-disable-next-line
+function useLoaded<T, L extends string = never>(_entity: Loaded<T, L>): void {}
+
+bench('Loaded LINEAR - no populate', () => {
+  useLoaded<Person>({} as Person);
+}).types([600, 'instantiations']);
+
+bench('Loaded LINEAR - 1 level (Ref)', () => {
+  useLoaded<Person, 'address'>({} as Loaded<Person, 'address'>);
+}).types([1600, 'instantiations']);
+
+bench('Loaded LINEAR - 2 levels (Ref)', () => {
+  useLoaded<Person, 'address.city'>({} as Loaded<Person, 'address.city'>);
+}).types([1600, 'instantiations']);
+
+bench('Loaded LINEAR - 3 levels (Ref)', () => {
+  useLoaded<Person, 'address.city.country'>({} as Loaded<Person, 'address.city.country'>);
+}).types([1600, 'instantiations']);
+
+// ============================================
+// SELF-REFERENCING entity (single type circular)
+// ============================================
+
+interface TreeNode {
+  id: number;
+  name: string;
+  parent?: Ref<TreeNode> | null;
+  children: Collection<TreeNode>;
+  [PrimaryKeyProp]?: 'id';
+}
+
+bench('AutoPath SELF-REF - 1 level', () => {
+  validatePath<TreeNode, 'parent'>('parent');
+}).types([2200, 'instantiations']);
+
+bench('AutoPath SELF-REF - 2 levels', () => {
+  validatePath<TreeNode, 'parent.parent'>('parent.parent');
+}).types([2300, 'instantiations']);
+
+bench('AutoPath SELF-REF - children (Collection)', () => {
+  validatePath<TreeNode, 'children'>('children');
+}).types([1800, 'instantiations']);
+
+bench('Loaded SELF-REF - 1 level (Ref)', () => {
+  useLoaded<TreeNode, 'parent'>({} as Loaded<TreeNode, 'parent'>);
+}).types([1600, 'instantiations']);
+
+bench('Loaded SELF-REF - 2 levels (Ref)', () => {
+  useLoaded<TreeNode, 'parent.parent'>({} as Loaded<TreeNode, 'parent.parent'>);
+}).types([1600, 'instantiations']);
+
+bench('Loaded SELF-REF - children (Collection)', () => {
+  useLoaded<TreeNode, 'children'>({} as Loaded<TreeNode, 'children'>);
+}).types([1000, 'instantiations']);
+
+// ============================================
+// TWO-WAY circular reference (A <-> B)
+// ============================================
+
+interface Employee {
+  id: number;
+  name: string;
+  department: Ref<Department>;
+  [PrimaryKeyProp]?: 'id';
+}
+
+interface Department {
+  id: number;
+  name: string;
+  employees: Collection<Employee>;
+  manager: Ref<Employee>;
+  [PrimaryKeyProp]?: 'id';
+}
+
+bench('AutoPath CIRCULAR - simple', () => {
+  validatePath<Employee, 'department'>('department');
+}).types([2100, 'instantiations']);
+
+bench('AutoPath CIRCULAR - 2 levels', () => {
+  validatePath<Employee, 'department.manager'>('department.manager');
+}).types([2400, 'instantiations']);
+
+bench('AutoPath CIRCULAR - 3 levels', () => {
+  validatePath<Employee, 'department.manager.department'>('department.manager.department');
+}).types([2500, 'instantiations']);
+
+bench('Loaded CIRCULAR - simple (Ref)', () => {
+  useLoaded<Employee, 'department'>({} as Loaded<Employee, 'department'>);
+}).types([1600, 'instantiations']);
+
+bench('Loaded CIRCULAR - 2 levels (Ref)', () => {
+  useLoaded<Employee, 'department.manager'>({} as Loaded<Employee, 'department.manager'>);
+}).types([1600, 'instantiations']);
+
+bench('Loaded CIRCULAR - back to start (Ref)', () => {
+  useLoaded<Employee, 'department.manager.department'>({} as Loaded<Employee, 'department.manager.department'>);
+}).types([1600, 'instantiations']);
+
+bench('Loaded CIRCULAR - collection', () => {
+  useLoaded<Department, 'employees'>({} as Loaded<Department, 'employees'>);
+}).types([1000, 'instantiations']);
+
+bench('Loaded CIRCULAR - collection nested', () => {
+  useLoaded<Department, 'employees.department'>({} as Loaded<Department, 'employees.department'>);
+}).types([1000, 'instantiations']);
+
+// ============================================
+// Entity with many properties (width test)
+// ============================================
+
+interface WideSimple {
+  id: number;
+  f1: string; f2: string; f3: string; f4: string; f5: string;
+  f6: string; f7: string; f8: string; f9: string; f10: string;
+  f11: string; f12: string; f13: string; f14: string; f15: string;
+  f16: string; f17: string; f18: string; f19: string; f20: string;
+  [PrimaryKeyProp]?: 'id';
+}
+
+interface WideWithRefs {
+  id: number;
+  f1: string; f2: string; f3: string; f4: string; f5: string;
+  r1: Ref<Country>;
+  r2: Ref<Country>;
+  r3: Ref<Country>;
+  r4: Ref<Country>;
+  r5: Ref<Country>;
+  [PrimaryKeyProp]?: 'id';
+}
+
+bench('AutoPath WIDE - 20 scalar props', () => {
+  validatePath<WideSimple, 'f1'>('f1');
+}).types([2000, 'instantiations']);
+
+bench('AutoPath WIDE - 5 refs', () => {
+  validatePath<WideWithRefs, 'r1'>('r1');
+}).types([2200, 'instantiations']);
+
+bench('Loaded WIDE - 20 scalar props', () => {
+  useLoaded<WideSimple>({} as WideSimple);
+}).types([1000, 'instantiations']);
+
+bench('Loaded WIDE - 5 refs no populate', () => {
+  useLoaded<WideWithRefs>({} as WideWithRefs);
+}).types([800, 'instantiations']);
+
+bench('Loaded WIDE - 5 refs all populated', () => {
+  useLoaded<WideWithRefs, 'r1' | 'r2' | 'r3' | 'r4' | 'r5'>({} as Loaded<WideWithRefs, 'r1' | 'r2' | 'r3' | 'r4' | 'r5'>);
+}).types([2300, 'instantiations']);

--- a/tests/bench/types/autopath-loaded.ts
+++ b/tests/bench/types/autopath-loaded.ts
@@ -1,0 +1,230 @@
+#!/usr/bin/env -S node --import=tsx
+
+import { bench } from '@ark/attest';
+import {
+  type AutoPath,
+  type Loaded,
+  type Ref,
+  type Collection,
+  type PopulatePath,
+  PrimaryKeyProp,
+  EagerProps,
+} from '@mikro-orm/core';
+
+// ============================================
+// Test Entity Definitions (simple hierarchy)
+// ============================================
+
+interface Tag {
+  id: number;
+  name: string;
+  [PrimaryKeyProp]?: 'id';
+}
+
+interface Publisher {
+  id: number;
+  name: string;
+  books: Collection<Book>;
+  [PrimaryKeyProp]?: 'id';
+}
+
+interface Book {
+  id: number;
+  title: string;
+  author: Author;
+  publisher?: Ref<Publisher> | null;
+  tags: Collection<Tag>;
+  [PrimaryKeyProp]?: 'id';
+}
+
+interface Author {
+  id: number;
+  name: string;
+  email: string;
+  age?: number;
+  books: Collection<Book>;
+  favouriteBook?: Ref<Book> | null;
+  friends: Collection<Author>;
+  [PrimaryKeyProp]?: 'id';
+}
+
+// ============================================
+// AutoPath benchmarks
+// ============================================
+
+// eslint-disable-next-line
+function validatePath<T, P extends string>(_path: AutoPath<T, P, PopulatePath.ALL>): void {}
+
+bench('AutoPath - simple property access', () => {
+  validatePath<Author, 'name'>('name');
+}).types([1800, 'instantiations']);
+
+bench('AutoPath - single relation', () => {
+  validatePath<Author, 'books'>('books');
+}).types([1900, 'instantiations']);
+
+bench('AutoPath - nested relation (2 levels)', () => {
+  validatePath<Author, 'books.publisher'>('books.publisher');
+}).types([2400, 'instantiations']);
+
+bench('AutoPath - nested relation (3 levels)', () => {
+  validatePath<Author, 'books.publisher.books'>('books.publisher.books');
+}).types([2500, 'instantiations']);
+
+bench('AutoPath - nested relation (4 levels)', () => {
+  validatePath<Author, 'books.publisher.books.author'>('books.publisher.books.author');
+}).types([2600, 'instantiations']);
+
+bench('AutoPath - collection with :ref', () => {
+  validatePath<Author, 'books:ref'>('books:ref');
+}).types([550, 'instantiations']);
+
+// ============================================
+// Loaded benchmarks
+// ============================================
+
+// eslint-disable-next-line
+function useLoaded<T, L extends string = never>(_entity: Loaded<T, L>): void {}
+
+bench('Loaded - no populate', () => {
+  useLoaded<Author>({} as Author);
+}).types([650, 'instantiations']);
+
+bench('Loaded - single relation', () => {
+  useLoaded<Author, 'books'>({} as Loaded<Author, 'books'>);
+}).types([1000, 'instantiations']);
+
+bench('Loaded - nested relation (2 levels)', () => {
+  useLoaded<Author, 'books.publisher'>({} as Loaded<Author, 'books.publisher'>);
+}).types([1000, 'instantiations']);
+
+bench('Loaded - nested relation (3 levels)', () => {
+  useLoaded<Author, 'books.publisher.books'>({} as Loaded<Author, 'books.publisher.books'>);
+}).types([1000, 'instantiations']);
+
+bench('Loaded - multiple relations', () => {
+  useLoaded<Author, 'books' | 'friends' | 'favouriteBook'>({} as Loaded<Author, 'books' | 'friends' | 'favouriteBook'>);
+}).types([1900, 'instantiations']);
+
+bench('Loaded - complex nested paths', () => {
+  useLoaded<Author, 'books.tags' | 'books.publisher' | 'friends.books'>({} as Loaded<Author, 'books.tags' | 'books.publisher' | 'friends.books'>);
+}).types([1200, 'instantiations']);
+
+// ============================================
+// Deep hierarchy tests
+// ============================================
+
+interface DeepLevel5 {
+  id: number;
+  value: string;
+  [PrimaryKeyProp]?: 'id';
+}
+
+interface DeepLevel4 {
+  id: number;
+  name: string;
+  level5: Ref<DeepLevel5>;
+  [PrimaryKeyProp]?: 'id';
+}
+
+interface DeepLevel3 {
+  id: number;
+  name: string;
+  level4: Ref<DeepLevel4>;
+  items: Collection<DeepLevel4>;
+  [PrimaryKeyProp]?: 'id';
+}
+
+interface DeepLevel2 {
+  id: number;
+  name: string;
+  level3: Ref<DeepLevel3>;
+  [PrimaryKeyProp]?: 'id';
+}
+
+interface DeepLevel1 {
+  id: number;
+  name: string;
+  level2: Ref<DeepLevel2>;
+  children: Collection<DeepLevel2>;
+  [PrimaryKeyProp]?: 'id';
+}
+
+interface DeepRoot {
+  id: number;
+  name: string;
+  level1: Ref<DeepLevel1>;
+  items: Collection<DeepLevel1>;
+  [PrimaryKeyProp]?: 'id';
+}
+
+bench('AutoPath - deep hierarchy (6 levels)', () => {
+  validatePath<DeepRoot, 'level1.level2.level3.level4.level5'>('level1.level2.level3.level4.level5');
+}).types([3300, 'instantiations']);
+
+bench('Loaded - deep hierarchy (6 levels)', () => {
+  useLoaded<DeepRoot, 'level1.level2.level3.level4.level5'>({} as Loaded<DeepRoot, 'level1.level2.level3.level4.level5'>);
+}).types([1700, 'instantiations']);
+
+// ============================================
+// Wide entity (many properties) tests
+// ============================================
+
+interface WideEntity {
+  id: number;
+  prop1: string;
+  prop2: string;
+  prop3: string;
+  prop4: string;
+  prop5: string;
+  prop6: string;
+  prop7: string;
+  prop8: string;
+  prop9: string;
+  prop10: string;
+  rel1: Ref<Tag>;
+  rel2: Ref<Tag>;
+  rel3: Ref<Tag>;
+  rel4: Ref<Tag>;
+  rel5: Collection<Tag>;
+  [PrimaryKeyProp]?: 'id';
+}
+
+bench('AutoPath - wide entity (15 properties)', () => {
+  validatePath<WideEntity, 'rel1'>('rel1');
+}).types([2300, 'instantiations']);
+
+bench('Loaded - wide entity (15 properties)', () => {
+  useLoaded<WideEntity, 'rel1' | 'rel2' | 'rel3'>({} as Loaded<WideEntity, 'rel1' | 'rel2' | 'rel3'>);
+}).types([2100, 'instantiations']);
+
+// ============================================
+// Eager props tests
+// ============================================
+
+interface EntityWithEager {
+  id: number;
+  name: string;
+  eagerRel: Ref<Tag>;
+  normalRel: Ref<Tag>;
+  [PrimaryKeyProp]?: 'id';
+  [EagerProps]?: 'eagerRel';
+}
+
+bench('Loaded - with eager props', () => {
+  useLoaded<EntityWithEager, 'normalRel'>({} as Loaded<EntityWithEager, 'normalRel'>);
+}).types([1700, 'instantiations']);
+
+// ============================================
+// Fields selection tests
+// ============================================
+
+bench('Loaded - with fields selection', () => {
+  const entity = {} as Loaded<Author, 'books', 'name' | 'email'>;
+  void entity;
+}).types([900, 'instantiations']);
+
+bench('Loaded - with exclude', () => {
+  const entity = {} as Loaded<Author, 'books', '*', 'age'>;
+  void entity;
+}).types([700, 'instantiations']);


### PR DESCRIPTION
Introduce `CollectionShape<T>` and `LoadedCollectionShape<T>` helper types for matching Collection without triggering full interface evaluation. This avoids forcing TypeScript to evaluate Collection's 30+ methods.

The generic parameter allows both matching (`T extends CollectionShape`) and inference (`T extends CollectionShape<infer U>`).

Before → After (type instantiations):

- AutoPath simple property: 133,933 → 1,747 (99% reduction)
- AutoPath with Collection: 134,050 → 1,842 (99% reduction)
- Loaded with Collection: 133,458 → 947 (99% reduction)
- Loaded no populate: 659 → 597 (9% reduction)

Also adds `yarn bench:types` script and CI job to run type performance benchmarks on PRs.