### PR TITLE
refactor: prefer explicit config options over env vars

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -662,7 +662,17 @@ The full list of deprecation warnings:
 
 ## Using environment variables
 
-Most of the ORM options can be configured via environment variables. Environment variables always have precedence over the ORM config.
+Most of the ORM options can be configured via environment variables. Environment variables override the config file, but explicit options passed to `MikroORM.init()` or the `MikroORM` constructor always have the highest precedence. The full priority order (highest to lowest) is: explicit options > env vars > config file > defaults.
+
+Note that when you import your config file and pass it to `MikroORM.init(config)`, all values from the config file are treated as explicit options, so env vars won't override them. If you want env vars to take precedence over the config (e.g. for per-environment overrides in deployment), enable the `preferEnvVars` option:
+
+```ts
+export default defineConfig({
+  preferEnvVars: true,
+  host: 'localhost',
+  // MIKRO_ORM_HOST env var will override 'localhost'
+});
+```
 
 Full list of supported options:
 

--- a/packages/cli/src/CLIHelper.ts
+++ b/packages/cli/src/CLIHelper.ts
@@ -55,7 +55,7 @@ export class CLIHelper {
     const result = await this.getConfigFile(paths);
     if (!result[0]) {
       if (Utils.hasObjectKeys(env)) {
-        return new Configuration(Utils.mergeConfig({ contextName }, options, env));
+        return new Configuration(Utils.mergeConfig({ contextName }, options.preferEnvVars ? options : env, options.preferEnvVars ? env : options));
       }
       throw new Error(`MikroORM config file not found in ['${paths.join(`', '`)}']`);
     }
@@ -107,7 +107,8 @@ export class CLIHelper {
     const esmConfigOptions = this.isESM() ? { entityGenerator: { esmImport: true } } : {};
     await loadOptionalDependencies(tmp);
 
-    return new Configuration(Utils.mergeConfig({}, esmConfigOptions, tmp, options, env));
+    const preferEnvVars = options.preferEnvVars ?? tmp.preferEnvVars;
+    return new Configuration(Utils.mergeConfig({}, esmConfigOptions, tmp, preferEnvVars ? options : env, preferEnvVars ? env : options));
   }
 
   static commonJSCompat(options: Partial<Options>): void {

--- a/packages/core/src/MikroORM.ts
+++ b/packages/core/src/MikroORM.ts
@@ -133,7 +133,9 @@ export class MikroORM<
    */
   constructor(options: Options<Driver, EM, Entities>) {
     const env = loadEnvironmentVars();
-    options = Utils.merge(options, env);
+    options = options.preferEnvVars
+      ? Utils.merge(options, env)
+      : Utils.merge(env, options);
     this.config = new Configuration(options);
     const discovery = this.config.get('discovery');
     this.driver = this.config.getDriver();

--- a/packages/core/src/utils/Configuration.ts
+++ b/packages/core/src/utils/Configuration.ts
@@ -992,6 +992,12 @@ export interface Options<
    */
   allowGlobalContext?: boolean;
   /**
+   * When enabled, environment variables take precedence over explicitly provided config options.
+   * By default, explicit options win over env vars.
+   * @default false
+   */
+  preferEnvVars?: boolean;
+  /**
    * Disable the identity map.
    * When disabled, each query returns new entity instances.
    * Not recommended for most use cases.


### PR DESCRIPTION
BREAKING CHANGE:

Previously, environment variables always had the highest precedence — they would override both the config file and explicit options passed to `MikroORM.init()` or the `MikroORM` constructor. This meant that a stale `MIKRO_ORM_HOST` env var could silently override an explicitly provided `host` option.

In v7, the priority order is: explicit options > env vars > config file > defaults. Environment variables still override the config file (which is the typical use case for per-environment overrides), but explicit options passed programmatically always win.

```ts
// v6: env var MIKRO_ORM_HOST=db.prod.internal would override the host below
// v7: the explicit host option wins, env var is ignored
const orm = await MikroORM.init({
  host: 'localhost',
  // ...
});
```

Note that when you import your config file and pass it to `MikroORM.init(config)`, all values from the config file are treated as explicit options, so env vars won't override them. If you want to restore the v6 behavior where env vars always win, use the `preferEnvVars` option:

```ts
export default defineConfig({
  preferEnvVars: true,
  host: 'localhost',
  // MIKRO_ORM_HOST env var will override 'localhost'
});
```