### PR TITLE
feat(core): add `populateHints` option to `FindOptions` for per-relation populate overrides

### DIFF
--- a/docs/docs/loading-strategies.md
+++ b/docs/docs/loading-strategies.md
@@ -112,6 +112,50 @@ MikroORM.init({
 
 This value will be used as the default, specifying the loading strategy on property level has precedence, as well as specifying it in the `FindOptions`.
 
+## Per-relation populate overrides
+
+While the `strategy` option applies to all populated relations, you can use `populateHints` to override the loading strategy or join type for individual relations. The keys are the same dot-separated paths used in the `populate` option, and they support autocomplete.
+
+```ts
+const author = await orm.em.findOne(Author, 1, {
+  populate: ['books.inspiredBy'],
+  strategy: 'joined',
+  populateHints: {
+    'books.inspiredBy': { strategy: 'select-in' },
+  },
+});
+```
+
+This will load books via a join, but use a separate `select-in` query for the `inspiredBy` relation.
+
+You can also override the join type. For example, a non-nullable `ManyToOne` relation defaults to `inner join` with the `joined` strategy. You can force a `left join` instead:
+
+```ts
+const books = await orm.em.find(Book, {}, {
+  populate: ['author'],
+  strategy: 'joined',
+  populateHints: {
+    author: { joinType: 'left join' },
+  },
+});
+```
+
+Both `strategy` and `joinType` can be combined in a single hint, and you can provide hints for multiple relations at once:
+
+```ts
+const author = await orm.em.findOne(Author, 1, {
+  populate: ['books.inspiredBy', 'favouriteBook'],
+  strategy: 'joined',
+  populateHints: {
+    books: { joinType: 'inner join' },
+    'books.inspiredBy': { strategy: 'select-in' },
+    favouriteBook: { joinType: 'left join' },
+  },
+});
+```
+
+Hints for paths that don't match any populate entry are silently ignored.
+
 ## Population `where` condition
 
 The where condition is by default applied only to the root entity. This can be controlled via `populateWhere` option. It accepts one of `all` (default), `infer` (use same condition as the `where` query) or an explicit filter query.

--- a/docs/docs/populating-relations.md
+++ b/docs/docs/populating-relations.md
@@ -122,6 +122,18 @@ A value provided on a specific query overrides whatever default is specified glo
 
 The way that MikroORM fetches the data based on populate hint is also configurable. By default, MikroORM uses a "select in" strategy which runs one separate query for each level of a populate. If you're using an SQL database you can also ask MikroORM to use a join for all tables involved in the populate and run it as a single query. This is again configurable globally or per query.
 
+You can also use `populateHints` to override the strategy or join type for individual relations:
+
+```ts
+const tags = await em.find(BookTag, {}, {
+  populate: ['books.author'],
+  strategy: 'joined',
+  populateHints: {
+    'books.author': { strategy: 'select-in' },
+  },
+});
+```
+
 For more information see the [Loading Strategies section](./loading-strategies.md).
 
 ## Populating already loaded entities

--- a/packages/core/src/drivers/IDatabaseDriver.ts
+++ b/packages/core/src/drivers/IDatabaseDriver.ts
@@ -1,6 +1,7 @@
 import type {
   ConnectionType, EntityData, EntityMetadata, EntityProperty, FilterQuery, Primary, Dictionary,
   IPrimaryKey, PopulateOptions, EntityDictionary, AutoPath, ObjectQuery, FilterObject, Populate, EntityName,
+  PopulateHintOptions, Prefixes,
 } from '../typings.js';
 import type { Connection, QueryResult, Transaction } from '../connections/Connection.js';
 import type { FlushMode, LockMode, QueryOrderMap, QueryFlag, LoadStrategy, PopulateHint, PopulatePath } from '../enums.js';
@@ -155,6 +156,9 @@ export interface FindOptions<
 
   /** Used for ordering of the populate queries. If not specified, the value of `options.orderBy` is used. */
   populateOrderBy?: OrderDefinition<Entity>;
+
+  /** Per-relation overrides for populate loading behavior. Keys are populate paths (same as used in `populate`). */
+  populateHints?: [Hint] extends [never] ? never : { [K in Prefixes<Hint>]?: PopulateHintOptions };
 
   /** Ordering of the results.Can be an object or array of objects, keys are property names, values are ordering (asc/desc) */
   orderBy?: OrderDefinition<Entity>;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,6 +12,7 @@ export type {
   EntityProps, ExpandProperty, ExpandScalar, FilterItemValue, ExpandQuery, Scalar, ExpandHint, FilterValue, MergeLoaded, MergeSelected, TypeConfig, AnyString,
   ClearDatabaseOptions, CreateSchemaOptions, EnsureDatabaseOptions, UpdateSchemaOptions, DropSchemaOptions, RefreshDatabaseOptions, AutoPath, UnboxArray, MetadataProcessor, ImportsResolver,
   RequiredNullable, DefineConfig, Opt, Hidden, EntitySchemaWithMeta, InferEntity, CheckConstraint, GeneratedColumnCallback, FilterDef, EntityCtor, Subquery,
+  PopulateHintOptions, Prefixes,
 } from './typings.js';
 export * from './enums.js';
 export * from './errors.js';

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -199,7 +199,7 @@ declare const __loadHint: unique symbol;
  * This reflects that loading 'a.b.c' means 'a' and 'a.b' are also loaded.
  * Special case: '*' returns string to ensure Loaded<T, '*'> is assignable to any Loaded<T, Hint>.
  */
-type Prefixes<S extends string> = S extends '*'
+export type Prefixes<S extends string> = S extends '*'
   ? string
   : S extends `${infer H}.${infer T}`
     ? H | `${H}.${Prefixes<T>}`
@@ -1380,6 +1380,11 @@ export type PopulateOptions<T> = {
   children?: PopulateOptions<T[keyof T]>[];
   /** When true, ignores `mapToPk` on the property and returns full entity data instead of just PKs. */
   dataOnly?: boolean;
+};
+
+export type PopulateHintOptions = {
+  strategy?: LoadStrategy.JOINED | LoadStrategy.SELECT_IN | 'joined' | 'select-in';
+  joinType?: 'inner join' | 'left join';
 };
 
 type ExtractType<T> =

--- a/tests/features/populate-hints.test.ts
+++ b/tests/features/populate-hints.test.ts
@@ -1,0 +1,156 @@
+import { Collection, LoadStrategy, MikroORM, ref, Ref } from '@mikro-orm/sqlite';
+import { Entity, ManyToOne, OneToMany, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+import { mockLogger } from '../bootstrap.js';
+
+@Entity()
+class Country {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+}
+
+@Entity()
+class Author {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @ManyToOne(() => Country)
+  country!: Ref<Country>;
+
+  @OneToMany(() => Book, b => b.author)
+  books = new Collection<Book>(this);
+
+}
+
+@Entity()
+class Book {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  title!: string;
+
+  @ManyToOne(() => Author)
+  author!: Author;
+
+}
+
+describe('populateHints', () => {
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      entities: [Country, Author, Book],
+      dbName: ':memory:',
+      metadataProvider: ReflectMetadataProvider,
+    });
+    await orm.schema.refresh();
+
+    const country = orm.em.create(Country, { name: 'France' });
+    const author = orm.em.create(Author, { name: 'Albert Camus', country: ref(country) });
+    orm.em.create(Book, { title: 'The Stranger', author });
+    orm.em.create(Book, { title: 'The Plague', author });
+    await orm.em.flush();
+    orm.em.clear();
+  });
+
+  afterAll(() => orm.close(true));
+
+  test('joinType override on non-nullable m:1 with joined strategy', async () => {
+    const mock = mockLogger(orm, ['query']);
+    await orm.em.fork().find(Book, {}, {
+      populate: ['author'],
+      strategy: LoadStrategy.JOINED,
+      populateHints: {
+        author: { joinType: 'left join' },
+      },
+    });
+    // Non-nullable m:1 would normally use inner join, but we override to left join
+    expect(mock.mock.calls[0][0]).toMatch(/left join `author`/);
+  });
+
+  test('strategy override from joined to select-in', async () => {
+    const mock = mockLogger(orm, ['query']);
+    await orm.em.fork().find(Book, {}, {
+      populate: ['author'],
+      strategy: LoadStrategy.JOINED,
+      populateHints: {
+        author: { strategy: LoadStrategy.SELECT_IN },
+      },
+    });
+    // Should produce two separate queries instead of a join
+    expect(mock.mock.calls.length).toBe(2);
+    expect(mock.mock.calls[0][0]).not.toMatch(/join `author`/);
+  });
+
+  test('nested path hint applies to correct level', async () => {
+    const mock = mockLogger(orm, ['query']);
+    await orm.em.fork().find(Author, {}, {
+      populate: ['books.author.country'],
+      strategy: LoadStrategy.JOINED,
+      populateHints: {
+        'books.author': { joinType: 'left join' },
+      },
+    });
+    // The nested `author` join within `books` should be left join
+    // SQL uses grouped join: left join (`author` as `a2` inner join `country` ...) on ...
+    const sql = mock.mock.calls[0][0];
+    expect(sql).toMatch(/left join `book`/);
+    expect(sql).toMatch(/left join \(`author`/);
+  });
+
+  test('strategy override on nested path', async () => {
+    const mock = mockLogger(orm, ['query']);
+    await orm.em.fork().find(Book, {}, {
+      populate: ['author.country'],
+      strategy: LoadStrategy.JOINED,
+      populateHints: {
+        'author.country': { strategy: LoadStrategy.SELECT_IN },
+      },
+    });
+    // author should still be joined, but country should be a separate query
+    const firstQuery = mock.mock.calls[0][0];
+    expect(firstQuery).toMatch(/join `author`/);
+    expect(firstQuery).not.toMatch(/join `country`/);
+    // country loaded via separate select-in query
+    expect(mock.mock.calls.length).toBe(2);
+  });
+
+  test('hints for non-existent paths are silently ignored', async () => {
+    const mock = mockLogger(orm, ['query']);
+    await orm.em.fork().find(Book, {}, {
+      populate: ['author'],
+      strategy: LoadStrategy.JOINED,
+      populateHints: {
+        nonexistent: { joinType: 'left join' },
+      } as any,
+    });
+    // Should still work normally without errors
+    expect(mock.mock.calls.length).toBe(1);
+    expect(mock.mock.calls[0][0]).toMatch(/join `author`/);
+  });
+
+  test('multiple hints for different relations', async () => {
+    const mock = mockLogger(orm, ['query']);
+    await orm.em.fork().find(Author, {}, {
+      populate: ['books', 'country'],
+      strategy: LoadStrategy.JOINED,
+      populateHints: {
+        books: { joinType: 'inner join' },
+        country: { joinType: 'left join' },
+      },
+    });
+    const sql = mock.mock.calls[0][0];
+    expect(sql).toMatch(/inner join `book`/);
+    expect(sql).toMatch(/left join `country`/);
+  });
+});


### PR DESCRIPTION
```ts
em.findAll(Book, {
  populate: ['author.country', 'tags'],
  populateHints: {
    author: { joinType: 'left join' },
    'author.country': { strategy: 'select-in' },
  },
});
```