### PR TITLE
fix(postgres): fix phantom diffs for check constraints

### DIFF
--- a/packages/postgresql/src/PostgreSqlSchemaHelper.ts
+++ b/packages/postgresql/src/PostgreSqlSchemaHelper.ts
@@ -227,11 +227,19 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
     const sql = this.getChecksSQL(tablesBySchemas);
     const allChecks = await connection.execute<{ name: string; column_name: string; schema_name: string; table_name: string; expression: string }[]>(sql);
     const ret = {} as Dictionary;
+    const seen = new Set<string>();
 
     for (const check of allChecks) {
       const key = this.getTableKey(check);
+      const dedupeKey = `${key}:${check.name}`;
+
+      if (seen.has(dedupeKey)) {
+        continue;
+      }
+
+      seen.add(dedupeKey);
       ret[key] ??= [];
-      const m = check.expression.match(/^check \(\((.*)\)\)$/i);
+      const m = check.expression.match(/^check \(\((.*)\)\)$/is);
       const def = m?.[1].replace(/\((.*?)\)::\w+/g, '$1');
       ret[key].push({
         name: check.name,
@@ -660,7 +668,7 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
       from pg_constraint pgc
       join pg_namespace nsp on nsp.oid = pgc.connamespace
       join pg_class cls on pgc.conrelid = cls.oid
-      join information_schema.constraint_column_usage ccu on pgc.conname = ccu.constraint_name and nsp.nspname = ccu.constraint_schema
+      join information_schema.constraint_column_usage ccu on pgc.conname = ccu.constraint_name and nsp.nspname = ccu.constraint_schema and cls.relname = ccu.table_name
       where contype = 'c' and (${[...tablesBySchemas.entries()].map(([schema, tables]) => `ccu.table_name in (${tables.map(t => this.platform.quoteValue(t.table_name)).join(',')}) and ccu.table_schema = ${this.platform.quoteValue(schema ?? this.platform.getDefaultSchemaName() ?? '')}`).join(' or ')})
       order by pgc.conname`;
   }

--- a/tests/features/schema-generator/check-constraint.postgres.test.ts
+++ b/tests/features/schema-generator/check-constraint.postgres.test.ts
@@ -160,4 +160,104 @@ describe('check constraint [postgres]', () => {
     await orm.close();
   });
 
+  test('duplicate check constraint names across tables do not cause drift [postgres]', async () => {
+    const orm = await initORMPostgreSql();
+    const meta = orm.getMetadata();
+    await orm.schema.updateSchema();
+
+    const tableAMeta = new EntitySchema({
+      properties: {
+        id: { primary: true, name: 'id', type: 'number', fieldName: 'id', columnType: 'int' },
+        value: { type: 'number', name: 'value', fieldName: 'value', columnType: 'int' },
+      },
+      name: 'DupCheckTableA',
+      tableName: 'dup_check_table_a',
+      checks: [{ name: 'chk_positive', expression: 'value >= 0' }],
+    }).init().meta;
+    meta.set('DupCheckTableA', tableAMeta);
+
+    const tableBMeta = new EntitySchema({
+      properties: {
+        id: { primary: true, name: 'id', type: 'number', fieldName: 'id', columnType: 'int' },
+        amount: { type: 'number', name: 'amount', fieldName: 'amount', columnType: 'int' },
+      },
+      name: 'DupCheckTableB',
+      tableName: 'dup_check_table_b',
+      checks: [{ name: 'chk_positive', expression: 'amount >= 0' }],
+    }).init().meta;
+    meta.set('DupCheckTableB', tableBMeta);
+
+    let diff = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(diff).not.toBe('');
+    await orm.schema.execute(diff);
+
+    diff = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(diff).toBe('');
+
+    await orm.schema.dropDatabase();
+    await orm.close();
+  });
+
+  test('multi-column check constraint does not cause drift [postgres]', async () => {
+    const orm = await initORMPostgreSql();
+    const meta = orm.getMetadata();
+    await orm.schema.updateSchema();
+
+    const newTableMeta = new EntitySchema({
+      properties: {
+        id: { primary: true, name: 'id', type: 'number', fieldName: 'id', columnType: 'int' },
+        min_price: { type: 'number', name: 'min_price', fieldName: 'min_price', columnType: 'int' },
+        max_price: { type: 'number', name: 'max_price', fieldName: 'max_price', columnType: 'int' },
+      },
+      name: 'MultiColCheckTable',
+      tableName: 'multi_col_check_table',
+      checks: [
+        { name: 'chk_price_range', expression: 'min_price >= 0 and max_price >= min_price' },
+      ],
+    }).init().meta;
+    meta.set('MultiColCheckTable', newTableMeta);
+
+    let diff = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(diff).not.toBe('');
+    await orm.schema.execute(diff);
+
+    diff = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(diff).toBe('');
+
+    await orm.schema.dropDatabase();
+    await orm.close();
+  });
+
+  test('check constraint with multiline expression does not cause drift [postgres]', async () => {
+    const orm = await initORMPostgreSql();
+    const meta = orm.getMetadata();
+    await orm.schema.updateSchema();
+
+    const newTableMeta = new EntitySchema({
+      properties: {
+        id: { primary: true, name: 'id', type: 'number', fieldName: 'id', columnType: 'int' },
+        status: { type: 'string', name: 'status', fieldName: 'status', columnType: 'varchar(20)' },
+      },
+      name: 'MultilineCheckTable',
+      tableName: 'multiline_check_table',
+      checks: [
+        {
+          name: 'chk_status_valid',
+          expression: "CASE WHEN status = 'active' THEN 1 WHEN status = 'inactive' THEN 1 ELSE 0 END = 1",
+        },
+      ],
+    }).init().meta;
+    meta.set('MultilineCheckTable', newTableMeta);
+
+    let diff = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(diff).not.toBe('');
+    await orm.schema.execute(diff);
+
+    diff = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(diff).toBe('');
+
+    await orm.schema.dropDatabase();
+    await orm.close();
+  });
+
 });


### PR DESCRIPTION
## Summary

Backport of #7216 to 6.x. Fixes three sources of phantom schema diffs for PostgreSQL check constraints:

- **Duplicate constraint names across tables**: add `cls.relname = ccu.table_name` to the join in `getChecksSQL` to prevent cross-join duplication when multiple tables share a constraint name
- **Multiline expressions**: add the `s` (dotAll) flag to the regex in `getAllChecks` so `.` matches newlines in pretty-printed `pg_get_constraintdef()` output (e.g. `CASE` expressions)
- **Multi-column constraints**: deduplicate rows from `constraint_column_usage` (which returns one row per referenced column) using a `Set` in `getAllChecks`

## Test plan

- [x] Added regression test for duplicate constraint names across tables
- [x] Added regression test for multi-column check constraints
- [x] Added regression test for multiline CASE expressions
- [x] All tests assert first diff is non-empty (table created) and second diff is empty (no phantom drift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)