### PR TITLE
perf(core): optimize type instantiation costs with structural shapes

### DIFF
--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -8,7 +8,7 @@ import type {
   IPrimaryKey,
 } from './typings.js';
 import { inspect } from './logging/inspect.js';
-import { Utils } from '@mikro-orm/core';
+import { Utils } from './utils/Utils.js';
 
 export class ValidationError<T extends AnyEntity = AnyEntity> extends Error {
 

--- a/tests/bench/types/api-methods.ts
+++ b/tests/bench/types/api-methods.ts
@@ -1,0 +1,227 @@
+#!/usr/bin/env -S node --import=tsx
+
+/**
+ * Benchmarks for common API method signatures.
+ * Tests em.find, em.create, em.populate, serialize, wrap().toObject(), etc.
+ */
+
+import { bench } from '@ark/attest';
+import {
+  type EntityManager,
+  type FilterQuery,
+  type Loaded,
+  type Ref,
+  type Collection,
+  type EntityData,
+  type EntityDTO,
+  type RequiredEntityData,
+  type New,
+  PrimaryKeyProp,
+} from '@mikro-orm/core';
+
+// ============================================
+// Test Entity Definitions
+// ============================================
+
+interface Tag {
+  id: number;
+  name: string;
+  [PrimaryKeyProp]?: 'id';
+}
+
+interface Publisher {
+  id: number;
+  name: string;
+  address: string;
+  books: Collection<Book>;
+  [PrimaryKeyProp]?: 'id';
+}
+
+interface Book {
+  id: number;
+  title: string;
+  price: number;
+  author: Author;
+  publisher?: Ref<Publisher> | null;
+  tags: Collection<Tag>;
+  [PrimaryKeyProp]?: 'id';
+}
+
+interface Author {
+  id: number;
+  name: string;
+  email: string;
+  age?: number;
+  bio?: string;
+  books: Collection<Book>;
+  favouriteBook?: Ref<Book> | null;
+  friends: Collection<Author>;
+  [PrimaryKeyProp]?: 'id';
+}
+
+// ============================================
+// em.find() - return type computation
+// ============================================
+
+// Simulating what happens when you call em.find()
+declare const em: EntityManager;
+
+bench('em.find() return type - no options', () => {
+  type R = ReturnType<typeof em.find<Author>>;
+  const x = {} as R;
+  void x;
+}).types([721, 'instantiations']);
+
+bench('em.find() return type - with populate', () => {
+  type R = ReturnType<typeof em.find<Author, 'books'>>;
+  const x = {} as R;
+  void x;
+}).types([721, 'instantiations']);
+
+bench('em.find() return type - with populate and fields', () => {
+  type R = ReturnType<typeof em.find<Author, 'books', 'name' | 'email'>>;
+  const x = {} as R;
+  void x;
+}).types([719, 'instantiations']);
+
+// ============================================
+// em.create() - input and return type computation
+// ============================================
+
+bench('em.create() return type', () => {
+  type R = ReturnType<typeof em.create<Author>>;
+  const x = {} as R;
+  void x;
+}).types([1741, 'instantiations']);
+
+bench('RequiredEntityData - Author', () => {
+  type R = RequiredEntityData<Author>;
+  const x = {} as R;
+  void x;
+}).types([1436, 'instantiations']);
+
+bench('RequiredEntityData - Book', () => {
+  type R = RequiredEntityData<Book>;
+  const x = {} as R;
+  void x;
+}).types([1249, 'instantiations']);
+
+// New<T> type (used as create return type)
+bench('New<Author>', () => {
+  type R = New<Author>;
+  const x = {} as R;
+  void x;
+}).types([611, 'instantiations']);
+
+bench('New<Author, "books">', () => {
+  type R = New<Author, 'books'>;
+  const x = {} as R;
+  void x;
+}).types([1032, 'instantiations']);
+
+// ============================================
+// em.populate() - return type computation
+// ============================================
+
+bench('em.populate() return type - plain', () => {
+  type R = ReturnType<typeof em.populate<Author>>;
+  const x = {} as R;
+  void x;
+}).types([149, 'instantiations']);
+
+// ============================================
+// EntityDTO - used by toObject(), serialize()
+// ============================================
+
+bench('EntityDTO<Author>', () => {
+  type R = EntityDTO<Author>;
+  const x = {} as R;
+  void x;
+}).types([1078, 'instantiations']);
+
+bench('EntityDTO<Book>', () => {
+  type R = EntityDTO<Book>;
+  const x = {} as R;
+  void x;
+}).types([954, 'instantiations']);
+
+bench('EntityDTO<Loaded<Author, "books">>', () => {
+  type R = EntityDTO<Loaded<Author, 'books'>>;
+  const x = {} as R;
+  void x;
+}).types([3617, 'instantiations']);
+
+bench('EntityDTO<Loaded<Author, "books.publisher">>', () => {
+  type R = EntityDTO<Loaded<Author, 'books.publisher'>>;
+  const x = {} as R;
+  void x;
+}).types([3617, 'instantiations']);
+
+// ============================================
+// FilterQuery - used in where clauses
+// ============================================
+
+bench('FilterQuery<Author>', () => {
+  type R = FilterQuery<Author>;
+  const x = {} as R;
+  void x;
+}).types([534, 'instantiations']);
+
+bench('FilterQuery<Book>', () => {
+  type R = FilterQuery<Book>;
+  const x = {} as R;
+  void x;
+}).types([503, 'instantiations']);
+
+bench('FilterQuery<Loaded<Author, "books">>', () => {
+  type R = FilterQuery<Loaded<Author, 'books'>>;
+  const x = {} as R;
+  void x;
+}).types([2497, 'instantiations']);
+
+// ============================================
+// EntityData - used in em.assign()
+// ============================================
+
+bench('EntityData<Author>', () => {
+  type R = EntityData<Author>;
+  const x = {} as R;
+  void x;
+}).types([216, 'instantiations']);
+
+bench('EntityData<Loaded<Author, "books">>', () => {
+  type R = EntityData<Loaded<Author, 'books'>>;
+  const x = {} as R;
+  void x;
+}).types([1880, 'instantiations']);
+
+// ============================================
+// Simulating wrap(e).toObject()
+// ============================================
+
+// toObject returns EntityDTO<Entity>
+type ToObjectReturn<T> = EntityDTO<T>;
+
+bench('wrap(author).toObject() return type', () => {
+  type R = ToObjectReturn<Author>;
+  const x = {} as R;
+  void x;
+}).types([1079, 'instantiations']);
+
+bench('wrap(loadedAuthor).toObject() return type', () => {
+  type R = ToObjectReturn<Loaded<Author, 'books'>>;
+  const x = {} as R;
+  void x;
+}).types([3619, 'instantiations']);
+
+// ============================================
+// Complex scenarios
+// ============================================
+
+// Chained operations: find -> populate -> toObject
+bench('find result then EntityDTO', () => {
+  type FindResult = Loaded<Author, 'books'>;
+  type DTOResult = EntityDTO<FindResult>;
+  const x = {} as DTOResult;
+  void x;
+}).types([3617, 'instantiations']);

--- a/tests/bench/types/assign-types.ts
+++ b/tests/bench/types/assign-types.ts
@@ -64,11 +64,13 @@ function useFromEntityType<T>(_result: FromEntityType<T>): void {}
 
 bench('FromEntityType - plain entity', () => {
   useFromEntityType<Author>({} as FromEntityType<Author>);
-}).types([30, 'instantiations']);
+}).types([23, 'instantiations']);
 
 bench('FromEntityType - Loaded entity', () => {
-  useFromEntityType<Loaded<Author, 'books'>>({} as FromEntityType<Loaded<Author, 'books'>>);
-}).types([1200, 'instantiations']);
+  useFromEntityType<Loaded<Author, 'books'>>(
+    {} as FromEntityType<Loaded<Author, 'books'>>,
+  );
+}).types([1150, 'instantiations']);
 
 // ============================================
 // IsSubset benchmarks
@@ -80,13 +82,13 @@ bench('IsSubset - simple', () => {
   type R = IsSubset<EntityData<Author>, TestData>;
   const x = {} as R;
   void x;
-}).types([150, 'instantiations']);
+}).types([135, 'instantiations']);
 
 bench('IsSubset - with Loaded', () => {
   type R = IsSubset<EntityData<Author>, TestData>;
   const x = {} as R;
   void x;
-}).types([150, 'instantiations']);
+}).types([135, 'instantiations']);
 
 // ============================================
 // MergeSelected benchmarks (the known expensive one)
@@ -97,49 +99,53 @@ bench('MergeSelected - plain entity', () => {
   type R = MergeSelected<Author, Author, 'name'>;
   const x = {} as R;
   void x;
-}).types([15, 'instantiations']);
+}).types([7, 'instantiations']);
 
 bench('MergeSelected - Loaded entity', () => {
   type R = MergeSelected<Loaded<Author, 'books'>, Author, 'name'>;
   const x = {} as R;
   void x;
-}).types([2000, 'instantiations']);
+}).types([1958, 'instantiations']);
 
 // ============================================
 // Full assign signature simulation
 // ============================================
 
 // Simulate the assign return type computation
-type AssignReturnType<Entity extends object, Data> =
-  MergeSelected<Entity, FromEntityType<Entity>, keyof Data & string>;
+type AssignReturnType<Entity extends object, Data> = MergeSelected<
+  Entity,
+  FromEntityType<Entity>,
+  keyof Data & string
+>;
 
 bench('assign return type - plain entity', () => {
   type R = AssignReturnType<Author, { name: string }>;
   const x = {} as R;
   void x;
-}).types([30, 'instantiations']);
+}).types([22, 'instantiations']);
 
 bench('assign return type - Loaded entity', () => {
   type R = AssignReturnType<Loaded<Author, 'books'>, { name: string }>;
   const x = {} as R;
   void x;
-}).types([2000, 'instantiations']);
+}).types([1977, 'instantiations']);
 
 // ============================================
 // Data parameter type computation
 // ============================================
 
 type AssignDataType<Entity extends object, Convert extends boolean = false> =
-  EntityData<FromEntityType<Entity>, Convert> | Partial<EntityDTO<FromEntityType<Entity>>>;
+  | EntityData<FromEntityType<Entity>, Convert>
+  | Partial<EntityDTO<FromEntityType<Entity>>>;
 
 bench('assign data type - plain entity', () => {
   type R = AssignDataType<Author>;
   const x = {} as R;
   void x;
-}).types([3200, 'instantiations']);
+}).types([2214, 'instantiations']);
 
 bench('assign data type - Loaded entity', () => {
   type R = AssignDataType<Loaded<Author, 'books'>>;
   const x = {} as R;
   void x;
-}).types([4000, 'instantiations']);
+}).types([3315, 'instantiations']);

--- a/tests/bench/types/asterisk-hints.ts
+++ b/tests/bench/types/asterisk-hints.ts
@@ -1,0 +1,144 @@
+#!/usr/bin/env -S node --import=tsx
+
+/**
+ * Benchmarks for asterisk (*) populate hints.
+ * Tests Loaded with wildcard patterns for recursive population.
+ */
+
+import { bench } from '@ark/attest';
+import {
+  type Loaded,
+  type Ref,
+  type Collection,
+  PrimaryKeyProp,
+} from '@mikro-orm/core';
+
+// ============================================
+// Test Entity Definitions
+// ============================================
+
+interface Tag {
+  id: number;
+  name: string;
+  [PrimaryKeyProp]?: 'id';
+}
+
+interface Publisher {
+  id: number;
+  name: string;
+  address: string;
+  books: Collection<Book>;
+  [PrimaryKeyProp]?: 'id';
+}
+
+interface Book {
+  id: number;
+  title: string;
+  price: number;
+  author: Author;
+  publisher?: Ref<Publisher> | null;
+  tags: Collection<Tag>;
+  [PrimaryKeyProp]?: 'id';
+}
+
+interface Author {
+  id: number;
+  name: string;
+  email: string;
+  age?: number;
+  bio?: string;
+  books: Collection<Book>;
+  favouriteBook?: Ref<Book> | null;
+  friends: Collection<Author>;
+  [PrimaryKeyProp]?: 'id';
+}
+
+// ============================================
+// Loaded with asterisk (recursive populate all)
+// ============================================
+
+// eslint-disable-next-line
+function useLoaded<T, L extends string = never, F extends string = "*">(
+  _entity: Loaded<T, L, F>,
+): void { /* empty */ }
+
+bench('Loaded<Author, "*"> - asterisk populate all', () => {
+  useLoaded<Author, '*'>({} as Loaded<Author, '*'>);
+}).types([1390, 'instantiations']);
+
+bench('Loaded<Book, "*"> - asterisk populate all', () => {
+  useLoaded<Book, '*'>({} as Loaded<Book, '*'>);
+}).types([1921, 'instantiations']);
+
+bench('Loaded<Publisher, "*"> - asterisk populate all', () => {
+  useLoaded<Publisher, '*'>({} as Loaded<Publisher, '*'>);
+}).types([1066, 'instantiations']);
+
+// Compare with explicit paths
+bench('Loaded<Author, "books"> - single relation', () => {
+  useLoaded<Author, 'books'>({} as Loaded<Author, 'books'>);
+}).types([1163, 'instantiations']);
+
+bench('Loaded<Author, "books" | "friends"> - multiple relations', () => {
+  useLoaded<Author, 'books' | 'friends'>(
+    {} as Loaded<Author, 'books' | 'friends'>,
+  );
+}).types([1295, 'instantiations']);
+
+// ============================================
+// Loaded with asterisk fields (F parameter)
+// ============================================
+
+bench('Loaded<Author, "books", "*"> - default fields', () => {
+  useLoaded<Author, 'books', '*'>({} as Loaded<Author, 'books', '*'>);
+}).types([1023, 'instantiations']);
+
+bench('Loaded<Author, "books", "name" | "email"> - specific fields', () => {
+  useLoaded<Author, 'books', 'name' | 'email'>(
+    {} as Loaded<Author, 'books', 'name' | 'email'>,
+  );
+}).types([985, 'instantiations']);
+
+// ============================================
+// Helper type benchmarks
+// ============================================
+
+type Prefix<T, K> = K extends `${infer S}.${string}`
+  ? S
+  : K extends '*'
+    ? keyof T
+    : K;
+
+// eslint-disable-next-line
+function testPrefix<T, K>(_val: Prefix<T, K>): void {}
+
+bench('Prefix<Author, "*"> - asterisk expansion', () => {
+  testPrefix<Author, '*'>('books');
+}).types([11, 'instantiations']);
+
+bench('Prefix<Author, "books.title"> - dotted path', () => {
+  testPrefix<Author, 'books.title'>('books');
+}).types([9, 'instantiations']);
+
+type Suffix<
+  Key,
+  Hint extends string,
+  All = true | '*',
+> = Hint extends `${infer Pref}.${infer Suf}`
+  ? Pref extends Key
+    ? Suf
+    : never
+  : Hint extends All
+    ? Hint
+    : never;
+
+// eslint-disable-next-line
+function testSuffix<K, H extends string>(_val: Suffix<K, H>): void {}
+
+bench('Suffix<"books", "*"> - asterisk as hint', () => {
+  testSuffix<'books', '*'>('*');
+}).types([15, 'instantiations']);
+
+bench('Suffix<"books", "books.title"> - extract suffix', () => {
+  testSuffix<'books', 'books.title'>('title');
+}).types([13, 'instantiations']);

--- a/tests/bench/types/autopath-loaded-isolated.ts
+++ b/tests/bench/types/autopath-loaded-isolated.ts
@@ -55,20 +55,22 @@ interface Person {
 // AutoPath with LINEAR entities
 // ============================================
 
-// eslint-disable-next-line
-function validatePath<T, P extends string>(_path: AutoPath<T, P, PopulatePath.ALL>): void {}
+
+function validatePath<T, P extends string>(
+  _path: AutoPath<T, P, PopulatePath.ALL>,
+): void { /* empty */ }
 
 bench('AutoPath LINEAR - 1 level', () => {
   validatePath<Person, 'address'>('address');
-}).types([2100, 'instantiations']);
+}).types([714, 'instantiations']);
 
 bench('AutoPath LINEAR - 2 levels', () => {
   validatePath<Person, 'address.city'>('address.city');
-}).types([2400, 'instantiations']);
+}).types([895, 'instantiations']);
 
 bench('AutoPath LINEAR - 3 levels', () => {
   validatePath<Person, 'address.city.country'>('address.city.country');
-}).types([2700, 'instantiations']);
+}).types([1042, 'instantiations']);
 
 // ============================================
 // Loaded with LINEAR entities (Ref only)
@@ -79,19 +81,21 @@ function useLoaded<T, L extends string = never>(_entity: Loaded<T, L>): void {}
 
 bench('Loaded LINEAR - no populate', () => {
   useLoaded<Person>({} as Person);
-}).types([600, 'instantiations']);
+}).types([533, 'instantiations']);
 
 bench('Loaded LINEAR - 1 level (Ref)', () => {
   useLoaded<Person, 'address'>({} as Loaded<Person, 'address'>);
-}).types([1600, 'instantiations']);
+}).types([929, 'instantiations']);
 
 bench('Loaded LINEAR - 2 levels (Ref)', () => {
   useLoaded<Person, 'address.city'>({} as Loaded<Person, 'address.city'>);
-}).types([1600, 'instantiations']);
+}).types([929, 'instantiations']);
 
 bench('Loaded LINEAR - 3 levels (Ref)', () => {
-  useLoaded<Person, 'address.city.country'>({} as Loaded<Person, 'address.city.country'>);
-}).types([1600, 'instantiations']);
+  useLoaded<Person, 'address.city.country'>(
+    {} as Loaded<Person, 'address.city.country'>,
+  );
+}).types([929, 'instantiations']);
 
 // ============================================
 // SELF-REFERENCING entity (single type circular)
@@ -107,27 +111,27 @@ interface TreeNode {
 
 bench('AutoPath SELF-REF - 1 level', () => {
   validatePath<TreeNode, 'parent'>('parent');
-}).types([2200, 'instantiations']);
+}).types([781, 'instantiations']);
 
 bench('AutoPath SELF-REF - 2 levels', () => {
   validatePath<TreeNode, 'parent.parent'>('parent.parent');
-}).types([2300, 'instantiations']);
+}).types([843, 'instantiations']);
 
 bench('AutoPath SELF-REF - children (Collection)', () => {
   validatePath<TreeNode, 'children'>('children');
-}).types([1800, 'instantiations']);
+}).types([607, 'instantiations']);
 
 bench('Loaded SELF-REF - 1 level (Ref)', () => {
   useLoaded<TreeNode, 'parent'>({} as Loaded<TreeNode, 'parent'>);
-}).types([1600, 'instantiations']);
+}).types([951, 'instantiations']);
 
 bench('Loaded SELF-REF - 2 levels (Ref)', () => {
   useLoaded<TreeNode, 'parent.parent'>({} as Loaded<TreeNode, 'parent.parent'>);
-}).types([1600, 'instantiations']);
+}).types([951, 'instantiations']);
 
 bench('Loaded SELF-REF - children (Collection)', () => {
   useLoaded<TreeNode, 'children'>({} as Loaded<TreeNode, 'children'>);
-}).types([1000, 'instantiations']);
+}).types([923, 'instantiations']);
 
 // ============================================
 // TWO-WAY circular reference (A <-> B)
@@ -150,35 +154,43 @@ interface Department {
 
 bench('AutoPath CIRCULAR - simple', () => {
   validatePath<Employee, 'department'>('department');
-}).types([2100, 'instantiations']);
+}).types([726, 'instantiations']);
 
 bench('AutoPath CIRCULAR - 2 levels', () => {
   validatePath<Employee, 'department.manager'>('department.manager');
-}).types([2400, 'instantiations']);
+}).types([903, 'instantiations']);
 
 bench('AutoPath CIRCULAR - 3 levels', () => {
-  validatePath<Employee, 'department.manager.department'>('department.manager.department');
-}).types([2500, 'instantiations']);
+  validatePath<Employee, 'department.manager.department'>(
+    'department.manager.department',
+  );
+}).types([951, 'instantiations']);
 
 bench('Loaded CIRCULAR - simple (Ref)', () => {
   useLoaded<Employee, 'department'>({} as Loaded<Employee, 'department'>);
-}).types([1600, 'instantiations']);
+}).types([929, 'instantiations']);
 
 bench('Loaded CIRCULAR - 2 levels (Ref)', () => {
-  useLoaded<Employee, 'department.manager'>({} as Loaded<Employee, 'department.manager'>);
-}).types([1600, 'instantiations']);
+  useLoaded<Employee, 'department.manager'>(
+    {} as Loaded<Employee, 'department.manager'>,
+  );
+}).types([929, 'instantiations']);
 
 bench('Loaded CIRCULAR - back to start (Ref)', () => {
-  useLoaded<Employee, 'department.manager.department'>({} as Loaded<Employee, 'department.manager.department'>);
-}).types([1600, 'instantiations']);
+  useLoaded<Employee, 'department.manager.department'>(
+    {} as Loaded<Employee, 'department.manager.department'>,
+  );
+}).types([929, 'instantiations']);
 
 bench('Loaded CIRCULAR - collection', () => {
   useLoaded<Department, 'employees'>({} as Loaded<Department, 'employees'>);
-}).types([1000, 'instantiations']);
+}).types([923, 'instantiations']);
 
 bench('Loaded CIRCULAR - collection nested', () => {
-  useLoaded<Department, 'employees.department'>({} as Loaded<Department, 'employees.department'>);
-}).types([1000, 'instantiations']);
+  useLoaded<Department, 'employees.department'>(
+    {} as Loaded<Department, 'employees.department'>,
+  );
+}).types([923, 'instantiations']);
 
 // ============================================
 // Entity with many properties (width test)
@@ -186,16 +198,36 @@ bench('Loaded CIRCULAR - collection nested', () => {
 
 interface WideSimple {
   id: number;
-  f1: string; f2: string; f3: string; f4: string; f5: string;
-  f6: string; f7: string; f8: string; f9: string; f10: string;
-  f11: string; f12: string; f13: string; f14: string; f15: string;
-  f16: string; f17: string; f18: string; f19: string; f20: string;
+  f1: string;
+  f2: string;
+  f3: string;
+  f4: string;
+  f5: string;
+  f6: string;
+  f7: string;
+  f8: string;
+  f9: string;
+  f10: string;
+  f11: string;
+  f12: string;
+  f13: string;
+  f14: string;
+  f15: string;
+  f16: string;
+  f17: string;
+  f18: string;
+  f19: string;
+  f20: string;
   [PrimaryKeyProp]?: 'id';
 }
 
 interface WideWithRefs {
   id: number;
-  f1: string; f2: string; f3: string; f4: string; f5: string;
+  f1: string;
+  f2: string;
+  f3: string;
+  f4: string;
+  f5: string;
   r1: Ref<Country>;
   r2: Ref<Country>;
   r3: Ref<Country>;
@@ -206,20 +238,22 @@ interface WideWithRefs {
 
 bench('AutoPath WIDE - 20 scalar props', () => {
   validatePath<WideSimple, 'f1'>('f1');
-}).types([2000, 'instantiations']);
+}).types([830, 'instantiations']);
 
 bench('AutoPath WIDE - 5 refs', () => {
   validatePath<WideWithRefs, 'r1'>('r1');
-}).types([2200, 'instantiations']);
+}).types([787, 'instantiations']);
 
 bench('Loaded WIDE - 20 scalar props', () => {
   useLoaded<WideSimple>({} as WideSimple);
-}).types([1000, 'instantiations']);
+}).types([893, 'instantiations']);
 
 bench('Loaded WIDE - 5 refs no populate', () => {
   useLoaded<WideWithRefs>({} as WideWithRefs);
-}).types([800, 'instantiations']);
+}).types([693, 'instantiations']);
 
 bench('Loaded WIDE - 5 refs all populated', () => {
-  useLoaded<WideWithRefs, 'r1' | 'r2' | 'r3' | 'r4' | 'r5'>({} as Loaded<WideWithRefs, 'r1' | 'r2' | 'r3' | 'r4' | 'r5'>);
-}).types([2300, 'instantiations']);
+  useLoaded<WideWithRefs, 'r1' | 'r2' | 'r3' | 'r4' | 'r5'>(
+    {} as Loaded<WideWithRefs, 'r1' | 'r2' | 'r3' | 'r4' | 'r5'>,
+  );
+}).types([1961, 'instantiations']);

--- a/tests/bench/types/autopath-loaded.ts
+++ b/tests/bench/types/autopath-loaded.ts
@@ -52,32 +52,36 @@ interface Author {
 // AutoPath benchmarks
 // ============================================
 
-// eslint-disable-next-line
-function validatePath<T, P extends string>(_path: AutoPath<T, P, PopulatePath.ALL>): void {}
+
+function validatePath<T, P extends string>(
+  _path: AutoPath<T, P, PopulatePath.ALL>,
+): void { /* empty */ }
 
 bench('AutoPath - simple property access', () => {
   validatePath<Author, 'name'>('name');
-}).types([1800, 'instantiations']);
+}).types([682, 'instantiations']);
 
 bench('AutoPath - single relation', () => {
   validatePath<Author, 'books'>('books');
-}).types([1900, 'instantiations']);
+}).types([773, 'instantiations']);
 
 bench('AutoPath - nested relation (2 levels)', () => {
   validatePath<Author, 'books.publisher'>('books.publisher');
-}).types([2400, 'instantiations']);
+}).types([1000, 'instantiations']);
 
 bench('AutoPath - nested relation (3 levels)', () => {
   validatePath<Author, 'books.publisher.books'>('books.publisher.books');
-}).types([2500, 'instantiations']);
+}).types([1043, 'instantiations']);
 
 bench('AutoPath - nested relation (4 levels)', () => {
-  validatePath<Author, 'books.publisher.books.author'>('books.publisher.books.author');
-}).types([2600, 'instantiations']);
+  validatePath<Author, 'books.publisher.books.author'>(
+    'books.publisher.books.author',
+  );
+}).types([1106, 'instantiations']);
 
 bench('AutoPath - collection with :ref', () => {
   validatePath<Author, 'books:ref'>('books:ref');
-}).types([550, 'instantiations']);
+}).types([496, 'instantiations']);
 
 // ============================================
 // Loaded benchmarks
@@ -88,27 +92,33 @@ function useLoaded<T, L extends string = never>(_entity: Loaded<T, L>): void {}
 
 bench('Loaded - no populate', () => {
   useLoaded<Author>({} as Author);
-}).types([650, 'instantiations']);
+}).types([613, 'instantiations']);
 
 bench('Loaded - single relation', () => {
   useLoaded<Author, 'books'>({} as Loaded<Author, 'books'>);
-}).types([1000, 'instantiations']);
+}).types([989, 'instantiations']);
 
 bench('Loaded - nested relation (2 levels)', () => {
   useLoaded<Author, 'books.publisher'>({} as Loaded<Author, 'books.publisher'>);
-}).types([1000, 'instantiations']);
+}).types([989, 'instantiations']);
 
 bench('Loaded - nested relation (3 levels)', () => {
-  useLoaded<Author, 'books.publisher.books'>({} as Loaded<Author, 'books.publisher.books'>);
-}).types([1000, 'instantiations']);
+  useLoaded<Author, 'books.publisher.books'>(
+    {} as Loaded<Author, 'books.publisher.books'>,
+  );
+}).types([989, 'instantiations']);
 
 bench('Loaded - multiple relations', () => {
-  useLoaded<Author, 'books' | 'friends' | 'favouriteBook'>({} as Loaded<Author, 'books' | 'friends' | 'favouriteBook'>);
-}).types([1900, 'instantiations']);
+  useLoaded<Author, 'books' | 'friends' | 'favouriteBook'>(
+    {} as Loaded<Author, 'books' | 'friends' | 'favouriteBook'>,
+  );
+}).types([1397, 'instantiations']);
 
 bench('Loaded - complex nested paths', () => {
-  useLoaded<Author, 'books.tags' | 'books.publisher' | 'friends.books'>({} as Loaded<Author, 'books.tags' | 'books.publisher' | 'friends.books'>);
-}).types([1200, 'instantiations']);
+  useLoaded<Author, 'books.tags' | 'books.publisher' | 'friends.books'>(
+    {} as Loaded<Author, 'books.tags' | 'books.publisher' | 'friends.books'>,
+  );
+}).types([1276, 'instantiations']);
 
 // ============================================
 // Deep hierarchy tests
@@ -159,12 +169,16 @@ interface DeepRoot {
 }
 
 bench('AutoPath - deep hierarchy (6 levels)', () => {
-  validatePath<DeepRoot, 'level1.level2.level3.level4.level5'>('level1.level2.level3.level4.level5');
-}).types([3300, 'instantiations']);
+  validatePath<DeepRoot, 'level1.level2.level3.level4.level5'>(
+    'level1.level2.level3.level4.level5',
+  );
+}).types([1402, 'instantiations']);
 
 bench('Loaded - deep hierarchy (6 levels)', () => {
-  useLoaded<DeepRoot, 'level1.level2.level3.level4.level5'>({} as Loaded<DeepRoot, 'level1.level2.level3.level4.level5'>);
-}).types([1700, 'instantiations']);
+  useLoaded<DeepRoot, 'level1.level2.level3.level4.level5'>(
+    {} as Loaded<DeepRoot, 'level1.level2.level3.level4.level5'>,
+  );
+}).types([951, 'instantiations']);
 
 // ============================================
 // Wide entity (many properties) tests
@@ -192,11 +206,13 @@ interface WideEntity {
 
 bench('AutoPath - wide entity (15 properties)', () => {
   validatePath<WideEntity, 'rel1'>('rel1');
-}).types([2300, 'instantiations']);
+}).types([843, 'instantiations']);
 
 bench('Loaded - wide entity (15 properties)', () => {
-  useLoaded<WideEntity, 'rel1' | 'rel2' | 'rel3'>({} as Loaded<WideEntity, 'rel1' | 'rel2' | 'rel3'>);
-}).types([2100, 'instantiations']);
+  useLoaded<WideEntity, 'rel1' | 'rel2' | 'rel3'>(
+    {} as Loaded<WideEntity, 'rel1' | 'rel2' | 'rel3'>,
+  );
+}).types([1698, 'instantiations']);
 
 // ============================================
 // Eager props tests
@@ -212,8 +228,10 @@ interface EntityWithEager {
 }
 
 bench('Loaded - with eager props', () => {
-  useLoaded<EntityWithEager, 'normalRel'>({} as Loaded<EntityWithEager, 'normalRel'>);
-}).types([1700, 'instantiations']);
+  useLoaded<EntityWithEager, 'normalRel'>(
+    {} as Loaded<EntityWithEager, 'normalRel'>,
+  );
+}).types([1069, 'instantiations']);
 
 // ============================================
 // Fields selection tests
@@ -222,9 +240,9 @@ bench('Loaded - with eager props', () => {
 bench('Loaded - with fields selection', () => {
   const entity = {} as Loaded<Author, 'books', 'name' | 'email'>;
   void entity;
-}).types([900, 'instantiations']);
+}).types([929, 'instantiations']);
 
 bench('Loaded - with exclude', () => {
   const entity = {} as Loaded<Author, 'books', '*', 'age'>;
   void entity;
-}).types([700, 'instantiations']);
+}).types([619, 'instantiations']);

--- a/tests/bench/types/defineEntity-extends.ts
+++ b/tests/bench/types/defineEntity-extends.ts
@@ -40,7 +40,7 @@ bench('entity extends entity with discriminator', () => {
       extra: p.string(),
     },
   });
-}).types([1400, 'instantiations']);
+}).types([1427, 'instantiations']);
 
 bench('embeddable extends embeddable', () => {
   const base = defineEntity({
@@ -60,7 +60,7 @@ bench('embeddable extends embeddable', () => {
       bar: p.string(),
     },
   });
-}).types([850, 'instantiations']);
+}).types([849, 'instantiations']);
 
 bench('embeddable extends embeddable with discriminator', () => {
   const base = defineEntity({
@@ -83,7 +83,7 @@ bench('embeddable extends embeddable with discriminator', () => {
       bar: p.string(),
     },
   });
-}).types([900, 'instantiations']);
+}).types([876, 'instantiations']);
 
 bench('polymorphic embeddables', () => {
   const base = defineEntity({
@@ -195,11 +195,14 @@ bench('polymorphic embeddables', () => {
     name: 'Document',
     tableName: 'documents',
     properties: {
-      data: () => p.embedded([
-        documentDataAwEdCard,
-        documentDataCoCheckMig,
-        documentDataMvDiCard,
-      ]).object(),
+      data: () =>
+        p
+          .embedded([
+            documentDataAwEdCard,
+            documentDataCoCheckMig,
+            documentDataMvDiCard,
+          ])
+          .object(),
     },
   });
-}).types([3500, 'instantiations']);
+}).types([3469, 'instantiations']);

--- a/tests/bench/types/defineEntity.ts
+++ b/tests/bench/types/defineEntity.ts
@@ -24,7 +24,7 @@ bench('defineEntity with relations', () => {
       scalarRefNullable: p.string().ref().nullable(),
     },
   });
-}).types([13000, 'instantiations']);
+}).types([12917, 'instantiations']);
 
 bench('defineEntity with ref and nullable', () => {
   const Foo = defineEntity({
@@ -41,7 +41,7 @@ bench('defineEntity with ref and nullable', () => {
       scalarRefNullable: p.string().ref().nullable(),
     },
   });
-}).types([13400, 'instantiations']);
+}).types([13269, 'instantiations']);
 
 bench('defineEntity only with ref and nullable', () => {
   const Foo = defineEntity({
@@ -51,7 +51,7 @@ bench('defineEntity only with ref and nullable', () => {
       toOneRefNullable: () => p.oneToOne(Foo).ref().nullable(),
     },
   });
-}).types([11300, 'instantiations']);
+}).types([11187, 'instantiations']);
 
 bench('defineEntity only with nullable and ref', () => {
   const Foo = defineEntity({
@@ -61,7 +61,7 @@ bench('defineEntity only with nullable and ref', () => {
       toOneRefNullable: () => p.oneToOne(Foo).nullable().ref(),
     },
   });
-}).types([11300, 'instantiations']);
+}).types([11191, 'instantiations']);
 
 bench('defineEntity with relations using class', () => {
   class Foo {
@@ -77,7 +77,7 @@ bench('defineEntity with relations using class', () => {
     scalarRefNullable!: ScalarReference<string | null | undefined>;
     [PrimaryKeyProp]?: 'name';
 
-  }
+}
 
   const FooSchema = defineEntity({
     class: Foo,
@@ -95,7 +95,7 @@ bench('defineEntity with relations using class', () => {
       scalarRefNullable: p.string().ref().nullable(),
     },
   });
-}).types([12000, 'instantiations']);
+}).types([11809, 'instantiations']);
 
 bench('defineEntity with ref and nullable using class', () => {
   class Foo {
@@ -111,7 +111,7 @@ bench('defineEntity with ref and nullable using class', () => {
     scalarRefNullable!: ScalarReference<string | null | undefined>;
     [PrimaryKeyProp]?: 'name';
 
-  }
+}
 
   const FooSchema = defineEntity({
     class: Foo,
@@ -129,7 +129,7 @@ bench('defineEntity with ref and nullable using class', () => {
       scalarRefNullable: p.string().ref().nullable(),
     },
   });
-}).types([12000, 'instantiations']);
+}).types([11809, 'instantiations']);
 
 bench('defineEntity only with ref and nullable using class', () => {
   class Foo {
@@ -138,7 +138,7 @@ bench('defineEntity only with ref and nullable using class', () => {
     toOneRefNullable!: Reference<Foo> | null | undefined;
     [PrimaryKeyProp]?: 'name';
 
-  }
+}
 
   const FooSchema = defineEntity({
     class: Foo,
@@ -149,7 +149,7 @@ bench('defineEntity only with ref and nullable using class', () => {
       toOneRefNullable: () => p.oneToOne(Foo).ref().nullable(),
     },
   });
-}).types([10000, 'instantiations']);
+}).types([9749, 'instantiations']);
 
 bench('defineEntity only with nullable and ref using class', () => {
   class Foo {
@@ -158,7 +158,7 @@ bench('defineEntity only with nullable and ref using class', () => {
     toOneRefNullable!: Reference<Foo> | null | undefined;
     [PrimaryKeyProp]?: 'name';
 
-  }
+}
 
   const FooSchema = defineEntity({
     class: Foo,
@@ -169,7 +169,7 @@ bench('defineEntity only with nullable and ref using class', () => {
       toOneRefNullable: () => p.oneToOne(Foo).nullable().ref(),
     },
   });
-}).types([10000, 'instantiations']);
+}).types([9753, 'instantiations']);
 
 bench('EntitySchema', () => {
   interface IFoo {
@@ -190,7 +190,11 @@ bench('EntitySchema', () => {
     properties: {
       name: { type: 'string', primary: true },
       toOne: { kind: '1:1', entity: () => FooSchema as any },
-      toOneNullable: { kind: '1:1', entity: () => FooSchema as any, nullable: true },
+      toOneNullable: {
+        kind: '1:1',
+        entity: () => FooSchema as any,
+        nullable: true,
+      },
       toOneRef: { kind: '1:1', entity: () => FooSchema as any, ref: true },
       toOneRefNullable: {
         kind: '1:1',
@@ -214,7 +218,7 @@ bench('EntitySchema', () => {
       },
     } as any,
   });
-}).types([300, 'instantiations']);
+}).types([305, 'instantiations']);
 
 bench('defineEntity with setClass pattern (circular relations)', () => {
   const AuthorSchema = defineEntity({
@@ -254,4 +258,4 @@ bench('defineEntity with setClass pattern (circular relations)', () => {
 
   AuthorSchema.setClass(Author);
   BookSchema.setClass(Book);
-}).types([8700, 'instantiations']);
+}).types([8484, 'instantiations']);

--- a/tests/bench/types/entitydto-isolated.ts
+++ b/tests/bench/types/entitydto-isolated.ts
@@ -1,0 +1,113 @@
+#!/usr/bin/env -S node --import=tsx
+
+/**
+ * Isolated benchmarks to identify bottlenecks in EntityDTO.
+ */
+
+import { bench } from '@ark/attest';
+import {
+  type EntityDTO,
+  type Loaded,
+  type Ref,
+  type Collection,
+  PrimaryKeyProp,
+  OptionalProps,
+} from '@mikro-orm/core';
+
+// Simple entity without relations
+interface SimpleEntity {
+  id: number;
+  name: string;
+  email: string;
+  age?: number;
+  [PrimaryKeyProp]?: 'id';
+  [OptionalProps]?: 'age';
+}
+
+// Entity with one relation
+interface EntityWithRef {
+  id: number;
+  name: string;
+  parent?: Ref<SimpleEntity> | null;
+  [PrimaryKeyProp]?: 'id';
+  [OptionalProps]?: 'parent';
+}
+
+// Entity with collection
+interface EntityWithCollection {
+  id: number;
+  name: string;
+  items: Collection<SimpleEntity>;
+  [PrimaryKeyProp]?: 'id';
+}
+
+// eslint-disable-next-line
+function useDTO<T>(_dto: EntityDTO<T>): void {}
+
+// ============================================
+// EntityDTO on plain entities
+// ============================================
+
+bench('EntityDTO<SimpleEntity> - no relations', () => {
+  useDTO<SimpleEntity>({} as EntityDTO<SimpleEntity>);
+}).types([891, 'instantiations']);
+
+bench('EntityDTO<EntityWithRef> - with Ref', () => {
+  useDTO<EntityWithRef>({} as EntityDTO<EntityWithRef>);
+}).types([832, 'instantiations']);
+
+bench('EntityDTO<EntityWithCollection> - with Collection', () => {
+  useDTO<EntityWithCollection>({} as EntityDTO<EntityWithCollection>);
+}).types([770, 'instantiations']);
+
+// ============================================
+// EntityDTO on Loaded entities
+// ============================================
+
+bench('EntityDTO<Loaded<SimpleEntity>> - loaded no relations', () => {
+  useDTO<Loaded<SimpleEntity>>({} as EntityDTO<Loaded<SimpleEntity>>);
+}).types([2143, 'instantiations']);
+
+bench('EntityDTO<Loaded<EntityWithRef>> - loaded with Ref', () => {
+  useDTO<Loaded<EntityWithRef>>({} as EntityDTO<Loaded<EntityWithRef>>);
+}).types([1934, 'instantiations']);
+
+bench(
+  'EntityDTO<Loaded<EntityWithRef, "parent">> - loaded with populated Ref',
+  () => {
+    useDTO<Loaded<EntityWithRef, 'parent'>>(
+      {} as EntityDTO<Loaded<EntityWithRef, 'parent'>>,
+    );
+  },
+).types([2415, 'instantiations']);
+
+bench(
+  'EntityDTO<Loaded<EntityWithCollection>> - loaded with Collection',
+  () => {
+    useDTO<Loaded<EntityWithCollection>>(
+      {} as EntityDTO<Loaded<EntityWithCollection>>,
+    );
+  },
+).types([1748, 'instantiations']);
+
+bench(
+  'EntityDTO<Loaded<EntityWithCollection, "items">> - loaded with populated Collection',
+  () => {
+    useDTO<Loaded<EntityWithCollection, 'items'>>(
+      {} as EntityDTO<Loaded<EntityWithCollection, 'items'>>,
+    );
+  },
+).types([2380, 'instantiations']);
+
+// ============================================
+// Comparison: EntityDTO vs direct Loaded
+// ============================================
+
+// eslint-disable-next-line
+function useLoaded<T, L extends string = never>(_entity: Loaded<T, L>): void {}
+
+bench('Loaded<EntityWithCollection, "items"> - without EntityDTO', () => {
+  useLoaded<EntityWithCollection, 'items'>(
+    {} as Loaded<EntityWithCollection, 'items'>,
+  );
+}).types([901, 'instantiations']);

--- a/tests/bench/types/filter-query.ts
+++ b/tests/bench/types/filter-query.ts
@@ -1,0 +1,146 @@
+#!/usr/bin/env -S node --import=tsx
+
+/**
+ * Benchmarks for FilterQuery and related types.
+ * Tests the type computation for where clauses.
+ */
+
+import { bench } from '@ark/attest';
+import {
+  type FilterQuery,
+  type FilterObject,
+  type EntityKey,
+  type Ref,
+  type Collection,
+  type Loaded,
+  PrimaryKeyProp,
+} from '@mikro-orm/core';
+
+// ============================================
+// Test Entity Definitions
+// ============================================
+
+interface Tag {
+  id: number;
+  name: string;
+  [PrimaryKeyProp]?: 'id';
+}
+
+interface Publisher {
+  id: number;
+  name: string;
+  address: string;
+  books: Collection<Book>;
+  [PrimaryKeyProp]?: 'id';
+}
+
+interface Book {
+  id: number;
+  title: string;
+  price: number;
+  author: Author;
+  publisher?: Ref<Publisher> | null;
+  tags: Collection<Tag>;
+  [PrimaryKeyProp]?: 'id';
+}
+
+interface Author {
+  id: number;
+  name: string;
+  email: string;
+  age?: number;
+  bio?: string;
+  books: Collection<Book>;
+  favouriteBook?: Ref<Book> | null;
+  friends: Collection<Author>;
+  [PrimaryKeyProp]?: 'id';
+}
+
+// ============================================
+// EntityKey benchmarks
+// ============================================
+
+bench('EntityKey<Author>', () => {
+  type R = EntityKey<Author>;
+  const x = {} as R;
+  void x;
+}).types([171, 'instantiations']);
+
+bench('EntityKey<Book>', () => {
+  type R = EntityKey<Book>;
+  const x = {} as R;
+  void x;
+}).types([142, 'instantiations']);
+
+bench('EntityKey<Loaded<Author, "books">>', () => {
+  type R = EntityKey<Loaded<Author, 'books'>>;
+  const x = {} as R;
+  void x;
+}).types([1759, 'instantiations']);
+
+// ============================================
+// FilterObject benchmarks
+// ============================================
+
+bench('FilterObject<Author>', () => {
+  type R = FilterObject<Author>;
+  const x = {} as R;
+  void x;
+}).types([318, 'instantiations']);
+
+bench('FilterObject<Book>', () => {
+  type R = FilterObject<Book>;
+  const x = {} as R;
+  void x;
+}).types([289, 'instantiations']);
+
+// ============================================
+// FilterQuery benchmarks (already in api-methods but more detailed here)
+// ============================================
+
+bench('FilterQuery<Author> - plain', () => {
+  type R = FilterQuery<Author>;
+  const x = {} as R;
+  void x;
+}).types([534, 'instantiations']);
+
+bench('FilterQuery<Book> - plain', () => {
+  type R = FilterQuery<Book>;
+  const x = {} as R;
+  void x;
+}).types([503, 'instantiations']);
+
+bench('FilterQuery<Tag> - simple entity', () => {
+  type R = FilterQuery<Tag>;
+  const x = {} as R;
+  void x;
+}).types([444, 'instantiations']);
+
+// ============================================
+// Union entity tests
+// ============================================
+
+type AuthorOrBook = Author | Book;
+
+bench('FilterQuery<Author | Book> - union', () => {
+  type R = FilterQuery<AuthorOrBook>;
+  const x = {} as R;
+  void x;
+}).types([478, 'instantiations']);
+
+// ============================================
+// Nested filter access simulation
+// ============================================
+
+// This simulates what happens when you do: em.find(Author, { books: { title: 'foo' } })
+bench('FilterQuery nested - author.books', () => {
+  type R = FilterObject<Author>['books'];
+  const x = {} as R;
+  void x;
+}).types([1246, 'instantiations']);
+
+bench('FilterQuery nested - book.author', () => {
+  type R = FilterObject<Book>['author'];
+  const x = {} as R;
+  void x;
+}).types([1312, 'instantiations']);

--- a/tests/bench/types/filterquery-deep.ts
+++ b/tests/bench/types/filterquery-deep.ts
@@ -1,0 +1,128 @@
+#!/usr/bin/env -S node --import=tsx
+
+/**
+ * Deep benchmarks for FilterQuery type to identify optimization opportunities.
+ */
+
+import { bench } from '@ark/attest';
+import {
+  type FilterQuery,
+  type FilterObject,
+  type ExpandQuery,
+  type EntityKey,
+  type Ref,
+  type Collection,
+  PrimaryKeyProp,
+} from '@mikro-orm/core';
+
+// ============================================
+// Test Entity Definitions
+// ============================================
+
+interface Tag {
+  id: number;
+  name: string;
+  [PrimaryKeyProp]?: 'id';
+}
+
+interface Publisher {
+  id: number;
+  name: string;
+  address: string;
+  books: Collection<Book>;
+  [PrimaryKeyProp]?: 'id';
+}
+
+interface Book {
+  id: number;
+  title: string;
+  price: number;
+  author: Author;
+  publisher?: Ref<Publisher> | null;
+  tags: Collection<Tag>;
+  [PrimaryKeyProp]?: 'id';
+}
+
+interface Author {
+  id: number;
+  name: string;
+  email: string;
+  age?: number;
+  bio?: string;
+  books: Collection<Book>;
+  favouriteBook?: Ref<Book> | null;
+  friends: Collection<Author>;
+  [PrimaryKeyProp]?: 'id';
+}
+
+// ============================================
+// FilterQuery type benchmarks
+// ============================================
+
+// eslint-disable-next-line
+function useFilter<T>(_filter: FilterQuery<T>): void {}
+
+bench('FilterQuery<Tag> - simple entity', () => {
+  useFilter<Tag>({ name: 'test' });
+}).types([434, 'instantiations']);
+
+bench('FilterQuery<Publisher> - entity with collection', () => {
+  useFilter<Publisher>({ name: 'test' });
+}).types([461, 'instantiations']);
+
+bench('FilterQuery<Book> - entity with relations', () => {
+  useFilter<Book>({ title: 'test' });
+}).types([493, 'instantiations']);
+
+bench('FilterQuery<Author> - complex entity', () => {
+  useFilter<Author>({ name: 'test' });
+}).types([524, 'instantiations']);
+
+// ============================================
+// Nested query benchmarks
+// ============================================
+
+bench('FilterQuery<Author> - nested 1 level', () => {
+  useFilter<Author>({ books: { title: 'test' } });
+}).types([1342, 'instantiations']);
+
+bench('FilterQuery<Author> - nested 2 levels', () => {
+  useFilter<Author>({ books: { publisher: { name: 'test' } } });
+}).types([1884, 'instantiations']);
+
+bench('FilterQuery<Author> - nested 3 levels', () => {
+  useFilter<Author>({ books: { publisher: { books: { title: 'test' } } } });
+}).types([1958, 'instantiations']);
+
+// ============================================
+// Component type benchmarks
+// ============================================
+
+// eslint-disable-next-line
+function useFilterObject<T>(_filter: FilterObject<T>): void {}
+
+bench('FilterObject<Author> - direct', () => {
+  useFilterObject<Author>({ name: 'test' });
+}).types([442, 'instantiations']);
+
+// eslint-disable-next-line
+function useExpandQuery<T>(_filter: ExpandQuery<T>): void {}
+
+bench('ExpandQuery<Author> - direct', () => {
+  useExpandQuery<Author>({ name: 'test' });
+}).types([594, 'instantiations']);
+
+// ============================================
+// EntityKey benchmarks
+// ============================================
+
+// eslint-disable-next-line
+function useEntityKey<T>(_key: EntityKey<T>): void {}
+
+bench('EntityKey<Author> - direct', () => {
+  useEntityKey<Author>('name');
+}).types([138, 'instantiations']);
+
+bench('EntityKey<Book> - direct', () => {
+  useEntityKey<Book>('title');
+}).types([109, 'instantiations']);

--- a/tests/bench/types/other-types.ts
+++ b/tests/bench/types/other-types.ts
@@ -1,0 +1,149 @@
+#!/usr/bin/env -S node --import=tsx
+
+/**
+ * Benchmarks for other commonly used types.
+ * Looking for optimization opportunities in FilterQuery, EntityData, etc.
+ */
+
+import { bench } from '@ark/attest';
+import {
+  type FilterQuery,
+  type EntityData,
+  type RequiredEntityData,
+  type Ref,
+  type Collection,
+  type Primary,
+  type EntityDTO,
+  type Loaded,
+  PrimaryKeyProp,
+  OptionalProps,
+} from '@mikro-orm/core';
+
+// ============================================
+// Test Entity Definitions
+// ============================================
+
+interface Tag {
+  id: number;
+  name: string;
+  [PrimaryKeyProp]?: 'id';
+}
+
+interface Publisher {
+  id: number;
+  name: string;
+  address: string;
+  books: Collection<Book>;
+  [PrimaryKeyProp]?: 'id';
+}
+
+interface Book {
+  id: number;
+  title: string;
+  price: number;
+  author: Author;
+  publisher?: Ref<Publisher> | null;
+  tags: Collection<Tag>;
+  [PrimaryKeyProp]?: 'id';
+  [OptionalProps]?: 'publisher' | 'tags';
+}
+
+interface Author {
+  id: number;
+  name: string;
+  email: string;
+  age?: number;
+  bio?: string;
+  books: Collection<Book>;
+  favouriteBook?: Ref<Book> | null;
+  friends: Collection<Author>;
+  [PrimaryKeyProp]?: 'id';
+  [OptionalProps]?: 'age' | 'bio' | 'favouriteBook';
+}
+
+// ============================================
+// FilterQuery benchmarks
+// ============================================
+
+// eslint-disable-next-line
+function useFilter<T>(_filter: FilterQuery<T>): void {}
+
+bench('FilterQuery<Author> - simple', () => {
+  useFilter<Author>({ name: 'test' });
+}).types([535, 'instantiations']);
+
+bench('FilterQuery<Author> - with relation', () => {
+  useFilter<Author>({ books: { title: 'test' } });
+}).types([1389, 'instantiations']);
+
+bench('FilterQuery<Author> - with operators', () => {
+  useFilter<Author>({ age: { $gt: 18 }, name: { $like: '%test%' } });
+}).types([684, 'instantiations']);
+
+bench('FilterQuery<Book> - nested relations', () => {
+  useFilter<Book>({ author: { books: { publisher: { name: 'test' } } } });
+}).types([2412, 'instantiations']);
+
+// ============================================
+// EntityData benchmarks
+// ============================================
+
+// eslint-disable-next-line
+function useEntityData<T>(_data: EntityData<T>): void {}
+
+bench('EntityData<Author> - simple', () => {
+  useEntityData<Author>({ name: 'test', email: 'test@test.com' });
+}).types([192, 'instantiations']);
+
+bench('EntityData<Book> - with relations', () => {
+  useEntityData<Book>({
+    title: 'test',
+    price: 10,
+    author: { name: 'test' } as any,
+  });
+}).types([554, 'instantiations']);
+
+// ============================================
+// RequiredEntityData benchmarks
+// ============================================
+
+// eslint-disable-next-line
+function useRequiredData<T>(_data: RequiredEntityData<T>): void {}
+
+bench('RequiredEntityData<Author> - simple', () => {
+  useRequiredData<Author>({ name: 'test', email: 'test@test.com' });
+}).types([2063, 'instantiations']);
+
+bench('RequiredEntityData<Book> - with required relations', () => {
+  useRequiredData<Book>({ title: 'test', price: 10, author: {} as Author });
+}).types([3342, 'instantiations']);
+
+// ============================================
+// Primary type benchmarks
+// ============================================
+
+// eslint-disable-next-line
+function usePrimary<T>(_pk: Primary<T>): void {}
+
+bench('Primary<Author> - simple PK', () => {
+  usePrimary<Author>(1);
+}).types([39, 'instantiations']);
+
+bench('Primary<Book> - simple PK', () => {
+  usePrimary<Book>(1);
+}).types([37, 'instantiations']);
+
+// ============================================
+// EntityDTO benchmarks
+// ============================================
+
+// eslint-disable-next-line
+function useDTO<T>(_dto: EntityDTO<T>): void {}
+
+bench('EntityDTO<Author> - simple', () => {
+  useDTO<Author>({} as EntityDTO<Author>);
+}).types([1141, 'instantiations']);
+
+bench('EntityDTO<Loaded<Author, "books">> - with loaded hint', () => {
+  useDTO<Loaded<Author, 'books'>>({} as EntityDTO<Loaded<Author, 'books'>>);
+}).types([3885, 'instantiations']);

--- a/tests/bench/types/populate-all.ts
+++ b/tests/bench/types/populate-all.ts
@@ -1,0 +1,85 @@
+#!/usr/bin/env -S node --import=tsx
+
+/**
+ * Benchmarks for populate: true (all relations) pattern.
+ * Tests the AutoPath with boolean which triggers the LoadableShape check.
+ */
+
+import { bench } from '@ark/attest';
+import {
+  type AutoPath,
+  type PopulatePath,
+  type Ref,
+  type Collection,
+  PrimaryKeyProp,
+} from '@mikro-orm/core';
+
+// ============================================
+// Test Entity Definitions
+// ============================================
+
+interface Tag {
+  id: number;
+  name: string;
+  [PrimaryKeyProp]?: 'id';
+}
+
+interface Publisher {
+  id: number;
+  name: string;
+  address: string;
+  books: Collection<Book>;
+  [PrimaryKeyProp]?: 'id';
+}
+
+interface Book {
+  id: number;
+  title: string;
+  price: number;
+  author: Author;
+  publisher?: Ref<Publisher> | null;
+  tags: Collection<Tag>;
+  [PrimaryKeyProp]?: 'id';
+}
+
+interface Author {
+  id: number;
+  name: string;
+  email: string;
+  age?: number;
+  bio?: string;
+  books: Collection<Book>;
+  favouriteBook?: Ref<Book> | null;
+  friends: Collection<Author>;
+  [PrimaryKeyProp]?: 'id';
+}
+
+// ============================================
+// AutoPath with boolean (populate: true pattern)
+// ============================================
+
+
+function validatePath<T, P extends string | boolean>(
+  _path: AutoPath<T, P, PopulatePath.ALL>,
+): void { /* empty */ }
+
+bench('AutoPath<Author, true> - populate all', () => {
+  validatePath<Author, true>(true);
+}).types([6, 'instantiations']);
+
+bench('AutoPath<Book, true> - populate all', () => {
+  validatePath<Book, true>(true);
+}).types([6, 'instantiations']);
+
+bench('AutoPath<Publisher, true> - populate all', () => {
+  validatePath<Publisher, true>(true);
+}).types([6, 'instantiations']);
+
+// Compare with string paths
+bench('AutoPath<Author, "books"> - string path', () => {
+  validatePath<Author, 'books'>('books');
+}).types([795, 'instantiations']);
+
+bench('AutoPath<Author, "books.publisher"> - nested string', () => {
+  validatePath<Author, 'books.publisher'>('books.publisher');
+}).types([1033, 'instantiations']);

--- a/tests/bench/types/scalar-test.ts
+++ b/tests/bench/types/scalar-test.ts
@@ -1,0 +1,40 @@
+#!/usr/bin/env -S node --import=tsx
+
+import { bench } from '@ark/attest';
+import {
+  type AutoPath,
+  type PopulatePath,
+  type Collection,
+  PrimaryKeyProp,
+} from '@mikro-orm/core';
+
+interface Author {
+  id: number;
+  name: string;
+  createdAt: Date;
+  books: Collection<Book>;
+  [PrimaryKeyProp]?: 'id';
+}
+
+interface Book {
+  id: number;
+  title: string;
+  [PrimaryKeyProp]?: 'id';
+}
+
+// Test: does 'createdAt.' get suggested?
+
+function validatePath<T, P extends string>(
+  _path: AutoPath<T, P, PopulatePath.ALL>,
+): void { /* empty */ }
+
+bench('AutoPath - scalar Date property should not expand', () => {
+  // If this compiles with 'createdAt.' it means Date properties are being suggested
+  // @ts-expect-error - createdAt is a Date, should not have nested paths
+  validatePath<Author, 'createdAt.'>('createdAt.');
+}).types([1303, 'instantiations']);
+
+bench('AutoPath - relation should expand', () => {
+  // Use 'books.title' - a valid nested path (not 'books.' which is just a prefix)
+  validatePath<Author, 'books.title'>('books.title');
+}).types([871, 'instantiations']);

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -698,6 +698,41 @@ describe('check typings', () => {
     const circularReference: Ref<Book> = ref(circularReferenceBook);
   });
 
+  test('assignability of Loaded<T> type propertly disallows not fully compatible types (GH #5433)', async () => {
+    interface D {
+      id: number;
+      name: string;
+    }
+
+    interface C {
+      id: number;
+      d: Collection<D>;
+    }
+
+    interface B {
+      id: number;
+      c: Ref<C>;
+    }
+
+    interface A {
+      id: number;
+      b: Ref<B>;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    function requireBCD(_a: Loaded<A, 'b.c.d'>) {}
+
+    const loadedABC: Loaded<A, 'b.c'> = {} as any;
+
+    // This SHOULD fail - we only have b.c loaded, not b.c.d
+    // @ts-expect-error - missing 'd' in the populate hint
+    requireBCD(loadedABC);
+
+    // But this should work - we have what's required
+    const loadedABCD: Loaded<A, 'b.c.d'> = {} as any;
+    requireBCD(loadedABCD);
+  });
+
   test('exclusion', async () => {
     interface Notification {
       id: string;


### PR DESCRIPTION
Replace direct `Reference`/`Collection` class checks with lightweight structural shapes (`ReferenceShape`, `LoadedReferenceShape`, `LoadableShape`) to avoid forcing TypeScript to evaluate full class interfaces during type resolution.

Key optimizations:
- Use structural matching instead of nominal class checks (~800→~15 instantiations)
- Simplify `AutoPath` by removing intermediate type computation
- Add fast path for '*' hint in IsPrefixed
- Simplify `StringKeys` and `FilterObject` type definitions

```
  AutoPath improvements (55-63% reduction)
  ┌──────────────────────────────┬────────┬──────┬────────┐
  │          Benchmark           │ Master │ New  │ Change │
  ├──────────────────────────────┼────────┼──────┼────────┤
  │ AutoPath - simple property   │ 1800   │ 682  │ -62%   │
  ├──────────────────────────────┼────────┼──────┼────────┤
  │ AutoPath - single relation   │ 1900   │ 773  │ -59%   │
  ├──────────────────────────────┼────────┼──────┼────────┤
  │ AutoPath - nested (2 levels) │ 2400   │ 1000 │ -58%   │
  ├──────────────────────────────┼────────┼──────┼────────┤
  │ AutoPath - nested (3 levels) │ 2500   │ 1043 │ -58%   │
  ├──────────────────────────────┼────────┼──────┼────────┤
  │ AutoPath - nested (4 levels) │ 2600   │ 1106 │ -57%   │
  ├──────────────────────────────┼────────┼──────┼────────┤
  │ AutoPath - deep (6 levels)   │ 3300   │ 1402 │ -58%   │
  ├──────────────────────────────┼────────┼──────┼────────┤
  │ AutoPath - wide entity       │ 2300   │ 843  │ -63%   │
  └──────────────────────────────┴────────┴──────┴────────┘
  Loaded type improvements (26-44% reduction)
  ┌─────────────────────────────┬────────┬──────┬────────┐
  │          Benchmark          │ Master │ New  │ Change │
  ├─────────────────────────────┼────────┼──────┼────────┤
  │ Loaded - multiple relations │ 1900   │ 1397 │ -26%   │
  ├─────────────────────────────┼────────┼──────┼────────┤
  │ Loaded - deep hierarchy     │ 1700   │ 951  │ -44%   │
  ├─────────────────────────────┼────────┼──────┼────────┤
  │ Loaded - with eager props   │ 1700   │ 1069 │ -37%   │
  └─────────────────────────────┴────────┴──────┴────────┘
  Other improvements
  ┌───────────────────────────────┬────────┬──────┬────────┐
  │           Benchmark           │ Master │ New  │ Change │
  ├───────────────────────────────┼────────┼──────┼────────┤
  │ FilterQuery nested (3 levels) │ 2200   │ 1958 │ -11%   │
  ├───────────────────────────────┼────────┼──────┼────────┤
  │ RequiredEntityData - Author   │ 1600   │ 1436 │ -10%   │
  ├───────────────────────────────┼────────┼──────┼────────┤
  │ EntityDTO - Author            │ 1200   │ 1078 │ -10%   │
  └───────────────────────────────┴────────┴──────┴────────┘
```

Also fixes `Loaded<T>` assignability (#5433) by adding `__loadHint` marker with contravariance, ensuring `Loaded<A, 'b.c'>` is not assignable to `Loaded<A, 'b.c.d'>`.

Closes #5433