### PR TITLE
feat(core): support pre-compiled functions for eval-free runtimes

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -429,6 +429,30 @@ MikroORM.init({
 });
 ```
 
+## Pre-compiled Functions
+
+MikroORM uses `new Function()` at runtime to generate optimized hydration, comparison, and serialization functions. Some runtimes (e.g. Cloudflare Workers) prohibit this. You can pre-compile these functions ahead of time using the CLI:
+
+```bash
+npx mikro-orm compile
+```
+
+This generates a `compiled-functions.js` file next to your ORM config. Then pass it to your config:
+
+```ts
+import compiledFunctions from './compiled-functions.js';
+
+export default defineConfig({
+  compiledFunctions,
+});
+```
+
+Use the `--out` option to customize the output path:
+
+```bash
+npx mikro-orm compile --out ./dist/compiled-functions.js
+```
+
 ## Custom Repository
 
 You can also register custom base repository (for all entities where you do not specify `repository` option) globally:

--- a/package.json
+++ b/package.json
@@ -68,8 +68,7 @@
   },
   "lint-staged": {
     "*.ts": [
-      "oxlint --fix",
-      "oxfmt --write"
+      "oxlint --fix"
     ]
   },
   "renovate": {

--- a/packages/cli/src/CLIConfigurator.ts
+++ b/packages/cli/src/CLIConfigurator.ts
@@ -7,6 +7,7 @@ import { CreateSeederCommand } from './commands/CreateSeederCommand.js';
 import { DatabaseSeedCommand } from './commands/DatabaseSeedCommand.js';
 import { DebugCommand } from './commands/DebugCommand.js';
 import { GenerateCacheCommand } from './commands/GenerateCacheCommand.js';
+import { CompileCommand } from './commands/CompileCommand.js';
 import { GenerateEntitiesCommand } from './commands/GenerateEntitiesCommand.js';
 import { ImportCommand } from './commands/ImportCommand.js';
 import { MigrationCommandFactory } from './commands/MigrationCommandFactory.js';
@@ -66,6 +67,7 @@ export async function configure() {
     .version(version)
     .command(new ClearCacheCommand())
     .command(new GenerateCacheCommand())
+    .command(new CompileCommand())
     .command(new GenerateEntitiesCommand())
     .command(new CreateDatabaseCommand())
     .command(new ImportCommand())

--- a/packages/cli/src/commands/CompileCommand.ts
+++ b/packages/cli/src/commands/CompileCommand.ts
@@ -1,0 +1,113 @@
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import type { ArgumentsCamelCase, Argv } from 'yargs';
+import { MetadataDiscovery, MetadataStorage, Utils, EntityComparator, ObjectHydrator, colors, type Configuration } from '@mikro-orm/core';
+import { fs } from '@mikro-orm/core/fs-utils';
+import type { BaseArgs, BaseCommand } from '../CLIConfigurator.js';
+import { CLIHelper } from '../CLIHelper.js';
+
+type CompileArgs = BaseArgs & { out?: string };
+
+export class CompileCommand implements BaseCommand<CompileArgs> {
+  command = 'compile';
+  describe = 'Pre-compile optimized entity functions for runtimes that prohibit eval (e.g. Cloudflare Workers)';
+
+  builder = (args: Argv<BaseArgs>) => {
+    args.option('out', {
+      type: 'string',
+      desc: 'Output path for the generated file (defaults to next to your ORM config)',
+    });
+    return args as Argv<CompileArgs>;
+  };
+
+  /**
+   * @inheritDoc
+   */
+  async handler(args: ArgumentsCamelCase<CompileArgs>) {
+    const config = await CLIHelper.getConfiguration(args.contextName, args.config);
+    const settings = CLIHelper.getSettings();
+    config.set('debug', !!settings.verbose);
+    const metadata = await new MetadataDiscovery(new MetadataStorage(), config.getDriver().getPlatform(), config).discover(false);
+
+    // Default output path to next to the ORM config file
+    if (!args.out) {
+      const configPaths = args.config ?? (await CLIHelper.getConfigPaths());
+
+      for (const configPath of configPaths) {
+        const absPath = fs.absolutePath(configPath);
+
+        if (fs.pathExists(absPath)) {
+          args.out = resolve(dirname(absPath), 'compiled-functions.js');
+          break;
+        }
+      }
+    }
+
+    const captured = CompileCommand.capture(metadata, config);
+
+    const entries = captured.map(({ key, contextKeys, code }) => {
+      const params = contextKeys.join(', ');
+      const indentedCode = code.replace(/\n/g, '\n    ');
+      return `  '${key}': function(${params}) {\n    ${indentedCode}\n  }`;
+    });
+
+    const esm = CLIHelper.isESM();
+    const version = Utils.getORMVersion();
+    const output = esm
+      ? `export default {\n  __version: '${version}',\n${entries.join(',\n')}\n};\n`
+      : `'use strict';\nmodule.exports = {\n  __version: '${version}',\n${entries.join(',\n')}\n};\n`;
+    const outPath = args.out ?? resolve(process.cwd(), 'compiled-functions.js');
+    const dtsPath = outPath.replace(/\.js$/, '.d.ts');
+    const dts = esm
+      ? `import type { CompiledFunctions } from '@mikro-orm/core';\ndeclare const compiledFunctions: CompiledFunctions;\nexport default compiledFunctions;\n`
+      : `import type { CompiledFunctions } from '@mikro-orm/core';\ndeclare const compiledFunctions: CompiledFunctions;\nexport = compiledFunctions;\n`;
+    mkdirSync(dirname(outPath), { recursive: true });
+    writeFileSync(outPath, output);
+    writeFileSync(dtsPath, dts);
+
+    CLIHelper.dump(colors.green(`Compiled functions generated to ${outPath} (${captured.length} functions)`));
+    CLIHelper.dump(`\nExample usage in your ORM config:\n`);
+    const importPath = esm ? './compiled-functions.js' : './compiled-functions';
+    CLIHelper.dump(`  ${esm ? 'import' : 'const'} compiledFunctions ${esm ? 'from ' : '= require('}${colors.cyan(`'${importPath}'`)}${esm ? '' : ')'};`);
+    CLIHelper.dump('');
+    CLIHelper.dump(`  export default defineConfig({ compiledFunctions });\n`);
+  }
+
+  static capture(metadata: MetadataStorage, config: Configuration) {
+    const captured: { key: string; contextKeys: string[]; code: string }[] = [];
+    const original = Utils.createFunction;
+    Utils.createFunction = (context, code, _compiledFunctions, key) => {
+      captured.push({ key: key!, contextKeys: [...context.keys()], code });
+      return original.call(Utils, context, code);
+    };
+
+    try {
+      const platform = config.getDriver().getPlatform();
+      const hydrator = new ObjectHydrator(metadata, platform, config);
+      const comparator = new EntityComparator(metadata, platform, config);
+
+      for (const meta of metadata) {
+        hydrator.getEntityHydrator(meta, 'full', false);
+        hydrator.getEntityHydrator(meta, 'full', true);
+        comparator.getEntityComparator(meta.class);
+        comparator.getSnapshotGenerator(meta.class);
+        comparator.getResultMapper(meta);
+
+        if (!meta.embeddable && !meta.virtual) {
+          hydrator.getEntityHydrator(meta, 'reference', false);
+          hydrator.getEntityHydrator(meta, 'reference', true);
+        }
+
+        if (meta.primaryKeys.length > 0) {
+          comparator.getPkGetter(meta);
+          comparator.getPkGetterConverted(meta);
+          comparator.getPkSerializer(meta);
+        }
+      }
+    } finally {
+      Utils.createFunction = original;
+    }
+
+    return captured;
+  }
+}

--- a/packages/core/src/hydration/ObjectHydrator.ts
+++ b/packages/core/src/hydration/ObjectHydrator.ts
@@ -427,7 +427,8 @@ export class ObjectHydrator extends Hydrator {
     const code = `// compiled hydrator for entity ${meta.className} (${type + normalizeAccessors ? ' normalized' : ''})\n`
       + `return function(entity, data, factory, newEntity, convertCustomTypes, schema, parentSchema, normalizeAccessors) {\n`
       + `${lines.join('\n')}\n}`;
-    const hydrator = Utils.createFunction(context, code);
+    const fnKey = `hydrator-${meta.uniqueName}-${type}-${normalizeAccessors}`;
+    const hydrator = Utils.createFunction(context, code, this.config.get('compiledFunctions'), fnKey);
     this.hydrators[key].set(meta.class, hydrator);
 
     return hydrator;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,7 +4,7 @@
  */
 export { EntityMetadata, PrimaryKeyProp, EntityRepositoryType, OptionalProps, EagerProps, HiddenProps, Config } from './typings.js';
 export type {
-  Constructor, ConnectionType, Dictionary, Primary, IPrimaryKey, ObjectQuery, FilterQuery, IWrappedEntity, EntityName, EntityData, Highlighter, MaybePromise,
+  CompiledFunctions, Constructor, ConnectionType, Dictionary, Primary, IPrimaryKey, ObjectQuery, FilterQuery, IWrappedEntity, EntityName, EntityData, Highlighter, MaybePromise,
   AnyEntity, EntityClass, EntityProperty, PopulateOptions, Populate, Loaded, New, LoadedReference, LoadedCollection, IMigrator, IMigrationGenerator, MigratorEvent,
   GetRepository, MigrationObject, DeepPartial, PrimaryProperty, Cast, IsUnknown, EntityDictionary, EntityDTO, MigrationDiff, GenerateOptions, FilterObject,
   IEntityGenerator, ISeedManager, RequiredEntityData, CheckCallback, IndexCallback, FormulaCallback, FormulaTable, SimpleColumnMeta, Rel, Ref, ScalarRef, EntityRef, ISchemaGenerator,

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -34,6 +34,7 @@ import { BaseEntity } from './entity/BaseEntity.js';
 
 export type Constructor<T = unknown> = new (...args: any[]) => T;
 export type Dictionary<T = any> = { [k: string]: T };
+export type CompiledFunctions = Record<string, (...args: any[]) => any>;
 // `EntityKey<T, true>` will skip scalar properties (and some other scalar like types like Date or Buffer)
 export type EntityKey<T = unknown, B extends boolean = false> = string & { [K in keyof T]-?: CleanKeys<T, K, B> extends never ? never : K; }[keyof T];
 export type EntityValue<T> = T[EntityKey<T>];

--- a/packages/core/src/utils/Utils.ts
+++ b/packages/core/src/utils/Utils.ts
@@ -1,5 +1,6 @@
 import { clone } from './clone.js';
 import type {
+  CompiledFunctions,
   Dictionary,
   EntityData,
   EntityDictionary,
@@ -856,7 +857,11 @@ export class Utils {
     return this.#ORM_VERSION;
   }
 
-  static createFunction(context: Map<string, any>, code: string) {
+  static createFunction(context: Map<string, any>, code: string, compiledFunctions?: CompiledFunctions, key?: string) {
+    if (key && compiledFunctions?.[key]) {
+      return compiledFunctions[key](...context.values());
+    }
+
     try {
       return new Function(...context.keys(), `'use strict';\n` + code)(...context.values());
       /* v8 ignore next */

--- a/tests/features/cli/CLIHelper.test.ts
+++ b/tests/features/cli/CLIHelper.test.ts
@@ -629,6 +629,7 @@ Maybe you want to check, or regenerate your yarn.lock or package-lock.json file?
     expect(cli.getInternalMethods().getCommandInstance().getCommands()).toEqual([
       'cache:clear',
       'cache:generate',
+      'compile',
       'generate-entities',
       'database:create',
       'database:import',

--- a/tests/features/cli/CompileCommand.test.ts
+++ b/tests/features/cli/CompileCommand.test.ts
@@ -1,0 +1,196 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync, unlinkSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { EntityMetadata, MetadataStorage, ReferenceKind, Utils } from '@mikro-orm/core';
+import { Configuration, MetadataDiscovery } from '@mikro-orm/core';
+import { fs as fsUtils } from '@mikro-orm/core/fs-utils';
+import { CLIHelper } from '@mikro-orm/cli';
+import { CompileCommand } from '../../../packages/cli/src/commands/CompileCommand.js';
+import { MySqlDriver } from '@mikro-orm/mysql';
+
+let tmpDir: string;
+let outPath: string;
+let outDtsPath: string;
+let defaultOutPath: string;
+let defaultOutDtsPath: string;
+let configRelativeOutPath: string;
+let configRelativeOutDtsPath: string;
+
+class User {
+  id!: number;
+  name!: string;
+}
+
+class Address {
+  street!: string;
+}
+
+function createSimpleMetadata(): MetadataStorage {
+  const storage = new MetadataStorage();
+  const meta = new EntityMetadata({
+    class: User as any,
+    className: 'User',
+    name: 'User',
+    tableName: 'user',
+    primaryKeys: ['id'],
+    comparableProps: [],
+    hydrateProps: [],
+    bidirectionalRelations: [],
+  });
+  meta.properties = {
+    id: {
+      name: 'id',
+      fieldNames: ['id'],
+      columnTypes: ['integer'],
+      kind: ReferenceKind.SCALAR,
+      primary: true,
+      type: 'number',
+    },
+    name: {
+      name: 'name',
+      fieldNames: ['name'],
+      columnTypes: ['varchar(255)'],
+      kind: ReferenceKind.SCALAR,
+      type: 'string',
+    },
+  } as any;
+  meta.props = Object.values(meta.properties);
+  meta.comparableProps = [meta.properties.id as any, meta.properties.name as any];
+  meta.hydrateProps = meta.props;
+  storage.set(User as any, meta);
+
+  const embeddableMeta = new EntityMetadata({
+    class: Address as any,
+    className: 'Address',
+    name: 'Address',
+    embeddable: true,
+    primaryKeys: [],
+    comparableProps: [],
+    hydrateProps: [],
+    bidirectionalRelations: [],
+  });
+  embeddableMeta.properties = {
+    street: {
+      name: 'street',
+      fieldNames: ['street'],
+      columnTypes: ['varchar(255)'],
+      kind: ReferenceKind.SCALAR,
+      type: 'string',
+    },
+  } as any;
+  embeddableMeta.props = Object.values(embeddableMeta.properties);
+  embeddableMeta.comparableProps = [embeddableMeta.properties.street as any];
+  embeddableMeta.hydrateProps = embeddableMeta.props;
+  storage.set(Address as any, embeddableMeta);
+
+  return storage;
+}
+
+describe('CompileCommand', () => {
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'mikro-orm-compile-test-'));
+    outPath = join(tmpDir, 'sub', 'compiled-functions.js');
+    outDtsPath = join(tmpDir, 'sub', 'compiled-functions.d.ts');
+    defaultOutPath = join(tmpDir, 'compiled-functions.js');
+    defaultOutDtsPath = join(tmpDir, 'compiled-functions.d.ts');
+    configRelativeOutPath = join(tmpDir, 'src', 'compiled-functions.js');
+    configRelativeOutDtsPath = join(tmpDir, 'src', 'compiled-functions.d.ts');
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('builder', () => {
+    const cmd = new CompileCommand();
+    const mockOption = vi.fn();
+    const args = { option: mockOption };
+    cmd.builder(args as any);
+    expect(mockOption).toHaveBeenCalledWith('out', {
+      type: 'string',
+      desc: 'Output path for the generated file (defaults to next to your ORM config)',
+    });
+  });
+
+  test('handler generates CJS output', async () => {
+    vi.spyOn(CLIHelper, 'getConfiguration').mockResolvedValue(
+      new Configuration({ driver: MySqlDriver, metadataCache: { enabled: true }, getDriver: () => ({ getPlatform: vi.fn() }) } as any, false),
+    );
+    const discoverMock = vi.spyOn(MetadataDiscovery.prototype, 'discover').mockResolvedValue(createSimpleMetadata());
+    const dumpMock = vi.spyOn(CLIHelper, 'dump').mockImplementation(i => i);
+    vi.spyOn(CLIHelper, 'isESM').mockReturnValue(false);
+
+    const cmd = new CompileCommand();
+
+    expect(discoverMock.mock.calls.length).toBe(0);
+    await expect(cmd.handler({ out: outPath } as any)).resolves.toBeUndefined();
+    expect(discoverMock.mock.calls.length).toBe(1);
+    expect(discoverMock.mock.calls[0][0]).toBe(false);
+
+    // Verify a valid CJS file was written with actual function entries
+    expect(existsSync(outPath)).toBe(true);
+    const content = readFileSync(outPath, 'utf-8');
+    expect(content).toMatchSnapshot();
+
+    // Verify .d.ts file was generated with CJS export
+    expect(existsSync(outDtsPath)).toBe(true);
+    const dts = readFileSync(outDtsPath, 'utf-8');
+    expect(dts).toContain('export = compiledFunctions');
+
+    // Verify the output message
+    expect(dumpMock).toHaveBeenCalledWith(expect.stringContaining('Compiled functions generated'));
+  });
+
+  test('handler generates ESM output when project uses type=module', async () => {
+    vi.spyOn(CLIHelper, 'getConfiguration').mockResolvedValue(
+      new Configuration({ driver: MySqlDriver, metadataCache: { enabled: true }, getDriver: () => ({ getPlatform: vi.fn() }) } as any, false),
+    );
+    vi.spyOn(MetadataDiscovery.prototype, 'discover').mockResolvedValue(createSimpleMetadata());
+    vi.spyOn(CLIHelper, 'dump').mockImplementation(i => i);
+    vi.spyOn(CLIHelper, 'isESM').mockReturnValue(true);
+
+    const cmd = new CompileCommand();
+    await cmd.handler({ out: outPath } as any);
+
+    const content = readFileSync(outPath, 'utf-8');
+    expect(content).toMatchSnapshot();
+
+    // Verify .d.ts file was generated with ESM export
+    expect(existsSync(outDtsPath)).toBe(true);
+    const dts = readFileSync(outDtsPath, 'utf-8');
+    expect(dts).toContain('export default compiledFunctions');
+  });
+
+  test('handler outputs next to ORM config file by default', async () => {
+    vi.spyOn(CLIHelper, 'getConfiguration').mockResolvedValue(
+      new Configuration({ driver: MySqlDriver, metadataCache: { enabled: true }, getDriver: () => ({ getPlatform: vi.fn() }) } as any, false),
+    );
+    vi.spyOn(MetadataDiscovery.prototype, 'discover').mockResolvedValue(createSimpleMetadata());
+    vi.spyOn(CLIHelper, 'dump').mockImplementation(i => i);
+    vi.spyOn(CLIHelper, 'getConfigPaths').mockResolvedValue([join(tmpDir, 'src', 'mikro-orm.config.ts')]);
+    vi.spyOn(fsUtils, 'absolutePath').mockImplementation(p => p);
+    vi.spyOn(fsUtils, 'pathExists').mockReturnValue(true);
+
+    const cmd = new CompileCommand();
+    await cmd.handler({} as any);
+
+    expect(existsSync(configRelativeOutPath)).toBe(true);
+  });
+
+  test('handler falls back to cwd when no config file is found', async () => {
+    vi.spyOn(CLIHelper, 'getConfiguration').mockResolvedValue(
+      new Configuration({ driver: MySqlDriver, metadataCache: { enabled: true }, getDriver: () => ({ getPlatform: vi.fn() }) } as any, false),
+    );
+    vi.spyOn(MetadataDiscovery.prototype, 'discover').mockResolvedValue(createSimpleMetadata());
+    vi.spyOn(CLIHelper, 'dump').mockImplementation(i => i);
+    vi.spyOn(CLIHelper, 'getConfigPaths').mockResolvedValue([join(tmpDir, 'src', 'mikro-orm.config.ts')]);
+    vi.spyOn(fsUtils, 'absolutePath').mockImplementation(p => p);
+    vi.spyOn(fsUtils, 'pathExists').mockReturnValue(false);
+    vi.spyOn(process, 'cwd').mockReturnValue(tmpDir);
+
+    const cmd = new CompileCommand();
+    await cmd.handler({} as any);
+
+    expect(existsSync(defaultOutPath)).toBe(true);
+  });
+});

--- a/tests/features/cli/__snapshots__/CompileCommand.test.ts.snap
+++ b/tests/features/cli/__snapshots__/CompileCommand.test.ts.snap
@@ -1,0 +1,396 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`CompileCommand > handler generates CJS output 1`] = `
+"'use strict';
+module.exports = {
+  __version: '[[MIKRO_ORM_VERSION]]',
+  'hydrator-user_0-full-false': function(isPrimaryKey, Collection, Reference) {
+    // compiled hydrator for entity User ( normalized)
+    return function(entity, data, factory, newEntity, convertCustomTypes, schema, parentSchema, normalizeAccessors) {
+      if (data.id === null) {
+        entity.id = null;
+      } else if (typeof data.id !== 'undefined') {
+        entity.id = data.id;
+      }
+      if (data.name === null) {
+        entity.name = null;
+      } else if (typeof data.name !== 'undefined') {
+        entity.name = data.name;
+      }
+    }
+  },
+  'hydrator-user_0-full-true': function(isPrimaryKey, Collection, Reference) {
+    // compiled hydrator for entity User ( normalized)
+    return function(entity, data, factory, newEntity, convertCustomTypes, schema, parentSchema, normalizeAccessors) {
+      if (data.id === null) {
+        entity.id = null;
+      } else if (typeof data.id !== 'undefined') {
+        entity.id = data.id;
+      }
+      if (data.name === null) {
+        entity.name = null;
+      } else if (typeof data.name !== 'undefined') {
+        entity.name = data.name;
+      }
+    }
+  },
+  'comparator-user_0': function(compareArrays, compareBooleans, compareBuffers, compareObjects, equals) {
+    // compiled comparator for entity User
+    return function(last, current, options) {
+      const diff = {};
+      if (current.id === null && last.id === undefined) {
+        diff.id = current.id;
+      } else if (current.id == null && last.id == null) {
+    
+      } else if ((current.id != null && last.id == null) || (current.id == null && last.id != null)) {
+        diff.id = current.id;
+      } else if (last.id !== current.id) {
+        diff.id = current.id;
+      }
+    
+      if (current.name === null && last.name === undefined) {
+        diff.name = current.name;
+      } else if (current.name == null && last.name == null) {
+    
+      } else if ((current.name != null && last.name == null) || (current.name == null && last.name != null)) {
+        diff.name = current.name;
+      } else if (last.name !== current.name) {
+        diff.name = current.name;
+      }
+    
+    if (options?.includeInverseSides) {
+    }
+      return diff;
+    }
+  },
+  'snapshotGenerator-user_0': function(clone, cloneEmbeddable) {
+    return function(entity) {
+      const ret = {};
+      if (typeof entity.id !== 'undefined') {
+        ret.id = entity.id;
+      }
+    
+      if (typeof entity.name !== 'undefined') {
+        ret.name = entity.name;
+      }
+    
+      return ret;
+    }
+  },
+  'resultMapper-user_0': function() {
+    // compiled mapper for entity User
+    return function(result) {
+      const ret = {};
+      const mapped = {};
+      if (typeof result.id !== 'undefined') {
+        ret.id = result.id;
+        mapped.id = true;
+      }
+      if (typeof result.name !== 'undefined') {
+        ret.name = result.name;
+        mapped.name = true;
+      }
+      for (let k in result) { if (Object.hasOwn(result, k) && !mapped[k] && ret[k] === undefined) ret[k] = result[k]; }
+      return ret;
+    }
+  },
+  'hydrator-user_0-reference-false': function(isPrimaryKey, Collection, Reference) {
+    // compiled hydrator for entity User ( normalized)
+    return function(entity, data, factory, newEntity, convertCustomTypes, schema, parentSchema, normalizeAccessors) {
+      if (data.id === null) {
+        entity.id = null;
+      } else if (typeof data.id !== 'undefined') {
+        entity.id = data.id;
+      }
+    }
+  },
+  'hydrator-user_0-reference-true': function(isPrimaryKey, Collection, Reference) {
+    // compiled hydrator for entity User ( normalized)
+    return function(entity, data, factory, newEntity, convertCustomTypes, schema, parentSchema, normalizeAccessors) {
+      if (data.id === null) {
+        entity.id = null;
+      } else if (typeof data.id !== 'undefined') {
+        entity.id = data.id;
+      }
+    }
+  },
+  'pkGetter-user_0': function() {
+    // compiled pk getter for entity User
+    return function(entity) {
+      return entity.id;
+    }
+  },
+  'pkGetterConverted-user_0': function() {
+    // compiled pk getter (with converted custom types) for entity User
+    return function(entity) {
+      return entity.id;
+    }
+  },
+  'pkSerializer-user_0': function(getCompositeKeyValue, getPrimaryKeyHash) {
+    // compiled pk serializer for entity User
+    return function(entity) {
+      return '' + entity.id;
+    }
+  },
+  'hydrator-undefined_1000-full-false': function(isPrimaryKey, Collection, Reference) {
+    // compiled hydrator for entity Address ( normalized)
+    return function(entity, data, factory, newEntity, convertCustomTypes, schema, parentSchema, normalizeAccessors) {
+      if (data.street === null) {
+        entity.street = null;
+      } else if (typeof data.street !== 'undefined') {
+        entity.street = data.street;
+      }
+    }
+  },
+  'hydrator-undefined_1000-full-true': function(isPrimaryKey, Collection, Reference) {
+    // compiled hydrator for entity Address ( normalized)
+    return function(entity, data, factory, newEntity, convertCustomTypes, schema, parentSchema, normalizeAccessors) {
+      if (data.street === null) {
+        entity.street = null;
+      } else if (typeof data.street !== 'undefined') {
+        entity.street = data.street;
+      }
+    }
+  },
+  'comparator-undefined_1000': function(compareArrays, compareBooleans, compareBuffers, compareObjects, equals) {
+    // compiled comparator for entity Address
+    return function(last, current, options) {
+      const diff = {};
+      if (current.street === null && last.street === undefined) {
+        diff.street = current.street;
+      } else if (current.street == null && last.street == null) {
+    
+      } else if ((current.street != null && last.street == null) || (current.street == null && last.street != null)) {
+        diff.street = current.street;
+      } else if (last.street !== current.street) {
+        diff.street = current.street;
+      }
+    
+    if (options?.includeInverseSides) {
+    }
+      return diff;
+    }
+  },
+  'snapshotGenerator-undefined_1000': function(clone, cloneEmbeddable) {
+    return function(entity) {
+      const ret = {};
+      if (typeof entity.street !== 'undefined') {
+        ret.street = entity.street;
+      }
+    
+      return ret;
+    }
+  },
+  'resultMapper-undefined_1000': function() {
+    // compiled mapper for entity Address
+    return function(result) {
+      const ret = {};
+      const mapped = {};
+      if (typeof result.street !== 'undefined') {
+        ret.street = result.street;
+        mapped.street = true;
+      }
+      for (let k in result) { if (Object.hasOwn(result, k) && !mapped[k] && ret[k] === undefined) ret[k] = result[k]; }
+      return ret;
+    }
+  }
+};
+"
+`;
+
+exports[`CompileCommand > handler generates ESM output when project uses type=module 1`] = `
+"export default {
+  __version: '[[MIKRO_ORM_VERSION]]',
+  'hydrator-user_2000-full-false': function(isPrimaryKey, Collection, Reference) {
+    // compiled hydrator for entity User ( normalized)
+    return function(entity, data, factory, newEntity, convertCustomTypes, schema, parentSchema, normalizeAccessors) {
+      if (data.id === null) {
+        entity.id = null;
+      } else if (typeof data.id !== 'undefined') {
+        entity.id = data.id;
+      }
+      if (data.name === null) {
+        entity.name = null;
+      } else if (typeof data.name !== 'undefined') {
+        entity.name = data.name;
+      }
+    }
+  },
+  'hydrator-user_2000-full-true': function(isPrimaryKey, Collection, Reference) {
+    // compiled hydrator for entity User ( normalized)
+    return function(entity, data, factory, newEntity, convertCustomTypes, schema, parentSchema, normalizeAccessors) {
+      if (data.id === null) {
+        entity.id = null;
+      } else if (typeof data.id !== 'undefined') {
+        entity.id = data.id;
+      }
+      if (data.name === null) {
+        entity.name = null;
+      } else if (typeof data.name !== 'undefined') {
+        entity.name = data.name;
+      }
+    }
+  },
+  'comparator-user_2000': function(compareArrays, compareBooleans, compareBuffers, compareObjects, equals) {
+    // compiled comparator for entity User
+    return function(last, current, options) {
+      const diff = {};
+      if (current.id === null && last.id === undefined) {
+        diff.id = current.id;
+      } else if (current.id == null && last.id == null) {
+    
+      } else if ((current.id != null && last.id == null) || (current.id == null && last.id != null)) {
+        diff.id = current.id;
+      } else if (last.id !== current.id) {
+        diff.id = current.id;
+      }
+    
+      if (current.name === null && last.name === undefined) {
+        diff.name = current.name;
+      } else if (current.name == null && last.name == null) {
+    
+      } else if ((current.name != null && last.name == null) || (current.name == null && last.name != null)) {
+        diff.name = current.name;
+      } else if (last.name !== current.name) {
+        diff.name = current.name;
+      }
+    
+    if (options?.includeInverseSides) {
+    }
+      return diff;
+    }
+  },
+  'snapshotGenerator-user_2000': function(clone, cloneEmbeddable) {
+    return function(entity) {
+      const ret = {};
+      if (typeof entity.id !== 'undefined') {
+        ret.id = entity.id;
+      }
+    
+      if (typeof entity.name !== 'undefined') {
+        ret.name = entity.name;
+      }
+    
+      return ret;
+    }
+  },
+  'resultMapper-user_2000': function() {
+    // compiled mapper for entity User
+    return function(result) {
+      const ret = {};
+      const mapped = {};
+      if (typeof result.id !== 'undefined') {
+        ret.id = result.id;
+        mapped.id = true;
+      }
+      if (typeof result.name !== 'undefined') {
+        ret.name = result.name;
+        mapped.name = true;
+      }
+      for (let k in result) { if (Object.hasOwn(result, k) && !mapped[k] && ret[k] === undefined) ret[k] = result[k]; }
+      return ret;
+    }
+  },
+  'hydrator-user_2000-reference-false': function(isPrimaryKey, Collection, Reference) {
+    // compiled hydrator for entity User ( normalized)
+    return function(entity, data, factory, newEntity, convertCustomTypes, schema, parentSchema, normalizeAccessors) {
+      if (data.id === null) {
+        entity.id = null;
+      } else if (typeof data.id !== 'undefined') {
+        entity.id = data.id;
+      }
+    }
+  },
+  'hydrator-user_2000-reference-true': function(isPrimaryKey, Collection, Reference) {
+    // compiled hydrator for entity User ( normalized)
+    return function(entity, data, factory, newEntity, convertCustomTypes, schema, parentSchema, normalizeAccessors) {
+      if (data.id === null) {
+        entity.id = null;
+      } else if (typeof data.id !== 'undefined') {
+        entity.id = data.id;
+      }
+    }
+  },
+  'pkGetter-user_2000': function() {
+    // compiled pk getter for entity User
+    return function(entity) {
+      return entity.id;
+    }
+  },
+  'pkGetterConverted-user_2000': function() {
+    // compiled pk getter (with converted custom types) for entity User
+    return function(entity) {
+      return entity.id;
+    }
+  },
+  'pkSerializer-user_2000': function(getCompositeKeyValue, getPrimaryKeyHash) {
+    // compiled pk serializer for entity User
+    return function(entity) {
+      return '' + entity.id;
+    }
+  },
+  'hydrator-undefined_3000-full-false': function(isPrimaryKey, Collection, Reference) {
+    // compiled hydrator for entity Address ( normalized)
+    return function(entity, data, factory, newEntity, convertCustomTypes, schema, parentSchema, normalizeAccessors) {
+      if (data.street === null) {
+        entity.street = null;
+      } else if (typeof data.street !== 'undefined') {
+        entity.street = data.street;
+      }
+    }
+  },
+  'hydrator-undefined_3000-full-true': function(isPrimaryKey, Collection, Reference) {
+    // compiled hydrator for entity Address ( normalized)
+    return function(entity, data, factory, newEntity, convertCustomTypes, schema, parentSchema, normalizeAccessors) {
+      if (data.street === null) {
+        entity.street = null;
+      } else if (typeof data.street !== 'undefined') {
+        entity.street = data.street;
+      }
+    }
+  },
+  'comparator-undefined_3000': function(compareArrays, compareBooleans, compareBuffers, compareObjects, equals) {
+    // compiled comparator for entity Address
+    return function(last, current, options) {
+      const diff = {};
+      if (current.street === null && last.street === undefined) {
+        diff.street = current.street;
+      } else if (current.street == null && last.street == null) {
+    
+      } else if ((current.street != null && last.street == null) || (current.street == null && last.street != null)) {
+        diff.street = current.street;
+      } else if (last.street !== current.street) {
+        diff.street = current.street;
+      }
+    
+    if (options?.includeInverseSides) {
+    }
+      return diff;
+    }
+  },
+  'snapshotGenerator-undefined_3000': function(clone, cloneEmbeddable) {
+    return function(entity) {
+      const ret = {};
+      if (typeof entity.street !== 'undefined') {
+        ret.street = entity.street;
+      }
+    
+      return ret;
+    }
+  },
+  'resultMapper-undefined_3000': function() {
+    // compiled mapper for entity Address
+    return function(result) {
+      const ret = {};
+      const mapped = {};
+      if (typeof result.street !== 'undefined') {
+        ret.street = result.street;
+        mapped.street = true;
+      }
+      for (let k in result) { if (Object.hasOwn(result, k) && !mapped[k] && ret[k] === undefined) ret[k] = result[k]; }
+      return ret;
+    }
+  }
+};
+"
+`;

--- a/tests/features/compiled-functions/compiled-functions.test.ts
+++ b/tests/features/compiled-functions/compiled-functions.test.ts
@@ -1,0 +1,285 @@
+import { MikroORM, ObjectHydrator, Utils } from '@mikro-orm/sqlite';
+import { CompileCommand } from '../../../packages/cli/src/commands/CompileCommand.js';
+import { Embeddable, Embedded, Entity, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+
+@Embeddable()
+class Address {
+  @Property()
+  street!: string;
+
+  @Property()
+  city!: string;
+}
+
+@Entity()
+class Author {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @Embedded(() => Address)
+  address!: Address;
+}
+
+@Entity()
+class Book {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  title!: string;
+
+  @Property()
+  price!: number;
+}
+
+const initOptions = {
+  metadataProvider: ReflectMetadataProvider,
+  entities: [Author, Book, Address],
+  dbName: ':memory:' as const,
+};
+
+describe('compiled functions', () => {
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init(initOptions);
+    await orm.schema.refresh();
+  });
+
+  afterAll(() => orm.close(true));
+
+  function generateCompiledFunctions(fromOrm: MikroORM): Record<string, (...args: any[]) => any> {
+    const captured = CompileCommand.capture(fromOrm.getMetadata(), fromOrm.config);
+    const result: Record<string, (...args: any[]) => any> = {};
+
+    for (const { key, contextKeys, code } of captured) {
+      // eslint-disable-next-line no-new-func
+      const fn = new Function(...contextKeys, `'use strict';\n` + code) as (...args: any[]) => any;
+      result[key] = fn;
+    }
+
+    return result;
+  }
+
+  test('Utils.createFunction uses compiledFunctions when key matches', () => {
+    const context = new Map<string, any>([
+      ['a', 1],
+      ['b', 2],
+    ]);
+    const mockFn = vi.fn((...args: any[]) => 'pregenerated');
+    const compiledFunctions = { 'test-key': mockFn };
+
+    const result = Utils.createFunction(context, 'return a + b;', compiledFunctions, 'test-key');
+
+    expect(result).toBe('pregenerated');
+    expect(mockFn).toHaveBeenCalledWith(1, 2);
+  });
+
+  test('Utils.createFunction falls back to new Function when key does not match', () => {
+    const context = new Map<string, any>([
+      ['a', 1],
+      ['b', 2],
+    ]);
+    const compiledFunctions = { 'other-key': vi.fn() };
+
+    const result = Utils.createFunction(context, 'return a + b;', compiledFunctions, 'test-key');
+
+    expect(result).toBe(3);
+  });
+
+  test('Utils.createFunction falls back to new Function when compiledFunctions is undefined', () => {
+    const context = new Map<string, any>([
+      ['a', 1],
+      ['b', 2],
+    ]);
+
+    const result = Utils.createFunction(context, 'return a + b;', undefined, 'test-key');
+
+    expect(result).toBe(3);
+  });
+
+  test('Utils.createFunction falls back to new Function when key is undefined', () => {
+    const context = new Map<string, any>([
+      ['a', 1],
+      ['b', 2],
+    ]);
+    const compiledFunctions = { 'test-key': vi.fn() };
+
+    const result = Utils.createFunction(context, 'return a + b;', compiledFunctions);
+
+    expect(result).toBe(3);
+  });
+
+  test('generates all expected function keys', () => {
+    const compiledFunctions = generateCompiledFunctions(orm);
+    const keys = Object.keys(compiledFunctions);
+
+    const authorMeta = orm.getMetadata().get(Author);
+    const bookMeta = orm.getMetadata().get(Book);
+
+    // Author functions (using uniqueName)
+    expect(keys).toContain(`hydrator-${authorMeta.uniqueName}-full-false`);
+    expect(keys).toContain(`hydrator-${authorMeta.uniqueName}-full-true`);
+    expect(keys).toContain(`hydrator-${authorMeta.uniqueName}-reference-false`);
+    expect(keys).toContain(`hydrator-${authorMeta.uniqueName}-reference-true`);
+    expect(keys).toContain(`comparator-${authorMeta.uniqueName}`);
+    expect(keys).toContain(`snapshotGenerator-${authorMeta.uniqueName}`);
+    expect(keys).toContain(`resultMapper-${authorMeta.uniqueName}`);
+    expect(keys).toContain(`pkGetter-${authorMeta.uniqueName}`);
+    expect(keys).toContain(`pkGetterConverted-${authorMeta.uniqueName}`);
+    expect(keys).toContain(`pkSerializer-${authorMeta.uniqueName}`);
+
+    // Book functions (using uniqueName)
+    expect(keys).toContain(`hydrator-${bookMeta.uniqueName}-full-false`);
+    expect(keys).toContain(`comparator-${bookMeta.uniqueName}`);
+    expect(keys).toContain(`snapshotGenerator-${bookMeta.uniqueName}`);
+    expect(keys).toContain(`resultMapper-${bookMeta.uniqueName}`);
+    expect(keys).toContain(`pkGetter-${bookMeta.uniqueName}`);
+    expect(keys).toContain(`pkGetterConverted-${bookMeta.uniqueName}`);
+    expect(keys).toContain(`pkSerializer-${bookMeta.uniqueName}`);
+  });
+
+  test('compiled functions produce identical results to JIT path', async () => {
+    const compiledFunctions = generateCompiledFunctions(orm);
+
+    const orm2 = await MikroORM.init({ ...initOptions, compiledFunctions });
+
+    try {
+      await orm2.schema.refresh();
+
+      // Insert test data via orm (JIT path)
+      const author = orm.em.create(Author, {
+        name: 'John',
+        address: { street: '123 Main St', city: 'Springfield' },
+      });
+      await orm.em.flush();
+
+      // Insert same data via orm2 (compiled functions path)
+      const author2 = orm2.em.create(Author, {
+        name: 'John',
+        address: { street: '123 Main St', city: 'Springfield' },
+      });
+      await orm2.em.flush();
+
+      // Test comparator - both ORMs should produce same snapshot
+      const comparator1 = orm.config.getComparator(orm.getMetadata());
+      const comparator2 = orm2.config.getComparator(orm2.getMetadata());
+      const meta = orm.getMetadata().get(Author);
+      const meta2 = orm2.getMetadata().get(Author);
+
+      const snapshot1 = comparator1.prepareEntity(author);
+      const snapshot2 = comparator2.prepareEntity(author2);
+
+      expect(snapshot1).toEqual(snapshot2);
+
+      // Test result mapper - both should map DB rows identically
+      const mapper1 = comparator1.getResultMapper(meta);
+      const mapper2 = comparator2.getResultMapper(meta2);
+      const testRow = { id: 1, name: 'John', address_street: '123 Main St', address_city: 'Springfield' };
+      expect(mapper1(testRow)).toEqual(mapper2(testRow));
+
+      // Test PK getter
+      const pkGetter1 = comparator1.getPkGetter(meta);
+      const pkGetter2 = comparator2.getPkGetter(meta2);
+      expect(pkGetter1(author)).toEqual(pkGetter2(author2));
+
+      // Test PK serializer
+      const pkSerializer1 = comparator1.getPkSerializer(meta);
+      const pkSerializer2 = comparator2.getPkSerializer(meta2);
+      expect(pkSerializer1(author)).toEqual(pkSerializer2(author2));
+    } finally {
+      await orm2.close(true);
+    }
+  });
+
+  test('no new Function calls when compiledFunctions covers all entities', async () => {
+    const compiledFunctions = generateCompiledFunctions(orm);
+
+    const orm2 = await MikroORM.init({ ...initOptions, compiledFunctions });
+
+    try {
+      // Wrap createFunction to track if new Function is ever called (JIT fallback)
+      let jitFallbackCalled = false;
+      const original = Utils.createFunction;
+      Utils.createFunction = (context, code, cf, key) => {
+        const result = original.call(Utils, context, code, cf, key);
+
+        if (!key || !cf?.[key]) {
+          jitFallbackCalled = true;
+        }
+
+        return result;
+      };
+
+      try {
+        // Trigger all compiled function paths
+        const metadata = orm2.getMetadata();
+        const comparator = orm2.config.getComparator(metadata);
+        const hydrator = orm2.config.getHydrator(metadata) as ObjectHydrator;
+
+        for (const meta of metadata) {
+          if (meta.abstract) {
+            continue;
+          }
+
+          hydrator.getEntityHydrator(meta, 'full', false);
+          hydrator.getEntityHydrator(meta, 'full', true);
+          comparator.getEntityComparator(meta.class);
+          comparator.getSnapshotGenerator(meta.class);
+          comparator.getResultMapper(meta);
+
+          if (!meta.embeddable && !meta.virtual) {
+            hydrator.getEntityHydrator(meta, 'reference', false);
+            hydrator.getEntityHydrator(meta, 'reference', true);
+          }
+
+          if (meta.primaryKeys.length > 0) {
+            comparator.getPkGetter(meta);
+            comparator.getPkGetterConverted(meta);
+            comparator.getPkSerializer(meta);
+          }
+        }
+      } finally {
+        Utils.createFunction = original;
+      }
+
+      // No JIT fallback should have occurred
+      expect(jitFallbackCalled).toBe(false);
+    } finally {
+      await orm2.close(true);
+    }
+  });
+
+  test('falls back to JIT when key is missing from compiledFunctions', async () => {
+    // Provide only partial compiled functions (missing Book)
+    const allFunctions = generateCompiledFunctions(orm);
+    const partialFunctions: Record<string, (...args: any[]) => any> = {};
+    const authorUniqueName = orm.getMetadata().get(Author).uniqueName;
+
+    for (const [key, fn] of Object.entries(allFunctions)) {
+      if (key.includes(authorUniqueName)) {
+        partialFunctions[key] = fn;
+      }
+    }
+
+    const orm2 = await MikroORM.init({ ...initOptions, compiledFunctions: partialFunctions });
+
+    try {
+      await orm2.schema.refresh();
+
+      // Should still work - Book uses JIT fallback, Author uses compiled
+      const book = orm2.em.create(Book, { title: 'Test', price: 9.99 });
+      await orm2.em.flush();
+      orm2.em.clear();
+
+      const loaded = await orm2.em.findOneOrFail(Book, book.id);
+      expect(loaded.title).toBe('Test');
+      expect(loaded.price).toBe(9.99);
+    } finally {
+      await orm2.close(true);
+    }
+  });
+});


### PR DESCRIPTION
### Summary

- Adds compiledFunctions config option to bypass new Function/eval at runtime, enabling deployment to Cloudflare Workers and other edge runtimes that prohibit dynamic code evaluation
- Adds `npx mikro-orm compile` CLI command that pre-generates all per-entity hydration and comparison functions into a .js file
- At runtime, when a matching pre-generated function exists, it is used directly; otherwise falls back to the existing JIT path

### How it works

MikroORM JIT-compiles optimized functions per entity via `Utils.createFunction` (which wraps `new Function`). This adds an optional lookup: if a `compiledFunctions` map is provided via config and contains a matching key, the pre-generated function is called instead.

The CLI compile command discovers metadata, triggers all compilations while intercepting `createFunction` to capture the code strings, then writes them as real function declarations to a .js file.

```bash
npx mikro-orm compile --out ./compiled-functions.js
```

```ts
import compiledFunctions from './compiled-functions.js';

await MikroORM.init({
  compiledFunctions,
  // ...
});
```