### PR TITLE
perf(core): improve `Loaded` type performance by optimizing field selection

### DIFF
--- a/tests/bench/types/api-methods.ts
+++ b/tests/bench/types/api-methods.ts
@@ -111,13 +111,13 @@ bench('New<Author>', () => {
   type R = New<Author>;
   const x = {} as R;
   void x;
-}).types([611, 'instantiations']);
+}).types([583, 'instantiations']);
 
 bench('New<Author, "books">', () => {
   type R = New<Author, 'books'>;
   const x = {} as R;
   void x;
-}).types([1032, 'instantiations']);
+}).types([1004, 'instantiations']);
 
 // ============================================
 // em.populate() - return type computation
@@ -137,25 +137,25 @@ bench('EntityDTO<Author>', () => {
   type R = EntityDTO<Author>;
   const x = {} as R;
   void x;
-}).types([1112, 'instantiations']);
+}).types([1114, 'instantiations']);
 
 bench('EntityDTO<Book>', () => {
   type R = EntityDTO<Book>;
   const x = {} as R;
   void x;
-}).types([982, 'instantiations']);
+}).types([984, 'instantiations']);
 
 bench('EntityDTO<Loaded<Author, "books">>', () => {
   type R = EntityDTO<Loaded<Author, 'books'>>;
   const x = {} as R;
   void x;
-}).types([3647, 'instantiations']);
+}).types([3621, 'instantiations']);
 
 bench('EntityDTO<Loaded<Author, "books.publisher">>', () => {
   type R = EntityDTO<Loaded<Author, 'books.publisher'>>;
   const x = {} as R;
   void x;
-}).types([3647, 'instantiations']);
+}).types([3621, 'instantiations']);
 
 // ============================================
 // FilterQuery - used in where clauses
@@ -177,7 +177,7 @@ bench('FilterQuery<Loaded<Author, "books">>', () => {
   type R = FilterQuery<Loaded<Author, 'books'>>;
   const x = {} as R;
   void x;
-}).types([2495, 'instantiations']);
+}).types([2467, 'instantiations']);
 
 // ============================================
 // EntityData - used in em.assign()
@@ -193,7 +193,7 @@ bench('EntityData<Loaded<Author, "books">>', () => {
   type R = EntityData<Loaded<Author, 'books'>>;
   const x = {} as R;
   void x;
-}).types([1876, 'instantiations']);
+}).types([1848, 'instantiations']);
 
 // ============================================
 // Simulating wrap(e).toObject()
@@ -206,13 +206,13 @@ bench('wrap(author).toObject() return type', () => {
   type R = ToObjectReturn<Author>;
   const x = {} as R;
   void x;
-}).types([1113, 'instantiations']);
+}).types([1115, 'instantiations']);
 
 bench('wrap(loadedAuthor).toObject() return type', () => {
   type R = ToObjectReturn<Loaded<Author, 'books'>>;
   const x = {} as R;
   void x;
-}).types([3649, 'instantiations']);
+}).types([3623, 'instantiations']);
 
 // ============================================
 // Complex scenarios
@@ -224,4 +224,4 @@ bench('find result then EntityDTO', () => {
   type DTOResult = EntityDTO<FindResult>;
   const x = {} as DTOResult;
   void x;
-}).types([3647, 'instantiations']);
+}).types([3621, 'instantiations']);

--- a/tests/bench/types/assign-types.ts
+++ b/tests/bench/types/assign-types.ts
@@ -68,7 +68,7 @@ bench('FromEntityType - plain entity', () => {
 
 bench('FromEntityType - Loaded entity', () => {
   useFromEntityType<Loaded<Author, 'books'>>({} as FromEntityType<Loaded<Author, 'books'>>);
-}).types([1150, 'instantiations']);
+}).types([1122, 'instantiations']);
 
 // ============================================
 // IsSubset benchmarks
@@ -103,7 +103,7 @@ bench('MergeSelected - Loaded entity', () => {
   type R = MergeSelected<Loaded<Author, 'books'>, Author, 'name'>;
   const x = {} as R;
   void x;
-}).types([1941, 'instantiations']);
+}).types([1646, 'instantiations']);
 
 // ============================================
 // Full assign signature simulation
@@ -122,7 +122,7 @@ bench('assign return type - Loaded entity', () => {
   type R = AssignReturnType<Loaded<Author, 'books'>, { name: string }>;
   const x = {} as R;
   void x;
-}).types([1960, 'instantiations']);
+}).types([1665, 'instantiations']);
 
 // ============================================
 // Data parameter type computation
@@ -136,10 +136,10 @@ bench('assign data type - plain entity', () => {
   type R = AssignDataType<Author>;
   const x = {} as R;
   void x;
-}).types([2343, 'instantiations']);
+}).types([2361, 'instantiations']);
 
 bench('assign data type - Loaded entity', () => {
   type R = AssignDataType<Loaded<Author, 'books'>>;
   const x = {} as R;
   void x;
-}).types([3442, 'instantiations']);
+}).types([3432, 'instantiations']);

--- a/tests/bench/types/asterisk-hints.ts
+++ b/tests/bench/types/asterisk-hints.ts
@@ -59,24 +59,24 @@ function useLoaded<T, L extends string = never, F extends string = '*'>(_entity:
 
 bench('Loaded<Author, "*"> - asterisk populate all', () => {
   useLoaded<Author, '*'>({} as Loaded<Author, '*'>);
-}).types([1390, 'instantiations']);
+}).types([1362, 'instantiations']);
 
 bench('Loaded<Book, "*"> - asterisk populate all', () => {
   useLoaded<Book, '*'>({} as Loaded<Book, '*'>);
-}).types([1921, 'instantiations']);
+}).types([1893, 'instantiations']);
 
 bench('Loaded<Publisher, "*"> - asterisk populate all', () => {
   useLoaded<Publisher, '*'>({} as Loaded<Publisher, '*'>);
-}).types([1066, 'instantiations']);
+}).types([1038, 'instantiations']);
 
 // Compare with explicit paths
 bench('Loaded<Author, "books"> - single relation', () => {
   useLoaded<Author, 'books'>({} as Loaded<Author, 'books'>);
-}).types([1163, 'instantiations']);
+}).types([1135, 'instantiations']);
 
 bench('Loaded<Author, "books" | "friends"> - multiple relations', () => {
   useLoaded<Author, 'books' | 'friends'>({} as Loaded<Author, 'books' | 'friends'>);
-}).types([1295, 'instantiations']);
+}).types([1255, 'instantiations']);
 
 // ============================================
 // Loaded with asterisk fields (F parameter)
@@ -84,11 +84,11 @@ bench('Loaded<Author, "books" | "friends"> - multiple relations', () => {
 
 bench('Loaded<Author, "books", "*"> - default fields', () => {
   useLoaded<Author, 'books', '*'>({} as Loaded<Author, 'books', '*'>);
-}).types([1023, 'instantiations']);
+}).types([995, 'instantiations']);
 
 bench('Loaded<Author, "books", "name" | "email"> - specific fields', () => {
   useLoaded<Author, 'books', 'name' | 'email'>({} as Loaded<Author, 'books', 'name' | 'email'>);
-}).types([862, 'instantiations']);
+}).types([662, 'instantiations']);
 
 // ============================================
 // Helper type benchmarks

--- a/tests/bench/types/autopath-loaded-isolated.ts
+++ b/tests/bench/types/autopath-loaded-isolated.ts
@@ -73,19 +73,19 @@ function useLoaded<T, L extends string = never>(_entity: Loaded<T, L>): void {}
 
 bench('Loaded LINEAR - no populate', () => {
   useLoaded<Person>({} as Person);
-}).types([533, 'instantiations']);
+}).types([505, 'instantiations']);
 
 bench('Loaded LINEAR - 1 level (Ref)', () => {
   useLoaded<Person, 'address'>({} as Loaded<Person, 'address'>);
-}).types([929, 'instantiations']);
+}).types([901, 'instantiations']);
 
 bench('Loaded LINEAR - 2 levels (Ref)', () => {
   useLoaded<Person, 'address.city'>({} as Loaded<Person, 'address.city'>);
-}).types([929, 'instantiations']);
+}).types([901, 'instantiations']);
 
 bench('Loaded LINEAR - 3 levels (Ref)', () => {
   useLoaded<Person, 'address.city.country'>({} as Loaded<Person, 'address.city.country'>);
-}).types([929, 'instantiations']);
+}).types([901, 'instantiations']);
 
 // ============================================
 // SELF-REFERENCING entity (single type circular)
@@ -113,15 +113,15 @@ bench('AutoPath SELF-REF - children (Collection)', () => {
 
 bench('Loaded SELF-REF - 1 level (Ref)', () => {
   useLoaded<TreeNode, 'parent'>({} as Loaded<TreeNode, 'parent'>);
-}).types([951, 'instantiations']);
+}).types([923, 'instantiations']);
 
 bench('Loaded SELF-REF - 2 levels (Ref)', () => {
   useLoaded<TreeNode, 'parent.parent'>({} as Loaded<TreeNode, 'parent.parent'>);
-}).types([951, 'instantiations']);
+}).types([923, 'instantiations']);
 
 bench('Loaded SELF-REF - children (Collection)', () => {
   useLoaded<TreeNode, 'children'>({} as Loaded<TreeNode, 'children'>);
-}).types([923, 'instantiations']);
+}).types([895, 'instantiations']);
 
 // ============================================
 // TWO-WAY circular reference (A <-> B)
@@ -156,23 +156,23 @@ bench('AutoPath CIRCULAR - 3 levels', () => {
 
 bench('Loaded CIRCULAR - simple (Ref)', () => {
   useLoaded<Employee, 'department'>({} as Loaded<Employee, 'department'>);
-}).types([929, 'instantiations']);
+}).types([901, 'instantiations']);
 
 bench('Loaded CIRCULAR - 2 levels (Ref)', () => {
   useLoaded<Employee, 'department.manager'>({} as Loaded<Employee, 'department.manager'>);
-}).types([929, 'instantiations']);
+}).types([901, 'instantiations']);
 
 bench('Loaded CIRCULAR - back to start (Ref)', () => {
   useLoaded<Employee, 'department.manager.department'>({} as Loaded<Employee, 'department.manager.department'>);
-}).types([929, 'instantiations']);
+}).types([901, 'instantiations']);
 
 bench('Loaded CIRCULAR - collection', () => {
   useLoaded<Department, 'employees'>({} as Loaded<Department, 'employees'>);
-}).types([923, 'instantiations']);
+}).types([895, 'instantiations']);
 
 bench('Loaded CIRCULAR - collection nested', () => {
   useLoaded<Department, 'employees.department'>({} as Loaded<Department, 'employees.department'>);
-}).types([923, 'instantiations']);
+}).types([895, 'instantiations']);
 
 // ============================================
 // Entity with many properties (width test)
@@ -228,12 +228,12 @@ bench('AutoPath WIDE - 5 refs', () => {
 
 bench('Loaded WIDE - 20 scalar props', () => {
   useLoaded<WideSimple>({} as WideSimple);
-}).types([893, 'instantiations']);
+}).types([865, 'instantiations']);
 
 bench('Loaded WIDE - 5 refs no populate', () => {
   useLoaded<WideWithRefs>({} as WideWithRefs);
-}).types([693, 'instantiations']);
+}).types([665, 'instantiations']);
 
 bench('Loaded WIDE - 5 refs all populated', () => {
   useLoaded<WideWithRefs, 'r1' | 'r2' | 'r3' | 'r4' | 'r5'>({} as Loaded<WideWithRefs, 'r1' | 'r2' | 'r3' | 'r4' | 'r5'>);
-}).types([1961, 'instantiations']);
+}).types([1554, 'instantiations']);

--- a/tests/bench/types/autopath-loaded.ts
+++ b/tests/bench/types/autopath-loaded.ts
@@ -81,27 +81,27 @@ function useLoaded<T, L extends string = never>(_entity: Loaded<T, L>): void {}
 
 bench('Loaded - no populate', () => {
   useLoaded<Author>({} as Author);
-}).types([613, 'instantiations']);
+}).types([585, 'instantiations']);
 
 bench('Loaded - single relation', () => {
   useLoaded<Author, 'books'>({} as Loaded<Author, 'books'>);
-}).types([989, 'instantiations']);
+}).types([961, 'instantiations']);
 
 bench('Loaded - nested relation (2 levels)', () => {
   useLoaded<Author, 'books.publisher'>({} as Loaded<Author, 'books.publisher'>);
-}).types([989, 'instantiations']);
+}).types([961, 'instantiations']);
 
 bench('Loaded - nested relation (3 levels)', () => {
   useLoaded<Author, 'books.publisher.books'>({} as Loaded<Author, 'books.publisher.books'>);
-}).types([989, 'instantiations']);
+}).types([961, 'instantiations']);
 
 bench('Loaded - multiple relations', () => {
   useLoaded<Author, 'books' | 'friends' | 'favouriteBook'>({} as Loaded<Author, 'books' | 'friends' | 'favouriteBook'>);
-}).types([1397, 'instantiations']);
+}).types([1242, 'instantiations']);
 
 bench('Loaded - complex nested paths', () => {
   useLoaded<Author, 'books.tags' | 'books.publisher' | 'friends.books'>({} as Loaded<Author, 'books.tags' | 'books.publisher' | 'friends.books'>);
-}).types([1276, 'instantiations']);
+}).types([1119, 'instantiations']);
 
 // ============================================
 // Deep hierarchy tests
@@ -157,7 +157,7 @@ bench('AutoPath - deep hierarchy (6 levels)', () => {
 
 bench('Loaded - deep hierarchy (6 levels)', () => {
   useLoaded<DeepRoot, 'level1.level2.level3.level4.level5'>({} as Loaded<DeepRoot, 'level1.level2.level3.level4.level5'>);
-}).types([951, 'instantiations']);
+}).types([923, 'instantiations']);
 
 // ============================================
 // Wide entity (many properties) tests
@@ -189,7 +189,7 @@ bench('AutoPath - wide entity (15 properties)', () => {
 
 bench('Loaded - wide entity (15 properties)', () => {
   useLoaded<WideEntity, 'rel1' | 'rel2' | 'rel3'>({} as Loaded<WideEntity, 'rel1' | 'rel2' | 'rel3'>);
-}).types([1698, 'instantiations']);
+}).types([1390, 'instantiations']);
 
 // ============================================
 // Eager props tests
@@ -206,7 +206,7 @@ interface EntityWithEager {
 
 bench('Loaded - with eager props', () => {
   useLoaded<EntityWithEager, 'normalRel'>({} as Loaded<EntityWithEager, 'normalRel'>);
-}).types([1069, 'instantiations']);
+}).types([1001, 'instantiations']);
 
 // ============================================
 // Fields selection tests
@@ -215,9 +215,9 @@ bench('Loaded - with eager props', () => {
 bench('Loaded - with fields selection', () => {
   const entity = {} as Loaded<Author, 'books', 'name' | 'email'>;
   void entity;
-}).types([808, 'instantiations']);
+}).types([625, 'instantiations']);
 
 bench('Loaded - with exclude', () => {
   const entity = {} as Loaded<Author, 'books', '*', 'age'>;
   void entity;
-}).types([619, 'instantiations']);
+}).types([591, 'instantiations']);

--- a/tests/bench/types/entitydto-isolated.ts
+++ b/tests/bench/types/entitydto-isolated.ts
@@ -43,15 +43,15 @@ function useDTO<T>(_dto: EntityDTO<T>): void {}
 
 bench('EntityDTO<SimpleEntity> - no relations', () => {
   useDTO<SimpleEntity>({} as EntityDTO<SimpleEntity>);
-}).types([916, 'instantiations']);
+}).types([918, 'instantiations']);
 
 bench('EntityDTO<EntityWithRef> - with Ref', () => {
   useDTO<EntityWithRef>({} as EntityDTO<EntityWithRef>);
-}).types([854, 'instantiations']);
+}).types([856, 'instantiations']);
 
 bench('EntityDTO<EntityWithCollection> - with Collection', () => {
   useDTO<EntityWithCollection>({} as EntityDTO<EntityWithCollection>);
-}).types([789, 'instantiations']);
+}).types([791, 'instantiations']);
 
 // ============================================
 // EntityDTO on Loaded entities
@@ -59,23 +59,23 @@ bench('EntityDTO<EntityWithCollection> - with Collection', () => {
 
 bench('EntityDTO<Loaded<SimpleEntity>> - loaded no relations', () => {
   useDTO<Loaded<SimpleEntity>>({} as EntityDTO<Loaded<SimpleEntity>>);
-}).types([2168, 'instantiations']);
+}).types([2142, 'instantiations']);
 
 bench('EntityDTO<Loaded<EntityWithRef>> - loaded with Ref', () => {
   useDTO<Loaded<EntityWithRef>>({} as EntityDTO<Loaded<EntityWithRef>>);
-}).types([1956, 'instantiations']);
+}).types([1930, 'instantiations']);
 
 bench('EntityDTO<Loaded<EntityWithRef, "parent">> - loaded with populated Ref', () => {
   useDTO<Loaded<EntityWithRef, 'parent'>>({} as EntityDTO<Loaded<EntityWithRef, 'parent'>>);
-}).types([2437, 'instantiations']);
+}).types([2411, 'instantiations']);
 
 bench('EntityDTO<Loaded<EntityWithCollection>> - loaded with Collection', () => {
   useDTO<Loaded<EntityWithCollection>>({} as EntityDTO<Loaded<EntityWithCollection>>);
-}).types([1767, 'instantiations']);
+}).types([1741, 'instantiations']);
 
 bench('EntityDTO<Loaded<EntityWithCollection, "items">> - loaded with populated Collection', () => {
   useDTO<Loaded<EntityWithCollection, 'items'>>({} as EntityDTO<Loaded<EntityWithCollection, 'items'>>);
-}).types([2395, 'instantiations']);
+}).types([2369, 'instantiations']);
 
 // ============================================
 // Comparison: EntityDTO vs direct Loaded
@@ -86,4 +86,4 @@ function useLoaded<T, L extends string = never>(_entity: Loaded<T, L>): void {}
 
 bench('Loaded<EntityWithCollection, "items"> - without EntityDTO', () => {
   useLoaded<EntityWithCollection, 'items'>({} as Loaded<EntityWithCollection, 'items'>);
-}).types([901, 'instantiations']);
+}).types([873, 'instantiations']);

--- a/tests/bench/types/filter-query.ts
+++ b/tests/bench/types/filter-query.ts
@@ -68,7 +68,7 @@ bench('EntityKey<Loaded<Author, "books">>', () => {
   type R = EntityKey<Loaded<Author, 'books'>>;
   const x = {} as R;
   void x;
-}).types([1755, 'instantiations']);
+}).types([1727, 'instantiations']);
 
 // ============================================
 // FilterObject benchmarks

--- a/tests/bench/types/other-types.ts
+++ b/tests/bench/types/other-types.ts
@@ -142,8 +142,8 @@ function useDTO<T>(_dto: EntityDTO<T>): void {}
 
 bench('EntityDTO<Author> - simple', () => {
   useDTO<Author>({} as EntityDTO<Author>);
-}).types([1178, 'instantiations']);
+}).types([1180, 'instantiations']);
 
 bench('EntityDTO<Loaded<Author, "books">> - with loaded hint', () => {
   useDTO<Loaded<Author, 'books'>>({} as EntityDTO<Loaded<Author, 'books'>>);
-}).types([3918, 'instantiations']);
+}).types([3892, 'instantiations']);

--- a/tests/bench/types/querybuilder.ts
+++ b/tests/bench/types/querybuilder.ts
@@ -255,7 +255,7 @@ bench('execute() return - 3-level nested with fields', () => {
   const r = {} as EntityDTOFlat<Loaded<Author, 'books' | 'books.publisher' | 'books.publisher.books', 'id' | 'books.title' | 'books.publisher.name' | 'books.publisher.books.title'>>;
   const _: number = r.id;
   void _;
-}).types([2648, 'instantiations']);
+}).types([2041, 'instantiations']);
 
 // ============================================
 // EntityDTOFlat vs EntityDTO comparison (wide entities)
@@ -319,22 +319,22 @@ bench('EntityDTO<Loaded<WideAuthor, "books">> - 2-pass recursive', () => {
   const r = {} as EntityDTO<Loaded<WideAuthor, 'books'>>;
   const _: string = r.name;
   void _;
-}).types([5677, 'instantiations']);
+}).types([5649, 'instantiations']);
 
 bench('EntityDTOFlat<Loaded<WideAuthor, "books">> - 1-pass recursive', () => {
   const r = {} as EntityDTOFlat<Loaded<WideAuthor, 'books'>>;
   const _: string = r.name;
   void _;
-}).types([4668, 'instantiations']);
+}).types([4640, 'instantiations']);
 
 bench('EntityDTO<Loaded<WideAuthor, "books.publisher">> - 2-pass recursive 2-level', () => {
   const r = {} as EntityDTO<Loaded<WideAuthor, 'books' | 'books.publisher'>>;
   const _: string = r.name;
   void _;
-}).types([5737, 'instantiations']);
+}).types([5681, 'instantiations']);
 
 bench('EntityDTOFlat<Loaded<WideAuthor, "books.publisher">> - 1-pass recursive 2-level', () => {
   const r = {} as EntityDTOFlat<Loaded<WideAuthor, 'books' | 'books.publisher'>>;
   const _: string = r.name;
   void _;
-}).types([4728, 'instantiations']);
+}).types([4672, 'instantiations']);


### PR DESCRIPTION
| Benchmark                               | Before | After | Change |
|----------------------------------------|--------|-------|--------|
| Loaded - wide entity (15 props)         | 1698   | 1390  | -18%   |
| Loaded - with fields selection          | 808    | 625   | -23%   |
| Loaded - multiple relations             | 1397   | 1242  | -11%   |
| Loaded - complex nested paths           | 1276   | 1119  | -12%   |
| execute() 3-level nested + fields       | 2648   | 2041  | -23%   |
| Loaded WIDE - 5 refs all populated      | 1961   | 1555  | -21%   |