### PR TITLE
refactor: separate driver-specific find options

### DIFF
--- a/packages/core/src/drivers/IDatabaseDriver.ts
+++ b/packages/core/src/drivers/IDatabaseDriver.ts
@@ -196,31 +196,11 @@ export interface FindOptions<
   disableIdentityMap?: boolean;
   schema?: string;
   flags?: QueryFlag[];
-  /** sql only */
-  groupBy?: string | string[];
-  having?: FilterQuery<Entity>;
-  /** sql only */
   strategy?: LoadStrategy | `${LoadStrategy}`;
   flushMode?: FlushMode | `${FlushMode}`;
   filters?: FilterOptions;
-  /** sql only */
-  lockMode?: Exclude<LockMode, LockMode.OPTIMISTIC>;
-  /** sql only */
-  lockTableAliases?: string[];
   ctx?: Transaction;
   connectionType?: ConnectionType;
-  /** SQL: appended to FROM clause (e.g. `'force index(my_index)'`); MongoDB: index name or spec passed as `hint`. */
-  indexHint?: string | Dictionary;
-  /** sql only */
-  comments?: string | string[];
-  /** sql only */
-  hintComments?: string | string[];
-  /** SQL: collation name string applied as COLLATE to ORDER BY; MongoDB: CollationOptions object. */
-  collation?: CollationOptions | string;
-  /** mongodb only */
-  maxTimeMS?: number;
-  /** mongodb only */
-  allowDiskUse?: boolean;
   loggerContext?: LogContext;
   logging?: LoggingOptions;
   /** @internal used to apply filters to the auto-joined relations */
@@ -270,8 +250,6 @@ export interface UpsertManyOptions<Entity, Fields extends string = never> extend
 export interface CountOptions<T extends object, P extends string = never>  {
   filters?: FilterOptions;
   schema?: string;
-  groupBy?: string | readonly string[];
-  having?: FilterQuery<T>;
   cache?: boolean | number | [string, number];
   populate?: Populate<T, P>;
   populateWhere?: ObjectQuery<T> | PopulateHint | `${PopulateHint}`;
@@ -279,16 +257,6 @@ export interface CountOptions<T extends object, P extends string = never>  {
   ctx?: Transaction;
   connectionType?: ConnectionType;
   flushMode?: FlushMode | `${FlushMode}`;
-  /** SQL: appended to FROM clause (e.g. `'force index(my_index)'`); MongoDB: index name or spec passed as `hint`. */
-  indexHint?: string | Dictionary;
-  /** sql only */
-  comments?: string | string[];
-  /** sql only */
-  hintComments?: string | string[];
-  /** SQL: collation name string applied as COLLATE; MongoDB: CollationOptions object. */
-  collation?: CollationOptions | string;
-  /** mongodb only */
-  maxTimeMS?: number;
   loggerContext?: LogContext;
   logging?: LoggingOptions;
   /** @internal used to apply filters to the auto-joined relations */
@@ -320,17 +288,6 @@ export interface DriverMethodOptions {
   ctx?: Transaction;
   schema?: string;
   loggerContext?: LogContext;
-}
-
-export interface CollationOptions {
-  locale: string;
-  caseLevel?: boolean;
-  caseFirst?: string;
-  strength?: number;
-  numericOrdering?: boolean;
-  alternate?: string;
-  maxVariable?: string;
-  backwards?: boolean;
 }
 
 export interface GetReferenceOptions {

--- a/packages/core/src/entity/EntityLoader.ts
+++ b/packages/core/src/entity/EntityLoader.ts
@@ -251,7 +251,7 @@ export class EntityLoader {
       filters, convertCustomTypes, lockMode, strategy, populateWhere, connectionType, logging,
       fields: fields as never[],
       populate: [],
-    });
+    } as any);
   }
 
   private async populatePolymorphic<Entity extends object>(entities: Entity[], prop: EntityProperty<Entity>, options: Required<EntityLoaderOptions<Entity>>, ref: boolean): Promise<AnyEntity[]> {
@@ -467,7 +467,7 @@ export class EntityLoader {
       refresh: refresh && !children.every(item => options.visited.has(item)),
       // @ts-ignore not a public option, will be propagated to the populate call
       visited: options.visited,
-    });
+    } as any);
 
     // For targetKey relations, wire up loaded entities to parent references
     // This is needed because the references were created under alternate key,

--- a/packages/mongodb/src/MongoDriver.ts
+++ b/packages/mongodb/src/MongoDriver.ts
@@ -308,11 +308,7 @@ export class MongoDriver extends DatabaseDriver<MongoConnection> {
     return this.platform;
   }
 
-  private buildQueryOptions(options: Pick<FindOptions<any, any, any, any>, 'collation' | 'indexHint' | 'maxTimeMS' | 'allowDiskUse'>): MongoQueryOptions {
-    if (options.collation != null && typeof options.collation === 'string') {
-      throw new Error('Collation option for MongoDB must be a CollationOptions object (e.g. { locale: \'en\' }). Use a string only with SQL drivers.');
-    }
-
+  private buildQueryOptions(options: Dictionary): MongoQueryOptions {
     const ret: MongoQueryOptions = {};
 
     if (options.collation) {

--- a/packages/mongodb/src/MongoEntityManager.ts
+++ b/packages/mongodb/src/MongoEntityManager.ts
@@ -1,16 +1,30 @@
 import {
   EntityManager,
   Utils,
+  type CountOptions,
+  type Cursor,
   type EntityName,
   type EntityRepository,
+  type FilterQuery,
+  type FindOneOrFailOptions,
+  type FromEntityType,
   type GetRepository,
-  type TransactionOptions,
-  type StreamOptions,
   type Loaded,
+  type MergeLoaded,
+  type TransactionOptions,
 } from '@mikro-orm/core';
 import type { Collection, Document, TransactionOptions as MongoTransactionOptions } from 'mongodb';
 import type { MongoDriver } from './MongoDriver.js';
 import type { MongoEntityRepository } from './MongoEntityRepository.js';
+import type {
+  MongoCountOptions,
+  MongoFindAllOptions,
+  MongoFindByCursorOptions,
+  MongoFindOneOptions,
+  MongoFindOneOrFailOptions,
+  MongoFindOptions,
+  MongoStreamOptions,
+} from './typings.js';
 
 /**
  * @inheritDoc
@@ -34,17 +48,113 @@ export class MongoEntityManager<Driver extends MongoDriver = MongoDriver> extend
   /**
    * @inheritDoc
    */
+  override find<
+    Entity extends object,
+    Hint extends string = never,
+    Fields extends string = '*',
+    Excludes extends string = never,
+  >(entityName: EntityName<Entity>, where: FilterQuery<NoInfer<Entity>>, options?: MongoFindOptions<Entity, Hint, Fields, Excludes>): Promise<Loaded<Entity, Hint, Fields, Excludes>[]> {
+    return super.find(entityName, where, options);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  override findOne<
+    Entity extends object,
+    Hint extends string = never,
+    Fields extends string = '*',
+    Excludes extends string = never,
+  >(entityName: EntityName<Entity>, where: FilterQuery<NoInfer<Entity>>, options?: MongoFindOneOptions<Entity, Hint, Fields, Excludes>): Promise<Loaded<Entity, Hint, Fields, Excludes> | null> {
+    return super.findOne(entityName, where, options);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  override findOneOrFail<
+    Entity extends object,
+    Hint extends string = never,
+    Fields extends string = '*',
+    Excludes extends string = never,
+  >(entityName: EntityName<Entity>, where: FilterQuery<NoInfer<Entity>>, options?: MongoFindOneOrFailOptions<Entity, Hint, Fields, Excludes>): Promise<Loaded<Entity, Hint, Fields, Excludes>> {
+    return super.findOneOrFail(entityName, where, options as FindOneOrFailOptions<Entity, Hint, Fields, Excludes>);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  override findAll<
+    Entity extends object,
+    Hint extends string = never,
+    Fields extends string = '*',
+    Excludes extends string = never,
+  >(entityName: EntityName<Entity>, options?: MongoFindAllOptions<NoInfer<Entity>, Hint, Fields, Excludes>): Promise<Loaded<Entity, Hint, Fields, Excludes>[]> {
+    return super.findAll(entityName, options);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  override findAndCount<
+    Entity extends object,
+    Hint extends string = never,
+    Fields extends string = '*',
+    Excludes extends string = never,
+  >(entityName: EntityName<Entity>, where: FilterQuery<NoInfer<Entity>>, options?: MongoFindOptions<Entity, Hint, Fields, Excludes>): Promise<[Loaded<Entity, Hint, Fields, Excludes>[], number]> {
+    return super.findAndCount(entityName, where, options);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  override findByCursor<
+    Entity extends object,
+    Hint extends string = never,
+    Fields extends string = '*',
+    Excludes extends string = never,
+    IncludeCount extends boolean = true,
+  >(entityName: EntityName<Entity>, options: MongoFindByCursorOptions<Entity, Hint, Fields, Excludes, IncludeCount>): Promise<Cursor<Entity, Hint, Fields, Excludes, IncludeCount>> {
+    return super.findByCursor(entityName, options);
+  }
+
+  /**
+   * @inheritDoc
+   */
   override async *stream<
     Entity extends object,
     Hint extends string = never,
     Fields extends string = '*',
     Excludes extends string = never,
-  >(entityName: EntityName<Entity>, options: StreamOptions<NoInfer<Entity>, Hint, Fields, Excludes> = {}): AsyncIterableIterator<Loaded<Entity, Hint, Fields, Excludes>> {
+  >(entityName: EntityName<Entity>, options: MongoStreamOptions<NoInfer<Entity>, Hint, Fields, Excludes> = {}): AsyncIterableIterator<Loaded<Entity, Hint, Fields, Excludes>> {
     if (!Utils.isEmpty(options.populate)) {
       throw new Error('Populate option is not supported when streaming results in MongoDB');
     }
 
     yield* super.stream(entityName, options);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  override count<
+    Entity extends object,
+    Hint extends string = never,
+  >(entityName: EntityName<Entity>, where?: FilterQuery<NoInfer<Entity>>, options?: MongoCountOptions<Entity, Hint>): Promise<number> {
+    return super.count(entityName, where, options as CountOptions<Entity, Hint>);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  override refresh<
+    Entity extends object,
+    Naked extends FromEntityType<Entity> = FromEntityType<Entity>,
+    Hint extends string = never,
+    Fields extends string = '*',
+    Excludes extends string = never,
+  >(entity: Entity, options?: MongoFindOneOptions<Entity, Hint, Fields, Excludes>): Promise<MergeLoaded<Entity, Naked, Hint, Fields, Excludes, true> | null> {
+    return super.refresh(entity, options);
   }
 
   getCollection<T extends Document>(entityName: EntityName<T>): Collection<T> {

--- a/packages/mongodb/src/MongoEntityRepository.ts
+++ b/packages/mongodb/src/MongoEntityRepository.ts
@@ -1,11 +1,26 @@
-import { EntityRepository, type EntityName } from '@mikro-orm/core';
+import {
+  EntityRepository,
+  type Cursor,
+  type EntityName,
+  type FilterQuery,
+  type Loaded,
+} from '@mikro-orm/core';
 import type { Collection } from 'mongodb';
 import type { MongoEntityManager } from './MongoEntityManager.js';
+import type {
+  MongoCountOptions,
+  MongoFindAllOptions,
+  MongoFindByCursorOptions,
+  MongoFindOneOptions,
+  MongoFindOneOrFailOptions,
+  MongoFindOptions,
+  MongoStreamOptions,
+} from './typings.js';
 
-export class MongoEntityRepository<T extends object> extends EntityRepository<T> {
+export class MongoEntityRepository<Entity extends object> extends EntityRepository<Entity> {
 
   constructor(protected override readonly em: MongoEntityManager,
-              entityName: EntityName<T>) {
+              entityName: EntityName<Entity>) {
     super(em, entityName);
   }
 
@@ -16,8 +31,93 @@ export class MongoEntityRepository<T extends object> extends EntityRepository<T>
     return this.getEntityManager().aggregate(this.entityName, pipeline);
   }
 
-  getCollection(): Collection<T> {
+  getCollection(): Collection<Entity> {
     return this.getEntityManager().getCollection(this.entityName);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  override async findOne<
+    Hint extends string = never,
+    Fields extends string = '*',
+    Excludes extends string = never,
+  >(where: FilterQuery<Entity>, options?: MongoFindOneOptions<Entity, Hint, Fields, Excludes>): Promise<Loaded<Entity, Hint, Fields, Excludes> | null> {
+    return this.getEntityManager().findOne<Entity, Hint, Fields, Excludes>(this.entityName, where as any, options);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  override async findOneOrFail<
+    Hint extends string = never,
+    Fields extends string = '*',
+    Excludes extends string = never,
+  >(where: FilterQuery<Entity>, options?: MongoFindOneOrFailOptions<Entity, Hint, Fields, Excludes>): Promise<Loaded<Entity, Hint, Fields, Excludes>> {
+    return this.getEntityManager().findOneOrFail<Entity, Hint, Fields, Excludes>(this.entityName, where as any, options);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  override async find<
+    Hint extends string = never,
+    Fields extends string = '*',
+    Excludes extends string = never,
+  >(where: FilterQuery<Entity>, options?: MongoFindOptions<Entity, Hint, Fields, Excludes>): Promise<Loaded<Entity, Hint, Fields, Excludes>[]> {
+    return this.getEntityManager().find(this.entityName, where as any, options);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  override async findAndCount<
+    Hint extends string = never,
+    Fields extends string = '*',
+    Excludes extends string = never,
+  >(where: FilterQuery<Entity>, options?: MongoFindOptions<Entity, Hint, Fields, Excludes>): Promise<[Loaded<Entity, Hint, Fields, Excludes>[], number]> {
+    return this.getEntityManager().findAndCount(this.entityName, where as any, options);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  override async findByCursor<
+    Hint extends string = never,
+    Fields extends string = '*',
+    Excludes extends string = never,
+    IncludeCount extends boolean = true,
+  >(options: MongoFindByCursorOptions<Entity, Hint, Fields, Excludes, IncludeCount>): Promise<Cursor<Entity, Hint, Fields, Excludes, IncludeCount>> {
+    return this.getEntityManager().findByCursor(this.entityName, options);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  override async findAll<
+    Hint extends string = never,
+    Fields extends string = '*',
+    Excludes extends string = never,
+  >(options?: MongoFindAllOptions<Entity, Hint, Fields, Excludes>): Promise<Loaded<Entity, Hint, Fields, Excludes>[]> {
+    return this.getEntityManager().findAll(this.entityName, options);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  override async *stream<
+    Hint extends string = never,
+    Fields extends string = '*',
+    Excludes extends string = never,
+  >(options?: MongoStreamOptions<Entity, Hint, Fields, Excludes>): AsyncIterableIterator<Loaded<Entity, Hint, Fields, Excludes>> {
+    yield* this.getEntityManager().stream(this.entityName, options);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  override async count<Hint extends string = never>(where: FilterQuery<Entity> = {} as FilterQuery<Entity>, options: MongoCountOptions<Entity, Hint> = {}): Promise<number> {
+    return this.getEntityManager().count<Entity, Hint>(this.entityName, where as any, options);
   }
 
   /**

--- a/packages/mongodb/src/index.ts
+++ b/packages/mongodb/src/index.ts
@@ -5,6 +5,7 @@ export * from './MongoDriver.js';
 export * from './MongoPlatform.js';
 export * from './MongoEntityManager.js';
 export * from './MongoEntityRepository.js';
+export * from './typings.js';
 export * from './MongoSchemaGenerator.js';
 export { MongoEntityManager as EntityManager } from './MongoEntityManager.js';
 export { MongoEntityRepository as EntityRepository } from './MongoEntityRepository.js';

--- a/packages/mongodb/src/typings.ts
+++ b/packages/mongodb/src/typings.ts
@@ -1,0 +1,81 @@
+import type {
+  CountOptions,
+  Dictionary,
+  FindAllOptions,
+  FindByCursorOptions,
+  FindOneOptions,
+  FindOneOrFailOptions,
+  FindOptions,
+  StreamOptions,
+} from '@mikro-orm/core';
+
+export interface CollationOptions {
+  locale: string;
+  caseLevel?: boolean;
+  caseFirst?: string;
+  strength?: number;
+  numericOrdering?: boolean;
+  alternate?: string;
+  maxVariable?: string;
+  backwards?: boolean;
+}
+
+export interface MongoQueryExtras {
+  /** Index name or spec passed as `hint`. */
+  indexHint?: string | Dictionary;
+  collation?: CollationOptions;
+  maxTimeMS?: number;
+  allowDiskUse?: boolean;
+}
+
+export interface MongoFindOptions<
+  Entity,
+  Hint extends string = never,
+  Fields extends string = '*',
+  Excludes extends string = never,
+> extends FindOptions<Entity, Hint, Fields, Excludes>, MongoQueryExtras {
+}
+
+export interface MongoFindOneOptions<
+  T,
+  P extends string = never,
+  F extends string = '*',
+  E extends string = never,
+> extends FindOneOptions<T, P, F, E>, MongoQueryExtras {
+}
+
+export interface MongoFindOneOrFailOptions<
+  T extends object,
+  P extends string = never,
+  F extends string = '*',
+  E extends string = never,
+> extends FindOneOrFailOptions<T, P, F, E>, MongoQueryExtras {
+}
+
+export interface MongoFindAllOptions<
+  T,
+  P extends string = never,
+  F extends string = '*',
+  E extends string = never,
+> extends FindAllOptions<T, P, F, E>, MongoQueryExtras {
+}
+
+export interface MongoFindByCursorOptions<
+  T extends object,
+  P extends string = never,
+  F extends string = '*',
+  E extends string = never,
+  I extends boolean = true,
+> extends FindByCursorOptions<T, P, F, E, I>, MongoQueryExtras {
+}
+
+export interface MongoStreamOptions<
+  Entity,
+  Populate extends string = never,
+  Fields extends string = '*',
+  Exclude extends string = never,
+> extends StreamOptions<Entity, Populate, Fields, Exclude>, MongoQueryExtras {
+}
+
+export interface MongoCountOptions<T extends object, P extends string = never> extends CountOptions<T, P>, Omit<MongoQueryExtras, 'allowDiskUse'> {
+}

--- a/packages/sql/src/SqlEntityManager.ts
+++ b/packages/sql/src/SqlEntityManager.ts
@@ -3,13 +3,19 @@ import {
   EntityManager,
   type AnyEntity,
   type ConnectionType,
+  type CountOptions,
+  type Cursor,
   type EntityData,
   type EntityName,
   type EntityRepository,
-  type GetRepository,
-  type QueryResult,
   type FilterQuery,
+  type FindOneOrFailOptions,
+  type FromEntityType,
+  type GetRepository,
+  type Loaded,
   type LoggingOptions,
+  type MergeLoaded,
+  type QueryResult,
   type RawQueryFragment,
 } from '@mikro-orm/core';
 import type { AbstractSqlDriver } from './AbstractSqlDriver.js';
@@ -17,7 +23,16 @@ import type { NativeQueryBuilder } from './query/NativeQueryBuilder.js';
 import type { QueryBuilder } from './query/QueryBuilder.js';
 import type { SqlEntityRepository } from './SqlEntityRepository.js';
 import type { Kysely } from 'kysely';
-import type { InferKyselyDB } from './typings.js';
+import type {
+  InferKyselyDB,
+  SqlCountOptions,
+  SqlFindAllOptions,
+  SqlFindByCursorOptions,
+  SqlFindOneOptions,
+  SqlFindOneOrFailOptions,
+  SqlFindOptions,
+  SqlStreamOptions,
+} from './typings.js';
 import { MikroKyselyPlugin, type MikroKyselyPluginOptions } from './plugin/index.js';
 
 export interface GetKyselyOptions extends MikroKyselyPluginOptions {
@@ -71,6 +86,114 @@ export class SqlEntityManager<Driver extends AbstractSqlDriver = AbstractSqlDriv
     loggerContext?: LoggingOptions,
   ): Promise<T> {
     return this.getDriver().execute(query, params, method, this.getContext(false).getTransactionContext(), loggerContext);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  override find<
+    Entity extends object,
+    Hint extends string = never,
+    Fields extends string = '*',
+    Excludes extends string = never,
+  >(entityName: EntityName<Entity>, where: FilterQuery<NoInfer<Entity>>, options?: SqlFindOptions<Entity, Hint, Fields, Excludes>): Promise<Loaded<Entity, Hint, Fields, Excludes>[]> {
+    return super.find(entityName, where, options);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  override findOne<
+    Entity extends object,
+    Hint extends string = never,
+    Fields extends string = '*',
+    Excludes extends string = never,
+  >(entityName: EntityName<Entity>, where: FilterQuery<NoInfer<Entity>>, options?: SqlFindOneOptions<Entity, Hint, Fields, Excludes>): Promise<Loaded<Entity, Hint, Fields, Excludes> | null> {
+    return super.findOne(entityName, where, options);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  override findOneOrFail<
+    Entity extends object,
+    Hint extends string = never,
+    Fields extends string = '*',
+    Excludes extends string = never,
+  >(entityName: EntityName<Entity>, where: FilterQuery<NoInfer<Entity>>, options?: SqlFindOneOrFailOptions<Entity, Hint, Fields, Excludes>): Promise<Loaded<Entity, Hint, Fields, Excludes>> {
+    return super.findOneOrFail(entityName, where, options as FindOneOrFailOptions<Entity, Hint, Fields, Excludes>);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  override findAll<
+    Entity extends object,
+    Hint extends string = never,
+    Fields extends string = '*',
+    Excludes extends string = never,
+  >(entityName: EntityName<Entity>, options?: SqlFindAllOptions<NoInfer<Entity>, Hint, Fields, Excludes>): Promise<Loaded<Entity, Hint, Fields, Excludes>[]> {
+    return super.findAll(entityName, options);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  override findAndCount<
+    Entity extends object,
+    Hint extends string = never,
+    Fields extends string = '*',
+    Excludes extends string = never,
+  >(entityName: EntityName<Entity>, where: FilterQuery<NoInfer<Entity>>, options?: SqlFindOptions<Entity, Hint, Fields, Excludes>): Promise<[Loaded<Entity, Hint, Fields, Excludes>[], number]> {
+    return super.findAndCount(entityName, where, options);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  override findByCursor<
+    Entity extends object,
+    Hint extends string = never,
+    Fields extends string = '*',
+    Excludes extends string = never,
+    IncludeCount extends boolean = true,
+  >(entityName: EntityName<Entity>, options: SqlFindByCursorOptions<Entity, Hint, Fields, Excludes, IncludeCount>): Promise<Cursor<Entity, Hint, Fields, Excludes, IncludeCount>> {
+    return super.findByCursor(entityName, options);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  override async *stream<
+    Entity extends object,
+    Hint extends string = never,
+    Fields extends string = '*',
+    Excludes extends string = never,
+  >(entityName: EntityName<Entity>, options?: SqlStreamOptions<NoInfer<Entity>, Hint, Fields, Excludes>): AsyncIterableIterator<Loaded<Entity, Hint, Fields, Excludes>> {
+    yield* super.stream(entityName, options);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  override count<
+    Entity extends object,
+    Hint extends string = never,
+  >(entityName: EntityName<Entity>, where?: FilterQuery<NoInfer<Entity>>, options?: SqlCountOptions<Entity, Hint>): Promise<number> {
+    return super.count(entityName, where, options as CountOptions<Entity, Hint>);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  override refresh<
+    Entity extends object,
+    Naked extends FromEntityType<Entity> = FromEntityType<Entity>,
+    Hint extends string = never,
+    Fields extends string = '*',
+    Excludes extends string = never,
+  >(entity: Entity, options?: SqlFindOneOptions<Entity, Hint, Fields, Excludes>): Promise<MergeLoaded<Entity, Naked, Hint, Fields, Excludes, true> | null> {
+    return super.refresh(entity, options);
   }
 
   override getRepository<T extends object, U extends EntityRepository<T> = SqlEntityRepository<T>>(entityName: EntityName<T>): GetRepository<T, U> {

--- a/packages/sql/src/SqlEntityRepository.ts
+++ b/packages/sql/src/SqlEntityRepository.ts
@@ -1,6 +1,21 @@
-import { EntityRepository, type EntityName } from '@mikro-orm/core';
+import {
+  EntityRepository,
+  type Cursor,
+  type EntityName,
+  type FilterQuery,
+  type Loaded,
+} from '@mikro-orm/core';
 import type { SqlEntityManager } from './SqlEntityManager.js';
 import type { QueryBuilder } from './query/QueryBuilder.js';
+import type {
+  SqlCountOptions,
+  SqlFindAllOptions,
+  SqlFindByCursorOptions,
+  SqlFindOneOptions,
+  SqlFindOneOrFailOptions,
+  SqlFindOptions,
+  SqlStreamOptions,
+} from './typings.js';
 
 export class SqlEntityRepository<Entity extends object> extends EntityRepository<Entity> {
 
@@ -23,6 +38,91 @@ export class SqlEntityRepository<Entity extends object> extends EntityRepository
    */
   qb<RootAlias extends string = never>(alias?: RootAlias): QueryBuilder<Entity, RootAlias> {
     return this.createQueryBuilder(alias);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  override async findOne<
+    Hint extends string = never,
+    Fields extends string = '*',
+    Excludes extends string = never,
+  >(where: FilterQuery<Entity>, options?: SqlFindOneOptions<Entity, Hint, Fields, Excludes>): Promise<Loaded<Entity, Hint, Fields, Excludes> | null> {
+    return this.getEntityManager().findOne<Entity, Hint, Fields, Excludes>(this.entityName, where as any, options);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  override async findOneOrFail<
+    Hint extends string = never,
+    Fields extends string = '*',
+    Excludes extends string = never,
+  >(where: FilterQuery<Entity>, options?: SqlFindOneOrFailOptions<Entity, Hint, Fields, Excludes>): Promise<Loaded<Entity, Hint, Fields, Excludes>> {
+    return this.getEntityManager().findOneOrFail<Entity, Hint, Fields, Excludes>(this.entityName, where as any, options);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  override async find<
+    Hint extends string = never,
+    Fields extends string = '*',
+    Excludes extends string = never,
+  >(where: FilterQuery<Entity>, options?: SqlFindOptions<Entity, Hint, Fields, Excludes>): Promise<Loaded<Entity, Hint, Fields, Excludes>[]> {
+    return this.getEntityManager().find(this.entityName, where as any, options);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  override async findAndCount<
+    Hint extends string = never,
+    Fields extends string = '*',
+    Excludes extends string = never,
+  >(where: FilterQuery<Entity>, options?: SqlFindOptions<Entity, Hint, Fields, Excludes>): Promise<[Loaded<Entity, Hint, Fields, Excludes>[], number]> {
+    return this.getEntityManager().findAndCount(this.entityName, where as any, options);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  override async findByCursor<
+    Hint extends string = never,
+    Fields extends string = '*',
+    Excludes extends string = never,
+    IncludeCount extends boolean = true,
+  >(options: SqlFindByCursorOptions<Entity, Hint, Fields, Excludes, IncludeCount>): Promise<Cursor<Entity, Hint, Fields, Excludes, IncludeCount>> {
+    return this.getEntityManager().findByCursor(this.entityName, options);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  override async findAll<
+    Hint extends string = never,
+    Fields extends string = '*',
+    Excludes extends string = never,
+  >(options?: SqlFindAllOptions<Entity, Hint, Fields, Excludes>): Promise<Loaded<Entity, Hint, Fields, Excludes>[]> {
+    return this.getEntityManager().findAll(this.entityName, options);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  override async *stream<
+    Hint extends string = never,
+    Fields extends string = '*',
+    Excludes extends string = never,
+  >(options?: SqlStreamOptions<Entity, Hint, Fields, Excludes>): AsyncIterableIterator<Loaded<Entity, Hint, Fields, Excludes>> {
+    yield* this.getEntityManager().stream(this.entityName, options);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  override async count<Hint extends string = never>(where: FilterQuery<Entity> = {} as FilterQuery<Entity>, options: SqlCountOptions<Entity, Hint> = {}): Promise<number> {
+    return this.getEntityManager().count<Entity, Hint>(this.entityName, where as any, options);
   }
 
   /**

--- a/tests/features/entity-manager/EntityManager.mongo.test.ts
+++ b/tests/features/entity-manager/EntityManager.mongo.test.ts
@@ -490,11 +490,33 @@ describe('EntityManagerMongo', () => {
     expect(countLog).toMatch(/maxTimeMS: 5000/);
   });
 
-  test('collation option rejects string for MongoDB', async () => {
-    await expect(orm.em.find(Author, {}, {
-      collation: 'en_US' as any,
-      orderBy: { name: QueryOrder.ASC },
-    })).rejects.toThrow('Collation option for MongoDB must be a CollationOptions object');
+  test('driver-specific find options type safety', async () => {
+    // MongoDB-specific options should be accepted
+    await orm.em.find(Author, {}, {
+      collation: { locale: 'en', strength: 2 },
+      maxTimeMS: 5000,
+      allowDiskUse: true,
+      indexHint: '_id_',
+    });
+
+    await orm.em.findOne(Author, { name: 'test' }, {
+      collation: { locale: 'en', strength: 2 },
+      maxTimeMS: 5000,
+      allowDiskUse: true,
+      indexHint: { _id: 1 },
+    });
+
+    await orm.em.findAndCount(Author, {}, {
+      collation: { locale: 'en' },
+      maxTimeMS: 1000,
+      allowDiskUse: true,
+    });
+
+    await orm.em.count(Author, {}, {
+      collation: { locale: 'en', strength: 2 },
+      indexHint: '_id_',
+      maxTimeMS: 5000,
+    });
   });
 
   test('should throw when trying to merge entity without id', async () => {

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -26,6 +26,7 @@ import type {
   ExpandQuery,
   RequiredNullable,
 } from '../packages/core/src/typings.js';
+import type { FindOptions, CountOptions } from '@mikro-orm/core';
 import type { Author2, Book2, BookTag2, Car2, FooBar2, FooParam2, Publisher2, User2 } from './entities-sql/index.js';
 import type { Author, Book } from './entities/index.js';
 
@@ -1197,5 +1198,35 @@ describe('check typings', () => {
     const partialDto: PartialDto = { firstNme: 'test' };
     // @ts-expect-error - firstNme does not exist on User entity
     em.create(User, partialDto, { partial: true });
+  });
+
+  test('driver-specific find options are not on core FindOptions/CountOptions', () => {
+    // Core FindOptions should NOT have SQL/MongoDB-specific properties
+    // @ts-expect-error - groupBy is SQL-specific
+    const _a: FindOptions<Author> = { groupBy: 'name' };
+    // @ts-expect-error - having is SQL-specific
+    const _b: FindOptions<Author> = { having: { name: 'foo' } };
+    // @ts-expect-error - indexHint is driver-specific
+    const _c: FindOptions<Author> = { indexHint: 'force index(idx)' };
+    // @ts-expect-error - collation is driver-specific
+    const _d: FindOptions<Author> = { collation: 'utf8mb4_general_ci' };
+    // @ts-expect-error - comments is SQL-specific
+    const _e: FindOptions<Author> = { comments: ['foo'] };
+    // @ts-expect-error - hintComments is SQL-specific
+    const _f: FindOptions<Author> = { hintComments: 'bar' };
+    // @ts-expect-error - maxTimeMS is MongoDB-specific
+    const _g: FindOptions<Author> = { maxTimeMS: 5000 };
+    // @ts-expect-error - allowDiskUse is MongoDB-specific
+    const _h: FindOptions<Author> = { allowDiskUse: true };
+
+    // @ts-expect-error - groupBy is SQL-specific on CountOptions
+    const _i: CountOptions<Author> = { groupBy: 'name' };
+    // @ts-expect-error - having is SQL-specific on CountOptions
+    const _j: CountOptions<Author> = { having: { name: 'foo' } };
+
+    // @ts-expect-error - lockTableAliases is SQL-specific
+    const _k: FindOptions<Author> = { lockTableAliases: ['a0'] };
+    // @ts-expect-error - pessimistic lockMode on find() is SQL-specific
+    const _l: FindOptions<Author> = { lockMode: 1 as any };
   });
 });


### PR DESCRIPTION
- Move SQL-only options (groupBy, having, lockMode, lockTableAliases, indexHint, collation, comments, hintComments) out of core FindOptions/CountOptions into SqlFindOptions, SqlCountOptions, etc. in `@mikro-orm/sql`
- Move MongoDB-only options (collation as CollationOptions, indexHint as string | Dictionary, maxTimeMS, allowDiskUse) into MongoFindOptions, MongoCountOptions, etc. in `@mikro-orm/mongodb`
- SqlEntityManager/MongoEntityManager and their repositories override find/count/stream methods to narrow the options type, so users get driver-appropriate autocomplete and type checking
- Replace runtime validation (validateSqlOptions, MongoDB string-collation guard) with compile-time type safety — passing a wrong option shape is now a type error instead of a runtime throw
- Shared base interfaces (SqlQueryExtras, MongoQueryExtras) eliminate property duplication across option variants
- lockMode (pessimistic) and lockTableAliases are SQL-only on find(); FindOneOptions.lockMode still includes LockMode.OPTIMISTIC for both drivers (versioned entity support)

### Breaking changes

- groupBy, having, lockMode, lockTableAliases, indexHint, collation, comments, hintComments removed from core FindOptions — use `SqlFindOptions` (available via `@mikro-orm/sql` and all SQL driver packages)
