### PR TITLE
feat(seeder): remove `tinyglobby` dependency, add `seedersList` option

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,7 +7,7 @@ export type {
   CompiledFunctions, Constructor, ConnectionType, Dictionary, Primary, IPrimaryKey, ObjectQuery, FilterQuery, IWrappedEntity, InferEntityName, EntityData, Highlighter, MaybePromise,
   AnyEntity, EntityClass, EntityProperty, PopulateOptions, Populate, Loaded, New, LoadedReference, LoadedCollection, IMigrator, IMigrationGenerator, MigratorEvent,
   GetRepository, MigrationObject, DeepPartial, PrimaryProperty, Cast, IsUnknown, EntityDictionary, EntityDTO, EntityDTOFlat, EntityDTOProp, SerializeDTO, MigrationDiff, GenerateOptions, FilterObject, IMigrationRunner,
-  IEntityGenerator, ISeedManager, IMigratorStorage, RequiredEntityData, CheckCallback, IndexCallback, FormulaCallback, FormulaTable, SchemaTable, SchemaColumns, SimpleColumnMeta, Rel, Ref, ScalarRef, EntityRef, ISchemaGenerator,
+  IEntityGenerator, ISeedManager, SeederObject, IMigratorStorage, RequiredEntityData, CheckCallback, IndexCallback, FormulaCallback, FormulaTable, SchemaTable, SchemaColumns, SimpleColumnMeta, Rel, Ref, ScalarRef, EntityRef, ISchemaGenerator,
   MigrationInfo, MigrateOptions, MigrationResult, MigrationRow, EntityKey, EntityValue, EntityDataValue, FilterKey, EntityType, FromEntityType, Selected, IsSubset,
   EntityProps, ExpandProperty, ExpandScalar, FilterItemValue, ExpandQuery, Scalar, ExpandHint, FilterValue, MergeLoaded, MergeSelected, TypeConfig, AnyString,
   ClearDatabaseOptions, CreateSchemaOptions, EnsureDatabaseOptions, UpdateSchemaOptions, DropSchemaOptions, RefreshDatabaseOptions, AutoPath, UnboxArray, MetadataProcessor, ImportsResolver,

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -1689,6 +1689,11 @@ export interface Seeder<T extends Dictionary = Dictionary> {
   run(em: EntityManager, context?: T): void | Promise<void>;
 }
 
+export interface SeederObject {
+  name: string;
+  class: Constructor<Seeder>;
+}
+
 export type ConnectionType = 'read' | 'write';
 
 export type MetadataProcessor = (metadata: EntityMetadata[], platform: Platform) => MaybePromise<void>;

--- a/packages/core/src/utils/Configuration.ts
+++ b/packages/core/src/utils/Configuration.ts
@@ -20,6 +20,8 @@ import type {
   MaybePromise,
   Migration,
   MigrationObject,
+  Seeder,
+  SeederObject,
 } from '../typings.js';
 import { ObjectHydrator } from '../hydration/ObjectHydrator.js';
 import { NullHighlighter } from '../utils/NullHighlighter.js';
@@ -633,6 +635,8 @@ export interface SeederOptions {
    * @default (className) => className
    */
   fileName?: (className: string) => string;
+  /** List of seeder classes or objects to use instead of file-based discovery. */
+  seedersList?: (SeederObject | Constructor<Seeder>)[];
 }
 
 /**

--- a/packages/seeder/package.json
+++ b/packages/seeder/package.json
@@ -50,9 +50,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "dependencies": {
-    "tinyglobby": "0.2.15"
-  },
   "devDependencies": {
     "@mikro-orm/core": "^6.6.4"
   },

--- a/tests/MikroORM.test.ts
+++ b/tests/MikroORM.test.ts
@@ -47,6 +47,7 @@ describe('MikroORM', () => {
     expect(orm1.seeder).toBeInstanceOf(SeedManager);
     // source folder detection is deferred to the first async call
     await (orm1.migrator as any).init();
+    await (orm1.seeder as any).init();
     expect(orm1.config.get('migrations')).toMatchObject({
       path: './src/migrations',
       pathTs: './src/migrations',
@@ -67,6 +68,7 @@ describe('MikroORM', () => {
     expect(orm2.migrator).toBeInstanceOf(Migrator);
     expect(orm2.seeder).toBeInstanceOf(SeedManager);
     await (orm2.migrator as any).init();
+    await (orm2.seeder as any).init();
     expect(orm2.config.get('migrations')).toMatchObject({
       path: './dist/migrations',
       pathTs: './src/migrations',
@@ -89,6 +91,7 @@ describe('MikroORM', () => {
     expect(orm3.migrator).toBeInstanceOf(MongoMigrator);
     expect(orm3.seeder).toBeInstanceOf(SeedManager);
     await (orm3.migrator as any).init();
+    await (orm3.seeder as any).init();
     expect(orm3.config.get('migrations')).toMatchObject({
       path: './build/migrations',
       pathTs: './src/migrations',

--- a/tests/features/seeder/seed-manager.test.ts
+++ b/tests/features/seeder/seed-manager.test.ts
@@ -57,6 +57,30 @@ describe('Seeder', () => {
     await expect(orm.seeder.seedString('Unknown')).rejects.toThrow(re);
   });
 
+  test('seedString with seedersList', async () => {
+    const options = orm.config.get('seeder');
+    options.seedersList = [Book3Seeder, { name: 'Author3Seeder', class: Author3Seeder }];
+    orm.config.set('seeder', options);
+
+    const bookRunMock = vi.spyOn(Book3Seeder.prototype, 'run');
+    bookRunMock.mockImplementation(async () => void 0);
+    const authorRunMock = vi.spyOn(Author3Seeder.prototype, 'run');
+    authorRunMock.mockImplementation(async () => void 0);
+
+    const seedMock = vi.spyOn(SeedManager.prototype, 'seed');
+
+    await orm.seeder.seedString('Book3Seeder');
+    expect(seedMock).toHaveBeenCalledTimes(1);
+
+    await orm.seeder.seedString('Book3Seeder', 'Author3Seeder');
+    expect(seedMock).toHaveBeenCalledTimes(3);
+
+    await expect(orm.seeder.seedString('Unknown')).rejects.toThrow('Seeder class Unknown not found in seedersList');
+
+    delete options.seedersList;
+    orm.config.set('seeder', options);
+  });
+
   test('createSeeder (TS)', async () => {
     const options = orm.config.get('seeder');
     options.path = fs.normalizePath(process.cwd()) + '/temp/seeders';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1657,7 +1657,6 @@ __metadata:
   resolution: "@mikro-orm/seeder@workspace:packages/seeder"
   dependencies:
     "@mikro-orm/core": "npm:^6.6.4"
-    tinyglobby: "npm:0.2.15"
   peerDependencies:
     "@mikro-orm/core": ^6.0.0
   languageName: unknown
@@ -9817,7 +9816,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tinyglobby@npm:0.2.15, tinyglobby@npm:^0.2.12, tinyglobby@npm:^0.2.14, tinyglobby@npm:^0.2.15":
+"tinyglobby@npm:^0.2.12, tinyglobby@npm:^0.2.14, tinyglobby@npm:^0.2.15":
   version: 0.2.15
   resolution: "tinyglobby@npm:0.2.15"
   dependencies:


### PR DESCRIPTION
Replace `tinyglobby` with `fs.glob()` from `@mikro-orm/core/fs-utils` and move all file system access behind dynamic imports so the seeder package loads cleanly in bundled environments. Add `seedersList` option (analogous to `migrationsList`) allowing users to provide seeder classes directly.