### PR TITLE
fix(entity-generator): strip schema prefix from FK property names

### DIFF
--- a/tests/features/entity-generator/GH5400.postgresql.test.ts
+++ b/tests/features/entity-generator/GH5400.postgresql.test.ts
@@ -1,0 +1,103 @@
+import { MikroORM, UnderscoreNamingStrategy } from '@mikro-orm/postgresql';
+import { ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+import { EntityGenerator } from '@mikro-orm/entity-generator';
+
+const schema = `
+  create table "public"."fr_usuario" (
+    "id" int8 not null,
+    "name" varchar,
+    primary key ("id")
+  );
+  create table "public"."sft_contato" (
+    "id" int8 not null,
+    "usr_codigo_app" int8 not null,
+    primary key ("id"),
+    constraint "sft_contato_usr_codigo_app_fkey" foreign key ("usr_codigo_app") references "public"."fr_usuario" ("id")
+  );
+`;
+
+test('GH5400: FK property names should not contain schema prefix', async () => {
+  const orm = await MikroORM.init({
+    metadataProvider: ReflectMetadataProvider,
+    dbName: '5400',
+    discovery: {
+      warnWhenNoEntities: false,
+    },
+    ensureDatabase: false,
+    extensions: [EntityGenerator],
+    namingStrategy: UnderscoreNamingStrategy,
+    entityGenerator: {
+      scalarPropertiesForRelations: 'always',
+    },
+  });
+
+  if (await orm.schema.ensureDatabase({ create: true })) {
+    await orm.schema.execute(schema);
+  }
+
+  const dump = await orm.entityGenerator.generate();
+  expect(dump).toMatchSnapshot();
+
+  // Verify that the FK property names don't contain 'public.' prefix
+  for (const file of dump) {
+    expect(file).not.toContain('public.');
+  }
+
+  await orm.close(true);
+});
+
+const crossSchemaConflictDdl = `
+  create schema if not exists "schema1";
+  create schema if not exists "schema2";
+
+  -- Same table name in different schemas
+  create table "schema1"."target" (
+    "id" int8 not null,
+    primary key ("id")
+  );
+  create table "schema2"."target" (
+    "id" int8 not null,
+    primary key ("id")
+  );
+
+  -- Table with FKs to both schema1.target and schema2.target
+  create table "public"."source" (
+    "id" int8 not null,
+    "schema1_target_id" int8 not null,
+    "schema2_target_id" int8 not null,
+    primary key ("id"),
+    constraint "source_schema1_fkey" foreign key ("schema1_target_id") references "schema1"."target" ("id"),
+    constraint "source_schema2_fkey" foreign key ("schema2_target_id") references "schema2"."target" ("id")
+  );
+`;
+
+test('GH5400: cross-schema FKs to same-named tables should use constraint names', async () => {
+  const orm = await MikroORM.init({
+    metadataProvider: ReflectMetadataProvider,
+    dbName: '5400_cross_schema',
+    discovery: {
+      warnWhenNoEntities: false,
+    },
+    ensureDatabase: false,
+    extensions: [EntityGenerator],
+    namingStrategy: UnderscoreNamingStrategy,
+    entityGenerator: {
+      scalarPropertiesForRelations: 'always',
+    },
+  });
+
+  if (await orm.schema.ensureDatabase({ create: true })) {
+    await orm.schema.execute(crossSchemaConflictDdl);
+  }
+
+  const dump = await orm.entityGenerator.generate();
+  expect(dump).toMatchSnapshot();
+
+  // Verify no schema prefixes in property names
+  for (const file of dump) {
+    expect(file).not.toMatch(/['"]schema[12]\./);
+    expect(file).not.toContain('public.');
+  }
+
+  await orm.close(true);
+});

--- a/tests/features/entity-generator/__snapshots__/GH5400.postgresql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/GH5400.postgresql.test.ts.snap
@@ -1,0 +1,106 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`GH5400: FK property names should not contain schema prefix 1`] = `
+[
+  "import { Collection, defineEntity, p } from '@mikro-orm/core';
+import { SftContato } from './SftContato';
+
+export class FrUsuario {
+  id!: bigint;
+  name?: string;
+  sftContatoCollection = new Collection<SftContato>(this);
+}
+
+export const FrUsuarioSchema = defineEntity({
+  class: FrUsuario,
+  properties: {
+    id: p.bigint().primary().autoincrement(false),
+    name: p.string().length(-1).nullable(),
+    sftContatoCollection: () => p.oneToMany(SftContato).mappedBy('frUsuario'),
+  },
+});
+",
+  "import { type Ref, defineEntity, p } from '@mikro-orm/core';
+import { FrUsuario } from './FrUsuario';
+
+export class SftContato {
+  id!: bigint;
+  usrCodigoApp!: bigint;
+  frUsuario!: Ref<FrUsuario>;
+}
+
+export const SftContatoSchema = defineEntity({
+  class: SftContato,
+  properties: {
+    id: p.bigint().primary().autoincrement(false),
+    usrCodigoApp: p.bigint().persist(false),
+    frUsuario: () => p.manyToOne(FrUsuario).ref().name('usr_codigo_app').updateRule('no action').deleteRule('no action'),
+  },
+});
+",
+]
+`;
+
+exports[`GH5400: cross-schema FKs to same-named tables should use constraint names 1`] = `
+[
+  "import { type Ref, defineEntity, p } from '@mikro-orm/core';
+import { Schema1Target } from './Schema1Target';
+import { Schema2Target } from './Schema2Target';
+
+export class Source {
+  id!: bigint;
+  schema1Target!: Ref<Schema1Target>;
+  schema1TargetId!: bigint;
+  schema2Target!: Ref<Schema2Target>;
+  schema2TargetId!: bigint;
+}
+
+export const SourceSchema = defineEntity({
+  class: Source,
+  properties: {
+    id: p.bigint().primary().autoincrement(false),
+    schema1Target: () => p.manyToOne(Schema1Target).ref().name('schema1_target_id').updateRule('no action').deleteRule('no action'),
+    schema1TargetId: p.bigint().name('schema1_target_id').persist(false),
+    schema2Target: () => p.manyToOne(Schema2Target).ref().name('schema2_target_id').updateRule('no action').deleteRule('no action'),
+    schema2TargetId: p.bigint().name('schema2_target_id').persist(false),
+  },
+});
+",
+  "import { Collection, defineEntity, p } from '@mikro-orm/core';
+import { Source } from './Source';
+
+export class Schema1Target {
+  id!: bigint;
+  sourceCollection = new Collection<Source>(this);
+}
+
+export const Schema1TargetSchema = defineEntity({
+  class: Schema1Target,
+  tableName: 'target',
+  schema: 'schema1',
+  properties: {
+    id: p.bigint().primary().autoincrement(false),
+    sourceCollection: () => p.oneToMany(Source).mappedBy('schema1Target'),
+  },
+});
+",
+  "import { Collection, defineEntity, p } from '@mikro-orm/core';
+import { Source } from './Source';
+
+export class Schema2Target {
+  id!: bigint;
+  sourceCollection = new Collection<Source>(this);
+}
+
+export const Schema2TargetSchema = defineEntity({
+  class: Schema2Target,
+  tableName: 'target',
+  schema: 'schema2',
+  properties: {
+    id: p.bigint().primary().autoincrement(false),
+    sourceCollection: () => p.oneToMany(Source).mappedBy('schema2Target'),
+  },
+});
+",
+]
+`;


### PR DESCRIPTION
When using `scalarPropertiesForRelations: 'always'` with PostgreSQL, FK property names were incorrectly including the schema prefix (e.g., `public.frUsuario` instead of `frUsuario`).

The fix strips the schema prefix when generating FK property base names and also when checking for naming conflicts, ensuring that cross-schema FKs to same-named tables are properly detected as conflicts and fall back to constraint-based naming.

Closes #5400