### PR TITLE
feat(sql): support aliasing formula and regular properties in `QueryBuilder` select

### DIFF
--- a/docs/docs/query-builder.md
+++ b/docs/docs/query-builder.md
@@ -493,6 +493,43 @@ const qb = em.createQueryBuilder(BookTag, 't')
 
 The `andHaving()` and `orHaving()` methods are also available for combining multiple having conditions.
 
+### Aliasing fields with `as`
+
+You can alias any selected field — including `@Formula` properties — using the `as` syntax:
+
+```ts
+// String 'as' syntax
+const qb = em.createQueryBuilder(Book, 'b')
+  .select(['b.title', 'b.priceTaxed as tax'])
+  .where({ title: 'test' });
+```
+
+```sql
+select `b`.`title`, `b`.`price` * 1.19 as `tax`
+from `book` as `b`
+where `b`.`title` = 'test'
+```
+
+You can also use `sql.ref().as()` for formula properties:
+
+```ts
+const qb = em.createQueryBuilder(Book, 'b')
+  .select(['b.title', sql.ref('b.priceTaxed').as('tax')])
+  .where({ title: 'test' });
+```
+
+Aliases created via either mechanism feed into `having()` and `orderBy()`, so you can type-check aggregated aliases:
+
+```ts
+const qb = em.createQueryBuilder(FooBar, 'fb')
+  .select(['fb.id', 'random as rnd'])
+  .groupBy('fb.id')
+  .having({ rnd: { $gt: 0 } }) // 'rnd' is type-checked!
+  .orderBy({ rnd: 'desc' });
+```
+
+> **Note:** Field aliasing is only supported in QueryBuilder. Custom aliases break entity hydration, so they are not available in `em.find()`.
+
 ## Overriding FROM clause
 
 You can specify the table used in the `FROM` clause, replacing the current table name if one has already been specified. This is typically used to specify a sub-query expression in SQL.

--- a/packages/sql/src/AbstractSqlDriver.ts
+++ b/packages/sql/src/AbstractSqlDriver.ts
@@ -2047,7 +2047,7 @@ export abstract class AbstractSqlDriver<
     }
 
     return prop.fieldNames.map(fieldName => {
-      return `${tableAlias}.${fieldName} as ${tableAlias}__${fieldName}`;
+      return raw('?? as ??', [`${tableAlias}.${fieldName}`, `${tableAlias}__${fieldName}`]);
     });
   }
 

--- a/packages/sql/src/query/QueryBuilderHelper.ts
+++ b/packages/sql/src/query/QueryBuilderHelper.ts
@@ -161,8 +161,8 @@ export class QueryBuilderHelper {
 
     if (prop?.formula) {
       const alias2 = this.platform.quoteIdentifier(a).toString();
-      const aliased = this.platform.quoteIdentifier(prop.fieldNames[0]).toString();
-      const as = alias === null ? '' : ` as ${aliased}`;
+      const aliasName = alias === undefined ? prop.fieldNames[0] : alias;
+      const as = aliasName === null ? '' : ` as ${this.platform.quoteIdentifier(aliasName)}`;
       const meta = this.aliasMap[a]?.meta ?? this.metadata.get(this.entityName);
       const table = this.createFormulaTable(alias2, meta, schema);
       const columns = meta.createColumnMappingObject(

--- a/tests/bench/types/defineEntity.ts
+++ b/tests/bench/types/defineEntity.ts
@@ -17,7 +17,7 @@ bench('defineEntity with relations', () => {
       scalarRefNullable: p.string().ref().nullable(),
     },
   });
-}).types([13132, 'instantiations']);
+}).types([13144, 'instantiations']);
 
 bench('defineEntity with ref and nullable', () => {
   const Foo = defineEntity({
@@ -34,7 +34,7 @@ bench('defineEntity with ref and nullable', () => {
       scalarRefNullable: p.string().ref().nullable(),
     },
   });
-}).types([13493, 'instantiations']);
+}).types([13505, 'instantiations']);
 
 bench('defineEntity only with ref and nullable', () => {
   const Foo = defineEntity({
@@ -44,7 +44,7 @@ bench('defineEntity only with ref and nullable', () => {
       toOneRefNullable: () => p.oneToOne(Foo).ref().nullable(),
     },
   });
-}).types([11357, 'instantiations']);
+}).types([11369, 'instantiations']);
 
 bench('defineEntity only with nullable and ref', () => {
   const Foo = defineEntity({
@@ -54,7 +54,7 @@ bench('defineEntity only with nullable and ref', () => {
       toOneRefNullable: () => p.oneToOne(Foo).nullable().ref(),
     },
   });
-}).types([11361, 'instantiations']);
+}).types([11373, 'instantiations']);
 
 bench('defineEntity with relations using class', () => {
   class Foo {
@@ -86,7 +86,7 @@ bench('defineEntity with relations using class', () => {
       scalarRefNullable: p.string().ref().nullable(),
     },
   });
-}).types([12071, 'instantiations']);
+}).types([12083, 'instantiations']);
 
 bench('defineEntity with ref and nullable using class', () => {
   class Foo {
@@ -118,7 +118,7 @@ bench('defineEntity with ref and nullable using class', () => {
       scalarRefNullable: p.string().ref().nullable(),
     },
   });
-}).types([12071, 'instantiations']);
+}).types([12083, 'instantiations']);
 
 bench('defineEntity only with ref and nullable using class', () => {
   class Foo {
@@ -136,7 +136,7 @@ bench('defineEntity only with ref and nullable using class', () => {
       toOneRefNullable: () => p.oneToOne(Foo).ref().nullable(),
     },
   });
-}).types([9957, 'instantiations']);
+}).types([9969, 'instantiations']);
 
 bench('defineEntity only with nullable and ref using class', () => {
   class Foo {
@@ -154,7 +154,7 @@ bench('defineEntity only with nullable and ref using class', () => {
       toOneRefNullable: () => p.oneToOne(Foo).nullable().ref(),
     },
   });
-}).types([9961, 'instantiations']);
+}).types([9973, 'instantiations']);
 
 bench('EntitySchema', () => {
   interface IFoo {
@@ -239,4 +239,4 @@ bench('defineEntity with setClass pattern (circular relations)', () => {
 
   AuthorSchema.setClass(Author);
   BookSchema.setClass(Book);
-}).types([8612, 'instantiations']);
+}).types([8623, 'instantiations']);

--- a/tests/bench/types/querybuilder.ts
+++ b/tests/bench/types/querybuilder.ts
@@ -56,22 +56,22 @@ function useField<E, R extends string, C>(_field: Field<E, R, C>): void {}
 
 bench('Field<Author, "a", never> - no context', () => {
   useField<Author, 'a', never>('name');
-}).types([137, 'instantiations']);
+}).types([144, 'instantiations']);
 
 bench('Field<Author, "a", never> - wildcard', () => {
   useField<Author, 'a', never>('*');
-}).types([137, 'instantiations']);
+}).types([144, 'instantiations']);
 
 bench('Field<Author, "a", never> - alias wildcard', () => {
   useField<Author, 'a', never>('a.*');
-}).types([137, 'instantiations']);
+}).types([144, 'instantiations']);
 
 // Context uses tuple format: [Path, Alias, Type, Select]
 type SimpleContext = { b: ['books', 'b', Book, false] };
 
 bench('Field<Author, "a", SimpleContext> - with one join', () => {
   useField<Author, 'a', SimpleContext>('b.title');
-}).types([228, 'instantiations']);
+}).types([240, 'instantiations']);
 
 type TwoJoinContext = {
   b: ['books', 'b', Book, false];
@@ -80,7 +80,7 @@ type TwoJoinContext = {
 
 bench('Field<Author, "a", TwoJoinContext> - with two joins', () => {
   useField<Author, 'a', TwoJoinContext>('t.name');
-}).types([273, 'instantiations']);
+}).types([285, 'instantiations']);
 
 // ============================================
 // ModifyHint benchmarks

--- a/tests/features/embeddables/expand-query-builder-select.test.ts
+++ b/tests/features/embeddables/expand-query-builder-select.test.ts
@@ -1,4 +1,4 @@
-import { JoinType, MikroORM, Ref } from '@mikro-orm/sqlite';
+import { JoinType, MikroORM, Ref, sql } from '@mikro-orm/sqlite';
 import { Embeddable, Embedded, Entity, OneToOne, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
 
 @Embeddable()
@@ -86,4 +86,12 @@ test('should populate with joinAndSelect', async () => {
   expect(user!.name).toBe('Foo');
   expect(user?.details?.toJSON().address).toBeDefined();
   expect(user?.details?.toJSON().address).toEqual({ name: 'Bar', addressNo: 1 });
+});
+
+test('alias on flat embedded property throws', async () => {
+  const qb = orm.em.createQueryBuilder(UserDetails, 'ud');
+  qb.select(['ud.phoneNumber', 'ud.address as addr']);
+  expect(() => qb.getQuery()).toThrow(
+    `Cannot use 'as addr' alias on embedded property 'ud.address' because it expands to multiple columns. Alias individual fields instead (e.g. 'ud.address.propertyName as addr').`,
+  );
 });


### PR DESCRIPTION
Allow `@Formula` and regular properties to be aliased in `qb.select()` via string `as` syntax (`'fullName as displayName'`) and `sql.ref().as()` (`sql.ref('fullName').as('displayName')`). Aliases feed into `having()` type system so `having({ displayName: ... })` type-checks.

Closes #7180