### PR TITLE
feat(core): add support for Table-Per-Type inheritance

### DIFF
--- a/docs/docs/raw-queries.md
+++ b/docs/docs/raw-queries.md
@@ -43,7 +43,7 @@ The `raw` helper can be used within indexes and uniques to write database-agnost
 ```ts
 // On postgres, will produce: create index "index custom_idx_on_name" on "library.author" ("country")
 // On mysql, will produce: create index `index custom_idx_on_name` on `library.author` (`country`)
-@Index({ name: 'custom_idx_on_name', expression: (table, columns) => raw(`create index ?? on ?? (??)`, ['custom_idx_on_name', table, columns.name]) })
+@Index({ name: 'custom_idx_on_name', expression: (columns, table, indexName) => raw(`create index ?? on ?? (??)`, [indexName, table, columns.name]) })
 @Entity({ schema: 'library' })
 export class Author { ... }
 ```
@@ -51,7 +51,7 @@ export class Author { ... }
 You can also use the `quote` tag function to write database-agnostic SQL expressions. The end-result is the same as using the `raw` function regarding database identifiers quoting, only to have a more elegant expression syntax:
 
 ```ts
-@Index({ name: 'custom_idx_on_name', expression: (table, columns) => quote`create index ${'custom_idx_on_name'} on ${table} (${columns.name})` })
+@Index({ name: 'custom_idx_on_name', expression: (columns, table, indexName) => quote`create index ${indexName} on ${table} (${columns.name})` })
 @Entity({ schema: 'library' })
 export class Author { ... }
 ```

--- a/docs/docs/schema-first-guide.md
+++ b/docs/docs/schema-first-guide.md
@@ -2892,7 +2892,7 @@ Let's add a count of comments to the article listing in that fashion. The proper
 +        runtimeType: 'number',
 +        default: 0,
 +        lazy: true,
-+        formula: (alias) => `(SELECT COUNT(*) FROM comments WHERE article = ${alias}.id)`,
++        formula: (cols, table) => `(SELECT COUNT(*) FROM comments WHERE article = ${table.alias}.id)`,
 +      });
 ...
 ```
@@ -2947,7 +2947,7 @@ import type { GenerateOptions } from '@mikro-orm/core';
         runtimeType: 'number',
         default: 0,
         lazy: true,
--        formula: (alias) => `(SELECT COUNT(*) FROM comments WHERE article = ${alias}.id)`,
+-        formula: (cols, table) => `(SELECT COUNT(*) FROM comments WHERE article = ${table.alias}.id)`,
 +        formula,
       });
 ```

--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -432,7 +432,7 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
   protected applyDiscriminatorCondition<Entity extends object>(entityName: EntityName<Entity>, where: FilterQuery<Entity>): FilterQuery<Entity> {
     const meta = this.metadata.find<Entity>(entityName);
 
-    if (!meta?.discriminatorValue) {
+    if (meta?.root.inheritanceType !== 'sti' || !meta?.discriminatorValue) {
       return where;
     }
 
@@ -1907,10 +1907,12 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
       p = p.split(':', 2)[0];
     }
 
-    const ret = p in meta.root.properties;
+    // For TPT inheritance, check the entity's own properties, not just the root's
+    // For STI, meta.properties includes all properties anyway
+    const ret = p in meta.properties;
 
     if (parts.length > 0) {
-      return this.canPopulate(meta.root.properties[p as EntityKey<Entity>].targetMeta!.class, parts.join('.'));
+      return this.canPopulate(meta.properties[p as EntityKey<Entity>].targetMeta!.class, parts.join('.'));
     }
 
     return ret;

--- a/packages/core/src/entity/defineEntity.ts
+++ b/packages/core/src/entity/defineEntity.ts
@@ -740,6 +740,9 @@ export interface EntityMetadataWithProperties<
   // Capture the repository type for InferEntity to include EntityRepositoryType
   repository?: () => TRepository;
 
+  // Table-per-type inheritance (each entity has its own table)
+  inheritance?: 'tpt';
+
   // use keyof TProperties instead of EntityKey<T> to avoid circular type inference
   discriminatorColumn?: keyof TProperties;
   versionProperty?: keyof TProperties;
@@ -927,13 +930,15 @@ type MaybeScalarRef<Value, Options> =
 
 type MaybeOpt<Value, Options> =
   Options extends { mapToPk: true } ? Value extends Opt<infer OriginalValue> ? OriginalValue : Value :
-  Options extends { autoincrement: true } ? Opt<Value> :
-  Options extends { onCreate: Function } ? Opt<Value> :
-  Options extends { default: string | string[] | number | number[] | boolean | null | Date | Raw } ? Opt<Value> :
-  Options extends { defaultRaw: string } ? Opt<Value> :
-  Options extends { persist: false } ? Opt<Value> :
-  Options extends { version: true } ? Opt<Value> :
-  Options extends { formula: string | ((...args: any[]) => string) } ? Opt<Value> :
+  Options extends
+    | { autoincrement: true }
+    | { onCreate: Function }
+    | { default: string | string[] | number | number[] | boolean | null | Date | Raw }
+    | { defaultRaw: string }
+    | { persist: false }
+    | { version: true }
+    | { formula: string | ((...args: any[]) => any) }
+    ? Opt<Value> :
     Value;
 
 type MaybeHidden<Value, Options> = Options extends { hidden: true } ? Hidden<Value> : Value;

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -319,6 +319,14 @@ export class MetadataError<T extends AnyEntity = AnyEntity> extends ValidationEr
     return new MetadataError(`View entity ${meta.className} is missing 'expression'. View entities must have an expression defining the SQL query.`);
   }
 
+  static mixedInheritanceStrategies(root: EntityMetadata, child: EntityMetadata): MetadataError {
+    return new MetadataError(`Entity ${child.className} cannot mix STI (Single Table Inheritance) and TPT (Table-Per-Type) inheritance. Root entity ${root.className} uses STI (discriminatorColumn) but also has inheritance: 'tpt'. Choose one inheritance strategy per hierarchy.`);
+  }
+
+  static tptNotSupportedByDriver(meta: EntityMetadata): MetadataError {
+    return new MetadataError(`Entity ${meta.className} uses TPT (Table-Per-Type) inheritance which is not supported by the current driver. TPT requires SQL JOINs and is only available with SQL drivers.`);
+  }
+
   private static fromMessage(meta: EntityMetadata, prop: EntityProperty, message: string): MetadataError {
     return new MetadataError(`${meta.className}.${prop.name} ${message}`);
   }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,7 +7,7 @@ export type {
   CompiledFunctions, Constructor, ConnectionType, Dictionary, Primary, IPrimaryKey, ObjectQuery, FilterQuery, IWrappedEntity, EntityName, EntityData, Highlighter, MaybePromise,
   AnyEntity, EntityClass, EntityProperty, PopulateOptions, Populate, Loaded, New, LoadedReference, LoadedCollection, IMigrator, IMigrationGenerator, MigratorEvent,
   GetRepository, MigrationObject, DeepPartial, PrimaryProperty, Cast, IsUnknown, EntityDictionary, EntityDTO, MigrationDiff, GenerateOptions, FilterObject,
-  IEntityGenerator, ISeedManager, RequiredEntityData, CheckCallback, IndexCallback, FormulaCallback, FormulaTable, SimpleColumnMeta, Rel, Ref, ScalarRef, EntityRef, ISchemaGenerator,
+  IEntityGenerator, ISeedManager, RequiredEntityData, CheckCallback, IndexCallback, FormulaCallback, FormulaTable, SchemaTable, SchemaColumns, SimpleColumnMeta, Rel, Ref, ScalarRef, EntityRef, ISchemaGenerator,
   UmzugMigration, MigrateOptions, MigrationResult, MigrationRow, EntityKey, EntityValue, EntityDataValue, FilterKey, EntityType, FromEntityType, Selected, IsSubset,
   EntityProps, ExpandProperty, ExpandScalar, FilterItemValue, ExpandQuery, Scalar, ExpandHint, FilterValue, MergeLoaded, MergeSelected, TypeConfig, AnyString,
   ClearDatabaseOptions, CreateSchemaOptions, EnsureDatabaseOptions, UpdateSchemaOptions, DropSchemaOptions, RefreshDatabaseOptions, AutoPath, UnboxArray, MetadataProcessor, ImportsResolver,

--- a/packages/core/src/metadata/types.ts
+++ b/packages/core/src/metadata/types.ts
@@ -12,13 +12,13 @@ import type {
   EntityClass,
   IndexCallback,
   ObjectQuery,
+  Raw,
 } from '../typings.js';
 import type { Cascade, LoadStrategy, DeferMode, QueryOrderMap, EmbeddedPrefixMode } from '../enums.js';
 import type { Type, types } from '../types/index.js';
 import type { EntityManager } from '../EntityManager.js';
 import type { FilterOptions, FindOptions } from '../drivers/IDatabaseDriver.js';
 import type { SerializeOptions } from '../serialization/EntitySerializer.js';
-import type { Raw } from '../utils/RawQueryFragment.js';
 
 export type EntityOptions<T, E = T extends EntityClass<infer P> ? P : T> = {
   /** Override default collection/table name. Alias for `collection`. */
@@ -33,6 +33,8 @@ export type EntityOptions<T, E = T extends EntityClass<infer P> ? P : T> = {
   discriminatorMap?: Dictionary<string>;
   /** For {@doclink inheritance-mapping#single-table-inheritance | Single Table Inheritance}. */
   discriminatorValue?: number | string;
+  /** Set inheritance strategy: 'tpt' for {@doclink inheritance-mapping#table-per-type-inheritance-tpt | Table-Per-Type} inheritance. When set on the root entity, each entity in the hierarchy gets its own table with a FK from child PK to parent PK. */
+  inheritance?: 'tpt';
   /**	Enforce use of constructor when creating managed entity instances. */
   forceConstructor?: boolean;
   /** Specify constructor parameters to be used in `em.create` or when `forceConstructor` is enabled. Those should be names of declared entity properties in the same order as your constructor uses them. The ORM tries to infer those automatically, use this option in case the inference fails. */
@@ -152,7 +154,7 @@ export interface PropertyOptions<Owner> {
   /**
    * For generated columns. This will be appended to the column type after the `generated always` clause.
    */
-  generated?: string | GeneratedColumnCallback<Owner>;
+  generated?: string | Raw | GeneratedColumnCallback<Owner>;
   /**
    * Set column as nullable for {@link https://mikro-orm.io/docs/schema-generator Schema Generator}.
    */

--- a/packages/core/src/unit-of-work/ChangeSet.ts
+++ b/packages/core/src/unit-of-work/ChangeSet.ts
@@ -74,6 +74,8 @@ export interface ChangeSet<T> {
   payload: EntityDictionary<T>;
   persisted: boolean;
   originalEntity?: EntityData<T>;
+  /** For TPT: changesets for parent tables, ordered from immediate parent to root */
+  tptChangeSets?: ChangeSet<T>[];
 }
 
 export enum ChangeSetType {

--- a/packages/core/src/utils/EntityComparator.ts
+++ b/packages/core/src/utils/EntityComparator.ts
@@ -262,7 +262,7 @@ export class EntityComparator {
     context.set('clone', clone);
     context.set('cloneEmbeddable', (o: any) => this.platform.cloneEmbeddable(o)); // do not clone prototypes
 
-    if (meta.discriminatorValue) {
+    if (meta.root.inheritanceType === 'sti' && meta.discriminatorValue) {
       lines.push(`  ret${this.wrap(meta.root.discriminatorColumn!)} = '${meta.discriminatorValue}'`);
     }
 

--- a/packages/mongodb/src/MongoPlatform.ts
+++ b/packages/mongodb/src/MongoPlatform.ts
@@ -114,6 +114,10 @@ export class MongoPlatform extends Platform {
   }
 
   override validateMetadata(meta: EntityMetadata): void {
+    if (meta.inheritanceType === 'tpt') {
+      throw MetadataError.tptNotSupportedByDriver(meta);
+    }
+
     const pk = meta.getPrimaryProps()[0];
 
     if (pk && pk.fieldNames?.[0] !== '_id') {

--- a/packages/mssql/src/MsSqlDriver.ts
+++ b/packages/mssql/src/MsSqlDriver.ts
@@ -57,7 +57,8 @@ export class MsSqlDriver extends AbstractSqlDriver<MsSqlConnection> {
       return res;
     }
 
-    if (props.some(prop => prop.autoincrement)) {
+    // For TPT child entities, the parent table owns the identity column, not the child table
+    if (props.some(prop => prop.autoincrement && (!meta.ownProps || meta.ownProps.includes(prop)))) {
       return super.nativeInsertMany(entityName, data, options, sql => {
         return `set identity_insert ${tableName} on; ${sql}; set identity_insert ${tableName} off`;
       });

--- a/tests/bench/types/api-methods.ts
+++ b/tests/bench/types/api-methods.ts
@@ -92,19 +92,19 @@ bench('em.create() return type', () => {
   type R = ReturnType<typeof em.create<Author>>;
   const x = {} as R;
   void x;
-}).types([2375, 'instantiations']);
+}).types([2401, 'instantiations']);
 
 bench('RequiredEntityData - Author', () => {
   type R = RequiredEntityData<Author>;
   const x = {} as R;
   void x;
-}).types([1436, 'instantiations']);
+}).types([1462, 'instantiations']);
 
 bench('RequiredEntityData - Book', () => {
   type R = RequiredEntityData<Book>;
   const x = {} as R;
   void x;
-}).types([1249, 'instantiations']);
+}).types([1275, 'instantiations']);
 
 // New<T> type (used as create return type)
 bench('New<Author>', () => {

--- a/tests/bench/types/assign-types.ts
+++ b/tests/bench/types/assign-types.ts
@@ -136,10 +136,10 @@ bench('assign data type - plain entity', () => {
   type R = AssignDataType<Author>;
   const x = {} as R;
   void x;
-}).types([2270, 'instantiations']);
+}).types([2312, 'instantiations']);
 
 bench('assign data type - Loaded entity', () => {
   type R = AssignDataType<Loaded<Author, 'books'>>;
   const x = {} as R;
   void x;
-}).types([3369, 'instantiations']);
+}).types([3411, 'instantiations']);

--- a/tests/bench/types/autopath-loaded.ts
+++ b/tests/bench/types/autopath-loaded.ts
@@ -70,7 +70,7 @@ bench('AutoPath - nested relation (4 levels)', () => {
 
 bench('AutoPath - collection with :ref', () => {
   validatePath<Author, 'books:ref'>('books:ref');
-}).types([496, 'instantiations']);
+}).types([581, 'instantiations']);
 
 // ============================================
 // Loaded benchmarks

--- a/tests/bench/types/defineEntity-extends.ts
+++ b/tests/bench/types/defineEntity-extends.ts
@@ -19,7 +19,7 @@ bench('entity extends entity', () => {
       extra: p.string(),
     },
   });
-}).types([1400, 'instantiations']);
+}).types([1436, 'instantiations']);
 
 bench('entity extends entity with discriminator', () => {
   const base = defineEntity({
@@ -40,7 +40,7 @@ bench('entity extends entity with discriminator', () => {
       extra: p.string(),
     },
   });
-}).types([1427, 'instantiations']);
+}).types([1463, 'instantiations']);
 
 bench('embeddable extends embeddable', () => {
   const base = defineEntity({
@@ -60,7 +60,7 @@ bench('embeddable extends embeddable', () => {
       bar: p.string(),
     },
   });
-}).types([849, 'instantiations']);
+}).types([879, 'instantiations']);
 
 bench('embeddable extends embeddable with discriminator', () => {
   const base = defineEntity({
@@ -83,7 +83,7 @@ bench('embeddable extends embeddable with discriminator', () => {
       bar: p.string(),
     },
   });
-}).types([876, 'instantiations']);
+}).types([906, 'instantiations']);
 
 bench('polymorphic embeddables', () => {
   const base = defineEntity({
@@ -198,4 +198,4 @@ bench('polymorphic embeddables', () => {
       data: () => p.embedded([documentDataAwEdCard, documentDataCoCheckMig, documentDataMvDiCard]).object(),
     },
   });
-}).types([3469, 'instantiations']);
+}).types([3517, 'instantiations']);

--- a/tests/bench/types/defineEntity.ts
+++ b/tests/bench/types/defineEntity.ts
@@ -17,7 +17,7 @@ bench('defineEntity with relations', () => {
       scalarRefNullable: p.string().ref().nullable(),
     },
   });
-}).types([12917, 'instantiations']);
+}).types([13130, 'instantiations']);
 
 bench('defineEntity with ref and nullable', () => {
   const Foo = defineEntity({
@@ -34,7 +34,7 @@ bench('defineEntity with ref and nullable', () => {
       scalarRefNullable: p.string().ref().nullable(),
     },
   });
-}).types([13269, 'instantiations']);
+}).types([13491, 'instantiations']);
 
 bench('defineEntity only with ref and nullable', () => {
   const Foo = defineEntity({
@@ -44,7 +44,7 @@ bench('defineEntity only with ref and nullable', () => {
       toOneRefNullable: () => p.oneToOne(Foo).ref().nullable(),
     },
   });
-}).types([11187, 'instantiations']);
+}).types([11355, 'instantiations']);
 
 bench('defineEntity only with nullable and ref', () => {
   const Foo = defineEntity({
@@ -54,7 +54,7 @@ bench('defineEntity only with nullable and ref', () => {
       toOneRefNullable: () => p.oneToOne(Foo).nullable().ref(),
     },
   });
-}).types([11191, 'instantiations']);
+}).types([11359, 'instantiations']);
 
 bench('defineEntity with relations using class', () => {
   class Foo {
@@ -86,7 +86,7 @@ bench('defineEntity with relations using class', () => {
       scalarRefNullable: p.string().ref().nullable(),
     },
   });
-}).types([11808, 'instantiations']);
+}).types([12066, 'instantiations']);
 
 bench('defineEntity with ref and nullable using class', () => {
   class Foo {
@@ -118,7 +118,7 @@ bench('defineEntity with ref and nullable using class', () => {
       scalarRefNullable: p.string().ref().nullable(),
     },
   });
-}).types([11808, 'instantiations']);
+}).types([12066, 'instantiations']);
 
 bench('defineEntity only with ref and nullable using class', () => {
   class Foo {
@@ -136,7 +136,7 @@ bench('defineEntity only with ref and nullable using class', () => {
       toOneRefNullable: () => p.oneToOne(Foo).ref().nullable(),
     },
   });
-}).types([9748, 'instantiations']);
+}).types([9952, 'instantiations']);
 
 bench('defineEntity only with nullable and ref using class', () => {
   class Foo {
@@ -154,7 +154,7 @@ bench('defineEntity only with nullable and ref using class', () => {
       toOneRefNullable: () => p.oneToOne(Foo).nullable().ref(),
     },
   });
-}).types([9752, 'instantiations']);
+}).types([9956, 'instantiations']);
 
 bench('EntitySchema', () => {
   interface IFoo {
@@ -203,7 +203,7 @@ bench('EntitySchema', () => {
       },
     } as any,
   });
-}).types([305, 'instantiations']);
+}).types([338, 'instantiations']);
 
 bench('defineEntity with setClass pattern (circular relations)', () => {
   const AuthorSchema = defineEntity({
@@ -239,4 +239,4 @@ bench('defineEntity with setClass pattern (circular relations)', () => {
 
   AuthorSchema.setClass(Author);
   BookSchema.setClass(Book);
-}).types([8484, 'instantiations']);
+}).types([8610, 'instantiations']);

--- a/tests/bench/types/other-types.ts
+++ b/tests/bench/types/other-types.ts
@@ -101,7 +101,7 @@ bench('EntityData<Book> - with relations', () => {
     price: 10,
     author: { name: 'test' } as any,
   });
-}).types([594, 'instantiations']);
+}).types([628, 'instantiations']);
 
 // ============================================
 // RequiredEntityData benchmarks
@@ -112,11 +112,11 @@ function useRequiredData<T>(_data: RequiredEntityData<T>): void {}
 
 bench('RequiredEntityData<Author> - simple', () => {
   useRequiredData<Author>({ name: 'test', email: 'test@test.com' });
-}).types([2063, 'instantiations']);
+}).types([2102, 'instantiations']);
 
 bench('RequiredEntityData<Book> - with required relations', () => {
   useRequiredData<Book>({ title: 'test', price: 10, author: {} as Author });
-}).types([3343, 'instantiations']);
+}).types([3442, 'instantiations']);
 
 // ============================================
 // Primary type benchmarks

--- a/tests/bench/types/scalar-test.ts
+++ b/tests/bench/types/scalar-test.ts
@@ -27,7 +27,7 @@ bench('AutoPath - scalar Date property should not expand', () => {
   // If this compiles with 'createdAt.' it means Date properties are being suggested
   // @ts-expect-error - createdAt is a Date, should not have nested paths
   validatePath<Author, 'createdAt.'>('createdAt.');
-}).types([1303, 'instantiations']);
+}).types([1501, 'instantiations']);
 
 bench('AutoPath - relation should expand', () => {
   // Use 'books.title' - a valid nested path (not 'books.' which is just a prefix)

--- a/tests/defineEntity.test.ts
+++ b/tests/defineEntity.test.ts
@@ -902,7 +902,7 @@ describe('defineEntity', () => {
       indexes: [
         {
           name: 'unique_name_children',
-          expression: (table, columns) =>
+          expression: (columns, table) =>
             `create unique index ${table.name}_${columns.name}_${columns.children} on ${table.name} (${columns.name}, ${columns.children})`,
         },
       ],

--- a/tests/entities-mssql/Book2.ts
+++ b/tests/entities-mssql/Book2.ts
@@ -1,5 +1,5 @@
 import { v4 } from 'uuid';
-import { Cascade, Collection, Ref, JsonType, OptionalProps, QueryOrder, t, sql } from '@mikro-orm/core';
+import { Cascade, Collection, Ref, JsonType, OptionalProps, QueryOrder, quote, t, sql } from '@mikro-orm/core';
 import { Entity, Filter, Formula, ManyToMany, ManyToOne, OneToOne, PrimaryKey, Property, Unique } from '@mikro-orm/decorators/legacy';
 import { Publisher2 } from './Publisher2.js';
 import { Author2 } from './Author2.js';
@@ -34,7 +34,7 @@ export class Book2 {
   @Property({ type: t.decimal, precision: 8, scale: 2, nullable: true })
   price?: number;
 
-  @Formula(alias => `(${alias}.[price] * 1.19)`)
+  @Formula(cols => quote`(${cols.price} * 1.19)`)
   priceTaxed?: number;
 
   @Property({ type: 'float', nullable: true })

--- a/tests/entities-schema/Book4.ts
+++ b/tests/entities-schema/Book4.ts
@@ -1,4 +1,4 @@
-import { p, defineEntity, InferEntity } from '@mikro-orm/core';
+import { p, defineEntity, InferEntity, quote } from '@mikro-orm/core';
 import { BaseEntity5 } from './BaseEntity5.js';
 import { Author4 } from './Author4.js';
 import { Publisher4 } from './Publisher4.js';
@@ -18,10 +18,7 @@ export const Book4 = defineEntity({
   properties: {
     title: p.string(),
     price: p.float().nullable(),
-    priceTaxed: p
-      .float()
-      .formula(a => `${a}.price * 1.19`)
-      .persist(false),
+    priceTaxed: p.float().formula(cols => quote`${cols.price} * 1.19`),
     author: () => p.manyToOne(Author4).nullable(),
     publisher: () => p.manyToOne(Publisher4).ref().nullable(),
     tags: () => p.manyToMany(BookTag4).pivotTable('tags_ordered').fixedOrder(true),

--- a/tests/entities-sql/Book2.ts
+++ b/tests/entities-sql/Book2.ts
@@ -1,6 +1,28 @@
 import { v4 } from 'uuid';
-import { Cascade, Collection, Ref, OptionalProps, QueryOrder, ref, rel, t, sql } from '@mikro-orm/core';
-import { Entity, Filter, Formula, Index, ManyToMany, ManyToOne, OneToOne, PrimaryKey, Property, Unique } from '@mikro-orm/decorators/legacy';
+import {
+  Cascade,
+  Collection,
+  Ref,
+  OptionalProps,
+  QueryOrder,
+  quote,
+  ref,
+  rel,
+  t,
+  sql,
+} from '@mikro-orm/core';
+import {
+  Entity,
+  Filter,
+  Formula,
+  Index,
+  ManyToMany,
+  ManyToOne,
+  OneToOne,
+  PrimaryKey,
+  Property,
+  Unique,
+} from '@mikro-orm/decorators/legacy';
 import { Publisher2 } from './Publisher2.js';
 import { Author2 } from './Author2.js';
 import { BookTag2 } from './BookTag2.js';
@@ -34,7 +56,7 @@ export class Book2 {
   @Property({ type: t.decimal, precision: 8, scale: 2, nullable: true })
   price?: number;
 
-  @Formula(alias => `${alias}.price * 1.19`)
+  @Formula(cols => quote`${cols.price} * 1.19`)
   priceTaxed?: string;
 
   @Property({ type: t.double, nullable: true })

--- a/tests/features/cli/CompileCommand.test.ts
+++ b/tests/features/cli/CompileCommand.test.ts
@@ -54,6 +54,7 @@ function createSimpleMetadata(): MetadataStorage {
       type: 'string',
     },
   } as any;
+  meta.root = meta;
   meta.props = Object.values(meta.properties);
   meta.comparableProps = [meta.properties.id as any, meta.properties.name as any];
   meta.hydrateProps = meta.props;
@@ -78,6 +79,7 @@ function createSimpleMetadata(): MetadataStorage {
       type: 'string',
     },
   } as any;
+  embeddableMeta.root = embeddableMeta;
   embeddableMeta.props = Object.values(embeddableMeta.properties);
   embeddableMeta.comparableProps = [embeddableMeta.properties.street as any];
   embeddableMeta.hydrateProps = embeddableMeta.props;

--- a/tests/features/decorators/es/formulas.sqlite.test.ts
+++ b/tests/features/decorators/es/formulas.sqlite.test.ts
@@ -16,7 +16,7 @@ class User {
   @Property({ type: 'string' })
   lastName!: string;
 
-  @Formula(alias => `(CONCAT(${alias}.first_name, ' ',${alias}.last_name))`, { type: 'string' })
+  @Formula(cols => `(CONCAT(${cols.firstName}, ' ',${cols.lastName}))`, { type: 'string' })
   name!: Opt<string>;
 
 }

--- a/tests/features/entity-generator/MetadataHooks.mysql.test.ts
+++ b/tests/features/entity-generator/MetadataHooks.mysql.test.ts
@@ -65,7 +65,7 @@ const initialMetadataProcessor: MetadataProcessor = (metadata, platform) => {
         type: 'integer',
         runtimeType: 'number',
         lazy: true,
-        formula: alias => `TIMESTAMPDIFF(SECONDS, NOW(), ${alias}.updated_at)`,
+        formula: cols => `TIMESTAMPDIFF(SECONDS, NOW(), ${cols.updatedAt})`,
       });
       Object.entries(entity.properties).forEach(propEntry => {
         const [propName, propOptions] = propEntry;
@@ -112,11 +112,11 @@ const initialMetadataProcessor: MetadataProcessor = (metadata, platform) => {
       // the expression's callback present.
       entity.indexes.push({
         name: 'author2_custom_idx_on_email',
-        expression: (table, columns) => `create index "author2_custom_idx_on_email" on "${table.schema}"."${table.name}" ("${columns.email}")`,
+        expression: (columns, table) => `create index "author2_custom_idx_on_email" on "${table.schema}"."${table.name}" ("${columns.email}")`,
       } as IndexOptions<Author2>);
       entity.uniques.push({
         name: 'author2_custom_unique_on_email',
-        expression: (table, columns) => `alter table ${table} add constraint "author2_custom_unique_on_email" unique ("${columns.email}")`,
+        expression: (columns, table) => `alter table ${table} add constraint "author2_custom_unique_on_email" unique ("${columns.email}")`,
       } as UniqueOptions<Author2>);
     }
   });

--- a/tests/features/entity-generator/__snapshots__/MetadataHooks.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/MetadataHooks.mysql.test.ts.snap
@@ -64,7 +64,7 @@ export const Author2Schema = defineEntity({
     { name: 'custom_email_index_name', properties: ['email'] },
     {
       name: 'author2_custom_idx_on_email',
-      expression: (table, columns) => \`create index "author2_custom_idx_on_email" on "\${table.schema}"."\${table.name}" ("\${columns.email}")\`,
+      expression: (columns, table) => \`create index "author2_custom_idx_on_email" on "\${table.schema}"."\${table.name}" ("\${columns.email}")\`,
     },
   ],
   uniques: [
@@ -72,7 +72,7 @@ export const Author2Schema = defineEntity({
     { name: 'custom_email_unique_name', properties: ['email'] },
     {
       name: 'author2_custom_unique_on_email',
-      expression: (table, columns) => \`alter table \${table} add constraint "author2_custom_unique_on_email" unique ("\${columns.email}")\`,
+      expression: (columns, table) => \`alter table \${table} add constraint "author2_custom_unique_on_email" unique ("\${columns.email}")\`,
     },
   ],
   properties: {
@@ -90,7 +90,7 @@ export const Author2Schema = defineEntity({
     favouriteBook: () => p.manyToOne(Book2).updateRule('no action').deleteRule('cascade').nullable().eager().cascade(Cascade.PERSIST, Cascade.MERGE),
     favouriteAuthor: () => p.manyToOne(Author2).updateRule('no action').nullable(),
     identity: () => p.embedded(IdentitiesContainer).array().prefix(false).nullable(),
-    secondsSinceLastModified: p.integer().formula((alias)=>\`TIMESTAMPDIFF(SECONDS, NOW(), \${alias}.updated_at)\`).lazy(),
+    secondsSinceLastModified: p.integer().formula((cols)=>\`TIMESTAMPDIFF(SECONDS, NOW(), \${cols.updatedAt})\`).lazy(),
     authorToFriend: () => p.manyToMany(Author2).pivotTable('author_to_friend').joinColumn('author2_1_id').inverseJoinColumn('author2_2_id').hidden(),
     following: () => p.manyToMany(Author2).joinColumn('author2_1_id').inverseJoinColumn('author2_2_id'),
     address2: () => p.oneToOne(Address2).mappedBy('author'),
@@ -751,7 +751,7 @@ export const Author2Schema = new EntitySchema({
     { name: 'custom_email_index_name', properties: ['email'] },
     {
       name: 'author2_custom_idx_on_email',
-      expression: (table, columns) => \`create index "author2_custom_idx_on_email" on "\${table.schema}"."\${table.name}" ("\${columns.email}")\`,
+      expression: (columns, table) => \`create index "author2_custom_idx_on_email" on "\${table.schema}"."\${table.name}" ("\${columns.email}")\`,
     },
   ],
   uniques: [
@@ -759,7 +759,7 @@ export const Author2Schema = new EntitySchema({
     { name: 'custom_email_unique_name', properties: ['email'] },
     {
       name: 'author2_custom_unique_on_email',
-      expression: (table, columns) => \`alter table \${table} add constraint "author2_custom_unique_on_email" unique ("\${columns.email}")\`,
+      expression: (columns, table) => \`alter table \${table} add constraint "author2_custom_unique_on_email" unique ("\${columns.email}")\`,
     },
   ],
   properties: {
@@ -824,7 +824,7 @@ export const Author2Schema = new EntitySchema({
     },
     secondsSinceLastModified: {
       type: 'integer',
-      formula: (alias)=>\`TIMESTAMPDIFF(SECONDS, NOW(), \${alias}.updated_at)\`,
+      formula: (cols)=>\`TIMESTAMPDIFF(SECONDS, NOW(), \${cols.updatedAt})\`,
       lazy: true,
     },
     authorToFriend: {
@@ -1669,9 +1669,9 @@ import { MyExtendedDataClass } from '../MyExtendedDataClass';
 
 @Entity({ readonly: true })
 @Index({ name: 'author2_name_age_index', properties: ['name', 'age'] })
-@Index({ name: 'author2_custom_idx_on_email', expression: (table, columns) => \`create index "author2_custom_idx_on_email" on "\${table.schema}"."\${table.name}" ("\${columns.email}")\` })
+@Index({ name: 'author2_custom_idx_on_email', expression: (columns, table) => \`create index "author2_custom_idx_on_email" on "\${table.schema}"."\${table.name}" ("\${columns.email}")\` })
 @Unique({ name: 'author2_name_email_unique', properties: ['name', 'email'] })
-@Unique({ name: 'author2_custom_unique_on_email', expression: (table, columns) => \`alter table \${table} add constraint "author2_custom_unique_on_email" unique ("\${columns.email}")\` })
+@Unique({ name: 'author2_custom_unique_on_email', expression: (columns, table) => \`alter table \${table} add constraint "author2_custom_unique_on_email" unique ("\${columns.email}")\` })
 export class Author2 {
 
   [EagerProps]?: 'favouriteBook';
@@ -1724,7 +1724,7 @@ export class Author2 {
   @Embedded({ entity: () => IdentitiesContainer, array: true, prefix: false, nullable: true })
   identity: IdentitiesContainer[] | null = null;
 
-  @Formula((alias)=>\`TIMESTAMPDIFF(SECONDS, NOW(), \${alias}.updated_at)\`, { lazy: true })
+  @Formula((cols)=>\`TIMESTAMPDIFF(SECONDS, NOW(), \${cols.updatedAt})\`, { lazy: true })
   secondsSinceLastModified!: number;
 
   @ManyToMany({ entity: () => Author2, pivotTable: 'author_to_friend', joinColumn: 'author2_1_id', inverseJoinColumn: 'author2_2_id', hidden: true })
@@ -2442,7 +2442,7 @@ export const Author2Schema = defineEntity({
     { name: 'custom_email_index_name', properties: ['email'] },
     {
       name: 'author2_custom_idx_on_email',
-      expression: (table, columns) => \`create index "author2_custom_idx_on_email" on "\${table.schema}"."\${table.name}" ("\${columns.email}")\`,
+      expression: (columns, table) => \`create index "author2_custom_idx_on_email" on "\${table.schema}"."\${table.name}" ("\${columns.email}")\`,
     },
   ],
   uniques: [
@@ -2450,7 +2450,7 @@ export const Author2Schema = defineEntity({
     { name: 'custom_email_unique_name', properties: ['email'] },
     {
       name: 'author2_custom_unique_on_email',
-      expression: (table, columns) => \`alter table \${table} add constraint "author2_custom_unique_on_email" unique ("\${columns.email}")\`,
+      expression: (columns, table) => \`alter table \${table} add constraint "author2_custom_unique_on_email" unique ("\${columns.email}")\`,
     },
   ],
   properties: {
@@ -2468,7 +2468,7 @@ export const Author2Schema = defineEntity({
     favouriteBook: () => p.manyToOne(Book2).ref().updateRule('no action').deleteRule('cascade').nullable().eager().cascade(Cascade.PERSIST, Cascade.MERGE),
     favouriteAuthor: () => p.manyToOne(Author2).ref().updateRule('no action').nullable(),
     identity: () => p.embedded(IdentitiesContainer).array().prefix(false).nullable(),
-    secondsSinceLastModified: p.integer().formula((alias)=>\`TIMESTAMPDIFF(SECONDS, NOW(), \${alias}.updated_at)\`).lazy(),
+    secondsSinceLastModified: p.integer().formula((cols)=>\`TIMESTAMPDIFF(SECONDS, NOW(), \${cols.updatedAt})\`).lazy(),
     authorToFriend: () => p.manyToMany(Author2).pivotTable('author_to_friend').joinColumn('author2_1_id').inverseJoinColumn('author2_2_id').hidden(),
     following: () => p.manyToMany(Author2).joinColumn('author2_1_id').inverseJoinColumn('author2_2_id'),
     address2: () => p.oneToOne(Address2).ref().mappedBy('author'),
@@ -3129,7 +3129,7 @@ export const Author2Schema = new EntitySchema({
     { name: 'custom_email_index_name', properties: ['email'] },
     {
       name: 'author2_custom_idx_on_email',
-      expression: (table, columns) => \`create index "author2_custom_idx_on_email" on "\${table.schema}"."\${table.name}" ("\${columns.email}")\`,
+      expression: (columns, table) => \`create index "author2_custom_idx_on_email" on "\${table.schema}"."\${table.name}" ("\${columns.email}")\`,
     },
   ],
   uniques: [
@@ -3137,7 +3137,7 @@ export const Author2Schema = new EntitySchema({
     { name: 'custom_email_unique_name', properties: ['email'] },
     {
       name: 'author2_custom_unique_on_email',
-      expression: (table, columns) => \`alter table \${table} add constraint "author2_custom_unique_on_email" unique ("\${columns.email}")\`,
+      expression: (columns, table) => \`alter table \${table} add constraint "author2_custom_unique_on_email" unique ("\${columns.email}")\`,
     },
   ],
   properties: {
@@ -3205,7 +3205,7 @@ export const Author2Schema = new EntitySchema({
     },
     secondsSinceLastModified: {
       type: 'integer',
-      formula: (alias)=>\`TIMESTAMPDIFF(SECONDS, NOW(), \${alias}.updated_at)\`,
+      formula: (cols)=>\`TIMESTAMPDIFF(SECONDS, NOW(), \${cols.updatedAt})\`,
       lazy: true,
     },
     authorToFriend: {
@@ -4074,9 +4074,9 @@ import { MyExtendedDataClass } from '../MyExtendedDataClass';
 
 @Entity({ readonly: true })
 @Index({ name: 'author2_name_age_index', properties: ['name', 'age'] })
-@Index({ name: 'author2_custom_idx_on_email', expression: (table, columns) => \`create index "author2_custom_idx_on_email" on "\${table.schema}"."\${table.name}" ("\${columns.email}")\` })
+@Index({ name: 'author2_custom_idx_on_email', expression: (columns, table) => \`create index "author2_custom_idx_on_email" on "\${table.schema}"."\${table.name}" ("\${columns.email}")\` })
 @Unique({ name: 'author2_name_email_unique', properties: ['name', 'email'] })
-@Unique({ name: 'author2_custom_unique_on_email', expression: (table, columns) => \`alter table \${table} add constraint "author2_custom_unique_on_email" unique ("\${columns.email}")\` })
+@Unique({ name: 'author2_custom_unique_on_email', expression: (columns, table) => \`alter table \${table} add constraint "author2_custom_unique_on_email" unique ("\${columns.email}")\` })
 export class Author2 {
 
   [EagerProps]?: 'favouriteBook';
@@ -4129,7 +4129,7 @@ export class Author2 {
   @Embedded({ entity: () => IdentitiesContainer, array: true, prefix: false, nullable: true })
   identity: IdentitiesContainer[] | null = null;
 
-  @Formula((alias)=>\`TIMESTAMPDIFF(SECONDS, NOW(), \${alias}.updated_at)\`, { lazy: true })
+  @Formula((cols)=>\`TIMESTAMPDIFF(SECONDS, NOW(), \${cols.updatedAt})\`, { lazy: true })
   secondsSinceLastModified!: number;
 
   @ManyToMany({ entity: () => Author2, pivotTable: 'author_to_friend', joinColumn: 'author2_1_id', inverseJoinColumn: 'author2_2_id', hidden: true })
@@ -4849,7 +4849,7 @@ export const Author2Schema = defineEntity({
     { name: 'custom_email_index_name', properties: ['email'] },
     {
       name: 'author2_custom_idx_on_email',
-      expression: (table, columns) => \`create index "author2_custom_idx_on_email" on "\${table.schema}"."\${table.name}" ("\${columns.email}")\`,
+      expression: (columns, table) => \`create index "author2_custom_idx_on_email" on "\${table.schema}"."\${table.name}" ("\${columns.email}")\`,
     },
   ],
   uniques: [
@@ -4857,7 +4857,7 @@ export const Author2Schema = defineEntity({
     { name: 'custom_email_unique_name', properties: ['email'] },
     {
       name: 'author2_custom_unique_on_email',
-      expression: (table, columns) => \`alter table \${table} add constraint "author2_custom_unique_on_email" unique ("\${columns.email}")\`,
+      expression: (columns, table) => \`alter table \${table} add constraint "author2_custom_unique_on_email" unique ("\${columns.email}")\`,
     },
   ],
   properties: {
@@ -4875,7 +4875,7 @@ export const Author2Schema = defineEntity({
     favouriteBook: () => p.manyToOne(Book2).updateRule('no action').deleteRule('cascade').nullable().eager().cascade(Cascade.PERSIST, Cascade.MERGE),
     favouriteAuthor: () => p.manyToOne(Author2).updateRule('no action').nullable(),
     identity: () => p.embedded(IdentitiesContainer).array().prefix(false).nullable(),
-    secondsSinceLastModified: p.integer().formula((alias)=>\`TIMESTAMPDIFF(SECONDS, NOW(), \${alias}.updated_at)\`).lazy(),
+    secondsSinceLastModified: p.integer().formula((cols)=>\`TIMESTAMPDIFF(SECONDS, NOW(), \${cols.updatedAt})\`).lazy(),
     authorToFriend: () => p.manyToMany(Author2).pivotTable('author_to_friend').joinColumn('author2_1_id').inverseJoinColumn('author2_2_id').hidden(),
     following: () => p.manyToMany(Author2).joinColumn('author2_1_id').inverseJoinColumn('author2_2_id'),
     address2: () => p.oneToOne(Address2).mappedBy('author'),
@@ -5536,7 +5536,7 @@ export const Author2Schema = new EntitySchema({
     { name: 'custom_email_index_name', properties: ['email'] },
     {
       name: 'author2_custom_idx_on_email',
-      expression: (table, columns) => \`create index "author2_custom_idx_on_email" on "\${table.schema}"."\${table.name}" ("\${columns.email}")\`,
+      expression: (columns, table) => \`create index "author2_custom_idx_on_email" on "\${table.schema}"."\${table.name}" ("\${columns.email}")\`,
     },
   ],
   uniques: [
@@ -5544,7 +5544,7 @@ export const Author2Schema = new EntitySchema({
     { name: 'custom_email_unique_name', properties: ['email'] },
     {
       name: 'author2_custom_unique_on_email',
-      expression: (table, columns) => \`alter table \${table} add constraint "author2_custom_unique_on_email" unique ("\${columns.email}")\`,
+      expression: (columns, table) => \`alter table \${table} add constraint "author2_custom_unique_on_email" unique ("\${columns.email}")\`,
     },
   ],
   properties: {
@@ -5609,7 +5609,7 @@ export const Author2Schema = new EntitySchema({
     },
     secondsSinceLastModified: {
       type: 'integer',
-      formula: (alias)=>\`TIMESTAMPDIFF(SECONDS, NOW(), \${alias}.updated_at)\`,
+      formula: (cols)=>\`TIMESTAMPDIFF(SECONDS, NOW(), \${cols.updatedAt})\`,
       lazy: true,
     },
     authorToFriend: {
@@ -6454,9 +6454,9 @@ import { MyExtendedDataClass } from '../MyExtendedDataClass';
 
 @Entity({ readonly: true })
 @Index({ name: 'author2_name_age_index', properties: ['name', 'age'] })
-@Index({ name: 'author2_custom_idx_on_email', expression: (table, columns) => \`create index "author2_custom_idx_on_email" on "\${table.schema}"."\${table.name}" ("\${columns.email}")\` })
+@Index({ name: 'author2_custom_idx_on_email', expression: (columns, table) => \`create index "author2_custom_idx_on_email" on "\${table.schema}"."\${table.name}" ("\${columns.email}")\` })
 @Unique({ name: 'author2_name_email_unique', properties: ['name', 'email'] })
-@Unique({ name: 'author2_custom_unique_on_email', expression: (table, columns) => \`alter table \${table} add constraint "author2_custom_unique_on_email" unique ("\${columns.email}")\` })
+@Unique({ name: 'author2_custom_unique_on_email', expression: (columns, table) => \`alter table \${table} add constraint "author2_custom_unique_on_email" unique ("\${columns.email}")\` })
 export class Author2 {
 
   [EagerProps]?: 'favouriteBook';
@@ -6509,7 +6509,7 @@ export class Author2 {
   @Embedded({ entity: () => IdentitiesContainer, array: true, prefix: false, nullable: true })
   identity?: IdentitiesContainer[];
 
-  @Formula((alias)=>\`TIMESTAMPDIFF(SECONDS, NOW(), \${alias}.updated_at)\`, { lazy: true })
+  @Formula((cols)=>\`TIMESTAMPDIFF(SECONDS, NOW(), \${cols.updatedAt})\`, { lazy: true })
   secondsSinceLastModified!: number;
 
   @ManyToMany({ entity: () => Author2, pivotTable: 'author_to_friend', joinColumn: 'author2_1_id', inverseJoinColumn: 'author2_2_id', hidden: true })
@@ -7227,7 +7227,7 @@ export const Author2Schema = defineEntity({
     { name: 'custom_email_index_name', properties: ['email'] },
     {
       name: 'author2_custom_idx_on_email',
-      expression: (table, columns) => \`create index "author2_custom_idx_on_email" on "\${table.schema}"."\${table.name}" ("\${columns.email}")\`,
+      expression: (columns, table) => \`create index "author2_custom_idx_on_email" on "\${table.schema}"."\${table.name}" ("\${columns.email}")\`,
     },
   ],
   uniques: [
@@ -7235,7 +7235,7 @@ export const Author2Schema = defineEntity({
     { name: 'custom_email_unique_name', properties: ['email'] },
     {
       name: 'author2_custom_unique_on_email',
-      expression: (table, columns) => \`alter table \${table} add constraint "author2_custom_unique_on_email" unique ("\${columns.email}")\`,
+      expression: (columns, table) => \`alter table \${table} add constraint "author2_custom_unique_on_email" unique ("\${columns.email}")\`,
     },
   ],
   properties: {
@@ -7253,7 +7253,7 @@ export const Author2Schema = defineEntity({
     favouriteBook: () => p.manyToOne(Book2).ref().updateRule('no action').deleteRule('cascade').nullable().eager().cascade(Cascade.PERSIST, Cascade.MERGE),
     favouriteAuthor: () => p.manyToOne(Author2).ref().updateRule('no action').nullable(),
     identity: () => p.embedded(IdentitiesContainer).array().prefix(false).nullable(),
-    secondsSinceLastModified: p.integer().formula((alias)=>\`TIMESTAMPDIFF(SECONDS, NOW(), \${alias}.updated_at)\`).lazy(),
+    secondsSinceLastModified: p.integer().formula((cols)=>\`TIMESTAMPDIFF(SECONDS, NOW(), \${cols.updatedAt})\`).lazy(),
     authorToFriend: () => p.manyToMany(Author2).pivotTable('author_to_friend').joinColumn('author2_1_id').inverseJoinColumn('author2_2_id').hidden(),
     following: () => p.manyToMany(Author2).joinColumn('author2_1_id').inverseJoinColumn('author2_2_id'),
     address2: () => p.oneToOne(Address2).ref().mappedBy('author'),
@@ -7914,7 +7914,7 @@ export const Author2Schema = new EntitySchema({
     { name: 'custom_email_index_name', properties: ['email'] },
     {
       name: 'author2_custom_idx_on_email',
-      expression: (table, columns) => \`create index "author2_custom_idx_on_email" on "\${table.schema}"."\${table.name}" ("\${columns.email}")\`,
+      expression: (columns, table) => \`create index "author2_custom_idx_on_email" on "\${table.schema}"."\${table.name}" ("\${columns.email}")\`,
     },
   ],
   uniques: [
@@ -7922,7 +7922,7 @@ export const Author2Schema = new EntitySchema({
     { name: 'custom_email_unique_name', properties: ['email'] },
     {
       name: 'author2_custom_unique_on_email',
-      expression: (table, columns) => \`alter table \${table} add constraint "author2_custom_unique_on_email" unique ("\${columns.email}")\`,
+      expression: (columns, table) => \`alter table \${table} add constraint "author2_custom_unique_on_email" unique ("\${columns.email}")\`,
     },
   ],
   properties: {
@@ -7990,7 +7990,7 @@ export const Author2Schema = new EntitySchema({
     },
     secondsSinceLastModified: {
       type: 'integer',
-      formula: (alias)=>\`TIMESTAMPDIFF(SECONDS, NOW(), \${alias}.updated_at)\`,
+      formula: (cols)=>\`TIMESTAMPDIFF(SECONDS, NOW(), \${cols.updatedAt})\`,
       lazy: true,
     },
     authorToFriend: {
@@ -8859,9 +8859,9 @@ import { MyExtendedDataClass } from '../MyExtendedDataClass';
 
 @Entity({ readonly: true })
 @Index({ name: 'author2_name_age_index', properties: ['name', 'age'] })
-@Index({ name: 'author2_custom_idx_on_email', expression: (table, columns) => \`create index "author2_custom_idx_on_email" on "\${table.schema}"."\${table.name}" ("\${columns.email}")\` })
+@Index({ name: 'author2_custom_idx_on_email', expression: (columns, table) => \`create index "author2_custom_idx_on_email" on "\${table.schema}"."\${table.name}" ("\${columns.email}")\` })
 @Unique({ name: 'author2_name_email_unique', properties: ['name', 'email'] })
-@Unique({ name: 'author2_custom_unique_on_email', expression: (table, columns) => \`alter table \${table} add constraint "author2_custom_unique_on_email" unique ("\${columns.email}")\` })
+@Unique({ name: 'author2_custom_unique_on_email', expression: (columns, table) => \`alter table \${table} add constraint "author2_custom_unique_on_email" unique ("\${columns.email}")\` })
 export class Author2 {
 
   [EagerProps]?: 'favouriteBook';
@@ -8914,7 +8914,7 @@ export class Author2 {
   @Embedded({ entity: () => IdentitiesContainer, array: true, prefix: false, nullable: true })
   identity?: IdentitiesContainer[];
 
-  @Formula((alias)=>\`TIMESTAMPDIFF(SECONDS, NOW(), \${alias}.updated_at)\`, { lazy: true })
+  @Formula((cols)=>\`TIMESTAMPDIFF(SECONDS, NOW(), \${cols.updatedAt})\`, { lazy: true })
   secondsSinceLastModified!: number;
 
   @ManyToMany({ entity: () => Author2, pivotTable: 'author_to_friend', joinColumn: 'author2_1_id', inverseJoinColumn: 'author2_2_id', hidden: true })

--- a/tests/features/entity-manager/EntityManager.mysql.test.ts
+++ b/tests/features/entity-manager/EntityManager.mysql.test.ts
@@ -483,13 +483,13 @@ describe('EntityManagerMySql', () => {
     await em.commit();
 
     expect(mock.mock.calls[0][0]).toMatch('begin');
-    expect(mock.mock.calls[1][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`isbn`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` from `book2` as `b0` left join `test2` as `t1` on `b0`.`uuid_pk` = `t1`.`book_uuid_pk` where `b0`.`author_id` is not null and `b0`.`uuid_pk` = ? limit ?');
+    expect(mock.mock.calls[1][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`isbn`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.`price` * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` from `book2` as `b0` left join `test2` as `t1` on `b0`.`uuid_pk` = `t1`.`book_uuid_pk` where `b0`.`author_id` is not null and `b0`.`uuid_pk` = ? limit ?');
     expect(mock.mock.calls[2][0]).toMatch('select `p0`.* from `publisher2` as `p0` where `p0`.`id` = ? limit ? for update');
     expect(mock.mock.calls[3][0]).toMatch('select `p0`.`id`, `p0`.`test2_id`, `p0`.`publisher2_id`, `t1`.`id` as `t1__id`, `t1`.`name` as `t1__name`, `t1`.`book_uuid_pk` as `t1__book_uuid_pk`, `t1`.`parent_id` as `t1__parent_id`, `t1`.`version` as `t1__version` from `publisher2_tests` as `p0` inner join `test2` as `t1` on `p0`.`test2_id` = `t1`.`id` where `p0`.`publisher2_id` in (?) order by `p0`.`id` asc for update');
     expect(mock.mock.calls[4][0]).toMatch('savepoint `trx');
     expect(mock.mock.calls[5][0]).toMatch('select 123');
     expect(mock.mock.calls[6][0]).toMatch('release savepoint `trx');
-    expect(mock.mock.calls[7][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`isbn`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` from `book2` as `b0` left join `test2` as `t1` on `b0`.`uuid_pk` = `t1`.`book_uuid_pk` where `b0`.`author_id` is not null and `b0`.`publisher_id` in (?) for update');
+    expect(mock.mock.calls[7][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`isbn`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.`price` * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` from `book2` as `b0` left join `test2` as `t1` on `b0`.`uuid_pk` = `t1`.`book_uuid_pk` where `b0`.`author_id` is not null and `b0`.`publisher_id` in (?) for update');
     expect(mock.mock.calls[8][0]).toMatch('commit');
   });
 
@@ -1814,7 +1814,7 @@ describe('EntityManagerMySql', () => {
       orderBy: { title: QueryOrder.DESC },
       strategy: 'joined',
     });
-    expect(mock.mock.calls[0][0]).toMatch('select `b0`.*, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `t1__id`, `t1`.`name` as `t1__name`, `t5`.`id` as `t5__id` ' +
+    expect(mock.mock.calls[0][0]).toMatch('select `b0`.*, `b0`.`price` * 1.19 as `price_taxed`, `t1`.`id` as `t1__id`, `t1`.`name` as `t1__name`, `t5`.`id` as `t5__id` ' +
       'from `book2` as `b0` ' +
       'left join `book_to_tag_unordered` as `b2` on `b0`.`uuid_pk` = `b2`.`book2_uuid_pk` ' +
       'left join `book_tag2` as `t1` on `b2`.`book_tag2_id` = `t1`.`id` ' +
@@ -1841,7 +1841,7 @@ describe('EntityManagerMySql', () => {
       orderBy: { title: QueryOrder.DESC },
       strategy: 'joined',
     });
-    expect(mock.mock.calls[0][0]).toMatch('select `b0`.*, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `t1__id`, `t1`.`name` as `t1__name`, `t3`.`id` as `t3__id` ' +
+    expect(mock.mock.calls[0][0]).toMatch('select `b0`.*, `b0`.`price` * 1.19 as `price_taxed`, `t1`.`id` as `t1__id`, `t1`.`name` as `t1__name`, `t3`.`id` as `t3__id` ' +
       'from `book2` as `b0` ' +
       'left join (`book_to_tag_unordered` as `b2` inner join `book_tag2` as `t1` on `b2`.`book_tag2_id` = `t1`.`id` and `t1`.`name` != ?) on `b0`.`uuid_pk` = `b2`.`book2_uuid_pk` ' +
       'left join `test2` as `t3` on `b0`.`uuid_pk` = `t3`.`book_uuid_pk` ' +
@@ -1867,7 +1867,7 @@ describe('EntityManagerMySql', () => {
       strategy: 'joined',
     });
 
-    expect(mock.mock.calls[0][0]).toMatch('select `b0`.*, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `t1__id`, `t1`.`name` as `t1__name`, `t5`.`id` as `t5__id` ' +
+    expect(mock.mock.calls[0][0]).toMatch('select `b0`.*, `b0`.`price` * 1.19 as `price_taxed`, `t1`.`id` as `t1__id`, `t1`.`name` as `t1__name`, `t5`.`id` as `t5__id` ' +
       'from `book2` as `b0` ' +
       'left join (`book_to_tag_unordered` as `b2` inner join `book_tag2` as `t1` on `b2`.`book_tag2_id` = `t1`.`id` and `t1`.`name` != ?) on `b0`.`uuid_pk` = `b2`.`book2_uuid_pk` ' +
       'left join `book_to_tag_unordered` as `b4` on `b0`.`uuid_pk` = `b4`.`book2_uuid_pk` ' +
@@ -1901,7 +1901,7 @@ describe('EntityManagerMySql', () => {
       'left join `book2` as `b1` on `b2`.`book2_uuid_pk` = `b1`.`uuid_pk` and `b1`.`author_id` is not null ' +
       'where `b1`.`title` != ? ' +
       'order by `b0`.`name` asc');
-    expect(mock.mock.calls[1][0]).toMatch('select `b0`.`book2_uuid_pk`, `b0`.`book_tag2_id`, `b1`.`uuid_pk` as `b1__uuid_pk`, `b1`.`created_at` as `b1__created_at`, `b1`.`isbn` as `b1__isbn`, `b1`.`title` as `b1__title`, `b1`.`perex` as `b1__perex`, `b1`.`price` as `b1__price`, `b1`.price * 1.19 as `b1__price_taxed`, `b1`.`double` as `b1__double`, `b1`.`meta` as `b1__meta`, `b1`.`author_id` as `b1__author_id`, `b1`.`publisher_id` as `b1__publisher_id`, `t2`.`id` as `t2__id` from `book_to_tag_unordered` as `b0` inner join `book2` as `b1` on `b0`.`book2_uuid_pk` = `b1`.`uuid_pk` ' +
+    expect(mock.mock.calls[1][0]).toMatch('select `b0`.`book2_uuid_pk`, `b0`.`book_tag2_id`, `b1`.`uuid_pk` as `b1__uuid_pk`, `b1`.`created_at` as `b1__created_at`, `b1`.`isbn` as `b1__isbn`, `b1`.`title` as `b1__title`, `b1`.`perex` as `b1__perex`, `b1`.`price` as `b1__price`, `b1`.`price` * 1.19 as `b1__price_taxed`, `b1`.`double` as `b1__double`, `b1`.`meta` as `b1__meta`, `b1`.`author_id` as `b1__author_id`, `b1`.`publisher_id` as `b1__publisher_id`, `t2`.`id` as `t2__id` from `book_to_tag_unordered` as `b0` inner join `book2` as `b1` on `b0`.`book2_uuid_pk` = `b1`.`uuid_pk` ' +
       'left join `test2` as `t2` on `b1`.`uuid_pk` = `t2`.`book_uuid_pk` ' +
       'where `b0`.`book_tag2_id` in (?, ?, ?, ?, ?, ?) and `b1`.`author_id` is not null and `b1`.`title` != ?');
   });
@@ -2247,7 +2247,7 @@ describe('EntityManagerMySql', () => {
     expect(res1[0].test).toBeInstanceOf(Test2);
     expect(wrap(res1[0].test!).isInitialized()).toBe(false);
     expect(mock.mock.calls).toHaveLength(1);
-    expect(mock.mock.calls[0][0]).toMatch('select `b0`.*, `b0`.price * 1.19 as `price_taxed`, `t2`.`id` as `t2__id` ' +
+    expect(mock.mock.calls[0][0]).toMatch('select `b0`.*, `b0`.`price` * 1.19 as `price_taxed`, `t2`.`id` as `t2__id` ' +
       'from `book2` as `b0` ' +
       'inner join `author2` as `a1` on `b0`.`author_id` = `a1`.`id` ' +
       'left join `test2` as `t2` on `b0`.`uuid_pk` = `t2`.`book_uuid_pk` ' + // auto-joined 1:1 to get test id as book is inverse side
@@ -2260,7 +2260,7 @@ describe('EntityManagerMySql', () => {
     expect(res2[0].test).toBeInstanceOf(Test2);
     expect(wrap(res2[0].test!).isInitialized()).toBe(false);
     expect(mock.mock.calls.length).toBe(1);
-    expect(mock.mock.calls[0][0]).toMatch('select `b0`.*, `b0`.price * 1.19 as `price_taxed`, `t4`.`id` as `t4__id` ' +
+    expect(mock.mock.calls[0][0]).toMatch('select `b0`.*, `b0`.`price` * 1.19 as `price_taxed`, `t4`.`id` as `t4__id` ' +
       'from `book2` as `b0` ' +
       'inner join `author2` as `a1` on `b0`.`author_id` = `a1`.`id` ' +
       'left join (`book2` as `b2` ' +
@@ -2276,7 +2276,7 @@ describe('EntityManagerMySql', () => {
     expect(res3[0].test).toBeInstanceOf(Test2);
     expect(wrap(res3[0].test!).isInitialized()).toBe(false);
     expect(mock.mock.calls.length).toBe(1);
-    expect(mock.mock.calls[0][0]).toMatch('select `b0`.*, `b0`.price * 1.19 as `price_taxed`, `t2`.`id` as `t2__id` ' +
+    expect(mock.mock.calls[0][0]).toMatch('select `b0`.*, `b0`.`price` * 1.19 as `price_taxed`, `t2`.`id` as `t2__id` ' +
       'from `book2` as `b0` ' +
       'inner join `author2` as `a1` on `b0`.`author_id` = `a1`.`id` ' +
       'left join `test2` as `t2` on `b0`.`uuid_pk` = `t2`.`book_uuid_pk` ' +
@@ -2289,7 +2289,7 @@ describe('EntityManagerMySql', () => {
     expect(res4[0].test).toBeInstanceOf(Test2);
     expect(wrap(res4[0].test!).isInitialized()).toBe(false);
     expect(mock.mock.calls.length).toBe(1);
-    expect(mock.mock.calls[0][0]).toMatch('select `b0`.*, `b0`.price * 1.19 as `price_taxed`, `t4`.`id` as `t4__id` ' +
+    expect(mock.mock.calls[0][0]).toMatch('select `b0`.*, `b0`.`price` * 1.19 as `price_taxed`, `t4`.`id` as `t4__id` ' +
       'from `book2` as `b0` ' +
       'inner join `author2` as `a1` on `b0`.`author_id` = `a1`.`id` ' +
       'left join (`book2` as `b2` ' +
@@ -2571,7 +2571,7 @@ describe('EntityManagerMySql', () => {
     const b = await orm.em.findOneOrFail(Book2, { author: { name: 'God' } }, { strategy: 'select-in' });
     expect(b.price).toBe(1000.00);
     expect(b.priceTaxed).toBe('1190.0000');
-    expect(mock.mock.calls[0][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`isbn`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t2`.`id` as `t2__id` ' +
+    expect(mock.mock.calls[0][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`isbn`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.`price` * 1.19 as `price_taxed`, `t2`.`id` as `t2__id` ' +
       'from `book2` as `b0` ' +
       'inner join `author2` as `a1` on `b0`.`author_id` = `a1`.`id` ' +
       'left join `test2` as `t2` on `b0`.`uuid_pk` = `t2`.`book_uuid_pk` ' +
@@ -2622,10 +2622,10 @@ describe('EntityManagerMySql', () => {
     const b = await orm.em.fork().findOneOrFail(Book2, { priceTaxed: '1190.0000' }, { strategy: 'select-in' });
     expect(b.price).toBe(1000.00);
     expect(b.priceTaxed).toBe('1190.0000');
-    expect(mock.mock.calls[0][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`isbn`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` ' +
+    expect(mock.mock.calls[0][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`isbn`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.`price` * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` ' +
       'from `book2` as `b0` ' +
       'left join `test2` as `t1` on `b0`.`uuid_pk` = `t1`.`book_uuid_pk` ' +
-      'where `b0`.`author_id` is not null and `b0`.price * 1.19 = ? limit ?');
+      'where `b0`.`author_id` is not null and `b0`.`price` * 1.19 = ? limit ?');
 
     const a1 = await orm.em.fork().find(Author2, { $or: [{ favouriteBook: { priceTaxed: '1190.0000' } }] }, { populate: ['books'], strategy: 'select-in' });
     expect(a1[0].books[0].price).toBe(1000.00);
@@ -2634,8 +2634,8 @@ describe('EntityManagerMySql', () => {
       'from `author2` as `a0` ' +
       'left join `book2` as `b1` on `a0`.`favourite_book_uuid_pk` = `b1`.`uuid_pk` and `b1`.`author_id` is not null ' +
       'left join `address2` as `a2` on `a0`.`id` = `a2`.`author_id` ' +
-      'where `b1`.price * 1.19 = ?');
-    expect(mock.mock.calls[2][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`isbn`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` ' +
+      'where `b1`.`price` * 1.19 = ?');
+    expect(mock.mock.calls[2][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`isbn`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.`price` * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` ' +
       'from `book2` as `b0` ' +
       'left join `test2` as `t1` on `b0`.`uuid_pk` = `t1`.`book_uuid_pk` ' +
       'where `b0`.`author_id` is not null and `b0`.`author_id` in (?) ' +
@@ -2648,8 +2648,8 @@ describe('EntityManagerMySql', () => {
       'from `author2` as `a0` ' +
       'left join `book2` as `b1` on `a0`.`favourite_book_uuid_pk` = `b1`.`uuid_pk` and `b1`.`author_id` is not null ' +
       'left join `address2` as `a2` on `a0`.`id` = `a2`.`author_id` ' +
-      'where `b1`.price * 1.19 = ?');
-    expect(mock.mock.calls[4][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`isbn`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` ' +
+      'where `b1`.`price` * 1.19 = ?');
+    expect(mock.mock.calls[4][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`isbn`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.`price` * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` ' +
       'from `book2` as `b0` ' +
       'left join `test2` as `t1` on `b0`.`uuid_pk` = `t1`.`book_uuid_pk` ' +
       'where `b0`.`author_id` is not null and `b0`.`author_id` in (?) ' +

--- a/tests/features/entity-manager/EntityManager.postgre.test.ts
+++ b/tests/features/entity-manager/EntityManager.postgre.test.ts
@@ -388,12 +388,12 @@ describe('EntityManagerPostgre', () => {
     await em.commit();
 
     expect(mock.mock.calls[0][0]).toMatch(`begin`);
-    expect(mock.mock.calls[1][0]).toMatch(`select "b0"."uuid_pk", "b0"."created_at", "b0"."isbn", "b0"."title", "b0"."price", "b0"."double", "b0"."meta", "b0"."author_id", "b0"."publisher_id", "b0".price * 1.19 as "price_taxed" from "book2" as "b0" where "b0"."author_id" is not null and "b0"."uuid_pk" = ? limit ?`);
+    expect(mock.mock.calls[1][0]).toMatch(`select "b0"."uuid_pk", "b0"."created_at", "b0"."isbn", "b0"."title", "b0"."price", "b0"."double", "b0"."meta", "b0"."author_id", "b0"."publisher_id", "b0"."price" * 1.19 as "price_taxed" from "book2" as "b0" where "b0"."author_id" is not null and "b0"."uuid_pk" = ? limit ?`);
     expect(mock.mock.calls[2][0]).toMatch(`select "p0".* from "publisher2" as "p0" where "p0"."id" = ? limit ? for update`);
     expect(mock.mock.calls[3][0]).toMatch(`select "p0"."id", "p0"."test2_id", "p0"."publisher2_id", "t1"."id" as "t1__id", "t1"."name" as "t1__name", "t1"."book_uuid_pk" as "t1__book_uuid_pk", "t1"."parent_id" as "t1__parent_id", "t1"."version" as "t1__version", "b2"."uuid_pk" as "b2__uuid_pk" from "publisher2_tests" as "p0" inner join "test2" as "t1" on "p0"."test2_id" = "t1"."id" left join "book2" as "b2" on "t1"."book_uuid_pk" = "b2"."uuid_pk" where "p0"."publisher2_id" in (?) order by "p0"."id" asc for update of "p0", "t1"`);
     expect(mock.mock.calls[4][0]).toMatch(`savepoint "trx`);
     expect(mock.mock.calls[5][0]).toMatch(`release savepoint "trx`);
-    expect(mock.mock.calls[6][0]).toMatch(`select "b0"."uuid_pk", "b0"."created_at", "b0"."isbn", "b0"."title", "b0"."price", "b0"."double", "b0"."meta", "b0"."author_id", "b0"."publisher_id", "b0".price * 1.19 as "price_taxed" from "book2" as "b0" where "b0"."author_id" is not null and "b0"."publisher_id" in (?) for update`);
+    expect(mock.mock.calls[6][0]).toMatch(`select "b0"."uuid_pk", "b0"."created_at", "b0"."isbn", "b0"."title", "b0"."price", "b0"."double", "b0"."meta", "b0"."author_id", "b0"."publisher_id", "b0"."price" * 1.19 as "price_taxed" from "book2" as "b0" where "b0"."author_id" is not null and "b0"."publisher_id" in (?) for update`);
     expect(mock.mock.calls[7][0]).toMatch(`commit`);
   });
 
@@ -924,7 +924,7 @@ describe('EntityManagerPostgre', () => {
     });
     expect(mock.mock.calls.length).toBe(3);
     expect(mock.mock.calls[0][0]).toMatch('begin');
-    expect(mock.mock.calls[1][0]).toMatch('select "b0"."uuid_pk", "b0"."created_at", "b0"."isbn", "b0"."title", "b0"."price", "b0"."double", "b0"."meta", "b0"."author_id", "b0"."publisher_id", "b0".price * 1.19 as "price_taxed", "a1"."id" as "a1__id", "a1"."created_at" as "a1__created_at", "a1"."updated_at" as "a1__updated_at", "a1"."name" as "a1__name", "a1"."email" as "a1__email", "a1"."age" as "a1__age", "a1"."terms_accepted" as "a1__terms_accepted", "a1"."optional" as "a1__optional", "a1"."identities" as "a1__identities", "a1"."born" as "a1__born", "a1"."born_time" as "a1__born_time", "a1"."favourite_book_uuid_pk" as "a1__favourite_book_uuid_pk", "a1"."favourite_author_id" as "a1__favourite_author_id", "a1"."identity" as "a1__identity", "f2"."uuid_pk" as "f2__uuid_pk" from "book2" as "b0" inner join "author2" as "a1" on "b0"."author_id" = "a1"."id" left join "book2" as "f2" on "a1"."favourite_book_uuid_pk" = "f2"."uuid_pk" and "f2"."author_id" is not null where "b0"."author_id" is not null for update of "b0" skip locked');
+    expect(mock.mock.calls[1][0]).toMatch('select "b0"."uuid_pk", "b0"."created_at", "b0"."isbn", "b0"."title", "b0"."price", "b0"."double", "b0"."meta", "b0"."author_id", "b0"."publisher_id", "b0"."price" * 1.19 as "price_taxed", "a1"."id" as "a1__id", "a1"."created_at" as "a1__created_at", "a1"."updated_at" as "a1__updated_at", "a1"."name" as "a1__name", "a1"."email" as "a1__email", "a1"."age" as "a1__age", "a1"."terms_accepted" as "a1__terms_accepted", "a1"."optional" as "a1__optional", "a1"."identities" as "a1__identities", "a1"."born" as "a1__born", "a1"."born_time" as "a1__born_time", "a1"."favourite_book_uuid_pk" as "a1__favourite_book_uuid_pk", "a1"."favourite_author_id" as "a1__favourite_author_id", "a1"."identity" as "a1__identity", "f2"."uuid_pk" as "f2__uuid_pk" from "book2" as "b0" inner join "author2" as "a1" on "b0"."author_id" = "a1"."id" left join "book2" as "f2" on "a1"."favourite_book_uuid_pk" = "f2"."uuid_pk" and "f2"."author_id" is not null where "b0"."author_id" is not null for update of "b0" skip locked');
     expect(mock.mock.calls[2][0]).toMatch('commit');
   });
 
@@ -942,7 +942,7 @@ describe('EntityManagerPostgre', () => {
     });
     expect(mock.mock.calls.length).toBe(5);
     expect(mock.mock.calls[0][0]).toMatch('begin');
-    expect(mock.mock.calls[1][0]).toMatch(`select "b0"."uuid_pk", "b0"."created_at", "b0"."isbn", "b0"."title", "b0"."price", "b0"."double", "b0"."meta", "b0"."author_id", "b0"."publisher_id", "b0".price * 1.19 as "price_taxed" from "book2" as "b0" where "b0"."author_id" is not null for update skip locked`);
+    expect(mock.mock.calls[1][0]).toMatch(`select "b0"."uuid_pk", "b0"."created_at", "b0"."isbn", "b0"."title", "b0"."price", "b0"."double", "b0"."meta", "b0"."author_id", "b0"."publisher_id", "b0"."price" * 1.19 as "price_taxed" from "book2" as "b0" where "b0"."author_id" is not null for update skip locked`);
     expect(mock.mock.calls[2][0]).toMatch(`select "a0".*, "f1"."uuid_pk" as "f1__uuid_pk" from "author2" as "a0" left join "book2" as "f1" on "a0"."favourite_book_uuid_pk" = "f1"."uuid_pk" and "f1"."author_id" is not null where "a0"."id" in (?) and "a0"."id" is not null for update of "a0" skip locked`);
     expect(mock.mock.calls[3][0]).toMatch(`select "b0"."order", "b0"."book_tag2_id", "b0"."book2_uuid_pk", "b1"."id" as "b1__id", "b1"."name" as "b1__name" from "book2_tags" as "b0" inner join "book_tag2" as "b1" on "b0"."book_tag2_id" = "b1"."id" where "b0"."book2_uuid_pk" in (?, ?, ?) order by "b0"."order" asc for update skip locked`);
     expect(mock.mock.calls[4][0]).toMatch('commit');
@@ -1554,7 +1554,7 @@ describe('EntityManagerPostgre', () => {
     expect(mock.mock.calls[0][0]).toMatch(`begin`);
     expect(mock.mock.calls[1][0]).toMatch(`insert into "book2" ("uuid_pk", "created_at", "title", "price", "author_id") values (?, ?, ?, ?, ?)`);
     expect(mock.mock.calls[2][0]).toMatch(`commit`);
-    expect(mock.mock.calls[3][0]).toMatch(`select "b0"."uuid_pk", "b0"."created_at", "b0"."isbn", "b0"."title", "b0"."price", "b0"."double", "b0"."meta", "b0"."author_id", "b0"."publisher_id", "b0".price * 1.19 as "price_taxed" from "book2" as "b0" where "b0"."author_id" is not null and "b0"."author_id" in (?) order by "b0"."title" asc`);
+    expect(mock.mock.calls[3][0]).toMatch(`select "b0"."uuid_pk", "b0"."created_at", "b0"."isbn", "b0"."title", "b0"."price", "b0"."double", "b0"."meta", "b0"."author_id", "b0"."publisher_id", "b0"."price" * 1.19 as "price_taxed" from "book2" as "b0" where "b0"."author_id" is not null and "b0"."author_id" in (?) order by "b0"."title" asc`);
   });
 
   test('nested populating', async () => {
@@ -1682,7 +1682,7 @@ describe('EntityManagerPostgre', () => {
     expect(res).toHaveLength(1);
     expect(res[0].books.length).toBe(3);
     expect(mock.mock.calls[0][0]).toMatch('select "a0".*, "f1"."uuid_pk" as "f1__uuid_pk" from "author2" as "a0" left join "book2" as "f1" on "a0"."favourite_book_uuid_pk" = "f1"."uuid_pk" and "f1"."author_id" is not null left join "book2" as "b2" on "a0"."id" = "b2"."author_id" and "b2"."author_id" is not null where "b2"."title" in (?, ?)');
-    expect(mock.mock.calls[1][0]).toMatch('select "b0".*, "b0".price * 1.19 as "price_taxed" from "book2" as "b0" where "b0"."author_id" is not null and "b0"."author_id" in (?) order by "b0"."title" asc');
+    expect(mock.mock.calls[1][0]).toMatch('select "b0".*, "b0"."price" * 1.19 as "price_taxed" from "book2" as "b0" where "b0"."author_id" is not null and "b0"."author_id" in (?) order by "b0"."title" asc');
   });
 
   test('trying to populate non-existing or non-reference property will throw', async () => {
@@ -1832,14 +1832,14 @@ describe('EntityManagerPostgre', () => {
       },
     }, { populate: ['perex'] });
     expect(books1).toHaveLength(2);
-    expect(mock.mock.calls[0][0]).toMatch(`select "b0".*, "b0".price * 1.19 as "price_taxed" from "book2" as "b0" inner join "author2" as "a1" on "b0"."author_id" = "a1"."id" where "b0"."author_id" is not null and a1.age::text ilike '%2%' and upper(title) in ('B1', 'B2')`);
+    expect(mock.mock.calls[0][0]).toMatch(`select "b0".*, "b0"."price" * 1.19 as "price_taxed" from "book2" as "b0" inner join "author2" as "a1" on "b0"."author_id" = "a1"."id" where "b0"."author_id" is not null and a1.age::text ilike '%2%' and upper(title) in ('B1', 'B2')`);
     orm.em.clear();
 
     const books2 = await orm.em.find(Book2, {
       [sql.upper('title')]: raw('upper(?)', ['b2']),
     }, { populate: ['perex'] });
     expect(books2).toHaveLength(1);
-    expect(mock.mock.calls[1][0]).toMatch(`select "b0".*, "b0".price * 1.19 as "price_taxed" from "book2" as "b0" where "b0"."author_id" is not null and upper(title) = upper('b2')`);
+    expect(mock.mock.calls[1][0]).toMatch(`select "b0".*, "b0"."price" * 1.19 as "price_taxed" from "book2" as "b0" where "b0"."author_id" is not null and upper(title) = upper('b2')`);
   });
 
   test('custom expressions require raw helper', async () => {
@@ -1974,7 +1974,7 @@ describe('EntityManagerPostgre', () => {
     expect(res1).toHaveLength(3);
     expect(res1[0].test).toBeUndefined();
     expect(mock.mock.calls.length).toBe(1);
-    expect(mock.mock.calls[0][0]).toMatch('select "b0".*, "b0".price * 1.19 as "price_taxed" ' +
+    expect(mock.mock.calls[0][0]).toMatch('select "b0".*, "b0"."price" * 1.19 as "price_taxed" ' +
       'from "book2" as "b0" ' +
       'inner join "author2" as "a1" on "b0"."author_id" = "a1"."id" ' +
       'where "b0"."author_id" is not null and "a1"."name" = ?');
@@ -1984,7 +1984,7 @@ describe('EntityManagerPostgre', () => {
     const res2 = await orm.em.find(Book2, { author: { favouriteBook: { author: { name: 'Jon Snow' } } } }, { populate: ['perex'] });
     expect(res2).toHaveLength(3);
     expect(mock.mock.calls.length).toBe(1);
-    expect(mock.mock.calls[0][0]).toMatch('select "b0".*, "b0".price * 1.19 as "price_taxed" ' +
+    expect(mock.mock.calls[0][0]).toMatch('select "b0".*, "b0"."price" * 1.19 as "price_taxed" ' +
       'from "book2" as "b0" ' +
       'inner join "author2" as "a1" on "b0"."author_id" = "a1"."id" ' +
       'left join ("book2" as "b2" ' +
@@ -1997,7 +1997,7 @@ describe('EntityManagerPostgre', () => {
     const res3 = await orm.em.find(Book2, { author: { favouriteBook: book3 } }, { populate: ['perex'] });
     expect(res3).toHaveLength(3);
     expect(mock.mock.calls.length).toBe(1);
-    expect(mock.mock.calls[0][0]).toMatch('select "b0".*, "b0".price * 1.19 as "price_taxed" ' +
+    expect(mock.mock.calls[0][0]).toMatch('select "b0".*, "b0"."price" * 1.19 as "price_taxed" ' +
       'from "book2" as "b0" ' +
       'inner join "author2" as "a1" on "b0"."author_id" = "a1"."id" ' +
       'where "b0"."author_id" is not null and "a1"."favourite_book_uuid_pk" = ?');
@@ -2007,7 +2007,7 @@ describe('EntityManagerPostgre', () => {
     const res4 = await orm.em.find(Book2, { author: { favouriteBook: { $or: [{ author: { name: 'Jon Snow' } }] } } }, { populate: ['perex'] });
     expect(res4).toHaveLength(3);
     expect(mock.mock.calls.length).toBe(1);
-    expect(mock.mock.calls[0][0]).toMatch('select "b0".*, "b0".price * 1.19 as "price_taxed" ' +
+    expect(mock.mock.calls[0][0]).toMatch('select "b0".*, "b0"."price" * 1.19 as "price_taxed" ' +
       'from "book2" as "b0" ' +
       'inner join "author2" as "a1" on "b0"."author_id" = "a1"."id" ' +
       'left join ("book2" as "b2" ' +
@@ -2057,9 +2057,9 @@ describe('EntityManagerPostgre', () => {
         },
       },
     });
-    expect(mock.mock.calls[0][0]).toMatch('select "b0".*, "b0".price * 1.19 as "price_taxed", ' +
+    expect(mock.mock.calls[0][0]).toMatch('select "b0".*, "b0"."price" * 1.19 as "price_taxed", ' +
       '"a1"."id" as "a1__id", "a1"."created_at" as "a1__created_at", "a1"."updated_at" as "a1__updated_at", "a1"."name" as "a1__name", "a1"."email" as "a1__email", "a1"."age" as "a1__age", "a1"."terms_accepted" as "a1__terms_accepted", "a1"."optional" as "a1__optional", "a1"."identities" as "a1__identities", "a1"."born" as "a1__born", "a1"."born_time" as "a1__born_time", "a1"."favourite_book_uuid_pk" as "a1__favourite_book_uuid_pk", "a1"."favourite_author_id" as "a1__favourite_author_id", "a1"."identity" as "a1__identity", ' +
-      '"b2"."uuid_pk" as "b2__uuid_pk", "b2"."created_at" as "b2__created_at", "b2"."isbn" as "b2__isbn", "b2"."title" as "b2__title", "b2"."price" as "b2__price", "b2".price * 1.19 as "b2__price_taxed", "b2"."double" as "b2__double", "b2"."meta" as "b2__meta", "b2"."author_id" as "b2__author_id", "b2"."publisher_id" as "b2__publisher_id", ' +
+      '"b2"."uuid_pk" as "b2__uuid_pk", "b2"."created_at" as "b2__created_at", "b2"."isbn" as "b2__isbn", "b2"."title" as "b2__title", "b2"."price" as "b2__price", "b2"."price" * 1.19 as "b2__price_taxed", "b2"."double" as "b2__double", "b2"."meta" as "b2__meta", "b2"."author_id" as "b2__author_id", "b2"."publisher_id" as "b2__publisher_id", ' +
       '"a3"."id" as "a3__id", "a3"."created_at" as "a3__created_at", "a3"."updated_at" as "a3__updated_at", "a3"."name" as "a3__name", "a3"."email" as "a3__email", "a3"."age" as "a3__age", "a3"."terms_accepted" as "a3__terms_accepted", "a3"."optional" as "a3__optional", "a3"."identities" as "a3__identities", "a3"."born" as "a3__born", "a3"."born_time" as "a3__born_time", "a3"."favourite_book_uuid_pk" as "a3__favourite_book_uuid_pk", "a3"."favourite_author_id" as "a3__favourite_author_id", "a3"."identity" as "a3__identity" ' +
       'from "book2" as "b0" ' +
       'inner join "author2" as "a1" on "b0"."author_id" = "a1"."id" ' +
@@ -2073,9 +2073,9 @@ describe('EntityManagerPostgre', () => {
     const res4 = await orm.em.find(Book2, { author: { favouriteBook: { $or: [{ author: { name: 'Jon Snow' } }] } } }, { populate: ['$infer'] });
     expect(res4).toHaveLength(3);
     expect(mock.mock.calls.length).toBe(1);
-    expect(mock.mock.calls[0][0]).toMatch('select "b0"."uuid_pk", "b0"."created_at", "b0"."isbn", "b0"."title", "b0"."price", "b0"."double", "b0"."meta", "b0"."author_id", "b0"."publisher_id", "b0".price * 1.19 as "price_taxed", ' +
+    expect(mock.mock.calls[0][0]).toMatch('select "b0"."uuid_pk", "b0"."created_at", "b0"."isbn", "b0"."title", "b0"."price", "b0"."double", "b0"."meta", "b0"."author_id", "b0"."publisher_id", "b0"."price" * 1.19 as "price_taxed", ' +
       '"a1"."id" as "a1__id", "a1"."created_at" as "a1__created_at", "a1"."updated_at" as "a1__updated_at", "a1"."name" as "a1__name", "a1"."email" as "a1__email", "a1"."age" as "a1__age", "a1"."terms_accepted" as "a1__terms_accepted", "a1"."optional" as "a1__optional", "a1"."identities" as "a1__identities", "a1"."born" as "a1__born", "a1"."born_time" as "a1__born_time", "a1"."favourite_book_uuid_pk" as "a1__favourite_book_uuid_pk", "a1"."favourite_author_id" as "a1__favourite_author_id", "a1"."identity" as "a1__identity", ' +
-      '"b2"."uuid_pk" as "b2__uuid_pk", "b2"."created_at" as "b2__created_at", "b2"."isbn" as "b2__isbn", "b2"."title" as "b2__title", "b2"."price" as "b2__price", "b2".price * 1.19 as "b2__price_taxed", "b2"."double" as "b2__double", "b2"."meta" as "b2__meta", "b2"."author_id" as "b2__author_id", "b2"."publisher_id" as "b2__publisher_id", ' +
+      '"b2"."uuid_pk" as "b2__uuid_pk", "b2"."created_at" as "b2__created_at", "b2"."isbn" as "b2__isbn", "b2"."title" as "b2__title", "b2"."price" as "b2__price", "b2"."price" * 1.19 as "b2__price_taxed", "b2"."double" as "b2__double", "b2"."meta" as "b2__meta", "b2"."author_id" as "b2__author_id", "b2"."publisher_id" as "b2__publisher_id", ' +
       '"a3"."id" as "a3__id", "a3"."created_at" as "a3__created_at", "a3"."updated_at" as "a3__updated_at", "a3"."name" as "a3__name", "a3"."email" as "a3__email", "a3"."age" as "a3__age", "a3"."terms_accepted" as "a3__terms_accepted", "a3"."optional" as "a3__optional", "a3"."identities" as "a3__identities", "a3"."born" as "a3__born", "a3"."born_time" as "a3__born_time", "a3"."favourite_book_uuid_pk" as "a3__favourite_book_uuid_pk", "a3"."favourite_author_id" as "a3__favourite_author_id", "a3"."identity" as "a3__identity" ' +
       'from "book2" as "b0" ' +
       'inner join "author2" as "a1" on "b0"."author_id" = "a1"."id" ' +

--- a/tests/features/entity-manager/EntityManager.sqlite.test.ts
+++ b/tests/features/entity-manager/EntityManager.sqlite.test.ts
@@ -267,13 +267,13 @@ describe.each(['sqlite', 'libsql'] as const)('EntityManager (%s)', driver => {
     expect(mock.mock.calls).toHaveLength(10);
     expect(mock.mock.calls[0][0]).toMatch('begin');
     expect(mock.mock.calls[1][0]).toMatch('savepoint `trx');
-    expect(mock.mock.calls[2][0]).toMatch('select `b0`.*, `b0`.price * 1.19 as `price_taxed` from `book4` as `b0` where `b0`.`title` is not null limit ?');
+    expect(mock.mock.calls[2][0]).toMatch('select `b0`.*, `b0`.`price` * 1.19 as `price_taxed` from `book4` as `b0` where `b0`.`title` is not null limit ?');
     expect(mock.mock.calls[3][0]).toMatch('insert into `author4` (`created_at`, `updated_at`, `name`, `email`, `terms_accepted`) values (?, ?, ?, ?, ?)');
-    expect(mock.mock.calls[4][0]).toMatch('select `b0`.*, `b0`.price * 1.19 as `price_taxed` from `book4` as `b0` where `b0`.`title` not in (?) limit ?');
+    expect(mock.mock.calls[4][0]).toMatch('select `b0`.*, `b0`.`price` * 1.19 as `price_taxed` from `book4` as `b0` where `b0`.`title` not in (?) limit ?');
     expect(mock.mock.calls[5][0]).toMatch('rollback to savepoint `trx');
-    expect(mock.mock.calls[6][0]).toMatch('select `b0`.*, `b0`.price * 1.19 as `price_taxed` from `book4` as `b0` where `b0`.`title` is not null limit ?');
+    expect(mock.mock.calls[6][0]).toMatch('select `b0`.*, `b0`.`price` * 1.19 as `price_taxed` from `book4` as `b0` where `b0`.`title` is not null limit ?');
     expect(mock.mock.calls[7][0]).toMatch('insert into `author4` (`created_at`, `updated_at`, `name`, `email`, `terms_accepted`) values (?, ?, ?, ?, ?)');
-    expect(mock.mock.calls[8][0]).toMatch('select `b0`.*, `b0`.price * 1.19 as `price_taxed` from `book4` as `b0` where `b0`.`title` not in (?) limit ?');
+    expect(mock.mock.calls[8][0]).toMatch('select `b0`.*, `b0`.`price` * 1.19 as `price_taxed` from `book4` as `b0` where `b0`.`title` not in (?) limit ?');
     expect(mock.mock.calls[9][0]).toMatch('commit');
     await expect(orm.em.findOne(Author4, { name: 'God Persisted!' })).resolves.not.toBeNull();
   });
@@ -1219,7 +1219,7 @@ describe.each(['sqlite', 'libsql'] as const)('EntityManager (%s)', driver => {
       .leftJoinAndSelect('b.tags', 't')
       .where({ 't.name': ['sick', 'sexy'] });
     const sql = 'select `a`.*, ' +
-      '`b`.`id` as `b__id`, `b`.`created_at` as `b__created_at`, `b`.`updated_at` as `b__updated_at`, `b`.`title` as `b__title`, `b`.`price` as `b__price`, `b`.price * 1.19 as `b__price_taxed`, `b`.`author_id` as `b__author_id`, `b`.`publisher_id` as `b__publisher_id`, `b`.`meta` as `b__meta`, ' +
+      '`b`.`id` as `b__id`, `b`.`created_at` as `b__created_at`, `b`.`updated_at` as `b__updated_at`, `b`.`title` as `b__title`, `b`.`price` as `b__price`, `b`.`price` * 1.19 as `b__price_taxed`, `b`.`author_id` as `b__author_id`, `b`.`publisher_id` as `b__publisher_id`, `b`.`meta` as `b__meta`, ' +
       '`t`.`id` as `t__id`, `t`.`created_at` as `t__created_at`, `t`.`updated_at` as `t__updated_at`, `t`.`name` as `t__name`, `t`.`version` as `t__version` ' +
       'from `author4` as `a` ' +
       'left join `book4` as `b` on `a`.`id` = `b`.`author_id` ' +
@@ -1325,9 +1325,9 @@ describe.each(['sqlite', 'libsql'] as const)('EntityManager (%s)', driver => {
     expect(wrap(ref).isInitialized()).toBe(true);
 
     expect(mock.mock.calls[0][0]).toMatch('begin');
-    expect(mock.mock.calls[1][0]).toMatch('select `b0`.*, `b0`.price * 1.19 as `price_taxed` from `book4` as `b0` where `b0`.`title` is not null limit ?');
+    expect(mock.mock.calls[1][0]).toMatch('select `b0`.*, `b0`.`price` * 1.19 as `price_taxed` from `book4` as `b0` where `b0`.`title` is not null limit ?');
     expect(mock.mock.calls[2][0]).toMatch('update `author4` set `name` = ?, `email` = ?, `updated_at` = ? where `id` = ?');
-    expect(mock.mock.calls[3][0]).toMatch('select `b0`.*, `b0`.price * 1.19 as `price_taxed` from `book4` as `b0` where `b0`.`title` not in (?) limit ?');
+    expect(mock.mock.calls[3][0]).toMatch('select `b0`.*, `b0`.`price` * 1.19 as `price_taxed` from `book4` as `b0` where `b0`.`title` not in (?) limit ?');
     expect(mock.mock.calls[4][0]).toMatch('commit');
   });
 
@@ -1496,9 +1496,9 @@ describe.each(['sqlite', 'libsql'] as const)('EntityManager (%s)', driver => {
     const mock = mockLogger(orm, ['query']);
     await orm.em.flush();
     expect(mock.mock.calls[0][0]).toMatch('begin');
-    expect(mock.mock.calls[1][0]).toMatch('select `b0`.*, `b0`.price * 1.19 as `price_taxed` from `book4` as `b0` where `b0`.`title` is not null limit ?');
+    expect(mock.mock.calls[1][0]).toMatch('select `b0`.*, `b0`.`price` * 1.19 as `price_taxed` from `book4` as `b0` where `b0`.`title` is not null limit ?');
     expect(mock.mock.calls[2][0]).toMatch('insert into `author4` (`created_at`, `updated_at`, `name`, `email`, `terms_accepted`) values');
-    expect(mock.mock.calls[3][0]).toMatch('select `b0`.*, `b0`.price * 1.19 as `price_taxed` from `book4` as `b0` where `b0`.`title` not in (?) limit ?');
+    expect(mock.mock.calls[3][0]).toMatch('select `b0`.*, `b0`.`price` * 1.19 as `price_taxed` from `book4` as `b0` where `b0`.`title` not in (?) limit ?');
     expect(mock.mock.calls[4][0]).toMatch('insert into `book4` (`created_at`, `updated_at`, `title`, `author_id`) values');
     expect(mock.mock.calls[5][0]).toMatch('commit');
   });

--- a/tests/features/filters/filters.mysql.test.ts
+++ b/tests/features/filters/filters.mysql.test.ts
@@ -37,7 +37,7 @@ describe('filters [mysql]', () => {
       orderBy: { title: QueryOrder.DESC },
       filters: ['long', 'expensive'],
     });
-    expect(mock.mock.calls[0][0]).toMatch('select `b0`.*, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` ' +
+    expect(mock.mock.calls[0][0]).toMatch('select `b0`.*, `b0`.`price` * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` ' +
       'from `book2` as `b0` ' +
       'left join `test2` as `t1` on `b0`.`uuid_pk` = `t1`.`book_uuid_pk` ' +
       'where `b0`.`author_id` is not null and length(perex) > 10000 and `b0`.`price` > 1000 and `b0`.`title` = \'123\' ' +
@@ -46,7 +46,7 @@ describe('filters [mysql]', () => {
     const books2 = await orm.em.find(Book2, { title: '123' }, {
       filters: { hasAuthor: false, long: true, writtenBy: { name: 'God' } },
     });
-    expect(mock.mock.calls[1][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`isbn`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t2`.`id` as `t2__id` ' +
+    expect(mock.mock.calls[1][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`isbn`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.`price` * 1.19 as `price_taxed`, `t2`.`id` as `t2__id` ' +
       'from `book2` as `b0` ' +
       'inner join `author2` as `a1` on `b0`.`author_id` = `a1`.`id` ' +
       'left join `test2` as `t2` on `b0`.`uuid_pk` = `t2`.`book_uuid_pk` ' +
@@ -55,7 +55,7 @@ describe('filters [mysql]', () => {
     const books3 = await orm.em.find(Book2, { title: '123' }, {
       filters: false,
     });
-    expect(mock.mock.calls[2][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`isbn`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` ' +
+    expect(mock.mock.calls[2][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`isbn`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.`price` * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` ' +
       'from `book2` as `b0` ' +
       'left join `test2` as `t1` on `b0`.`uuid_pk` = `t1`.`book_uuid_pk` ' +
       'where `b0`.`title` = \'123\'');
@@ -63,7 +63,7 @@ describe('filters [mysql]', () => {
     const books4 = await orm.em.find(Book2, { title: '123' }, {
       filters: true,
     });
-    expect(mock.mock.calls[3][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`isbn`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` ' +
+    expect(mock.mock.calls[3][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`isbn`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.`price` * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` ' +
       'from `book2` as `b0` ' +
       'left join `test2` as `t1` on `b0`.`uuid_pk` = `t1`.`book_uuid_pk` ' +
       'where `b0`.`author_id` is not null and `b0`.`title` = \'123\'');
@@ -71,7 +71,7 @@ describe('filters [mysql]', () => {
     const b1 = await orm.em.findOne(Book2, '123', {
       filters: { long: true },
     });
-    expect(mock.mock.calls[4][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`isbn`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` ' +
+    expect(mock.mock.calls[4][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`isbn`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.`price` * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` ' +
       'from `book2` as `b0` ' +
       'left join `test2` as `t1` on `b0`.`uuid_pk` = `t1`.`book_uuid_pk` ' +
       'where `b0`.`author_id` is not null and length(perex) > 10000 and `b0`.`uuid_pk` = \'123\' limit 1');
@@ -79,7 +79,7 @@ describe('filters [mysql]', () => {
     const b2 = await orm.em.findOne(Book2, { author: { name: 'Jon' } }, {
       filters: { hasAuthor: false, long: true },
     });
-    expect(mock.mock.calls[5][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`isbn`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t2`.`id` as `t2__id` ' +
+    expect(mock.mock.calls[5][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`isbn`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.`price` * 1.19 as `price_taxed`, `t2`.`id` as `t2__id` ' +
       'from `book2` as `b0` ' +
       'inner join `author2` as `a1` on `b0`.`author_id` = `a1`.`id` ' +
       'left join `test2` as `t2` on `b0`.`uuid_pk` = `t2`.`book_uuid_pk` ' +
@@ -135,7 +135,7 @@ describe('filters [mysql]', () => {
       orderBy: { title: QueryOrder.DESC },
       filters: ['long', 'expensive'],
     });
-    expect(mock.mock.calls[0][0]).toMatch('select `b0`.*, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` ' +
+    expect(mock.mock.calls[0][0]).toMatch('select `b0`.*, `b0`.`price` * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` ' +
       'from `book2` as `b0` ' +
       'left join `test2` as `t1` on `b0`.`uuid_pk` = `t1`.`book_uuid_pk` ' +
       'where `b0`.`author_id` is not null and length(perex) > 10000 and `b0`.`price` > 1000 and `b0`.`title` = \'123\' ' +
@@ -144,7 +144,7 @@ describe('filters [mysql]', () => {
     const books2 = await orm.em.find(Book2, { title: '123' }, {
       filters: { hasAuthor: false, long: true, writtenBy: { name: 'God' } },
     });
-    expect(mock.mock.calls[1][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`isbn`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t2`.`id` as `t2__id` ' +
+    expect(mock.mock.calls[1][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`isbn`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.`price` * 1.19 as `price_taxed`, `t2`.`id` as `t2__id` ' +
       'from `book2` as `b0` ' +
       'inner join `author2` as `a1` on `b0`.`author_id` = `a1`.`id` ' +
       'left join `test2` as `t2` on `b0`.`uuid_pk` = `t2`.`book_uuid_pk` ' +
@@ -153,7 +153,7 @@ describe('filters [mysql]', () => {
     const books3 = await orm.em.find(Book2, { title: '123' }, {
       filters: false,
     });
-    expect(mock.mock.calls[2][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`isbn`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` ' +
+    expect(mock.mock.calls[2][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`isbn`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.`price` * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` ' +
       'from `book2` as `b0` ' +
       'left join `test2` as `t1` on `b0`.`uuid_pk` = `t1`.`book_uuid_pk` ' +
       'where `b0`.`title` = \'123\'');
@@ -161,7 +161,7 @@ describe('filters [mysql]', () => {
     const books4 = await orm.em.find(Book2, { title: '123' }, {
       filters: true,
     });
-    expect(mock.mock.calls[3][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`isbn`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` ' +
+    expect(mock.mock.calls[3][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`isbn`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.`price` * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` ' +
       'from `book2` as `b0` ' +
       'left join `test2` as `t1` on `b0`.`uuid_pk` = `t1`.`book_uuid_pk` ' +
       'where `b0`.`author_id` is not null and `b0`.`title` = \'123\'');
@@ -169,7 +169,7 @@ describe('filters [mysql]', () => {
     const b1 = await orm.em.findOne(Book2, '123', {
       filters: { long: true },
     });
-    expect(mock.mock.calls[4][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`isbn`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` ' +
+    expect(mock.mock.calls[4][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`isbn`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.`price` * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` ' +
       'from `book2` as `b0` ' +
       'left join `test2` as `t1` on `b0`.`uuid_pk` = `t1`.`book_uuid_pk` ' +
       'where `b0`.`author_id` is not null and length(perex) > 10000 and `b0`.`uuid_pk` = \'123\' limit 1');
@@ -177,7 +177,7 @@ describe('filters [mysql]', () => {
     const b2 = await orm.em.findOne(Book2, { author: { name: 'Jon' } }, {
       filters: { hasAuthor: false, long: true },
     });
-    expect(mock.mock.calls[5][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`isbn`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t2`.`id` as `t2__id` ' +
+    expect(mock.mock.calls[5][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`isbn`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.`price` * 1.19 as `price_taxed`, `t2`.`id` as `t2__id` ' +
       'from `book2` as `b0` ' +
       'inner join `author2` as `a1` on `b0`.`author_id` = `a1`.`id` ' +
       'left join `test2` as `t2` on `b0`.`uuid_pk` = `t2`.`book_uuid_pk` ' +

--- a/tests/features/formulas/GH6620.test.ts
+++ b/tests/features/formulas/GH6620.test.ts
@@ -13,7 +13,7 @@ class User {
   @Property()
   lastName!: string;
 
-  @Formula(alias => `(CONCAT(${alias}.first_name, ' ',${alias}.last_name))`)
+  @Formula(cols => `(CONCAT(${cols.firstName}, ' ',${cols.lastName}))`)
   name!: Opt<string>;
 
 }

--- a/tests/features/joined-strategy.postgre.test.ts
+++ b/tests/features/joined-strategy.postgre.test.ts
@@ -113,7 +113,7 @@ describe('Joined loading strategy', () => {
     await orm.em.findOneOrFail(Author2, { id: author2.id }, { populate: ['books2.perex'] });
     expect(mock.mock.calls.length).toBe(1);
     expect(mock.mock.calls[0][0]).toMatch('select "a0".*, ' +
-      '"b1"."uuid_pk" as "b1__uuid_pk", "b1"."created_at" as "b1__created_at", "b1"."isbn" as "b1__isbn", "b1"."title" as "b1__title", "b1"."perex" as "b1__perex", "b1"."price" as "b1__price", "b1".price * 1.19 as "b1__price_taxed", "b1"."double" as "b1__double", "b1"."meta" as "b1__meta", "b1"."author_id" as "b1__author_id", "b1"."publisher_id" as "b1__publisher_id", ' +
+      '"b1"."uuid_pk" as "b1__uuid_pk", "b1"."created_at" as "b1__created_at", "b1"."isbn" as "b1__isbn", "b1"."title" as "b1__title", "b1"."perex" as "b1__perex", "b1"."price" as "b1__price", "b1"."price" * 1.19 as "b1__price_taxed", "b1"."double" as "b1__double", "b1"."meta" as "b1__meta", "b1"."author_id" as "b1__author_id", "b1"."publisher_id" as "b1__publisher_id", ' +
       '"f2"."uuid_pk" as "f2__uuid_pk" ' +
       'from "author2" as "a0" ' +
       'left join "book2" as "b1" on "a0"."id" = "b1"."author_id" and "b1"."author_id" is not null ' +
@@ -126,7 +126,7 @@ describe('Joined loading strategy', () => {
     await orm.em.findOneOrFail(Author2, { id: author2.id }, { populate: ['books2'] });
     expect(mock.mock.calls.length).toBe(1);
     expect(mock.mock.calls[0][0]).toMatch('select "a0".*, ' +
-      '"b1"."uuid_pk" as "b1__uuid_pk", "b1"."created_at" as "b1__created_at", "b1"."isbn" as "b1__isbn", "b1"."title" as "b1__title", "b1"."price" as "b1__price", "b1".price * 1.19 as "b1__price_taxed", "b1"."double" as "b1__double", "b1"."meta" as "b1__meta", "b1"."author_id" as "b1__author_id", "b1"."publisher_id" as "b1__publisher_id", ' +
+      '"b1"."uuid_pk" as "b1__uuid_pk", "b1"."created_at" as "b1__created_at", "b1"."isbn" as "b1__isbn", "b1"."title" as "b1__title", "b1"."price" as "b1__price", "b1"."price" * 1.19 as "b1__price_taxed", "b1"."double" as "b1__double", "b1"."meta" as "b1__meta", "b1"."author_id" as "b1__author_id", "b1"."publisher_id" as "b1__publisher_id", ' +
       '"f2"."uuid_pk" as "f2__uuid_pk" ' +
       'from "author2" as "a0" ' +
       'left join "book2" as "b1" on "a0"."id" = "b1"."author_id" and "b1"."author_id" is not null ' +
@@ -139,7 +139,7 @@ describe('Joined loading strategy', () => {
     await orm.em.findOneOrFail(Author2, { id: author2.id }, { populate: ['books'], filters: false });
     expect(mock.mock.calls.length).toBe(1);
     expect(mock.mock.calls[0][0]).toMatch('select "a0".*, ' +
-      '"b1"."uuid_pk" as "b1__uuid_pk", "b1"."created_at" as "b1__created_at", "b1"."isbn" as "b1__isbn", "b1"."title" as "b1__title", "b1"."price" as "b1__price", "b1".price * 1.19 as "b1__price_taxed", "b1"."double" as "b1__double", "b1"."meta" as "b1__meta", "b1"."author_id" as "b1__author_id", "b1"."publisher_id" as "b1__publisher_id" ' +
+      '"b1"."uuid_pk" as "b1__uuid_pk", "b1"."created_at" as "b1__created_at", "b1"."isbn" as "b1__isbn", "b1"."title" as "b1__title", "b1"."price" as "b1__price", "b1"."price" * 1.19 as "b1__price_taxed", "b1"."double" as "b1__double", "b1"."meta" as "b1__meta", "b1"."author_id" as "b1__author_id", "b1"."publisher_id" as "b1__publisher_id" ' +
       'from "author2" as "a0" ' +
       'left join "book2" as "b1" on "a0"."id" = "b1"."author_id" ' +
       'where "a0"."id" = ?');
@@ -149,7 +149,7 @@ describe('Joined loading strategy', () => {
     await orm.em.findOneOrFail(Author2, { id: author2.id }, { populate: ['books.perex'] });
     expect(mock.mock.calls.length).toBe(1);
     expect(mock.mock.calls[0][0]).toMatch('select "a0".*, ' +
-      '"b1"."uuid_pk" as "b1__uuid_pk", "b1"."created_at" as "b1__created_at", "b1"."isbn" as "b1__isbn", "b1"."title" as "b1__title", "b1"."perex" as "b1__perex", "b1"."price" as "b1__price", "b1".price * 1.19 as "b1__price_taxed", "b1"."double" as "b1__double", "b1"."meta" as "b1__meta", "b1"."author_id" as "b1__author_id", "b1"."publisher_id" as "b1__publisher_id", ' +
+      '"b1"."uuid_pk" as "b1__uuid_pk", "b1"."created_at" as "b1__created_at", "b1"."isbn" as "b1__isbn", "b1"."title" as "b1__title", "b1"."perex" as "b1__perex", "b1"."price" as "b1__price", "b1"."price" * 1.19 as "b1__price_taxed", "b1"."double" as "b1__double", "b1"."meta" as "b1__meta", "b1"."author_id" as "b1__author_id", "b1"."publisher_id" as "b1__publisher_id", ' +
       '"f2"."uuid_pk" as "f2__uuid_pk" ' +
       'from "author2" as "a0" ' +
       'left join "book2" as "b1" on "a0"."id" = "b1"."author_id" and "b1"."author_id" is not null ' +
@@ -175,7 +175,7 @@ describe('Joined loading strategy', () => {
     await orm.em.find(Author2, { id: author2.id }, { populate: ['books2.perex'], filters: false });
     expect(mock.mock.calls).toHaveLength(1);
     expect(mock.mock.calls[0][0]).toMatch('select "a0".*, ' +
-      '"b1"."uuid_pk" as "b1__uuid_pk", "b1"."created_at" as "b1__created_at", "b1"."isbn" as "b1__isbn", "b1"."title" as "b1__title", "b1"."perex" as "b1__perex", "b1"."price" as "b1__price", "b1".price * 1.19 as "b1__price_taxed", "b1"."double" as "b1__double", "b1"."meta" as "b1__meta", "b1"."author_id" as "b1__author_id", "b1"."publisher_id" as "b1__publisher_id" ' +
+      '"b1"."uuid_pk" as "b1__uuid_pk", "b1"."created_at" as "b1__created_at", "b1"."isbn" as "b1__isbn", "b1"."title" as "b1__title", "b1"."perex" as "b1__perex", "b1"."price" as "b1__price", "b1"."price" * 1.19 as "b1__price_taxed", "b1"."double" as "b1__double", "b1"."meta" as "b1__meta", "b1"."author_id" as "b1__author_id", "b1"."publisher_id" as "b1__publisher_id" ' +
       'from "author2" as "a0" ' +
       'left join "book2" as "b1" on "a0"."id" = "b1"."author_id" ' +
       'where "a0"."id" = ?');
@@ -185,7 +185,7 @@ describe('Joined loading strategy', () => {
     await orm.em.find(Author2, { id: author2.id }, { populate: ['books2'] });
     expect(mock.mock.calls.length).toBe(1);
     expect(mock.mock.calls[0][0]).toMatch('select "a0".*, ' +
-      '"b1"."uuid_pk" as "b1__uuid_pk", "b1"."created_at" as "b1__created_at", "b1"."isbn" as "b1__isbn", "b1"."title" as "b1__title", "b1"."price" as "b1__price", "b1".price * 1.19 as "b1__price_taxed", "b1"."double" as "b1__double", "b1"."meta" as "b1__meta", "b1"."author_id" as "b1__author_id", "b1"."publisher_id" as "b1__publisher_id", ' +
+      '"b1"."uuid_pk" as "b1__uuid_pk", "b1"."created_at" as "b1__created_at", "b1"."isbn" as "b1__isbn", "b1"."title" as "b1__title", "b1"."price" as "b1__price", "b1"."price" * 1.19 as "b1__price_taxed", "b1"."double" as "b1__double", "b1"."meta" as "b1__meta", "b1"."author_id" as "b1__author_id", "b1"."publisher_id" as "b1__publisher_id", ' +
       '"f2"."uuid_pk" as "f2__uuid_pk" ' +
       'from "author2" as "a0" ' +
       'left join "book2" as "b1" on "a0"."id" = "b1"."author_id" and "b1"."author_id" is not null ' +
@@ -197,7 +197,7 @@ describe('Joined loading strategy', () => {
     await orm.em.find(Author2, { id: author2.id }, { populate: ['books'], strategy: LoadStrategy.JOINED });
     expect(mock.mock.calls.length).toBe(1);
     expect(mock.mock.calls[0][0]).toMatch('select "a0".*, ' +
-      '"b1"."uuid_pk" as "b1__uuid_pk", "b1"."created_at" as "b1__created_at", "b1"."isbn" as "b1__isbn", "b1"."title" as "b1__title", "b1"."price" as "b1__price", "b1".price * 1.19 as "b1__price_taxed", "b1"."double" as "b1__double", "b1"."meta" as "b1__meta", "b1"."author_id" as "b1__author_id", "b1"."publisher_id" as "b1__publisher_id", ' +
+      '"b1"."uuid_pk" as "b1__uuid_pk", "b1"."created_at" as "b1__created_at", "b1"."isbn" as "b1__isbn", "b1"."title" as "b1__title", "b1"."price" as "b1__price", "b1"."price" * 1.19 as "b1__price_taxed", "b1"."double" as "b1__double", "b1"."meta" as "b1__meta", "b1"."author_id" as "b1__author_id", "b1"."publisher_id" as "b1__publisher_id", ' +
       '"f2"."uuid_pk" as "f2__uuid_pk" ' +
       'from "author2" as "a0" ' +
       'left join "book2" as "b1" on "a0"."id" = "b1"."author_id" and "b1"."author_id" is not null ' +
@@ -209,7 +209,7 @@ describe('Joined loading strategy', () => {
     await orm.em.find(Author2, { id: author2.id }, { populate: ['books.perex'] });
     expect(mock.mock.calls.length).toBe(1);
     expect(mock.mock.calls[0][0]).toMatch('select "a0".*, ' +
-      '"b1"."uuid_pk" as "b1__uuid_pk", "b1"."created_at" as "b1__created_at", "b1"."isbn" as "b1__isbn", "b1"."title" as "b1__title", "b1"."perex" as "b1__perex", "b1"."price" as "b1__price", "b1".price * 1.19 as "b1__price_taxed", "b1"."double" as "b1__double", "b1"."meta" as "b1__meta", "b1"."author_id" as "b1__author_id", "b1"."publisher_id" as "b1__publisher_id", ' +
+      '"b1"."uuid_pk" as "b1__uuid_pk", "b1"."created_at" as "b1__created_at", "b1"."isbn" as "b1__isbn", "b1"."title" as "b1__title", "b1"."perex" as "b1__perex", "b1"."price" as "b1__price", "b1"."price" * 1.19 as "b1__price_taxed", "b1"."double" as "b1__double", "b1"."meta" as "b1__meta", "b1"."author_id" as "b1__author_id", "b1"."publisher_id" as "b1__publisher_id", ' +
       '"f2"."uuid_pk" as "f2__uuid_pk" ' +
       'from "author2" as "a0" ' +
       'left join "book2" as "b1" on "a0"."id" = "b1"."author_id" and "b1"."author_id" is not null ' +
@@ -243,7 +243,7 @@ describe('Joined loading strategy', () => {
     mock.mock.calls.length = 0;
     const books = await orm.em.find(Book2, {}, { populate: ['tags'], strategy: LoadStrategy.JOINED, orderBy: { tags: { name: 'desc' } } });
     expect(mock.mock.calls.length).toBe(1);
-    expect(mock.mock.calls[0][0]).toMatch('select "b0"."uuid_pk", "b0"."created_at", "b0"."isbn", "b0"."title", "b0"."price", "b0"."double", "b0"."meta", "b0"."author_id", "b0"."publisher_id", "b0".price * 1.19 as "price_taxed", ' +
+    expect(mock.mock.calls[0][0]).toMatch('select "b0"."uuid_pk", "b0"."created_at", "b0"."isbn", "b0"."title", "b0"."price", "b0"."double", "b0"."meta", "b0"."author_id", "b0"."publisher_id", "b0"."price" * 1.19 as "price_taxed", ' +
       '"t1"."id" as "t1__id", "t1"."name" as "t1__name" ' +
       'from "book2" as "b0" ' +
       'left join "book2_tags" as "b2" on "b0"."uuid_pk" = "b2"."book2_uuid_pk" ' +
@@ -417,7 +417,7 @@ describe('Joined loading strategy', () => {
     });
     expect(mock.mock.calls.length).toBe(1);
     expect(mock.mock.calls[0][0]).toMatch('select "b0".*, ' +
-      '"b1"."uuid_pk" as "b1__uuid_pk", "b1"."created_at" as "b1__created_at", "b1"."isbn" as "b1__isbn", "b1"."title" as "b1__title", "b1"."price" as "b1__price", "b1".price * 1.19 as "b1__price_taxed", "b1"."double" as "b1__double", "b1"."meta" as "b1__meta", "b1"."author_id" as "b1__author_id", "b1"."publisher_id" as "b1__publisher_id", ' +
+      '"b1"."uuid_pk" as "b1__uuid_pk", "b1"."created_at" as "b1__created_at", "b1"."isbn" as "b1__isbn", "b1"."title" as "b1__title", "b1"."price" as "b1__price", "b1"."price" * 1.19 as "b1__price_taxed", "b1"."double" as "b1__double", "b1"."meta" as "b1__meta", "b1"."author_id" as "b1__author_id", "b1"."publisher_id" as "b1__publisher_id", ' +
       '"a3"."id" as "a3__id", "a3"."created_at" as "a3__created_at", "a3"."updated_at" as "a3__updated_at", "a3"."name" as "a3__name", "a3"."email" as "a3__email", "a3"."age" as "a3__age", "a3"."terms_accepted" as "a3__terms_accepted", "a3"."optional" as "a3__optional", "a3"."identities" as "a3__identities", "a3"."born" as "a3__born", "a3"."born_time" as "a3__born_time", "a3"."favourite_book_uuid_pk" as "a3__favourite_book_uuid_pk", "a3"."favourite_author_id" as "a3__favourite_author_id", "a3"."identity" as "a3__identity", ' +
       '"f4"."uuid_pk" as "f4__uuid_pk", ' +
       '"p5"."id" as "p5__id", "p5"."name" as "p5__name", "p5"."type" as "p5__type", "p5"."type2" as "p5__type2", "p5"."enum1" as "p5__enum1", "p5"."enum2" as "p5__enum2", "p5"."enum3" as "p5__enum3", "p5"."enum4" as "p5__enum4", "p5"."enum5" as "p5__enum5", ' +
@@ -495,7 +495,7 @@ describe('Joined loading strategy', () => {
     expect(res1).toHaveLength(3);
     expect(res1[0].test).toBeUndefined();
     expect(mock.mock.calls.length).toBe(1);
-    expect(mock.mock.calls[0][0]).toMatch('select "b0".*, "b0".price * 1.19 as "price_taxed", ' +
+    expect(mock.mock.calls[0][0]).toMatch('select "b0".*, "b0"."price" * 1.19 as "price_taxed", ' +
       '"a1"."id" as "a1__id", "a1"."created_at" as "a1__created_at", "a1"."updated_at" as "a1__updated_at", "a1"."name" as "a1__name", "a1"."email" as "a1__email", "a1"."age" as "a1__age", "a1"."terms_accepted" as "a1__terms_accepted", "a1"."optional" as "a1__optional", "a1"."identities" as "a1__identities", "a1"."born" as "a1__born", "a1"."born_time" as "a1__born_time", "a1"."favourite_book_uuid_pk" as "a1__favourite_book_uuid_pk", "a1"."favourite_author_id" as "a1__favourite_author_id", "a1"."identity" as "a1__identity", "f2"."uuid_pk" as "f2__uuid_pk" ' +
       'from "book2" as "b0" ' +
       'inner join "author2" as "a1" on "b0"."author_id" = "a1"."id" ' +
@@ -510,9 +510,9 @@ describe('Joined loading strategy', () => {
     });
     expect(res2).toHaveLength(3);
     expect(mock.mock.calls.length).toBe(1);
-    expect(mock.mock.calls[0][0]).toMatch('select "b0".*, "b0".price * 1.19 as "price_taxed", ' +
+    expect(mock.mock.calls[0][0]).toMatch('select "b0".*, "b0"."price" * 1.19 as "price_taxed", ' +
       '"a1"."id" as "a1__id", "a1"."created_at" as "a1__created_at", "a1"."updated_at" as "a1__updated_at", "a1"."name" as "a1__name", "a1"."email" as "a1__email", "a1"."age" as "a1__age", "a1"."terms_accepted" as "a1__terms_accepted", "a1"."optional" as "a1__optional", "a1"."identities" as "a1__identities", "a1"."born" as "a1__born", "a1"."born_time" as "a1__born_time", "a1"."favourite_book_uuid_pk" as "a1__favourite_book_uuid_pk", "a1"."favourite_author_id" as "a1__favourite_author_id", "a1"."identity" as "a1__identity", ' +
-      '"f2"."uuid_pk" as "f2__uuid_pk", "f2"."created_at" as "f2__created_at", "f2"."isbn" as "f2__isbn", "f2"."title" as "f2__title", "f2"."price" as "f2__price", "f2".price * 1.19 as "f2__price_taxed", "f2"."double" as "f2__double", "f2"."meta" as "f2__meta", "f2"."author_id" as "f2__author_id", "f2"."publisher_id" as "f2__publisher_id", "a3"."id" as "a3__id", "a3"."created_at" as "a3__created_at", "a3"."updated_at" as "a3__updated_at", "a3"."name" as "a3__name", "a3"."email" as "a3__email", "a3"."age" as "a3__age", ' +
+      '"f2"."uuid_pk" as "f2__uuid_pk", "f2"."created_at" as "f2__created_at", "f2"."isbn" as "f2__isbn", "f2"."title" as "f2__title", "f2"."price" as "f2__price", "f2"."price" * 1.19 as "f2__price_taxed", "f2"."double" as "f2__double", "f2"."meta" as "f2__meta", "f2"."author_id" as "f2__author_id", "f2"."publisher_id" as "f2__publisher_id", "a3"."id" as "a3__id", "a3"."created_at" as "a3__created_at", "a3"."updated_at" as "a3__updated_at", "a3"."name" as "a3__name", "a3"."email" as "a3__email", "a3"."age" as "a3__age", ' +
       '"a3"."terms_accepted" as "a3__terms_accepted", "a3"."optional" as "a3__optional", "a3"."identities" as "a3__identities", "a3"."born" as "a3__born", "a3"."born_time" as "a3__born_time", "a3"."favourite_book_uuid_pk" as "a3__favourite_book_uuid_pk", "a3"."favourite_author_id" as "a3__favourite_author_id", "a3"."identity" as "a3__identity", ' +
       '"f4"."uuid_pk" as "f4__uuid_pk" ' +
       'from "book2" as "b0" ' +
@@ -528,7 +528,7 @@ describe('Joined loading strategy', () => {
     const res3 = await orm.em.find(Book2, { author: { favouriteBook: book3 } }, { populate: ['perex'] });
     expect(res3).toHaveLength(3);
     expect(mock.mock.calls.length).toBe(1);
-    expect(mock.mock.calls[0][0]).toMatch('select "b0".*, "b0".price * 1.19 as "price_taxed" ' +
+    expect(mock.mock.calls[0][0]).toMatch('select "b0".*, "b0"."price" * 1.19 as "price_taxed" ' +
       'from "book2" as "b0" ' +
       'inner join "author2" as "a1" on "b0"."author_id" = "a1"."id" ' +
       'where "b0"."author_id" is not null and "a1"."favourite_book_uuid_pk" = ?');
@@ -542,9 +542,9 @@ describe('Joined loading strategy', () => {
     });
     expect(res4).toHaveLength(3);
     expect(mock.mock.calls.length).toBe(1);
-    expect(mock.mock.calls[0][0]).toMatch('select "b0".*, "b0".price * 1.19 as "price_taxed", ' +
+    expect(mock.mock.calls[0][0]).toMatch('select "b0".*, "b0"."price" * 1.19 as "price_taxed", ' +
       '"a1"."id" as "a1__id", "a1"."created_at" as "a1__created_at", "a1"."updated_at" as "a1__updated_at", "a1"."name" as "a1__name", "a1"."email" as "a1__email", "a1"."age" as "a1__age", "a1"."terms_accepted" as "a1__terms_accepted", "a1"."optional" as "a1__optional", "a1"."identities" as "a1__identities", "a1"."born" as "a1__born", "a1"."born_time" as "a1__born_time", "a1"."favourite_book_uuid_pk" as "a1__favourite_book_uuid_pk", "a1"."favourite_author_id" as "a1__favourite_author_id", "a1"."identity" as "a1__identity", ' +
-      '"f2"."uuid_pk" as "f2__uuid_pk", "f2"."created_at" as "f2__created_at", "f2"."isbn" as "f2__isbn", "f2"."title" as "f2__title", "f2"."price" as "f2__price", "f2".price * 1.19 as "f2__price_taxed", "f2"."double" as "f2__double", "f2"."meta" as "f2__meta", "f2"."author_id" as "f2__author_id", "f2"."publisher_id" as "f2__publisher_id", ' +
+      '"f2"."uuid_pk" as "f2__uuid_pk", "f2"."created_at" as "f2__created_at", "f2"."isbn" as "f2__isbn", "f2"."title" as "f2__title", "f2"."price" as "f2__price", "f2"."price" * 1.19 as "f2__price_taxed", "f2"."double" as "f2__double", "f2"."meta" as "f2__meta", "f2"."author_id" as "f2__author_id", "f2"."publisher_id" as "f2__publisher_id", ' +
       '"a3"."id" as "a3__id", "a3"."created_at" as "a3__created_at", "a3"."updated_at" as "a3__updated_at", "a3"."name" as "a3__name", "a3"."email" as "a3__email", "a3"."age" as "a3__age", "a3"."terms_accepted" as "a3__terms_accepted", "a3"."optional" as "a3__optional", "a3"."identities" as "a3__identities", "a3"."born" as "a3__born", "a3"."born_time" as "a3__born_time", "a3"."favourite_book_uuid_pk" as "a3__favourite_book_uuid_pk", "a3"."favourite_author_id" as "a3__favourite_author_id", "a3"."identity" as "a3__identity", ' +
       '"f4"."uuid_pk" as "f4__uuid_pk" ' +
       'from "book2" as "b0" ' +

--- a/tests/features/lazy-scalar-properties/lazy-scalar-properties.mysql.test.ts
+++ b/tests/features/lazy-scalar-properties/lazy-scalar-properties.mysql.test.ts
@@ -31,7 +31,7 @@ describe('lazy scalar properties (mysql)', () => {
     expect(r1[0].books[0].perex?.unwrap()).toBe('123');
     expect(mock.mock.calls).toHaveLength(3);
     expect(mock.mock.calls[0][0]).toMatch('select `a0`.*, `a1`.`author_id` as `a1__author_id` from `author2` as `a0` left join `address2` as `a1` on `a0`.`id` = `a1`.`author_id`');
-    expect(mock.mock.calls[1][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`isbn`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` ' +
+    expect(mock.mock.calls[1][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`isbn`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.`price` * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` ' +
       'from `book2` as `b0` ' +
       'left join `test2` as `t1` on `b0`.`uuid_pk` = `t1`.`book_uuid_pk` ' +
       'where `b0`.`author_id` is not null and `b0`.`author_id` in (?) ' +
@@ -44,7 +44,7 @@ describe('lazy scalar properties (mysql)', () => {
     expect(r2[0].books[0].perex?.get()).toBe('123');
     expect(mock.mock.calls).toHaveLength(2);
     expect(mock.mock.calls[0][0]).toMatch('select `a0`.*, `a1`.`author_id` as `a1__author_id` from `author2` as `a0` left join `address2` as `a1` on `a0`.`id` = `a1`.`author_id`');
-    expect(mock.mock.calls[1][0]).toMatch('select `b0`.*, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` ' +
+    expect(mock.mock.calls[1][0]).toMatch('select `b0`.*, `b0`.`price` * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` ' +
       'from `book2` as `b0` ' +
       'left join `test2` as `t1` on `b0`.`uuid_pk` = `t1`.`book_uuid_pk` ' +
       'where `b0`.`author_id` is not null and `b0`.`author_id` in (?) ' +
@@ -57,7 +57,7 @@ describe('lazy scalar properties (mysql)', () => {
     await expect(r3!.books[0].perex?.load()).resolves.toBe('123');
     expect(mock.mock.calls).toHaveLength(3);
     expect(mock.mock.calls[0][0]).toMatch('select `a0`.*, `a1`.`author_id` as `a1__author_id` from `author2` as `a0` left join `address2` as `a1` on `a0`.`id` = `a1`.`author_id`');
-    expect(mock.mock.calls[1][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`isbn`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` ' +
+    expect(mock.mock.calls[1][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`isbn`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.`price` * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` ' +
       'from `book2` as `b0` ' +
       'left join `test2` as `t1` on `b0`.`uuid_pk` = `t1`.`book_uuid_pk` ' +
       'where `b0`.`author_id` is not null and `b0`.`author_id` in (?) ' +
@@ -70,7 +70,7 @@ describe('lazy scalar properties (mysql)', () => {
     expect(r4!.books[0].perex?.$).toBe('123');
     expect(mock.mock.calls).toHaveLength(2);
     expect(mock.mock.calls[0][0]).toMatch('select `a0`.*, `a1`.`author_id` as `a1__author_id` from `author2` as `a0` left join `address2` as `a1` on `a0`.`id` = `a1`.`author_id`');
-    expect(mock.mock.calls[1][0]).toMatch('select `b0`.*, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` ' +
+    expect(mock.mock.calls[1][0]).toMatch('select `b0`.*, `b0`.`price` * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` ' +
       'from `book2` as `b0` ' +
       'left join `test2` as `t1` on `b0`.`uuid_pk` = `t1`.`book_uuid_pk` ' +
       'where `b0`.`author_id` is not null and `b0`.`author_id` in (?) ' +
@@ -92,7 +92,7 @@ describe('lazy scalar properties (mysql)', () => {
     await wrap(r1[0]).populate(['books.perex']);
     expect(r1[0].books[0].perex?.unwrap()).toBe('123');
     expect(mock.mock.calls).toHaveLength(2);
-    expect(mock.mock.calls[0][0]).toMatch('select `a0`.*, `b1`.`uuid_pk` as `b1__uuid_pk`, `b1`.`created_at` as `b1__created_at`, `b1`.`isbn` as `b1__isbn`, `b1`.`title` as `b1__title`, `b1`.`price` as `b1__price`, `b1`.price * 1.19 as `b1__price_taxed`, `b1`.`double` as `b1__double`, `b1`.`meta` as `b1__meta`, `b1`.`author_id` as `b1__author_id`, `b1`.`publisher_id` as `b1__publisher_id`, `a2`.`author_id` as `a2__author_id` ' +
+    expect(mock.mock.calls[0][0]).toMatch('select `a0`.*, `b1`.`uuid_pk` as `b1__uuid_pk`, `b1`.`created_at` as `b1__created_at`, `b1`.`isbn` as `b1__isbn`, `b1`.`title` as `b1__title`, `b1`.`price` as `b1__price`, `b1`.`price` * 1.19 as `b1__price_taxed`, `b1`.`double` as `b1__double`, `b1`.`meta` as `b1__meta`, `b1`.`author_id` as `b1__author_id`, `b1`.`publisher_id` as `b1__publisher_id`, `a2`.`author_id` as `a2__author_id` ' +
       'from `author2` as `a0` ' +
       'left join `book2` as `b1` on `a0`.`id` = `b1`.`author_id` and `b1`.`author_id` is not null ' +
       'left join `address2` as `a2` on `a0`.`id` = `a2`.`author_id` ' +
@@ -103,7 +103,7 @@ describe('lazy scalar properties (mysql)', () => {
     const r2 = await orm.em.find(Author2, {}, { populate: ['books.perex'] });
     expect(r2[0].books[0].perex?.get()).toBe('123');
     expect(mock.mock.calls).toHaveLength(1);
-    expect(mock.mock.calls[0][0]).toMatch('select `a0`.*, `b1`.`uuid_pk` as `b1__uuid_pk`, `b1`.`created_at` as `b1__created_at`, `b1`.`isbn` as `b1__isbn`, `b1`.`title` as `b1__title`, `b1`.`perex` as `b1__perex`, `b1`.`price` as `b1__price`, `b1`.price * 1.19 as `b1__price_taxed`, `b1`.`double` as `b1__double`, `b1`.`meta` as `b1__meta`, `b1`.`author_id` as `b1__author_id`, `b1`.`publisher_id` as `b1__publisher_id`, `a2`.`author_id` as `a2__author_id` ' +
+    expect(mock.mock.calls[0][0]).toMatch('select `a0`.*, `b1`.`uuid_pk` as `b1__uuid_pk`, `b1`.`created_at` as `b1__created_at`, `b1`.`isbn` as `b1__isbn`, `b1`.`title` as `b1__title`, `b1`.`perex` as `b1__perex`, `b1`.`price` as `b1__price`, `b1`.`price` * 1.19 as `b1__price_taxed`, `b1`.`double` as `b1__double`, `b1`.`meta` as `b1__meta`, `b1`.`author_id` as `b1__author_id`, `b1`.`publisher_id` as `b1__publisher_id`, `a2`.`author_id` as `a2__author_id` ' +
       'from `author2` as `a0` ' +
       'left join `book2` as `b1` on `a0`.`id` = `b1`.`author_id` and `b1`.`author_id` is not null ' +
       'left join `address2` as `a2` on `a0`.`id` = `a2`.`author_id` ' +
@@ -115,7 +115,7 @@ describe('lazy scalar properties (mysql)', () => {
     expect(r3!.books[0].perex?.unwrap()).not.toBe('123');
     await expect(r3!.books[0].perex?.load()).resolves.toBe('123');
     expect(mock.mock.calls).toHaveLength(2);
-    expect(mock.mock.calls[0][0]).toMatch('select `a0`.*, `b1`.`uuid_pk` as `b1__uuid_pk`, `b1`.`created_at` as `b1__created_at`, `b1`.`isbn` as `b1__isbn`, `b1`.`title` as `b1__title`, `b1`.`price` as `b1__price`, `b1`.price * 1.19 as `b1__price_taxed`, `b1`.`double` as `b1__double`, `b1`.`meta` as `b1__meta`, `b1`.`author_id` as `b1__author_id`, `b1`.`publisher_id` as `b1__publisher_id`, `a2`.`author_id` as `a2__author_id` from `author2` as `a0` left join `book2` as `b1` on `a0`.`id` = `b1`.`author_id` and `b1`.`author_id` is not null left join `address2` as `a2` on `a0`.`id` = `a2`.`author_id` where `a0`.`id` = ? order by `b1`.`title` asc');
+    expect(mock.mock.calls[0][0]).toMatch('select `a0`.*, `b1`.`uuid_pk` as `b1__uuid_pk`, `b1`.`created_at` as `b1__created_at`, `b1`.`isbn` as `b1__isbn`, `b1`.`title` as `b1__title`, `b1`.`price` as `b1__price`, `b1`.`price` * 1.19 as `b1__price_taxed`, `b1`.`double` as `b1__double`, `b1`.`meta` as `b1__meta`, `b1`.`author_id` as `b1__author_id`, `b1`.`publisher_id` as `b1__publisher_id`, `a2`.`author_id` as `a2__author_id` from `author2` as `a0` left join `book2` as `b1` on `a0`.`id` = `b1`.`author_id` and `b1`.`author_id` is not null left join `address2` as `a2` on `a0`.`id` = `a2`.`author_id` where `a0`.`id` = ? order by `b1`.`title` asc');
     expect(mock.mock.calls[1][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`perex` from `book2` as `b0` where `b0`.`author_id` is not null and `b0`.`uuid_pk` in (?)');
 
     orm.em.clear();
@@ -123,7 +123,7 @@ describe('lazy scalar properties (mysql)', () => {
     const r4 = await orm.em.findOne(Author2, book.author, { populate: ['books.perex'] });
     expect(r4!.books[0].perex?.$).toBe('123');
     expect(mock.mock.calls).toHaveLength(1);
-    expect(mock.mock.calls[0][0]).toMatch('select `a0`.*, `b1`.`uuid_pk` as `b1__uuid_pk`, `b1`.`created_at` as `b1__created_at`, `b1`.`isbn` as `b1__isbn`, `b1`.`title` as `b1__title`, `b1`.`perex` as `b1__perex`, `b1`.`price` as `b1__price`, `b1`.price * 1.19 as `b1__price_taxed`, `b1`.`double` as `b1__double`, `b1`.`meta` as `b1__meta`, `b1`.`author_id` as `b1__author_id`, `b1`.`publisher_id` as `b1__publisher_id`, `a2`.`author_id` as `a2__author_id` from `author2` as `a0` left join `book2` as `b1` on `a0`.`id` = `b1`.`author_id` and `b1`.`author_id` is not null left join `address2` as `a2` on `a0`.`id` = `a2`.`author_id` where `a0`.`id` = ? order by `b1`.`title` asc');
+    expect(mock.mock.calls[0][0]).toMatch('select `a0`.*, `b1`.`uuid_pk` as `b1__uuid_pk`, `b1`.`created_at` as `b1__created_at`, `b1`.`isbn` as `b1__isbn`, `b1`.`title` as `b1__title`, `b1`.`perex` as `b1__perex`, `b1`.`price` as `b1__price`, `b1`.`price` * 1.19 as `b1__price_taxed`, `b1`.`double` as `b1__double`, `b1`.`meta` as `b1__meta`, `b1`.`author_id` as `b1__author_id`, `b1`.`publisher_id` as `b1__publisher_id`, `a2`.`author_id` as `a2__author_id` from `author2` as `a0` left join `book2` as `b1` on `a0`.`id` = `b1`.`author_id` and `b1`.`author_id` is not null left join `address2` as `a2` on `a0`.`id` = `a2`.`author_id` where `a0`.`id` = ? order by `b1`.`title` asc');
   });
 
   test('em.populate() respects lazy scalar properties', async () => {
@@ -142,7 +142,7 @@ describe('lazy scalar properties (mysql)', () => {
 
     expect(mock.mock.calls).toHaveLength(3);
     expect(mock.mock.calls[0][0]).toMatch('select `a0`.*, `a1`.`author_id` as `a1__author_id` from `author2` as `a0` left join `address2` as `a1` on `a0`.`id` = `a1`.`author_id`');
-    expect(mock.mock.calls[1][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`isbn`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` from `book2` as `b0` left join `test2` as `t1` on `b0`.`uuid_pk` = `t1`.`book_uuid_pk` where `b0`.`author_id` is not null and `b0`.`author_id` in (?) order by `b0`.`title` asc');
+    expect(mock.mock.calls[1][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`isbn`, `b0`.`title`, `b0`.`price`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.`price` * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` from `book2` as `b0` left join `test2` as `t1` on `b0`.`uuid_pk` = `t1`.`book_uuid_pk` where `b0`.`author_id` is not null and `b0`.`author_id` in (?) order by `b0`.`title` asc');
     expect(mock.mock.calls[2][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`perex` from `book2` as `b0` where `b0`.`author_id` is not null and `b0`.`uuid_pk` in (?)');
 
     mock.mockReset();

--- a/tests/features/partial-loading/partial-loading-exclude.mysql.test.ts
+++ b/tests/features/partial-loading/partial-loading-exclude.mysql.test.ts
@@ -124,12 +124,8 @@ describe('partial loading via `exclude` (mysql)', () => {
     expect(r1[0].books[0].price).toBeUndefined();
     expect(r1[0].books[0].author).toBeDefined();
     expect(mock.mock.calls).toHaveLength(2);
-    expect(mock.mock.calls[0][0]).toMatch(
-      'select `a0`.`id`, `a0`.`created_at`, `a0`.`updated_at`, `a0`.`email`, `a0`.`age`, `a0`.`terms_accepted`, `a0`.`optional`, `a0`.`identities`, `a0`.`born`, `a0`.`born_time`, `a0`.`favourite_book_uuid_pk`, `a0`.`favourite_author_id`, `a0`.`identity`, `a1`.`author_id` as `a1__author_id` from `author2` as `a0` left join `address2` as `a1` on `a0`.`id` = `a1`.`author_id` where `a0`.`id` = ?',
-    );
-    expect(mock.mock.calls[1][0]).toMatch(
-      'select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`isbn`, `b0`.`title`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` from `book2` as `b0` left join `test2` as `t1` on `b0`.`uuid_pk` = `t1`.`book_uuid_pk` where `b0`.`author_id` is not null and `b0`.`author_id` in (?) order by `b0`.`title` asc',
-    );
+    expect(mock.mock.calls[0][0]).toMatch('select `a0`.`id`, `a0`.`created_at`, `a0`.`updated_at`, `a0`.`email`, `a0`.`age`, `a0`.`terms_accepted`, `a0`.`optional`, `a0`.`identities`, `a0`.`born`, `a0`.`born_time`, `a0`.`favourite_book_uuid_pk`, `a0`.`favourite_author_id`, `a0`.`identity`, `a1`.`author_id` as `a1__author_id` from `author2` as `a0` left join `address2` as `a1` on `a0`.`id` = `a1`.`author_id` where `a0`.`id` = ?');
+    expect(mock.mock.calls[1][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`isbn`, `b0`.`title`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.`price` * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` from `book2` as `b0` left join `test2` as `t1` on `b0`.`uuid_pk` = `t1`.`book_uuid_pk` where `b0`.`author_id` is not null and `b0`.`author_id` in (?) order by `b0`.`title` asc');
     orm.em.clear();
     mock.mock.calls.length = 0;
 
@@ -140,9 +136,7 @@ describe('partial loading via `exclude` (mysql)', () => {
     expect(r0[0].name).toBeUndefined();
     expect(r0[0].books[0].uuid).toBe(god.books[0].uuid);
     expect(r0[0].books[0].title).toBe('Bible 1');
-    expect(mock.mock.calls[0][0]).toMatch(
-      'select `a0`.`id`, `a0`.`created_at`, `a0`.`updated_at`, `a0`.`email`, `a0`.`age`, `a0`.`terms_accepted`, `a0`.`optional`, `a0`.`identities`, `a0`.`born`, `a0`.`born_time`, `a0`.`favourite_book_uuid_pk`, `a0`.`favourite_author_id`, `a0`.`identity`, `b1`.`uuid_pk` as `b1__uuid_pk`, `b1`.`created_at` as `b1__created_at`, `b1`.`isbn` as `b1__isbn`, `b1`.`title` as `b1__title`, `b1`.price * 1.19 as `b1__price_taxed`, `b1`.`double` as `b1__double`, `b1`.`meta` as `b1__meta`, `b1`.`author_id` as `b1__author_id`, `b1`.`publisher_id` as `b1__publisher_id`, `a2`.`author_id` as `a2__author_id` from `author2` as `a0` left join `book2` as `b1` on `a0`.`id` = `b1`.`author_id` and `b1`.`author_id` is not null left join `address2` as `a2` on `a0`.`id` = `a2`.`author_id` where `a0`.`id` = ? order by `b1`.`title` asc',
-    );
+    expect(mock.mock.calls[0][0]).toMatch('select `a0`.`id`, `a0`.`created_at`, `a0`.`updated_at`, `a0`.`email`, `a0`.`age`, `a0`.`terms_accepted`, `a0`.`optional`, `a0`.`identities`, `a0`.`born`, `a0`.`born_time`, `a0`.`favourite_book_uuid_pk`, `a0`.`favourite_author_id`, `a0`.`identity`, `b1`.`uuid_pk` as `b1__uuid_pk`, `b1`.`created_at` as `b1__created_at`, `b1`.`isbn` as `b1__isbn`, `b1`.`title` as `b1__title`, `b1`.`price` * 1.19 as `b1__price_taxed`, `b1`.`double` as `b1__double`, `b1`.`meta` as `b1__meta`, `b1`.`author_id` as `b1__author_id`, `b1`.`publisher_id` as `b1__publisher_id`, `a2`.`author_id` as `a2__author_id` from `author2` as `a0` left join `book2` as `b1` on `a0`.`id` = `b1`.`author_id` and `b1`.`author_id` is not null left join `address2` as `a2` on `a0`.`id` = `a2`.`author_id` where `a0`.`id` = ? order by `b1`.`title` asc');
     // @ts-expect-error
     expect(r0[0].books[0].price).toBeUndefined();
     expect(r0[0].books[0].author).toBeDefined();
@@ -193,9 +187,7 @@ describe('partial loading via `exclude` (mysql)', () => {
     // @ts-expect-error
     expect(r1[0].author.name).toBeUndefined();
     expect(r1[0].author.email).toBeDefined();
-    expect(mock.mock.calls[0][0]).toMatch(
-      'select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`isbn`, `b0`.`title`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `a1`.`id` as `a1__id`, `a1`.`created_at` as `a1__created_at`, `a1`.`updated_at` as `a1__updated_at`, `a1`.`email` as `a1__email`, `a1`.`age` as `a1__age`, `a1`.`terms_accepted` as `a1__terms_accepted`, `a1`.`optional` as `a1__optional`, `a1`.`identities` as `a1__identities`, `a1`.`born` as `a1__born`, `a1`.`born_time` as `a1__born_time`, `a1`.`favourite_book_uuid_pk` as `a1__favourite_book_uuid_pk`, `a1`.`favourite_author_id` as `a1__favourite_author_id`, `a1`.`identity` as `a1__identity`, `t2`.`id` as `t2__id` from `book2` as `b0` inner join `author2` as `a1` on `b0`.`author_id` = `a1`.`id` left join `test2` as `t2` on `b0`.`uuid_pk` = `t2`.`book_uuid_pk` where `b0`.`uuid_pk` = ?',
-    );
+    expect(mock.mock.calls[0][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`isbn`, `b0`.`title`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.`price` * 1.19 as `price_taxed`, `a1`.`id` as `a1__id`, `a1`.`created_at` as `a1__created_at`, `a1`.`updated_at` as `a1__updated_at`, `a1`.`email` as `a1__email`, `a1`.`age` as `a1__age`, `a1`.`terms_accepted` as `a1__terms_accepted`, `a1`.`optional` as `a1__optional`, `a1`.`identities` as `a1__identities`, `a1`.`born` as `a1__born`, `a1`.`born_time` as `a1__born_time`, `a1`.`favourite_book_uuid_pk` as `a1__favourite_book_uuid_pk`, `a1`.`favourite_author_id` as `a1__favourite_author_id`, `a1`.`identity` as `a1__identity`, `t2`.`id` as `t2__id` from `book2` as `b0` inner join `author2` as `a1` on `b0`.`author_id` = `a1`.`id` left join `test2` as `t2` on `b0`.`uuid_pk` = `t2`.`book_uuid_pk` where `b0`.`uuid_pk` = ?');
     orm.em.clear();
     mock.mock.calls.length = 0;
 
@@ -215,12 +207,8 @@ describe('partial loading via `exclude` (mysql)', () => {
     // @ts-expect-error
     expect(r2[0].author.name).toBeUndefined();
     expect(r2[0].author.email).toBeDefined();
-    expect(mock.mock.calls[0][0]).toMatch(
-      'select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`isbn`, `b0`.`title`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` from `book2` as `b0` left join `test2` as `t1` on `b0`.`uuid_pk` = `t1`.`book_uuid_pk` where `b0`.`uuid_pk` = ?',
-    );
-    expect(mock.mock.calls[1][0]).toMatch(
-      'select `a0`.`id`, `a0`.`created_at`, `a0`.`updated_at`, `a0`.`email`, `a0`.`age`, `a0`.`terms_accepted`, `a0`.`optional`, `a0`.`identities`, `a0`.`born`, `a0`.`born_time`, `a0`.`favourite_book_uuid_pk`, `a0`.`favourite_author_id`, `a0`.`identity`, `a1`.`author_id` as `a1__author_id` from `author2` as `a0` left join `address2` as `a1` on `a0`.`id` = `a1`.`author_id` where `a0`.`id` in (?)',
-    );
+    expect(mock.mock.calls[0][0]).toMatch('select `b0`.`uuid_pk`, `b0`.`created_at`, `b0`.`isbn`, `b0`.`title`, `b0`.`double`, `b0`.`meta`, `b0`.`author_id`, `b0`.`publisher_id`, `b0`.`price` * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` from `book2` as `b0` left join `test2` as `t1` on `b0`.`uuid_pk` = `t1`.`book_uuid_pk` where `b0`.`uuid_pk` = ?');
+    expect(mock.mock.calls[1][0]).toMatch('select `a0`.`id`, `a0`.`created_at`, `a0`.`updated_at`, `a0`.`email`, `a0`.`age`, `a0`.`terms_accepted`, `a0`.`optional`, `a0`.`identities`, `a0`.`born`, `a0`.`born_time`, `a0`.`favourite_book_uuid_pk`, `a0`.`favourite_author_id`, `a0`.`identity`, `a1`.`author_id` as `a1__author_id` from `author2` as `a0` left join `address2` as `a1` on `a0`.`id` = `a1`.`author_id` where `a0`.`id` in (?)');
     orm.em.clear();
     mock.mock.calls.length = 0;
   });
@@ -246,9 +234,7 @@ describe('partial loading via `exclude` (mysql)', () => {
     expect(r1[0].books[0].price).toBeUndefined();
     // @ts-expect-error
     expect(r1[0].books[0].author).toBeUndefined();
-    expect(mock.mock.calls[0][0]).toMatch(
-      'select `b0`.`id`, `b0`.`name`, `b1`.`uuid_pk` as `b1__uuid_pk`, `b1`.`created_at` as `b1__created_at`, `b1`.`isbn` as `b1__isbn`, `b1`.`title` as `b1__title`, `b1`.price * 1.19 as `b1__price_taxed`, `b1`.`double` as `b1__double`, `b1`.`meta` as `b1__meta`, `b1`.`publisher_id` as `b1__publisher_id` from `book_tag2` as `b0` left join `book2_tags` as `b2` on `b0`.`id` = `b2`.`book_tag2_id` left join `book2` as `b1` on `b2`.`book2_uuid_pk` = `b1`.`uuid_pk` order by `b2`.`order` asc',
-    );
+    expect(mock.mock.calls[0][0]).toMatch('select `b0`.`id`, `b0`.`name`, `b1`.`uuid_pk` as `b1__uuid_pk`, `b1`.`created_at` as `b1__created_at`, `b1`.`isbn` as `b1__isbn`, `b1`.`title` as `b1__title`, `b1`.`price` * 1.19 as `b1__price_taxed`, `b1`.`double` as `b1__double`, `b1`.`meta` as `b1__meta`, `b1`.`publisher_id` as `b1__publisher_id` from `book_tag2` as `b0` left join `book2_tags` as `b2` on `b0`.`id` = `b2`.`book_tag2_id` left join `book2` as `b1` on `b2`.`book2_uuid_pk` = `b1`.`uuid_pk` order by `b2`.`order` asc');
     orm.em.clear();
     mock.mock.calls.length = 0;
 
@@ -270,9 +256,7 @@ describe('partial loading via `exclude` (mysql)', () => {
     // @ts-expect-error
     expect(r2[0].books[0].author).toBeUndefined();
     expect(mock.mock.calls[0][0]).toMatch('select `b0`.`id`, `b0`.`name` from `book_tag2` as `b0` where `b0`.`name` = ?');
-    expect(mock.mock.calls[1][0]).toMatch(
-      'select `b0`.`order`, `b0`.`book2_uuid_pk`, `b0`.`book_tag2_id`, `b1`.`uuid_pk` as `b1__uuid_pk`, `b1`.`created_at` as `b1__created_at`, `b1`.`isbn` as `b1__isbn`, `b1`.`title` as `b1__title`, `b1`.price * 1.19 as `b1__price_taxed`, `b1`.`double` as `b1__double`, `b1`.`meta` as `b1__meta`, `b1`.`publisher_id` as `b1__publisher_id`, `t2`.`id` as `t2__id` from `book2_tags` as `b0` inner join `book2` as `b1` on `b0`.`book2_uuid_pk` = `b1`.`uuid_pk` left join `test2` as `t2` on `b1`.`uuid_pk` = `t2`.`book_uuid_pk` where `b0`.`book_tag2_id` in (?) order by `b0`.`order` asc',
-    );
+    expect(mock.mock.calls[1][0]).toMatch('select `b0`.`order`, `b0`.`book2_uuid_pk`, `b0`.`book_tag2_id`, `b1`.`uuid_pk` as `b1__uuid_pk`, `b1`.`created_at` as `b1__created_at`, `b1`.`isbn` as `b1__isbn`, `b1`.`title` as `b1__title`, `b1`.`price` * 1.19 as `b1__price_taxed`, `b1`.`double` as `b1__double`, `b1`.`meta` as `b1__meta`, `b1`.`publisher_id` as `b1__publisher_id`, `t2`.`id` as `t2__id` from `book2_tags` as `b0` inner join `book2` as `b1` on `b0`.`book2_uuid_pk` = `b1`.`uuid_pk` left join `test2` as `t2` on `b1`.`uuid_pk` = `t2`.`book_uuid_pk` where `b0`.`book_tag2_id` in (?) order by `b0`.`order` asc');
   });
 
   test('partial nested loading (m:n -> m:1)', async () => {
@@ -300,12 +284,8 @@ describe('partial loading via `exclude` (mysql)', () => {
     expect(r1[0].books[0].author.name).toBeUndefined();
     expect(r1[0].books[0].author.email).toBe(god.email);
     expect(mock.mock.calls[0][0]).toMatch('select `b0`.`id`, `b0`.`name` from `book_tag2` as `b0`');
-    expect(mock.mock.calls[1][0]).toMatch(
-      'select `b0`.`order`, `b0`.`book2_uuid_pk`, `b0`.`book_tag2_id`, `b1`.`uuid_pk` as `b1__uuid_pk`, `b1`.`created_at` as `b1__created_at`, `b1`.`isbn` as `b1__isbn`, `b1`.`title` as `b1__title`, `b1`.price * 1.19 as `b1__price_taxed`, `b1`.`double` as `b1__double`, `b1`.`meta` as `b1__meta`, `b1`.`author_id` as `b1__author_id`, `b1`.`publisher_id` as `b1__publisher_id`, `t2`.`id` as `t2__id` from `book2_tags` as `b0` inner join `book2` as `b1` on `b0`.`book2_uuid_pk` = `b1`.`uuid_pk` left join `test2` as `t2` on `b1`.`uuid_pk` = `t2`.`book_uuid_pk` where `b0`.`book_tag2_id` in (?, ?, ?, ?, ?, ?) order by `b0`.`order` asc',
-    );
-    expect(mock.mock.calls[2][0]).toMatch(
-      'select `a0`.`id`, `a0`.`created_at`, `a0`.`updated_at`, `a0`.`email`, `a0`.`age`, `a0`.`terms_accepted`, `a0`.`optional`, `a0`.`identities`, `a0`.`born`, `a0`.`born_time`, `a0`.`favourite_book_uuid_pk`, `a0`.`favourite_author_id`, `a0`.`identity`, `a1`.`author_id` as `a1__author_id` from `author2` as `a0` left join `address2` as `a1` on `a0`.`id` = `a1`.`author_id` where `a0`.`id` in (?)',
-    );
+    expect(mock.mock.calls[1][0]).toMatch('select `b0`.`order`, `b0`.`book2_uuid_pk`, `b0`.`book_tag2_id`, `b1`.`uuid_pk` as `b1__uuid_pk`, `b1`.`created_at` as `b1__created_at`, `b1`.`isbn` as `b1__isbn`, `b1`.`title` as `b1__title`, `b1`.`price` * 1.19 as `b1__price_taxed`, `b1`.`double` as `b1__double`, `b1`.`meta` as `b1__meta`, `b1`.`author_id` as `b1__author_id`, `b1`.`publisher_id` as `b1__publisher_id`, `t2`.`id` as `t2__id` from `book2_tags` as `b0` inner join `book2` as `b1` on `b0`.`book2_uuid_pk` = `b1`.`uuid_pk` left join `test2` as `t2` on `b1`.`uuid_pk` = `t2`.`book_uuid_pk` where `b0`.`book_tag2_id` in (?, ?, ?, ?, ?, ?) order by `b0`.`order` asc');
+    expect(mock.mock.calls[2][0]).toMatch('select `a0`.`id`, `a0`.`created_at`, `a0`.`updated_at`, `a0`.`email`, `a0`.`age`, `a0`.`terms_accepted`, `a0`.`optional`, `a0`.`identities`, `a0`.`born`, `a0`.`born_time`, `a0`.`favourite_book_uuid_pk`, `a0`.`favourite_author_id`, `a0`.`identity`, `a1`.`author_id` as `a1__author_id` from `author2` as `a0` left join `address2` as `a1` on `a0`.`id` = `a1`.`author_id` where `a0`.`id` in (?)');
     orm.em.clear();
     mock.mock.calls.length = 0;
 
@@ -326,15 +306,13 @@ describe('partial loading via `exclude` (mysql)', () => {
     expect(r2[0].books[0].author.name).toBeUndefined();
     expect(r2[0].books[0].author.email).toBe(god.email);
     expect(mock.mock.calls).toHaveLength(1);
-    expect(mock.mock.calls[0][0]).toMatch(
-      'select `b0`.`id`, `b0`.`name`, `b1`.`uuid_pk` as `b1__uuid_pk`, `b1`.`created_at` as `b1__created_at`, `b1`.`isbn` as `b1__isbn`, `b1`.`title` as `b1__title`, `b1`.price * 1.19 as `b1__price_taxed`, `b1`.`double` as `b1__double`, `b1`.`meta` as `b1__meta`, `b1`.`author_id` as `b1__author_id`, `b1`.`publisher_id` as `b1__publisher_id`, `a3`.`id` as `a3__id`, `a3`.`created_at` as `a3__created_at`, `a3`.`updated_at` as `a3__updated_at`, `a3`.`email` as `a3__email`, `a3`.`age` as `a3__age`, `a3`.`terms_accepted` as `a3__terms_accepted`, `a3`.`optional` as `a3__optional`, `a3`.`identities` as `a3__identities`, `a3`.`born` as `a3__born`, `a3`.`born_time` as `a3__born_time`, `a3`.`favourite_book_uuid_pk` as `a3__favourite_book_uuid_pk`, `a3`.`favourite_author_id` as `a3__favourite_author_id`, `a3`.`identity` as `a3__identity` ' +
-        'from `book_tag2` as `b0` ' +
-        'left join `book2_tags` as `b2` on `b0`.`id` = `b2`.`book_tag2_id` ' +
-        'left join (`book2` as `b1` ' +
-        'inner join `author2` as `a3` on `b1`.`author_id` = `a3`.`id`) ' +
-        'on `b2`.`book2_uuid_pk` = `b1`.`uuid_pk` ' +
-        'order by `b2`.`order` asc',
-    );
+    expect(mock.mock.calls[0][0]).toMatch('select `b0`.`id`, `b0`.`name`, `b1`.`uuid_pk` as `b1__uuid_pk`, `b1`.`created_at` as `b1__created_at`, `b1`.`isbn` as `b1__isbn`, `b1`.`title` as `b1__title`, `b1`.`price` * 1.19 as `b1__price_taxed`, `b1`.`double` as `b1__double`, `b1`.`meta` as `b1__meta`, `b1`.`author_id` as `b1__author_id`, `b1`.`publisher_id` as `b1__publisher_id`, `a3`.`id` as `a3__id`, `a3`.`created_at` as `a3__created_at`, `a3`.`updated_at` as `a3__updated_at`, `a3`.`email` as `a3__email`, `a3`.`age` as `a3__age`, `a3`.`terms_accepted` as `a3__terms_accepted`, `a3`.`optional` as `a3__optional`, `a3`.`identities` as `a3__identities`, `a3`.`born` as `a3__born`, `a3`.`born_time` as `a3__born_time`, `a3`.`favourite_book_uuid_pk` as `a3__favourite_book_uuid_pk`, `a3`.`favourite_author_id` as `a3__favourite_author_id`, `a3`.`identity` as `a3__identity` ' +
+      'from `book_tag2` as `b0` ' +
+      'left join `book2_tags` as `b2` on `b0`.`id` = `b2`.`book_tag2_id` ' +
+      'left join (`book2` as `b1` ' +
+      'inner join `author2` as `a3` on `b1`.`author_id` = `a3`.`id`) ' +
+      'on `b2`.`book2_uuid_pk` = `b1`.`uuid_pk` ' +
+      'order by `b2`.`order` asc');
   });
 
   test('populate partial (joined)', async () => {

--- a/tests/features/query-builder/query-builder-advanced.test.ts
+++ b/tests/features/query-builder/query-builder-advanced.test.ts
@@ -103,7 +103,7 @@ describe('QueryBuilder - Advanced', () => {
     await qb.getResult();
 
     const sql =
-      'select `p`.*, `b`.`uuid_pk` as `b__uuid_pk`, `b`.`created_at` as `b__created_at`, `b`.`isbn` as `b__isbn`, `b`.`title` as `b__title`, `b`.`price` as `b__price`, `b`.price * 1.19 as `b__price_taxed`, `b`.`double` as `b__double`, `b`.`meta` as `b__meta`, `b`.`author_id` as `b__author_id`, `b`.`publisher_id` as `b__publisher_id`, ' +
+      'select `p`.*, `b`.`uuid_pk` as `b__uuid_pk`, `b`.`created_at` as `b__created_at`, `b`.`isbn` as `b__isbn`, `b`.`title` as `b__title`, `b`.`price` as `b__price`, `b`.`price` * 1.19 as `b__price_taxed`, `b`.`double` as `b__double`, `b`.`meta` as `b__meta`, `b`.`author_id` as `b__author_id`, `b`.`publisher_id` as `b__publisher_id`, ' +
       '`a`.`id` as `a__id`, `a`.`created_at` as `a__created_at`, `a`.`updated_at` as `a__updated_at`, `a`.`name` as `a__name`, `a`.`email` as `a__email`, `a`.`age` as `a__age`, `a`.`terms_accepted` as `a__terms_accepted`, `a`.`optional` as `a__optional`, `a`.`identities` as `a__identities`, `a`.`born` as `a__born`, `a`.`born_time` as `a__born_time`, `a`.`favourite_book_uuid_pk` as `a__favourite_book_uuid_pk`, `a`.`favourite_author_id` as `a__favourite_author_id`, `a`.`identity` as `a__identity`, ' +
       '`t`.`id` as `t__id`, `t`.`name` as `t__name` ' +
       'from `publisher2` as `p` ' +
@@ -362,7 +362,7 @@ describe('QueryBuilder - Advanced', () => {
       },
     };
     const expected =
-      "select `e0`.*, `e0`.price * 1.19 as `price_taxed` from `book2` as `e0` inner join `author2` as `e1` on `e0`.`author_id` = `e1`.`id` where (`e1`.`id` = 123 or `e1`.`name` like '%jon%')";
+      "select `e0`.*, `e0`.`price` * 1.19 as `price_taxed` from `book2` as `e0` inner join `author2` as `e1` on `e0`.`author_id` = `e1`.`id` where (`e1`.`id` = 123 or `e1`.`name` like '%jon%')";
     const sql1 = orm.em.createQueryBuilder(Book2).select('*').where(query).getFormattedQuery();
     expect(sql1).toBe(expected);
     const sql2 = orm.em.createQueryBuilder(Book2).where(query).getFormattedQuery();
@@ -386,7 +386,7 @@ describe('QueryBuilder - Advanced', () => {
         author: { email: 'ASC' },
       });
     expect(qb1.getQuery()).toEqual(
-      'select `a`.*, `a`.price * 1.19 as `price_taxed` from `book2` as `a` ' +
+      'select `a`.*, `a`.`price` * 1.19 as `price_taxed` from `book2` as `a` ' +
         'inner join `author2` as `e1` on `a`.`author_id` = `e1`.`id` ' +
         'left join `publisher2` as `e2` on `a`.`publisher_id` = `e2`.`id` ' +
         'where (`e1`.`name` = ? or `e2`.`name` = ?) ' +
@@ -400,7 +400,7 @@ describe('QueryBuilder - Advanced', () => {
       $or: [{ author: { name: 'test' } }, { $not: { author: { name: 'wut' } } }],
     });
     expect(qb1.getQuery()).toEqual(
-      'select `a`.*, `a`.price * 1.19 as `price_taxed` ' +
+      'select `a`.*, `a`.`price` * 1.19 as `price_taxed` ' +
         'from `book2` as `a` ' +
         'inner join `author2` as `e1` on `a`.`author_id` = `e1`.`id` ' +
         'where (`e1`.`name` = ? or not (`e1`.`name` = ?))',
@@ -413,7 +413,7 @@ describe('QueryBuilder - Advanced', () => {
       $or: [{ author: { name: 'test' } }, { author: { [raw(a => `lower(${a}.name)`)]: 'wut' } }],
     });
     expect(qb1.getQuery()).toEqual(
-      'select `a`.*, `a`.price * 1.19 as `price_taxed` ' +
+      'select `a`.*, `a`.`price` * 1.19 as `price_taxed` ' +
         'from `book2` as `a` ' +
         'inner join `author2` as `e1` on `a`.`author_id` = `e1`.`id` ' +
         'where (`e1`.`name` = ? or lower(e1.name) = ?)',

--- a/tests/features/query-builder/query-builder-deep.test.ts
+++ b/tests/features/query-builder/query-builder-deep.test.ts
@@ -30,7 +30,7 @@ describe('QueryBuilder - Deep', () => {
     const qb1 = orm.em.createQueryBuilder(Book2);
     qb1.select('*').where({ author: { name: 'Jon Snow', termsAccepted: true } });
     expect(qb1.getQuery()).toEqual(
-      'select `e0`.*, `e0`.price * 1.19 as `price_taxed` from `book2` as `e0` inner join `author2` as `e1` on `e0`.`author_id` = `e1`.`id` where `e1`.`name` = ? and `e1`.`terms_accepted` = ?',
+      'select `e0`.*, `e0`.`price` * 1.19 as `price_taxed` from `book2` as `e0` inner join `author2` as `e1` on `e0`.`author_id` = `e1`.`id` where `e1`.`name` = ? and `e1`.`terms_accepted` = ?',
     );
     expect(qb1.getParams()).toEqual(['Jon Snow', true]);
 
@@ -66,7 +66,7 @@ describe('QueryBuilder - Deep', () => {
     const qb5 = orm.em.createQueryBuilder(Book2);
     qb5.select('*').where({ tags: ['1', '2', '3'] });
     expect(qb5.getQuery()).toEqual(
-      'select `e0`.*, `e0`.price * 1.19 as `price_taxed` ' +
+      'select `e0`.*, `e0`.`price` * 1.19 as `price_taxed` ' +
         'from `book2` as `e0` ' +
         'left join `book2_tags` as `e1` on `e0`.`uuid_pk` = `e1`.`book2_uuid_pk` ' +
         'where `e1`.`book_tag2_id` in (?, ?, ?)',
@@ -77,7 +77,7 @@ describe('QueryBuilder - Deep', () => {
     const qb6 = orm.em.createQueryBuilder(Book2);
     qb6.select('*').where({ tags: { name: 'Tag 3' } });
     expect(qb6.getQuery()).toEqual(
-      'select `e0`.*, `e0`.price * 1.19 as `price_taxed` ' +
+      'select `e0`.*, `e0`.`price` * 1.19 as `price_taxed` ' +
         'from `book2` as `e0` ' +
         'left join `book2_tags` as `e2` on `e0`.`uuid_pk` = `e2`.`book2_uuid_pk` ' +
         'left join `book_tag2` as `e1` on `e2`.`book_tag2_id` = `e1`.`id` ' +
@@ -123,7 +123,7 @@ describe('QueryBuilder - Deep', () => {
     const qb10 = orm.em.createQueryBuilder(Book2);
     qb10.select('*').where({ author: { favouriteBook: { author: { name: 'Jon Snow' } } } });
     expect(qb10.getQuery()).toEqual(
-      'select `e0`.*, `e0`.price * 1.19 as `price_taxed` from `book2` as `e0` ' +
+      'select `e0`.*, `e0`.`price` * 1.19 as `price_taxed` from `book2` as `e0` ' +
         'inner join `author2` as `e1` on `e0`.`author_id` = `e1`.`id` ' +
         'left join (`book2` as `e2` ' +
         'inner join `author2` as `e3` on `e2`.`author_id` = `e3`.`id`) ' +
@@ -181,7 +181,7 @@ describe('QueryBuilder - Deep', () => {
     const qb1 = orm.em.createQueryBuilder(Book2);
     qb1.select('*').where({ author: { favouriteAuthor: { name: 'Jon Snow', termsAccepted: true } } });
     expect(qb1.getQuery()).toEqual(
-      'select `e0`.*, `e0`.price * 1.19 as `price_taxed` from `book2` as `e0` ' +
+      'select `e0`.*, `e0`.`price` * 1.19 as `price_taxed` from `book2` as `e0` ' +
         'inner join `author2` as `e1` on `e0`.`author_id` = `e1`.`id` ' +
         'left join `author2` as `e2` on `e1`.`favourite_author_id` = `e2`.`id` ' +
         'where `e2`.`name` = ? and `e2`.`terms_accepted` = ?',
@@ -193,7 +193,7 @@ describe('QueryBuilder - Deep', () => {
     const qb1 = orm.em.createQueryBuilder(Book2);
     qb1.select('*').orderBy({ author: { name: QueryOrder.DESC } });
     expect(qb1.getQuery()).toEqual(
-      'select `e0`.*, `e0`.price * 1.19 as `price_taxed` from `book2` as `e0` inner join `author2` as `e1` on `e0`.`author_id` = `e1`.`id` order by `e1`.`name` desc',
+      'select `e0`.*, `e0`.`price` * 1.19 as `price_taxed` from `book2` as `e0` inner join `author2` as `e1` on `e0`.`author_id` = `e1`.`id` order by `e1`.`name` desc',
     );
 
     const qb2 = orm.em.createQueryBuilder(Author2);
@@ -221,7 +221,7 @@ describe('QueryBuilder - Deep', () => {
     const qb5 = orm.em.createQueryBuilder(Book2);
     qb5.select('*').orderBy({ tags: { name: QueryOrder.DESC } });
     expect(qb5.getQuery()).toEqual(
-      'select `e0`.*, `e0`.price * 1.19 as `price_taxed` ' +
+      'select `e0`.*, `e0`.`price` * 1.19 as `price_taxed` ' +
         'from `book2` as `e0` ' +
         'left join `book2_tags` as `e2` on `e0`.`uuid_pk` = `e2`.`book2_uuid_pk` ' +
         'left join `book_tag2` as `e1` on `e2`.`book_tag2_id` = `e1`.`id` ' +
@@ -243,7 +243,7 @@ describe('QueryBuilder - Deep', () => {
       .populate([{ field: 'tags' }])
       .leftJoin('tags', 't');
     expect(qb.getQuery()).toEqual(
-      'select `e0`.*, `e0`.price * 1.19 as `price_taxed` ' +
+      'select `e0`.*, `e0`.`price` * 1.19 as `price_taxed` ' +
         'from `book2` as `e0` ' +
         'left join `book2_tags` as `e1` on `e0`.`uuid_pk` = `e1`.`book2_uuid_pk` ' +
         'left join `book_tag2` as `t` on `e1`.`book_tag2_id` = `t`.`id`',
@@ -257,7 +257,7 @@ describe('QueryBuilder - Deep', () => {
       .where({ author: { name: 'Jon Snow' } })
       .orderBy({ author: { name: QueryOrder.DESC } });
     expect(qb1.getQuery()).toEqual(
-      'select `e0`.*, `e0`.price * 1.19 as `price_taxed` from `book2` as `e0` inner join `author2` as `e1` on `e0`.`author_id` = `e1`.`id` where `e1`.`name` = ? order by `e1`.`name` desc',
+      'select `e0`.*, `e0`.`price` * 1.19 as `price_taxed` from `book2` as `e0` inner join `author2` as `e1` on `e0`.`author_id` = `e1`.`id` where `e1`.`name` = ? order by `e1`.`name` desc',
     );
     expect(qb1.getParams()).toEqual(['Jon Snow']);
 
@@ -304,7 +304,7 @@ describe('QueryBuilder - Deep', () => {
       .where({ tags: { name: 'Tag 3' } })
       .orderBy({ tags: { name: QueryOrder.DESC } });
     expect(qb5.getQuery()).toEqual(
-      'select `e0`.*, `e0`.price * 1.19 as `price_taxed` ' +
+      'select `e0`.*, `e0`.`price` * 1.19 as `price_taxed` ' +
         'from `book2` as `e0` ' +
         'left join `book2_tags` as `e2` on `e0`.`uuid_pk` = `e2`.`book2_uuid_pk` ' +
         'left join `book_tag2` as `e1` on `e2`.`book_tag2_id` = `e1`.`id` ' +
@@ -317,7 +317,7 @@ describe('QueryBuilder - Deep', () => {
     const qb0 = orm.em.createQueryBuilder(Book2);
     qb0.select('*').where({ author: { $or: [{ name: 'Jon Snow 1' }, { email: /^snow@/ }] } });
     expect(qb0.getQuery()).toEqual(
-      'select `e0`.*, `e0`.price * 1.19 as `price_taxed` from `book2` as `e0` ' +
+      'select `e0`.*, `e0`.`price` * 1.19 as `price_taxed` from `book2` as `e0` ' +
         'inner join `author2` as `e1` on `e0`.`author_id` = `e1`.`id` ' +
         'where (`e1`.`name` = ? or `e1`.`email` like ?)',
     );
@@ -326,7 +326,7 @@ describe('QueryBuilder - Deep', () => {
     const qb1 = orm.em.createQueryBuilder(Book2);
     qb1.select('*').where({ $or: [{ author: { name: 'Jon Snow 1', termsAccepted: true } }, { author: { name: 'Jon Snow 2' } }] });
     expect(qb1.getQuery()).toEqual(
-      'select `e0`.*, `e0`.price * 1.19 as `price_taxed` ' +
+      'select `e0`.*, `e0`.`price` * 1.19 as `price_taxed` ' +
         'from `book2` as `e0` ' +
         'inner join `author2` as `e1` on `e0`.`author_id` = `e1`.`id` ' +
         'where ((`e1`.`name` = ? and `e1`.`terms_accepted` = ?) or `e1`.`name` = ?)',
@@ -336,7 +336,7 @@ describe('QueryBuilder - Deep', () => {
     const qb2 = orm.em.createQueryBuilder(Book2);
     qb2.select('*').where({ $or: [{ author: { $or: [{ name: 'Jon Snow 1' }, { email: /^snow@/ }] } }, { publisher: { name: 'My Publisher' } }] });
     expect(qb2.getQuery()).toEqual(
-      'select `e0`.*, `e0`.price * 1.19 as `price_taxed` from `book2` as `e0` ' +
+      'select `e0`.*, `e0`.`price` * 1.19 as `price_taxed` from `book2` as `e0` ' +
         'inner join `author2` as `e1` on `e0`.`author_id` = `e1`.`id` ' +
         'left join `publisher2` as `e2` on `e0`.`publisher_id` = `e2`.`id` ' +
         'where (((`e1`.`name` = ? or `e1`.`email` like ?)) or `e2`.`name` = ?)',
@@ -348,7 +348,7 @@ describe('QueryBuilder - Deep', () => {
       .select('*')
       .where({ $or: [{ author: { $or: [{ name: { $in: ['Jon Snow 1', 'Jon Snow 2'] } }, { email: /^snow@/ }] } }, { publisher: { name: 'My Publisher' } }] });
     expect(qb3.getQuery()).toEqual(
-      'select `e0`.*, `e0`.price * 1.19 as `price_taxed` from `book2` as `e0` ' +
+      'select `e0`.*, `e0`.`price` * 1.19 as `price_taxed` from `book2` as `e0` ' +
         'inner join `author2` as `e1` on `e0`.`author_id` = `e1`.`id` ' +
         'left join `publisher2` as `e2` on `e0`.`publisher_id` = `e2`.`id` ' +
         'where (((`e1`.`name` in (?, ?) or `e1`.`email` like ?)) or `e2`.`name` = ?)',
@@ -358,7 +358,7 @@ describe('QueryBuilder - Deep', () => {
     const qb4 = orm.em.createQueryBuilder(Book2);
     qb4.select('*').where({ $or: [{ author: { $or: [{ $not: { name: 'Jon Snow 1' } }, { email: /^snow@/ }] } }, { publisher: { name: 'My Publisher' } }] });
     expect(qb4.getQuery()).toEqual(
-      'select `e0`.*, `e0`.price * 1.19 as `price_taxed` from `book2` as `e0` ' +
+      'select `e0`.*, `e0`.`price` * 1.19 as `price_taxed` from `book2` as `e0` ' +
         'inner join `author2` as `e1` on `e0`.`author_id` = `e1`.`id` ' +
         'left join `publisher2` as `e2` on `e0`.`publisher_id` = `e2`.`id` ' +
         'where (((not (`e1`.`name` = ?) or `e1`.`email` like ?)) or `e2`.`name` = ?)',
@@ -388,7 +388,7 @@ describe('QueryBuilder - Deep', () => {
     const qb7 = orm.em.createQueryBuilder(Book2);
     qb7.select('*').where({ tags: { name: { $in: ['Tag 1', 'Tag 2'] } } });
     expect(qb7.getQuery()).toEqual(
-      'select `e0`.*, `e0`.price * 1.19 as `price_taxed` ' +
+      'select `e0`.*, `e0`.`price` * 1.19 as `price_taxed` ' +
         'from `book2` as `e0` ' +
         'left join `book2_tags` as `e2` on `e0`.`uuid_pk` = `e2`.`book2_uuid_pk` ' +
         'left join `book_tag2` as `e1` on `e2`.`book_tag2_id` = `e1`.`id` ' +

--- a/tests/features/query-builder/query-builder-gh-issues.test.ts
+++ b/tests/features/query-builder/query-builder-gh-issues.test.ts
@@ -148,7 +148,7 @@ describe('QueryBuilder - GH Issues', () => {
       .where({ test: { id: 1 } })
       .getQuery();
     expect(sql4).toBe(
-      'select `e0`.*, `e1`.`id` as `e1__id`, `e0`.price * 1.19 as `price_taxed` ' +
+      'select `e0`.*, `e1`.`id` as `e1__id`, `e0`.`price` * 1.19 as `price_taxed` ' +
         'from `book2` as `e0` ' +
         'left join `test2` as `e1` on `e0`.`uuid_pk` = `e1`.`book_uuid_pk` ' +
         'where `e1`.`id` = ?',

--- a/tests/features/query-builder/query-builder-pivot.test.ts
+++ b/tests/features/query-builder/query-builder-pivot.test.ts
@@ -40,7 +40,7 @@ describe('QueryBuilder - Pivot', () => {
       .select('b.*')
       .where({ $or: [{ tags: null }, { tags: { $ne: 1 } }] });
     expect(qb2.getQuery()).toMatch(
-      'select `b`.*, `b`.price * 1.19 as `price_taxed` ' +
+      'select `b`.*, `b`.`price` * 1.19 as `price_taxed` ' +
         'from `book2` as `b` ' +
         'left join `book2_tags` as `e1` on `b`.`uuid_pk` = `e1`.`book2_uuid_pk` ' +
         'where (`e1`.`book_tag2_id` is null or `e1`.`book_tag2_id` != ?)',
@@ -96,7 +96,7 @@ describe('QueryBuilder - Pivot', () => {
       .select('b.*')
       .where({ tags: { id: 1 } });
     expect(qb1.getQuery()).toMatch(
-      'select `b`.*, `b`.price * 1.19 as `price_taxed` ' +
+      'select `b`.*, `b`.`price` * 1.19 as `price_taxed` ' +
         'from `book2` as `b` ' +
         'left join `book2_tags` as `e1` on `b`.`uuid_pk` = `e1`.`book2_uuid_pk` ' +
         'where `e1`.`book_tag2_id` = ?',
@@ -139,7 +139,7 @@ describe('QueryBuilder - Pivot', () => {
       .select('b.*')
       .where({ $or: [{ tags: { id: null } }, { tags: { $ne: 1 } }] });
     expect(qb2.getQuery()).toMatch(
-      'select `b`.*, `b`.price * 1.19 as `price_taxed` ' +
+      'select `b`.*, `b`.`price` * 1.19 as `price_taxed` ' +
         'from `book2` as `b` ' +
         'left join `book2_tags` as `e1` on `b`.`uuid_pk` = `e1`.`book2_uuid_pk` ' +
         'where (`e1`.`book_tag2_id` is null or `e1`.`book_tag2_id` != ?)',
@@ -171,7 +171,7 @@ describe('QueryBuilder - Pivot', () => {
       })
       .orderBy({ tags: { name: 1 } });
     expect(qb0.getQuery()).toEqual(
-      'select `e0`.*, `e0`.price * 1.19 as `price_taxed` ' +
+      'select `e0`.*, `e0`.`price` * 1.19 as `price_taxed` ' +
         'from `book2` as `e0` ' +
         'left join `book2_tags` as `e2` on `e0`.`uuid_pk` = `e2`.`book2_uuid_pk` ' +
         'left join `book_tag2` as `e1` on `e2`.`book_tag2_id` = `e1`.`id` ' +
@@ -185,7 +185,7 @@ describe('QueryBuilder - Pivot', () => {
       $and: [{ tags: { name: 'tag1' } }, { tags: { name: 'tag2' } }],
     });
     expect(qb1.getQuery()).toEqual(
-      'select `e0`.*, `e0`.price * 1.19 as `price_taxed` ' +
+      'select `e0`.*, `e0`.`price` * 1.19 as `price_taxed` ' +
         'from `book2` as `e0` ' +
         'left join `book2_tags` as `e2` on `e0`.`uuid_pk` = `e2`.`book2_uuid_pk` ' +
         'left join `book_tag2` as `e1` on `e2`.`book_tag2_id` = `e1`.`id` ' +
@@ -200,7 +200,7 @@ describe('QueryBuilder - Pivot', () => {
       $and: [{ author: { name: 'a1' } }, { author: { name: 'a2' } }],
     });
     expect(qb2.getQuery()).toEqual(
-      'select `e0`.*, `e0`.price * 1.19 as `price_taxed` ' +
+      'select `e0`.*, `e0`.`price` * 1.19 as `price_taxed` ' +
         'from `book2` as `e0` ' +
         'inner join `author2` as `e1` on `e0`.`author_id` = `e1`.`id` ' +
         'where `e1`.`name` = ? and `e1`.`name` = ?',
@@ -212,7 +212,7 @@ describe('QueryBuilder - Pivot', () => {
       $or: [{ author: { name: 'a1' } }, { author: { name: 'a2' } }],
     });
     expect(qb3.getQuery()).toEqual(
-      'select `e0`.*, `e0`.price * 1.19 as `price_taxed` ' +
+      'select `e0`.*, `e0`.`price` * 1.19 as `price_taxed` ' +
         'from `book2` as `e0` ' +
         'inner join `author2` as `e1` on `e0`.`author_id` = `e1`.`id` ' +
         'where (`e1`.`name` = ? or `e1`.`name` = ?)',
@@ -251,7 +251,7 @@ describe('QueryBuilder - Pivot', () => {
       },
     });
     expect(qb6.getQuery()).toEqual(
-      'select `e0`.*, `e0`.price * 1.19 as `price_taxed` ' +
+      'select `e0`.*, `e0`.`price` * 1.19 as `price_taxed` ' +
         'from `book2` as `e0` ' +
         'left join `book2_tags` as `e2` on `e0`.`uuid_pk` = `e2`.`book2_uuid_pk` ' +
         'left join `book_tag2` as `e1` on `e2`.`book_tag2_id` = `e1`.`id` ' +
@@ -264,7 +264,7 @@ describe('QueryBuilder - Pivot', () => {
       $and: [{ author: { favouriteBook: { title: 'a1' } } }, { author: { favouriteBook: { title: 'a2' } } }],
     });
     expect(qb7.getQuery()).toEqual(
-      'select `e0`.*, `e0`.price * 1.19 as `price_taxed` ' +
+      'select `e0`.*, `e0`.`price` * 1.19 as `price_taxed` ' +
         'from `book2` as `e0` ' +
         'inner join `author2` as `e1` on `e0`.`author_id` = `e1`.`id` ' +
         'left join `book2` as `e2` on `e1`.`favourite_book_uuid_pk` = `e2`.`uuid_pk` ' +
@@ -305,7 +305,7 @@ describe('QueryBuilder - Pivot', () => {
       ],
     });
     expect(qb9.getQuery()).toEqual(
-      'select `e0`.*, `e0`.price * 1.19 as `price_taxed` ' +
+      'select `e0`.*, `e0`.`price` * 1.19 as `price_taxed` ' +
         'from `book2` as `e0` ' +
         'inner join `author2` as `e1` on `e0`.`author_id` = `e1`.`id` ' +
         'left join `book2` as `e2` on `e1`.`favourite_book_uuid_pk` = `e2`.`uuid_pk` ' +
@@ -420,7 +420,7 @@ describe('QueryBuilder - Pivot', () => {
 
   test('query json property with operator directly (GH #3246)', async () => {
     const qb = orm.em.createQueryBuilder(Book2).where({ meta: { $ne: null } });
-    expect(qb.getFormattedQuery()).toBe('select `e0`.*, `e0`.price * 1.19 as `price_taxed` from `book2` as `e0` where `e0`.`meta` is not null');
+    expect(qb.getFormattedQuery()).toBe('select `e0`.*, `e0`.`price` * 1.19 as `price_taxed` from `book2` as `e0` where `e0`.`meta` is not null');
   });
 
   test('GH issue 786', async () => {
@@ -429,7 +429,7 @@ describe('QueryBuilder - Pivot', () => {
       $and: [{ uuid: { $ne: '...' }, createdAt: { $gt: '2020-08-26T20:01:48.863Z' } }, { tags: { name: { $in: ['tag1'] } } }],
     });
     expect(qb1.getQuery()).toEqual(
-      'select `e0`.*, `e0`.price * 1.19 as `price_taxed` ' +
+      'select `e0`.*, `e0`.`price` * 1.19 as `price_taxed` ' +
         'from `book2` as `e0` ' +
         'left join `book2_tags` as `e2` on `e0`.`uuid_pk` = `e2`.`book2_uuid_pk` ' +
         'left join `book_tag2` as `e1` on `e2`.`book_tag2_id` = `e1`.`id` ' +
@@ -441,7 +441,7 @@ describe('QueryBuilder - Pivot', () => {
       $and: [{ tags: { name: { $in: ['tag1'] } } }, { uuid: { $ne: '...' }, createdAt: { $gt: '2020-08-26T20:01:48.863Z' } }],
     });
     expect(qb2.getQuery()).toEqual(
-      'select `e0`.*, `e0`.price * 1.19 as `price_taxed` ' +
+      'select `e0`.*, `e0`.`price` * 1.19 as `price_taxed` ' +
         'from `book2` as `e0` ' +
         'left join `book2_tags` as `e2` on `e0`.`uuid_pk` = `e2`.`book2_uuid_pk` ' +
         'left join `book_tag2` as `e1` on `e2`.`book_tag2_id` = `e1`.`id` ' +

--- a/tests/features/query-builder/query-builder-select.test.ts
+++ b/tests/features/query-builder/query-builder-select.test.ts
@@ -201,13 +201,13 @@ describe('QueryBuilder - Select', () => {
   test('select query with auto-joined query with operator and scalar', async () => {
     const qb1 = orm.em.createQueryBuilder(Book2);
     qb1.select('*').where({ author: { $ne: null } });
-    expect(qb1.getQuery()).toEqual('select `e0`.*, `e0`.price * 1.19 as `price_taxed` from `book2` as `e0` where `e0`.`author_id` is not null');
+    expect(qb1.getQuery()).toEqual('select `e0`.*, `e0`.`price` * 1.19 as `price_taxed` from `book2` as `e0` where `e0`.`author_id` is not null');
     expect(qb1.getParams()).toEqual([]);
 
     const qb2 = orm.em.createQueryBuilder(Book2);
     qb2.select('*').where({ author: { $ne: null, name: 'Jon Snow' } });
     expect(qb2.getQuery()).toEqual(
-      'select `e0`.*, `e0`.price * 1.19 as `price_taxed` from `book2` as `e0` inner join `author2` as `e1` on `e0`.`author_id` = `e1`.`id` where `e0`.`author_id` is not null and `e1`.`name` = ?',
+      'select `e0`.*, `e0`.`price` * 1.19 as `price_taxed` from `book2` as `e0` inner join `author2` as `e1` on `e0`.`author_id` = `e1`.`id` where `e0`.`author_id` is not null and `e1`.`name` = ?',
     );
     expect(qb2.getParams()).toEqual(['Jon Snow']);
   });
@@ -363,7 +363,7 @@ describe('QueryBuilder - Select', () => {
     const qb = orm.em.createQueryBuilder(Book2, 'b');
     qb.leftJoin('b.author', 'a').select(['a.*', 'b.*']).where({ 'a.name': 'test 123' });
     const sql =
-      'select `a`.*, `b`.*, `b`.price * 1.19 as `price_taxed` from `book2` as `b` ' +
+      'select `a`.*, `b`.*, `b`.`price` * 1.19 as `price_taxed` from `book2` as `b` ' +
       'left join `author2` as `a` on `b`.`author_id` = `a`.`id` ' +
       'where `a`.`name` = ?';
     expect(qb.getQuery()).toEqual(sql);
@@ -489,7 +489,7 @@ describe('QueryBuilder - Select', () => {
     const qb = orm.em.createQueryBuilder(Book2, 'b');
     qb.leftJoin('b.tags', 't').select(['b.*', 't.*']).where({ 't.name': 'test 123' });
     const sql =
-      'select `b`.*, `t`.*, `b`.price * 1.19 as `price_taxed` from `book2` as `b` ' +
+      'select `b`.*, `t`.*, `b`.`price` * 1.19 as `price_taxed` from `book2` as `b` ' +
       'left join `book2_tags` as `e1` on `b`.`uuid_pk` = `e1`.`book2_uuid_pk` ' +
       'left join `book_tag2` as `t` on `e1`.`book_tag2_id` = `t`.`id` ' +
       'where `t`.`name` = ?';
@@ -548,7 +548,7 @@ describe('QueryBuilder - Select', () => {
     const qb = orm.em.createQueryBuilder(Book2);
     qb.select('*').where({ author: { termsAccepted: true } });
     expect(qb.getFormattedQuery()).toEqual(
-      'select `e0`.*, `e0`.price * 1.19 as `price_taxed` from `book2` as `e0` inner join `author2` as `e1` on `e0`.`author_id` = `e1`.`id` where `e1`.`terms_accepted` = true',
+      'select `e0`.*, `e0`.`price` * 1.19 as `price_taxed` from `book2` as `e0` inner join `author2` as `e1` on `e0`.`author_id` = `e1`.`id` where `e1`.`terms_accepted` = true',
     );
   });
 
@@ -557,14 +557,14 @@ describe('QueryBuilder - Select', () => {
     qb1.select('*').where({
       [raw('json_contains(`e0`.`meta`, ?)', [{ foo: 'bar' }])]: [],
     });
-    expect(qb1.getQuery()).toEqual('select `e0`.*, `e0`.price * 1.19 as `price_taxed` from `book2` as `e0` where json_contains(`e0`.`meta`, ?)');
+    expect(qb1.getQuery()).toEqual('select `e0`.*, `e0`.`price` * 1.19 as `price_taxed` from `book2` as `e0` where json_contains(`e0`.`meta`, ?)');
     expect(qb1.getParams()).toEqual([{ foo: 'bar' }]);
 
     const qb2 = orm.em.createQueryBuilder(Book2);
     qb2.select('*').where({
       [raw(a => `json_contains(\`${a}\`.??, ?) = ?`, ['meta', { foo: 'baz' }, false])]: [],
     });
-    expect(qb2.getQuery()).toEqual('select `e0`.*, `e0`.price * 1.19 as `price_taxed` from `book2` as `e0` where json_contains(`e0`.??, ?) = ?');
+    expect(qb2.getQuery()).toEqual('select `e0`.*, `e0`.`price` * 1.19 as `price_taxed` from `book2` as `e0` where json_contains(`e0`.??, ?) = ?');
     expect(qb2.getParams()).toEqual(['meta', { foo: 'baz' }, false]);
   });
 
@@ -573,7 +573,7 @@ describe('QueryBuilder - Select', () => {
     const filter = Object.create(null);
     filter.meta = { foo: 'bar' };
     qb1.select('*').where(filter);
-    expect(qb1.getQuery()).toEqual("select `e0`.*, `e0`.price * 1.19 as `price_taxed` from `book2` as `e0` where json_extract(`e0`.`meta`, '$.foo') = ?");
+    expect(qb1.getQuery()).toEqual("select `e0`.*, `e0`.`price` * 1.19 as `price_taxed` from `book2` as `e0` where json_extract(`e0`.`meta`, '$.foo') = ?");
     expect(qb1.getParams()).toEqual(['bar']);
   });
 
@@ -756,7 +756,7 @@ describe('QueryBuilder - Select', () => {
     const qb = orm.em.createQueryBuilder(Book2);
     qb.select('*').where({ test: 123 });
     expect(qb.getQuery()).toEqual(
-      'select `e0`.*, `e1`.`id` as `e1__id`, `e0`.price * 1.19 as `price_taxed` from `book2` as `e0` left join `test2` as `e1` on `e0`.`uuid_pk` = `e1`.`book_uuid_pk` where `e1`.`id` = ?',
+      'select `e0`.*, `e1`.`id` as `e1__id`, `e0`.`price` * 1.19 as `price_taxed` from `book2` as `e0` left join `test2` as `e1` on `e0`.`uuid_pk` = `e1`.`book_uuid_pk` where `e1`.`id` = ?',
     );
     expect(qb.getParams()).toEqual([123]);
   });
@@ -767,7 +767,7 @@ describe('QueryBuilder - Select', () => {
       .where({ test: 123 })
       .populate([{ field: 'test' }]);
     expect(qb.getQuery()).toEqual(
-      'select `e0`.*, `e1`.`id` as `e1__id`, `e0`.price * 1.19 as `price_taxed` from `book2` as `e0` left join `test2` as `e1` on `e0`.`uuid_pk` = `e1`.`book_uuid_pk` where `e1`.`id` = ?',
+      'select `e0`.*, `e1`.`id` as `e1__id`, `e0`.`price` * 1.19 as `price_taxed` from `book2` as `e0` left join `test2` as `e1` on `e0`.`uuid_pk` = `e1`.`book_uuid_pk` where `e1`.`id` = ?',
     );
     expect(qb.getParams()).toEqual([123]);
   });
@@ -778,7 +778,7 @@ describe('QueryBuilder - Select', () => {
       .populate([{ field: 'test' }])
       .where({ test: 123 });
     expect(qb.getQuery()).toEqual(
-      'select `e0`.*, `e1`.`id` as `e1__id`, `e0`.price * 1.19 as `price_taxed` from `book2` as `e0` left join `test2` as `e1` on `e0`.`uuid_pk` = `e1`.`book_uuid_pk` where `e1`.`id` = ?',
+      'select `e0`.*, `e1`.`id` as `e1__id`, `e0`.`price` * 1.19 as `price_taxed` from `book2` as `e0` left join `test2` as `e1` on `e0`.`uuid_pk` = `e1`.`book_uuid_pk` where `e1`.`id` = ?',
     );
     expect(qb.getParams()).toEqual([123]);
   });
@@ -787,7 +787,7 @@ describe('QueryBuilder - Select', () => {
     const qb = orm.em.createQueryBuilder(Book2);
     qb.select('*').where({ tags: '123' });
     expect(qb.getQuery()).toEqual(
-      'select `e0`.*, `e0`.price * 1.19 as `price_taxed` from `book2` as `e0` ' +
+      'select `e0`.*, `e0`.`price` * 1.19 as `price_taxed` from `book2` as `e0` ' +
         'left join `book2_tags` as `e1` on `e0`.`uuid_pk` = `e1`.`book2_uuid_pk` ' +
         'where `e1`.`book_tag2_id` = ?',
     );
@@ -1014,12 +1014,12 @@ describe('QueryBuilder - Select', () => {
   test('select where (not) null via $eq/$ne operators', async () => {
     const qb1 = orm.em.createQueryBuilder(Book2);
     qb1.select('*').where({ publisher: { $ne: null } });
-    expect(qb1.getQuery()).toEqual('select `e0`.*, `e0`.price * 1.19 as `price_taxed` from `book2` as `e0` where `e0`.`publisher_id` is not null');
+    expect(qb1.getQuery()).toEqual('select `e0`.*, `e0`.`price` * 1.19 as `price_taxed` from `book2` as `e0` where `e0`.`publisher_id` is not null');
     expect(qb1.getParams()).toEqual([]);
 
     const qb2 = orm.em.createQueryBuilder(Book2);
     qb2.select('*').where({ publisher: { $eq: null } });
-    expect(qb2.getQuery()).toEqual('select `e0`.*, `e0`.price * 1.19 as `price_taxed` from `book2` as `e0` where `e0`.`publisher_id` is null');
+    expect(qb2.getQuery()).toEqual('select `e0`.*, `e0`.`price` * 1.19 as `price_taxed` from `book2` as `e0` where `e0`.`publisher_id` is null');
     expect(qb2.getParams()).toEqual([]);
   });
 
@@ -1052,15 +1052,15 @@ describe('QueryBuilder - Select', () => {
     await orm.em.transactional(async em => {
       const qb2 = em.createQueryBuilder(Book2);
       qb2.select('*').where({ title: 'test 123' }).setLockMode(LockMode.NONE);
-      expect(qb2.getQuery()).toEqual('select `e0`.*, `e0`.price * 1.19 as `price_taxed` from `book2` as `e0` where `e0`.`title` = ?');
+      expect(qb2.getQuery()).toEqual('select `e0`.*, `e0`.`price` * 1.19 as `price_taxed` from `book2` as `e0` where `e0`.`title` = ?');
 
       const qb3 = em.createQueryBuilder(Book2);
       qb3.select('*').where({ title: 'test 123' }).setLockMode(LockMode.PESSIMISTIC_READ);
-      expect(qb3.getQuery()).toEqual('select `e0`.*, `e0`.price * 1.19 as `price_taxed` from `book2` as `e0` where `e0`.`title` = ? lock in share mode');
+      expect(qb3.getQuery()).toEqual('select `e0`.*, `e0`.`price` * 1.19 as `price_taxed` from `book2` as `e0` where `e0`.`title` = ? lock in share mode');
 
       const qb4 = em.createQueryBuilder(Book2);
       qb4.select('*').where({ title: 'test 123' }).setLockMode(LockMode.PESSIMISTIC_WRITE);
-      expect(qb4.getQuery()).toEqual('select `e0`.*, `e0`.price * 1.19 as `price_taxed` from `book2` as `e0` where `e0`.`title` = ? for update');
+      expect(qb4.getQuery()).toEqual('select `e0`.*, `e0`.`price` * 1.19 as `price_taxed` from `book2` as `e0` where `e0`.`title` = ? for update');
     });
   });
 
@@ -1174,7 +1174,7 @@ describe('QueryBuilder - Select', () => {
       .populate([{ field: 'tags' }])
       .leftJoin('tags', 't');
     expect(qb.getQuery()).toEqual(
-      'select `e0`.*, `e0`.price * 1.19 as `price_taxed` ' +
+      'select `e0`.*, `e0`.`price` * 1.19 as `price_taxed` ' +
         'from `book2` as `e0` ' +
         'left join `book2_tags` as `e1` on `e0`.`uuid_pk` = `e1`.`book2_uuid_pk` ' +
         'left join `book_tag2` as `t` on `e1`.`book_tag2_id` = `t`.`id`',
@@ -1242,25 +1242,25 @@ describe('QueryBuilder - Select', () => {
 
   test(`order by forumla field should not include 'as'`, async () => {
     const sql = orm.em.createQueryBuilder(Book2).select('*').orderBy({ priceTaxed: QueryOrder.DESC }).getFormattedQuery();
-    expect(sql).toBe('select `e0`.*, `e0`.price * 1.19 as `price_taxed` from `book2` as `e0` order by `e0`.price * 1.19 desc');
+    expect(sql).toBe('select `e0`.*, `e0`.`price` * 1.19 as `price_taxed` from `book2` as `e0` order by `e0`.`price` * 1.19 desc');
   });
 
   test('aliased join condition', () => {
     const sql1 = orm.em.createQueryBuilder(Book2, 'b').select('*').innerJoinAndSelect('author', 'a').where({ 'a.born': '1990-03-23' }).getFormattedQuery();
     expect(sql1).toBe(
-      "select `b`.*, `a`.`id` as `a__id`, `a`.`created_at` as `a__created_at`, `a`.`updated_at` as `a__updated_at`, `a`.`name` as `a__name`, `a`.`email` as `a__email`, `a`.`age` as `a__age`, `a`.`terms_accepted` as `a__terms_accepted`, `a`.`optional` as `a__optional`, `a`.`identities` as `a__identities`, `a`.`born` as `a__born`, `a`.`born_time` as `a__born_time`, `a`.`favourite_book_uuid_pk` as `a__favourite_book_uuid_pk`, `a`.`favourite_author_id` as `a__favourite_author_id`, `a`.`identity` as `a__identity`, `b`.price * 1.19 as `price_taxed` from `book2` as `b` inner join `author2` as `a` on `b`.`author_id` = `a`.`id` where `a`.`born` = '1990-03-23'",
+      "select `b`.*, `a`.`id` as `a__id`, `a`.`created_at` as `a__created_at`, `a`.`updated_at` as `a__updated_at`, `a`.`name` as `a__name`, `a`.`email` as `a__email`, `a`.`age` as `a__age`, `a`.`terms_accepted` as `a__terms_accepted`, `a`.`optional` as `a__optional`, `a`.`identities` as `a__identities`, `a`.`born` as `a__born`, `a`.`born_time` as `a__born_time`, `a`.`favourite_book_uuid_pk` as `a__favourite_book_uuid_pk`, `a`.`favourite_author_id` as `a__favourite_author_id`, `a`.`identity` as `a__identity`, `b`.`price` * 1.19 as `price_taxed` from `book2` as `b` inner join `author2` as `a` on `b`.`author_id` = `a`.`id` where `a`.`born` = '1990-03-23'",
     );
 
     const sql2 = orm.em.createQueryBuilder(Book2, 'b').select('*').joinAndSelect('author', 'a', { 'a.born': '1990-03-23' }).getFormattedQuery();
     expect(sql2).toBe(
-      "select `b`.*, `a`.`id` as `a__id`, `a`.`created_at` as `a__created_at`, `a`.`updated_at` as `a__updated_at`, `a`.`name` as `a__name`, `a`.`email` as `a__email`, `a`.`age` as `a__age`, `a`.`terms_accepted` as `a__terms_accepted`, `a`.`optional` as `a__optional`, `a`.`identities` as `a__identities`, `a`.`born` as `a__born`, `a`.`born_time` as `a__born_time`, `a`.`favourite_book_uuid_pk` as `a__favourite_book_uuid_pk`, `a`.`favourite_author_id` as `a__favourite_author_id`, `a`.`identity` as `a__identity`, `b`.price * 1.19 as `price_taxed` from `book2` as `b` inner join `author2` as `a` on `b`.`author_id` = `a`.`id` and `a`.`born` = '1990-03-23'",
+      "select `b`.*, `a`.`id` as `a__id`, `a`.`created_at` as `a__created_at`, `a`.`updated_at` as `a__updated_at`, `a`.`name` as `a__name`, `a`.`email` as `a__email`, `a`.`age` as `a__age`, `a`.`terms_accepted` as `a__terms_accepted`, `a`.`optional` as `a__optional`, `a`.`identities` as `a__identities`, `a`.`born` as `a__born`, `a`.`born_time` as `a__born_time`, `a`.`favourite_book_uuid_pk` as `a__favourite_book_uuid_pk`, `a`.`favourite_author_id` as `a__favourite_author_id`, `a`.`identity` as `a__identity`, `b`.`price` * 1.19 as `price_taxed` from `book2` as `b` inner join `author2` as `a` on `b`.`author_id` = `a`.`id` and `a`.`born` = '1990-03-23'",
     );
   });
 
   test('join condition with M:N (GH #4644)', () => {
     const sql1 = orm.em.createQueryBuilder(Book2, 'b').select('*').leftJoin('tags', 't', { 't.name': 't1' }).getFormattedQuery();
     expect(sql1).toBe(
-      'select `b`.*, `b`.price * 1.19 as `price_taxed` ' +
+      'select `b`.*, `b`.`price` * 1.19 as `price_taxed` ' +
         'from `book2` as `b` ' +
         'left join `book2_tags` as `e1` on `b`.`uuid_pk` = `e1`.`book2_uuid_pk` ' +
         "left join `book_tag2` as `t` on `e1`.`book_tag2_id` = `t`.`id` and `t`.`name` = 't1'",

--- a/tests/features/query-builder/query-builder-subqueries.test.ts
+++ b/tests/features/query-builder/query-builder-subqueries.test.ts
@@ -117,7 +117,7 @@ describe('QueryBuilder - Subqueries', () => {
       .select(['*', 'sub.*'])
       .where({ 'sub.title': /^foo/ });
     expect(qb2.getFormattedQuery()).toEqual(
-      "select `a`.*, `sub`.* from `author2` as `a` left join (select `b`.*, `b`.price * 1.19 as `price_taxed` from `book2` as `b` order by `b`.`title` asc limit 1) as `sub` on `sub`.`author_id` = `a`.`id` where `sub`.`title` like 'foo%'",
+      "select `a`.*, `sub`.* from `author2` as `a` left join (select `b`.*, `b`.`price` * 1.19 as `price_taxed` from `book2` as `b` order by `b`.`title` asc limit 1) as `sub` on `sub`.`author_id` = `a`.`id` where `sub`.`title` like 'foo%'",
     );
     const res2 = await qb2.execute();
     expect(res2).toHaveLength(1);
@@ -140,7 +140,7 @@ describe('QueryBuilder - Subqueries', () => {
       .select(['*', 'sub.*'])
       .where({ 'sub.title': /^foo/ });
     expect(qb2.getFormattedQuery()).toEqual(
-      "select `a`.*, `sub`.* from `author2` as `a` left join (select `b`.*, `b`.price * 1.19 as `price_taxed` from `book2` as `b` order by `b`.`title` asc limit 1) as `sub` on `sub`.`author_id` = `a`.`id` where `sub`.`title` like 'foo%'",
+      "select `a`.*, `sub`.* from `author2` as `a` left join (select `b`.*, `b`.`price` * 1.19 as `price_taxed` from `book2` as `b` order by `b`.`title` asc limit 1) as `sub` on `sub`.`author_id` = `a`.`id` where `sub`.`title` like 'foo%'",
     );
     const res3 = await qb3.execute();
     expect(res3).toHaveLength(1);
@@ -160,7 +160,7 @@ describe('QueryBuilder - Subqueries', () => {
     const qb4 = orm.em.createQueryBuilder(Author2, 'a');
     qb4.select(['*']).leftJoinAndSelect(['a.books', qb1], 'sub').leftJoinAndSelect('sub.tags', 't').where({ 'sub.title': /^foo/ });
     expect(qb4.getFormattedQuery()).toEqual(
-      "select `a`.*, `sub`.`uuid_pk` as `sub__uuid_pk`, `sub`.`created_at` as `sub__created_at`, `sub`.`isbn` as `sub__isbn`, `sub`.`title` as `sub__title`, `sub`.`price` as `sub__price`, `sub`.price * 1.19 as `sub__price_taxed`, `sub`.`double` as `sub__double`, `sub`.`meta` as `sub__meta`, `sub`.`author_id` as `sub__author_id`, `sub`.`publisher_id` as `sub__publisher_id`, `t`.`id` as `t__id`, `t`.`name` as `t__name` from `author2` as `a` left join (select `b`.*, `b`.price * 1.19 as `price_taxed` from `book2` as `b` order by `b`.`title` asc limit 1) as `sub` on `a`.`id` = `sub`.`author_id` left join `book2_tags` as `e1` on `sub`.`uuid_pk` = `e1`.`book2_uuid_pk` left join `book_tag2` as `t` on `e1`.`book_tag2_id` = `t`.`id` where `sub`.`title` like 'foo%'",
+      "select `a`.*, `sub`.`uuid_pk` as `sub__uuid_pk`, `sub`.`created_at` as `sub__created_at`, `sub`.`isbn` as `sub__isbn`, `sub`.`title` as `sub__title`, `sub`.`price` as `sub__price`, `sub`.`price` * 1.19 as `sub__price_taxed`, `sub`.`double` as `sub__double`, `sub`.`meta` as `sub__meta`, `sub`.`author_id` as `sub__author_id`, `sub`.`publisher_id` as `sub__publisher_id`, `t`.`id` as `t__id`, `t`.`name` as `t__name` from `author2` as `a` left join (select `b`.*, `b`.`price` * 1.19 as `price_taxed` from `book2` as `b` order by `b`.`title` asc limit 1) as `sub` on `a`.`id` = `sub`.`author_id` left join `book2_tags` as `e1` on `sub`.`uuid_pk` = `e1`.`book2_uuid_pk` left join `book_tag2` as `t` on `e1`.`book_tag2_id` = `t`.`id` where `sub`.`title` like 'foo%'",
     );
     const res4 = await qb4.getResult();
     expect(res4).toHaveLength(1);
@@ -180,7 +180,7 @@ describe('QueryBuilder - Subqueries', () => {
     // with a regular join we get two books, as there is no limit
     const qb5 = orm.em.createQueryBuilder(Author2, 'a').select(['*']).leftJoinAndSelect('a.books', 'sub').where({ 'sub.title': /^foo/ });
     expect(qb5.getFormattedQuery()).toEqual(
-      "select `a`.*, `sub`.`uuid_pk` as `sub__uuid_pk`, `sub`.`created_at` as `sub__created_at`, `sub`.`isbn` as `sub__isbn`, `sub`.`title` as `sub__title`, `sub`.`price` as `sub__price`, `sub`.price * 1.19 as `sub__price_taxed`, `sub`.`double` as `sub__double`, `sub`.`meta` as `sub__meta`, `sub`.`author_id` as `sub__author_id`, `sub`.`publisher_id` as `sub__publisher_id` from `author2` as `a` left join `book2` as `sub` on `a`.`id` = `sub`.`author_id` where `sub`.`title` like 'foo%'",
+      "select `a`.*, `sub`.`uuid_pk` as `sub__uuid_pk`, `sub`.`created_at` as `sub__created_at`, `sub`.`isbn` as `sub__isbn`, `sub`.`title` as `sub__title`, `sub`.`price` as `sub__price`, `sub`.`price` * 1.19 as `sub__price_taxed`, `sub`.`double` as `sub__double`, `sub`.`meta` as `sub__meta`, `sub`.`author_id` as `sub__author_id`, `sub`.`publisher_id` as `sub__publisher_id` from `author2` as `a` left join `book2` as `sub` on `a`.`id` = `sub`.`author_id` where `sub`.`title` like 'foo%'",
     );
     const res5 = await qb5.getResult();
     expect(res5).toHaveLength(1);
@@ -191,7 +191,7 @@ describe('QueryBuilder - Subqueries', () => {
     const qb6 = orm.em.createQueryBuilder(Author2, 'a');
     qb6.select(['*']).leftJoinAndSelect(['a.books', qb1.toRaw()], 'sub').leftJoinAndSelect('sub.tags', 't').where({ 'sub.title': /^foo/ });
     expect(qb6.getFormattedQuery()).toEqual(
-      "select `a`.*, `sub`.`uuid_pk` as `sub__uuid_pk`, `sub`.`created_at` as `sub__created_at`, `sub`.`isbn` as `sub__isbn`, `sub`.`title` as `sub__title`, `sub`.`price` as `sub__price`, `sub`.price * 1.19 as `sub__price_taxed`, `sub`.`double` as `sub__double`, `sub`.`meta` as `sub__meta`, `sub`.`author_id` as `sub__author_id`, `sub`.`publisher_id` as `sub__publisher_id`, `t`.`id` as `t__id`, `t`.`name` as `t__name` from `author2` as `a` left join (select `b`.*, `b`.price * 1.19 as `price_taxed` from `book2` as `b` order by `b`.`title` asc limit 1) as `sub` on `a`.`id` = `sub`.`author_id` left join `book2_tags` as `e1` on `sub`.`uuid_pk` = `e1`.`book2_uuid_pk` left join `book_tag2` as `t` on `e1`.`book_tag2_id` = `t`.`id` where `sub`.`title` like 'foo%'",
+      "select `a`.*, `sub`.`uuid_pk` as `sub__uuid_pk`, `sub`.`created_at` as `sub__created_at`, `sub`.`isbn` as `sub__isbn`, `sub`.`title` as `sub__title`, `sub`.`price` as `sub__price`, `sub`.`price` * 1.19 as `sub__price_taxed`, `sub`.`double` as `sub__double`, `sub`.`meta` as `sub__meta`, `sub`.`author_id` as `sub__author_id`, `sub`.`publisher_id` as `sub__publisher_id`, `t`.`id` as `t__id`, `t`.`name` as `t__name` from `author2` as `a` left join (select `b`.*, `b`.`price` * 1.19 as `price_taxed` from `book2` as `b` order by `b`.`title` asc limit 1) as `sub` on `a`.`id` = `sub`.`author_id` left join `book2_tags` as `e1` on `sub`.`uuid_pk` = `e1`.`book2_uuid_pk` left join `book_tag2` as `t` on `e1`.`book_tag2_id` = `t`.`id` where `sub`.`title` like 'foo%'",
     );
     const res6 = await qb6.getResult();
     expect(res6).toHaveLength(1);
@@ -215,7 +215,7 @@ describe('QueryBuilder - Subqueries', () => {
       .leftJoin(qb1.toRaw(), 'sub', { author_id: sql.ref('a.id') })
       .where({ 'sub.title': /^foo/ });
     expect(qb7.getFormattedQuery()).toEqual(
-      "select `a`.* from `author2` as `a` left join (select `b`.*, `b`.price * 1.19 as `price_taxed` from `book2` as `b` order by `b`.`title` asc limit 1) as `sub` on `sub`.`author_id` = `a`.`id` where `sub`.`title` like 'foo%'",
+      "select `a`.* from `author2` as `a` left join (select `b`.*, `b`.`price` * 1.19 as `price_taxed` from `book2` as `b` order by `b`.`title` asc limit 1) as `sub` on `sub`.`author_id` = `a`.`id` where `sub`.`title` like 'foo%'",
     );
     const res7 = await qb7.getResult();
     expect(res7).toHaveLength(1);
@@ -228,7 +228,7 @@ describe('QueryBuilder - Subqueries', () => {
 
   test('sub-query order-by fields are always fully qualified', () => {
     const expected =
-      'select `e0`.*, `books`.`uuid_pk` as `books__uuid_pk`, `books`.`created_at` as `books__created_at`, `books`.`isbn` as `books__isbn`, `books`.`title` as `books__title`, `books`.`price` as `books__price`, `books`.price * 1.19 as `books__price_taxed`, `books`.`double` as `books__double`, `books`.`meta` as `books__meta`, `books`.`author_id` as `books__author_id`, `books`.`publisher_id` as `books__publisher_id` from `author2` as `e0` inner join `book2` as `books` on `e0`.`id` = `books`.`author_id` where `e0`.`id` in (select `e0`.`id` from (select `e0`.`id` from `author2` as `e0` inner join `book2` as `books` on `e0`.`id` = `books`.`author_id` group by `e0`.`id` order by min(`e0`.`id`) desc limit 10) as `e0`) order by `e0`.`id` desc';
+      'select `e0`.*, `books`.`uuid_pk` as `books__uuid_pk`, `books`.`created_at` as `books__created_at`, `books`.`isbn` as `books__isbn`, `books`.`title` as `books__title`, `books`.`price` as `books__price`, `books`.`price` * 1.19 as `books__price_taxed`, `books`.`double` as `books__double`, `books`.`meta` as `books__meta`, `books`.`author_id` as `books__author_id`, `books`.`publisher_id` as `books__publisher_id` from `author2` as `e0` inner join `book2` as `books` on `e0`.`id` = `books`.`author_id` where `e0`.`id` in (select `e0`.`id` from (select `e0`.`id` from `author2` as `e0` inner join `book2` as `books` on `e0`.`id` = `books`.`author_id` group by `e0`.`id` order by min(`e0`.`id`) desc limit 10) as `e0`) order by `e0`.`id` desc';
     const sql = orm.em.createQueryBuilder(Author2).select('*').joinAndSelect('books', 'books').orderBy({ id: QueryOrder.DESC }).limit(10).getFormattedQuery();
     expect(sql).toBe(expected);
   });
@@ -242,7 +242,7 @@ describe('QueryBuilder - Subqueries', () => {
       .limit(10)
       .getFormattedQuery();
     expect(sql).toBe(
-      'select `e0`.*, `books`.`uuid_pk` as `books__uuid_pk`, `books`.`created_at` as `books__created_at`, `books`.`isbn` as `books__isbn`, `books`.`title` as `books__title`, `books`.`price` as `books__price`, `books`.price * 1.19 as `books__price_taxed`, `books`.`double` as `books__double`, `books`.`meta` as `books__meta`, `books`.`author_id` as `books__author_id`, `books`.`publisher_id` as `books__publisher_id` from `author2` as `e0` inner join `book2` as `books` on `e0`.`id` = `books`.`author_id` where `e0`.`id` in (select `e0`.`id` from (select `e0`.`id` from `author2` as `e0` inner join `book2` as `books` on `e0`.`id` = `books`.`author_id` group by `e0`.`id` order by min(`books`.price * 1.19) desc, min(`e0`.`id`) desc limit 10) as `e0`) order by `books`.price * 1.19 desc, `e0`.`id` desc',
+      'select `e0`.*, `books`.`uuid_pk` as `books__uuid_pk`, `books`.`created_at` as `books__created_at`, `books`.`isbn` as `books__isbn`, `books`.`title` as `books__title`, `books`.`price` as `books__price`, `books`.`price` * 1.19 as `books__price_taxed`, `books`.`double` as `books__double`, `books`.`meta` as `books__meta`, `books`.`author_id` as `books__author_id`, `books`.`publisher_id` as `books__publisher_id` from `author2` as `e0` inner join `book2` as `books` on `e0`.`id` = `books`.`author_id` where `e0`.`id` in (select `e0`.`id` from (select `e0`.`id` from `author2` as `e0` inner join `book2` as `books` on `e0`.`id` = `books`.`author_id` group by `e0`.`id` order by min(`books`.`price` * 1.19) desc, min(`e0`.`id`) desc limit 10) as `e0`) order by `books`.`price` * 1.19 desc, `e0`.`id` desc',
     );
   });
 
@@ -255,7 +255,7 @@ describe('QueryBuilder - Subqueries', () => {
       .limit(10)
       .getFormattedQuery();
     expect(sql).toBe(
-      'select `e0`.`id`, `books`.price * 1.19 as `price_taxed` from `author2` as `e0` inner join `book2` as `books` on `e0`.`id` = `books`.`author_id` group by `books`.price * 1.19 limit 10',
+      'select `e0`.`id`, `books`.`price` * 1.19 as `price_taxed` from `author2` as `e0` inner join `book2` as `books` on `e0`.`id` = `books`.`author_id` group by `books`.`price` * 1.19 limit 10',
     );
   });
 

--- a/tests/features/query-builder/query-builder.postgres.test.ts
+++ b/tests/features/query-builder/query-builder.postgres.test.ts
@@ -234,24 +234,24 @@ describe('QueryBuilder - Postgres', () => {
 
   test('json property queries', async () => {
     const qb11 = pg.em.createQueryBuilder(Book2).where({ meta: { foo: 123 } });
-    expect(qb11.getFormattedQuery()).toBe(`select "b0".*, "b0".price * 1.19 as "price_taxed" from "book2" as "b0" where ("b0"."meta"->>'foo')::float8 = 123`);
+    expect(qb11.getFormattedQuery()).toBe(`select "b0".*, "b0"."price" * 1.19 as "price_taxed" from "book2" as "b0" where ("b0"."meta"->>'foo')::float8 = 123`);
 
     const qb12 = pg.em.createQueryBuilder(Book2).where({ meta: { foo: { $eq: 123 } } });
-    expect(qb12.getFormattedQuery()).toBe(`select "b0".*, "b0".price * 1.19 as "price_taxed" from "book2" as "b0" where ("b0"."meta"->>'foo')::float8 = 123`);
+    expect(qb12.getFormattedQuery()).toBe(`select "b0".*, "b0"."price" * 1.19 as "price_taxed" from "book2" as "b0" where ("b0"."meta"->>'foo')::float8 = 123`);
 
     const qb13 = pg.em.createQueryBuilder(Book2).where({ meta: { foo: { $lte: 123 } } });
-    expect(qb13.getFormattedQuery()).toBe(`select "b0".*, "b0".price * 1.19 as "price_taxed" from "book2" as "b0" where ("b0"."meta"->>'foo')::float8 <= 123`);
+    expect(qb13.getFormattedQuery()).toBe(`select "b0".*, "b0"."price" * 1.19 as "price_taxed" from "book2" as "b0" where ("b0"."meta"->>'foo')::float8 <= 123`);
   });
 
   test('order by json property', async () => {
     const qb14 = pg.em.createQueryBuilder(Book2).orderBy({ meta: { foo: 'asc' } });
-    expect(qb14.getFormattedQuery()).toBe(`select "b0".*, "b0".price * 1.19 as "price_taxed" from "book2" as "b0" order by "b0"."meta"->>'foo' asc`);
+    expect(qb14.getFormattedQuery()).toBe(`select "b0".*, "b0"."price" * 1.19 as "price_taxed" from "book2" as "b0" order by "b0"."meta"->>'foo' asc`);
 
     const qb15 = pg.em.createQueryBuilder(Book2).orderBy({ meta: { bar: { str: 'asc' } } });
-    expect(qb15.getFormattedQuery()).toBe(`select "b0".*, "b0".price * 1.19 as "price_taxed" from "book2" as "b0" order by "b0"."meta"->'bar'->>'str' asc`);
+    expect(qb15.getFormattedQuery()).toBe(`select "b0".*, "b0"."price" * 1.19 as "price_taxed" from "book2" as "b0" order by "b0"."meta"->'bar'->>'str' asc`);
 
     const qb16 = pg.em.createQueryBuilder(Book2).orderBy({ meta: { bar: { num: QueryOrder.DESC } } });
-    expect(qb16.getFormattedQuery()).toBe(`select "b0".*, "b0".price * 1.19 as "price_taxed" from "book2" as "b0" order by "b0"."meta"->'bar'->>'num' desc`);
+    expect(qb16.getFormattedQuery()).toBe(`select "b0".*, "b0"."price" * 1.19 as "price_taxed" from "book2" as "b0" order by "b0"."meta"->'bar'->>'num' desc`);
   });
 
   test('complex condition for json property with update query (GH #2839)', async () => {
@@ -300,24 +300,24 @@ describe('QueryBuilder - Postgres', () => {
     await pg.em.transactional(async em => {
       const qb1 = em.createQueryBuilder(Book2);
       qb1.select('*').where({ title: 'test 123' }).setLockMode(LockMode.PESSIMISTIC_PARTIAL_READ);
-      expect(qb1.getQuery()).toEqual('select "b0".*, "b0".price * 1.19 as "price_taxed" from "book2" as "b0" where "b0"."title" = ? for share skip locked');
+      expect(qb1.getQuery()).toEqual('select "b0".*, "b0"."price" * 1.19 as "price_taxed" from "book2" as "b0" where "b0"."title" = ? for share skip locked');
 
       const qb2 = em.createQueryBuilder(Book2);
       qb2.select('*').where({ title: 'test 123' }).setLockMode(LockMode.PESSIMISTIC_PARTIAL_WRITE);
-      expect(qb2.getQuery()).toEqual('select "b0".*, "b0".price * 1.19 as "price_taxed" from "book2" as "b0" where "b0"."title" = ? for update skip locked');
+      expect(qb2.getQuery()).toEqual('select "b0".*, "b0"."price" * 1.19 as "price_taxed" from "book2" as "b0" where "b0"."title" = ? for update skip locked');
 
       const qb3 = em.createQueryBuilder(Book2);
       qb3.select('*').where({ title: 'test 123' }).setLockMode(LockMode.PESSIMISTIC_READ_OR_FAIL);
-      expect(qb3.getQuery()).toEqual('select "b0".*, "b0".price * 1.19 as "price_taxed" from "book2" as "b0" where "b0"."title" = ? for share nowait');
+      expect(qb3.getQuery()).toEqual('select "b0".*, "b0"."price" * 1.19 as "price_taxed" from "book2" as "b0" where "b0"."title" = ? for share nowait');
 
       const qb4 = em.createQueryBuilder(Book2);
       qb4.select('*').where({ title: 'test 123' }).setLockMode(LockMode.PESSIMISTIC_WRITE_OR_FAIL);
-      expect(qb4.getQuery()).toEqual('select "b0".*, "b0".price * 1.19 as "price_taxed" from "book2" as "b0" where "b0"."title" = ? for update nowait');
+      expect(qb4.getQuery()).toEqual('select "b0".*, "b0"."price" * 1.19 as "price_taxed" from "book2" as "b0" where "b0"."title" = ? for update nowait');
 
       const qb5 = em.createQueryBuilder(Book2);
       qb5.select('*').leftJoin('author', 'a').where({ title: 'test 123' }).setLockMode(LockMode.PESSIMISTIC_WRITE, ['book2']);
       expect(qb5.getQuery()).toEqual(
-        'select "b0".*, "b0".price * 1.19 as "price_taxed" from "book2" as "b0" left join "author2" as "a" on "b0"."author_id" = "a"."id" where "b0"."title" = ? for update of "book2"',
+        'select "b0".*, "b0"."price" * 1.19 as "price_taxed" from "book2" as "b0" left join "author2" as "a" on "b0"."author_id" = "a"."id" where "b0"."title" = ? for update of "book2"',
       );
     });
   });
@@ -326,7 +326,7 @@ describe('QueryBuilder - Postgres', () => {
     const qb = pg.em.createQueryBuilder(Book2, 'b');
     qb.select('*').leftJoinAndSelect('b.tags', 't').where({ 't.name': 'tag name' }).setFlag(QueryFlag.PAGINATE).offset(1).limit(20);
     const sql0 =
-      'select "b".*, "t"."id" as "t__id", "t"."name" as "t__name", "b".price * 1.19 as "price_taxed" ' +
+      'select "b".*, "t"."id" as "t__id", "t"."name" as "t__name", "b"."price" * 1.19 as "price_taxed" ' +
       'from "book2" as "b" ' +
       'left join "book2_tags" as "b1" on "b"."uuid_pk" = "b1"."book2_uuid_pk" ' +
       'left join "book_tag2" as "t" on "b1"."book_tag2_id" = "t"."id" where "b"."uuid_pk" in ' +
@@ -424,7 +424,7 @@ describe('QueryBuilder - Postgres', () => {
       .select(['*', 'sub.*'])
       .where({ 'sub.title': /^foo/ });
     expect(qb2.getFormattedQuery()).toEqual(
-      'select "a".*, "sub".* from "author2" as "a" left join lateral (select "b".*, "b".price * 1.19 as "price_taxed" from "book2" as "b" order by "b"."title" asc limit 1) as "sub" on "sub"."author_id" = "a"."id" where "sub"."title" like \'foo%\'',
+      'select "a".*, "sub".* from "author2" as "a" left join lateral (select "b".*, "b"."price" * 1.19 as "price_taxed" from "book2" as "b" order by "b"."title" asc limit 1) as "sub" on "sub"."author_id" = "a"."id" where "sub"."title" like \'foo%\'',
     );
     const res2 = await qb2.execute();
     expect(res2).toHaveLength(1);
@@ -446,7 +446,7 @@ describe('QueryBuilder - Postgres', () => {
       .select(['*', 'sub.*'])
       .where({ 'sub.title': /^foo/ });
     expect(qb2.getFormattedQuery()).toEqual(
-      'select "a".*, "sub".* from "author2" as "a" left join lateral (select "b".*, "b".price * 1.19 as "price_taxed" from "book2" as "b" order by "b"."title" asc limit 1) as "sub" on "sub"."author_id" = "a"."id" where "sub"."title" like \'foo%\'',
+      'select "a".*, "sub".* from "author2" as "a" left join lateral (select "b".*, "b"."price" * 1.19 as "price_taxed" from "book2" as "b" order by "b"."title" asc limit 1) as "sub" on "sub"."author_id" = "a"."id" where "sub"."title" like \'foo%\'',
     );
     const res3 = await qb3.execute();
     expect(res3).toHaveLength(1);
@@ -465,7 +465,7 @@ describe('QueryBuilder - Postgres', () => {
     const qb4 = pg.em.createQueryBuilder(Author2, 'a');
     qb4.select(['*']).innerJoinLateralAndSelect(['a.books', qb1], 'sub').leftJoinAndSelect('sub.tags', 't').where({ 'sub.title': /^foo/ });
     expect(qb4.getFormattedQuery()).toEqual(
-      'select "a".*, "sub"."uuid_pk" as "sub__uuid_pk", "sub"."created_at" as "sub__created_at", "sub"."isbn" as "sub__isbn", "sub"."title" as "sub__title", "sub"."price" as "sub__price", "sub".price * 1.19 as "sub__price_taxed", "sub"."double" as "sub__double", "sub"."meta" as "sub__meta", "sub"."author_id" as "sub__author_id", "sub"."publisher_id" as "sub__publisher_id", "t"."id" as "t__id", "t"."name" as "t__name" from "author2" as "a" inner join lateral (select "b".*, "b".price * 1.19 as "price_taxed" from "book2" as "b" order by "b"."title" asc limit 1) as "sub" on "a"."id" = "sub"."author_id" left join "book2_tags" as "b1" on "sub"."uuid_pk" = "b1"."book2_uuid_pk" left join "book_tag2" as "t" on "b1"."book_tag2_id" = "t"."id" where "sub"."title" like \'foo%\'',
+      'select "a".*, "sub"."uuid_pk" as "sub__uuid_pk", "sub"."created_at" as "sub__created_at", "sub"."isbn" as "sub__isbn", "sub"."title" as "sub__title", "sub"."price" as "sub__price", "sub"."price" * 1.19 as "sub__price_taxed", "sub"."double" as "sub__double", "sub"."meta" as "sub__meta", "sub"."author_id" as "sub__author_id", "sub"."publisher_id" as "sub__publisher_id", "t"."id" as "t__id", "t"."name" as "t__name" from "author2" as "a" inner join lateral (select "b".*, "b"."price" * 1.19 as "price_taxed" from "book2" as "b" order by "b"."title" asc limit 1) as "sub" on "a"."id" = "sub"."author_id" left join "book2_tags" as "b1" on "sub"."uuid_pk" = "b1"."book2_uuid_pk" left join "book_tag2" as "t" on "b1"."book_tag2_id" = "t"."id" where "sub"."title" like \'foo%\'',
     );
     const res4 = await qb4.getResult();
     expect(res4).toHaveLength(1);

--- a/tests/features/read-replicas.test.ts
+++ b/tests/features/read-replicas.test.ts
@@ -272,8 +272,8 @@ describe('read-replicas', () => {
     const schema = `${orm.config.get('dbName')}_schema_2`;
     const res1 = await orm.em.find(Book2, { publisher: { $ne: null } }, { schema, populate: ['perex'] });
     const res2 = await orm.em.find(Book2, { publisher: { $ne: null } }, { populate: ['perex'] });
-    expect(mock.mock.calls[0][0]).toMatch(`select \`b0\`.*, \`b0\`.price * 1.19 as \`price_taxed\`, \`t1\`.\`id\` as \`t1__id\` from \`${schema}\`.\`book2\` as \`b0\` left join \`${schema}\`.\`test2\` as \`t1\` on \`b0\`.\`uuid_pk\` = \`t1\`.\`book_uuid_pk\` where \`b0\`.\`author_id\` is not null and \`b0\`.\`publisher_id\` is not null`);
-    expect(mock.mock.calls[1][0]).toMatch('select `b0`.*, `b0`.price * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` from `book2` as `b0` left join `test2` as `t1` on `b0`.`uuid_pk` = `t1`.`book_uuid_pk` where `b0`.`author_id` is not null and `b0`.`publisher_id` is not null');
+    expect(mock.mock.calls[0][0]).toMatch(`select \`b0\`.*, \`b0\`.\`price\` * 1.19 as \`price_taxed\`, \`t1\`.\`id\` as \`t1__id\` from \`${schema}\`.\`book2\` as \`b0\` left join \`${schema}\`.\`test2\` as \`t1\` on \`b0\`.\`uuid_pk\` = \`t1\`.\`book_uuid_pk\` where \`b0\`.\`author_id\` is not null and \`b0\`.\`publisher_id\` is not null`);
+    expect(mock.mock.calls[1][0]).toMatch('select `b0`.*, `b0`.`price` * 1.19 as `price_taxed`, `t1`.`id` as `t1__id` from `book2` as `b0` left join `test2` as `t1` on `b0`.`uuid_pk` = `t1`.`book_uuid_pk` where `b0`.`author_id` is not null and `b0`.`publisher_id` is not null');
     expect(res1.length).toBe(0);
     expect(res2.length).toBe(1);
   });

--- a/tests/features/single-table-inheritance/single-table-inheritance.mysql.test.ts
+++ b/tests/features/single-table-inheritance/single-table-inheritance.mysql.test.ts
@@ -127,10 +127,10 @@ describe('single table inheritance in mysql', () => {
       favouriteManager: users[2],
       type: Type.Owner,
     });
-    expect(Object.keys(users[0])).toEqual(['id', 'firstName', 'lastName', 'type', 'employeeProp']);
-    expect(Object.keys(users[1])).toEqual(['id', 'firstName', 'lastName', 'type', 'employeeProp']);
-    expect(Object.keys(users[2])).toEqual(['id', 'firstName', 'lastName', 'type', 'managerProp']);
-    expect(Object.keys(users[3])).toEqual(['id', 'firstName', 'lastName', 'type', 'managerProp', 'ownerProp', 'favouriteEmployee', 'favouriteManager']);
+    expect(Object.keys(users[0]).sort()).toEqual(['employeeProp', 'firstName', 'id', 'lastName', 'type']);
+    expect(Object.keys(users[1]).sort()).toEqual(['employeeProp', 'firstName', 'id', 'lastName', 'type']);
+    expect(Object.keys(users[2]).sort()).toEqual(['firstName', 'id', 'lastName', 'managerProp', 'type']);
+    expect(Object.keys(users[3]).sort()).toEqual(['favouriteEmployee', 'favouriteManager', 'firstName', 'id', 'lastName', 'managerProp', 'ownerProp', 'type']);
 
     expect([...orm.em.getUnitOfWork().getIdentityMap().keys()]).toEqual(['BaseUser2-4', 'BaseUser2-1', 'BaseUser2-2', 'BaseUser2-3']);
 

--- a/tests/features/table-per-type-inheritance/table-per-type-inheritance-define-entity.test.ts
+++ b/tests/features/table-per-type-inheritance/table-per-type-inheritance-define-entity.test.ts
@@ -1,0 +1,423 @@
+/**
+ * TPT (Table-Per-Type) Inheritance tests using defineEntity
+ */
+
+import { defineEntity, LoadStrategy, MikroORM, p } from '@mikro-orm/sqlite';
+import { mockLogger } from '../../helpers.js';
+
+// ============================================================
+// Basic TPT hierarchy without relations
+// ============================================================
+
+// Base vehicle entity with TPT inheritance
+const VehicleDef = defineEntity({
+  name: 'VehicleDef',
+  abstract: true,
+  inheritance: 'tpt',
+  properties: {
+    id: p.integer().primary(),
+    brand: p.string(),
+    model: p.string(),
+  },
+});
+
+// Car extends Vehicle
+const CarDef = defineEntity({
+  name: 'CarDef',
+  extends: VehicleDef,
+  properties: {
+    numDoors: p.integer(),
+  },
+});
+
+// Motorcycle extends Vehicle
+const MotorcycleDef = defineEntity({
+  name: 'MotorcycleDef',
+  extends: VehicleDef,
+  properties: {
+    engineCC: p.integer(),
+  },
+});
+
+// ============================================================
+// TPT hierarchy with relations
+// ============================================================
+
+// Base vehicle with owner relation - must come first so Owner can reference it
+const OwnedVehicleDef = defineEntity({
+  name: 'OwnedVehicleDef',
+  abstract: true,
+  inheritance: 'tpt',
+  properties: {
+    id: p.integer().primary(),
+    brand: p.string(),
+    owner: () => p.manyToOne(OwnerDef).ref().nullable(),
+  },
+});
+
+// Owner that can own vehicles (relation to abstract base)
+const OwnerDef = defineEntity({
+  name: 'OwnerDef',
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+    vehicles: () => p.oneToMany(OwnedVehicleDef).mappedBy('owner'),
+  },
+});
+
+// Owned car
+const OwnedCarDef = defineEntity({
+  name: 'OwnedCarDef',
+  extends: OwnedVehicleDef,
+  properties: {
+    numDoors: p.integer(),
+  },
+});
+
+// Owned motorcycle
+const OwnedMotorcycleDef = defineEntity({
+  name: 'OwnedMotorcycleDef',
+  extends: OwnedVehicleDef,
+  properties: {
+    engineCC: p.integer(),
+  },
+});
+
+// ============================================================
+// Multi-level TPT hierarchy
+// ============================================================
+
+const AnimalDef = defineEntity({
+  name: 'AnimalDef',
+  abstract: true,
+  inheritance: 'tpt',
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+  },
+});
+
+const MammalDef = defineEntity({
+  name: 'MammalDef',
+  abstract: true,
+  extends: AnimalDef,
+  properties: {
+    warmBlooded: p.boolean().default(true),
+  },
+});
+
+const DogDef = defineEntity({
+  name: 'DogDef',
+  extends: MammalDef,
+  properties: {
+    breed: p.string(),
+  },
+});
+
+const CatDef = defineEntity({
+  name: 'CatDef',
+  extends: MammalDef,
+  properties: {
+    indoor: p.boolean(),
+  },
+});
+
+// ============================================================
+// Tests
+// ============================================================
+
+describe('TPT with defineEntity', () => {
+
+  describe('basic TPT operations', () => {
+
+    test('basic TPT operations without relations to abstract', async () => {
+      const orm = await MikroORM.init({
+        dbName: ':memory:',
+        entities: [VehicleDef, CarDef, MotorcycleDef],
+      });
+
+      await orm.schema.create();
+
+      // Create entities
+      const car = orm.em.create(CarDef, { brand: 'Toyota', model: 'Camry', numDoors: 4 });
+      const motorcycle = orm.em.create(MotorcycleDef, { brand: 'Honda', model: 'CBR', engineCC: 600 });
+      await orm.em.flush();
+      orm.em.clear();
+
+      // Load them back
+      const loadedCar = await orm.em.findOneOrFail(CarDef, car.id);
+      expect(loadedCar.brand).toBe('Toyota');
+      expect(loadedCar.numDoors).toBe(4);
+
+      const loadedMotorcycle = await orm.em.findOneOrFail(MotorcycleDef, motorcycle.id);
+      expect(loadedMotorcycle.brand).toBe('Honda');
+      expect(loadedMotorcycle.engineCC).toBe(600);
+
+      // Polymorphic query
+      const vehicles = await orm.em.find(VehicleDef, {}, { orderBy: { brand: 'ASC' } });
+      expect(vehicles).toHaveLength(2);
+      expect(vehicles[0].brand).toBe('Honda');
+      expect('engineCC' in vehicles[0]).toBe(true);
+      expect(vehicles[1].brand).toBe('Toyota');
+      expect('numDoors' in vehicles[1]).toBe(true);
+
+      await orm.close();
+    });
+
+    test('update and delete operations', async () => {
+      const orm = await MikroORM.init({
+        dbName: ':memory:',
+        entities: [VehicleDef, CarDef, MotorcycleDef],
+      });
+
+      await orm.schema.create();
+
+      // Create and update
+      const car = orm.em.create(CarDef, { brand: 'Toyota', model: 'Camry', numDoors: 4 });
+      await orm.em.flush();
+
+      car.brand = 'Honda';
+      car.numDoors = 2;
+      await orm.em.flush();
+      orm.em.clear();
+
+      // Verify update
+      const loaded = await orm.em.findOneOrFail(CarDef, car.id);
+      expect(loaded.brand).toBe('Honda');
+      expect(loaded.numDoors).toBe(2);
+
+      // Delete
+      orm.em.remove(loaded);
+      await orm.em.flush();
+      orm.em.clear();
+
+      // Verify deletion
+      const deleted = await orm.em.findOne(CarDef, car.id);
+      expect(deleted).toBeNull();
+
+      await orm.close();
+    });
+
+    test('filtering on child properties in polymorphic query', async () => {
+      const orm = await MikroORM.init({
+        dbName: ':memory:',
+        entities: [VehicleDef, CarDef, MotorcycleDef],
+      });
+
+      await orm.schema.create();
+
+      orm.em.create(CarDef, { brand: 'Toyota', model: 'Camry', numDoors: 4 });
+      orm.em.create(CarDef, { brand: 'Honda', model: 'Civic', numDoors: 2 });
+      orm.em.create(MotorcycleDef, { brand: 'Kawasaki', model: 'Ninja', engineCC: 600 });
+      await orm.em.flush();
+      orm.em.clear();
+
+      // Filter by parent property
+      const toyotas = await orm.em.find(VehicleDef, { brand: 'Toyota' });
+      expect(toyotas).toHaveLength(1);
+
+      // Filter by both parent and child properties (requires querying specific child)
+      const smallCars = await orm.em.find(CarDef, { brand: 'Honda', numDoors: 2 });
+      expect(smallCars).toHaveLength(1);
+
+      await orm.close();
+    });
+
+  });
+
+  describe('TPT with relations', () => {
+
+    test('relation to abstract base class (owner -> vehicles)', async () => {
+      const orm = await MikroORM.init({
+        dbName: ':memory:',
+        entities: [OwnerDef, OwnedVehicleDef, OwnedCarDef, OwnedMotorcycleDef],
+      });
+
+      await orm.schema.create();
+
+      // Create owner and vehicles
+      const owner = orm.em.create(OwnerDef, { name: 'John' });
+      const car = orm.em.create(OwnedCarDef, { brand: 'Toyota', owner, numDoors: 4 });
+      const motorcycle = orm.em.create(OwnedMotorcycleDef, { brand: 'Honda', owner, engineCC: 600 });
+      await orm.em.flush();
+      orm.em.clear();
+
+      // Load owner with vehicles
+      const loaded = await orm.em.findOneOrFail(OwnerDef, owner.id, { populate: ['vehicles'] });
+      expect(loaded.vehicles).toHaveLength(2);
+
+      // Verify vehicles are correct types
+      const loadedVehicles = loaded.vehicles.getItems();
+      expect(loadedVehicles.some(v => 'numDoors' in v)).toBe(true);
+      expect(loadedVehicles.some(v => 'engineCC' in v)).toBe(true);
+
+      await orm.close();
+    });
+
+    test('loading strategies with relations', async () => {
+      const orm = await MikroORM.init({
+        dbName: ':memory:',
+        entities: [OwnerDef, OwnedVehicleDef, OwnedCarDef, OwnedMotorcycleDef],
+      });
+
+      await orm.schema.create();
+
+      const owner = orm.em.create(OwnerDef, { name: 'John' });
+      orm.em.create(OwnedCarDef, { brand: 'Toyota', owner, numDoors: 4 });
+      orm.em.create(OwnedMotorcycleDef, { brand: 'Honda', owner, engineCC: 600 });
+      await orm.em.flush();
+      orm.em.clear();
+
+      // Test with JOINED strategy
+      const mock = mockLogger(orm);
+      const loadedJoined = await orm.em.findOneOrFail(OwnerDef, owner.id, {
+        populate: ['vehicles'],
+        strategy: LoadStrategy.JOINED,
+      });
+      expect(loadedJoined.vehicles).toHaveLength(2);
+      expect(mock.mock.calls.some(c => c[0].includes('left join'))).toBe(true);
+
+      await orm.close();
+    });
+
+  });
+
+  describe('multi-level TPT inheritance', () => {
+
+    test('three-level hierarchy (Animal -> Mammal -> Dog/Cat)', async () => {
+      const orm = await MikroORM.init({
+        dbName: ':memory:',
+        entities: [AnimalDef, MammalDef, DogDef, CatDef],
+      });
+
+      await orm.schema.create();
+
+      // Verify schema has all tables
+      const schemaSQL = await orm.schema.getCreateSchemaSQL();
+      expect(schemaSQL).toContain('animal_def');
+      expect(schemaSQL).toContain('mammal_def');
+      expect(schemaSQL).toContain('dog_def');
+      expect(schemaSQL).toContain('cat_def');
+
+      // Create instances
+      const dog = orm.em.create(DogDef, { name: 'Buddy', breed: 'Labrador' });
+      const cat = orm.em.create(CatDef, { name: 'Whiskers', indoor: true });
+      await orm.em.flush();
+      orm.em.clear();
+
+      // Load and verify
+      const loadedDog = await orm.em.findOneOrFail(DogDef, dog.id);
+      expect(loadedDog.name).toBe('Buddy');
+      expect(loadedDog.warmBlooded).toBe(true); // default value from Mammal
+      expect(loadedDog.breed).toBe('Labrador');
+
+      const loadedCat = await orm.em.findOneOrFail(CatDef, cat.id);
+      expect(loadedCat.name).toBe('Whiskers');
+      expect(loadedCat.warmBlooded).toBe(true);
+      expect(loadedCat.indoor).toBe(true);
+
+      // Polymorphic queries at different levels
+      const animals = await orm.em.find(AnimalDef, {});
+      expect(animals).toHaveLength(2);
+
+      const mammals = await orm.em.find(MammalDef, {});
+      expect(mammals).toHaveLength(2);
+
+      await orm.close();
+    });
+
+  });
+
+  describe('partial loading and fields', () => {
+
+    test('partial loading with fields option', async () => {
+      const orm = await MikroORM.init({
+        dbName: ':memory:',
+        entities: [VehicleDef, CarDef, MotorcycleDef],
+      });
+
+      await orm.schema.create();
+
+      orm.em.create(CarDef, { brand: 'Toyota', model: 'Camry', numDoors: 4 });
+      await orm.em.flush();
+      orm.em.clear();
+
+      // Load only specific fields
+      const mock = mockLogger(orm);
+      const [car] = await orm.em.find(CarDef, {}, { fields: ['brand', 'numDoors'] });
+
+      // Brand and numDoors should be loaded
+      expect(car.brand).toBe('Toyota');
+      expect(car.numDoors).toBe(4);
+
+      // Check that only requested fields were queried
+      const selectQuery = mock.mock.calls.find(c => c[0].includes('select'));
+      expect(selectQuery).toBeDefined();
+
+      await orm.close();
+    });
+
+  });
+
+  describe('ordering and pagination', () => {
+
+    test('ordering by parent and child properties', async () => {
+      const orm = await MikroORM.init({
+        dbName: ':memory:',
+        entities: [VehicleDef, CarDef, MotorcycleDef],
+      });
+
+      await orm.schema.create();
+
+      orm.em.create(CarDef, { brand: 'Toyota', model: 'Camry', numDoors: 4 });
+      orm.em.create(CarDef, { brand: 'Honda', model: 'Civic', numDoors: 2 });
+      orm.em.create(CarDef, { brand: 'Honda', model: 'Accord', numDoors: 4 });
+      await orm.em.flush();
+      orm.em.clear();
+
+      // Order by child property
+      const byDoors = await orm.em.find(CarDef, {}, { orderBy: { numDoors: 'ASC' } });
+      expect(byDoors[0].numDoors).toBe(2);
+      expect(byDoors[2].numDoors).toBe(4);
+
+      // Order by parent property
+      const byBrand = await orm.em.find(CarDef, {}, { orderBy: { brand: 'ASC', model: 'ASC' } });
+      expect(byBrand[0].brand).toBe('Honda');
+      expect(byBrand[0].model).toBe('Accord');
+
+      await orm.close();
+    });
+
+    test('pagination with limit and offset', async () => {
+      const orm = await MikroORM.init({
+        dbName: ':memory:',
+        entities: [VehicleDef, CarDef, MotorcycleDef],
+      });
+
+      await orm.schema.create();
+
+      // Use padded numbers for correct alphabetical sorting
+      for (let i = 1; i <= 10; i++) {
+        const padded = i.toString().padStart(2, '0');
+        orm.em.create(CarDef, { brand: `Brand${padded}`, model: `Model${padded}`, numDoors: 4 });
+      }
+      await orm.em.flush();
+      orm.em.clear();
+
+      // Get page 2 with 3 items per page
+      const page2 = await orm.em.find(CarDef, {}, {
+        orderBy: { brand: 'ASC' },
+        limit: 3,
+        offset: 3,
+      });
+
+      expect(page2).toHaveLength(3);
+      expect(page2[0].brand).toBe('Brand04');
+      expect(page2[2].brand).toBe('Brand06');
+
+      await orm.close();
+    });
+
+  });
+
+});

--- a/tests/features/table-per-type-inheritance/table-per-type-inheritance.mssql.test.ts
+++ b/tests/features/table-per-type-inheritance/table-per-type-inheritance.mssql.test.ts
@@ -1,0 +1,79 @@
+import { MikroORM, MsSqlDriver, Opt } from '@mikro-orm/mssql';
+import { Entity, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+import { mockLogger } from '../../bootstrap.js';
+
+@Entity({ tableName: 'tpt_base', inheritance: 'tpt' })
+abstract class TptBase {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  baseName!: string;
+
+  @Property({ defaultRaw: 'getdate()' })
+  createdAt!: Opt<Date>;
+
+}
+
+@Entity({ tableName: 'tpt_child' })
+class TptChild extends TptBase {
+
+  @Property()
+  childValue!: string;
+
+}
+
+describe('TPT (Table-Per-Type) Inheritance [mssql]', () => {
+
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    const dbName = `mikro_orm_test_tpt_${(Math.random() + 1).toString(36).substring(2)}`;
+    orm = await MikroORM.init({
+      driver: MsSqlDriver,
+      metadataProvider: ReflectMetadataProvider,
+      dbName,
+      password: 'Root.Root',
+      entities: [TptBase, TptChild],
+      debug: true,
+      logger: i => i,
+    });
+    await orm.schema.create();
+  }, 120_000);
+
+  afterAll(async () => {
+    await orm.schema.dropDatabase();
+    await orm.close(true);
+  }, 120_000);
+
+  test('nativeInsertMany OUTPUT clause only includes own table columns', async () => {
+    const driver = orm.em.getDriver();
+    const mock = mockLogger(orm, ['query']);
+
+    // Insert into parent table first
+    const parentResult = await driver.nativeInsertMany(TptBase, [
+      { baseName: 'child 1' },
+      { baseName: 'child 2' },
+      { baseName: 'child 3' },
+    ]);
+
+    // Parent table INSERT should include OUTPUT for autoincrement id and defaultRaw createdAt
+    expect(mock.mock.calls[0][0]).toMatch('insert into [tpt_base]');
+    expect(mock.mock.calls[0][0]).toMatch('output inserted.[id], inserted.[created_at]');
+
+    // Insert into child table
+    await driver.nativeInsertMany(TptChild, [
+      { id: parentResult.rows![0].id, childValue: 'val1' },
+      { id: parentResult.rows![1].id, childValue: 'val2' },
+      { id: parentResult.rows![2].id, childValue: 'val3' },
+    ]);
+
+    // Child table INSERT should NOT include parent-only columns (created_at) in OUTPUT
+    const childInsertCall = mock.mock.calls.find(c => c[0].includes('[tpt_child]'));
+    expect(childInsertCall).toBeDefined();
+    expect(childInsertCall![0]).toMatch('insert into [tpt_child]');
+    expect(childInsertCall![0]).not.toMatch('inserted.[created_at]');
+  });
+
+});

--- a/tests/features/table-per-type-inheritance/table-per-type-inheritance.test.ts
+++ b/tests/features/table-per-type-inheritance/table-per-type-inheritance.test.ts
@@ -1,0 +1,2930 @@
+import { Collection, EntitySchema, MikroORM, quote, Ref, wrap, raw, Type, Opt } from '@mikro-orm/sqlite';
+import { Embeddable, Embedded, Entity, ManyToOne, OneToMany, OneToOne, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+import { mockLogger } from '../../bootstrap.js';
+
+// Base entity with TPT inheritance strategy
+@Entity({ inheritance: 'tpt' })
+abstract class Integration {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @Property({ default: true })
+  active?: boolean = true;
+
+}
+
+// Child entity - FooIntegration
+@Entity()
+class FooIntegration extends Integration {
+
+  @Property()
+  fooData!: string;
+
+  // Generated column to test TPT with createSchemaColumnMappingObject
+  // Uses table.toString() to cover that code path
+  @Property({
+    length: 100,
+    generated: (cols, table) => `(upper(${cols.fooData}) || ' from ' || '${table}') stored`,
+  })
+  fooDataUpper!: Opt<string>;
+
+}
+
+// Child entity - BarIntegration
+@Entity()
+class BarIntegration extends Integration {
+
+  @Property()
+  barData!: string;
+
+  @Property({ nullable: true })
+  barExtra?: string;
+
+}
+
+// Multi-level TPT: GrandChild extends BarIntegration
+@Entity()
+class BazIntegration extends BarIntegration {
+
+  @Property()
+  bazData!: string;
+
+}
+
+// Entity that references TPT entities
+@Entity()
+class Project {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  title!: string;
+
+  @ManyToOne(() => Integration, { ref: true, nullable: true })
+  integration?: Ref<Integration>;
+
+}
+
+// Entity with collection of TPT entities
+@Entity()
+class Workspace {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @OneToMany(() => WorkspaceIntegration, wi => wi.workspace)
+  integrations = new Collection<WorkspaceIntegration>(this);
+
+}
+
+@Entity()
+class WorkspaceIntegration {
+
+  @PrimaryKey()
+  id!: number;
+
+  @ManyToOne(() => Workspace, { ref: true })
+  workspace!: Ref<Workspace>;
+
+  @ManyToOne(() => Integration, { ref: true })
+  integration!: Ref<Integration>;
+
+}
+
+describe('TPT (Table-Per-Type) Inheritance', () => {
+
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      dbName: ':memory:',
+      entities: [Integration, FooIntegration, BarIntegration, BazIntegration, Project, Workspace, WorkspaceIntegration],
+    });
+    await orm.schema.create();
+  });
+
+  afterAll(async () => {
+    await orm.close(true);
+  });
+
+  beforeEach(async () => {
+    await orm.schema.clear();
+  });
+
+  describe('metadata', () => {
+
+    test('TPT metadata is set correctly', () => {
+      const integrationMeta = orm.getMetadata().get(Integration);
+      const fooMeta = orm.getMetadata().get(FooIntegration);
+      const barMeta = orm.getMetadata().get(BarIntegration);
+      const bazMeta = orm.getMetadata().get(BazIntegration);
+
+      // Root entity has TPT inheritance type
+      expect(integrationMeta.inheritanceType).toBe('tpt');
+      expect(integrationMeta.tptParent).toBeUndefined();
+      expect(integrationMeta.tptChildren).toContain(fooMeta);
+      expect(integrationMeta.tptChildren).toContain(barMeta);
+
+      // FooIntegration is a direct child
+      expect(fooMeta.inheritanceType).toBe('tpt');
+      expect(fooMeta.tptParent).toBe(integrationMeta);
+      expect(fooMeta.tptChildren).toBeUndefined();
+
+      // BarIntegration is a direct child with its own child
+      expect(barMeta.inheritanceType).toBe('tpt');
+      expect(barMeta.tptParent).toBe(integrationMeta);
+      expect(barMeta.tptChildren).toContain(bazMeta);
+
+      // BazIntegration is a grandchild
+      expect(bazMeta.inheritanceType).toBe('tpt');
+      expect(bazMeta.tptParent).toBe(barMeta);
+      expect(bazMeta.tptChildren).toBeUndefined();
+    });
+
+    test('ownProps contains only properties defined in the entity', () => {
+      const integrationMeta = orm.getMetadata().get(Integration);
+      const fooMeta = orm.getMetadata().get(FooIntegration);
+      const barMeta = orm.getMetadata().get(BarIntegration);
+      const bazMeta = orm.getMetadata().get(BazIntegration);
+
+      // Integration owns id, name, active
+      expect(integrationMeta.ownProps?.map(p => p.name).sort()).toEqual(['active', 'id', 'name']);
+
+      // FooIntegration owns fooData, fooDataUpper
+      expect(fooMeta.ownProps?.map(p => p.name)).toEqual(['fooData', 'fooDataUpper']);
+
+      // BarIntegration owns barData and barExtra
+      expect(barMeta.ownProps?.map(p => p.name).sort()).toEqual(['barData', 'barExtra']);
+
+      // BazIntegration owns only bazData
+      expect(bazMeta.ownProps?.map(p => p.name)).toEqual(['bazData']);
+    });
+
+  });
+
+  describe('schema', () => {
+
+    test('generates separate tables with FK constraints', async () => {
+      const sql = await orm.schema.getCreateSchemaSQL();
+
+      // Each entity has its own table
+      expect(sql).toMatch(/create table.*integration/i);
+      expect(sql).toMatch(/create table.*foo_integration/i);
+      expect(sql).toMatch(/create table.*bar_integration/i);
+      expect(sql).toMatch(/create table.*baz_integration/i);
+
+      // Child tables have FK to parent
+      expect(sql).toMatch(/foo_integration.*references.*integration/is);
+      expect(sql).toMatch(/bar_integration.*references.*integration/is);
+      expect(sql).toMatch(/baz_integration.*references.*bar_integration/is);
+    });
+
+  });
+
+  describe('persistence', () => {
+
+    test('INSERT creates records in multiple tables', async () => {
+      const mock = mockLogger(orm);
+
+      const foo = orm.em.create(FooIntegration, {
+        name: 'Foo Integration',
+        fooData: 'foo-data',
+      });
+      await orm.em.flush();
+
+      // Should have INSERT for both integration and foo_integration tables
+      const logs = mock.mock.calls.map(c => c[0]);
+      expect(logs.some((l: string) => l.includes('insert into `integration`'))).toBe(true);
+      expect(logs.some((l: string) => l.includes('insert into `foo_integration`'))).toBe(true);
+
+      orm.em.clear();
+
+      // Verify data was inserted correctly
+      const loaded = await orm.em.findOneOrFail(FooIntegration, foo.id);
+      expect(loaded.name).toBe('Foo Integration');
+      expect(loaded.fooData).toBe('foo-data');
+      expect(loaded.active).toBe(true);
+    });
+
+    test('INSERT with multi-level inheritance', async () => {
+      const mock = mockLogger(orm);
+
+      const baz = orm.em.create(BazIntegration, {
+        name: 'Baz Integration',
+        barData: 'bar-data',
+        bazData: 'baz-data',
+      });
+      await orm.em.flush();
+
+      // Should have INSERT for integration, bar_integration, and baz_integration
+      const logs = mock.mock.calls.map(c => c[0]);
+      expect(logs.some((l: string) => l.includes('insert into `integration`'))).toBe(true);
+      expect(logs.some((l: string) => l.includes('insert into `bar_integration`'))).toBe(true);
+      expect(logs.some((l: string) => l.includes('insert into `baz_integration`'))).toBe(true);
+
+      orm.em.clear();
+
+      // Verify data
+      const loaded = await orm.em.findOneOrFail(BazIntegration, baz.id);
+      expect(loaded.name).toBe('Baz Integration');
+      expect(loaded.barData).toBe('bar-data');
+      expect(loaded.bazData).toBe('baz-data');
+    });
+
+    test('UPDATE only updates changed tables', async () => {
+      const foo = orm.em.create(FooIntegration, {
+        name: 'Foo Integration',
+        fooData: 'foo-data',
+      });
+      await orm.em.flush();
+      orm.em.clear();
+
+      const loaded = await orm.em.findOneOrFail(FooIntegration, foo.id);
+      const mock = mockLogger(orm);
+
+      // Update only child property
+      loaded.fooData = 'updated-foo-data';
+      await orm.em.flush();
+
+      let logs = mock.mock.calls.map(c => c[0]);
+      expect(logs.some((l: string) => l.includes('update `foo_integration`'))).toBe(true);
+      expect(logs.some((l: string) => l.includes('update `integration`'))).toBe(false);
+
+      mock.mockClear();
+
+      // Update only parent property
+      loaded.name = 'Updated Name';
+      await orm.em.flush();
+
+      logs = mock.mock.calls.map(c => c[0]);
+      expect(logs.some((l: string) => l.includes('update `integration`'))).toBe(true);
+      expect(logs.some((l: string) => l.includes('update `foo_integration`'))).toBe(false);
+    });
+
+    test('DELETE removes records via cascade', async () => {
+      const foo = orm.em.create(FooIntegration, {
+        name: 'Foo Integration',
+        fooData: 'foo-data',
+      });
+      await orm.em.flush();
+      const fooId = foo.id;
+      orm.em.clear();
+
+      const loaded = await orm.em.findOneOrFail(FooIntegration, fooId);
+      orm.em.remove(loaded);
+      await orm.em.flush();
+
+      // Verify both tables are empty
+      const integrationCount = await orm.em.count(Integration, { id: fooId });
+      expect(integrationCount).toBe(0);
+    });
+
+  });
+
+  describe.each(['select-in', 'joined'] as const)('querying (%s strategy)', strategy => {
+
+    beforeEach(async () => {
+      // Create test data
+      orm.em.create(FooIntegration, { name: 'Foo 1', fooData: 'foo-data-1' });
+      orm.em.create(FooIntegration, { name: 'Foo 2', fooData: 'foo-data-2' });
+      orm.em.create(BarIntegration, { name: 'Bar 1', barData: 'bar-data-1' });
+      orm.em.create(BazIntegration, { name: 'Baz 1', barData: 'bar-data-baz', bazData: 'baz-data-1' });
+      await orm.em.flush();
+      orm.em.clear();
+    });
+
+    test('SELECT joins parent tables', async () => {
+      const mock = mockLogger(orm);
+
+      const foos = await orm.em.find(FooIntegration, {}, { strategy });
+      expect(foos).toHaveLength(2);
+
+      // Should INNER JOIN the parent table
+      const selectLog = mock.mock.calls.find(c => c[0].includes('select'));
+      expect(selectLog?.[0]).toMatch(/inner join `integration`/i);
+
+      // All properties should be loaded
+      expect(foos[0].name).toBe('Foo 1');
+      expect(foos[0].fooData).toBe('foo-data-1');
+      expect(foos[0].active).toBe(true);
+    });
+
+    test('SELECT with multi-level inheritance', async () => {
+      const mock = mockLogger(orm);
+
+      const bazs = await orm.em.find(BazIntegration, {}, { strategy });
+      expect(bazs).toHaveLength(1);
+
+      // Should INNER JOIN both parent tables
+      const selectLog = mock.mock.calls.find(c => c[0].includes('select'));
+      expect(selectLog?.[0]).toMatch(/inner join `bar_integration`/i);
+      expect(selectLog?.[0]).toMatch(/inner join `integration`/i);
+
+      // All properties should be loaded
+      expect(bazs[0].name).toBe('Baz 1');
+      expect(bazs[0].barData).toBe('bar-data-baz');
+      expect(bazs[0].bazData).toBe('baz-data-1');
+    });
+
+    test('WHERE on inherited properties', async () => {
+      const mock = mockLogger(orm);
+
+      const foos = await orm.em.find(FooIntegration, { name: 'Foo 1' }, { strategy });
+      expect(foos).toHaveLength(1);
+      expect(foos[0].fooData).toBe('foo-data-1');
+
+      // WHERE should reference the correct parent table alias
+      const selectLog = mock.mock.calls.find(c => c[0].includes('select'));
+      expect(selectLog?.[0]).toMatch(/`name`\s*=\s*'Foo 1'/);
+    });
+
+    test('WHERE on own properties', async () => {
+      const foos = await orm.em.find(FooIntegration, { fooData: 'foo-data-2' }, { strategy });
+      expect(foos).toHaveLength(1);
+      expect(foos[0].name).toBe('Foo 2');
+    });
+
+    test('ORDER BY on inherited properties', async () => {
+      const foos = await orm.em.find(FooIntegration, {}, {
+        strategy,
+        orderBy: { name: 'DESC' },
+      });
+      expect(foos).toHaveLength(2);
+      expect(foos[0].name).toBe('Foo 2');
+      expect(foos[1].name).toBe('Foo 1');
+    });
+
+    test('ORDER BY on own properties', async () => {
+      const foos = await orm.em.find(FooIntegration, {}, {
+        strategy,
+        orderBy: { fooData: 'DESC' },
+      });
+      expect(foos).toHaveLength(2);
+      expect(foos[0].fooData).toBe('foo-data-2');
+      expect(foos[1].fooData).toBe('foo-data-1');
+    });
+
+    test('partial loading with fields option', async () => {
+      const foos = await orm.em.find(FooIntegration, {}, {
+        strategy,
+        fields: ['name', 'fooData'],
+      });
+      expect(foos).toHaveLength(2);
+      expect(wrap(foos[0]).toObject()).toMatchObject({
+        id: expect.any(Number),
+        name: expect.any(String),
+        fooData: expect.any(String),
+      });
+    });
+
+    test('partial loading with only child fields', async () => {
+      const foos = await orm.em.find(FooIntegration, {}, {
+        strategy,
+        fields: ['id', 'fooData'],
+      });
+      expect(foos).toHaveLength(2);
+      expect(foos[0].fooData).toBeDefined();
+      expect(foos[0].id).toBeDefined();
+    });
+
+    test('partial loading with only inherited fields', async () => {
+      const foos = await orm.em.find(FooIntegration, {}, {
+        strategy,
+        fields: ['id', 'name'],
+      });
+      expect(foos).toHaveLength(2);
+      expect(foos[0].name).toBeDefined();
+      expect(foos[0].id).toBeDefined();
+    });
+
+  });
+
+  describe('relations with TPT entities', () => {
+
+    test('ManyToOne to TPT entity', async () => {
+      const foo = orm.em.create(FooIntegration, { name: 'Foo', fooData: 'data' });
+      const project = orm.em.create(Project, { title: 'Project 1', integration: foo });
+      await orm.em.flush();
+      orm.em.clear();
+
+      const loaded = await orm.em.findOneOrFail(Project, project.id, {
+        populate: ['integration'],
+      });
+
+      expect(loaded.integration?.unwrap()).toBeInstanceOf(FooIntegration);
+      expect((loaded.integration?.unwrap() as FooIntegration).fooData).toBe('data');
+    });
+
+    test('collection of TPT entities', async () => {
+      const foo = orm.em.create(FooIntegration, { name: 'Foo', fooData: 'data' });
+      const bar = orm.em.create(BarIntegration, { name: 'Bar', barData: 'data' });
+      const workspace = orm.em.create(Workspace, { name: 'Workspace 1' });
+      const wi1 = orm.em.create(WorkspaceIntegration, { workspace, integration: foo });
+      const wi2 = orm.em.create(WorkspaceIntegration, { workspace, integration: bar });
+      await orm.em.flush();
+      orm.em.clear();
+
+      const loaded = await orm.em.findOneOrFail(Workspace, workspace.id, {
+        populate: ['integrations.integration'],
+      });
+      expect(loaded.integrations).toHaveLength(2);
+      expect(loaded.integrations[0].integration?.unwrap()).toBeInstanceOf(Integration);
+      expect(loaded.integrations[1].integration?.unwrap()).toBeInstanceOf(Integration);
+    });
+
+  });
+
+});
+
+describe('TPT validation and edge cases', () => {
+
+  test('throws when mixing STI and TPT', async () => {
+    // Entity with both discriminatorColumn (STI) and inheritance: 'tpt'
+    @Entity({
+      inheritance: 'tpt',
+      discriminatorColumn: 'type',
+      discriminatorMap: { base: 'MixedBase2', child: 'MixedChild2' },
+    })
+    abstract class MixedBase2 {
+
+      @PrimaryKey()
+      id!: number;
+
+      @Property()
+      type!: string;
+
+    }
+
+    @Entity({ discriminatorValue: 'child' })
+    class MixedChild2 extends MixedBase2 {
+
+      @Property()
+      data!: string;
+
+    }
+
+    await expect(MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      dbName: ':memory:',
+      entities: [MixedBase2, MixedChild2],
+    })).rejects.toThrow(/cannot mix STI.*and TPT/i);
+  });
+
+  test('TPT with non-abstract root entity', async () => {
+    // Non-abstract root entity is allowed
+    @Entity({ inheritance: 'tpt' })
+    class ConcreteRoot {
+
+      @PrimaryKey()
+      id!: number;
+
+      @Property()
+      rootProp!: string;
+
+    }
+
+    @Entity()
+    class ConcreteChild extends ConcreteRoot {
+
+      @Property()
+      childProp!: string;
+
+    }
+
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      dbName: ':memory:',
+      entities: [ConcreteRoot, ConcreteChild],
+    });
+
+    await orm.schema.create();
+
+    // Can persist root entity directly
+    const root = orm.em.create(ConcreteRoot, { rootProp: 'root-data' });
+    await orm.em.flush();
+    expect(root.id).toBeDefined();
+
+    orm.em.clear();
+
+    // Can query root entity
+    const loaded = await orm.em.findOneOrFail(ConcreteRoot, root.id);
+    expect(loaded.rootProp).toBe('root-data');
+
+    await orm.close();
+  });
+
+  test('TPT query with complex WHERE conditions', async () => {
+    @Entity({ inheritance: 'tpt' })
+    abstract class Base {
+
+      @PrimaryKey()
+      id!: number;
+
+      @Property()
+      name!: string;
+
+      @Property({ nullable: true })
+      optional?: string;
+
+    }
+
+    @Entity()
+    class Child extends Base {
+
+      @Property()
+      value!: number;
+
+    }
+
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      dbName: ':memory:',
+      entities: [Base, Child],
+    });
+
+    await orm.schema.create();
+
+    // Create test data
+    orm.em.create(Child, { name: 'A', value: 10, optional: 'x' });
+    orm.em.create(Child, { name: 'B', value: 20 });
+    orm.em.create(Child, { name: 'C', value: 30, optional: 'y' });
+    await orm.em.flush();
+    orm.em.clear();
+
+    // Query with conditions on both parent and child properties
+    const results = await orm.em.find(Child, {
+      $or: [
+        { name: 'A', value: { $gte: 10 } },
+        { optional: 'y' },
+      ],
+    }, { orderBy: { name: 'ASC' } });
+
+    expect(results).toHaveLength(2);
+    expect(results[0].name).toBe('A');
+    expect(results[1].name).toBe('C');
+
+    await orm.close();
+  });
+
+  test('TPT with raw query fragments', async () => {
+    @Entity({ inheritance: 'tpt' })
+    abstract class BaseEntity {
+
+      @PrimaryKey()
+      id!: number;
+
+      @Property()
+      score!: number;
+
+    }
+
+    @Entity()
+    class DerivedEntity extends BaseEntity {
+
+      @Property()
+      multiplier!: number;
+
+    }
+
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      dbName: ':memory:',
+      entities: [BaseEntity, DerivedEntity],
+    });
+
+    await orm.schema.create();
+
+    orm.em.create(DerivedEntity, { score: 10, multiplier: 2 });
+    orm.em.create(DerivedEntity, { score: 20, multiplier: 3 });
+    await orm.em.flush();
+    orm.em.clear();
+
+    // Query with raw SQL in WHERE
+    const results = await orm.em.find(DerivedEntity, {
+      [raw('score * multiplier')]: { $gte: 50 },
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0].score).toBe(20);
+
+    await orm.close();
+  });
+
+  test('TPT with COUNT queries', async () => {
+    @Entity({ inheritance: 'tpt' })
+    abstract class CountBase {
+
+      @PrimaryKey()
+      id!: number;
+
+      @Property()
+      category!: string;
+
+    }
+
+    @Entity()
+    class CountChild extends CountBase {
+
+      @Property()
+      value!: number;
+
+    }
+
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      dbName: ':memory:',
+      entities: [CountBase, CountChild],
+    });
+
+    await orm.schema.create();
+
+    // Create test data
+    orm.em.create(CountChild, { category: 'A', value: 10 });
+    orm.em.create(CountChild, { category: 'A', value: 20 });
+    orm.em.create(CountChild, { category: 'B', value: 30 });
+    await orm.em.flush();
+    orm.em.clear();
+
+    // Count with condition on inherited property
+    const countA = await orm.em.count(CountChild, { category: 'A' });
+    expect(countA).toBe(2);
+
+    // Count with condition on own property
+    const countHigh = await orm.em.count(CountChild, { value: { $gte: 20 } });
+    expect(countHigh).toBe(2);
+
+    // Count all
+    const countAll = await orm.em.count(CountChild);
+    expect(countAll).toBe(3);
+
+    await orm.close();
+  });
+
+  test('TPT with bulk insert (insertMany)', async () => {
+    @Entity({ inheritance: 'tpt' })
+    abstract class BulkBase {
+
+      @PrimaryKey()
+      id!: number;
+
+      @Property()
+      name!: string;
+
+    }
+
+    @Entity()
+    class BulkChild extends BulkBase {
+
+      @Property()
+      data!: string;
+
+    }
+
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      dbName: ':memory:',
+      entities: [BulkBase, BulkChild],
+    });
+
+    await orm.schema.create();
+
+    // Create multiple entities at once
+    const entities = [
+      orm.em.create(BulkChild, { name: 'One', data: 'data-1' }),
+      orm.em.create(BulkChild, { name: 'Two', data: 'data-2' }),
+      orm.em.create(BulkChild, { name: 'Three', data: 'data-3' }),
+    ];
+
+    await orm.em.flush();
+
+    // Verify all were persisted correctly
+    expect(entities[0].id).toBeDefined();
+    expect(entities[1].id).toBeDefined();
+    expect(entities[2].id).toBeDefined();
+
+    orm.em.clear();
+
+    // Reload and verify
+    const loaded = await orm.em.find(BulkChild, {}, { orderBy: { name: 'ASC' } });
+    expect(loaded).toHaveLength(3);
+    expect(loaded[0].name).toBe('One');
+    expect(loaded[0].data).toBe('data-1');
+    expect(loaded[1].name).toBe('Three');
+    expect(loaded[2].name).toBe('Two');
+
+    await orm.close();
+  });
+
+  test('TPT with findOne and findOneOrFail', async () => {
+    @Entity({ inheritance: 'tpt' })
+    abstract class FindBase {
+
+      @PrimaryKey()
+      id!: number;
+
+      @Property()
+      name!: string;
+
+    }
+
+    @Entity()
+    class FindChild extends FindBase {
+
+      @Property()
+      data!: string;
+
+    }
+
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      dbName: ':memory:',
+      entities: [FindBase, FindChild],
+    });
+
+    await orm.schema.create();
+
+    const entity = orm.em.create(FindChild, { name: 'Test', data: 'test-data' });
+    await orm.em.flush();
+    orm.em.clear();
+
+    // findOne by primary key
+    const found1 = await orm.em.findOne(FindChild, entity.id);
+    expect(found1?.name).toBe('Test');
+    expect(found1?.data).toBe('test-data');
+
+    orm.em.clear();
+
+    // findOne by inherited property
+    const found2 = await orm.em.findOne(FindChild, { name: 'Test' });
+    expect(found2?.data).toBe('test-data');
+
+    orm.em.clear();
+
+    // findOneOrFail by own property
+    const found3 = await orm.em.findOneOrFail(FindChild, { data: 'test-data' });
+    expect(found3.name).toBe('Test');
+
+    await orm.close();
+  });
+
+  test('TPT with qb.getCount()', async () => {
+    @Entity({ inheritance: 'tpt' })
+    abstract class QbCountBase {
+
+      @PrimaryKey()
+      id!: number;
+
+      @Property()
+      status!: string;
+
+    }
+
+    @Entity()
+    class QbCountChild extends QbCountBase {
+
+      @Property()
+      priority!: number;
+
+    }
+
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      dbName: ':memory:',
+      entities: [QbCountBase, QbCountChild],
+    });
+
+    await orm.schema.create();
+
+    orm.em.create(QbCountChild, { status: 'active', priority: 1 });
+    orm.em.create(QbCountChild, { status: 'active', priority: 2 });
+    orm.em.create(QbCountChild, { status: 'inactive', priority: 3 });
+    await orm.em.flush();
+    orm.em.clear();
+
+    // QueryBuilder count with condition on inherited property
+    const qb1 = orm.em.createQueryBuilder(QbCountChild).where({ status: 'active' });
+    const count1 = await qb1.getCount();
+    expect(count1).toBe(2);
+
+    // QueryBuilder count with condition on own property
+    const qb2 = orm.em.createQueryBuilder(QbCountChild).where({ priority: { $gte: 2 } });
+    const count2 = await qb2.getCount();
+    expect(count2).toBe(2);
+
+    await orm.close();
+  });
+
+  test('TPT entity only has root metadata when inheritance option not set on child', async () => {
+    // When a child extends a TPT root, it automatically becomes TPT
+    @Entity({ inheritance: 'tpt' })
+    abstract class AutoBase {
+
+      @PrimaryKey()
+      id!: number;
+
+    }
+
+    @Entity()
+    class AutoChild extends AutoBase {
+
+      @Property()
+      data!: string;
+
+    }
+
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      dbName: ':memory:',
+      entities: [AutoBase, AutoChild],
+    });
+
+    const baseMeta = orm.getMetadata().get(AutoBase);
+    const childMeta = orm.getMetadata().get(AutoChild);
+
+    // Both should have TPT inheritance type
+    expect(baseMeta.inheritanceType).toBe('tpt');
+    expect(childMeta.inheritanceType).toBe('tpt');
+
+    // Child should point to parent
+    expect(childMeta.tptParent).toBe(baseMeta);
+
+    await orm.close();
+  });
+
+});
+
+describe('TPT with EntitySchema', () => {
+
+  test('TPT works with EntitySchema-based entities', async () => {
+    // Define entities using EntitySchema instead of decorators
+    // Note: Using non-abstract base entity since abstract entities don't have their own table in TPT
+    class SchemaBase {
+
+      id!: number;
+      baseName!: string;
+
+    }
+
+    class SchemaChild extends SchemaBase {
+
+      childValue!: number;
+
+    }
+
+    const schemaBase = new EntitySchema({
+      class: SchemaBase,
+      tableName: 'schema_base',
+      inheritance: 'tpt',
+      properties: {
+        id: { type: 'number', primary: true },
+        baseName: { type: 'string' },
+      },
+    });
+
+    const schemaChild = new EntitySchema({
+      class: SchemaChild,
+      tableName: 'schema_child',
+      extends: schemaBase,
+      properties: {
+        childValue: { type: 'number' },
+      },
+    });
+
+    const orm = await MikroORM.init({
+      dbName: ':memory:',
+      entities: [schemaBase, schemaChild],
+    });
+
+    await orm.schema.create();
+
+    // Verify TPT metadata
+    const childMeta = orm.getMetadata().get(SchemaChild);
+
+    expect(childMeta.inheritanceType).toBe('tpt');
+    expect(childMeta.tptParent).toBeDefined();
+    expect(childMeta.tptParent?.className).toBe('SchemaBase');
+
+    // Verify ownProps
+    expect(childMeta.ownProps?.map(p => p.name)).toEqual(['childValue']);
+
+    // Create and persist entity
+    const child = orm.em.create(SchemaChild, { baseName: 'test', childValue: 42 });
+    await orm.em.flush();
+    orm.em.clear();
+
+    // Load entity
+    const loaded = await orm.em.findOneOrFail(SchemaChild, child.id);
+    expect(loaded.baseName).toBe('test');
+    expect(loaded.childValue).toBe(42);
+
+    await orm.close();
+  });
+
+});
+
+describe('TPT with OneToOne owner relation in parent', () => {
+
+  test('TPT parent with OneToOne owner relation', async () => {
+    // Target entity for the OneToOne relation
+    @Entity()
+    class Profile {
+
+      @PrimaryKey()
+      id!: number;
+
+      @Property()
+      bio!: string;
+
+    }
+
+    // TPT base with OneToOne owner relation
+    @Entity({ inheritance: 'tpt' })
+    abstract class Person {
+
+      @PrimaryKey()
+      id!: number;
+
+      @Property()
+      name!: string;
+
+      @OneToOne(() => Profile, { owner: true, nullable: true, ref: true })
+      profile?: Ref<Profile>;
+
+    }
+
+    @Entity()
+    class Employee extends Person {
+
+      @Property()
+      department!: string;
+
+    }
+
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      dbName: ':memory:',
+      entities: [Profile, Person, Employee],
+    });
+
+    await orm.schema.create();
+
+    // Verify the OneToOne relation is in parent's ownProps
+    const personMeta = orm.getMetadata().get(Person);
+    expect(personMeta.ownProps?.some(p => p.name === 'profile')).toBe(true);
+
+    // Create and persist
+    const profile = orm.em.create(Profile, { bio: 'Developer' });
+    const employee = orm.em.create(Employee, { name: 'John', department: 'Engineering', profile });
+    await orm.em.flush();
+    orm.em.clear();
+
+    // First test: Load without populate - just basic select should work with TPT parent columns
+    const mock = mockLogger(orm);
+    const simpleLoad = await orm.em.findOneOrFail(Employee, employee.id);
+    expect(simpleLoad.name).toBe('John');
+    expect(simpleLoad.department).toBe('Engineering');
+
+    // Check the SQL generated for simple load
+    const selectLog = mock.mock.calls.find(c => c[0].includes('select'));
+    // Should select from employee (e0) and join person (p0), with profile_id coming from p0
+    expect(selectLog?.[0]).toMatch(/inner join.*person/i);
+
+    orm.em.clear();
+    mock.mockReset();
+
+    // Second test: Load with populate - should also work
+    const loaded = await orm.em.findOneOrFail(Employee, employee.id, { populate: ['profile'] });
+
+    expect(loaded.name).toBe('John');
+    expect(loaded.department).toBe('Engineering');
+    expect(loaded.profile?.unwrap().bio).toBe('Developer');
+
+    await orm.close();
+  });
+
+});
+
+describe('TPT polymorphic queries', () => {
+
+  test('querying base class returns concrete types', async () => {
+    @Entity({ inheritance: 'tpt' })
+    abstract class Animal {
+
+      @PrimaryKey()
+      id!: number;
+
+      @Property()
+      name!: string;
+
+    }
+
+    @Entity()
+    class Dog extends Animal {
+
+      @Property()
+      breed!: string;
+
+    }
+
+    @Entity()
+    class Cat extends Animal {
+
+      @Property()
+      color!: string;
+
+    }
+
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      dbName: ':memory:',
+      entities: [Animal, Dog, Cat],
+    });
+
+    await orm.schema.create();
+
+    // Create some animals
+    orm.em.create(Dog, { name: 'Buddy', breed: 'Labrador' });
+    orm.em.create(Cat, { name: 'Whiskers', color: 'Orange' });
+    orm.em.create(Dog, { name: 'Max', breed: 'Poodle' });
+    await orm.em.flush();
+    orm.em.clear();
+
+    // Query the base class - should return concrete types
+    const animals = await orm.em.find(Animal, {}, { orderBy: { name: 'ASC' } });
+
+    expect(animals).toHaveLength(3);
+
+    // Verify concrete types are returned
+    expect(animals[0]).toBeInstanceOf(Dog);
+    expect(animals[0].name).toBe('Buddy');
+    expect((animals[0] as Dog).breed).toBe('Labrador');
+
+    expect(animals[1]).toBeInstanceOf(Dog);
+    expect(animals[1].name).toBe('Max');
+    expect((animals[1] as Dog).breed).toBe('Poodle');
+
+    expect(animals[2]).toBeInstanceOf(Cat);
+    expect(animals[2].name).toBe('Whiskers');
+    expect((animals[2] as Cat).color).toBe('Orange');
+
+    await orm.close();
+  });
+
+});
+
+describe('TPT UPDATE and DELETE operations', () => {
+
+  test('UPDATE on TPT entity updates only changed columns in correct tables', async () => {
+    @Entity({ inheritance: 'tpt' })
+    abstract class UpdateBase {
+
+      @PrimaryKey()
+      id!: number;
+
+      @Property()
+      baseProp!: string;
+
+    }
+
+    @Entity()
+    class UpdateChild extends UpdateBase {
+
+      @Property()
+      childProp!: string;
+
+    }
+
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      dbName: ':memory:',
+      entities: [UpdateBase, UpdateChild],
+    });
+
+    await orm.schema.create();
+    const mock = mockLogger(orm);
+
+    const entity = orm.em.create(UpdateChild, { baseProp: 'base-1', childProp: 'child-1' });
+    await orm.em.flush();
+
+    // Clear mock to only capture updates
+    mock.mockReset();
+
+    // Update only child property
+    entity.childProp = 'child-2';
+    await orm.em.flush();
+
+    // Verify UPDATE was issued
+    const updateLog = mock.mock.calls.find(c => c[0].includes('update'));
+    expect(updateLog).toBeDefined();
+
+    orm.em.clear();
+
+    // Reload and verify
+    const loaded = await orm.em.findOneOrFail(UpdateChild, entity.id);
+    expect(loaded.baseProp).toBe('base-1');
+    expect(loaded.childProp).toBe('child-2');
+
+    await orm.close();
+  });
+
+  test('DELETE on TPT entity cascades to all tables', async () => {
+    @Entity({ inheritance: 'tpt' })
+    abstract class DeleteBase {
+
+      @PrimaryKey()
+      id!: number;
+
+      @Property()
+      baseProp!: string;
+
+    }
+
+    @Entity()
+    class DeleteChild extends DeleteBase {
+
+      @Property()
+      childProp!: string;
+
+    }
+
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      dbName: ':memory:',
+      entities: [DeleteBase, DeleteChild],
+    });
+
+    await orm.schema.create();
+
+    const entity = orm.em.create(DeleteChild, { baseProp: 'base', childProp: 'child' });
+    await orm.em.flush();
+    const id = entity.id;
+
+    orm.em.remove(entity);
+    await orm.em.flush();
+    orm.em.clear();
+
+    // Verify entity is deleted
+    const found = await orm.em.findOne(DeleteChild, id);
+    expect(found).toBeNull();
+
+    await orm.close();
+  });
+
+});
+
+describe('TPT loading strategies', () => {
+
+  test('LoadStrategy.JOINED loads TPT entities in single query', async () => {
+    @Entity({ inheritance: 'tpt' })
+    abstract class Animal {
+
+      @PrimaryKey()
+      id!: number;
+
+      @Property()
+      name!: string;
+
+    }
+
+    @Entity()
+    class Dog extends Animal {
+
+      @Property()
+      breed!: string;
+
+    }
+
+    @Entity()
+    class Cat extends Animal {
+
+      @Property()
+      color!: string;
+
+    }
+
+    @Entity()
+    class Person {
+
+      @PrimaryKey()
+      id!: number;
+
+      @Property()
+      name!: string;
+
+      @ManyToOne(() => Animal, { ref: true, nullable: true })
+      pet?: Ref<Animal>;
+
+    }
+
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      dbName: ':memory:',
+      entities: [Animal, Dog, Cat, Person],
+    });
+
+    await orm.schema.create();
+
+    const dog = orm.em.create(Dog, { name: 'Buddy', breed: 'Labrador' });
+    const cat = orm.em.create(Cat, { name: 'Whiskers', color: 'Orange' });
+    orm.em.create(Person, { name: 'Alice', pet: dog });
+    orm.em.create(Person, { name: 'Bob', pet: cat });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const mock = mockLogger(orm);
+
+    const { LoadStrategy } = await import('@mikro-orm/core');
+    const people = await orm.em.find(Person, {}, {
+      populate: ['pet'],
+      strategy: LoadStrategy.JOINED,
+      orderBy: { name: 'ASC' },
+    });
+
+    expect(people).toHaveLength(2);
+
+    expect(people[0].name).toBe('Alice');
+    expect(people[0].pet?.unwrap()).toBeInstanceOf(Dog);
+    expect((people[0].pet?.unwrap() as Dog).breed).toBe('Labrador');
+
+    expect(people[1].name).toBe('Bob');
+    expect(people[1].pet?.unwrap()).toBeInstanceOf(Cat);
+    expect((people[1].pet?.unwrap() as Cat).color).toBe('Orange');
+
+    // Should use a single SELECT with JOINs
+    expect(mock.mock.calls.filter(c => c[0].includes('select'))).toHaveLength(1);
+
+    await orm.close();
+  });
+
+  test('LoadStrategy.SELECT_IN loads TPT polymorphic relations', async () => {
+    @Entity({ inheritance: 'tpt' })
+    abstract class Animal {
+
+      @PrimaryKey()
+      id!: number;
+
+      @Property()
+      name!: string;
+
+    }
+
+    @Entity()
+    class Dog extends Animal {
+
+      @Property()
+      breed!: string;
+
+    }
+
+    @Entity()
+    class Cat extends Animal {
+
+      @Property()
+      color!: string;
+
+    }
+
+    @Entity()
+    class Person {
+
+      @PrimaryKey()
+      id!: number;
+
+      @Property()
+      name!: string;
+
+      @ManyToOne(() => Animal, { ref: true, nullable: true })
+      pet?: Ref<Animal>;
+
+    }
+
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      dbName: ':memory:',
+      entities: [Animal, Dog, Cat, Person],
+    });
+
+    await orm.schema.create();
+
+    const dog = orm.em.create(Dog, { name: 'Max', breed: 'Poodle' });
+    const cat = orm.em.create(Cat, { name: 'Luna', color: 'Black' });
+    orm.em.create(Person, { name: 'Charlie', pet: dog });
+    orm.em.create(Person, { name: 'Diana', pet: cat });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const mock = mockLogger(orm);
+
+    const { LoadStrategy } = await import('@mikro-orm/core');
+    const people = await orm.em.find(Person, {}, {
+      populate: ['pet'],
+      strategy: LoadStrategy.SELECT_IN,
+      orderBy: { name: 'ASC' },
+    });
+
+    expect(people).toHaveLength(2);
+    expect(people[0].pet?.unwrap()).toBeInstanceOf(Dog);
+    expect((people[0].pet?.unwrap() as Dog).breed).toBe('Poodle');
+    expect(people[1].pet?.unwrap()).toBeInstanceOf(Cat);
+    expect((people[1].pet?.unwrap() as Cat).color).toBe('Black');
+
+    // SELECT_IN uses multiple queries
+    expect(mock.mock.calls.filter(c => c[0].includes('select')).length).toBeGreaterThan(1);
+
+    await orm.close();
+  });
+
+});
+
+describe('TPT nested relations', () => {
+
+  test('deep nesting with TPT at multiple levels', async () => {
+    @Entity({ inheritance: 'tpt' })
+    abstract class Content {
+
+      @PrimaryKey()
+      id!: number;
+
+      @Property()
+      title!: string;
+
+    }
+
+    @Entity()
+    class Article extends Content {
+
+      @Property()
+      body!: string;
+
+    }
+
+    @Entity()
+    class Video extends Content {
+
+      @Property()
+      duration!: number;
+
+    }
+
+    @Entity()
+    class Category {
+
+      @PrimaryKey()
+      id!: number;
+
+      @Property()
+      name!: string;
+
+      @OneToMany(() => ContentItem, ci => ci.category)
+      items = new Collection<ContentItem>(this);
+
+    }
+
+    @Entity()
+    class ContentItem {
+
+      @PrimaryKey()
+      id!: number;
+
+      @ManyToOne(() => Category, { ref: true })
+      category!: Ref<Category>;
+
+      @ManyToOne(() => Content, { ref: true })
+      content!: Ref<Content>;
+
+      @Property({ default: 0 })
+      sortOrder?: number;
+
+    }
+
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      dbName: ':memory:',
+      entities: [Content, Article, Video, Category, ContentItem],
+    });
+
+    await orm.schema.create();
+
+    const cat1 = orm.em.create(Category, { name: 'Tech' });
+    const cat2 = orm.em.create(Category, { name: 'Entertainment' });
+
+    const article1 = orm.em.create(Article, { title: 'TypeScript Tips', body: 'Here are some tips...' });
+    const article2 = orm.em.create(Article, { title: 'Node.js Best Practices', body: 'Best practices...' });
+    const video1 = orm.em.create(Video, { title: 'React Tutorial', duration: 3600 });
+    const video2 = orm.em.create(Video, { title: 'Movie Trailer', duration: 120 });
+
+    orm.em.create(ContentItem, { category: cat1, content: article1, sortOrder: 1 });
+    orm.em.create(ContentItem, { category: cat1, content: article2, sortOrder: 2 });
+    orm.em.create(ContentItem, { category: cat1, content: video1, sortOrder: 3 });
+    orm.em.create(ContentItem, { category: cat2, content: video2, sortOrder: 1 });
+
+    await orm.em.flush();
+    orm.em.clear();
+
+    const categories = await orm.em.find(Category, {}, {
+      populate: ['items.content'],
+      orderBy: { name: 'ASC' },
+    });
+
+    expect(categories).toHaveLength(2);
+
+    // Entertainment has 1 video
+    expect(categories[0].name).toBe('Entertainment');
+    expect(categories[0].items).toHaveLength(1);
+    expect(categories[0].items[0].content.unwrap()).toBeInstanceOf(Video);
+
+    // Tech has 2 articles and 1 video
+    expect(categories[1].name).toBe('Tech');
+    expect(categories[1].items).toHaveLength(3);
+
+    const techContent = categories[1].items.getItems().map(i => i.content.unwrap());
+    expect(techContent.filter(c => c instanceof Article)).toHaveLength(2);
+    expect(techContent.filter(c => c instanceof Video)).toHaveLength(1);
+
+    // Verify article body is loaded
+    const articles = techContent.filter(c => c instanceof Article) as Article[];
+    expect(articles[0].body).toBeDefined();
+
+    // Verify video duration is loaded
+    const videos = techContent.filter(c => c instanceof Video) as Video[];
+    expect(videos[0].duration).toBe(3600);
+
+    await orm.close();
+  });
+
+  test('bidirectional relations with TPT', async () => {
+    @Entity({ inheritance: 'tpt' })
+    abstract class TeamMember {
+
+      @PrimaryKey()
+      id!: number;
+
+      @Property()
+      name!: string;
+
+      @ManyToOne(() => Team, { ref: true })
+      team!: Ref<Team>;
+
+    }
+
+    @Entity()
+    class TeamManager extends TeamMember {
+
+      @Property()
+      budget!: number;
+
+    }
+
+    @Entity()
+    class TeamDeveloper extends TeamMember {
+
+      @Property()
+      programmingLanguage!: string;
+
+    }
+
+    @Entity()
+    class Team {
+
+      @PrimaryKey()
+      id!: number;
+
+      @Property()
+      name!: string;
+
+      @OneToMany(() => TeamMember, e => e.team)
+      members = new Collection<TeamMember>(this);
+
+    }
+
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      dbName: ':memory:',
+      entities: [TeamMember, TeamManager, TeamDeveloper, Team],
+    });
+
+    await orm.schema.create();
+
+    const engineering = orm.em.create(Team, { name: 'Engineering' });
+    const hr = orm.em.create(Team, { name: 'HR' });
+
+    orm.em.create(TeamManager, { name: 'John', team: engineering, budget: 500000 });
+    orm.em.create(TeamDeveloper, { name: 'Alice', team: engineering, programmingLanguage: 'TypeScript' });
+    orm.em.create(TeamDeveloper, { name: 'Bob', team: engineering, programmingLanguage: 'Python' });
+    orm.em.create(TeamManager, { name: 'Carol', team: hr, budget: 200000 });
+
+    await orm.em.flush();
+    orm.em.clear();
+
+    const teams = await orm.em.find(Team, {}, {
+      populate: ['members'],
+      orderBy: { name: 'ASC' },
+    });
+
+    expect(teams).toHaveLength(2);
+
+    // Engineering has 1 manager and 2 developers
+    expect(teams[0].name).toBe('Engineering');
+    expect(teams[0].members).toHaveLength(3);
+
+    const engMembers = teams[0].members.getItems();
+    expect(engMembers.filter(e => e instanceof TeamManager)).toHaveLength(1);
+    expect(engMembers.filter(e => e instanceof TeamDeveloper)).toHaveLength(2);
+
+    const engManager = engMembers.find(e => e instanceof TeamManager) as TeamManager;
+    expect(engManager.budget).toBe(500000);
+
+    const developers = engMembers.filter(e => e instanceof TeamDeveloper) as TeamDeveloper[];
+    expect(developers.map(d => d.programmingLanguage).sort()).toEqual(['Python', 'TypeScript']);
+
+    // HR has 1 manager
+    expect(teams[1].name).toBe('HR');
+    expect(teams[1].members).toHaveLength(1);
+    expect(teams[1].members[0]).toBeInstanceOf(TeamManager);
+
+    await orm.close();
+  });
+
+});
+
+describe('TPT with different primary key types', () => {
+
+  test('TPT with UUID primary key', async () => {
+    @Entity({ inheritance: 'tpt' })
+    abstract class UuidBase {
+
+      @PrimaryKey({ type: 'uuid' })
+      id: string = crypto.randomUUID();
+
+      @Property({ default: 'now()' })
+      createdAt?: Date = new Date();
+
+    }
+
+    @Entity()
+    class UuidUser extends UuidBase {
+
+      @Property()
+      username!: string;
+
+    }
+
+    @Entity()
+    class UuidAdmin extends UuidUser {
+
+      @Property()
+      adminLevel!: number;
+
+    }
+
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      dbName: ':memory:',
+      entities: [UuidBase, UuidUser, UuidAdmin],
+    });
+
+    await orm.schema.create();
+
+    const user = orm.em.create(UuidUser, { username: 'john' });
+    const admin = orm.em.create(UuidAdmin, { username: 'admin', adminLevel: 10 });
+    await orm.em.flush();
+
+    const userId = user.id;
+    const adminId = admin.id;
+
+    orm.em.clear();
+
+    // Query base class
+    const entities = await orm.em.find(UuidBase, {}, { orderBy: { createdAt: 'ASC' } });
+    expect(entities).toHaveLength(2);
+
+    // Query specific user
+    const loadedUser = await orm.em.findOneOrFail(UuidUser, userId);
+    expect(loadedUser.username).toBe('john');
+
+    // Query admin
+    const loadedAdmin = await orm.em.findOneOrFail(UuidAdmin, adminId);
+    expect(loadedAdmin.username).toBe('admin');
+    expect(loadedAdmin.adminLevel).toBe(10);
+
+    await orm.close();
+  });
+
+});
+
+describe('TPT edge cases', () => {
+
+  test('empty collection with TPT entities', async () => {
+    @Entity({ inheritance: 'tpt' })
+    abstract class Item {
+
+      @PrimaryKey()
+      id!: number;
+
+      @Property()
+      name!: string;
+
+    }
+
+    @Entity()
+    class PhysicalItem extends Item {
+
+      @Property()
+      weight!: number;
+
+    }
+
+    @Entity()
+    class Container {
+
+      @PrimaryKey()
+      id!: number;
+
+      @Property()
+      label!: string;
+
+      @OneToMany(() => ContainerItem, ci => ci.container)
+      items = new Collection<ContainerItem>(this);
+
+    }
+
+    @Entity()
+    class ContainerItem {
+
+      @PrimaryKey()
+      id!: number;
+
+      @ManyToOne(() => Container, { ref: true })
+      container!: Ref<Container>;
+
+      @ManyToOne(() => Item, { ref: true })
+      item!: Ref<Item>;
+
+    }
+
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      dbName: ':memory:',
+      entities: [Item, PhysicalItem, Container, ContainerItem],
+    });
+
+    await orm.schema.create();
+
+    // Create container without items
+    orm.em.create(Container, { label: 'Empty Box' });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const containers = await orm.em.find(Container, {}, { populate: ['items.item'] });
+
+    expect(containers).toHaveLength(1);
+    expect(containers[0].items).toHaveLength(0);
+
+    await orm.close();
+  });
+
+  test('null reference to TPT entity', async () => {
+    @Entity({ inheritance: 'tpt' })
+    abstract class Vehicle {
+
+      @PrimaryKey()
+      id!: number;
+
+      @Property()
+      brand!: string;
+
+    }
+
+    @Entity()
+    class Car extends Vehicle {
+
+      @Property()
+      model!: string;
+
+    }
+
+    @Entity()
+    class Driver {
+
+      @PrimaryKey()
+      id!: number;
+
+      @Property()
+      name!: string;
+
+      @ManyToOne(() => Vehicle, { ref: true, nullable: true })
+      vehicle?: Ref<Vehicle>;
+
+    }
+
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      dbName: ':memory:',
+      entities: [Vehicle, Car, Driver],
+    });
+
+    await orm.schema.create();
+
+    orm.em.create(Driver, { name: 'No Car Driver' });
+    const car = orm.em.create(Car, { brand: 'Toyota', model: 'Camry' });
+    orm.em.create(Driver, { name: 'Car Owner', vehicle: car });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const drivers = await orm.em.find(Driver, {}, {
+      populate: ['vehicle'],
+      orderBy: { name: 'ASC' },
+    });
+
+    expect(drivers).toHaveLength(2);
+    expect(drivers[0].name).toBe('Car Owner');
+    expect(drivers[0].vehicle?.unwrap()).toBeInstanceOf(Car);
+
+    expect(drivers[1].name).toBe('No Car Driver');
+    expect(drivers[1].vehicle).toBeNull();
+
+    await orm.close();
+  });
+
+  test('querying with orderBy on child property', async () => {
+    @Entity({ inheritance: 'tpt' })
+    abstract class Shape {
+
+      @PrimaryKey()
+      id!: number;
+
+      @Property()
+      color!: string;
+
+    }
+
+    @Entity()
+    class Rectangle extends Shape {
+
+      @Property()
+      width!: number;
+
+      @Property()
+      height!: number;
+
+    }
+
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      dbName: ':memory:',
+      entities: [Shape, Rectangle],
+    });
+
+    await orm.schema.create();
+
+    orm.em.create(Rectangle, { color: 'red', width: 10, height: 5 });
+    orm.em.create(Rectangle, { color: 'blue', width: 20, height: 10 });
+    orm.em.create(Rectangle, { color: 'green', width: 5, height: 15 });
+    await orm.em.flush();
+    orm.em.clear();
+
+    // Order by child property
+    const rectangles = await orm.em.find(Rectangle, {}, { orderBy: { width: 'ASC' } });
+
+    expect(rectangles).toHaveLength(3);
+    expect(rectangles[0].width).toBe(5);
+    expect(rectangles[1].width).toBe(10);
+    expect(rectangles[2].width).toBe(20);
+
+    await orm.close();
+  });
+
+  test('querying with WHERE on both parent and child properties', async () => {
+    @Entity({ inheritance: 'tpt' })
+    abstract class Appliance {
+
+      @PrimaryKey()
+      id!: number;
+
+      @Property()
+      brand!: string;
+
+      @Property()
+      powerWatts!: number;
+
+    }
+
+    @Entity()
+    class WashingMachine extends Appliance {
+
+      @Property()
+      capacityKg!: number;
+
+      @Property()
+      spinSpeed!: number;
+
+    }
+
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      dbName: ':memory:',
+      entities: [Appliance, WashingMachine],
+    });
+
+    await orm.schema.create();
+
+    orm.em.create(WashingMachine, { brand: 'Samsung', powerWatts: 2000, capacityKg: 8, spinSpeed: 1400 });
+    orm.em.create(WashingMachine, { brand: 'LG', powerWatts: 1800, capacityKg: 10, spinSpeed: 1200 });
+    orm.em.create(WashingMachine, { brand: 'Samsung', powerWatts: 1500, capacityKg: 6, spinSpeed: 1000 });
+    await orm.em.flush();
+    orm.em.clear();
+
+    // Query with conditions on both parent (brand) and child (capacityKg) properties
+    const machines = await orm.em.find(WashingMachine, {
+      brand: 'Samsung',
+      capacityKg: { $gte: 7 },
+    });
+
+    expect(machines).toHaveLength(1);
+    expect(machines[0].capacityKg).toBe(8);
+    expect(machines[0].spinSpeed).toBe(1400);
+
+    await orm.close();
+  });
+
+});
+
+describe('TPT additional coverage', () => {
+
+  test('TPT entity with nullable FK to non-TPT entity', async () => {
+    // Tests the findExtraUpdates non-entity check for TPT
+
+    @Entity()
+    class Department {
+
+      @PrimaryKey()
+      id!: number;
+
+      @Property()
+      name!: string;
+
+    }
+
+    @Entity({ inheritance: 'tpt' })
+    abstract class Worker {
+
+      @PrimaryKey()
+      id!: number;
+
+      @Property()
+      name!: string;
+
+      @ManyToOne(() => Department, { ref: true, nullable: true })
+      department?: Ref<Department>;
+
+    }
+
+    @Entity()
+    class Engineer extends Worker {
+
+      @Property()
+      specialty!: string;
+
+    }
+
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      dbName: ':memory:',
+      entities: [Department, Worker, Engineer],
+    });
+
+    await orm.schema.create();
+
+    // Create department and engineer in same flush
+    const dept = orm.em.create(Department, { name: 'R&D' });
+    const engineer = orm.em.create(Engineer, { name: 'Alice', specialty: 'Backend', department: dept });
+
+    await orm.em.flush();
+    orm.em.clear();
+
+    // Verify the relation
+    const loaded = await orm.em.findOneOrFail(Engineer, engineer.id, { populate: ['department'] });
+    expect(loaded.name).toBe('Alice');
+    expect(loaded.specialty).toBe('Backend');
+    expect(loaded.department?.unwrap().name).toBe('R&D');
+
+    await orm.close();
+  });
+
+  test('TPT update that only changes child table properties', async () => {
+    // Tests that UPDATE skips parent table when only child properties changed
+
+    @Entity({ inheritance: 'tpt' })
+    abstract class Shape {
+
+      @PrimaryKey()
+      id!: number;
+
+      @Property()
+      color!: string;
+
+    }
+
+    @Entity()
+    class Rectangle extends Shape {
+
+      @Property()
+      width!: number;
+
+      @Property()
+      height!: number;
+
+    }
+
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      dbName: ':memory:',
+      entities: [Shape, Rectangle],
+    });
+
+    await orm.schema.create();
+
+    const rect = orm.em.create(Rectangle, { color: 'red', width: 10, height: 20 });
+    await orm.em.flush();
+    const rectId = rect.id;
+    orm.em.clear();
+
+    // Load entity fresh before updating
+    const loaded = await orm.em.findOneOrFail(Rectangle, rectId);
+    const mock = mockLogger(orm, ['query']);
+
+    // Update only child property
+    loaded.width = 15;
+    await orm.em.flush();
+
+    // Should only update rectangle table, not shape table
+    const logs = mock.mock.calls.map(c => c[0]);
+    expect(logs.some((l: string) => l.includes('update `rectangle`'))).toBe(true);
+    expect(logs.some((l: string) => l.includes('update `shape`'))).toBe(false);
+
+    orm.em.clear();
+
+    // Verify the update
+    const verified = await orm.em.findOneOrFail(Rectangle, rectId);
+    expect(verified.width).toBe(15);
+    expect(verified.color).toBe('red');
+
+    await orm.close();
+  });
+
+  test('TPT update that changes both parent and child properties', async () => {
+    @Entity({ inheritance: 'tpt' })
+    abstract class Product {
+
+      @PrimaryKey()
+      id!: number;
+
+      @Property()
+      name!: string;
+
+      @Property()
+      price!: number;
+
+    }
+
+    @Entity()
+    class Book extends Product {
+
+      @Property()
+      isbn!: string;
+
+      @Property()
+      pages!: number;
+
+    }
+
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      dbName: ':memory:',
+      entities: [Product, Book],
+    });
+
+    await orm.schema.create();
+
+    const book = orm.em.create(Book, { name: 'Clean Code', price: 39.99, isbn: '978-0132350884', pages: 464 });
+    await orm.em.flush();
+    const bookId = book.id;
+    orm.em.clear();
+
+    // Load entity fresh before updating
+    const loaded = await orm.em.findOneOrFail(Book, bookId);
+    const mock = mockLogger(orm, ['query']);
+
+    // Update both parent and child properties
+    loaded.price = 29.99; // parent property
+    loaded.pages = 500;   // child property
+    await orm.em.flush();
+
+    // Should update both tables
+    const logs = mock.mock.calls.map(c => c[0]);
+    expect(logs.some((l: string) => l.includes('update `product`'))).toBe(true);
+    expect(logs.some((l: string) => l.includes('update `book`'))).toBe(true);
+
+    orm.em.clear();
+
+    const verified = await orm.em.findOneOrFail(Book, bookId);
+    expect(verified.price).toBe(29.99);
+    expect(verified.pages).toBe(500);
+
+    await orm.close();
+  });
+
+  test('TPT delete cascades properly', async () => {
+    @Entity({ inheritance: 'tpt' })
+    abstract class Document {
+
+      @PrimaryKey()
+      id!: number;
+
+      @Property()
+      title!: string;
+
+    }
+
+    @Entity()
+    class Report extends Document {
+
+      @Property()
+      author!: string;
+
+    }
+
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      dbName: ':memory:',
+      entities: [Document, Report],
+    });
+
+    await orm.schema.create();
+
+    const report = orm.em.create(Report, { title: 'Q1 Report', author: 'John' });
+    await orm.em.flush();
+
+    const reportId = report.id;
+
+    // Delete the entity
+    orm.em.remove(report);
+    await orm.em.flush();
+    orm.em.clear();
+
+    // Verify deletion
+    const loaded = await orm.em.findOne(Report, reportId);
+    expect(loaded).toBeNull();
+
+    // Verify parent table row is also deleted (via CASCADE)
+    const parentRow = await orm.em.findOne(Document, reportId);
+    expect(parentRow).toBeNull();
+
+    await orm.close();
+  });
+
+  test('non-abstract TPT root entity', async () => {
+    // Tests that non-abstract TPT roots get discriminator value
+
+    @Entity({ inheritance: 'tpt' })
+    class Creature {
+
+      @PrimaryKey()
+      id!: number;
+
+      @Property()
+      name!: string;
+
+    }
+
+    @Entity()
+    class Canine extends Creature {
+
+      @Property()
+      breed!: string;
+
+    }
+
+    @Entity()
+    class Feline extends Creature {
+
+      @Property()
+      indoor!: boolean;
+
+    }
+
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      dbName: ':memory:',
+      entities: [Creature, Canine, Feline],
+    });
+
+    await orm.schema.create();
+
+    // Create instances of all types including base class
+    const creature = orm.em.create(Creature, { name: 'Generic' });
+    const canine = orm.em.create(Canine, { name: 'Buddy', breed: 'Labrador' });
+    const feline = orm.em.create(Feline, { name: 'Whiskers', indoor: true });
+    await orm.em.flush();
+    orm.em.clear();
+
+    // Polymorphic query should return all types
+    const creatures = await orm.em.find(Creature, {}, { orderBy: { name: 'ASC' } });
+    expect(creatures).toHaveLength(3);
+
+    // Check types
+    expect(creatures[0].name).toBe('Buddy');
+    expect(creatures[0]).toBeInstanceOf(Canine);
+    expect((creatures[0] as Canine).breed).toBe('Labrador');
+
+    expect(creatures[1].name).toBe('Generic');
+    expect(creatures[1]).toBeInstanceOf(Creature);
+    expect(creatures[1]).not.toBeInstanceOf(Canine);
+    expect(creatures[1]).not.toBeInstanceOf(Feline);
+
+    expect(creatures[2].name).toBe('Whiskers');
+    expect(creatures[2]).toBeInstanceOf(Feline);
+    expect((creatures[2] as Feline).indoor).toBe(true);
+
+    await orm.close();
+  });
+
+  test('TPT polymorphic query with Date fields in child', async () => {
+    // Tests mapTPTChildFields with Date type handling
+
+    @Entity({ inheritance: 'tpt' })
+    abstract class Event {
+
+      @PrimaryKey()
+      id!: number;
+
+      @Property()
+      title!: string;
+
+    }
+
+    @Entity()
+    class Meeting extends Event {
+
+      @Property()
+      startTime!: Date;
+
+      @Property()
+      location!: string;
+
+    }
+
+    @Entity()
+    class Reminder extends Event {
+
+      @Property()
+      remindAt!: Date;
+
+    }
+
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      dbName: ':memory:',
+      entities: [Event, Meeting, Reminder],
+    });
+
+    await orm.schema.create();
+
+    const meetingDate = new Date('2024-01-15T10:00:00Z');
+    const reminderDate = new Date('2024-01-20T09:00:00Z');
+
+    orm.em.create(Meeting, { title: 'Team Sync', startTime: meetingDate, location: 'Room A' });
+    orm.em.create(Reminder, { title: 'Pay Bills', remindAt: reminderDate });
+    await orm.em.flush();
+    orm.em.clear();
+
+    // Polymorphic query should load Date fields correctly
+    const events = await orm.em.find(Event, {}, { orderBy: { title: 'ASC' } });
+    expect(events).toHaveLength(2);
+
+    const payBills = events[0] as Reminder;
+    expect(payBills.title).toBe('Pay Bills');
+    expect(payBills.remindAt).toBeInstanceOf(Date);
+
+    const teamSync = events[1] as Meeting;
+    expect(teamSync.title).toBe('Team Sync');
+    expect(teamSync.startTime).toBeInstanceOf(Date);
+    expect(teamSync.location).toBe('Room A');
+
+    await orm.close();
+  });
+
+});
+
+describe('TPT with advanced properties', () => {
+
+  test('TPT with formula referencing inherited property', async () => {
+    @Entity({ inheritance: 'tpt' })
+    abstract class FormulaDocument {
+
+      @PrimaryKey()
+      id!: number;
+
+      @Property({ type: 'string' })
+      firstName!: string;
+
+      @Property({ type: 'string' })
+      lastName!: string;
+
+    }
+
+    @Entity()
+    class FormulaEmployee extends FormulaDocument {
+
+      @Property({ type: 'string' })
+      department!: string;
+
+      // Formula that references inherited properties (firstName, lastName)
+      // Use the quote helper for proper identifier quoting
+      @Property({ type: 'string', persist: false, formula: cols => quote`${cols.firstName} || ' ' || ${cols.lastName}` })
+      fullName!: Opt<string>;
+
+    }
+
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      dbName: ':memory:',
+      entities: [FormulaDocument, FormulaEmployee],
+    });
+    await orm.schema.create();
+
+    const em = orm.em.fork();
+    const employee = em.create(FormulaEmployee, {
+      firstName: 'John',
+      lastName: 'Doe',
+      department: 'Engineering',
+    });
+    await em.flush();
+    em.clear();
+
+    // Load the entity - formula should resolve correctly
+    const mock = mockLogger(orm);
+    const loaded = await em.findOneOrFail(FormulaEmployee, employee.id);
+    expect(loaded.firstName).toBe('John');
+    expect(loaded.lastName).toBe('Doe');
+    expect(loaded.department).toBe('Engineering');
+    expect(loaded.fullName).toBe('John Doe');
+
+    // Verify the SQL uses the correct alias for the parent table
+    const query = mock.mock.calls[0][0];
+    // The formula should reference the parent table alias (f1), not the main table alias (f0)
+    // With quote helper, both alias and column are fully quoted (e.g., `f1`.`first_name` for SQLite)
+    expect(query).toMatch(/`f1`\.`first_name`/);
+    // Verify the formula is correct in the query (with quoted aliases and columns)
+    expect(query).toContain("`f1`.`first_name` || ' ' || `f1`.`last_name`");
+
+    await orm.close();
+  });
+
+  test('TPT with lazy property', async () => {
+    @Entity({ inheritance: 'tpt' })
+    abstract class LazyDocument {
+
+      @PrimaryKey()
+      id!: number;
+
+      @Property({ type: 'string' })
+      title!: string;
+
+    }
+
+    @Entity()
+    class LazyArticle extends LazyDocument {
+
+      @Property({ type: 'string', lazy: true })
+      content!: string;
+
+      @Property({ type: 'string' })
+      summary!: string;
+
+    }
+
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      dbName: ':memory:',
+      entities: [LazyDocument, LazyArticle],
+    });
+    await orm.schema.create();
+
+    const em = orm.em.fork();
+    const article = em.create(LazyArticle, {
+      title: 'Test Article',
+      content: 'This is the full content of the article...',
+      summary: 'A brief summary',
+    });
+    await em.flush();
+    em.clear();
+
+    // Load without lazy property
+    const mock = mockLogger(orm);
+    const loaded = await em.findOneOrFail(LazyArticle, article.id);
+    expect(loaded.title).toBe('Test Article');
+    expect(loaded.summary).toBe('A brief summary');
+    // Lazy property not loaded initially
+    expect(wrap(loaded).isInitialized()).toBe(true);
+
+    // Verify content wasn't in the query
+    expect(mock.mock.calls[0][0]).not.toContain('content');
+
+    // Now explicitly load the lazy property
+    em.clear();
+    const loadedWithContent = await em.findOneOrFail(LazyArticle, article.id, { populate: ['content'] });
+    expect(loadedWithContent.content).toBe('This is the full content of the article...');
+
+    await orm.close();
+  });
+
+  test('TPT with embedded property in child', async () => {
+    @Embeddable()
+    class Address {
+
+      @Property({ type: 'string' })
+      street!: string;
+
+      @Property({ type: 'string' })
+      city!: string;
+
+      @Property({ type: 'string' })
+      zipCode!: string;
+
+    }
+
+    @Entity({ inheritance: 'tpt' })
+    abstract class Person {
+
+      @PrimaryKey()
+      id!: number;
+
+      @Property({ type: 'string' })
+      name!: string;
+
+    }
+
+    @Entity()
+    class Customer extends Person {
+
+      @Embedded(() => Address)
+      address!: Address;
+
+    }
+
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      dbName: ':memory:',
+      entities: [Person, Customer, Address],
+    });
+    await orm.schema.create();
+
+    const em = orm.em.fork();
+    const customer = em.create(Customer, {
+      name: 'John Doe',
+      address: { street: '123 Main St', city: 'Springfield', zipCode: '12345' },
+    });
+    await em.flush();
+    em.clear();
+
+    const loaded = await em.findOneOrFail(Customer, customer.id);
+    expect(loaded.name).toBe('John Doe');
+    expect(loaded.address.street).toBe('123 Main St');
+    expect(loaded.address.city).toBe('Springfield');
+    expect(loaded.address.zipCode).toBe('12345');
+
+    await orm.close();
+  });
+
+  test('TPT with custom type', async () => {
+    class PointType extends Type<{ x: number; y: number }, string> {
+
+      convertToDatabaseValue(value: { x: number; y: number }): string {
+        return `${value.x},${value.y}`;
+      }
+
+      convertToJSValue(value: string): { x: number; y: number } {
+        const [x, y] = value.split(',').map(Number);
+        return { x, y };
+      }
+
+      getColumnType(): string {
+        return 'text';
+      }
+
+    }
+
+    @Entity({ inheritance: 'tpt' })
+    abstract class CustomTypeShape {
+
+      @PrimaryKey()
+      id!: number;
+
+      @Property({ type: 'string' })
+      name!: string;
+
+    }
+
+    @Entity()
+    class CustomTypeCircle extends CustomTypeShape {
+
+      @Property({ type: PointType })
+      center!: { x: number; y: number };
+
+      @Property({ type: 'number' })
+      radius!: number;
+
+    }
+
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      dbName: ':memory:',
+      entities: [CustomTypeShape, CustomTypeCircle],
+    });
+    await orm.schema.create();
+
+    const em = orm.em.fork();
+    const circle = em.create(CustomTypeCircle, {
+      name: 'My Circle',
+      center: { x: 10, y: 20 },
+      radius: 5,
+    });
+    await em.flush();
+    em.clear();
+
+    const loaded = await em.findOneOrFail(CustomTypeCircle, circle.id);
+    expect(loaded.name).toBe('My Circle');
+    expect(loaded.center).toEqual({ x: 10, y: 20 });
+    expect(loaded.radius).toBe(5);
+
+    await orm.close();
+  });
+
+  test('TPT with default values in child', async () => {
+    @Entity({ inheritance: 'tpt' })
+    abstract class Notification {
+
+      @PrimaryKey()
+      id!: number;
+
+      @Property({ type: 'string' })
+      message!: string;
+
+      @Property({ type: 'boolean', default: false })
+      read: boolean & Opt = false;
+
+    }
+
+    @Entity()
+    class EmailNotification extends Notification {
+
+      @Property({ type: 'string' })
+      emailAddress!: string;
+
+      @Property({ type: 'string', default: 'low' })
+      priority: string & Opt = 'low';
+
+    }
+
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      dbName: ':memory:',
+      entities: [Notification, EmailNotification],
+    });
+    await orm.schema.create();
+
+    const em = orm.em.fork();
+    const notification = em.create(EmailNotification, {
+      message: 'Hello',
+      emailAddress: 'test@example.com',
+    });
+    await em.flush();
+    em.clear();
+
+    const loaded = await em.findOneOrFail(EmailNotification, notification.id);
+    expect(loaded.message).toBe('Hello');
+    expect(loaded.read).toBe(false);
+    expect(loaded.emailAddress).toBe('test@example.com');
+    expect(loaded.priority).toBe('low');
+
+    // Test with custom values
+    em.clear();
+    const notification2 = em.create(EmailNotification, {
+      message: 'Urgent',
+      emailAddress: 'urgent@example.com',
+      read: true,
+      priority: 'high',
+    });
+    await em.flush();
+    em.clear();
+
+    const loaded2 = await em.findOneOrFail(EmailNotification, notification2.id);
+    expect(loaded2.read).toBe(true);
+    expect(loaded2.priority).toBe('high');
+
+    await orm.close();
+  });
+
+  test('TPT with onCreate and onUpdate hooks', async () => {
+    @Entity({ inheritance: 'tpt' })
+    abstract class AuditedEntity {
+
+      @PrimaryKey()
+      id!: number;
+
+      @Property({ type: 'Date', onCreate: () => new Date() })
+      createdAt!: Date & Opt;
+
+      @Property({ type: 'Date', onCreate: () => new Date(), onUpdate: () => new Date() })
+      updatedAt!: Date & Opt;
+
+    }
+
+    @Entity()
+    class AuditedPost extends AuditedEntity {
+
+      @Property({ type: 'string' })
+      title!: string;
+
+    }
+
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      dbName: ':memory:',
+      entities: [AuditedEntity, AuditedPost],
+    });
+    await orm.schema.create();
+
+    const em = orm.em.fork();
+    const post = em.create(AuditedPost, { title: 'Test Post' });
+    await em.flush();
+
+    expect(post.createdAt).toBeInstanceOf(Date);
+    expect(post.updatedAt).toBeInstanceOf(Date);
+    const originalUpdatedAt = post.updatedAt;
+
+    // Wait a bit and update
+    await new Promise(resolve => setTimeout(resolve, 10));
+    post.title = 'Updated Post';
+    await em.flush();
+
+    expect(post.updatedAt.getTime()).toBeGreaterThan(originalUpdatedAt.getTime());
+
+    em.clear();
+    const loaded = await em.findOneOrFail(AuditedPost, post.id);
+    expect(loaded.title).toBe('Updated Post');
+    expect(loaded.createdAt).toBeInstanceOf(Date);
+    expect(loaded.updatedAt).toBeInstanceOf(Date);
+
+    await orm.close();
+  });
+
+});
+
+describe('TPT with composite primary key', () => {
+
+  test('TPT with composite PK inserts and queries correctly', async () => {
+    @Entity({ inheritance: 'tpt' })
+    abstract class CompositeBase {
+
+      @PrimaryKey()
+      tenantId!: number;
+
+      @PrimaryKey()
+      localId!: number;
+
+      @Property()
+      name!: string;
+
+    }
+
+    @Entity()
+    class CompositeChild extends CompositeBase {
+
+      @Property()
+      childData!: string;
+
+    }
+
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      dbName: ':memory:',
+      entities: [CompositeBase, CompositeChild],
+    });
+
+    await orm.schema.create();
+
+    // Verify schema has FK on composite PK
+    const sql = await orm.schema.getCreateSchemaSQL();
+    expect(sql).toMatch(/composite_child.*references.*composite_base/is);
+
+    const entity = orm.em.create(CompositeChild, { tenantId: 1, localId: 100, name: 'Test', childData: 'data' });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const loaded = await orm.em.findOneOrFail(CompositeChild, { tenantId: 1, localId: 100 });
+    expect(loaded.name).toBe('Test');
+    expect(loaded.childData).toBe('data');
+
+    // Update
+    loaded.childData = 'updated';
+    await orm.em.flush();
+    orm.em.clear();
+
+    const reloaded = await orm.em.findOneOrFail(CompositeChild, { tenantId: 1, localId: 100 });
+    expect(reloaded.childData).toBe('updated');
+
+    await orm.close();
+  });
+
+});
+
+describe('TPT with filters', () => {
+
+  test('filter on inherited property works with TPT', async () => {
+    @Entity({
+      inheritance: 'tpt',
+    })
+    abstract class FilterBase {
+
+      @PrimaryKey()
+      id!: number;
+
+      @Property()
+      name!: string;
+
+      @Property({ default: true })
+      active: boolean & Opt = true;
+
+    }
+
+    @Entity()
+    class FilterChild extends FilterBase {
+
+      @Property()
+      childProp!: string;
+
+    }
+
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      dbName: ':memory:',
+      entities: [FilterBase, FilterChild],
+    });
+
+    await orm.schema.create();
+
+    orm.em.create(FilterChild, { name: 'Active', childProp: 'a', active: true });
+    orm.em.create(FilterChild, { name: 'Inactive', childProp: 'b', active: false });
+    await orm.em.flush();
+    orm.em.clear();
+
+    // Query with WHERE on inherited property (simulates what a filter would produce)
+    const active = await orm.em.find(FilterChild, { active: true });
+    expect(active).toHaveLength(1);
+    expect(active[0].name).toBe('Active');
+
+    // Without filter, should return all
+    const all = await orm.em.find(FilterChild, {});
+    expect(all).toHaveLength(2);
+
+    await orm.close();
+  });
+
+});
+
+describe('TPT concurrent flush', () => {
+
+  test('two TPT entities referencing each other in same flush', async () => {
+    @Entity()
+    class Tag {
+
+      @PrimaryKey()
+      id!: number;
+
+      @Property()
+      label!: string;
+
+    }
+
+    @Entity({ inheritance: 'tpt' })
+    abstract class Node {
+
+      @PrimaryKey()
+      id!: number;
+
+      @Property()
+      title!: string;
+
+    }
+
+    @Entity()
+    class LeafNode extends Node {
+
+      @Property()
+      content!: string;
+
+      @ManyToOne(() => Tag, { ref: true, nullable: true })
+      tag?: Ref<Tag>;
+
+    }
+
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      dbName: ':memory:',
+      entities: [Tag, Node, LeafNode],
+    });
+
+    await orm.schema.create();
+
+    // Create both tag and leaf in same flush
+    const tag = orm.em.create(Tag, { label: 'Important' });
+    const leaf = orm.em.create(LeafNode, { title: 'Note', content: 'text', tag });
+    await orm.em.flush();
+
+    expect(tag.id).toBeDefined();
+    expect(leaf.id).toBeDefined();
+
+    orm.em.clear();
+
+    const loaded = await orm.em.findOneOrFail(LeafNode, leaf.id, { populate: ['tag'] });
+    expect(loaded.title).toBe('Note');
+    expect(loaded.content).toBe('text');
+    expect(loaded.tag?.unwrap().label).toBe('Important');
+
+    await orm.close();
+  });
+
+});
+
+test('createColumnMappingObject warns when accessing old FormulaTable properties', async () => {
+  const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => void 0);
+
+  const testOrm = await MikroORM.init({
+    dbName: ':memory:',
+    entities: [Integration, FooIntegration, BarIntegration],
+    metadataProvider: ReflectMetadataProvider,
+  });
+
+  const meta = testOrm.getMetadata().get(FooIntegration);
+  const columns = meta.createColumnMappingObject('e0');
+
+  // Accessing normal property should NOT warn
+  expect(columns.fooData).toBe('e0.foo_data');
+  expect(warnSpy).not.toHaveBeenCalled();
+
+  // Accessing `.alias` (FormulaTable-only property) should warn
+  expect((columns as any).alias).toBeUndefined();
+  expect(warnSpy).toHaveBeenCalledTimes(1);
+  expect(warnSpy.mock.calls[0][0]).toMatch(/old formula callback signature/);
+
+  // Accessing `.qualifiedName` should also warn
+  warnSpy.mockClear();
+  expect((columns as any).qualifiedName).toBeUndefined();
+  expect(warnSpy).toHaveBeenCalledTimes(1);
+
+  warnSpy.mockRestore();
+  await testOrm.close();
+});
+
+describe('TPT MongoDB validation', () => {
+
+  test('MongoPlatform rejects TPT inheritance', async () => {
+    const { MongoPlatform } = await import('@mikro-orm/mongodb');
+    const platform = new MongoPlatform();
+    const meta = { className: 'TestEntity', inheritanceType: 'tpt' } as any;
+
+    expect(() => platform.validateMetadata(meta)).toThrow(/TPT.*not supported by the current driver/);
+  });
+
+});
+
+describe('TPT delete operations', () => {
+
+  test('em.remove() on 3-level entity only issues DELETE for leaf table', async () => {
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      dbName: ':memory:',
+      entities: [Integration, FooIntegration, BarIntegration, BazIntegration],
+    });
+    await orm.schema.create();
+
+    const baz = orm.em.create(BazIntegration, {
+      name: 'Baz',
+      barData: 'bar',
+      bazData: 'baz',
+    });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const loaded = await orm.em.findOneOrFail(BazIntegration, baz.id);
+    const mock = mockLogger(orm);
+    orm.em.remove(loaded);
+    await orm.em.flush();
+
+    // Only one DELETE statement should be issued - the DB cascade handles the rest
+    const deletes = mock.mock.calls.map(c => c[0]).filter((l: string) => l.includes('delete from'));
+    expect(deletes).toHaveLength(1);
+    expect(deletes[0]).toContain('`integration`');
+
+    await orm.close();
+  });
+
+  test('cascade delete through 3+ levels when deleting root', async () => {
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      dbName: ':memory:',
+      entities: [Integration, FooIntegration, BarIntegration, BazIntegration],
+    });
+    await orm.schema.create();
+
+    // Create a foo and a baz (3-level)
+    const foo = orm.em.create(FooIntegration, { name: 'Foo', fooData: 'fd' });
+    const baz = orm.em.create(BazIntegration, { name: 'Baz', barData: 'bd', bazData: 'bzd' });
+    await orm.em.flush();
+    orm.em.clear();
+
+    // Delete foo directly - should cascade from integration table
+    const loadedFoo = await orm.em.findOneOrFail(FooIntegration, foo.id);
+    orm.em.remove(loadedFoo);
+    await orm.em.flush();
+
+    // Verify foo is fully deleted (both tables)
+    expect(await orm.em.count(Integration, { id: foo.id })).toBe(0);
+
+    orm.em.clear();
+
+    // Baz should still exist
+    const loadedBaz = await orm.em.findOneOrFail(BazIntegration, baz.id);
+    expect(loadedBaz.bazData).toBe('bzd');
+
+    // Now delete baz - should cascade through bar_integration and integration
+    orm.em.remove(loadedBaz);
+    await orm.em.flush();
+
+    expect(await orm.em.count(Integration, { id: baz.id })).toBe(0);
+
+    await orm.close();
+  });
+
+});
+
+describe('TPT QueryBuilder update/delete', () => {
+
+  test('qb.update() on child entity targets correct table', async () => {
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      dbName: ':memory:',
+      entities: [Integration, FooIntegration, BarIntegration, BazIntegration],
+    });
+    await orm.schema.create();
+
+    const foo = orm.em.create(FooIntegration, { name: 'Foo', fooData: 'original' });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const mock = mockLogger(orm);
+    await orm.em.createQueryBuilder(FooIntegration).update({ fooData: 'updated' }).where({ id: foo.id }).execute();
+
+    const logs = mock.mock.calls.map(c => c[0]);
+    expect(logs.some((l: string) => l.includes('update `foo_integration`'))).toBe(true);
+
+    orm.em.clear();
+    const loaded = await orm.em.findOneOrFail(FooIntegration, foo.id);
+    expect(loaded.fooData).toBe('updated');
+
+    await orm.close();
+  });
+
+  test('qb.delete() on child entity targets correct table', async () => {
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      dbName: ':memory:',
+      entities: [Integration, FooIntegration, BarIntegration, BazIntegration],
+    });
+    await orm.schema.create();
+
+    const foo = orm.em.create(FooIntegration, { name: 'Foo', fooData: 'data' });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const mock = mockLogger(orm);
+    await orm.em.createQueryBuilder(FooIntegration).delete().where({ id: foo.id }).execute();
+
+    const logs = mock.mock.calls.map(c => c[0]);
+    expect(logs.some((l: string) => l.includes('delete from `foo_integration`'))).toBe(true);
+
+    await orm.close();
+  });
+
+});

--- a/tests/features/view-entities/view-entities.postgres.test.ts
+++ b/tests/features/view-entities/view-entities.postgres.test.ts
@@ -62,10 +62,10 @@ class BookPriceView {
   @Property({ type: 'decimal', precision: 8, scale: 2 })
   price!: string;
 
-  @Formula(alias => `${alias}.price * 1.19`)
+  @Formula(cols => `${cols.price} * 1.19`)
   priceTaxed!: string;
 
-  @Formula(alias => `upper(${alias}.title)`)
+  @Formula(cols => `upper(${cols.title})`)
   titleUpper!: string;
 
 }
@@ -150,9 +150,9 @@ const AuthorWithComputedFields = defineEntity({
     name: p.string(),
     email: p.string(),
     age: p.integer().nullable(),
-    // Formula computed from view columns
-    displayName: p.string().formula(alias => `${alias}.name || ' <' || ${alias}.email || '>'`),
-    isAdult: p.boolean().formula(alias => `${alias}.age >= 18`),
+    // Formula computed from view columns - cols contains fully-qualified alias.fieldName
+    displayName: p.string().formula(cols => `${cols.name} || ' <' || ${cols.email} || '>'`),
+    isAdult: p.boolean().formula(cols => `${cols.age} >= 18`),
   },
 });
 

--- a/tests/features/wilcardSchemaIndex/wilcardSchemaIndex.mariadb.test.ts
+++ b/tests/features/wilcardSchemaIndex/wilcardSchemaIndex.mariadb.test.ts
@@ -9,9 +9,9 @@ const schema1 = `library1`;
 const schema2 = `library2`;
 
 @Entity({ tableName: 'author', schema: '*' })
-@Index({ name: 'custom_idx_on_name', expression: (table, columns) => `create index custom_idx_on_name on \`${table.schema}\`.\`${table.name}\` (\`${columns.name}\`)` })
-@Index({ name: 'custom_idx_on_country', expression: (table, columns) => quote`create index ${'custom_idx_on_country'} on ${table} (${columns.country})` })
-@Unique({ name: 'custom_unique_on_email', expression: (table, columns) => raw(`alter table ?? add constraint ?? unique (??)`, [table, 'custom_unique_on_email', columns.email]) })
+@Index({ name: 'custom_idx_on_name', expression: (columns, table) => `create index custom_idx_on_name on \`${table.schema}\`.\`${table.name}\` (\`${columns.name}\`)` })
+@Index({ name: 'custom_idx_on_country', expression: (columns, table) => quote`create index ${'custom_idx_on_country'} on ${table} (${columns.country})` })
+@Unique({ name: 'custom_unique_on_email', expression: (columns, table) => raw(`alter table ?? add constraint ?? unique (??)`, [table, 'custom_unique_on_email', columns.email]) })
 export class Author {
 
   @PrimaryKey()
@@ -35,7 +35,7 @@ export class Author {
 }
 
 @Entity({ tableName: 'author2' })
-@Index({ name: 'custom_idx_on_name', expression: (table, columns) => `create index custom_idx_on_name on \`${table}\` (\`${columns.name}\`)` })
+@Index({ name: 'custom_idx_on_name', expression: (columns, table) => `create index custom_idx_on_name on \`${table}\` (\`${columns.name}\`)` })
 export class Author2 {
 
   @PrimaryKey()

--- a/tests/features/wilcardSchemaIndex/wilcardSchemaIndex.mssql.test.ts
+++ b/tests/features/wilcardSchemaIndex/wilcardSchemaIndex.mssql.test.ts
@@ -9,9 +9,9 @@ const schema1 = `library1`;
 const schema2 = `library2`;
 
 @Entity({ tableName: 'author', schema: '*' })
-@Index({ name: 'custom_idx_on_name', expression: (table, columns) => `create index custom_idx_on_name on [${table.schema}].[${table.name}] ([${columns.name}])` })
-@Index({ name: 'custom_idx_on_country', expression: (table, columns) => quote`create index ${'custom_idx_on_country'} on ${table} (${columns.country})` })
-@Unique({ name: 'custom_unique_on_email', expression: (table, columns) => raw(`create unique index ?? on ?? (??) where ?? is not null`, ['custom_unique_on_email', table, columns.email, columns.email]) })
+@Index({ name: 'custom_idx_on_name', expression: (columns, table) => `create index custom_idx_on_name on [${table.schema}].[${table.name}] ([${columns.name}])` })
+@Index({ name: 'custom_idx_on_country', expression: (columns, table) => quote`create index ${'custom_idx_on_country'} on ${table} (${columns.country})` })
+@Unique({ name: 'custom_unique_on_email', expression: (columns, table) => raw(`create unique index ?? on ?? (??) where ?? is not null`, ['custom_unique_on_email', table, columns.email, columns.email]) })
 export class Author {
 
   @PrimaryKey()
@@ -35,7 +35,7 @@ export class Author {
 }
 
 @Entity({ tableName: 'author2' })
-@Index({ name: 'custom_idx_on_name', expression: (table, columns) => `create index custom_idx_on_name on [${table}] ([${columns.name}])` })
+@Index({ name: 'custom_idx_on_name', expression: (columns, table) => `create index custom_idx_on_name on [${table}] ([${columns.name}])` })
 export class Author2 {
 
   @PrimaryKey()

--- a/tests/features/wilcardSchemaIndex/wilcardSchemaIndex.mysql.test.ts
+++ b/tests/features/wilcardSchemaIndex/wilcardSchemaIndex.mysql.test.ts
@@ -9,9 +9,9 @@ const schema1 = `library1`;
 const schema2 = `library2`;
 
 @Entity({ tableName: 'author', schema: '*' })
-@Index({ name: 'custom_idx_on_name', expression: (table, columns, name) => `create index ${name} on \`${table.schema}\`.\`${table.name}\` (\`${columns.name}\`)` })
-@Index({ name: 'custom_idx_on_country', expression: (table, columns, name) => quote`create index ${name} on ${table} (${columns.country})` })
-@Unique({ name: 'custom_unique_on_email', expression: (table, columns, name) => raw(`alter table ?? add constraint ?? unique (??)`, [table, name, columns.email]) })
+@Index({ name: 'custom_idx_on_name', expression: (columns, table, name) => `create index ${name} on \`${table.schema}\`.\`${table.name}\` (\`${columns.name}\`)` })
+@Index({ name: 'custom_idx_on_country', expression: (columns, table, name) => quote`create index ${name} on ${table} (${columns.country})` })
+@Unique({ name: 'custom_unique_on_email', expression: (columns, table, name) => raw(`alter table ?? add constraint ?? unique (??)`, [table, name, columns.email]) })
 export class Author {
 
   @PrimaryKey()
@@ -35,7 +35,7 @@ export class Author {
 }
 
 @Entity({ tableName: 'author2' })
-@Index({ name: 'custom_idx_on_name', expression: (table, columns) => `create index custom_idx_on_name on \`${table}\` (\`${columns.name}\`)` })
+@Index({ name: 'custom_idx_on_name', expression: (columns, table) => `create index custom_idx_on_name on \`${table}\` (\`${columns.name}\`)` })
 export class Author2 {
 
   @PrimaryKey()

--- a/tests/features/wilcardSchemaIndex/wilcardSchemaIndex.postgres.test.ts
+++ b/tests/features/wilcardSchemaIndex/wilcardSchemaIndex.postgres.test.ts
@@ -9,9 +9,9 @@ const schema1 = `library1`;
 const schema2 = `library2`;
 
 @Entity({ tableName: 'author', schema: '*' })
-@Index({ name: 'custom_idx_on_name', expression: (table, columns) => `create index custom_idx_on_name on "${table.schema}"."${table.name}" ("${columns.name}")` })
-@Index({ name: 'custom_idx_on_country', expression: (table, columns) => quote`create index ${'custom_idx_on_country'} on ${table} (${columns.country})` })
-@Unique({ name: 'custom_unique_on_email', expression: (table, columns) => raw(`alter table ?? add constraint ?? unique (??)`, [table, 'custom_unique_on_email', columns.email]) })
+@Index({ name: 'custom_idx_on_name', expression: (columns, table) => `create index custom_idx_on_name on "${table.schema}"."${table.name}" ("${columns.name}")` })
+@Index({ name: 'custom_idx_on_country', expression: (columns, table) => quote`create index ${'custom_idx_on_country'} on ${table} (${columns.country})` })
+@Unique({ name: 'custom_unique_on_email', expression: (columns, table) => raw(`alter table ?? add constraint ?? unique (??)`, [table, 'custom_unique_on_email', columns.email]) })
 export class Author {
 
   @PrimaryKey()
@@ -35,7 +35,7 @@ export class Author {
 }
 
 @Entity({ tableName: 'author2' })
-@Index({ name: 'custom_idx_on_name', expression: (table, columns) => `create index custom_idx_on_name on "${table}" ("${columns.name}")` })
+@Index({ name: 'custom_idx_on_name', expression: (columns, table) => `create index custom_idx_on_name on "${table}" ("${columns.name}")` })
 export class Author2 {
 
   @PrimaryKey()

--- a/tests/issues/GH4759.test.ts
+++ b/tests/issues/GH4759.test.ts
@@ -29,7 +29,7 @@ class Author {
   @OneToOne({
     entity: () => Book,
     ref: true,
-    formula: alias =>
+    formula: (cols, alias) =>
       `(select "b"."id"
       from (
         select "b"."author_id", min("b"."release_date") "release_date"

--- a/tests/issues/GH5705.test.ts
+++ b/tests/issues/GH5705.test.ts
@@ -14,7 +14,7 @@ class User {
     entity: () => Rating,
     ref: true,
     nullable: true,
-    formula: tableAlias => {
+    formula: (cols, tableAlias) => {
       return `(select rating.id
               from rating
               where rating.user_id = ${tableAlias}.id

--- a/tests/issues/GH6558.test.ts
+++ b/tests/issues/GH6558.test.ts
@@ -15,8 +15,7 @@ const Employee = defineEntity({
     id: p.uuid().primary().onCreate(() => uuidv4()),
     surname: p.string(),
     name: p.string(),
-    // label: p.string().formula(alias => `${alias}.surname ||' '|| ${alias}.name`), // FIXME this should work too
-    label: p.string().persist(false).formula(alias => `${alias}.surname ||' '|| ${alias}.name`),
+    label: p.string().formula(cols => `${cols.surname} ||' '|| ${cols.name}`),
     boss: () => p.manyToOne(Employee).deleteRule('set null').updateRule('no action'),
   },
 });

--- a/tests/issues/GH7102.test.ts
+++ b/tests/issues/GH7102.test.ts
@@ -1,5 +1,6 @@
-import { MikroORM } from '@mikro-orm/postgresql';
-import { Entity, Formula, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+import { Collection, MikroORM, Opt, OptionalProps, quote, Ref } from '@mikro-orm/postgresql';
+import { Check, Entity, Formula, ManyToOne, OneToMany, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+import { vi } from 'vitest';
 
 @Entity({ schema: '*' })
 class User {
@@ -14,14 +15,87 @@ class User {
   email!: string;
 
   @Formula(
-    table => `(select ${table.schema}.user.id from ${table.schema}.user where ${table.alias}.id = 1)`,
+    (_cols, table) => `(select ${table.schema}.user.id from ${table.schema}.user where ${table.alias}.id = 1)`,
     { lazy: true },
   )
   baz?: string;
 
+  @Formula(
+    (cols, table) => quote`(select ${cols.id} from ${table.qualifiedName} where ${cols.id} = 1)`,
+    { lazy: true },
+  )
+  baz2?: string;
+
+}
+
+// Entities for testing formula with quote in joins
+@Entity()
+class Author7102 {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @OneToMany(() => Book7102, book => book.author)
+  books = new Collection<Book7102>(this);
+
+}
+
+@Entity()
+class Book7102 {
+
+  [OptionalProps]?: 'priceTaxed';
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  title!: string;
+
+  @Property({ type: 'decimal', precision: 8, scale: 2 })
+  price!: string;
+
+  // Non-lazy formula with quote helper - uses table.toString() to cover that code path
+  @Formula((cols, table) => quote`${cols.price} * 1.19 /* ${table} */`)
+  priceTaxed?: string;
+
+  // Lazy formula that uses table.toString() to cover buildFields code path (line 2009)
+  @Formula((cols, table) => quote`${cols.price} * 1.21 /* ${table} */`, { lazy: true })
+  priceTaxedLazy?: string;
+
+  @ManyToOne(() => Author7102, { ref: true })
+  author!: Ref<Author7102>;
+
+}
+
+// Entities for testing generated column with quote helper
+// Check constraint uses table.toString() to cover that code path in MetadataDiscovery
+@Entity()
+@Check({ expression: (cols, table) => `${cols.firstName} is not null /* ${table} */` })
+class Product7102 {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  firstName!: string;
+
+  @Property()
+  lastName!: string;
+
+  // Generated column with quote helper returning Raw - uses table.toString() to cover that code path
+  @Property({
+    length: 100,
+    generated: (cols, table) => quote`(${cols.firstName} || ' ' || ${cols.lastName} || ' from ' || '${table}') stored`,
+  })
+  fullName!: Opt<string>;
+
 }
 
 let orm: MikroORM;
+let orm2: MikroORM;
 
 beforeAll(async () => {
   orm = await MikroORM.init({
@@ -29,18 +103,89 @@ beforeAll(async () => {
     dbName: 'mikro_orm_test_gh_7102',
     entities: [User],
   });
+  orm2 = await MikroORM.init({
+    metadataProvider: ReflectMetadataProvider,
+    dbName: 'mikro_orm_test_gh_7102_2',
+    entities: [Author7102, Book7102, Product7102],
+  });
 });
 
 afterAll(async () => {
   await orm.close(true);
+  await orm2.close(true);
 });
 
 test('formula should support a schema parameter', async () => {
   const em = orm.em.fork({ schema: 'theSpecificSchema' });
-  const qb = em.createQueryBuilder(User).select(['name', 'baz']);
+  const qb = em.createQueryBuilder(User).select(['name', 'baz', 'baz2']);
   const sql = qb.getFormattedQuery();
 
   // Schema should be present in the formula (not undefined)
   expect(sql).not.toContain('undefined');
   expect(sql).toContain('theSpecificSchema.user.id');
+  expect(sql).toContain('select "u0"."id" from "theSpecificSchema"."user" where "u0"."id" = 1');
+});
+
+test('formula with quote helper should work with joins', async () => {
+  const qb = orm2.em.createQueryBuilder(Author7102)
+    .select('*')
+    .leftJoinAndSelect('books', 'b');
+  const sql = qb.getFormattedQuery();
+
+  // Formula should be properly quoted (priceTaxed formula)
+  expect(sql).toContain('"b"."price" * 1.19');
+});
+
+test('formula with quote helper should work when querying directly', async () => {
+  const qb = orm2.em.createQueryBuilder(Book7102).select('*');
+  const sql = qb.getFormattedQuery();
+
+  // Formula should use quoted column reference
+  expect(sql).toContain('"b0"."price" * 1.19');
+});
+
+test('generated column with quote helper should produce correct schema', async () => {
+  const createSQL = await orm2.schema.getCreateSchemaSQL({ wrap: false });
+
+  // Generated column SQL should have properly quoted identifiers and include table name from toString()
+  // The quote helper quotes the table name as an identifier
+  expect(createSQL).toContain('"first_name" || \' \' || "last_name" || \' from \' || \'"product7102"\'');
+});
+
+test('formula with quote helper should work with em.find (buildFields path)', async () => {
+  // This tests AbstractSqlDriver.buildFields which processes lazy formulas
+  // Lazy formulas trigger the addFormulas code path in buildFields (line 2009)
+  const mock = vi.fn();
+  const em = orm2.em.fork();
+  em.getConnection().execute = mock;
+
+  try {
+    // Request the lazy formula field to trigger buildFields formula processing
+    await em.find(Book7102, {}, { populate: ['priceTaxedLazy'] });
+  } catch {
+    // Expected to fail since we mock execute, but we just need to check the SQL
+  }
+
+  expect(mock).toHaveBeenCalled();
+  const sql = mock.mock.calls[0][0];
+  // Lazy formula should be properly quoted in the SQL and include table.toString() result
+  expect(sql).toContain('"b0"."price" * 1.21');
+});
+
+test('formula with quote helper should work with em.find and joined strategy (mapPropToFieldNames path)', async () => {
+  // This tests AbstractSqlDriver.mapPropToFieldNames which processes formulas during joined loading
+  const mock = vi.fn();
+  const em = orm2.em.fork();
+  em.getConnection().execute = mock;
+
+  try {
+    await em.find(Author7102, {}, { populate: ['books'], strategy: 'joined' });
+  } catch {
+    // Expected to fail since we mock execute, but we just need to check the SQL
+  }
+
+  expect(mock).toHaveBeenCalled();
+  const sql = mock.mock.calls[0][0];
+  // Formula should be properly quoted in the SQL for joined loading
+  expect(sql).toContain('"price" * 1.19');
 });

--- a/tests/issues/GHx18.test.ts
+++ b/tests/issues/GHx18.test.ts
@@ -33,7 +33,7 @@ class Article {
   images = new Collection<Image>(this);
 
   @OneToOne(() => Image, {
-    formula: alias => {
+    formula: (cols, alias) => {
       return `(select i.id from image i where i.type = '${ImageType.COVER}' and i.article_id = ${alias}.id)`;
     },
     ref: true,
@@ -42,7 +42,7 @@ class Article {
   cover?: Ref<Image>;
 
   @OneToOne(() => Image, {
-    formula: alias => {
+    formula: (cols, alias) => {
       return `(select i.id from image i where i.type = '${ImageType.THUMBNAIL}' and i.article_id = ${alias}.id)`;
     },
     nullable: true,
@@ -50,7 +50,7 @@ class Article {
   thumbnail?: Image;
 
   @OneToOne(() => Image, {
-    formula: alias => {
+    formula: (cols, alias) => {
       return `(select i.id from image i where i.type = '${ImageType.ICON}' and i.article_id = ${alias}.id)`;
     },
     nullable: true,


### PR DESCRIPTION
Implements Table-Per-Type inheritance strategy where each entity in an inheritance hierarchy gets its own dedicated table. Child tables have a FK to parent table using the same PK value.

```ts
@Entity({ inheritance: 'tpt' })
abstract class Integration { ... }

@Entity()
class FooIntegration extends Integration { ... }
```

Closes #1575