### PR TITLE
feat(core): add `collation` support and MongoDB query options

### DIFF
--- a/docs/docs/query-builder.md
+++ b/docs/docs/query-builder.md
@@ -637,6 +637,33 @@ console.log(qb.getQuery()); // for Postgres
 //   for update of "u" skip locked
 ```
 
+## Collation
+
+You can set a collation for `ORDER BY` expressions using the `collation()` method. This appends `COLLATE <collation>` to **every** column in the `ORDER BY` clause:
+
+```ts
+const qb = em.createQueryBuilder(User);
+qb.select('*')
+  .collation('utf8mb4_general_ci')
+  .orderBy({ name: 'asc' });
+
+console.log(qb.getQuery());
+// select `e0`.* from `user` as `e0`
+//   order by `e0`.`name` collate `utf8mb4_general_ci` asc
+```
+
+To use collation in `WHERE` conditions, use raw SQL fragments:
+
+```ts
+const qb = em.createQueryBuilder(User);
+qb.select('*')
+  .where({ [sql`name collate utf8mb4_general_ci`]: 'john' });
+
+console.log(qb.getQuery());
+// select `e0`.* from `user` as `e0`
+//   where name collate `utf8mb4_general_ci` = ?
+```
+
 ## Using Kysely
 
 MikroORM builds SQL queries natively and executes them via [Kysely](https://kysely.dev/). You can access the configured Kysely instance via `em.getKysely()` method and use it to run your own queries:

--- a/docs/docs/upgrading-v6-to-v7.md
+++ b/docs/docs/upgrading-v6-to-v7.md
@@ -724,6 +724,16 @@ Check constraints now receive a `table` parameter for consistency with other cal
 
 Generated column callbacks now receive a `table` parameter for consistency.
 
-### TPT inheritance behavior
+## `MongoConnection` method signatures changed
 
-For Table-Per-Type (TPT) inheritance, the `columns` parameter in schema callbacks (indexes, checks, generated columns) only includes properties that belong to the current entity's table. Inherited properties from parent tables are not included, since they physically exist in different tables and cannot be referenced in schema definitions.
+The `MongoConnection.find()`, `MongoConnection.stream()`, and `MongoConnection.countDocuments()` methods now accept an options object instead of many positional parameters. This is only relevant if you call these methods directly (not through the EntityManager).
+
+```diff
+-connection.find(entityName, where, orderBy, limit, offset, fields, ctx, loggerContext);
++connection.find(entityName, where, { orderBy, limit, offset, fields, ctx, loggerContext });
+
+-connection.countDocuments(entityName, where, ctx);
++connection.countDocuments(entityName, where, { ctx });
+```
+
+The `MongoDriver.count()` method no longer accepts a separate `ctx` parameter — use `options.ctx` instead.

--- a/docs/docs/usage-with-mongo.md
+++ b/docs/docs/usage-with-mongo.md
@@ -167,3 +167,45 @@ There is also shortcut for calling `aggregate` method:
 em.aggregate(entityName: string, pipeline: any[]): Promise<any[]>;
 EntityRepository.aggregate(pipeline: any[]): Promise<any[]>;
 ```
+
+## Query Options
+
+You can pass MongoDB-specific query options to `em.find()` and `em.count()`:
+
+### Collation
+
+Controls string comparison rules for both filtering and sorting. Pass a `CollationOptions` object — in MongoDB, collation applies to the entire query operation, affecting both `WHERE` conditions and `ORDER BY`:
+
+```ts
+// Case-insensitive find and sort
+const users = await em.find(User, { name: 'john' }, {
+  collation: { locale: 'en', strength: 2 },
+  orderBy: { name: QueryOrder.ASC },
+});
+```
+
+### Index Hints
+
+Pass a string (index name) or object (index spec) to the native `hint` option:
+
+```ts
+const users = await em.find(User, {}, {
+  indexHint: 'name_1',
+});
+
+// or with index spec
+const users = await em.find(User, {}, {
+  indexHint: { name: 1 },
+});
+```
+
+### `maxTimeMS` and `allowDiskUse`
+
+```ts
+const users = await em.find(User, {}, {
+  maxTimeMS: 5000,     // query timeout in milliseconds
+  allowDiskUse: true,  // allow disk use for large sorts
+});
+```
+
+> The `collation`, `indexHint`, and `maxTimeMS` options also work with `em.count()`. The `allowDiskUse` option is only available for `em.find()`.

--- a/packages/core/src/drivers/IDatabaseDriver.ts
+++ b/packages/core/src/drivers/IDatabaseDriver.ts
@@ -209,12 +209,18 @@ export interface FindOptions<
   lockTableAliases?: string[];
   ctx?: Transaction;
   connectionType?: ConnectionType;
-  /** sql only */
-  indexHint?: string;
+  /** SQL: appended to FROM clause (e.g. `'force index(my_index)'`); MongoDB: index name or spec passed as `hint`. */
+  indexHint?: string | Dictionary;
   /** sql only */
   comments?: string | string[];
   /** sql only */
   hintComments?: string | string[];
+  /** SQL: collation name string applied as COLLATE to ORDER BY; MongoDB: CollationOptions object. */
+  collation?: CollationOptions | string;
+  /** mongodb only */
+  maxTimeMS?: number;
+  /** mongodb only */
+  allowDiskUse?: boolean;
   loggerContext?: LogContext;
   logging?: LoggingOptions;
   /** @internal used to apply filters to the auto-joined relations */
@@ -273,12 +279,16 @@ export interface CountOptions<T extends object, P extends string = never>  {
   ctx?: Transaction;
   connectionType?: ConnectionType;
   flushMode?: FlushMode | `${FlushMode}`;
-  /** sql only */
-  indexHint?: string;
+  /** SQL: appended to FROM clause (e.g. `'force index(my_index)'`); MongoDB: index name or spec passed as `hint`. */
+  indexHint?: string | Dictionary;
   /** sql only */
   comments?: string | string[];
   /** sql only */
   hintComments?: string | string[];
+  /** SQL: collation name string applied as COLLATE; MongoDB: CollationOptions object. */
+  collation?: CollationOptions | string;
+  /** mongodb only */
+  maxTimeMS?: number;
   loggerContext?: LogContext;
   logging?: LoggingOptions;
   /** @internal used to apply filters to the auto-joined relations */
@@ -310,6 +320,17 @@ export interface DriverMethodOptions {
   ctx?: Transaction;
   schema?: string;
   loggerContext?: LogContext;
+}
+
+export interface CollationOptions {
+  locale: string;
+  caseLevel?: boolean;
+  caseFirst?: string;
+  strength?: number;
+  numericOrdering?: boolean;
+  alternate?: string;
+  maxVariable?: string;
+  backwards?: boolean;
 }
 
 export interface GetReferenceOptions {

--- a/packages/mssql/src/MsSqlPlatform.ts
+++ b/packages/mssql/src/MsSqlPlatform.ts
@@ -272,18 +272,26 @@ export class MsSqlPlatform extends AbstractSqlPlatform {
     return false;
   }
 
-  override getOrderByExpression(column: string, direction: QueryOrder): string[] {
+  /** @internal MSSQL collation names are not quoted. */
+  override quoteCollation(collation: string): string {
+    this.validateCollationName(collation);
+    return collation;
+  }
+
+  override getOrderByExpression(column: string, direction: QueryOrder, collation?: string): string[] {
+    const col = collation ? `${column} collate ${this.quoteCollation(collation)}` : column;
+
     switch (direction.toUpperCase()) {
       case QueryOrder.ASC_NULLS_FIRST:
-        return [`case when ${column} is null then 0 else 1 end, ${column} asc`];
+        return [`case when ${column} is null then 0 else 1 end, ${col} asc`];
       case QueryOrder.ASC_NULLS_LAST:
-        return [`case when ${column} is null then 1 else 0 end, ${column} asc`];
+        return [`case when ${column} is null then 1 else 0 end, ${col} asc`];
       case QueryOrder.DESC_NULLS_FIRST:
-        return [`case when ${column} is null then 0 else 1 end, ${column} desc`];
+        return [`case when ${column} is null then 0 else 1 end, ${col} desc`];
       case QueryOrder.DESC_NULLS_LAST:
-        return [`case when ${column} is null then 1 else 0 end, ${column} desc`];
+        return [`case when ${column} is null then 1 else 0 end, ${col} desc`];
       default:
-        return [`${column} ${direction.toLowerCase()}`];
+        return [`${col} ${direction.toLowerCase()}`];
     }
   }
 

--- a/packages/sql/src/AbstractSqlPlatform.ts
+++ b/packages/sql/src/AbstractSqlPlatform.ts
@@ -137,8 +137,28 @@ export abstract class AbstractSqlPlatform extends Platform {
   /**
    * @internal
    */
-  getOrderByExpression(column: string, direction: string): string[] {
-    return [ `${column} ${direction.toLowerCase()}` ];
+  getOrderByExpression(column: string, direction: string, collation?: string): string[] {
+    if (collation) {
+      return [`${column} collate ${this.quoteCollation(collation)} ${direction.toLowerCase()}`];
+    }
+
+    return [`${column} ${direction.toLowerCase()}`];
+  }
+
+  /**
+   * Quotes a collation name for use in COLLATE clauses.
+   * @internal
+   */
+  quoteCollation(collation: string): string {
+    this.validateCollationName(collation);
+    return this.quoteIdentifier(collation);
+  }
+
+  /** @internal */
+  protected validateCollationName(collation: string): void {
+    if (!/^[\w]+$/.test(collation)) {
+      throw new Error(`Invalid collation name: '${collation}'. Collation names must contain only word characters.`);
+    }
   }
 
 }

--- a/packages/sql/src/dialects/mysql/BaseMySqlPlatform.ts
+++ b/packages/sql/src/dialects/mysql/BaseMySqlPlatform.ts
@@ -150,15 +150,16 @@ export class BaseMySqlPlatform extends AbstractSqlPlatform {
     return `alter table ${quotedTableName} add fulltext index ${quotedIndexName}(${quotedColumnNames.join(',')})`;
   }
 
-  override getOrderByExpression(column: string, direction: string): string[] {
+  override getOrderByExpression(column: string, direction: string, collation?: string): string[] {
     const ret: string[] = [];
     const dir = direction.toLowerCase() as keyof typeof this.ORDER_BY_NULLS_TRANSLATE;
+    const col = collation ? `${column} collate ${this.quoteCollation(collation)}` : column;
 
     if (dir in this.ORDER_BY_NULLS_TRANSLATE) {
-      ret.push(`${column} ${this.ORDER_BY_NULLS_TRANSLATE[dir]}`);
+      ret.push(`${col} ${this.ORDER_BY_NULLS_TRANSLATE[dir]}`);
     }
 
-    ret.push(`${column} ${dir.replace(/(\s|nulls|first|last)*/gi, '')}`);
+    ret.push(`${col} ${dir.replace(/(\s|nulls|first|last)*/gi, '')}`);
 
     return ret;
   }

--- a/packages/sql/src/query/QueryBuilder.ts
+++ b/packages/sql/src/query/QueryBuilder.ts
@@ -491,6 +491,7 @@ export class QueryBuilder<
   protected _joinedProps = new Map<string, PopulateOptions<any>>();
   protected _cache?: boolean | number | [string, number];
   protected _indexHint?: string;
+  protected _collation?: string;
   protected _comments: string[] = [];
   protected _hintComments: string[] = [];
   protected flushMode?: FlushMode;
@@ -1628,6 +1629,15 @@ export class QueryBuilder<
   }
 
   /**
+   * Adds COLLATE clause to ORDER BY expressions.
+   */
+  collation(collation: string | undefined): this {
+    this.ensureNotFinalized();
+    this._collation = collation;
+    return this;
+  }
+
+  /**
    * Prepend comment to the sql query using the syntax `/* ... *&#8205;/`. Some characters are forbidden such as `/*, *&#8205;/` and `?`.
    */
   comment(comment: string | string[] | undefined): this {
@@ -1691,7 +1701,7 @@ export class QueryBuilder<
     Utils.runIfNotEmpty(() => qb.groupBy(this.prepareFields(this._groupBy, 'groupBy', schema)), isNotEmptyObject(this._groupBy));
     Utils.runIfNotEmpty(() => this.helper.appendQueryCondition(this.type, this._having, qb, undefined, 'having'), isNotEmptyObject(this._having));
     Utils.runIfNotEmpty(() => {
-      const queryOrder = this.helper.getQueryOrder(this.type, this._orderBy as FlatQueryOrderMap[], this._populateMap);
+      const queryOrder = this.helper.getQueryOrder(this.type, this._orderBy as FlatQueryOrderMap[], this._populateMap, this._collation);
 
       if (queryOrder.length > 0) {
         const sql = Utils.unique(queryOrder).join(', ');
@@ -2121,7 +2131,7 @@ export class QueryBuilder<
     // clone array/object properties
     const properties = [
       'flags', '_populate', '_populateWhere', '_populateFilter', '__populateWhere', '_populateMap', '_joins', '_joinedProps', '_cond', '_data', '_orderBy',
-      '_schema', '_indexHint', '_cache', 'subQueries', 'lockMode', 'lockTables', '_groupBy', '_having', '_returning',
+      '_schema', '_indexHint', '_collation', '_cache', 'subQueries', 'lockMode', 'lockTables', '_groupBy', '_having', '_returning',
       '_comments', '_hintComments', 'aliasCounter',
     ];
 

--- a/packages/sql/src/query/QueryBuilderHelper.ts
+++ b/packages/sql/src/query/QueryBuilderHelper.ts
@@ -779,15 +779,15 @@ export class QueryBuilderHelper {
     }
   }
 
-  getQueryOrder(type: QueryType, orderBy: FlatQueryOrderMap | FlatQueryOrderMap[], populate: Dictionary<string>): string[] {
+  getQueryOrder(type: QueryType, orderBy: FlatQueryOrderMap | FlatQueryOrderMap[], populate: Dictionary<string>, collation?: string): string[] {
     if (Array.isArray(orderBy)) {
-      return orderBy.flatMap(o => this.getQueryOrder(type, o, populate));
+      return orderBy.flatMap(o => this.getQueryOrder(type, o, populate, collation));
     }
 
-    return this.getQueryOrderFromObject(type, orderBy, populate);
+    return this.getQueryOrderFromObject(type, orderBy, populate, collation);
   }
 
-  getQueryOrderFromObject(type: QueryType, orderBy: FlatQueryOrderMap, populate: Dictionary<string>): string[] {
+  getQueryOrderFromObject(type: QueryType, orderBy: FlatQueryOrderMap, populate: Dictionary<string>, collation?: string): string[] {
     const ret: string[] = [];
 
     for (const key of Utils.getObjectQueryKeys(orderBy)) {
@@ -796,7 +796,7 @@ export class QueryBuilderHelper {
 
       if (Raw.isKnownFragmentSymbol(key)) {
         const raw = Raw.getKnownFragment(key)!;
-        ret.push(...this.platform.getOrderByExpression(this.platform.formatQuery(raw.sql, raw.params), order));
+        ret.push(...this.platform.getOrderByExpression(this.platform.formatQuery(raw.sql, raw.params), order, collation));
         continue;
       }
 
@@ -821,9 +821,9 @@ export class QueryBuilderHelper {
         }
 
         if (Array.isArray(order)) {
-          order.forEach(part => ret.push(...this.getQueryOrderFromObject(type, part, populate)));
+          order.forEach(part => ret.push(...this.getQueryOrderFromObject(type, part, populate, collation)));
         } else {
-          ret.push(...this.platform.getOrderByExpression(colPart, order));
+          ret.push(...this.platform.getOrderByExpression(colPart, order, collation));
         }
       }
     }

--- a/tests/features/entity-manager/EntityManager.mssql.test.ts
+++ b/tests/features/entity-manager/EntityManager.mssql.test.ts
@@ -1375,6 +1375,15 @@ describe('EntityManagerMsSql', () => {
     expect(author.books.getItems().every(b => b.uuid)).toBe(true);
   });
 
+  test('collation option', async () => {
+    const mock = mockLogger(orm, ['query']);
+    await orm.em.find(Author2, {}, {
+      collation: 'Latin1_General_CI_AS',
+      orderBy: { name: 'asc' },
+    });
+    expect(mock.mock.calls[0][0]).toMatch('order by [a0].[name] collate Latin1_General_CI_AS asc');
+  });
+
   // this should run in ~700ms (when running single test locally)
   test('perf: batch insert and update', async () => {
     const authors = new Set<Author2>();

--- a/tests/features/entity-manager/EntityManager.postgre.test.ts
+++ b/tests/features/entity-manager/EntityManager.postgre.test.ts
@@ -2328,6 +2328,15 @@ describe('EntityManagerPostgre', () => {
     expect(ttt1.parent).toBe(t3.id);
   });
 
+  test('collation option', async () => {
+    const mock = mockLogger(orm, ['query']);
+    await orm.em.find(Author2, {}, {
+      collation: 'en_US',
+      orderBy: { name: 'asc' },
+    });
+    expect(mock.mock.calls[0][0]).toMatch('order by "a0"."name" collate "en_US" asc');
+  });
+
   test('perf: delete', async () => {
     const start = performance.now();
     for (let i = 1; i <= 5_000; i++) {

--- a/tests/features/entity-manager/EntityManager.sqlite.test.ts
+++ b/tests/features/entity-manager/EntityManager.sqlite.test.ts
@@ -1345,6 +1345,15 @@ describe.each(['sqlite', 'libsql'] as const)('EntityManager (%s)', driver => {
     expect(author.books.getItems().every(b => b.id)).toBe(true);
   });
 
+  test('collation option', async () => {
+    const mock = mockLogger(orm, ['query']);
+    await orm.em.find(Author4, {}, {
+      collation: 'NOCASE',
+      orderBy: { name: 'asc' },
+    });
+    expect(mock.mock.calls[0][0]).toMatch('order by `a0`.`name` collate `NOCASE` asc');
+  });
+
   // this should run in ~400ms (when running single test locally)
   test('perf: batch insert and update', async () => {
     const authors = new Set<Author4>();

--- a/tests/features/query-builder/query-builder-mutations.test.ts
+++ b/tests/features/query-builder/query-builder-mutations.test.ts
@@ -444,6 +444,29 @@ describe('QueryBuilder - Mutations', () => {
     expect(sql3).toBe("update `my_schema`.`author2` force index(custom_email_index_name) set `name` = '...' where `favourite_book_uuid_pk` in ('1', '2', '3')");
   });
 
+  test('collation', async () => {
+    const sql1 = orm.em
+      .createQueryBuilder(Author2)
+      .collation('utf8_general_ci')
+      .orderBy({ name: 'asc' })
+      .getFormattedQuery();
+    expect(sql1).toBe('select `e0`.* from `author2` as `e0` order by `e0`.`name` collate `utf8_general_ci` asc');
+
+    const sql2 = orm.em
+      .createQueryBuilder(Author2)
+      .collation('utf8_general_ci')
+      .orderBy({ name: 'asc', email: 'desc' })
+      .getFormattedQuery();
+    expect(sql2).toBe('select `e0`.* from `author2` as `e0` order by `e0`.`name` collate `utf8_general_ci` asc, `e0`.`email` collate `utf8_general_ci` desc');
+
+    // without collation, normal behavior
+    const sql3 = orm.em
+      .createQueryBuilder(Author2)
+      .orderBy({ name: 'asc' })
+      .getFormattedQuery();
+    expect(sql3).toBe('select `e0`.* from `author2` as `e0` order by `e0`.`name` asc');
+  });
+
   test('query comments', async () => {
     const sql1 = orm.em
       .createQueryBuilder(Author2)

--- a/tests/features/query-builder/query-builder.postgres.test.ts
+++ b/tests/features/query-builder/query-builder.postgres.test.ts
@@ -408,6 +408,29 @@ describe('QueryBuilder - Postgres', () => {
     );
   });
 
+  test('collation', async () => {
+    const sql1 = pg.em
+      .createQueryBuilder(Author2)
+      .collation('en_US')
+      .orderBy({ name: 'asc' })
+      .getFormattedQuery();
+    expect(sql1).toBe('select "a0".* from "author2" as "a0" order by "a0"."name" collate "en_US" asc');
+
+    const sql2 = pg.em
+      .createQueryBuilder(Author2)
+      .collation('en_US')
+      .orderBy({ name: 'asc', email: 'desc' })
+      .getFormattedQuery();
+    expect(sql2).toBe('select "a0".* from "author2" as "a0" order by "a0"."name" collate "en_US" asc, "a0"."email" collate "en_US" desc');
+
+    // without collation, normal behavior
+    const sql3 = pg.em
+      .createQueryBuilder(Author2)
+      .orderBy({ name: 'asc' })
+      .getFormattedQuery();
+    expect(sql3).toBe('select "a0".* from "author2" as "a0" order by "a0"."name" asc');
+  });
+
   test('lateral join', async () => {
     const author = await pg.em.insert(Author2, { name: 'a', email: 'e' });
     const t1 = await pg.em.insert(BookTag2, { name: 't1' });


### PR DESCRIPTION
Add `collation` option to `FindOptions`/`CountOptions` for ORDER BY collation in SQL drivers and native collation in MongoDB. Add `indexHint` (object form), `maxTimeMS`, and `allowDiskUse` options for MongoDB.

Refactor `MongoConnection` to use options objects instead of positional params, consolidate `MongoFindExtra`/`MongoCountExtra` into `MongoQueryOptions`, and fix `loggerContext` not being propagated through `MongoConnection.runQuery`.

Add input validation for SQL collation names to prevent injection, and extract shared `validateCollationName` and `validateSqlOptions` helpers.

Closes #1603