### PR TITLE
perf(core): improve `defineEntity` type performance

### DIFF
--- a/docs/docs/upgrading-v6-to-v7.md
+++ b/docs/docs/upgrading-v6-to-v7.md
@@ -617,6 +617,37 @@ const UserSchema2 = new EntitySchema<User>({
 });
 ```
 
+## Property builder boolean methods no longer accept `true`
+
+The `defineEntity` property builder methods like `nullable()`, `ref()`, `owner()`, `primary()`, `hidden()`, `array()`, `version()`, `lazy()`, and `mapToPk()` no longer accept an explicit `true` argument. Call them without arguments instead — the behavior is identical.
+
+```diff
+-name: p.string().nullable(true),
++name: p.string().nullable(),
+
+-tags: () => p.manyToMany(BookTag).owner(true),
++tags: () => p.manyToMany(BookTag).owner(),
+
+-id: p.integer().primary(true).autoincrement(true),
++id: p.integer().primary().autoincrement(),
+```
+
+The `persist()` and `autoincrement()` methods still accept `false` as an argument via overloads:
+
+```ts
+// This still works:
+id: p.number().autoincrement(false),
+token: p.string().persist(false),
+```
+
+The `lazy()` method no longer implies `ref()`. If you want a lazy scalar property wrapped in `ScalarReference`, chain `.ref()` explicitly:
+
+```diff
+-bio: p.text().lazy(),        // previously wrapped in ScalarReference
++bio: p.text().lazy(),        // now plain lazy scalar
++bio: p.text().lazy().ref(),  // use this for ScalarReference wrapper
+```
+
 ## Self-referencing M:N pivot table column naming
 
 When you have a self-referencing many-to-many relation with an **explicit `tableName`** that differs from the class name, the pivot table column names now use the `tableName` instead of `className`.

--- a/packages/entity-generator/src/SourceFile.ts
+++ b/packages/entity-generator/src/SourceFile.ts
@@ -939,10 +939,8 @@ export class SourceFile {
       if (!prop.primary || !this.platform.isNumericColumn(mappedColumnType) || this.meta.getPrimaryProps().length !== 1) {
         options.autoincrement = true;
       }
-    } else {
-      if (prop.primary && this.platform.isNumericColumn(mappedColumnType) && this.meta.getPrimaryProps().length === 1) {
-        options.autoincrement = false;
-      }
+    } else if (prop.primary && this.platform.isNumericColumn(mappedColumnType) && this.meta.getPrimaryProps().length === 1) {
+      options.autoincrement = false;
     }
 
     if (prop.generated) {

--- a/tests/bench/types/defineEntity-extends.ts
+++ b/tests/bench/types/defineEntity-extends.ts
@@ -19,7 +19,7 @@ bench('entity extends entity', () => {
       extra: p.string(),
     },
   });
-}).types([1438, 'instantiations']);
+}).types([1465, 'instantiations']);
 
 bench('entity extends entity with discriminator', () => {
   const base = defineEntity({
@@ -40,7 +40,7 @@ bench('entity extends entity with discriminator', () => {
       extra: p.string(),
     },
   });
-}).types([1459, 'instantiations']);
+}).types([1486, 'instantiations']);
 
 bench('embeddable extends embeddable', () => {
   const base = defineEntity({
@@ -60,7 +60,7 @@ bench('embeddable extends embeddable', () => {
       bar: p.string(),
     },
   });
-}).types([881, 'instantiations']);
+}).types([918, 'instantiations']);
 
 bench('embeddable extends embeddable with discriminator', () => {
   const base = defineEntity({
@@ -83,7 +83,7 @@ bench('embeddable extends embeddable with discriminator', () => {
       bar: p.string(),
     },
   });
-}).types([902, 'instantiations']);
+}).types([939, 'instantiations']);
 
 bench('polymorphic embeddables', () => {
   const base = defineEntity({
@@ -198,4 +198,4 @@ bench('polymorphic embeddables', () => {
       data: () => p.embedded([documentDataAwEdCard, documentDataCoCheckMig, documentDataMvDiCard]).object(),
     },
   });
-}).types([3513, 'instantiations']);
+}).types([3167, 'instantiations']);

--- a/tests/bench/types/defineEntity.ts
+++ b/tests/bench/types/defineEntity.ts
@@ -17,7 +17,7 @@ bench('defineEntity with relations', () => {
       scalarRefNullable: p.string().ref().nullable(),
     },
   });
-}).types([13144, 'instantiations']);
+}).types([6496, 'instantiations']);
 
 bench('defineEntity with ref and nullable', () => {
   const Foo = defineEntity({
@@ -34,7 +34,7 @@ bench('defineEntity with ref and nullable', () => {
       scalarRefNullable: p.string().ref().nullable(),
     },
   });
-}).types([13505, 'instantiations']);
+}).types([6510, 'instantiations']);
 
 bench('defineEntity only with ref and nullable', () => {
   const Foo = defineEntity({
@@ -44,7 +44,7 @@ bench('defineEntity only with ref and nullable', () => {
       toOneRefNullable: () => p.oneToOne(Foo).ref().nullable(),
     },
   });
-}).types([11369, 'instantiations']);
+}).types([1844, 'instantiations']);
 
 bench('defineEntity only with nullable and ref', () => {
   const Foo = defineEntity({
@@ -54,7 +54,7 @@ bench('defineEntity only with nullable and ref', () => {
       toOneRefNullable: () => p.oneToOne(Foo).nullable().ref(),
     },
   });
-}).types([11373, 'instantiations']);
+}).types([1844, 'instantiations']);
 
 bench('defineEntity with relations using class', () => {
   class Foo {
@@ -86,7 +86,7 @@ bench('defineEntity with relations using class', () => {
       scalarRefNullable: p.string().ref().nullable(),
     },
   });
-}).types([12083, 'instantiations']);
+}).types([6966, 'instantiations']);
 
 bench('defineEntity with ref and nullable using class', () => {
   class Foo {
@@ -118,7 +118,7 @@ bench('defineEntity with ref and nullable using class', () => {
       scalarRefNullable: p.string().ref().nullable(),
     },
   });
-}).types([12083, 'instantiations']);
+}).types([6966, 'instantiations']);
 
 bench('defineEntity only with ref and nullable using class', () => {
   class Foo {
@@ -136,7 +136,7 @@ bench('defineEntity only with ref and nullable using class', () => {
       toOneRefNullable: () => p.oneToOne(Foo).ref().nullable(),
     },
   });
-}).types([9969, 'instantiations']);
+}).types([2325, 'instantiations']);
 
 bench('defineEntity only with nullable and ref using class', () => {
   class Foo {
@@ -154,7 +154,7 @@ bench('defineEntity only with nullable and ref using class', () => {
       toOneRefNullable: () => p.oneToOne(Foo).nullable().ref(),
     },
   });
-}).types([9973, 'instantiations']);
+}).types([2325, 'instantiations']);
 
 bench('EntitySchema', () => {
   interface IFoo {
@@ -239,4 +239,4 @@ bench('defineEntity with setClass pattern (circular relations)', () => {
 
   AuthorSchema.setClass(Author);
   BookSchema.setClass(Book);
-}).types([8623, 'instantiations']);
+}).types([5453, 'instantiations']);

--- a/tests/features/get-kysely.test.ts
+++ b/tests/features/get-kysely.test.ts
@@ -18,7 +18,7 @@ describe('InferKyselyDB', () => {
     const UserProfile = defineEntity({
       name: 'UserProfile',
       properties: {
-        user: () => p.oneToOne(User).owner(true).primary(),
+        user: () => p.oneToOne(User).owner().primary(),
         bio: p.string().nullable(),
         avatar: p.string().nullable(),
         location: p.string().nullable(),
@@ -117,7 +117,7 @@ describe('InferKyselyDB', () => {
       name: 'UserProfile',
       tableName: 'user_profiles',
       properties: {
-        user: () => p.oneToOne(User).owner(true).primary(),
+        user: () => p.oneToOne(User).owner().primary(),
         bio: p.string().nullable(),
         avatar: p.string().nullable(),
         location: p.string().nullable(),
@@ -156,7 +156,7 @@ describe('InferKyselyDB', () => {
       name: 'UserProfile',
       tableName: 'user_profiles',
       properties: {
-        user: () => p.oneToOne(User).owner(true).primary(),
+        user: () => p.oneToOne(User).owner().primary(),
         bio: p.string().nullable(),
         avatar: p.string().nullable(),
         location: p.string().nullable(),
@@ -359,7 +359,7 @@ describe('InferKyselyDB', () => {
       className: 'UserProfile',
       tableName: 'user_profiles',
       properties: {
-        user: () => p.oneToOne(User).owner(true).primary(),
+        user: () => p.oneToOne(User).owner().primary(),
         bio: p.string().nullable(),
         avatar: p.string().nullable(),
         location: p.string().nullable(),


### PR DESCRIPTION
| Benchmark                               | Master | PR Branch | Change |
|-----------------------------------------|--------|-----------|--------|
| defineEntity with relations              | 13,144 | 6,496     | -51%   |
| defineEntity with ref and nullable       | 13,505 | 6,510     | -52%   |
| defineEntity only ref+nullable           | 11,369 | 1,844     | -84%   |
| defineEntity with relations (class)      | 12,083 | 6,966     | -42%   |
| defineEntity only ref+nullable (class)   | 9,969  | 2,325     | -77%   |
| defineEntity setClass (circular)         | 8,623  | 5,453     | -37%   |
| polymorphic embeddables                  | 3,513  | 3,167     | -10%   |

The main problem was that `<T extends boolean = true>` generics cost ~440 instantiations each. This was always a bit weird and unnecessary, we don't really need to care about using `nullable(false)` when it's the default (and if we really need to, we can think of some other way, but let's not reintroduce this unless we see a good reason).

BREAKING CHANGE:

## Property builder boolean methods no longer accept `true`

The `defineEntity` property builder methods like `nullable()`, `ref()`, `owner()`, `primary()`, `hidden()`, `array()`, `version()`, `lazy()`, and `mapToPk()` no longer accept an explicit `true` argument. Call them without arguments instead — the behavior is identical.

```diff
-name: p.string().nullable(true),
+name: p.string().nullable(),

-tags: () => p.manyToMany(BookTag).owner(true),
+tags: () => p.manyToMany(BookTag).owner(),

-id: p.integer().primary(true).autoincrement(true),
+id: p.integer().primary().autoincrement(),
```

The `persist()` and `autoincrement()` methods still accepts `false` as an argument via overloads:

```ts
// This still works:
id: p.number().autoincrement(false),
token: p.string().persist(false),
```

The `lazy()` method no longer implies `ref()`. If you want a lazy scalar property wrapped in `ScalarReference`, chain `.ref()` explicitly:

```diff
-bio: p.text().lazy(),        // previously wrapped in ScalarReference
+bio: p.text().lazy(),        // now plain lazy scalar
+bio: p.text().lazy().ref(),  // use this for ScalarReference wrapper
```