### PR TITLE
feat(sqlite): add `ATTACH DATABASE` support for multiple database files

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -224,6 +224,7 @@ export interface ConnectionOptions {
   charset?: string;
   multipleStatements?: boolean; // for mysql driver
   pool?: PoolConfig;
+  attachDatabases?: { name: string; path: string }[]; // SQLite/libSQL only
 }
 ```
 
@@ -255,6 +256,12 @@ MikroORM.init({
 ```
 
 Read more about this in [Installation](./quick-start.md) and [Read Connections](./read-connections.md) sections.
+
+### Attached Databases (SQLite)
+
+SQLite and libSQL drivers support attaching additional database files to a single connection via the `attachDatabases` option. Each attached database acts as a separate schema, allowing you to organize entities across multiple database files.
+
+Read more about this in [Using Multiple Schemas](./multiple-schemas.md#sqlite-attach-database) section.
 
 ### Using short-lived tokens
 

--- a/docs/docs/multiple-schemas.md
+++ b/docs/docs/multiple-schemas.md
@@ -2,7 +2,10 @@
 title: Using Multiple Schemas
 ---
 
-In MySQL and PostgreSQL it is possible to define your entities in multiple schemas. In MySQL terminology, it is called database, but from an implementation point of view, it is a schema.
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+In MySQL, PostgreSQL, and SQLite (via ATTACH DATABASE) it is possible to define your entities in multiple schemas. In MySQL terminology, it is called database, but from an implementation point of view, it is a schema.
 
 > To use multiple schemas, your connection needs to have access to all of them (multiple connections are not supported in a single MikroORM instance).
 
@@ -97,3 +100,184 @@ On runtime, the wildcard schema will be replaced with either `FindOptions.schema
 ### Note about migrations
 
 Currently, this is not supported via migrations, they will always ignore wildcard schema entities, and `SchemaGenerator` needs to be used explicitly. Given the dynamic nature of such entities, it makes sense to only sync the schema dynamically, e.g. in an API endpoint. We could still use the ORM migrations, but we need to add the dynamic schema queries manually to migration files. It makes sense to use the `safe` mode for such queries.
+
+## SQLite ATTACH DATABASE
+
+SQLite supports multiple schemas via the `ATTACH DATABASE` command, which allows attaching additional database files to a single connection. Each attached database acts as a separate schema, and tables are accessed using the `schema.table_name` syntax.
+
+### Configuration
+
+Use the `attachDatabases` option to specify databases to attach on connection:
+
+```ts
+import { MikroORM } from '@mikro-orm/sqlite'; // or @mikro-orm/libsql
+
+const orm = await MikroORM.init({
+  dbName: './main.db',
+  entities: [Author, Book, UserProfile, LogEntry],
+  attachDatabases: [
+    { name: 'users_db', path: './users.db' },
+    { name: 'logs_db', path: '/var/data/logs.db' },
+  ],
+});
+```
+
+Relative paths are resolved from the `baseDir` option (or current working directory if not set).
+
+### Entity Definition
+
+Reference attached databases using the `schema` option:
+
+<Tabs
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'defineEntity', value: 'define-entity'},
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'EntitySchema', value: 'entity-schema'},
+  ]
+  }>
+  <TabItem value="define-entity">
+
+```ts
+import { defineEntity, p } from '@mikro-orm/core';
+
+// Entity in the main database (schema is optional for main)
+export const Author = defineEntity({
+  name: 'Author',
+  schema: 'main',
+  properties: {
+    id: p.number().primary(),
+    name: p.string(),
+  },
+});
+
+// Entity in an attached database
+export const UserProfile = defineEntity({
+  name: 'UserProfile',
+  schema: 'users_db',
+  properties: {
+    id: p.number().primary(),
+    username: p.string(),
+  },
+});
+```
+
+  </TabItem>
+  <TabItem value="reflect-metadata">
+
+```ts
+// Entity in the main database (schema is optional for main)
+@Entity({ schema: 'main' })
+class Author {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+}
+
+// Entity in an attached database
+@Entity({ schema: 'users_db' })
+class UserProfile {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  username!: string;
+
+}
+```
+
+  </TabItem>
+  <TabItem value="ts-morph">
+
+```ts
+// Entity in the main database (schema is optional for main)
+@Entity({ schema: 'main' })
+class Author {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+}
+
+// Entity in an attached database
+@Entity({ schema: 'users_db' })
+class UserProfile {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  username!: string;
+
+}
+```
+
+  </TabItem>
+  <TabItem value="entity-schema">
+
+```ts
+export interface IAuthor {
+  id: number;
+  name: string;
+}
+
+export interface IUserProfile {
+  id: number;
+  username: string;
+}
+
+// Entity in the main database (schema is optional for main)
+export const Author = new EntitySchema<IAuthor>({
+  name: 'Author',
+  schema: 'main',
+  properties: {
+    id: { type: 'number', primary: true },
+    name: { type: 'string' },
+  },
+});
+
+// Entity in an attached database
+export const UserProfile = new EntitySchema<IUserProfile>({
+  name: 'UserProfile',
+  schema: 'users_db',
+  properties: {
+    id: { type: 'number', primary: true },
+    username: { type: 'string' },
+  },
+});
+```
+
+  </TabItem>
+</Tabs>
+
+### Schema Generator Support
+
+The schema generator fully supports attached databases. It will:
+
+- Create tables in the correct attached database based on the entity's `schema` option
+- Detect and diff tables across all attached databases
+- Generate proper migration SQL for each database
+
+```ts
+// Creates tables in all databases (main and attached)
+await orm.schema.create();
+
+// Updates schema across all databases
+await orm.schema.updateSchema();
+```
+
+### Limitations
+
+- **libSQL remote connections**: ATTACH DATABASE is not supported when using remote libSQL URLs (`libsql://`, `https://`). Only local file-based databases can be attached.
+- **Cross-database foreign keys**: While SQLite allows foreign keys between attached databases within the same connection, the referenced table name in the SQL syntax cannot include a schema prefix. MikroORM handles this automatically.
+- **Transactions**: All attached databases share the same transaction scope within a connection.

--- a/packages/core/src/utils/Configuration.ts
+++ b/packages/core/src/utils/Configuration.ts
@@ -497,6 +497,18 @@ export interface ConnectionOptions {
   driverOptions?: Dictionary;
   /** Callback to execute when a new connection is created. */
   onCreateConnection?: (connection: unknown) => Promise<void>;
+  /**
+   * SQLite/libSQL: databases to attach on connection.
+   * Each attached database acts as a schema, accessible via `schema.table` syntax.
+   * Entities can reference attached databases via `@Entity({ schema: 'db_name' })`.
+   * Note: Not supported for remote libSQL connections.
+   * @example
+   * attachDatabases: [
+   *   { name: 'users_db', path: './users.db' },
+   *   { name: 'logs_db', path: '/var/data/logs.db' },
+   * ]
+   */
+  attachDatabases?: { name: string; path: string }[];
 }
 
 /**

--- a/packages/libsql/src/LibSqlConnection.ts
+++ b/packages/libsql/src/LibSqlConnection.ts
@@ -6,6 +6,11 @@ export class LibSqlConnection extends BaseSqliteConnection {
 
   private database!: Database.Database;
 
+  override async connect(options?: { skipOnConnect?: boolean }): Promise<void> {
+    this.validateAttachSupport();
+    await super.connect(options);
+  }
+
   override createKyselyDialect(options: Dictionary & Options) {
     const dbName = options.url ?? this.config.get('dbName');
     options.authToken ??= this.config.get('password');
@@ -21,6 +26,20 @@ export class LibSqlConnection extends BaseSqliteConnection {
   override async executeDump(source: string): Promise<void> {
     await this.ensureConnection();
     this.database.exec(source);
+  }
+
+  private validateAttachSupport(): void {
+    const attachDatabases = this.config.get('attachDatabases');
+    if (!attachDatabases?.length) {
+      return;
+    }
+    const dbName = this.config.get('dbName') as string;
+    if (dbName?.match(/^(https?|libsql):\/\//)) {
+      throw new Error(
+        'ATTACH DATABASE is not supported for remote libSQL connections. ' +
+        'Use local file-based databases only.',
+      );
+    }
   }
 
 }

--- a/packages/sql/src/dialects/sqlite/BaseSqliteConnection.ts
+++ b/packages/sql/src/dialects/sqlite/BaseSqliteConnection.ts
@@ -6,6 +6,23 @@ export abstract class BaseSqliteConnection extends AbstractSqlConnection {
   override async connect(options?: { skipOnConnect?: boolean }): Promise<void> {
     await super.connect(options);
     await this.getClient().executeQuery(CompiledQuery.raw('pragma foreign_keys = on'));
+    await this.attachDatabases();
+  }
+
+  protected async attachDatabases(): Promise<void> {
+    const attachDatabases = this.config.get('attachDatabases');
+
+    if (!attachDatabases?.length) {
+      return;
+    }
+
+    const { fs } = await import('@mikro-orm/core/fs-utils');
+    const baseDir = this.config.get('baseDir');
+
+    for (const db of attachDatabases) {
+      const path = fs.absolutePath(db.path, baseDir);
+      await this.execute(`attach database '${path}' as ${this.platform.quoteIdentifier(db.name)}`);
+    }
   }
 
 }

--- a/packages/sql/src/dialects/sqlite/BaseSqlitePlatform.ts
+++ b/packages/sql/src/dialects/sqlite/BaseSqlitePlatform.ts
@@ -115,6 +115,20 @@ export abstract class BaseSqlitePlatform extends AbstractSqlPlatform {
     return false;
   }
 
+  /**
+   * SQLite supports schemas via ATTACH DATABASE. Returns true when there are
+   * attached databases configured.
+   */
+  override supportsSchemas(): boolean {
+    const attachDatabases = this.config.get('attachDatabases');
+    return !!attachDatabases?.length;
+  }
+
+  override getDefaultSchemaName(): string | undefined {
+    // Return 'main' only when schema support is active (i.e., databases are attached)
+    return this.supportsSchemas() ? 'main' : undefined;
+  }
+
   override getFullTextWhereClause(): string {
     return `:column: match :query`;
   }

--- a/packages/sql/src/schema/DatabaseSchema.ts
+++ b/packages/sql/src/schema/DatabaseSchema.ts
@@ -8,7 +8,7 @@ import {
 } from '@mikro-orm/core';
 import { DatabaseTable } from './DatabaseTable.js';
 import type { AbstractSqlConnection } from '../AbstractSqlConnection.js';
-import type { DatabaseView, Table } from '../typings.js';
+import type { DatabaseView } from '../typings.js';
 import type { AbstractSqlPlatform } from '../AbstractSqlPlatform.js';
 
 /**
@@ -106,7 +106,7 @@ export class DatabaseSchema {
 
   static async create(connection: AbstractSqlConnection, platform: AbstractSqlPlatform, config: Configuration, schemaName?: string, schemas?: string[], takeTables?: (string | RegExp)[], skipTables?: (string | RegExp)[]): Promise<DatabaseSchema> {
     const schema = new DatabaseSchema(platform, schemaName ?? config.get('schema') ?? platform.getDefaultSchemaName());
-    const allTables = await connection.execute<Table[]>(platform.getSchemaHelper()!.getListTablesSQL());
+    const allTables = await platform.getSchemaHelper()!.getAllTables(connection, schemas);
     const parts = config.get('migrations').tableName!.split('.');
     const migrationsTableName = parts[1] ?? parts[0];
     const migrationsSchemaName = parts.length > 1 ? parts[0] : config.get('schema', platform.getDefaultSchemaName());

--- a/packages/sql/src/schema/SchemaHelper.ts
+++ b/packages/sql/src/schema/SchemaHelper.ts
@@ -92,6 +92,10 @@ export abstract class SchemaHelper {
     throw new Error('Not supported by given driver');
   }
 
+  async getAllTables(connection: AbstractSqlConnection, schemas?: string[]): Promise<Table[]> {
+    return connection.execute<Table[]>(this.getListTablesSQL());
+  }
+
   getListViewsSQL(): string {
     throw new Error('Not supported by given driver');
   }

--- a/tests/features/attach-database/attach-database.sqlite.test.ts
+++ b/tests/features/attach-database/attach-database.sqlite.test.ts
@@ -1,0 +1,457 @@
+import 'reflect-metadata';
+import { existsSync, mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  Collection,
+  MikroORM,
+  Ref,
+  SimpleLogger,
+} from '@mikro-orm/core';
+import { Entity, ManyToOne, OneToMany, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+import { SqliteDriver } from '@mikro-orm/sqlite';
+import { LibSqlDriver } from '@mikro-orm/libsql';
+
+// Test entities for the main database
+@Entity({ schema: 'main' })
+class MainAuthor {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @OneToMany(() => MainBook, book => book.author)
+  books = new Collection<MainBook>(this);
+
+}
+
+@Entity({ schema: 'main' })
+class MainBook {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  title!: string;
+
+  @ManyToOne(() => MainAuthor, { ref: true })
+  author!: Ref<MainAuthor>;
+
+}
+
+// Test entities for the attached 'users_db' database
+@Entity({ schema: 'users_db' })
+class UserProfile {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  username!: string;
+
+  @Property()
+  email!: string;
+
+}
+
+// Test entities for the attached 'logs_db' database
+@Entity({ schema: 'logs_db' })
+class LogEntry {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  level!: string;
+
+  @Property()
+  message!: string;
+
+  @Property()
+  createdAt: Date = new Date();
+
+}
+
+describe.each(['sqlite', 'libsql'] as const)('ATTACH DATABASE (%s)', driver => {
+  const tempDir = join(tmpdir(), `mikro-orm-attach-test-${Date.now()}`);
+  let orm: MikroORM<SqliteDriver | LibSqlDriver>;
+
+  beforeAll(async () => {
+    // Create temp directory for database files
+    if (!existsSync(tempDir)) {
+      mkdirSync(tempDir, { recursive: true });
+    }
+
+    const mainDbPath = join(tempDir, 'main.db');
+    const usersDbPath = join(tempDir, 'users.db');
+    const logsDbPath = join(tempDir, 'logs.db');
+
+    orm = await MikroORM.init({
+      entities: [MainAuthor, MainBook, UserProfile, LogEntry],
+      dbName: mainDbPath,
+      driver: driver === 'sqlite' ? SqliteDriver : LibSqlDriver as any,
+      metadataProvider: ReflectMetadataProvider,
+      debug: ['query'],
+      logger: i => i,
+      loggerFactory: SimpleLogger.create,
+      attachDatabases: [
+        { name: 'users_db', path: usersDbPath },
+        { name: 'logs_db', path: logsDbPath },
+      ],
+    });
+
+    // Create tables in all databases
+    await orm.schema.create();
+  });
+
+  afterAll(async () => {
+    await orm?.close(true);
+    // Clean up temp directory - ignore errors on Windows where files may still be locked
+    try {
+      rmSync(tempDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+    } catch {
+      // noop
+    }
+  });
+
+  test('should attach databases on connection', async () => {
+    // Verify all databases are attached
+    const connection = orm.em.getConnection();
+    const databases = await connection.execute<{ name: string; file: string }[]>('pragma database_list');
+    const dbNames = databases.map(d => d.name);
+
+    expect(dbNames).toContain('main');
+    expect(dbNames).toContain('users_db');
+    expect(dbNames).toContain('logs_db');
+  });
+
+  test('should create tables in correct databases', async () => {
+    const connection = orm.em.getConnection();
+
+    // Check tables in main database
+    const mainTables = await connection.execute<{ name: string }[]>(
+      `select name from main.sqlite_master where type = 'table' and name not like 'sqlite_%'`,
+    );
+    const mainTableNames = mainTables.map(t => t.name);
+    expect(mainTableNames).toContain('main_author');
+    expect(mainTableNames).toContain('main_book');
+
+    // Check tables in users_db database
+    const usersTables = await connection.execute<{ name: string }[]>(
+      `select name from users_db.sqlite_master where type = 'table' and name not like 'sqlite_%'`,
+    );
+    const usersTableNames = usersTables.map(t => t.name);
+    expect(usersTableNames).toContain('user_profile');
+
+    // Check tables in logs_db database
+    const logsTables = await connection.execute<{ name: string }[]>(
+      `select name from logs_db.sqlite_master where type = 'table' and name not like 'sqlite_%'`,
+    );
+    const logsTableNames = logsTables.map(t => t.name);
+    expect(logsTableNames).toContain('log_entry');
+  });
+
+  test('should perform CRUD operations on main database entities', async () => {
+    const author = new MainAuthor();
+    author.name = 'Test Author';
+    orm.em.persist(author);
+    await orm.em.flush();
+    orm.em.clear();
+
+    const loadedAuthor = await orm.em.findOneOrFail(MainAuthor, { name: 'Test Author' });
+    expect(loadedAuthor.name).toBe('Test Author');
+
+    loadedAuthor.name = 'Updated Author';
+    await orm.em.flush();
+    orm.em.clear();
+
+    const updatedAuthor = await orm.em.findOneOrFail(MainAuthor, loadedAuthor.id);
+    expect(updatedAuthor.name).toBe('Updated Author');
+
+    orm.em.remove(updatedAuthor);
+    await orm.em.flush();
+
+    const count = await orm.em.count(MainAuthor);
+    expect(count).toBe(0);
+  });
+
+  test('should perform CRUD operations on attached database entities', async () => {
+    // Test UserProfile in users_db
+    const profile = new UserProfile();
+    profile.username = 'testuser';
+    profile.email = 'test@example.com';
+    orm.em.persist(profile);
+    await orm.em.flush();
+    orm.em.clear();
+
+    const loadedProfile = await orm.em.findOneOrFail(UserProfile, { username: 'testuser' });
+    expect(loadedProfile.email).toBe('test@example.com');
+
+    // Test LogEntry in logs_db
+    const log = new LogEntry();
+    log.level = 'info';
+    log.message = 'Test log message';
+    orm.em.persist(log);
+    await orm.em.flush();
+    orm.em.clear();
+
+    const loadedLog = await orm.em.findOneOrFail(LogEntry, { level: 'info' });
+    expect(loadedLog.message).toBe('Test log message');
+
+    // Cleanup
+    orm.em.remove(loadedProfile);
+    orm.em.remove(loadedLog);
+    await orm.em.flush();
+  });
+
+  test('should detect all tables across attached databases via schema generator', async () => {
+    const schemaHelper = orm.em.getDriver().getPlatform().getSchemaHelper()!;
+    const connection = orm.em.getConnection();
+
+    // Get tables from all databases
+    const tables = await schemaHelper.getAllTables(connection);
+    const tableNames = tables.map(t => `${t.schema_name}.${t.table_name}`);
+
+    expect(tableNames).toContain('main.main_author');
+    expect(tableNames).toContain('main.main_book');
+    expect(tableNames).toContain('users_db.user_profile');
+    expect(tableNames).toContain('logs_db.log_entry');
+  });
+
+  test('should get namespaces (attached databases)', async () => {
+    const schemaHelper = orm.em.getDriver().getPlatform().getSchemaHelper()!;
+    const connection = orm.em.getConnection();
+
+    const namespaces = await schemaHelper.getNamespaces(connection);
+    expect(namespaces).toContain('main');
+    expect(namespaces).toContain('users_db');
+    expect(namespaces).toContain('logs_db');
+  });
+
+  test('should load views from attached databases', async () => {
+    const connection = orm.em.getConnection();
+
+    // Create a view in the users_db
+    await connection.execute(`create view users_db.active_users as select * from users_db.user_profile`);
+
+    const schemaHelper = orm.em.getDriver().getPlatform().getSchemaHelper()!;
+    const { DatabaseSchema } = await import('@mikro-orm/sql');
+
+    const schema = new DatabaseSchema(orm.em.getDriver().getPlatform(), 'main');
+    await schemaHelper.loadViews(schema, connection);
+
+    const views = schema.getViews();
+    const viewNames = views.map(v => `${v.schema}.${v.name}`);
+    expect(viewNames).toContain('users_db.active_users');
+
+    // Cleanup
+    await connection.execute('drop view users_db.active_users');
+  });
+
+  test('platform should report schema support', () => {
+    const platform = orm.em.getDriver().getPlatform();
+    expect(platform.supportsSchemas()).toBe(true);
+    expect(platform.getDefaultSchemaName()).toBe('main');
+  });
+
+  test('schema.update() should work with attached databases', async () => {
+    const connection = orm.em.getConnection();
+
+    // Add a column via raw SQL to an attached database table
+    await connection.execute('alter table users_db.user_profile add column bio text');
+
+    // schema.update should detect the difference
+    const updateSQL = await orm.schema.getUpdateSchemaSQL({ wrap: false, safe: false });
+    // Should want to drop the extra 'bio' column
+    expect(updateSQL).toContain('drop column');
+    expect(updateSQL).toContain('bio');
+
+    // Clean up - recreate the table without the extra column
+    await connection.execute('drop table users_db.user_profile');
+    await connection.execute('create table users_db.user_profile (id integer not null primary key autoincrement, username text not null, email text not null)');
+  });
+
+  test('schema.getCreateSchemaSQL() should not include CREATE SCHEMA statements', async () => {
+    const sql = await orm.schema.getCreateSchemaSQL({ wrap: false });
+    // Should not contain CREATE SCHEMA since SQLite uses ATTACH DATABASE
+    expect(sql).not.toContain('create schema');
+    // But should contain table creation for attached databases
+    expect(sql).toContain('users_db');
+    expect(sql).toContain('logs_db');
+  });
+
+  test('schema.getUpdateSchemaSQL() should handle tables across multiple databases', async () => {
+    const updateSQL = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    // Should not contain CREATE SCHEMA since SQLite uses ATTACH DATABASE
+    expect(updateSQL).not.toContain('create schema');
+  });
+
+  test('should use dynamic schema from FindOptions', async () => {
+    // Create a user in the users_db
+    const profile = new UserProfile();
+    profile.username = 'dynamictest';
+    profile.email = 'dynamic@test.com';
+    orm.em.persist(profile);
+    await orm.em.flush();
+    const profileId = profile.id;
+    orm.em.clear();
+
+    // Find using explicit schema in FindOptions (should work the same)
+    const found = await orm.em.findOne(UserProfile, { id: profileId }, { schema: 'users_db' });
+    expect(found).not.toBeNull();
+    expect(found!.username).toBe('dynamictest');
+
+    // Cleanup
+    orm.em.remove(found!);
+    await orm.em.flush();
+  });
+
+  test('should use schema from forked EntityManager', async () => {
+    // Create a user in users_db
+    const profile = new UserProfile();
+    profile.username = 'forktest';
+    profile.email = 'fork@test.com';
+    orm.em.persist(profile);
+    await orm.em.flush();
+    const profileId = profile.id;
+    orm.em.clear();
+
+    // Fork EM with specific schema
+    const fork = orm.em.fork({ schema: 'users_db' });
+
+    // Find using forked EM - schema should be used
+    const found = await fork.findOne(UserProfile, { id: profileId });
+    expect(found).not.toBeNull();
+    expect(found!.username).toBe('forktest');
+
+    // Cleanup
+    fork.remove(found!);
+    await fork.flush();
+  });
+
+  test('should support QueryBuilder with schema', async () => {
+    // Create test data
+    const profile = new UserProfile();
+    profile.username = 'qbtest';
+    profile.email = 'qb@test.com';
+    orm.em.persist(profile);
+    await orm.em.flush();
+    orm.em.clear();
+
+    // Query using QueryBuilder
+    const qb = orm.em.createQueryBuilder(UserProfile);
+    const result = await qb.where({ username: 'qbtest' }).getSingleResult();
+    expect(result).not.toBeNull();
+    expect(result!.email).toBe('qb@test.com');
+
+    // Cleanup
+    orm.em.remove(result!);
+    await orm.em.flush();
+  });
+
+});
+
+@Entity({ schema: 'attached_db' })
+class RelPathTestEntity {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  value!: string;
+
+}
+
+@Entity()
+class RemoteTestEntity {
+
+  @PrimaryKey()
+  id!: number;
+
+}
+
+describe('ATTACH DATABASE - relative path resolution', () => {
+  const tempDir = join(tmpdir(), `mikro-orm-attach-relpath-${Date.now()}`);
+  let orm: MikroORM<SqliteDriver>;
+
+  beforeAll(async () => {
+    if (!existsSync(tempDir)) {
+      mkdirSync(tempDir, { recursive: true });
+    }
+  });
+
+  afterAll(async () => {
+    await orm?.close(true);
+    // Clean up temp directory - ignore errors on Windows where files may still be locked
+    try {
+      rmSync(tempDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+    } catch {
+      // noop
+    }
+  });
+
+  test('should resolve relative paths from baseDir', async () => {
+    const mainDbPath = join(tempDir, 'main.db');
+
+    orm = await MikroORM.init({
+      entities: [RelPathTestEntity],
+      dbName: mainDbPath,
+      baseDir: tempDir,
+      driver: SqliteDriver,
+      metadataProvider: ReflectMetadataProvider,
+      logger: i => i,
+      loggerFactory: SimpleLogger.create,
+      attachDatabases: [
+        // Relative path - should resolve from tempDir
+        { name: 'attached_db', path: './attached.db' },
+      ],
+    });
+
+    await orm.schema.create();
+
+    // Verify the attached database was created in the baseDir
+    expect(existsSync(join(tempDir, 'attached.db'))).toBe(true);
+
+    // Verify we can use the attached database
+    const connection = orm.em.getConnection();
+    const databases = await connection.execute<{ name: string }[]>('pragma database_list');
+    const dbNames = databases.map(d => d.name);
+    expect(dbNames).toContain('attached_db');
+  });
+});
+
+describe('ATTACH DATABASE - libSQL remote validation', () => {
+  test('should throw error when trying to attach databases to remote libSQL', async () => {
+    const orm = await MikroORM.init({
+      entities: [RemoteTestEntity],
+      dbName: 'libsql://example.turso.io',
+      driver: LibSqlDriver,
+      metadataProvider: ReflectMetadataProvider,
+      logger: i => i,
+      attachDatabases: [
+        { name: 'attached_db', path: './attached.db' },
+      ],
+    });
+    // Connection happens lazily - calling connect() should trigger the error
+    await expect(orm.connect()).rejects.toThrow('ATTACH DATABASE is not supported for remote libSQL connections');
+    await orm.close(true);
+  });
+
+  test('should throw error for https remote libSQL', async () => {
+    const orm = await MikroORM.init({
+      entities: [RemoteTestEntity],
+      dbName: 'https://example.turso.io',
+      driver: LibSqlDriver,
+      metadataProvider: ReflectMetadataProvider,
+      logger: i => i,
+      attachDatabases: [
+        { name: 'attached_db', path: './attached.db' },
+      ],
+    });
+    // Connection happens lazily - calling connect() should trigger the error
+    await expect(orm.connect()).rejects.toThrow('ATTACH DATABASE is not supported for remote libSQL connections');
+    await orm.close(true);
+  });
+});

--- a/tests/features/migrations/__snapshots__/Migrator.sqlite.test.ts.snap
+++ b/tests/features/migrations/__snapshots__/Migrator.sqlite.test.ts.snap
@@ -222,6 +222,7 @@ exports[`Migrator (sqlite) > generate schema migration > migration-dump 1`] = `
 exports[`Migrator (sqlite) > up/down params [all or nothing disabled] > all-or-nothing-disabled 1`] = `
 [
   "select name as table_name from sqlite_master where type = 'table' and name != 'sqlite_sequence' and name != 'geometry_columns' and name != 'spatial_ref_sys' union all select name as table_name from sqlite_temp_master where type = 'table' order by name",
+  "pragma database_list",
   "create table \`mikro_orm_migrations\` (\`id\` integer not null primary key autoincrement, \`name\` text not null, \`executed_at\` datetime not null default current_timestamp);",
   "select \`m0\`.* from \`mikro_orm_migrations\` as \`m0\` order by \`m0\`.\`id\` asc",
   "[migrator] Processing 'Migration20191013214813'",
@@ -278,6 +279,7 @@ exports[`Migrator (sqlite) > up/down params [all or nothing disabled] > all-or-n
 exports[`Migrator (sqlite) > up/down params [all or nothing enabled] > all-or-nothing 1`] = `
 [
   "select name as table_name from sqlite_master where type = 'table' and name != 'sqlite_sequence' and name != 'geometry_columns' and name != 'spatial_ref_sys' union all select name as table_name from sqlite_temp_master where type = 'table' order by name",
+  "pragma database_list",
   "create table \`mikro_orm_migrations\` (\`id\` integer not null primary key autoincrement, \`name\` text not null, \`executed_at\` datetime not null default current_timestamp);",
   "begin",
   "select \`m0\`.* from \`mikro_orm_migrations\` as \`m0\` order by \`m0\`.\`id\` asc",


### PR DESCRIPTION
Implement SQLite's ATTACH DATABASE feature to allow multiple database files on a single connection. Tables in attached databases are accessed via schema prefix (e.g., `schema.table_name`), mapping to MikroORM's existing schema infrastructure.

Closes #1180