### PR TITLE
feat(sql): strictly type `SelectQueryBuilder.execute()` return type

### DIFF
--- a/docs/docs/query-builder.md
+++ b/docs/docs/query-builder.md
@@ -84,6 +84,29 @@ const rows = await em.createQueryBuilder(Author, 'a')
 // Returns flat array with duplicated author data per book
 ```
 
+### Typed Raw Results
+
+The return type of `execute()` is based on `EntityDTO` — plain objects with Collections unwrapped to arrays and References unwrapped to their target types. When you use `select()` or `joinAndSelect()`, the return type automatically reflects which fields and relations were selected:
+
+```ts
+// Without joins: Pick<EntityDTO<Author>, 'id' | 'email'>[]
+const result1 = await em.createQueryBuilder(Author, 'a')
+  .select(['a.id', 'a.email'])
+  .execute();
+
+// With joins: EntityDTO<Loaded<Author, 'books', 'id' | 'email' | 'books.title'>>[]
+const result2 = await em.createQueryBuilder(Author, 'a')
+  .select(['a.id', 'a.email'])
+  .leftJoinAndSelect('a.books', 'b', {}, ['title'])
+  .execute();
+```
+
+If you need to opt out of the inferred type (e.g. when using `mapResults: false` which returns raw column names instead of property names), you can provide an explicit type parameter:
+
+```ts
+const result = await qb.execute<Dictionary[]>('all', false);
+```
+
 ### Getting Entity Instances
 
 To get fully hydrated entity instances (tracked by the identity map), use `getResult()` or `getSingleResult()`:

--- a/packages/core/src/entity/BaseEntity.ts
+++ b/packages/core/src/entity/BaseEntity.ts
@@ -1,5 +1,5 @@
 import { Reference, type Ref } from './Reference.js';
-import type { AutoPath, EntityData, EntityDTO, Loaded, LoadedReference, AddEager, EntityKey, FromEntityType, IsSubset, MergeSelected } from '../typings.js';
+import type { AutoPath, EntityData, EntityDTO, Loaded, LoadedReference, AddEager, EntityKey, FromEntityType, IsSubset, MergeSelected, SerializeDTO } from '../typings.js';
 import { EntityAssigner, type AssignOptions } from './EntityAssigner.js';
 import type { EntityLoaderOptions } from './EntityLoader.js';
 import { EntitySerializer, type SerializeOptions } from '../serialization/EntitySerializer.js';
@@ -102,7 +102,7 @@ export abstract class BaseEntity {
     Naked extends FromEntityType<Entity> = FromEntityType<Entity>,
     Hint extends string = never,
     Exclude extends string = never,
-  >(options?: SerializeOptions<Naked, Hint, Exclude>): EntityDTO<Loaded<Naked, Hint>> {
+  >(options?: SerializeOptions<Naked, Hint, Exclude>): SerializeDTO<Naked, Hint, Exclude> {
     return EntitySerializer.serialize(this as unknown as Naked, options);
   }
 

--- a/packages/core/src/entity/WrappedEntity.ts
+++ b/packages/core/src/entity/WrappedEntity.ts
@@ -18,6 +18,7 @@ import type {
   LoadedReference,
   EntityDTO,
   Loaded,
+  SerializeDTO,
   FromEntityType,
   IsSubset,
   MergeSelected,
@@ -131,7 +132,7 @@ export class WrappedEntity<Entity extends object> {
     return EntityTransformer.toObject(this.entity, ignoreFields);
   }
 
-  serialize<Hint extends string = never, Exclude extends string = never>(options?: SerializeOptions<Entity, Hint, Exclude>): EntityDTO<Loaded<Entity, Hint>> {
+  serialize<Hint extends string = never, Exclude extends string = never>(options?: SerializeOptions<Entity, Hint, Exclude>): SerializeDTO<Entity, Hint, Exclude> {
     return EntitySerializer.serialize(this.entity, options);
   }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,7 +6,7 @@ export { EntityMetadata, PrimaryKeyProp, EntityRepositoryType, OptionalProps, Ea
 export type {
   CompiledFunctions, Constructor, ConnectionType, Dictionary, Primary, IPrimaryKey, ObjectQuery, FilterQuery, IWrappedEntity, EntityName, EntityData, Highlighter, MaybePromise,
   AnyEntity, EntityClass, EntityProperty, PopulateOptions, Populate, Loaded, New, LoadedReference, LoadedCollection, IMigrator, IMigrationGenerator, MigratorEvent,
-  GetRepository, MigrationObject, DeepPartial, PrimaryProperty, Cast, IsUnknown, EntityDictionary, EntityDTO, MigrationDiff, GenerateOptions, FilterObject,
+  GetRepository, MigrationObject, DeepPartial, PrimaryProperty, Cast, IsUnknown, EntityDictionary, EntityDTO, EntityDTOFlat, EntityDTOProp, SerializeDTO, MigrationDiff, GenerateOptions, FilterObject,
   IEntityGenerator, ISeedManager, RequiredEntityData, CheckCallback, IndexCallback, FormulaCallback, FormulaTable, SchemaTable, SchemaColumns, SimpleColumnMeta, Rel, Ref, ScalarRef, EntityRef, ISchemaGenerator,
   UmzugMigration, MigrateOptions, MigrationResult, MigrationRow, EntityKey, EntityValue, EntityDataValue, FilterKey, EntityType, FromEntityType, Selected, IsSubset,
   EntityProps, ExpandProperty, ExpandScalar, FilterItemValue, ExpandQuery, Scalar, ExpandHint, FilterValue, MergeLoaded, MergeSelected, TypeConfig, AnyString,

--- a/packages/core/src/serialization/EntitySerializer.ts
+++ b/packages/core/src/serialization/EntitySerializer.ts
@@ -6,6 +6,7 @@ import type {
   Dictionary,
   EntityDTO,
   EntityDTOProp,
+  SerializeDTO,
   EntityKey,
   EntityMetadata,
   EntityProperty,
@@ -59,7 +60,7 @@ function isPopulated(propName: string, options: SerializeOptions<any, any, any>)
 
 export class EntitySerializer {
 
-  static serialize<T extends object, P extends string = never, E extends string = never>(entity: T, options: SerializeOptions<T, P, E> = {}): EntityDTO<Loaded<T, P>> {
+  static serialize<T extends object, P extends string = never, E extends string = never>(entity: T, options: SerializeOptions<T, P, E> = {}): SerializeDTO<T, P, E> {
     const wrapped = helper(entity);
     const meta = wrapped.__meta;
     let contextCreated = false;
@@ -140,7 +141,7 @@ export class EntitySerializer {
     }
 
     if (!wrapped.isInitialized()) {
-      return ret as EntityDTO<Loaded<T, P>>;
+      return ret as SerializeDTO<T, P, E>;
     }
 
     for (const prop of meta.getterProps) {
@@ -161,7 +162,7 @@ export class EntitySerializer {
       }
     }
 
-    return ret as EntityDTO<Loaded<T, P>>;
+    return ret as SerializeDTO<T, P, E>;
   }
 
   private static propertyName<T>(meta: EntityMetadata<T>, prop: EntityKey<T>): EntityKey<T> {
@@ -353,7 +354,7 @@ export function serialize<
   Populate extends string = never,
   Exclude extends string = never,
   Config extends TypeConfig = never,
->(entity: Entity, options?: Config & SerializeOptions<UnboxArray<Entity>, Populate, Exclude>): Naked extends object[] ? EntityDTO<Loaded<ArrayElement<Naked>, Populate>, CleanTypeConfig<Config>>[] : EntityDTO<Loaded<Naked, Populate>, CleanTypeConfig<Config>>;
+>(entity: Entity, options?: Config & SerializeOptions<UnboxArray<Entity>, Populate, Exclude>): Naked extends object[] ? SerializeDTO<ArrayElement<Naked>, Populate, Exclude, CleanTypeConfig<Config>>[] : SerializeDTO<Naked, Populate, Exclude, CleanTypeConfig<Config>>;
 
 /**
  * Converts entity instance to POJO, converting the `Collection`s to arrays and unwrapping the `Reference` wrapper, while respecting the serialization options.
@@ -373,7 +374,7 @@ export function serialize<
   Populate extends string = never,
   Exclude extends string = never,
   Config extends TypeConfig = never,
->(entities: Entity | Entity[], options?: SerializeOptions<Entity, Populate, Exclude>): EntityDTO<Loaded<Naked, Populate>, CleanTypeConfig<Config>> | EntityDTO<Loaded<Naked, Populate>, CleanTypeConfig<Config>>[] {
+>(entities: Entity | Entity[], options?: SerializeOptions<Entity, Populate, Exclude>): SerializeDTO<Naked, Populate, Exclude, CleanTypeConfig<Config>> | SerializeDTO<Naked, Populate, Exclude, CleanTypeConfig<Config>>[] {
   if (Array.isArray(entities)) {
     return entities.map(e => EntitySerializer.serialize(e, options)) as any;
   }

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -348,7 +348,7 @@ export interface IWrappedEntity<Entity extends object> {
     Naked extends FromEntityType<Entity> = FromEntityType<Entity>,
     Hint extends string = never,
     Exclude extends string = never,
-  >(options?: SerializeOptions<Naked, Hint, Exclude>): EntityDTO<Loaded<Naked, Hint>>;
+  >(options?: SerializeOptions<Naked, Hint, Exclude>): SerializeDTO<Naked, Hint, Exclude>;
   setSerializationContext<
     Hint extends string = never,
     Fields extends string = '*',
@@ -545,26 +545,28 @@ type PrimaryOrObject<T, U, C extends TypeConfig> =
     ? { [K in PrimaryProperty<U> & keyof U]: U[K] }
     : Primary<U>;
 
-export type EntityDTOProp<E, T, C extends TypeConfig = never> = T extends Scalar
+type DTOWrapper<T, C extends TypeConfig, Flat extends boolean> = Flat extends true ? EntityDTOFlat<T, C> : EntityDTO<T, C>;
+
+export type EntityDTOProp<E, T, C extends TypeConfig = never, Flat extends boolean = false> = T extends Scalar
   ? T
   : T extends ScalarReference<infer U>
     ? U
     : T extends { __serialized?: infer U }
       ? (IsUnknown<U> extends false ? U : T)
       : T extends LoadedReferenceShape<infer U>
-        ? EntityDTO<U, C>
+        ? DTOWrapper<U, C, Flat>
         : T extends ReferenceShape<infer U>
           ? PrimaryOrObject<E, U, C>
           : T extends LoadedCollectionShape<infer U>
-            ? EntityDTO<U & object, C>[]
+            ? DTOWrapper<U & object, C, Flat>[]
             : T extends CollectionShape<infer U>
               ? PrimaryOrObject<E, U & object, C>[]
               : T extends readonly (infer U)[]
                 ? U extends Scalar
                   ? T
-                  : EntityDTOProp<E, U, C>[]
+                  : EntityDTOProp<E, U, C, Flat>[]
                 : T extends Relation<T>
-                  ? EntityDTO<T, C>
+                  ? DTOWrapper<T, C, Flat>
                   : T;
 
 // ideally this should also mark not populated collections as optional, but that would be breaking
@@ -586,6 +588,37 @@ export type EntityDTO<T, C extends TypeConfig = never> = {
 } & {
   [K in keyof T as DTOOptionalKeys<T, K>]?: EntityDTOProp<T, T[K], C> | AddOptional<T[K]>
 };
+
+/**
+ * @internal
+ * 1-pass variant of EntityDTO — ~2x cheaper to resolve but all keys are required
+ * (optional keys use `| undefined` in value type instead of `?` modifier).
+ * Use only for internal type computations (output types), never as a user-facing
+ * function parameter type where generic assignability checks are needed.
+ */
+export type EntityDTOFlat<T, C extends TypeConfig = never> = {
+  [K in keyof T as ExcludeHidden<T, K> & CleanKeys<T, K>]: EntityDTOProp<T, T[K], C, true> | AddOptional<T[K]>
+};
+
+/**
+ * @internal
+ * Single-pass fused type that combines Loaded + EntityDTO into one mapped type.
+ * ~40x faster than `EntityDTO<Loaded<T, H>>` for populated entities.
+ */
+type SerializeTopHints<H extends string> = H extends `${infer Top}.${string}` ? Top : H;
+type SerializeSubHints<K extends string, H extends string> = H extends `${K}.${infer Rest}` ? Rest : never;
+type SerializePropValue<T, K extends keyof T, H extends string, C extends TypeConfig = never> =
+  (K & string) extends SerializeTopHints<H>
+    ? NonNullable<T[K]> extends CollectionShape<infer U>
+      ? SerializeDTO<U & object, SerializeSubHints<K & string, H>, never, C>[]
+      : SerializeDTO<ExpandProperty<T[K]>, SerializeSubHints<K & string, H>, never, C>
+        | Extract<T[K], null | undefined>
+    : EntityDTOProp<T, T[K], C>;
+
+export type SerializeDTO<T, H extends string = never, E extends string = never, C extends TypeConfig = never> =
+  string extends H
+    ? EntityDTOFlat<T, C>
+    : { [K in keyof T as ExcludeHidden<T, K> & CleanKeys<T, K> & (IsNever<E> extends true ? K : Exclude<K, E>)]: SerializePropValue<T, K, H, C> | Extract<T[K], null | undefined> };
 
 type TargetKeys<T> = T extends EntityClass<infer P> ? keyof P : keyof T;
 type PropertyName<T> = IsUnknown<T> extends false ? TargetKeys<T> : string;
@@ -1530,9 +1563,8 @@ export type AddEager<T> = ExtractEagerProps<T> & string;
 export type ExpandHint<T, L extends string> = L | AddEager<T>;
 
 export type Selected<T, L extends string = never, F extends string = '*'> = {
-  [K in keyof T as IsPrefixed<T, K, L | F | AddEager<T>>]: LoadedProp<NonNullable<T[K]>, Suffix<K, L, true>, Suffix<K, F, true>> | AddOptional<T[K]>;
-} & {
-  [K in keyof T as FunctionKeys<T, K>]: T[K];
+  [K in keyof T as IsPrefixed<T, K, L | F | AddEager<T>> | FunctionKeys<T, K>]:
+    T[K] extends Function ? T[K] : LoadedProp<NonNullable<T[K]>, Suffix<K, L, true>, Suffix<K, F, true>> | AddOptional<T[K]>;
 } & { [__selectedType]?: T };
 
 type LoadedEntityType<T> = { [__loadedType]?: T } | { [__selectedType]?: T };

--- a/tests/bench/types/api-methods.ts
+++ b/tests/bench/types/api-methods.ts
@@ -82,7 +82,7 @@ bench('em.find() return type - with populate and fields', () => {
   type R = ReturnType<typeof em.find<Author, 'books', 'name' | 'email'>>;
   const x = {} as R;
   void x;
-}).types([703, 'instantiations']);
+}).types([699, 'instantiations']);
 
 // ============================================
 // em.create() - input and return type computation

--- a/tests/bench/types/assign-types.ts
+++ b/tests/bench/types/assign-types.ts
@@ -103,7 +103,7 @@ bench('MergeSelected - Loaded entity', () => {
   type R = MergeSelected<Loaded<Author, 'books'>, Author, 'name'>;
   const x = {} as R;
   void x;
-}).types([1958, 'instantiations']);
+}).types([1941, 'instantiations']);
 
 // ============================================
 // Full assign signature simulation
@@ -122,7 +122,7 @@ bench('assign return type - Loaded entity', () => {
   type R = AssignReturnType<Loaded<Author, 'books'>, { name: string }>;
   const x = {} as R;
   void x;
-}).types([1977, 'instantiations']);
+}).types([1960, 'instantiations']);
 
 // ============================================
 // Data parameter type computation

--- a/tests/bench/types/asterisk-hints.ts
+++ b/tests/bench/types/asterisk-hints.ts
@@ -88,7 +88,7 @@ bench('Loaded<Author, "books", "*"> - default fields', () => {
 
 bench('Loaded<Author, "books", "name" | "email"> - specific fields', () => {
   useLoaded<Author, 'books', 'name' | 'email'>({} as Loaded<Author, 'books', 'name' | 'email'>);
-}).types([985, 'instantiations']);
+}).types([862, 'instantiations']);
 
 // ============================================
 // Helper type benchmarks

--- a/tests/bench/types/autopath-loaded.ts
+++ b/tests/bench/types/autopath-loaded.ts
@@ -215,7 +215,7 @@ bench('Loaded - with eager props', () => {
 bench('Loaded - with fields selection', () => {
   const entity = {} as Loaded<Author, 'books', 'name' | 'email'>;
   void entity;
-}).types([929, 'instantiations']);
+}).types([808, 'instantiations']);
 
 bench('Loaded - with exclude', () => {
   const entity = {} as Loaded<Author, 'books', '*', 'age'>;

--- a/tests/bench/types/querybuilder.ts
+++ b/tests/bench/types/querybuilder.ts
@@ -5,7 +5,7 @@
  */
 
 import { bench } from '@ark/attest';
-import type { Collection, Ref, PrimaryKeyProp } from '@mikro-orm/core';
+import type { Collection, EntityDTO, EntityDTOFlat, EntityDTOProp, Loaded, PrimaryProperty, Ref, PrimaryKeyProp, SerializeDTO } from '@mikro-orm/core';
 import type { Field, ContextOrderByMap, QBFilterQuery, ModifyHint, ModifyContext, ModifyFields, JoinSelectField } from '@mikro-orm/sql';
 
 // ============================================
@@ -189,3 +189,152 @@ bench('JoinSelectField<Book, "b"> - plain key', () => {
 bench('JoinSelectField<Book, "b"> - alias-prefixed key', () => {
   useJoinField<Book, 'b'>('b.title');
 }).types([6, 'instantiations']);
+
+// ============================================
+// execute() return type benchmarks
+// Uses ExecuteDTO with DirectDTO shortcut:
+// - No joins, wildcard: EntityDTOFlat<T>
+// - No joins, selected fields: DirectDTO<T, F> (bypasses full EntityDTO computation)
+// - Wildcard + single-level join: Omit<EntityDTOFlat<T>> + override relations
+// - Selected fields + single-level join: DirectDTO for root + DirectDTO for joined
+// - Nested joins (wildcard): SerializeDTO<T, H>
+// - Nested joins (fields): EntityDTOFlat<Loaded<T, H, F>>
+// ============================================
+
+// DirectDTO: only iterates selected keys, not all entity keys
+type DirectDTO<T, F extends keyof T> = {
+  [K in F]: EntityDTOProp<T, NonNullable<T[K]>> | Extract<T[K], null | undefined>;
+};
+
+// Force type resolution by accessing a property — prevents TypeScript from
+// identity-matching identical type aliases without resolving their structure.
+
+bench('execute() return - wildcard fields', () => {
+  const r = {} as EntityDTOFlat<Author>;
+  const _: string = r.name;
+  void _;
+}).types([446, 'instantiations']);
+
+bench('execute() return - selected fields', () => {
+  const r = {} as DirectDTO<Author, 'id' | 'email'>;
+  const _: string = r.email;
+  void _;
+}).types([21, 'instantiations']);
+
+bench('execute("get") return - selected fields (single)', () => {
+  const r = {} as DirectDTO<Author, 'id' | 'email'>;
+  const _: number = r.id;
+  void _;
+}).types([21, 'instantiations']);
+
+bench('execute() return - with join hint', () => {
+  const r = {} as DirectDTO<Author, 'id'> & { books: DirectDTO<Book, 'title' | PrimaryProperty<Book>>[] };
+  const _: number = r.id;
+  void _;
+}).types([42, 'instantiations']);
+
+bench('execute() return - with join hint and wildcard', () => {
+  const r = {} as Omit<EntityDTOFlat<Author>, 'books'> & { books: EntityDTOFlat<Book>[] };
+  const _: string = r.name;
+  void _;
+}).types([656, 'instantiations']);
+
+bench('execute() return - 2-level nested wildcard', () => {
+  const r = {} as SerializeDTO<Author, 'books' | 'books.publisher'>;
+  const _: string = r.name;
+  void _;
+}).types([590, 'instantiations']);
+
+bench('execute() return - 3-level nested wildcard', () => {
+  const r = {} as SerializeDTO<Author, 'books' | 'books.publisher' | 'books.publisher.books'>;
+  const _: string = r.name;
+  void _;
+}).types([596, 'instantiations']);
+
+bench('execute() return - 3-level nested with fields', () => {
+  const r = {} as EntityDTOFlat<Loaded<Author, 'books' | 'books.publisher' | 'books.publisher.books', 'id' | 'books.title' | 'books.publisher.name' | 'books.publisher.books.title'>>;
+  const _: number = r.id;
+  void _;
+}).types([2648, 'instantiations']);
+
+// ============================================
+// EntityDTOFlat vs EntityDTO comparison (wide entities)
+// Demonstrates recursive 1-pass savings on wider entity graphs
+// ============================================
+
+interface WidePublisher {
+  id: number;
+  name: string;
+  address: string;
+  city: string;
+  country: string;
+  phone: string;
+  email: string;
+  website: string;
+  foundedYear: number;
+  revenue: number;
+  employeeCount: number;
+  isPublic: boolean;
+  books: Collection<WideBook>;
+  [PrimaryKeyProp]?: 'id';
+}
+
+interface WideBook {
+  uuid: string;
+  title: string;
+  price: number;
+  isbn: string;
+  pageCount: number;
+  language: string;
+  format: string;
+  edition: number;
+  rating: number;
+  synopsis: string;
+  publishDate: Date;
+  inStock: boolean;
+  author: WideAuthor;
+  publisher?: Ref<WidePublisher> | null;
+  [PrimaryKeyProp]?: 'uuid';
+}
+
+interface WideAuthor {
+  id: number;
+  name: string;
+  email: string;
+  age?: number;
+  bio: string;
+  website: string;
+  twitter: string;
+  country: string;
+  birthDate: Date;
+  debutYear: number;
+  isActive: boolean;
+  penName?: string;
+  books: Collection<WideBook>;
+  favouriteBook?: Ref<WideBook> | null;
+  [PrimaryKeyProp]?: 'id';
+}
+
+bench('EntityDTO<Loaded<WideAuthor, "books">> - 2-pass recursive', () => {
+  const r = {} as EntityDTO<Loaded<WideAuthor, 'books'>>;
+  const _: string = r.name;
+  void _;
+}).types([5677, 'instantiations']);
+
+bench('EntityDTOFlat<Loaded<WideAuthor, "books">> - 1-pass recursive', () => {
+  const r = {} as EntityDTOFlat<Loaded<WideAuthor, 'books'>>;
+  const _: string = r.name;
+  void _;
+}).types([4668, 'instantiations']);
+
+bench('EntityDTO<Loaded<WideAuthor, "books.publisher">> - 2-pass recursive 2-level', () => {
+  const r = {} as EntityDTO<Loaded<WideAuthor, 'books' | 'books.publisher'>>;
+  const _: string = r.name;
+  void _;
+}).types([5737, 'instantiations']);
+
+bench('EntityDTOFlat<Loaded<WideAuthor, "books.publisher">> - 1-pass recursive 2-level', () => {
+  const r = {} as EntityDTOFlat<Loaded<WideAuthor, 'books' | 'books.publisher'>>;
+  const _: string = r.name;
+  void _;
+}).types([4728, 'instantiations']);


### PR DESCRIPTION
The execute() overloads now return `EntityDTO<Loaded<Entity, Hint, Fields>>` instead of plain `Entity`, reflecting that execute() returns mapped POJOs with Collections as arrays and References unwrapped.