### PR TITLE
feat(core): add entity-level default `orderBy` option

### DIFF
--- a/docs/docs/collections.md
+++ b/docs/docs/collections.md
@@ -285,6 +285,12 @@ await book.tags.init({
 
 > You should never modify partially loaded collections.
 
+## Entity-level default ordering
+
+You can define a default `orderBy` on the entity itself using `@Entity({ orderBy: ... })`. When populating a collection, all applicable orderings are combined with runtime `orderBy` taking highest priority, followed by relation-level `orderBy`, and finally entity-level `orderBy`.
+
+See [Default Entity Ordering](./defining-entities.md#default-entity-ordering) for full documentation and examples.
+
 ## Declarative partial loading
 
 Collections can also represent only a subset of the target entities:

--- a/docs/docs/decorators.md
+++ b/docs/docs/decorators.md
@@ -29,20 +29,21 @@ For detailed information about decorator types, metadata providers, and configur
 
 `@Entity` decorator is used to mark your model classes as entities. Do not use it for abstract base classes.
 
-| Parameter             | Type                     | Optional | Description                                                                        |
-|-----------------------|--------------------------|----------|------------------------------------------------------------------------------------|
-| `tableName`           | `string`                 | yes      | Override default collection/table name.                                            |
-| `schema`              | `string`                 | yes      | Sets the schema name.                                                              |
-| `collection`          | `string`                 | yes      | Alias for `tableName`.                                                             |
-| `comment`             | `string`                 | yes      | Specify comment to table. **(SQL only)**                                           |
-| `repository`          | `() => EntityRepository` | yes      | Set [custom repository class](./repositories.md#custom-repository).                |
-| `inheritance`         | `'tpt'`                  | yes      | For [Table-Per-Type Inheritance](./inheritance-mapping.md#table-per-type-inheritance-tpt). |
-| `discriminatorColumn` | `string`                 | yes      | For [Single Table Inheritance](./inheritance-mapping.md#single-table-inheritance). |
-| `discriminatorMap`    | `Dictionary<string>`     | yes      | For [Single Table Inheritance](./inheritance-mapping.md#single-table-inheritance). |
-| `discriminatorValue`  | `number` &#124; `string` | yes      | For [Single Table Inheritance](./inheritance-mapping.md#single-table-inheritance). |
-| `forceConstructor`    | `boolean`                | yes      | Enforce use of constructor when creating managed entity instances                  |
-| `abstract`            | `boolean`                | yes      | Marks entity as abstract, such entities are inlined during discovery.              |
-| `readonly`            | `boolean`                | yes      | Disables change tracking - such entities are ignored during flush.                 |
+| Parameter             | Type                       | Optional | Description                                                                        |
+|-----------------------|----------------------------|----------|------------------------------------------------------------------------------------|
+| `tableName`           | `string`                   | yes      | Override default collection/table name.                                            |
+| `schema`              | `string`                   | yes      | Sets the schema name.                                                              |
+| `collection`          | `string`                   | yes      | Alias for `tableName`.                                                             |
+| `comment`             | `string`                   | yes      | Specify comment to table. **(SQL only)**                                           |
+| `repository`          | `() => EntityRepository`   | yes      | Set [custom repository class](./repositories.md#custom-repository).                |
+| `inheritance`         | `'tpt'`                    | yes      | For [Table-Per-Type Inheritance](./inheritance-mapping.md#table-per-type-inheritance-tpt). |
+| `discriminatorColumn` | `string`                   | yes      | For [Single Table Inheritance](./inheritance-mapping.md#single-table-inheritance). |
+| `discriminatorMap`    | `Dictionary<string>`       | yes      | For [Single Table Inheritance](./inheritance-mapping.md#single-table-inheritance). |
+| `discriminatorValue`  | `number` &#124; `string`   | yes      | For [Single Table Inheritance](./inheritance-mapping.md#single-table-inheritance). |
+| `forceConstructor`    | `boolean`                  | yes      | Enforce use of constructor when creating managed entity instances                  |
+| `abstract`            | `boolean`                  | yes      | Marks entity as abstract, such entities are inlined during discovery.              |
+| `readonly`            | `boolean`                  | yes      | Disables change tracking - such entities are ignored during flush.                 |
+| `orderBy`             | `QueryOrderMap` &#124; `QueryOrderMap[]` | yes      | Set default ordering for this entity. See [collections](./collections.md#entity-level-default-ordering). |
 
 ```ts
 @Entity({ tableName: 'authors' })

--- a/docs/docs/entity-schema.md
+++ b/docs/docs/entity-schema.md
@@ -134,6 +134,7 @@ uniques: { properties: string | string[]; name?: string }[];
 repository: () => Constructor<EntityRepository<T>>;
 hooks: Partial<Record<keyof typeof EventType, ((string & keyof T) | NonNullable<EventSubscriber[keyof EventSubscriber]>)[]>>;
 abstract: boolean;
+orderBy: QueryOrderMap<T> | QueryOrderMap<T>[]; // default ordering for the entity
 ```
 
 Every property then needs to contain a type specification - one of `type` or `entity` options. Here are some examples of various property types:

--- a/packages/core/src/metadata/types.ts
+++ b/packages/core/src/metadata/types.ts
@@ -27,6 +27,17 @@ export type EntityOptions<T, E = T extends EntityClass<infer P> ? P : T> = {
   schema?: string;
   /** Override default collection/table name. Alias for `tableName`. */
   collection?: string;
+  /**
+   * Set default ordering for this entity. This ordering is applied when:
+   * - Querying the entity directly via `em.find()`, `em.findAll()`, etc.
+   * - Populating the entity as a relation
+   *
+   * All orderings are combined together. Precedence (highest to lowest):
+   * 1. Runtime `FindOptions.orderBy`
+   * 2. Relation-level `@OneToMany({ orderBy })` / `@ManyToMany({ orderBy })`
+   * 3. Entity-level `@Entity({ orderBy })`
+   */
+  orderBy?: QueryOrderMap<E> | QueryOrderMap<E>[];
   /** For {@doclink inheritance-mapping#single-table-inheritance | Single Table Inheritance}. */
   discriminatorColumn?: (T extends EntityClass<infer P> ? keyof P : string) | AnyString;
   /** For {@doclink inheritance-mapping#single-table-inheritance | Single Table Inheritance}. */

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -1115,6 +1115,11 @@ export interface EntityMetadata<Entity = any, Class extends EntityCtor<Entity> =
   ownProps?: EntityProperty<Entity>[];
   // used to make ORM aware of externally defined triggers, can change resulting SQL in some condition like when inserting in mssql
   hasTriggers?: boolean;
+  /**
+   * Default ordering for this entity. Applied when querying this entity directly
+   * or when it's populated as a relation. Combined with other orderings based on precedence.
+   */
+  orderBy?: QueryOrderMap<Entity> | QueryOrderMap<Entity>[];
   /** @internal can be used for computed numeric cache keys */
   readonly _id: number;
 }

--- a/packages/sql/src/AbstractSqlDriver.ts
+++ b/packages/sql/src/AbstractSqlDriver.ts
@@ -2298,21 +2298,21 @@ export abstract class AbstractSqlDriver<
         orderBy.push({ [`${alias}.${prop.fixedOrderColumn}`]: QueryOrder.ASC } as QueryOrderMap<T>);
       }
 
-      if (propOrderBy) {
-        for (const item of Utils.asArray(propOrderBy)) {
-          for (const field of Utils.getObjectQueryKeys(item)) {
-            const order = item[field as keyof typeof item];
+      const effectiveOrderBy = QueryHelper.mergeOrderBy(propOrderBy, prop.targetMeta?.orderBy);
 
-            if (RawQueryFragment.isKnownFragmentSymbol(field)) {
-              const { sql, params } = RawQueryFragment.getKnownFragment(field)!;
-              const sql2 = propAlias ? sql.replace(new RegExp(ALIAS_REPLACEMENT_RE, 'g'), propAlias) : sql;
-              const key = raw(sql2, params);
-              orderBy.push({ [key]: order } as QueryOrderMap<T>);
-              continue;
-            }
+      for (const item of effectiveOrderBy) {
+        for (const field of Utils.getObjectQueryKeys(item!)) {
+          const order = item![field as keyof typeof item];
 
-            orderBy.push({ [`${propAlias}.${field}` as EntityKey]: order } as QueryOrderMap<T>);
+          if (RawQueryFragment.isKnownFragmentSymbol(field)) {
+            const { sql, params } = RawQueryFragment.getKnownFragment(field)!;
+            const sql2 = propAlias ? sql.replace(new RegExp(ALIAS_REPLACEMENT_RE, 'g'), propAlias) : sql;
+            const key = raw(sql2, params);
+            orderBy.push({ [key]: order } as QueryOrderMap<T>);
+            continue;
           }
+
+          orderBy.push({ [`${propAlias}.${field}` as EntityKey]: order } as QueryOrderMap<T>);
         }
       }
 

--- a/tests/bench/types/api-methods.ts
+++ b/tests/bench/types/api-methods.ts
@@ -149,13 +149,13 @@ bench('EntityDTO<Loaded<Author, "books">>', () => {
   type R = EntityDTO<Loaded<Author, 'books'>>;
   const x = {} as R;
   void x;
-}).types([3617, 'instantiations']);
+}).types([3613, 'instantiations']);
 
 bench('EntityDTO<Loaded<Author, "books.publisher">>', () => {
   type R = EntityDTO<Loaded<Author, 'books.publisher'>>;
   const x = {} as R;
   void x;
-}).types([3617, 'instantiations']);
+}).types([3613, 'instantiations']);
 
 // ============================================
 // FilterQuery - used in where clauses
@@ -177,7 +177,7 @@ bench('FilterQuery<Loaded<Author, "books">>', () => {
   type R = FilterQuery<Loaded<Author, 'books'>>;
   const x = {} as R;
   void x;
-}).types([2499, 'instantiations']);
+}).types([2495, 'instantiations']);
 
 // ============================================
 // EntityData - used in em.assign()
@@ -193,7 +193,7 @@ bench('EntityData<Loaded<Author, "books">>', () => {
   type R = EntityData<Loaded<Author, 'books'>>;
   const x = {} as R;
   void x;
-}).types([1880, 'instantiations']);
+}).types([1876, 'instantiations']);
 
 // ============================================
 // Simulating wrap(e).toObject()
@@ -212,7 +212,7 @@ bench('wrap(loadedAuthor).toObject() return type', () => {
   type R = ToObjectReturn<Loaded<Author, 'books'>>;
   const x = {} as R;
   void x;
-}).types([3619, 'instantiations']);
+}).types([3615, 'instantiations']);
 
 // ============================================
 // Complex scenarios
@@ -224,4 +224,4 @@ bench('find result then EntityDTO', () => {
   type DTOResult = EntityDTO<FindResult>;
   const x = {} as DTOResult;
   void x;
-}).types([3617, 'instantiations']);
+}).types([3613, 'instantiations']);

--- a/tests/bench/types/defineEntity-extends.ts
+++ b/tests/bench/types/defineEntity-extends.ts
@@ -19,7 +19,7 @@ bench('entity extends entity', () => {
       extra: p.string(),
     },
   });
-}).types([1436, 'instantiations']);
+}).types([1438, 'instantiations']);
 
 bench('entity extends entity with discriminator', () => {
   const base = defineEntity({
@@ -40,7 +40,7 @@ bench('entity extends entity with discriminator', () => {
       extra: p.string(),
     },
   });
-}).types([1463, 'instantiations']);
+}).types([1459, 'instantiations']);
 
 bench('embeddable extends embeddable', () => {
   const base = defineEntity({
@@ -60,7 +60,7 @@ bench('embeddable extends embeddable', () => {
       bar: p.string(),
     },
   });
-}).types([879, 'instantiations']);
+}).types([881, 'instantiations']);
 
 bench('embeddable extends embeddable with discriminator', () => {
   const base = defineEntity({
@@ -83,7 +83,7 @@ bench('embeddable extends embeddable with discriminator', () => {
       bar: p.string(),
     },
   });
-}).types([906, 'instantiations']);
+}).types([902, 'instantiations']);
 
 bench('polymorphic embeddables', () => {
   const base = defineEntity({
@@ -198,4 +198,4 @@ bench('polymorphic embeddables', () => {
       data: () => p.embedded([documentDataAwEdCard, documentDataCoCheckMig, documentDataMvDiCard]).object(),
     },
   });
-}).types([3517, 'instantiations']);
+}).types([3513, 'instantiations']);

--- a/tests/bench/types/defineEntity.ts
+++ b/tests/bench/types/defineEntity.ts
@@ -17,7 +17,7 @@ bench('defineEntity with relations', () => {
       scalarRefNullable: p.string().ref().nullable(),
     },
   });
-}).types([13130, 'instantiations']);
+}).types([13132, 'instantiations']);
 
 bench('defineEntity with ref and nullable', () => {
   const Foo = defineEntity({
@@ -34,7 +34,7 @@ bench('defineEntity with ref and nullable', () => {
       scalarRefNullable: p.string().ref().nullable(),
     },
   });
-}).types([13491, 'instantiations']);
+}).types([13493, 'instantiations']);
 
 bench('defineEntity only with ref and nullable', () => {
   const Foo = defineEntity({
@@ -44,7 +44,7 @@ bench('defineEntity only with ref and nullable', () => {
       toOneRefNullable: () => p.oneToOne(Foo).ref().nullable(),
     },
   });
-}).types([11355, 'instantiations']);
+}).types([11357, 'instantiations']);
 
 bench('defineEntity only with nullable and ref', () => {
   const Foo = defineEntity({
@@ -54,7 +54,7 @@ bench('defineEntity only with nullable and ref', () => {
       toOneRefNullable: () => p.oneToOne(Foo).nullable().ref(),
     },
   });
-}).types([11359, 'instantiations']);
+}).types([11361, 'instantiations']);
 
 bench('defineEntity with relations using class', () => {
   class Foo {
@@ -86,7 +86,7 @@ bench('defineEntity with relations using class', () => {
       scalarRefNullable: p.string().ref().nullable(),
     },
   });
-}).types([12066, 'instantiations']);
+}).types([12071, 'instantiations']);
 
 bench('defineEntity with ref and nullable using class', () => {
   class Foo {
@@ -118,7 +118,7 @@ bench('defineEntity with ref and nullable using class', () => {
       scalarRefNullable: p.string().ref().nullable(),
     },
   });
-}).types([12066, 'instantiations']);
+}).types([12071, 'instantiations']);
 
 bench('defineEntity only with ref and nullable using class', () => {
   class Foo {
@@ -136,7 +136,7 @@ bench('defineEntity only with ref and nullable using class', () => {
       toOneRefNullable: () => p.oneToOne(Foo).ref().nullable(),
     },
   });
-}).types([9952, 'instantiations']);
+}).types([9957, 'instantiations']);
 
 bench('defineEntity only with nullable and ref using class', () => {
   class Foo {
@@ -154,7 +154,7 @@ bench('defineEntity only with nullable and ref using class', () => {
       toOneRefNullable: () => p.oneToOne(Foo).nullable().ref(),
     },
   });
-}).types([9956, 'instantiations']);
+}).types([9961, 'instantiations']);
 
 bench('EntitySchema', () => {
   interface IFoo {
@@ -203,7 +203,7 @@ bench('EntitySchema', () => {
       },
     } as any,
   });
-}).types([338, 'instantiations']);
+}).types([341, 'instantiations']);
 
 bench('defineEntity with setClass pattern (circular relations)', () => {
   const AuthorSchema = defineEntity({
@@ -239,4 +239,4 @@ bench('defineEntity with setClass pattern (circular relations)', () => {
 
   AuthorSchema.setClass(Author);
   BookSchema.setClass(Book);
-}).types([8610, 'instantiations']);
+}).types([8612, 'instantiations']);

--- a/tests/bench/types/entitydto-isolated.ts
+++ b/tests/bench/types/entitydto-isolated.ts
@@ -75,7 +75,7 @@ bench('EntityDTO<Loaded<EntityWithCollection>> - loaded with Collection', () => 
 
 bench('EntityDTO<Loaded<EntityWithCollection, "items">> - loaded with populated Collection', () => {
   useDTO<Loaded<EntityWithCollection, 'items'>>({} as EntityDTO<Loaded<EntityWithCollection, 'items'>>);
-}).types([2380, 'instantiations']);
+}).types([2376, 'instantiations']);
 
 // ============================================
 // Comparison: EntityDTO vs direct Loaded

--- a/tests/bench/types/filter-query.ts
+++ b/tests/bench/types/filter-query.ts
@@ -68,7 +68,7 @@ bench('EntityKey<Loaded<Author, "books">>', () => {
   type R = EntityKey<Loaded<Author, 'books'>>;
   const x = {} as R;
   void x;
-}).types([1759, 'instantiations']);
+}).types([1755, 'instantiations']);
 
 // ============================================
 // FilterObject benchmarks

--- a/tests/bench/types/other-types.ts
+++ b/tests/bench/types/other-types.ts
@@ -146,4 +146,4 @@ bench('EntityDTO<Author> - simple', () => {
 
 bench('EntityDTO<Loaded<Author, "books">> - with loaded hint', () => {
   useDTO<Loaded<Author, 'books'>>({} as EntityDTO<Loaded<Author, 'books'>>);
-}).types([3885, 'instantiations']);
+}).types([3881, 'instantiations']);

--- a/tests/features/entity-default-order.test.ts
+++ b/tests/features/entity-default-order.test.ts
@@ -1,0 +1,532 @@
+import { defineEntity, LoadStrategy, MikroORM, p, QueryOrder } from '@mikro-orm/sqlite';
+import { mockLogger } from '../bootstrap.js';
+
+const Author = defineEntity({
+  name: 'Author',
+  orderBy: { name: QueryOrder.ASC },
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+    posts: () => p.oneToMany(Post).mappedBy('author'),
+  },
+});
+
+const Post = defineEntity({
+  name: 'Post',
+  orderBy: { createdAt: QueryOrder.DESC },
+  properties: {
+    id: p.integer().primary(),
+    title: p.string(),
+    createdAt: p.datetime(),
+    author: () => p.manyToOne(Author),
+    comments: () => p.oneToMany(Comment).mappedBy('post'),
+    commentsAlphabetical: () => p.oneToMany(Comment).mappedBy('post').orderBy({ text: QueryOrder.ASC }),
+    tags: () => p.manyToMany(Tag).inversedBy('posts').owner(),
+    tagsReversed: () => p.manyToMany(Tag).inversedBy('posts').owner().orderBy({ title: QueryOrder.DESC }),
+  },
+});
+
+const Comment = defineEntity({
+  name: 'Comment',
+  orderBy: { createdAt: QueryOrder.DESC, id: QueryOrder.DESC },
+  properties: {
+    id: p.integer().primary(),
+    text: p.string(),
+    createdAt: p.datetime(),
+    post: () => p.manyToOne(Post),
+    replies: () => p.oneToMany(Reply).mappedBy('comment'),
+  },
+});
+
+const Reply = defineEntity({
+  name: 'Reply',
+  orderBy: { createdAt: QueryOrder.ASC },
+  properties: {
+    id: p.integer().primary(),
+    text: p.string(),
+    createdAt: p.datetime(),
+    comment: () => p.manyToOne(Comment),
+  },
+});
+
+const Tag = defineEntity({
+  name: 'Tag',
+  orderBy: { title: QueryOrder.ASC },
+  properties: {
+    id: p.integer().primary(),
+    title: p.string(),
+    posts: () => p.manyToMany(Post).mappedBy('tags'),
+  },
+});
+
+const Item = defineEntity({
+  name: 'Item',
+  orderBy: { priority: QueryOrder.DESC, name: QueryOrder.ASC },
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+    priority: p.integer(),
+  },
+});
+
+// Test that `extends` with spread base properties works with orderBy on base keys
+const BaseProperties = {
+  id: p.integer().primary(),
+  createdAt: p.datetime(),
+};
+
+const BaseEntity = defineEntity({
+  name: 'BaseEntity',
+  abstract: true,
+  properties: BaseProperties,
+});
+
+const Event = defineEntity({
+  name: 'Event',
+  extends: BaseEntity,
+  orderBy: { createdAt: QueryOrder.DESC },
+  properties: {
+    title: p.string(),
+  },
+});
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    entities: [Author, Post, Comment, Reply, Tag, Item, Event],
+    dbName: ':memory:',
+  });
+
+  await orm.schema.refresh();
+  await createTestData();
+});
+
+beforeEach(() => orm.em.clear());
+afterAll(() => orm.close(true));
+
+async function createTestData() {
+  const em = orm.em.fork();
+
+  const author1 = em.create(Author, { name: 'Charlie' });
+  em.create(Author, { name: 'Alice' });
+  em.create(Author, { name: 'Bob' });
+
+  const post1 = em.create(Post, { title: 'Post 1', createdAt: new Date('2024-01-15'), author: author1 });
+  const post2 = em.create(Post, { title: 'Post 2', createdAt: new Date('2024-01-20'), author: author1 });
+  em.create(Post, { title: 'Post 3', createdAt: new Date('2024-01-10'), author: author1 });
+
+  const c1 = em.create(Comment, { text: 'First comment', createdAt: new Date('2024-01-01'), post: post1 });
+  em.create(Comment, { text: 'Second comment', createdAt: new Date('2024-01-03'), post: post1 });
+  em.create(Comment, { text: 'Third comment', createdAt: new Date('2024-01-02'), post: post1 });
+
+  em.create(Reply, { text: 'Reply A', createdAt: new Date('2024-01-01T12:00:00'), comment: c1 });
+  em.create(Reply, { text: 'Reply B', createdAt: new Date('2024-01-01T10:00:00'), comment: c1 });
+  em.create(Reply, { text: 'Reply C', createdAt: new Date('2024-01-01T11:00:00'), comment: c1 });
+
+  const tag1 = em.create(Tag, { title: 'Zebra' });
+  const tag2 = em.create(Tag, { title: 'Apple' });
+  const tag3 = em.create(Tag, { title: 'Banana' });
+
+  post1.tags.add(tag1, tag2, tag3);
+  post1.tagsReversed.add(tag1, tag2, tag3);
+  post2.tags.add(tag2, tag3);
+
+  em.create(Item, { name: 'Item A', priority: 1 });
+  em.create(Item, { name: 'Item B', priority: 3 });
+  em.create(Item, { name: 'Item C', priority: 2 });
+  em.create(Item, { name: 'Item D', priority: 3 });
+
+  em.create(Event, { title: 'Event A', createdAt: new Date('2024-03-01') });
+  em.create(Event, { title: 'Event B', createdAt: new Date('2024-01-01') });
+  em.create(Event, { title: 'Event C', createdAt: new Date('2024-02-01') });
+
+  await em.flush();
+}
+
+describe('entity-level default orderBy', () => {
+
+  describe('em.find() with entity-level orderBy', () => {
+
+    test('applies entity-level orderBy when querying directly', async () => {
+      const comments = await orm.em.find(Comment, {});
+      expect(comments.map(c => c.text)).toEqual([
+        'Second comment',
+        'Third comment',
+        'First comment',
+      ]);
+    });
+
+    test('runtime orderBy overrides entity-level orderBy', async () => {
+      const comments = await orm.em.find(Comment, {}, {
+        orderBy: { text: QueryOrder.ASC },
+      });
+      expect(comments.map(c => c.text)).toEqual([
+        'First comment',
+        'Second comment',
+        'Third comment',
+      ]);
+    });
+
+    test('runtime orderBy for same key as entity-level deduplicates', async () => {
+      const mock = mockLogger(orm);
+      // Comment entity has orderBy: { createdAt: DESC, id: DESC }
+      // Runtime specifies createdAt ASC — should dedup createdAt, append id as tiebreaker
+      await orm.em.find(Comment, {}, {
+        orderBy: { createdAt: QueryOrder.ASC },
+      });
+      const sql = mock.mock.calls[0][0];
+      // createdAt should appear exactly once in the order by clause
+      const orderByPart = sql.split('order by')[1];
+      const createdAtCount = (orderByPart.match(/created_at/g) || []).length;
+      expect(createdAtCount).toBe(1);
+      // id should be appended as tiebreaker
+      expect(orderByPart).toMatch(/created_at.*asc/);
+      expect(orderByPart).toMatch(/id.*desc/);
+    });
+
+    test('runtime orderBy on different key appends entity-level as tiebreaker', async () => {
+      const mock = mockLogger(orm);
+      // Comment entity has orderBy: { createdAt: DESC, id: DESC }
+      // Runtime specifies text ASC — should append createdAt and id as tiebreakers
+      await orm.em.find(Comment, {}, {
+        orderBy: { text: QueryOrder.ASC },
+      });
+      const sql = mock.mock.calls[0][0];
+      const orderByPart = sql.split('order by')[1];
+      // text first, then createdAt and id as tiebreakers
+      expect(orderByPart).toMatch(/text.*asc.*created_at.*desc.*id.*desc/s);
+    });
+
+    test('works with findAll', async () => {
+      const tags = await orm.em.findAll(Tag);
+      expect(tags.map(t => t.title)).toEqual(['Apple', 'Banana', 'Zebra']);
+    });
+
+    test('works with findAndCount', async () => {
+      const [comments, count] = await orm.em.findAndCount(Comment, {});
+      expect(count).toBe(3);
+      expect(comments.map(c => c.text)).toEqual([
+        'Second comment',
+        'Third comment',
+        'First comment',
+      ]);
+    });
+
+    test('works with multi-column entity-level orderBy', async () => {
+      const items = await orm.em.find(Item, {});
+      expect(items.map(i => `${i.name}:${i.priority}`)).toEqual([
+        'Item B:3',
+        'Item D:3',
+        'Item C:2',
+        'Item A:1',
+      ]);
+    });
+
+  });
+
+  describe('populate with entity-level orderBy', () => {
+
+    test('entity-level orderBy applies when populating relations', async () => {
+      const post = await orm.em.findOneOrFail(Post, { title: 'Post 1' }, {
+        populate: ['comments'],
+      });
+      expect(post.comments.getItems().map(c => c.text)).toEqual([
+        'Second comment',
+        'Third comment',
+        'First comment',
+      ]);
+    });
+
+    test('relation-level orderBy overrides entity-level orderBy', async () => {
+      const post = await orm.em.findOneOrFail(Post, { title: 'Post 1' }, {
+        populate: ['commentsAlphabetical'],
+      });
+      expect(post.commentsAlphabetical.getItems().map(c => c.text)).toEqual([
+        'First comment',
+        'Second comment',
+        'Third comment',
+      ]);
+    });
+
+    test('runtime orderBy overrides both relation and entity-level orderBy', async () => {
+      const post = await orm.em.findOneOrFail(Post, { title: 'Post 1' }, {
+        populate: ['comments'],
+        orderBy: { comments: { createdAt: QueryOrder.ASC } },
+      });
+      expect(post.comments.getItems().map(c => c.text)).toEqual([
+        'First comment',
+        'Third comment',
+        'Second comment',
+      ]);
+    });
+
+  });
+
+  describe('Collection.init() with entity-level orderBy', () => {
+
+    test('Collection.init() uses entity-level orderBy', async () => {
+      const post = await orm.em.findOneOrFail(Post, { title: 'Post 1' });
+      await post.comments.init();
+      expect(post.comments.getItems().map(c => c.text)).toEqual([
+        'Second comment',
+        'Third comment',
+        'First comment',
+      ]);
+    });
+
+    test('Collection.init() with explicit orderBy overrides entity-level', async () => {
+      const post = await orm.em.findOneOrFail(Post, { title: 'Post 1' });
+      await post.comments.init({ orderBy: { text: QueryOrder.ASC } });
+      expect(post.comments.getItems().map(c => c.text)).toEqual([
+        'First comment',
+        'Second comment',
+        'Third comment',
+      ]);
+    });
+
+  });
+
+  describe('Collection.matching() with entity-level orderBy', () => {
+
+    test('Collection.matching() uses entity-level orderBy', async () => {
+      const post = await orm.em.findOneOrFail(Post, { title: 'Post 1' });
+      const comments = await post.comments.matching({});
+      expect(comments.map(c => c.text)).toEqual([
+        'Second comment',
+        'Third comment',
+        'First comment',
+      ]);
+    });
+
+    test('Collection.matching() with explicit orderBy overrides', async () => {
+      const post = await orm.em.findOneOrFail(Post, { title: 'Post 1' });
+      const comments = await post.comments.matching({ orderBy: { text: QueryOrder.DESC } });
+      expect(comments.map(c => c.text)).toEqual([
+        'Third comment',
+        'Second comment',
+        'First comment',
+      ]);
+    });
+
+  });
+
+  describe('LoadStrategy variations', () => {
+
+    test('works with LoadStrategy.SELECT_IN', async () => {
+      const mock = mockLogger(orm);
+      const post = await orm.em.findOneOrFail(Post, { title: 'Post 1' }, {
+        populate: ['comments'],
+        strategy: LoadStrategy.SELECT_IN,
+      });
+      expect(post.comments.getItems().map(c => c.text)).toEqual([
+        'Second comment',
+        'Third comment',
+        'First comment',
+      ]);
+      expect(mock.mock.calls.some(call =>
+        call[0].includes('order by') &&
+        call[0].includes('created_at') &&
+        call[0].includes('desc'),
+      )).toBe(true);
+    });
+
+    test('works with LoadStrategy.JOINED', async () => {
+      const mock = mockLogger(orm);
+      const post = await orm.em.findOneOrFail(Post, { title: 'Post 1' }, {
+        populate: ['comments'],
+        strategy: LoadStrategy.JOINED,
+      });
+      expect(post.comments.getItems().map(c => c.text)).toEqual([
+        'Second comment',
+        'Third comment',
+        'First comment',
+      ]);
+      expect(mock.mock.calls.some(call =>
+        call[0].includes('order by') &&
+        call[0].includes('created_at'),
+      )).toBe(true);
+    });
+
+  });
+
+  describe('M:N relations with entity-level orderBy', () => {
+
+    test('M:N relation uses target entity orderBy', async () => {
+      const post = await orm.em.findOneOrFail(Post, { title: 'Post 1' }, {
+        populate: ['tags'],
+      });
+      expect(post.tags.getItems().map(t => t.title)).toEqual([
+        'Apple',
+        'Banana',
+        'Zebra',
+      ]);
+    });
+
+    test('M:N relation with relation-level orderBy', async () => {
+      const post = await orm.em.findOneOrFail(Post, { title: 'Post 1' }, {
+        populate: ['tagsReversed'],
+      });
+      expect(post.tagsReversed.getItems().map(t => t.title)).toEqual([
+        'Zebra',
+        'Banana',
+        'Apple',
+      ]);
+    });
+
+  });
+
+  describe('multiple orderBy columns', () => {
+
+    test('multiple columns in entity-level orderBy work correctly', async () => {
+      const items = await orm.em.find(Item, {});
+      expect(items.map(i => i.name)).toEqual([
+        'Item B',
+        'Item D',
+        'Item C',
+        'Item A',
+      ]);
+    });
+
+  });
+
+  describe('extends with base properties', () => {
+
+    test('orderBy on base property works with extends + spread', async () => {
+      const events = await orm.em.find(Event, {});
+      expect(events.map(e => e.title)).toEqual([
+        'Event A',
+        'Event C',
+        'Event B',
+      ]);
+    });
+
+  });
+
+  describe('deeply nested relations', () => {
+
+    test('3-level nesting with SELECT_IN: Author -> Posts -> Comments', async () => {
+      const author = await orm.em.findOneOrFail(Author, { name: 'Charlie' }, {
+        populate: ['posts.comments'],
+        strategy: LoadStrategy.SELECT_IN,
+      });
+
+      expect(author.posts.getItems().map(x => x.title)).toEqual([
+        'Post 2',
+        'Post 1',
+        'Post 3',
+      ]);
+
+      const post1 = author.posts.getItems().find(x => x.title === 'Post 1')!;
+      expect(post1.comments.getItems().map(c => c.text)).toEqual([
+        'Second comment',
+        'Third comment',
+        'First comment',
+      ]);
+    });
+
+    test('3-level nesting with JOINED: Author -> Posts -> Comments', async () => {
+      const author = await orm.em.findOneOrFail(Author, { name: 'Charlie' }, {
+        populate: ['posts.comments'],
+        strategy: LoadStrategy.JOINED,
+      });
+
+      expect(author.posts.getItems().map(x => x.title)).toEqual([
+        'Post 2',
+        'Post 1',
+        'Post 3',
+      ]);
+
+      const post1 = author.posts.getItems().find(x => x.title === 'Post 1')!;
+      expect(post1.comments.getItems().map(c => c.text)).toEqual([
+        'Second comment',
+        'Third comment',
+        'First comment',
+      ]);
+    });
+
+    test('4-level nesting: Author -> Posts -> Comments -> Replies', async () => {
+      const author = await orm.em.findOneOrFail(Author, { name: 'Charlie' }, {
+        populate: ['posts.comments.replies'],
+        strategy: LoadStrategy.SELECT_IN,
+      });
+
+      const post1 = author.posts.getItems().find(x => x.title === 'Post 1')!;
+      const firstComment = post1.comments.getItems().find(c => c.text === 'First comment')!;
+
+      expect(firstComment.replies.getItems().map(r => r.text)).toEqual([
+        'Reply B',
+        'Reply C',
+        'Reply A',
+      ]);
+    });
+
+    test('mixed 1:m and m:n nesting with SELECT_IN: Author -> Posts -> Tags', async () => {
+      const author = await orm.em.findOneOrFail(Author, { name: 'Charlie' }, {
+        populate: ['posts.tags'],
+        strategy: LoadStrategy.SELECT_IN,
+      });
+
+      expect(author.posts.getItems().map(x => x.title)).toEqual([
+        'Post 2',
+        'Post 1',
+        'Post 3',
+      ]);
+
+      const post1 = author.posts.getItems().find(x => x.title === 'Post 1')!;
+      expect(post1.tags.getItems().map(t => t.title)).toEqual([
+        'Apple',
+        'Banana',
+        'Zebra',
+      ]);
+
+      const post2 = author.posts.getItems().find(x => x.title === 'Post 2')!;
+      expect(post2.tags.getItems().map(t => t.title)).toEqual([
+        'Apple',
+        'Banana',
+      ]);
+    });
+
+    test('mixed 1:m and m:n nesting with JOINED: Author -> Posts -> Tags', async () => {
+      const author = await orm.em.findOneOrFail(Author, { name: 'Charlie' }, {
+        populate: ['posts.tags'],
+        strategy: LoadStrategy.JOINED,
+      });
+
+      expect(author.posts.getItems().map(x => x.title)).toEqual([
+        'Post 2',
+        'Post 1',
+        'Post 3',
+      ]);
+
+      const post1 = author.posts.getItems().find(x => x.title === 'Post 1')!;
+      expect(post1.tags.getItems().map(t => t.title)).toEqual([
+        'Apple',
+        'Banana',
+        'Zebra',
+      ]);
+    });
+
+    test('multiple nested paths populated together', async () => {
+      const author = await orm.em.findOneOrFail(Author, { name: 'Charlie' }, {
+        populate: ['posts.comments', 'posts.tags'],
+        strategy: LoadStrategy.SELECT_IN,
+      });
+
+      const post1 = author.posts.getItems().find(x => x.title === 'Post 1')!;
+
+      expect(post1.comments.getItems().map(c => c.text)).toEqual([
+        'Second comment',
+        'Third comment',
+        'First comment',
+      ]);
+      expect(post1.tags.getItems().map(t => t.title)).toEqual([
+        'Apple',
+        'Banana',
+        'Zebra',
+      ]);
+    });
+
+  });
+
+});

--- a/tests/features/entity-manager/EntityManager.mongo.test.ts
+++ b/tests/features/entity-manager/EntityManager.mongo.test.ts
@@ -1008,8 +1008,8 @@ describe('EntityManagerMongo', () => {
     expect(orm.em.getUnitOfWork().getIdentityMap().keys()).toEqual([
       'Author-' + author.id,
       'Book-' + book1.id,
-      'BookTag-' + tag1.id,
       'BookTag-' + tag3.id,
+      'BookTag-' + tag1.id,
     ]);
     expect(author).not.toBe(cachedAuthor);
     expect(author.id).toBe(cachedAuthor.id);
@@ -2108,9 +2108,10 @@ describe('EntityManagerMongo', () => {
     orm.em.clear();
 
     const a4 = await orm.em.findOneOrFail(Author, god.id, { populate: ['books.tags'] });
-    expect(a4.books[0].tags.getIdentifiers()).toEqual([tag1.id, tag3.id]);
-    expect(a4.books[1].tags.getIdentifiers()).toEqual([tag1.id, tag2.id, tag5.id]);
-    expect(a4.books[2].tags.getIdentifiers()).toEqual([tag5.id, tag4.id]);
+    // Book.tags has orderBy: { name: 'asc' }, so tags are sorted alphabetically
+    expect(a4.books[0].tags.getIdentifiers()).toEqual([tag3.id, tag1.id]); // sick, silly
+    expect(a4.books[1].tags.getIdentifiers()).toEqual([tag2.id, tag5.id, tag1.id]); // funny, sexy, silly
+    expect(a4.books[2].tags.getIdentifiers()).toEqual([tag5.id, tag4.id]); // sexy, strange
   });
 
   test('property onCreate and onUpdate have reference to entity', async () => {


### PR DESCRIPTION
Adds `orderBy` option to `@Entity()` decorator and `defineEntity` that provides default ordering when querying the entity directly or when it's populated as a relation.

Precedence (highest to lowest):
1. Runtime `FindOptions.orderBy`
2. Relation-level `orderBy` (`@OneToMany`, `@ManyToMany`)
3. Entity-level `orderBy` (`@Entity`)

Closes #6659