### PR TITLE
feat(entity-generator): add `manyToManyPropertyName` to `NamingStrategy`

### DIFF
--- a/docs/docs/naming-strategy.md
+++ b/docs/docs/naming-strategy.md
@@ -133,8 +133,16 @@ Returns alias name for given entity. The alias needs to be unique across the que
 Returns the name of the inverse side property. Used in the `EntityGenerator` with `bidirectionalRelations` option. The default implementation will vary based on the property kind:
 
 - M:N relations will be named as `${propertyName}Inverse` (the property name is inferred from pivot table name).
-- Other relation kinds will use the target entity name, with first character lowercased, and `Collection` appended in case it's a 1:M collection. 
+- Other relation kinds will use the target entity name, with first character lowercased, and `Collection` appended in case it's a 1:M collection.
 
 > This behavior changed in v6.3, before that, all the properties were named with the `Inverse` suffix as the M:N relations are now.
+
+---
+
+#### `NamingStrategy.manyToManyPropertyName(ownerEntityName: string, targetEntityName: string, pivotTableName: string, ownerTableName: string, schemaName?: string): string`
+
+Returns the property name for a many-to-many relation. Used in the `EntityGenerator` when generating M:N relations from pivot tables. The default implementation strips the owner table name prefix from the pivot table name and converts it to a property name using `columnNameToProperty`.
+
+For example, with a pivot table `author_books` and owner table `author`, the default implementation returns `books`.
 
 ---

--- a/packages/core/src/naming-strategy/AbstractNamingStrategy.ts
+++ b/packages/core/src/naming-strategy/AbstractNamingStrategy.ts
@@ -104,6 +104,19 @@ export abstract class AbstractNamingStrategy implements NamingStrategy {
     return entityName[0].toLowerCase() + entityName.substring(1) + suffix;
   }
 
+  /**
+   * @inheritDoc
+   */
+  manyToManyPropertyName(
+    ownerEntityName: string,
+    targetEntityName: string,
+    pivotTableName: string,
+    ownerTableName: string,
+    schemaName?: string,
+  ): string {
+    return this.columnNameToProperty(pivotTableName.replace(new RegExp('^' + ownerTableName + '_'), ''));
+  }
+
   abstract classToTableName(entityName: string, tableName?: string): string;
 
   abstract joinColumnName(propertyName: string): string;

--- a/packages/core/src/naming-strategy/NamingStrategy.ts
+++ b/packages/core/src/naming-strategy/NamingStrategy.ts
@@ -103,4 +103,21 @@ export interface NamingStrategy {
    */
   inverseSideName(entityName: string, propertyName: string, kind: ReferenceKind): string;
 
+  /**
+   * Return a property name for a many-to-many relation (used in `EntityGenerator`).
+   *
+   * @param ownerEntityName - The owner entity class name
+   * @param targetEntityName - The target entity class name
+   * @param pivotTableName - The pivot table name
+   * @param ownerTableName - The owner table name
+   * @param schemaName - The schema name (if any)
+   */
+  manyToManyPropertyName(
+    ownerEntityName: string,
+    targetEntityName: string,
+    pivotTableName: string,
+    ownerTableName: string,
+    schemaName?: string,
+  ): string;
+
 }

--- a/packages/entity-generator/src/EntityGenerator.ts
+++ b/packages/entity-generator/src/EntityGenerator.ts
@@ -346,8 +346,15 @@ export class EntityGenerator {
       }
 
       const owner = metadata.find(m => m.className === meta.relations[0].type)!;
+      const target = metadata.find(m => m.className === meta.relations[1].type)!;
 
-      const name = this.namingStrategy.columnNameToProperty(meta.tableName.replace(new RegExp('^' + owner.tableName + '_'), ''));
+      const name = this.namingStrategy.manyToManyPropertyName(
+        owner.className,
+        target.className,
+        meta.tableName,
+        owner.tableName,
+        meta.schema,
+      );
       const ownerProp = {
         name,
         kind: ReferenceKind.MANY_TO_MANY,

--- a/tests/UnderscoreNamingStrategy.test.ts
+++ b/tests/UnderscoreNamingStrategy.test.ts
@@ -30,4 +30,12 @@ describe('UnderscoreNamingStrategy', () => {
     expect(ns.inverseSideName('User', 'friends', ReferenceKind.MANY_TO_MANY)).toBe('friendsInverse');
   });
 
+  test('many to many property name', async () => {
+    expect(ns.manyToManyPropertyName('Author', 'Book', 'author_books', 'author')).toBe('books');
+    expect(ns.manyToManyPropertyName('Author', 'Book', 'author_favorite_books', 'author')).toBe('favoriteBooks');
+    expect(ns.manyToManyPropertyName('User', 'Role', 'user_roles', 'user')).toBe('roles');
+    // when pivot table doesn't have owner prefix, returns full name
+    expect(ns.manyToManyPropertyName('Author', 'Book', 'books_authors', 'author')).toBe('booksAuthors');
+  });
+
 });


### PR DESCRIPTION
Allow customizing the property name for many-to-many relations in the `EntityGenerator` via a dedicated `NamingStrategy` method. This enables users to override M:N property naming without affecting other column-to-property conversions.

Closes #5871