### PR TITLE
docs: replace EntitySchema tabs with defineEntity + class pattern

### DIFF
--- a/docs/docs/defining-entities.md
+++ b/docs/docs/defining-entities.md
@@ -29,14 +29,63 @@ Example definition of a `Book` entity follows. You can switch the tabs to see th
 
 <Tabs
   groupId="entity-def"
-  defaultValue="define-entity"
+  defaultValue="define-entity-class"
   values={[
+    {label: 'defineEntity + class', value: 'define-entity-class'},
     {label: 'defineEntity', value: 'define-entity'},
     {label: 'reflect-metadata', value: 'reflect-metadata'},
     {label: 'ts-morph', value: 'ts-morph'},
-    {label: 'EntitySchema', value: 'entity-schema'},
-  ]
-  }>
+]
+  }
+>
+  <TabItem value="define-entity-class">
+
+```ts title="./entities/Book.ts"
+import { defineEntity, p } from '@mikro-orm/core';
+
+const BookSchema = defineEntity({
+  name: 'Book',
+  extends: CustomBaseEntity,
+  properties: {
+    title: p.string(),
+    author: () => p.manyToOne(Author),
+    publisher: () => p.manyToOne(Publisher)
+      .ref()
+      .nullable(),
+    tags: () => p.manyToMany(BookTag)
+      .fixedOrder(),
+  },
+});
+
+export class Book extends BookSchema.class {}
+BookSchema.setClass(Book);
+```
+
+  </TabItem>
+
+  <TabItem value="define-entity">
+
+```ts title="./entities/Book.ts"
+import { type InferEntity, defineEntity, p } from '@mikro-orm/core';
+
+export const Book = defineEntity({
+  name: 'Book',
+  extends: CustomBaseEntity,
+  properties: {
+    title: p.string(),
+    author: () => p.manyToOne(Author),
+    publisher: () => p.manyToOne(Publisher)
+      .ref()
+      .nullable(),
+    tags: () => p.manyToMany(BookTag)
+      .fixedOrder(),
+  },
+});
+
+export type IBook = InferEntity<typeof Book>;
+```
+
+  </TabItem>
   <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Book.ts"
@@ -81,52 +130,6 @@ export class Book extends CustomBaseEntity {
 ```
 
   </TabItem>
-  <TabItem value="define-entity">
-
-```ts title="./entities/Book.ts"
-import { type InferEntity, defineEntity, p } from '@mikro-orm/core';
-
-export const Book = defineEntity({
-  name: 'Book',
-  extends: CustomBaseEntity,
-  properties: {
-    title: p.string(),
-    author: () => p.manyToOne(Author),
-    publisher: () => p.manyToOne(Publisher)
-      .ref()
-      .nullable(),
-    tags: () => p.manyToMany(BookTag)
-      .fixedOrder(),
-  },
-});
-
-export type IBook = InferEntity<typeof Book>;
-```
-
-  </TabItem>
-  <TabItem value="entity-schema">
-
-```ts title="./entities/Book.ts"
-export interface IBook extends ICustomBaseEntity {
-  title: string;
-  author: Author;
-  publisher?: Ref<Publisher>;
-  tags: Collection<BookTag>;
-}
-
-export const Book = new EntitySchema<IBook>({
-  name: 'Book',
-  extends: CustomBaseEntity,
-  properties: {
-    title: { type: 'string' },
-    author: { kind: 'm:1', entity: () => Author },
-    publisher: { kind: 'm:1', entity: () => Publisher, ref: true, nullable: true },
-    tags: { kind: 'm:n', entity: () => BookTag, fixedOrder: true },
-  },
-});
-```
-
-  </TabItem>
 </Tabs>
 
 > Including `{ ref: true }` in your `Ref` property definitions will wrap the reference, providing access to helper methods like `.load` and `.unwrap`, which can be helpful for loading data and changing the type of your references where you plan to use them.
@@ -135,14 +138,79 @@ Here is another example of `Author` entity, that was referenced from the `Book` 
 
 <Tabs
   groupId="entity-def"
-  defaultValue="define-entity"
+  defaultValue="define-entity-class"
   values={[
+    {label: 'defineEntity + class', value: 'define-entity-class'},
     {label: 'defineEntity', value: 'define-entity'},
     {label: 'reflect-metadata', value: 'reflect-metadata'},
     {label: 'ts-morph', value: 'ts-morph'},
-    {label: 'EntitySchema', value: 'entity-schema'},
-  ]
-  }>
+]
+  }
+>
+  <TabItem value="define-entity-class">
+
+```ts title="./entities/Author.ts"
+import { defineEntity, p } from '@mikro-orm/core';
+
+const AuthorSchema = defineEntity({
+  name: 'Author',
+  properties: {
+    _id: p.type(ObjectId).primary(),
+    id: p.string().serializedPrimaryKey(),
+    createdAt: p.datetime().onCreate(() => new Date()),
+    updatedAt: p.datetime()
+      .onCreate(() => new Date())
+      .onUpdate(() => new Date()),
+    name: p.string(),
+    email: p.string(),
+    age: p.integer().nullable(),
+    termsAccepted: p.boolean(),
+    identities: p.array().nullable(),
+    born: p.date().nullable(),
+    books: () => p.oneToMany(Book).mappedBy(book => book.author),
+    friends: () => p.manyToMany(Author),
+    favouriteBook: () => p.manyToOne(Book).nullable(),
+    version: p.integer().version(),
+  },
+});
+
+export class Author extends AuthorSchema.class {}
+AuthorSchema.setClass(Author);
+```
+
+  </TabItem>
+
+  <TabItem value="define-entity">
+
+```ts title="./entities/Author.ts"
+import { type InferEntity, defineEntity, p } from '@mikro-orm/core';
+
+export const Author = defineEntity({
+  name: 'Author',
+  properties: {
+    _id: p.type(ObjectId).primary(),
+    id: p.string().serializedPrimaryKey(),
+    createdAt: p.datetime().onCreate(() => new Date()),
+    updatedAt: p.datetime()
+      .onCreate(() => new Date())
+      .onUpdate(() => new Date()),
+    name: p.string(),
+    email: p.string(),
+    age: p.integer().nullable(),
+    termsAccepted: p.boolean(),
+    identities: p.array().nullable(),
+    born: p.date().nullable(),
+    books: () => p.oneToMany(Book).mappedBy(book => book.author),
+    friends: () => p.manyToMany(Author),
+    favouriteBook: () => p.manyToOne(Book).nullable(),
+    version: p.integer().version(),
+  },
+});
+
+export type IAuthor = InferEntity<typeof Author>;
+```
+
+  </TabItem>
   <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Author.ts"
@@ -257,86 +325,6 @@ export class Author {
 ```
 
   </TabItem>
-  <TabItem value="define-entity">
-
-```ts title="./entities/Author.ts"
-import { type InferEntity, defineEntity, p } from '@mikro-orm/core';
-
-export const Author = defineEntity({
-  name: 'Author',
-  properties: {
-    _id: p.type(ObjectId).primary(),
-    id: p.string().serializedPrimaryKey(),
-    createdAt: p.datetime().onCreate(() => new Date()),
-    updatedAt: p.datetime()
-      .onCreate(() => new Date())
-      .onUpdate(() => new Date()),
-    name: p.string(),
-    email: p.string(),
-    age: p.integer().nullable(),
-    termsAccepted: p.boolean(),
-    identities: p.array().nullable(),
-    born: p.date().nullable(),
-    books: () => p.oneToMany(Book).mappedBy(book => book.author),
-    friends: () => p.manyToMany(Author),
-    favouriteBook: () => p.manyToOne(Book).nullable(),
-    version: p.integer().version(),
-  },
-});
-
-export type IAuthor = InferEntity<typeof Author>;
-```
-
-  </TabItem>
-  <TabItem value="entity-schema">
-
-```ts title="./entities/Author.ts"
-export class Author {
-
-  _id!: ObjectId;
-  id!: string;
-  createdAt = new Date();
-  updatedAt = new Date();
-  name!: string;
-  email!: string;
-  age?: number;
-  termsAccepted = false;
-  identities?: string[];
-  born?: string;
-  books = new Collection<Book>(this);
-  friends = new Collection<Author>(this);
-  favouriteBook?: Book;
-  version!: number;
-
-  constructor(name: string, email: string) {
-    this.name = name;
-    this.email = email;
-  }
-
-}
-
-export const AuthorSchema = new EntitySchema({
-  class: Author,
-  properties: {
-    _id: { type: 'ObjectId', primary: true },
-    id: { type: String, serializedPrimaryKey: true },
-    createdAt: { type: Date },
-    updatedAt: { type: Date, onUpdate: () => new Date() },
-    name: { type: String },
-    email: { type: String },
-    age: { type: Number, nullable: true },
-    termsAccepted: { type: Boolean },
-    identities: { type: 'string[]', nullable: true },
-    born: { type: 'date', nullable: true },
-    books: { kind: '1:m', entity: () => Book, mappedBy: book => book.author },
-    friends: { kind: 'm:n', entity: () => Author },
-    favouriteBook: { kind: 'm:1', entity: () => Book, nullable: true },
-    version: { type: Number, version: true },
-  },
-});
-```
-
-  </TabItem>
 </Tabs>
 
 More information about modelling relationships can be found on [modelling relationships page](./relationships.md).
@@ -349,14 +337,45 @@ With the default `reflect-metadata` provider, you need to mark each optional pro
 
 <Tabs
   groupId="entity-def"
-  defaultValue="define-entity"
+  defaultValue="define-entity-class"
   values={[
+    {label: 'defineEntity + class', value: 'define-entity-class'},
     {label: 'defineEntity', value: 'define-entity'},
     {label: 'reflect-metadata', value: 'reflect-metadata'},
     {label: 'ts-morph', value: 'ts-morph'},
-    {label: 'EntitySchema', value: 'entity-schema'},
-  ]
-  }>
+]
+  }
+>
+  <TabItem value="define-entity-class">
+
+```ts title="./entities/Author.ts"
+const SomeEntitySchema = defineEntity({
+  name: 'SomeEntity',
+  properties: {
+    favouriteBook: p.manyToOne(Book).nullable(),
+  },
+});
+
+export class SomeEntity extends SomeEntitySchema.class {}
+SomeEntitySchema.setClass(SomeEntity);
+```
+
+  </TabItem>
+
+  <TabItem value="define-entity">
+
+```ts title="./entities/Author.ts"
+const SomeEntity = defineEntity({
+  name: 'SomeEntity',
+  properties: {
+    favouriteBook: p.manyToOne(Book).nullable(),
+  },
+});
+
+export type ISomeEntity = InferEntity<typeof SomeEntity>;
+```
+
+  </TabItem>
   <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Author.ts"
@@ -373,29 +392,6 @@ favouriteBook?: Book;
 ```
 
   </TabItem>
-  <TabItem value="define-entity">
-
-```ts title="./entities/Author.ts"
-const SomeEntity = defineEntity({
-  name: 'SomeEntity',
-  properties: {
-    favouriteBook: p.manyToOne(Book).nullable(),
-  },
-});
-
-export type ISomeEntity = InferEntity<typeof SomeEntity>;
-```
-
-  </TabItem>
-  <TabItem value="entity-schema">
-
-```ts title="./entities/Author.ts"
-properties: {
-  favouriteBook: { kind: 'm:1', entity: () => Book, nullable: true },
-},
-```
-
-  </TabItem>
 </Tabs>
 
 To make a nullable field required in methods like `em.create()` (i.e. you cannot omit the property), use `RequiredNullable` type. Such property needs to be provided explicitly in the `em.create()` method, but will accept a `null` value.
@@ -403,14 +399,47 @@ To make a nullable field required in methods like `em.create()` (i.e. you cannot
 
 <Tabs
   groupId="entity-def"
-  defaultValue="define-entity"
+  defaultValue="define-entity-class"
   values={[
+    {label: 'defineEntity + class', value: 'define-entity-class'},
     {label: 'defineEntity', value: 'define-entity'},
     {label: 'reflect-metadata', value: 'reflect-metadata'},
     {label: 'ts-morph', value: 'ts-morph'},
-    {label: 'EntitySchema', value: 'entity-schema'},
-  ]
-  }>
+]
+  }
+>
+  <TabItem value="define-entity-class">
+
+```ts title='./entities/Book.ts'
+const BookSchema = defineEntity({
+  name: 'Book',
+  properties: {
+    title: p.string().$type<RequiredNullable<string>>(),
+  },
+});
+
+em.create(Book, { title: "Alice in Wonderland" }); // ok
+em.create(Book, { title: null }); // ok
+em.create(Book, {}); // compile error: missing title```
+
+  </TabItem>
+
+  <TabItem value="define-entity">
+
+```ts title='./entities/Book.ts'
+const Book = defineEntity({
+  name: 'Book',
+  properties: {
+    title: p.string().$type<RequiredNullable<string>>(),
+  },
+});
+
+em.create(Book, { title: "Alice in Wonderland" }); // ok
+em.create(Book, { title: null }); // ok
+em.create(Book, {}); // compile error: missing title
+```
+
+  </TabItem>
   <TabItem value="reflect-metadata">
 
 ```ts title='./entities/Book.ts'
@@ -432,42 +461,6 @@ class Book {
   @Property()
   title!: RequiredNullable<string>;
 }
-
-em.create(Book, { title: "Alice in Wonderland" }); // ok
-em.create(Book, { title: null }); // ok
-em.create(Book, {}); // compile error: missing title
-```
-
-  </TabItem>
-  <TabItem value="define-entity">
-
-```ts title='./entities/Book.ts'
-const Book = defineEntity({
-  name: 'Book',
-  properties: {
-    title: p.string().$type<RequiredNullable<string>>(),
-  },
-});
-
-em.create(Book, { title: "Alice in Wonderland" }); // ok
-em.create(Book, { title: null }); // ok
-em.create(Book, {}); // compile error: missing title
-```
-
-  </TabItem>
-  <TabItem value="entity-schema">
-
-```ts title="./entities/Author.ts"
-class Book {
-  title!: RequiredNullable<string>;
-}
-
-const schema = new EntitySchema({
-  class: Book,
-  properties: {
-    title: { type: 'string' },
-  },
-});
 
 em.create(Book, { title: "Alice in Wonderland" }); // ok
 em.create(Book, { title: null }); // ok
@@ -487,42 +480,33 @@ You can set default value of a property in 2 ways:
 
 <Tabs
 groupId="entity-def"
-defaultValue="define-entity"
+defaultValue="define-entity-class"
 values={[
+{label: 'defineEntity + class', value: 'define-entity-class'},
 {label: 'defineEntity', value: 'define-entity'},
 {label: 'reflect-metadata', value: 'reflect-metadata'},
 {label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
 ]
-}>
-<TabItem value="reflect-metadata">
+}
+>
+  <TabItem value="define-entity-class">
 
 ```ts title="./entities/Author.ts"
-@Property()
-foo: number & Opt = 1;
+const SomeEntitySchema = defineEntity({
+  name: 'SomeEntity',
+  properties: {
+    foo: p.number().onCreate(() => 1),
+    bar: p.string().onCreate(() => 'abc'),
+    baz: p.datetime().onCreate(() => new Date()),
+  },
+});
 
-@Property()
-bar: string & Opt = 'abc';
-
-@Property()
-baz: Date & Opt = new Date();
+export class SomeEntity extends SomeEntitySchema.class {}
+SomeEntitySchema.setClass(SomeEntity);
 ```
 
   </TabItem>
-  <TabItem value="ts-morph">
 
-```ts title="./entities/Author.ts"
-@Property()
-foo: number & Opt = 1;
-
-@Property()
-bar: string & Opt = 'abc';
-
-@Property()
-baz: Date & Opt = new Date();
-```
-
-  </TabItem>
   <TabItem value="define-entity">
 
 ```ts title="./entities/Author.ts"
@@ -537,25 +521,31 @@ const SomeEntity = defineEntity({
 ```
 
   </TabItem>
-  <TabItem value="entity-schema">
+<TabItem value="reflect-metadata">
 
 ```ts title="./entities/Author.ts"
-class Author {
+@Property()
+foo: number & Opt = 1;
 
-  foo: number & Opt = 1;
-  bar: string & Opt = 'abc';
-  baz: Date & Opt = new Date();
+@Property()
+bar: string & Opt = 'abc';
 
-}
+@Property()
+baz: Date & Opt = new Date();
+```
 
-const schema = new EntitySchema({
-  class: Author,
-  properties: {
-    foo: { type: Number },
-    bar: { type: String },
-    baz: { type: Date },
-  },
-});
+  </TabItem>
+  <TabItem value="ts-morph">
+
+```ts title="./entities/Author.ts"
+@Property()
+foo: number & Opt = 1;
+
+@Property()
+bar: string & Opt = 'abc';
+
+@Property()
+baz: Date & Opt = new Date();
 ```
 
   </TabItem>
@@ -567,14 +557,47 @@ const schema = new EntitySchema({
 
 <Tabs
 groupId="entity-def"
-defaultValue="define-entity"
+defaultValue="define-entity-class"
 values={[
+{label: 'defineEntity + class', value: 'define-entity-class'},
 {label: 'defineEntity', value: 'define-entity'},
 {label: 'reflect-metadata', value: 'reflect-metadata'},
 {label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
 ]
-}>
+}
+>
+  <TabItem value="define-entity-class">
+
+```ts title="./entities/Author.ts"
+const SomeEntitySchema = defineEntity({
+  name: 'SomeEntity',
+  properties: {
+    foo: p.number().default(1),
+    bar: p.string().default('abc'),
+    baz: p.datetime().defaultRaw('now'),
+  },
+});
+
+export class SomeEntity extends SomeEntitySchema.class {}
+SomeEntitySchema.setClass(SomeEntity);
+```
+
+  </TabItem>
+
+  <TabItem value="define-entity">
+
+```ts title="./entities/Author.ts"
+const SomeEntity = defineEntity({
+  name: 'SomeEntity',
+  properties: {
+    foo: p.number().default(1),
+    bar: p.string().default('abc'),
+    baz: p.datetime().defaultRaw('now'),
+  },
+});
+```
+
+  </TabItem>
 <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Author.ts"
@@ -600,31 +623,6 @@ bar!: string & Opt;
 
 @Property({ defaultRaw: 'now' })
 baz!: Date & Opt;
-```
-
-  </TabItem>
-  <TabItem value="define-entity">
-
-```ts title="./entities/Author.ts"
-const SomeEntity = defineEntity({
-  name: 'SomeEntity',
-  properties: {
-    foo: p.number().default(1),
-    bar: p.string().default('abc'),
-    baz: p.datetime().defaultRaw('now'),
-  },
-});
-```
-
-  </TabItem>
-  <TabItem value="entity-schema">
-
-```ts title="./entities/Author.ts"
-properties: {
-  foo: { type: Number, default: 1 },
-  bar: { type: String, default: 'abc' },
-  baz: { type: Date, defaultRaw: 'now' },
-},
 ```
 
   </TabItem>
@@ -644,14 +642,57 @@ You can also provide the reference to the enum implementation in the decorator v
 
 <Tabs
 groupId="entity-def"
-defaultValue="define-entity"
+defaultValue="define-entity-class"
 values={[
+{label: 'defineEntity + class', value: 'define-entity-class'},
 {label: 'defineEntity', value: 'define-entity'},
 {label: 'reflect-metadata', value: 'reflect-metadata'},
 {label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
 ]
-}>
+}
+>
+  <TabItem value="define-entity-class">
+
+```ts title="./entities/User.ts"
+const SomeEntitySchema = defineEntity({
+  name: 'SomeEntity',
+  properties: {
+    // string enum
+    role: p.enum(['admin', 'user']),
+    // numeric enum
+    status: p.enum(() => UserStatus),
+    // string enum defined outside of this file
+    outside: p.enum(() => OutsideEnum),
+    // string enum defined outside of this file, may be null
+    outsideNullable: p.enum(() => OutsideNullableEnum).nullable(),
+  },
+});
+
+export class SomeEntity extends SomeEntitySchema.class {}
+SomeEntitySchema.setClass(SomeEntity);
+```
+
+  </TabItem>
+
+  <TabItem value="define-entity">
+
+```ts title="./entities/User.ts"
+const SomeEntity = defineEntity({
+  name: 'SomeEntity',
+  properties: {
+    // string enum
+    role: p.enum(['admin', 'user']),
+    // numeric enum
+    status: p.enum(() => UserStatus),
+    // string enum defined outside of this file
+    outside: p.enum(() => OutsideEnum),
+    // string enum defined outside of this file, may be null
+    outsideNullable: p.enum(() => OutsideNullableEnum).nullable(),
+  },
+});
+```
+
+  </TabItem>
 <TabItem value="reflect-metadata">
 
 ```ts title="./entities/User.ts"
@@ -728,41 +769,6 @@ export const enum UserStatus {
 ```
 
   </TabItem>
-  <TabItem value="define-entity">
-
-```ts title="./entities/User.ts"
-const SomeEntity = defineEntity({
-  name: 'SomeEntity',
-  properties: {
-    // string enum
-    role: p.enum(['admin', 'user']),
-    // numeric enum
-    status: p.enum(() => UserStatus),
-    // string enum defined outside of this file
-    outside: p.enum(() => OutsideEnum),
-    // string enum defined outside of this file, may be null
-    outsideNullable: p.enum(() => OutsideNullableEnum).nullable(),
-  },
-});
-```
-
-  </TabItem>
-  <TabItem value="entity-schema">
-
-```ts title="./entities/User.ts"
-properties: {
-  // string enum
-  role: { enum: true, items: () => UserRole },
-  // numeric enum
-  status: { enum: true, items: () => UserStatus },
-  // string enum defined outside of this file
-  outside: { enum: true, items: () => OutsideEnum },
-  // string enum defined outside of this file, may be null
-  outsideNullable: { enum: true, items: () => OutsideNullableEnum, nullable: true },
-},
-```
-
-  </TabItem>
 </Tabs>
 
 ### PostgreSQL native enums
@@ -771,14 +777,55 @@ By default, the PostgreSQL driver, represents enums as a text columns with check
 
 <Tabs
 groupId="entity-def"
-defaultValue="define-entity"
+defaultValue="define-entity-class"
 values={[
+{label: 'defineEntity + class', value: 'define-entity-class'},
 {label: 'defineEntity', value: 'define-entity'},
 {label: 'reflect-metadata', value: 'reflect-metadata'},
 {label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
 ]
-}>
+}
+>
+  <TabItem value="define-entity-class">
+
+```ts title="./entities/User.ts"
+export enum UserRole {
+  ADMIN = 'admin',
+  MODERATOR = 'moderator',
+  USER = 'user',
+}
+
+const SomeEntitySchema = defineEntity({
+  name: 'SomeEntity',
+  properties: {
+    role: p.enum(() => UserRole).nativeEnumName('user_role'),
+  },
+});
+
+export class SomeEntity extends SomeEntitySchema.class {}
+SomeEntitySchema.setClass(SomeEntity);
+```
+
+  </TabItem>
+
+  <TabItem value="define-entity">
+
+```ts title="./entities/User.ts"
+export enum UserRole {
+  ADMIN = 'admin',
+  MODERATOR = 'moderator',
+  USER = 'user',
+}
+
+export const SomeEntity = defineEntity({
+  name: 'SomeEntity',
+  properties: {
+    role: p.enum(() => UserRole).nativeEnumName('user_role'),
+  },
+});
+```
+
+  </TabItem>
 <TabItem value="reflect-metadata">
 
 ```ts title="./entities/User.ts"
@@ -817,39 +864,6 @@ export enum UserRole {
 ```
 
   </TabItem>
-  <TabItem value="define-entity">
-
-```ts title="./entities/User.ts"
-export enum UserRole {
-  ADMIN = 'admin',
-  MODERATOR = 'moderator',
-  USER = 'user',
-}
-
-export const SomeEntity = defineEntity({
-  name: 'SomeEntity',
-  properties: {
-    role: p.enum(() => UserRole).nativeEnumName('user_role'),
-  },
-});
-```
-
-  </TabItem>
-  <TabItem value="entity-schema">
-
-```ts title="./entities/User.ts"
-export enum UserRole {
-  ADMIN = 'admin',
-  MODERATOR = 'moderator',
-  USER = 'user',
-}
-
-properties: {
-  role: { enum: true, nativeEnumName: 'user_role', items: () => UserRole },
-},
-```
-
-  </TabItem>
 </Tabs>
 
 ## Enum arrays
@@ -858,14 +872,53 @@ You can also use array of values for enum, in that case, `EnumArrayType` type wi
 
 <Tabs
 groupId="entity-def"
-defaultValue="define-entity"
+defaultValue="define-entity-class"
 values={[
+{label: 'defineEntity + class', value: 'define-entity-class'},
 {label: 'defineEntity', value: 'define-entity'},
 {label: 'reflect-metadata', value: 'reflect-metadata'},
 {label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
 ]
-}>
+}
+>
+  <TabItem value="define-entity-class">
+
+```ts title="./entities/User.ts"
+enum Role {
+  User = 'user',
+  Admin = 'admin',
+}
+
+const SomeEntitySchema = defineEntity({
+  name: 'SomeEntity',
+  properties: {
+    roles: p.enum(() => Role).array().default([Role.User]),
+  },
+});
+
+export class SomeEntity extends SomeEntitySchema.class {}
+SomeEntitySchema.setClass(SomeEntity);
+```
+
+  </TabItem>
+
+  <TabItem value="define-entity">
+
+```ts title="./entities/User.ts"
+enum Role {
+  User = 'user',
+  Admin = 'admin',
+}
+
+export const SomeEntity = defineEntity({
+  name: 'SomeEntity',
+  properties: {
+    roles: p.enum(() => Role).array().default([Role.User]),
+  },
+});
+```
+
+  </TabItem>
 <TabItem value="reflect-metadata">
 
 ```ts title="./entities/User.ts"
@@ -892,37 +945,6 @@ roles = [Role.User];
 ```
 
   </TabItem>
-  <TabItem value="define-entity">
-
-```ts title="./entities/User.ts"
-enum Role {
-  User = 'user',
-  Admin = 'admin',
-}
-
-export const SomeEntity = defineEntity({
-  name: 'SomeEntity',
-  properties: {
-    roles: p.enum(() => Role).array().default([Role.User]),
-  },
-});
-```
-
-  </TabItem>
-  <TabItem value="entity-schema">
-
-```ts title="./entities/User.ts"
-enum Role {
-  User = 'user',
-  Admin = 'admin',
-}
-
-properties: {
-  roles: { enum: true, array: true, default: [Role.User], items: () => Role },
-},
-```
-
-  </TabItem>
 </Tabs>
 
 ## Mapping directly to primary keys
@@ -931,14 +953,43 @@ Sometimes you might want to work only with the primary key of a relation. To do 
 
 <Tabs
 groupId="entity-def"
-defaultValue="define-entity"
+defaultValue="define-entity-class"
 values={[
+{label: 'defineEntity + class', value: 'define-entity-class'},
 {label: 'defineEntity', value: 'define-entity'},
 {label: 'reflect-metadata', value: 'reflect-metadata'},
 {label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
 ]
-}>
+}
+>
+  <TabItem value="define-entity-class">
+
+```ts title="./entities/User.ts"
+const SomeEntitySchema = defineEntity({
+  name: 'SomeEntity',
+  properties: {
+    user: () => p.manyToOne(User).mapToPk(),
+  },
+});
+
+export class SomeEntity extends SomeEntitySchema.class {}
+SomeEntitySchema.setClass(SomeEntity);
+```
+
+  </TabItem>
+
+  <TabItem value="define-entity">
+
+```ts title="./entities/User.ts"
+export const SomeEntity = defineEntity({
+  name: 'SomeEntity',
+  properties: {
+    user: () => p.manyToOne(User).mapToPk(),
+  },
+});
+```
+
+  </TabItem>
 <TabItem value="reflect-metadata">
 
 ```ts title="./entities/User.ts"
@@ -952,27 +1003,6 @@ user: number;
 ```ts title="./entities/User.ts"
 @ManyToOne(() => User, { mapToPk: true })
 user: number;
-```
-
-  </TabItem>
-  <TabItem value="define-entity">
-
-```ts title="./entities/User.ts"
-export const SomeEntity = defineEntity({
-  name: 'SomeEntity',
-  properties: {
-    user: () => p.manyToOne(User).mapToPk(),
-  },
-});
-```
-
-  </TabItem>
-  <TabItem value="entity-schema">
-
-```ts title="./entities/User.ts"
-properties: {
-  user: { entity: () => User, mapToPk: true },
-},
 ```
 
   </TabItem>
@@ -982,14 +1012,43 @@ For composite keys, this will give us ordered tuple representing the raw PKs, wh
 
 <Tabs
 groupId="entity-def"
-defaultValue="define-entity"
+defaultValue="define-entity-class"
 values={[
+{label: 'defineEntity + class', value: 'define-entity-class'},
 {label: 'defineEntity', value: 'define-entity'},
 {label: 'reflect-metadata', value: 'reflect-metadata'},
 {label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
 ]
-}>
+}
+>
+  <TabItem value="define-entity-class">
+
+```ts title="./entities/User.ts"
+const SomeEntitySchema = defineEntity({
+  name: 'SomeEntity',
+  properties: {
+    user: () => p.manyToOne(User).mapToPk(),
+  },
+});
+
+export class SomeEntity extends SomeEntitySchema.class {}
+SomeEntitySchema.setClass(SomeEntity);
+```
+
+  </TabItem>
+
+  <TabItem value="define-entity">
+
+```ts title="./entities/User.ts"
+export const SomeEntity = defineEntity({
+  name: 'SomeEntity',
+  properties: {
+    user: () => p.manyToOne(User).mapToPk(),
+  },
+});
+```
+
+  </TabItem>
 <TabItem value="reflect-metadata">
 
 ```ts title="./entities/User.ts"
@@ -1003,27 +1062,6 @@ user: [string, string]; // [first_name, last_name]
 ```ts title="./entities/User.ts"
 @ManyToOne(() => User, { mapToPk: true })
 user: [string, string]; // [first_name, last_name]
-```
-
-  </TabItem>
-  <TabItem value="define-entity">
-
-```ts title="./entities/User.ts"
-export const SomeEntity = defineEntity({
-  name: 'SomeEntity',
-  properties: {
-    user: () => p.manyToOne(User).mapToPk(),
-  },
-});
-```
-
-  </TabItem>
-  <TabItem value="entity-schema">
-
-```ts title="./entities/User.ts"
-properties: {
-  user: { entity: () => User, mapToPk: true },
-},
 ```
 
   </TabItem>
@@ -1035,30 +1073,31 @@ properties: {
 
 <Tabs
 groupId="entity-def"
-defaultValue="define-entity"
+defaultValue="define-entity-class"
 values={[
+{label: 'defineEntity + class', value: 'define-entity-class'},
 {label: 'defineEntity', value: 'define-entity'},
 {label: 'reflect-metadata', value: 'reflect-metadata'},
 {label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
 ]
-}>
-<TabItem value="reflect-metadata">
+}
+>
+  <TabItem value="define-entity-class">
 
 ```ts title="./entities/Box.ts"
-@Formula('obj_length * obj_height * obj_width')
-objectVolume?: number;
+const BoxSchema = defineEntity({
+  name: 'Box',
+  properties: {
+    objectVolume: p.formula<number>('obj_length * obj_height * obj_width'),
+  },
+});
+
+export class Box extends BoxSchema.class {}
+BoxSchema.setClass(Box);
 ```
 
   </TabItem>
-  <TabItem value="ts-morph">
 
-```ts title="./entities/Box.ts"
-@Formula('obj_length * obj_height * obj_width')
-objectVolume?: number;
-```
-
-  </TabItem>
   <TabItem value="define-entity">
 
 ```ts title="./entities/Box.ts"
@@ -1071,12 +1110,19 @@ export const Box = defineEntity({
 ```
 
   </TabItem>
-  <TabItem value="entity-schema">
+<TabItem value="reflect-metadata">
 
 ```ts title="./entities/Box.ts"
-properties: {
-  objectVolume: { formula: 'obj_length * obj_height * obj_width' },
-},
+@Formula('obj_length * obj_height * obj_width')
+objectVolume?: number;
+```
+
+  </TabItem>
+  <TabItem value="ts-morph">
+
+```ts title="./entities/Box.ts"
+@Formula('obj_length * obj_height * obj_width')
+objectVolume?: number;
 ```
 
   </TabItem>
@@ -1086,34 +1132,33 @@ Formulas will be added to the select clause automatically. You can define the fo
 
 <Tabs
 groupId="entity-def"
-defaultValue="define-entity"
+defaultValue="define-entity-class"
 values={[
+{label: 'defineEntity + class', value: 'define-entity-class'},
 {label: 'defineEntity', value: 'define-entity'},
 {label: 'reflect-metadata', value: 'reflect-metadata'},
 {label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
 ]
-}>
-<TabItem value="reflect-metadata">
+}
+>
+  <TabItem value="define-entity-class">
 
 ```ts title="./entities/Box.ts"
 import { quote } from '@mikro-orm/core';
 
-@Formula(cols => quote`${cols.objLength} * ${cols.objHeight} * ${cols.objWidth}`)
-objectVolume?: number;
+const BoxSchema = defineEntity({
+  name: 'Box',
+  properties: {
+    objectVolume: p.formula<number>(cols => quote`${cols.objLength} * ${cols.objHeight} * ${cols.objWidth}`),
+  },
+});
+
+export class Box extends BoxSchema.class {}
+BoxSchema.setClass(Box);
 ```
 
   </TabItem>
-  <TabItem value="ts-morph">
 
-```ts title="./entities/Box.ts"
-import { quote } from '@mikro-orm/core';
-
-@Formula(cols => quote`${cols.objLength} * ${cols.objHeight} * ${cols.objWidth}`)
-objectVolume?: number;
-```
-
-  </TabItem>
   <TabItem value="define-entity">
 
 ```ts title="./entities/Box.ts"
@@ -1128,14 +1173,23 @@ export const Box = defineEntity({
 ```
 
   </TabItem>
-  <TabItem value="entity-schema">
+<TabItem value="reflect-metadata">
 
 ```ts title="./entities/Box.ts"
 import { quote } from '@mikro-orm/core';
 
-properties: {
-  objectVolume: { formula: cols => quote`${cols.objLength} * ${cols.objHeight} * ${cols.objWidth}` },
-},
+@Formula(cols => quote`${cols.objLength} * ${cols.objHeight} * ${cols.objWidth}`)
+objectVolume?: number;
+```
+
+  </TabItem>
+  <TabItem value="ts-morph">
+
+```ts title="./entities/Box.ts"
+import { quote } from '@mikro-orm/core';
+
+@Formula(cols => quote`${cols.objLength} * ${cols.objHeight} * ${cols.objWidth}`)
+objectVolume?: number;
 ```
 
   </TabItem>
@@ -1178,95 +1232,49 @@ To define an index expression, you can either provide a raw SQL string, or use t
 
 <Tabs
 groupId="entity-def"
-defaultValue="define-entity"
+defaultValue="define-entity-class"
 values={[
+{label: 'defineEntity + class', value: 'define-entity-class'},
 {label: 'defineEntity', value: 'define-entity'},
 {label: 'reflect-metadata', value: 'reflect-metadata'},
 {label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
 ]
-}>
-<TabItem value="reflect-metadata">
+}
+>
+  <TabItem value="define-entity-class">
 
 ```ts title="./entities/Author.ts"
-@Entity()
-@Index({ properties: ['name', 'age'] }) // compound index, with generated name
-@Index({ name: 'custom_idx_name', properties: ['name'] }) // simple index, with custom name
-@Unique({ properties: ['name', 'email'] })
-export class Author {
+const AuthorSchema = defineEntity({
+  name: 'Author',
+  properties: {
+    email: p.string().unique(),
+    age: p.number().nullable().index(),
+    born: p.date().nullable().index('born_index'),
+    title: p.string(),
+    country: p.string(),
+  },
+  indexes: [
+    { properties: ['name', 'age'] }, // compound index, with generated name
+    { name: 'custom_idx_name', properties: ['name'] }, // simple index, with custom name
+    // Custom index using expression callback
+    // ${table.schema}, ${table.name}, and ${columns.title} return the unquoted identifiers.
+    { name: 'custom_index_country1', expression: (columns, table, indexName) => `create index \`${indexName}\` on \`${table.schema}\`.\`${table.name}\` (\`${columns.country}\`)` },
+    // Using quote helper to automatically quote identifiers.
+    { name: 'custom_index_country2', expression: (columns, table, indexName) => quote`create index ${indexName} on ${table} (${columns.country})` },
+    // Using raw function to automatically quote identifiers.
+    { name: 'custom_index_country3', expression: (columns, table, indexName) => raw(`create index ?? on ?? (??)`, [indexName, table, columns.country]) },
+  ],
+  uniques: [
+    { properties: ['name', 'email'] },
+  ],
+});
 
-  @Property()
-  @Unique()
-  email!: string;
-
-  @Property()
-  @Index() // generated name
-  age?: number;
-
-  @Index({ name: 'born_index' })
-  @Property()
-  born?: string;
-
-  // Custom index using raw SQL string expression
-  @Index({ name: 'custom_index_expr', expression: 'alter table `author` add index `custom_index_expr`(`title`)' })
-  @Property()
-  title!: string;
-
-  // Custom index using expression callback
-  // ${table.schema}, ${table.name}, and ${columns.title} return the unquoted identifiers.
-  @Index({ name: 'custom_index_country1', expression: (columns, table, indexName) => `create index \`${indexName}\` on \`${table.schema}\`.\`${table.name}\` (\`${columns.country}\`)` })
-  // Using quote helper to automatically quote identifiers.
-  @Index({ name: 'custom_index_country2', expression: (columns, table, indexName) => quote`create index ${indexName} on ${table} (${columns.country})` })
-  // Using raw function to automatically quote identifiers.
-  @Index({ name: 'custom_index_country3', expression: (columns, table, indexName) => raw(`create index ?? on ?? (??)`, [indexName, table, columns.country]) })
-  @Property()
-  country!: string;
-
-}
+export class Author extends AuthorSchema.class {}
+AuthorSchema.setClass(Author);
 ```
 
   </TabItem>
-  <TabItem value="ts-morph">
 
-```ts title="./entities/Author.ts"
-@Entity()
-@Index({ properties: ['name', 'age'] }) // compound index, with generated name
-@Index({ name: 'custom_idx_name', properties: ['name'] }) // simple index, with custom name
-@Unique({ properties: ['name', 'email'] })
-export class Author {
-
-  @Property()
-  @Unique()
-  email!: string;
-
-  @Property()
-  @Index() // generated name
-  age?: number;
-
-  @Index({ name: 'born_index' })
-  @Property()
-  born?: string;
-
-  // Custom index using raw SQL string expression
-  @Index({ name: 'custom_index_expr', expression: 'alter table `author` add index `custom_index_expr`(`title`)' })
-  @Property()
-  title!: string;
-
-  // Custom index using expression callback
-  // ${table.schema}, ${table.name}, and ${columns.title} return the unquoted identifiers.
-  @Index({ name: 'custom_index_country1', expression: (columns, table, indexName) => `create index \`${indexName}\` on \`${table.schema}\`.\`${table.name}\` (\`${columns.country}\`)` })
-  // Using quote helper to automatically quote identifiers.
-  @Index({ name: 'custom_index_country2', expression: (columns, table, indexName) => quote`create index ${indexName} on ${table} (${columns.country})` })
-  // Using raw function to automatically quote identifiers.
-  @Index({ name: 'custom_index_country3', expression: (columns, table, indexName) => raw(`create index ?? on ?? (??)`, [indexName, table, columns.country]) })
-  @Property()
-  country!: string;
-
-}
-
-```
-
-  </TabItem>
   <TabItem value="define-entity">
 
 ```ts title="./entities/Author.ts"
@@ -1297,34 +1305,84 @@ export const Author = defineEntity({
 ```
 
   </TabItem>
-  <TabItem value="entity-schema">
+<TabItem value="reflect-metadata">
 
 ```ts title="./entities/Author.ts"
-export const AuthorSchema = new EntitySchema<Author, CustomBaseEntity>({
-  class: Author,
-  indexes: [
-    { properties: ['name', 'age'] }, // compound index, with generated name
-    { name: 'custom_idx_name', properties: ['name'] }, // simple index, with custom name
-    // Custom index using raw SQL string expression
-    { name: 'custom_index_expr', expression: 'alter table `author` add index `custom_index_expr`(`title`)' },
-    // Custom index using expression callback
-    // ${table.schema}, ${table.name}, and ${columns.title} return the unquoted identifiers.
-    { name: 'custom_index_country1', expression: (columns, table, indexName) => `create index \`${indexName}\` on \`${table.schema}\`.\`${table.name}\` (\`${columns.country}\`)` },
-    // Using quote helper to automatically quote identifiers.
-    { name: 'custom_index_country2', expression: (columns, table, indexName) => quote`create index ${indexName} on ${table} (${columns.country})` },
-    // Using raw function to automatically quote identifiers.
-    { name: 'custom_index_country3', expression: (columns, table, indexName) => raw(`create index ?? on ?? (??)`, [indexName, table, columns.country]) },
-  ],
-  uniques: [
-    { properties: ['name', 'email'] },
-  ],
-  properties: {
-    email: { type: 'string', unique: true }, // generated name
-    age: { type: 'number', nullable: true, index: true }, // generated name
-    born: { type: 'date', nullable: true, index: 'born_index' },
-    title: { type: 'string' },
-  },
-});
+@Entity()
+@Index({ properties: ['name', 'age'] }) // compound index, with generated name
+@Index({ name: 'custom_idx_name', properties: ['name'] }) // simple index, with custom name
+@Unique({ properties: ['name', 'email'] })
+export class Author {
+
+  @Property()
+  @Unique()
+  email!: string;
+
+  @Property()
+  @Index() // generated name
+  age?: number;
+
+  @Index({ name: 'born_index' })
+  @Property()
+  born?: string;
+
+  // Custom index using raw SQL string expression
+  @Index({ name: 'custom_index_expr', expression: 'alter table `author` add index `custom_index_expr`(`title`)' })
+  @Property()
+  title!: string;
+
+  // Custom index using expression callback
+  // ${table.schema}, ${table.name}, and ${columns.title} return the unquoted identifiers.
+  @Index({ name: 'custom_index_country1', expression: (columns, table, indexName) => `create index \`${indexName}\` on \`${table.schema}\`.\`${table.name}\` (\`${columns.country}\`)` })
+  // Using quote helper to automatically quote identifiers.
+  @Index({ name: 'custom_index_country2', expression: (columns, table, indexName) => quote`create index ${indexName} on ${table} (${columns.country})` })
+  // Using raw function to automatically quote identifiers.
+  @Index({ name: 'custom_index_country3', expression: (columns, table, indexName) => raw(`create index ?? on ?? (??)`, [indexName, table, columns.country]) })
+  @Property()
+  country!: string;
+
+}
+```
+
+  </TabItem>
+  <TabItem value="ts-morph">
+
+```ts title="./entities/Author.ts"
+@Entity()
+@Index({ properties: ['name', 'age'] }) // compound index, with generated name
+@Index({ name: 'custom_idx_name', properties: ['name'] }) // simple index, with custom name
+@Unique({ properties: ['name', 'email'] })
+export class Author {
+
+  @Property()
+  @Unique()
+  email!: string;
+
+  @Property()
+  @Index() // generated name
+  age?: number;
+
+  @Index({ name: 'born_index' })
+  @Property()
+  born?: string;
+
+  // Custom index using raw SQL string expression
+  @Index({ name: 'custom_index_expr', expression: 'alter table `author` add index `custom_index_expr`(`title`)' })
+  @Property()
+  title!: string;
+
+  // Custom index using expression callback
+  // ${table.schema}, ${table.name}, and ${columns.title} return the unquoted identifiers.
+  @Index({ name: 'custom_index_country1', expression: (columns, table, indexName) => `create index \`${indexName}\` on \`${table.schema}\`.\`${table.name}\` (\`${columns.country}\`)` })
+  // Using quote helper to automatically quote identifiers.
+  @Index({ name: 'custom_index_country2', expression: (columns, table, indexName) => quote`create index ${indexName} on ${table} (${columns.country})` })
+  // Using raw function to automatically quote identifiers.
+  @Index({ name: 'custom_index_country3', expression: (columns, table, indexName) => raw(`create index ?? on ?? (??)`, [indexName, table, columns.country]) })
+  @Property()
+  country!: string;
+
+}
+
 ```
 
   </TabItem>
@@ -1338,14 +1396,63 @@ You can define check constraints via `@Check()` decorator. You can use it either
 
 <Tabs
 groupId="entity-def"
-defaultValue="define-entity"
+defaultValue="define-entity-class"
 values={[
+{label: 'defineEntity + class', value: 'define-entity-class'},
 {label: 'defineEntity', value: 'define-entity'},
 {label: 'reflect-metadata', value: 'reflect-metadata'},
 {label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
 ]
-}>
+}
+>
+  <TabItem value="define-entity-class">
+
+```ts title="./entities/Book.ts"
+const BookSchema = defineEntity({
+  name: 'Book',
+  properties: {
+    id: p.number().primary(),
+    price1: p.number(),
+    price2: p.number(),
+    price3: p.number(),
+  },
+  checks: [
+    { expression: 'price1 >= 0' },
+    { name: 'foo', expression: columns => `${columns.price1} >= 0` },
+    { expression: columns => `${columns.price1} >= 0` },
+    { propertyName: 'price2', expression: 'price2 >= 0' },
+    { propertyName: 'price3', expression: columns => `${columns.price3} >= 0` },
+  ],
+});
+
+export class Book extends BookSchema.class {}
+BookSchema.setClass(Book);
+```
+
+  </TabItem>
+
+  <TabItem value="define-entity">
+
+```ts title="./entities/Book.ts"
+export const Book = defineEntity({
+  name: 'Book',
+  properties: {
+    id: p.number().primary(),
+    price1: p.number(),
+    price2: p.number(),
+    price3: p.number(),
+  },
+  checks: [
+    { expression: 'price1 >= 0' },
+    { name: 'foo', expression: columns => `${columns.price1} >= 0` },
+    { expression: columns => `${columns.price1} >= 0` },
+    { propertyName: 'price2', expression: 'price2 >= 0' },
+    { propertyName: 'price3', expression: columns => `${columns.price3} >= 0` },
+  ],
+});
+```
+
+  </TabItem>
 <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Book.ts"
@@ -1397,50 +1504,6 @@ export class Book {
   price3!: number;
 
 }
-```
-
-  </TabItem>
-  <TabItem value="define-entity">
-
-```ts title="./entities/Book.ts"
-export const Book = defineEntity({
-  name: 'Book',
-  properties: {
-    id: p.number().primary(),
-    price1: p.number(),
-    price2: p.number(),
-    price3: p.number(),
-  },
-  checks: [
-    { expression: 'price1 >= 0' },
-    { name: 'foo', expression: columns => `${columns.price1} >= 0` },
-    { expression: columns => `${columns.price1} >= 0` },
-    { propertyName: 'price2', expression: 'price2 >= 0' },
-    { propertyName: 'price3', expression: columns => `${columns.price3} >= 0` },
-  ],
-});
-```
-
-  </TabItem>
-  <TabItem value="entity-schema">
-
-```ts title="./entities/Book.ts"
-export const BookSchema = new EntitySchema({
-  class: Book,
-  checks: [
-    { expression: 'price1 >= 0' },
-    { name: 'foo', expression: columns => `${columns.price1} >= 0` },
-    { expression: columns => `${columns.price1} >= 0` },
-    { propertyName: 'price2', expression: 'price2 >= 0' },
-    { propertyName: 'price3', expression: columns => `${columns.price3} >= 0` },
-  ],
-  properties: {
-    id: { type: 'number', primary: true },
-    price1: { type: 'number' },
-    price2: { type: 'number' },
-    price3: { type: 'number' },
-  },
-});
 ```
 
   </TabItem>
@@ -1474,14 +1537,43 @@ You can mark any property as `lazy: true` to omit it from the select clause. Thi
 
 <Tabs
 groupId="entity-def"
-defaultValue="define-entity"
+defaultValue="define-entity-class"
 values={[
+{label: 'defineEntity + class', value: 'define-entity-class'},
 {label: 'defineEntity', value: 'define-entity'},
 {label: 'reflect-metadata', value: 'reflect-metadata'},
 {label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
 ]
-}>
+}
+>
+  <TabItem value="define-entity-class">
+
+```ts title="./entities/Book.ts"
+const BookSchema = defineEntity({
+  name: 'Book',
+  properties: {
+    text: p.text().lazy(),
+  },
+});
+
+export class Book extends BookSchema.class {}
+BookSchema.setClass(Book);
+```
+
+  </TabItem>
+
+  <TabItem value="define-entity">
+
+```ts title="./entities/Book.ts"
+export const Book = defineEntity({
+  name: 'Book',
+  properties: {
+    text: p.text().lazy(),
+  },
+});
+```
+
+  </TabItem>
 <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Book.ts"
@@ -1495,27 +1587,6 @@ text: string;
 ```ts title="./entities/Book.ts"
 @Property({ columnType: 'text', lazy: true })
 text: string;
-```
-
-  </TabItem>
-  <TabItem value="define-entity">
-
-```ts title="./entities/Book.ts"
-export const Book = defineEntity({
-  name: 'Book',
-  properties: {
-    text: p.text().lazy(),
-  },
-});
-```
-
-  </TabItem>
-  <TabItem value="entity-schema">
-
-```ts title="./entities/Book.ts"
-properties: {
-  text: { columnType: 'text', lazy: true },
-}
 ```
 
   </TabItem>
@@ -1578,14 +1649,70 @@ If the `accessor` option points to something, the ORM will use the backing prope
 
 <Tabs
 groupId="entity-def"
-defaultValue="define-entity"
+defaultValue="define-entity-class"
 values={[
+{label: 'defineEntity + class', value: 'define-entity-class'},
 {label: 'defineEntity', value: 'define-entity'},
 {label: 'reflect-metadata', value: 'reflect-metadata'},
 {label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
 ]
-}>
+}
+>
+  <TabItem value="define-entity-class">
+
+```ts title="./entities/User.ts"
+export class User {
+  id!: number;
+  private _email!: unknown;
+
+  get email(): unknown {
+    return this._email;
+  }
+
+  set email(email: unknown) {
+    this._email = email;
+  }
+}
+
+export const UserSchema = defineEntity({
+  class: User,
+  properties: {
+    id: p.integer().primary(),
+    // the ORM will use the backing field directly
+    email: p.string().accessor('_email'),
+  },
+});
+```
+
+  </TabItem>
+
+  <TabItem value="define-entity">
+
+```ts title="./entities/User.ts"
+export class User {
+  id!: number;
+  private _email!: unknown;
+
+  get email(): unknown {
+    return this._email;
+  }
+
+  set email(email: unknown) {
+    this._email = email;
+  }
+}
+
+export const UserSchema = defineEntity({
+  class: User,
+  properties: {
+    id: p.integer().primary(),
+    // the ORM will use the backing field directly
+    email: p.string().accessor('_email'),
+  },
+});
+```
+
+  </TabItem>
   <TabItem value="reflect-metadata">
 
 ```ts title="./entities/User.ts"
@@ -1632,74 +1759,80 @@ export class User {
 ```
 
   </TabItem>
-  <TabItem value="define-entity">
-
-```ts title="./entities/User.ts"
-export class User {
-  id!: number;
-  private _email!: unknown;
-
-  get email(): unknown {
-    return this._email;
-  }
-
-  set email(email: unknown) {
-    this._email = email;
-  }
-}
-
-export const UserSchema = defineEntity({
-  class: User,
-  properties: {
-    id: p.integer().primary(),
-    // the ORM will use the backing field directly
-    email: p.string().accessor('_email'),
-  },
-});
-```
-
-  </TabItem>
-  <TabItem value="entity-schema">
-
-```ts title="./entities/User.ts"
-export class User {
-  id!: string;
-  private _email!: string;
-
-  get email() {
-    return this._email;
-  }
-
-  set email(email: string) {
-    return this._email;
-  }
-}
-
-export const UserSchema = new EntitySchema({
-  class: User,
-  properties: {
-    id: { type: 'integer', primary: true },
-    // the ORM will use the backing property internally
-    email: { type: 'string', accessor: '_email' },
-  },
-});
-```
-
-  </TabItem>
 </Tabs>
 
 If you want the ORM to use the accessor internally (e.g. for hydration or change tracking), use `accessor: true` on the get/set property instead. This is handy if you want to use a **native private property** for the backing field. 
 
 <Tabs
 groupId="entity-def"
-defaultValue="define-entity"
+defaultValue="define-entity-class"
 values={[
+{label: 'defineEntity + class', value: 'define-entity-class'},
 {label: 'defineEntity', value: 'define-entity'},
 {label: 'reflect-metadata', value: 'reflect-metadata'},
 {label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
 ]
-}>
+}
+>
+  <TabItem value="define-entity-class">
+
+```ts title="./entities/User.ts"
+export class User {
+  id!: string;
+  #email!: string;
+
+  get email() {
+    return this.#email;
+  }
+
+  set email(email: string) {
+    return this.#email;
+  }
+}
+
+export const UserSchema = defineEntity({
+  class: User,
+  // constructors are required for native private fields
+  forceConstructor: true,
+  properties: {
+    id: p.integer().primary(),
+    // the ORM will use the accessor internally
+    email: p.string().accessor(),
+  },
+});
+```
+
+  </TabItem>
+
+  <TabItem value="define-entity">
+
+```ts title="./entities/User.ts"
+export class User {
+  id!: string;
+  #email!: string;
+
+  get email() {
+    return this.#email;
+  }
+
+  set email(email: string) {
+    return this.#email;
+  }
+}
+
+export const UserSchema = defineEntity({
+  class: User,
+  // constructors are required for native private fields
+  forceConstructor: true,
+  properties: {
+    id: p.integer().primary(),
+    // the ORM will use the accessor internally
+    email: p.string().accessor(),
+  },
+});
+```
+
+  </TabItem>
   <TabItem value="reflect-metadata">
 
 ```ts title="./entities/User.ts"
@@ -1746,64 +1879,6 @@ export class User {
 ```
 
   </TabItem>
-  <TabItem value="define-entity">
-
-```ts title="./entities/User.ts"
-export class User {
-  id!: string;
-  #email!: string;
-
-  get email() {
-    return this.#email;
-  }
-
-  set email(email: string) {
-    return this.#email;
-  }
-}
-
-export const UserSchema = defineEntity({
-  class: User,
-  // constructors are required for native private fields
-  forceConstructor: true,
-  properties: {
-    id: p.integer().primary(),
-    // the ORM will use the accessor internally
-    email: p.string().accessor(),
-  },
-});
-```
-
-  </TabItem>
-  <TabItem value="entity-schema">
-
-```ts title="./entities/User.ts"
-export class User {
-  id!: string;
-  #email!: string;
-
-  get email() {
-    return this.#email;
-  }
-
-  set email(email: string) {
-    return this.#email;
-  }
-}
-
-export const UserSchema = new EntitySchema({
-  class: User,
-  // constructors are required for native private fields
-  forceConstructor: true,
-  properties: {
-    id: { type: 'integer', primary: true },
-    // the ORM will use the accessor internally
-    email: { type: 'string', accessor: true },
-  },
-});
-```
-
-  </TabItem>
 </Tabs>
 
 ## Virtual Properties
@@ -1816,14 +1891,80 @@ Following example defines User entity with `firstName` and `lastName` database f
 
 <Tabs
 groupId="entity-def"
-defaultValue="define-entity"
+defaultValue="define-entity-class"
 values={[
+{label: 'defineEntity + class', value: 'define-entity-class'},
 {label: 'defineEntity', value: 'define-entity'},
 {label: 'reflect-metadata', value: 'reflect-metadata'},
 {label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
 ]
-}>
+}
+>
+  <TabItem value="define-entity-class">
+
+```ts title="./entities/User.ts"
+export class User {
+
+  [HiddenProps]?: 'firstName' | 'lastName';
+
+  firstName!: string;
+  lastName!: string;
+
+  getFullName() {
+    return `${this.firstName} ${this.lastName}`;
+  }
+
+  get fullName2() {
+    return `${this.firstName} ${this.lastName}`;
+  }
+}
+
+export const UserSchema = defineEntity({
+  class: User,
+  name: 'User',
+  properties: {
+    firstName: p.string().hidden(),
+    lastName: p.string().hidden(),
+    fullName: p.type('method').persist(false).getter().getterName('getFullName'),
+    fullName2: p.type('method').persist(false).getter(),
+  },
+});
+```
+
+  </TabItem>
+
+  <TabItem value="define-entity">
+
+```ts title="./entities/User.ts"
+export class User {
+
+  [HiddenProps]?: 'firstName' | 'lastName';
+
+  firstName!: string;
+  lastName!: string;
+
+  getFullName() {
+    return `${this.firstName} ${this.lastName}`;
+  }
+
+  get fullName2() {
+    return `${this.firstName} ${this.lastName}`;
+  }
+}
+
+export const UserSchema = defineEntity({
+  class: User,
+  name: 'User',
+  properties: {
+    firstName: p.string().hidden(),
+    lastName: p.string().hidden(),
+    fullName: p.type('method').persist(false).getter().getterName('getFullName'),
+    fullName2: p.type('method').persist(false).getter(),
+  },
+});
+```
+
+  </TabItem>
 <TabItem value="reflect-metadata">
 
 ```ts title="./entities/User.ts"
@@ -1880,66 +2021,6 @@ export class User {
 ```
 
   </TabItem>
-  <TabItem value="define-entity">
-
-```ts title="./entities/User.ts"
-export class User {
-
-  [HiddenProps]?: 'firstName' | 'lastName';
-
-  firstName!: string;
-  lastName!: string;
-
-  getFullName() {
-    return `${this.firstName} ${this.lastName}`;
-  }
-
-  get fullName2() {
-    return `${this.firstName} ${this.lastName}`;
-  }
-}
-
-export const UserSchema = defineEntity({
-  class: User,
-  name: 'User',
-  properties: {
-    firstName: p.string().hidden(),
-    lastName: p.string().hidden(),
-    fullName: p.type('method').persist(false).getter().getterName('getFullName'),
-    fullName2: p.type('method').persist(false).getter(),
-  },
-});
-```
-
-  </TabItem>
-  <TabItem value="entity-schema">
-
-```ts title="./entities/User.ts"
-export class User {
-
-  [HiddenProps]?: 'firstName' | 'lastName';
-
-  firstName!: string;
-  lastName!: string;
-
-  getFullName() {
-    return `${this.firstName} ${this.lastName}`;
-  }
-
-  get fullName2() {
-    return `${this.firstName} ${this.lastName}`;
-  }
-}
-
-properties: {
-  firstName: { type: String, hidden: true },
-  lastName: { type: String, hidden: true },
-  fullName: { type: 'method', persist: false, getter: true, getterName: 'getFullName' },
-  fullName2: { type: 'method', persist: false, getter: true },
-}
-```
-
-  </TabItem>
 </Tabs>
 
 ```ts
@@ -1966,14 +2047,55 @@ All applicable orderings are combined together, with higher-priority orderings t
 
 <Tabs
 groupId="entity-def"
-defaultValue="define-entity"
+defaultValue="define-entity-class"
 values={[
+{label: 'defineEntity + class', value: 'define-entity-class'},
 {label: 'defineEntity', value: 'define-entity'},
 {label: 'reflect-metadata', value: 'reflect-metadata'},
 {label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
 ]
-}>
+}
+>
+  <TabItem value="define-entity-class">
+
+```ts title="./entities/Comment.ts"
+import { defineEntity, p } from '@mikro-orm/core';
+
+const CommentSchema = defineEntity({
+  name: 'Comment',
+  orderBy: { createdAt: QueryOrder.DESC, id: QueryOrder.DESC },
+  properties: {
+    id: p.number().primary(),
+    createdAt: p.datetime(),
+    text: p.string(),
+    post: () => p.manyToOne(Post),
+  },
+});
+
+export class Comment extends CommentSchema.class {}
+CommentSchema.setClass(Comment);
+```
+
+  </TabItem>
+
+  <TabItem value="define-entity">
+
+```ts title="./entities/Comment.ts"
+import { defineEntity, p } from '@mikro-orm/core';
+
+export const Comment = defineEntity({
+  name: 'Comment',
+  orderBy: { createdAt: QueryOrder.DESC, id: QueryOrder.DESC },
+  properties: {
+    id: p.number().primary(),
+    createdAt: p.datetime(),
+    text: p.string(),
+    post: () => p.manyToOne(Post),
+  },
+});
+```
+
+  </TabItem>
 <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Comment.ts"
@@ -2018,40 +2140,6 @@ export class Comment {
 ```
 
   </TabItem>
-  <TabItem value="define-entity">
-
-```ts title="./entities/Comment.ts"
-import { defineEntity, p } from '@mikro-orm/core';
-
-export const Comment = defineEntity({
-  name: 'Comment',
-  orderBy: { createdAt: QueryOrder.DESC, id: QueryOrder.DESC },
-  properties: {
-    id: p.number().primary(),
-    createdAt: p.datetime(),
-    text: p.string(),
-    post: () => p.manyToOne(Post),
-  },
-});
-```
-
-  </TabItem>
-  <TabItem value="entity-schema">
-
-```ts title="./entities/Comment.ts"
-export const CommentSchema = new EntitySchema({
-  name: 'Comment',
-  orderBy: { createdAt: QueryOrder.DESC, id: QueryOrder.DESC },
-  properties: {
-    id: { type: 'number', primary: true },
-    createdAt: { type: 'Date' },
-    text: { type: 'string' },
-    post: { kind: 'm:1', entity: () => Post },
-  },
-});
-```
-
-  </TabItem>
 </Tabs>
 
 The ordering precedence (from highest to lowest) is:
@@ -2064,14 +2152,51 @@ All levels are combined together - if you specify `{ name: 'asc' }` at runtime a
 
 <Tabs
 groupId="entity-def"
-defaultValue="define-entity"
+defaultValue="define-entity-class"
 values={[
+{label: 'defineEntity + class', value: 'define-entity-class'},
 {label: 'defineEntity', value: 'define-entity'},
 {label: 'reflect-metadata', value: 'reflect-metadata'},
 {label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
 ]
-}>
+}
+>
+  <TabItem value="define-entity-class">
+
+```ts title="./entities/Post.ts"
+import { defineEntity, p } from '@mikro-orm/core';
+
+const PostSchema = defineEntity({
+  name: 'Post',
+  properties: {
+    id: p.number().primary(),
+    comments: () => p.oneToMany(Comment).mappedBy('post'),
+    commentsAlphabetical: () => p.oneToMany(Comment).mappedBy('post').orderBy({ text: QueryOrder.ASC }),
+  },
+});
+
+export class Post extends PostSchema.class {}
+PostSchema.setClass(Post);
+```
+
+  </TabItem>
+
+  <TabItem value="define-entity">
+
+```ts title="./entities/Post.ts"
+import { defineEntity, p } from '@mikro-orm/core';
+
+export const Post = defineEntity({
+  name: 'Post',
+  properties: {
+    id: p.number().primary(),
+    comments: () => p.oneToMany(Comment).mappedBy('post'),
+    commentsAlphabetical: () => p.oneToMany(Comment).mappedBy('post').orderBy({ text: QueryOrder.ASC }),
+  },
+});
+```
+
+  </TabItem>
 <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Post.ts"
@@ -2107,36 +2232,6 @@ export class Post {
   commentsAlphabetical = new Collection<Comment>(this);
 
 }
-```
-
-  </TabItem>
-  <TabItem value="define-entity">
-
-```ts title="./entities/Post.ts"
-import { defineEntity, p } from '@mikro-orm/core';
-
-export const Post = defineEntity({
-  name: 'Post',
-  properties: {
-    id: p.number().primary(),
-    comments: () => p.oneToMany(Comment).mappedBy('post'),
-    commentsAlphabetical: () => p.oneToMany(Comment).mappedBy('post').orderBy({ text: QueryOrder.ASC }),
-  },
-});
-```
-
-  </TabItem>
-  <TabItem value="entity-schema">
-
-```ts title="./entities/Post.ts"
-export const PostSchema = new EntitySchema({
-  name: 'Post',
-  properties: {
-    id: { type: 'number', primary: true },
-    comments: { kind: '1:m', entity: () => Comment, mappedBy: 'post' },
-    commentsAlphabetical: { kind: '1:m', entity: () => Comment, mappedBy: 'post', orderBy: { text: QueryOrder.ASC } },
-  },
-});
 ```
 
   </TabItem>
@@ -2166,14 +2261,50 @@ Read more about this topic in [Inheritance Mapping](./inheritance-mapping.md) se
 
 <Tabs
 groupId="entity-def"
-defaultValue="define-entity"
+defaultValue="define-entity-class"
 values={[
+{label: 'defineEntity + class', value: 'define-entity-class'},
 {label: 'defineEntity', value: 'define-entity'},
 {label: 'reflect-metadata', value: 'reflect-metadata'},
 {label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
 ]
-}>
+}
+>
+  <TabItem value="define-entity-class">
+
+```ts title="./entities/CustomBaseEntity.ts"
+const p = defineEntity.properties;
+const CustomBaseProperties = {
+  uuid: p.uuid().primary().onCreate(() => v4()),
+  createdAt: p.datetime()
+    .onCreate(() => new Date())
+    .nullable(),
+  updatedAt: p.datetime()
+    .onCreate(() => new Date())
+    .onUpdate(() => new Date())
+    .nullable(),
+}
+```
+
+  </TabItem>
+
+  <TabItem value="define-entity">
+
+```ts title="./entities/CustomBaseEntity.ts"
+const p = defineEntity.properties;
+const CustomBaseProperties = {
+  uuid: p.uuid().primary().onCreate(() => v4()),
+  createdAt: p.datetime()
+    .onCreate(() => new Date())
+    .nullable(),
+  updatedAt: p.datetime()
+    .onCreate(() => new Date())
+    .onUpdate(() => new Date())
+    .nullable(),
+}
+```
+
+  </TabItem>
 <TabItem value="reflect-metadata">
 
 ```ts title="./entities/CustomBaseEntity.ts"
@@ -2211,46 +2342,6 @@ export abstract class CustomBaseEntity {
   updatedAt = new Date();
 
 }
-```
-
-  </TabItem>
-  <TabItem value="define-entity">
-
-```ts title="./entities/CustomBaseEntity.ts"
-const p = defineEntity.properties;
-const CustomBaseProperties = {
-  uuid: p.uuid().primary().onCreate(() => v4()),
-  createdAt: p.datetime()
-    .onCreate(() => new Date())
-    .nullable(),
-  updatedAt: p.datetime()
-    .onCreate(() => new Date())
-    .onUpdate(() => new Date())
-    .nullable(),
-}
-```
-
-  </TabItem>
-  <TabItem value="entity-schema">
-
-```ts title="./entities/CustomBaseEntity.ts"
-import { v4 } from 'uuid';
-
-export interface CustomBaseEntity {
-  uuid: string;
-  createdAt: Date;
-  updatedAt: Date;
-}
-
-export const schema = new EntitySchema<CustomBaseEntity>({
-  name: 'CustomBaseEntity',
-  abstract: true,
-  properties: {
-    uuid: { type: 'uuid', onCreate: () => v4(), primary: true },
-    createdAt: { type: 'Date', onCreate: () => new Date(), nullable: true },
-    updatedAt: { type: 'Date', onCreate: () => new Date(), onUpdate: () => new Date(), nullable: true },
-  },
-});
 ```
 
   </TabItem>
@@ -2271,64 +2362,39 @@ To use generated columns, you can either use the `generated` option, or specify 
 
 <Tabs
 groupId="entity-def"
-defaultValue="define-entity"
+defaultValue="define-entity-class"
 values={[
+{label: 'defineEntity + class', value: 'define-entity-class'},
 {label: 'defineEntity', value: 'define-entity'},
 {label: 'reflect-metadata', value: 'reflect-metadata'},
 {label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
 ]
-}>
-<TabItem value="reflect-metadata">
+}
+>
+  <TabItem value="define-entity-class">
 
 ```ts title="./entities/User.ts"
-@Entity()
-export class User {
+const UserSchema = defineEntity({
+  name: 'User',
+  properties: {
+    id: p.integer().primary(),
+    firstName: p.string().length(50),
+    lastName: p.string().length(50),
+    fullName: p.string()
+      .length(100)
+      .generated(cols => `(concat(${cols.firstName}, ' ', ${cols.lastName})) stored`),
+    fullName2: p.string()
+      .length(100)
+      .columnType(`varchar(100) generated always as (concat(first_name, ' ', last_name)) virtual`),
+  },
+});
 
-  @PrimaryKey()
-  id!: number;
-
-  @Property({ length: 50 })
-  firstName!: string;
-
-  @Property({ length: 50 })
-  lastName!: string;
-
-  @Property({ length: 100, generated: cols => `(concat(${cols.firstName}, ' ', ${cols.lastName})) stored` })
-  fullName!: string & Opt;
-
-  @Property({ columnType: `varchar(100) generated always as (concat(first_name, ' ', last_name)) virtual` })
-  fullName2!: string & Opt;
-
-}
+export class User extends UserSchema.class {}
+UserSchema.setClass(User);
 ```
 
   </TabItem>
-  <TabItem value="ts-morph">
 
-```ts title="./entities/User.ts"
-@Entity()
-export class User {
-
-  @PrimaryKey()
-  id!: number;
-
-  @Property({ length: 50 })
-  firstName!: string;
-
-  @Property({ length: 50 })
-  lastName!: string;
-
-  @Property({ length: 100, generated: cols => `(concat(${cols.firstName}, ' ', ${cols.lastName})) stored` })
-  fullName!: string & Opt;
-
-  @Property({ columnType: `varchar(100) generated always as (concat(first_name, ' ', last_name)) virtual` })
-  fullName2!: string & Opt;
-
-}
-```
-
-  </TabItem>
   <TabItem value="define-entity">
 
 ```ts title="./entities/User.ts"
@@ -2349,34 +2415,53 @@ export const User = defineEntity({
 ```
 
   </TabItem>
-  <TabItem value="entity-schema">
+<TabItem value="reflect-metadata">
 
 ```ts title="./entities/User.ts"
-export interface IUser {
-  id: number;
-  firstName: string;
-  lastName: string;
-  fullName: string & Opt;
-  fullName2: string & Opt;
-}
+@Entity()
+export class User {
 
-export const User = new EntitySchema<IUser>({
-  name: 'User',
-  properties: {
-    id: { type: 'number', primary: true },
-    firstName: { type: 'string', length: 50 },
-    lastName: { type: 'string', length: 50 },
-    fullName: {
-      type: 'string',
-      length: 100,
-      generated: cols => `(concat(${cols.firstName}, ' ', ${cols.lastName})) stored`,
-    },
-    fullName2: {
-      type: 'string',
-      columnType: `varchar(100) generated always as (concat(first_name, ' ', last_name)) virtual`,
-    },
-  },
-});
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ length: 50 })
+  firstName!: string;
+
+  @Property({ length: 50 })
+  lastName!: string;
+
+  @Property({ length: 100, generated: cols => `(concat(${cols.firstName}, ' ', ${cols.lastName})) stored` })
+  fullName!: string & Opt;
+
+  @Property({ columnType: `varchar(100) generated always as (concat(first_name, ' ', last_name)) virtual` })
+  fullName2!: string & Opt;
+
+}
+```
+
+  </TabItem>
+  <TabItem value="ts-morph">
+
+```ts title="./entities/User.ts"
+@Entity()
+export class User {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ length: 50 })
+  firstName!: string;
+
+  @Property({ length: 50 })
+  lastName!: string;
+
+  @Property({ length: 100, generated: cols => `(concat(${cols.firstName}, ' ', ${cols.lastName})) stored` })
+  fullName!: string & Opt;
+
+  @Property({ columnType: `varchar(100) generated always as (concat(first_name, ' ', last_name)) virtual` })
+  fullName2!: string & Opt;
+
+}
 ```
 
   </TabItem>
@@ -2388,14 +2473,43 @@ To use a generated identity column in PostgreSQL, set the `generated` option to 
 
 <Tabs
 groupId="entity-def"
-defaultValue="define-entity"
+defaultValue="define-entity-class"
 values={[
+{label: 'defineEntity + class', value: 'define-entity-class'},
 {label: 'defineEntity', value: 'define-entity'},
 {label: 'reflect-metadata', value: 'reflect-metadata'},
 {label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
 ]
-}>
+}
+>
+  <TabItem value="define-entity-class">
+
+```ts title="./entities/User.ts"
+const UserSchema = defineEntity({
+  name: 'User',
+  properties: {
+    id: p.integer().primary().generated('identity'),
+  },
+});
+
+export class User extends UserSchema.class {}
+UserSchema.setClass(User);
+```
+
+  </TabItem>
+
+  <TabItem value="define-entity">
+
+```ts title="./entities/User.ts"
+export const User = defineEntity({
+  name: 'User',
+  properties: {
+    id: p.integer().primary().generated('identity'),
+  },
+});
+```
+
+  </TabItem>
 <TabItem value="reflect-metadata">
 
 ```ts title="./entities/User.ts"
@@ -2422,34 +2536,6 @@ export class User {
 ```
 
   </TabItem>
-  <TabItem value="define-entity">
-
-```ts title="./entities/User.ts"
-export const User = defineEntity({
-  name: 'User',
-  properties: {
-    id: p.integer().primary().generated('identity'),
-  },
-});
-```
-
-  </TabItem>
-  <TabItem value="entity-schema">
-
-```ts title="./entities/User.ts"
-export interface IUser {
-  id: number;
-}
-
-export const User = new EntitySchema<IUser>({
-  name: 'User',
-  properties: {
-    id: { type: 'number', primary: true, generated: 'identity' },
-  },
-});
-```
-
-  </TabItem>
 </Tabs>
 
 ## Examples of entity definition with various primary keys
@@ -2458,14 +2544,49 @@ export const User = new EntitySchema<IUser>({
 
 <Tabs
 groupId="entity-def"
-defaultValue="define-entity"
+defaultValue="define-entity-class"
 values={[
+{label: 'defineEntity + class', value: 'define-entity-class'},
 {label: 'defineEntity', value: 'define-entity'},
 {label: 'reflect-metadata', value: 'reflect-metadata'},
 {label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
 ]
-}>
+}
+>
+  <TabItem value="define-entity-class">
+
+```ts title="./entities/Book.ts"
+const BookSchema = defineEntity({
+  name: 'Book',
+  properties: {
+    id: p.integer().primary(),
+    title: p.string(),
+    author: () => p.manyToOne(Author),
+    publisher: () => p.manyToOne(Publisher).nullable(),
+  },
+});
+
+export class Book extends BookSchema.class {}
+BookSchema.setClass(Book);
+```
+
+  </TabItem>
+
+  <TabItem value="define-entity">
+
+```ts title="./entities/Book.ts"
+export const Book = defineEntity({
+  name: 'Book',
+  properties: {
+    id: p.integer().primary(),
+    title: p.string(),
+    author: () => p.manyToOne(Author),
+    publisher: () => p.manyToOne(Publisher).nullable(),
+  },
+});
+```
+
+  </TabItem>
 <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Book.ts"
@@ -2510,98 +2631,39 @@ export class Book {
 ```
 
   </TabItem>
-  <TabItem value="define-entity">
-
-```ts title="./entities/Book.ts"
-export const Book = defineEntity({
-  name: 'Book',
-  properties: {
-    id: p.integer().primary(),
-    title: p.string(),
-    author: () => p.manyToOne(Author),
-    publisher: () => p.manyToOne(Publisher).nullable(),
-  },
-});
-```
-
-  </TabItem>
-  <TabItem value="entity-schema">
-
-```ts title="./entities/Book.ts"
-export interface Book {
-  id: number;
-  title: string;
-  author: Author;
-}
-
-export const BookSchema = new EntitySchema<Book>({
-  name: 'Book',
-  properties: {
-    id: { type: Number, primary: true },
-    title: { type: String },
-    author: { kind: 'm:1', entity: () => Author },
-    publisher: { kind: 'm:1', entity: () => Publisher, ref: true, nullable: true },
-  },
-});
-```
-
-  </TabItem>
 </Tabs>
 
 ### Using UUID as primary key (SQL drivers)
 
 <Tabs
 groupId="entity-def"
-defaultValue="define-entity"
+defaultValue="define-entity-class"
 values={[
+{label: 'defineEntity + class', value: 'define-entity-class'},
 {label: 'defineEntity', value: 'define-entity'},
 {label: 'reflect-metadata', value: 'reflect-metadata'},
 {label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
 ]
-}>
-<TabItem value="reflect-metadata">
+}
+>
+  <TabItem value="define-entity-class">
 
 ```ts title="./entities/Book.ts"
-import { v4 } from 'uuid';
+const BookSchema = defineEntity({
+  name: 'Book',
+  properties: {
+    uuid: p.uuid().primary().onCreate(() => v4()),
+    title: p.string(),
+    author: () => p.manyToOne(Author),
+  },
+});
 
-@Entity()
-export class Book {
-
-  @PrimaryKey()
-  uuid = v4();
-
-  @Property()
-  title!: string;
-
-  @ManyToOne(() => Author)
-  author!: Author;
-
-}
+export class Book extends BookSchema.class {}
+BookSchema.setClass(Book);
 ```
 
   </TabItem>
-  <TabItem value="ts-morph">
 
-```ts title="./entities/Book.ts"
-import { v4 } from 'uuid';
-
-@Entity()
-export class Book {
-
-  @PrimaryKey()
-  uuid = v4();
-
-  @Property()
-  title!: string;
-
-  @ManyToOne()
-  author!: Author;
-
-}
-```
-
-  </TabItem>
   <TabItem value="define-entity">
 
 ```ts title="./entities/Book.ts"
@@ -2616,23 +2678,45 @@ export const Book = defineEntity({
 ```
 
   </TabItem>
-  <TabItem value="entity-schema">
+<TabItem value="reflect-metadata">
 
 ```ts title="./entities/Book.ts"
-export interface IBook {
-  uuid: string;
-  title: string;
-  author: Author;
-}
+import { v4 } from 'uuid';
 
-export const Book = new EntitySchema<IBook>({
-  name: 'Book',
-  properties: {
-    uuid: { type: 'uuid', onCreate: () => v4(), primary: true },
-    title: { type: 'string' },
-    author: { entity: () => Author, kind: 'm:1' },
-  },
-});
+@Entity()
+export class Book {
+
+  @PrimaryKey()
+  uuid = v4();
+
+  @Property()
+  title!: string;
+
+  @ManyToOne(() => Author)
+  author!: Author;
+
+}
+```
+
+  </TabItem>
+  <TabItem value="ts-morph">
+
+```ts title="./entities/Book.ts"
+import { v4 } from 'uuid';
+
+@Entity()
+export class Book {
+
+  @PrimaryKey()
+  uuid = v4();
+
+  @Property()
+  title!: string;
+
+  @ManyToOne()
+  author!: Author;
+
+}
 ```
 
   </TabItem>
@@ -2642,14 +2726,47 @@ export const Book = new EntitySchema<IBook>({
 
 <Tabs
 groupId="entity-def"
-defaultValue="define-entity"
+defaultValue="define-entity-class"
 values={[
+{label: 'defineEntity + class', value: 'define-entity-class'},
 {label: 'defineEntity', value: 'define-entity'},
 {label: 'reflect-metadata', value: 'reflect-metadata'},
 {label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
 ]
-}>
+}
+>
+  <TabItem value="define-entity-class">
+
+```ts title="./entities/Book.ts"
+const BookSchema = defineEntity({
+  name: 'Book',
+  properties: {
+    uuid: p.uuid().primary().defaultRaw('gen_random_uuid()'),
+    title: p.string(),
+    author: () => p.manyToOne(Author),
+  },
+});
+
+export class Book extends BookSchema.class {}
+BookSchema.setClass(Book);
+```
+
+  </TabItem>
+
+  <TabItem value="define-entity">
+
+```ts title="./entities/Book.ts"
+export const Book = defineEntity({
+  name: 'Book',
+  properties: {
+    uuid: p.uuid().primary().defaultRaw('gen_random_uuid()'),
+    title: p.string(),
+    author: () => p.manyToOne(Author),
+  },
+});
+```
+
+  </TabItem>
 <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Book.ts"
@@ -2685,40 +2802,6 @@ export class Book {
   author!: Author;
 
 }
-```
-
-  </TabItem>
-  <TabItem value="define-entity">
-
-```ts title="./entities/Book.ts"
-export const Book = defineEntity({
-  name: 'Book',
-  properties: {
-    uuid: p.uuid().primary().defaultRaw('gen_random_uuid()'),
-    title: p.string(),
-    author: () => p.manyToOne(Author),
-  },
-});
-```
-
-  </TabItem>
-  <TabItem value="entity-schema">
-
-```ts title="./entities/Book.ts"
-export class Book {
-  uuid: string;
-  title!: string;
-  author!: Author;
-}
-
-export const BookSchema = new EntitySchema<Book>({
-  class: Book,
-  properties: {
-    uuid: { type: 'uuid', defaultRaw: 'gen_random_uuid()', primary: true },
-    title: { type: 'string' },
-    author: { entity: () => Author, kind: 'm:1' },
-  },
-});
 ```
 
   </TabItem>
@@ -2750,14 +2833,43 @@ id3: number;
 
 <Tabs
 groupId="entity-def"
-defaultValue="define-entity"
+defaultValue="define-entity-class"
 values={[
+{label: 'defineEntity + class', value: 'define-entity-class'},
 {label: 'defineEntity', value: 'define-entity'},
 {label: 'reflect-metadata', value: 'reflect-metadata'},
 {label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
 ]
-}>
+}
+>
+  <TabItem value="define-entity-class">
+
+```ts title="./entities/CustomBaseEntity.ts"
+const SomeEntitySchema = defineEntity({
+  name: 'SomeEntity',
+  properties: {
+    id: p.bigint().primary(),
+  },
+});
+
+export class SomeEntity extends SomeEntitySchema.class {}
+SomeEntitySchema.setClass(SomeEntity);
+```
+
+  </TabItem>
+
+  <TabItem value="define-entity">
+
+```ts title="./entities/CustomBaseEntity.ts"
+const SomeEntity = defineEntity({
+  name: 'SomeEntity',
+  properties: {
+    id: p.bigint().primary(),
+  },
+});
+```
+
+  </TabItem>
 <TabItem value="reflect-metadata">
 
 ```ts title="./entities/CustomBaseEntity.ts"
@@ -2784,27 +2896,6 @@ export class Book {
 ```
 
   </TabItem>
-  <TabItem value="define-entity">
-
-```ts title="./entities/CustomBaseEntity.ts"
-const SomeEntity = defineEntity({
-  name: 'SomeEntity',
-  properties: {
-    id: p.bigint().primary(),
-  },
-});
-```
-
-  </TabItem>
-  <TabItem value="entity-schema">
-
-```ts title="./entities/CustomBaseEntity.ts"
-properties: {
-  id: { type: 'bigint' },
-},
-```
-
-  </TabItem>
 </Tabs>
 
 If you want to use native `bigint`s, read the following guide: [Using native BigInt PKs](./using-bigint-pks.md).
@@ -2813,14 +2904,47 @@ If you want to use native `bigint`s, read the following guide: [Using native Big
 
 <Tabs
 groupId="entity-def"
-defaultValue="define-entity"
+defaultValue="define-entity-class"
 values={[
+{label: 'defineEntity + class', value: 'define-entity-class'},
 {label: 'defineEntity', value: 'define-entity'},
 {label: 'reflect-metadata', value: 'reflect-metadata'},
 {label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
 ]
-}>
+}
+>
+  <TabItem value="define-entity-class">
+
+```ts title="./entities/Book.ts"
+const BookSchema = defineEntity({
+  name: 'Book',
+  properties: {
+    _id: p.type(ObjectId).primary(),
+    id: p.string().serializedPrimaryKey(),
+    title: p.string(),
+  },
+});
+
+export class Book extends BookSchema.class {}
+BookSchema.setClass(Book);
+```
+
+  </TabItem>
+
+  <TabItem value="define-entity">
+
+```ts title="./entities/Book.ts"
+export const Book = defineEntity({
+  name: 'Book',
+  properties: {
+    _id: p.type(ObjectId).primary(),
+    id: p.string().serializedPrimaryKey(),
+    title: p.string(),
+  },
+});
+```
+
+  </TabItem>
 <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Book.ts"
@@ -2862,41 +2986,6 @@ export class Book {
   author!: Author;
 
 }
-```
-
-  </TabItem>
-  <TabItem value="define-entity">
-
-```ts title="./entities/Book.ts"
-export const Book = defineEntity({
-  name: 'Book',
-  properties: {
-    _id: p.type(ObjectId).primary(),
-    id: p.string().serializedPrimaryKey(),
-    title: p.string(),
-  },
-});
-```
-
-  </TabItem>
-  <TabItem value="entity-schema">
-
-```ts title="./entities/Book.ts"
-export interface IBook {
-  _id: ObjectId;
-  id: string;
-  title: string;
-  author: Author;
-}
-
-export const Book = new EntitySchema<IBook>({
-  name: 'Book',
-  properties: {
-    _id: { type: 'ObjectId', primary: true },
-    id: { type: String, serializedPrimaryKey: true },
-    title: { type: String },
-  },
-});
 ```
 
   </TabItem>

--- a/docs/docs/embeddables.md
+++ b/docs/docs/embeddables.md
@@ -18,14 +18,76 @@ For the purposes of this tutorial, let's assume that you have a `User` class in 
 
 <Tabs
   groupId="entity-def"
-  defaultValue="define-entity"
+  defaultValue="define-entity-class"
   values={[
+    {label: 'defineEntity + class', value: 'define-entity-class'},
     {label: 'defineEntity', value: 'define-entity'},
     {label: 'reflect-metadata', value: 'reflect-metadata'},
     {label: 'ts-morph', value: 'ts-morph'},
-    {label: 'EntitySchema', value: 'entity-schema'},
-  ]
-  }>
+]
+  }
+>
+  <TabItem value="define-entity-class">
+
+```ts
+import { defineEntity, p } from '@mikro-orm/core';
+
+const UserSchema = defineEntity({
+  name: 'User',
+  properties: {
+    id: p.integer().primary(),
+    address: () => p.embedded(Address),
+  },
+});
+
+
+export const Address = defineEntity({
+  name: 'Address',
+  embeddable: true,
+  properties: {
+    street: p.string(),
+    postalCode: p.string(),
+    city: p.string(),
+    country: p.string(),
+  },
+});
+
+export class User extends UserSchema.class {}
+UserSchema.setClass(User);
+```
+
+  </TabItem>
+
+  <TabItem value="define-entity">
+
+```ts
+import { type InferEntity, defineEntity, p } from '@mikro-orm/core';
+
+export const User = defineEntity({
+  name: 'User',
+  properties: {
+    id: p.integer().primary(),
+    address: () => p.embedded(Address),
+  },
+});
+
+export type IUser = InferEntity<typeof User>;
+
+export const Address = defineEntity({
+  name: 'Address',
+  embeddable: true,
+  properties: {
+    street: p.string(),
+    postalCode: p.string(),
+    city: p.string(),
+    country: p.string(),
+  },
+});
+
+export type IAddress = InferEntity<typeof Address>;
+```
+
+  </TabItem>
   <TabItem value="reflect-metadata">
 
 ```ts
@@ -96,74 +158,6 @@ export class User {
 ```
 
   </TabItem>
-  <TabItem value="define-entity">
-
-```ts
-import { type InferEntity, defineEntity, p } from '@mikro-orm/core';
-
-export const User = defineEntity({
-  name: 'User',
-  properties: {
-    id: p.integer().primary(),
-    address: () => p.embedded(Address),
-  },
-});
-
-export type IUser = InferEntity<typeof User>;
-
-export const Address = defineEntity({
-  name: 'Address',
-  embeddable: true,
-  properties: {
-    street: p.string(),
-    postalCode: p.string(),
-    city: p.string(),
-    country: p.string(),
-  },
-});
-
-export type IAddress = InferEntity<typeof Address>;
-```
-
-  </TabItem>
-  <TabItem value="entity-schema">
-
-```ts
-import { EntitySchema } from '@mikro-orm/core';
-
-export class Address {
-  street!: string;
-  postalCode!: string;
-  city!: string;
-  country!: string;
-}
-
-export class User {
-  id!: number;
-  address!: Address;
-}
-
-export const UserSchema = new EntitySchema({
-  class: User,
-  properties: {
-    id: { primary: true, type: 'number' },
-    address: { kind: 'embedded', entity: () => Address },
-  },
-});
-
-export const AddressSchema = new EntitySchema({
-  class: Address,
-  embeddable: true,
-  properties: {
-    street: { type: 'string' },
-    postalCode: { type: 'string' },
-    city: { type: 'string' },
-    country: { type: 'string' },
-  },
-});
-```
-
-  </TabItem>
 </Tabs>
 
 > When using ReflectMetadataProvider, you might need to provide the class in decorator options: `@Embedded(() => Address)` or `@Embedded({ entity: () => Address })`.
@@ -176,30 +170,33 @@ In case all fields in the embeddable are nullable, you might want to initialize 
 
 <Tabs
   groupId="entity-def"
-  defaultValue="define-entity"
+  defaultValue="define-entity-class"
   values={[
+    {label: 'defineEntity + class', value: 'define-entity-class'},
     {label: 'defineEntity', value: 'define-entity'},
     {label: 'reflect-metadata', value: 'reflect-metadata'},
     {label: 'ts-morph', value: 'ts-morph'},
-    {label: 'EntitySchema', value: 'entity-schema'},
-  ]
-  }>
-  <TabItem value="reflect-metadata">
+]
+  }
+>
+  <TabItem value="define-entity-class">
 
 ```ts title="./entities/User.ts"
-@Embedded(() => Address)
-address = new Address();
+const UserSchema = defineEntity({
+  name: 'User',
+  properties: {
+    id: p.integer().primary(),
+    address: () => p.embedded(Address)
+      .onCreate(() => new Address()),
+  },
+});
+
+export class User extends UserSchema.class {}
+UserSchema.setClass(User);
 ```
 
   </TabItem>
-  <TabItem value="ts-morph">
 
-```ts title="./entities/User.ts"
-@Embedded()
-address = new Address();
-```
-
-  </TabItem>
   <TabItem value="define-entity">
 
 ```ts title="./entities/User.ts"
@@ -214,10 +211,19 @@ const User = defineEntity({
 ```
 
   </TabItem>
-  <TabItem value="entity-schema">
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/User.ts"
-address: { kind: 'embedded', entity: () => Address, onCreate: () => new Address() },
+@Embedded(() => Address)
+address = new Address();
+```
+
+  </TabItem>
+  <TabItem value="ts-morph">
+
+```ts title="./entities/User.ts"
+@Embedded()
+address = new Address();
 ```
 
   </TabItem>
@@ -235,14 +241,45 @@ The following example shows you how to set your prefix to `myPrefix_`:
 
 <Tabs
   groupId="entity-def"
-  defaultValue="define-entity"
+  defaultValue="define-entity-class"
   values={[
+    {label: 'defineEntity + class', value: 'define-entity-class'},
     {label: 'defineEntity', value: 'define-entity'},
     {label: 'reflect-metadata', value: 'reflect-metadata'},
     {label: 'ts-morph', value: 'ts-morph'},
-    {label: 'EntitySchema', value: 'entity-schema'},
-  ]
-  }>
+]
+  }
+>
+  <TabItem value="define-entity-class">
+
+```ts title="./entities/User.ts"
+const UserSchema = defineEntity({
+  name: 'User',
+  properties: {
+    id: p.integer().primary(),
+    address: () => p.embedded(Address).prefix('myPrefix_')
+  },
+});
+
+export class User extends UserSchema.class {}
+UserSchema.setClass(User);
+```
+
+  </TabItem>
+
+  <TabItem value="define-entity">
+
+```ts title="./entities/User.ts"
+const User = defineEntity({
+  name: 'User',
+  properties: {
+    id: p.integer().primary(),
+    address: () => p.embedded(Address).prefix('myPrefix_')
+  },
+});
+```
+
+  </TabItem>
   <TabItem value="reflect-metadata">
 
 ```ts title="./entities/User.ts"
@@ -269,26 +306,6 @@ export class User {
 ```
 
   </TabItem>
-  <TabItem value="define-entity">
-
-```ts title="./entities/User.ts"
-const User = defineEntity({
-  name: 'User',
-  properties: {
-    id: p.integer().primary(),
-    address: () => p.embedded(Address).prefix('myPrefix_')
-  },
-});
-```
-
-  </TabItem>
-  <TabItem value="entity-schema">
-
-```ts title="./entities/User.ts"
-address: { kind: 'embedded', entity: () => Address, prefix: 'myPrefix_' },
-```
-
-  </TabItem>
 </Tabs>
 
 You can also decide more precisely how the column name is determined with an explicit prefix. With the example below:
@@ -298,14 +315,68 @@ You can also decide more precisely how the column name is determined with an exp
 
 <Tabs
   groupId="entity-def"
-  defaultValue="define-entity"
+  defaultValue="define-entity-class"
   values={[
+    {label: 'defineEntity + class', value: 'define-entity-class'},
     {label: 'defineEntity', value: 'define-entity'},
     {label: 'reflect-metadata', value: 'reflect-metadata'},
     {label: 'ts-morph', value: 'ts-morph'},
-    {label: 'EntitySchema', value: 'entity-schema'},
-  ]
-  }>
+]
+  }
+>
+  <TabItem value="define-entity-class">
+
+```ts title="./entities/User.ts"
+const ContactSchema = defineEntity({
+  name: 'Contact',
+  embeddable: true,
+  properties: {
+    address: () => p.embedded(Address).prefix('addr_').prefixMode('absolute'),
+    address2: () => p.embedded(Address).prefix('addr2_').prefixMode('relative'),
+  },
+});
+
+
+export const User = defineEntity({
+  name: 'User',
+  properties: {
+    id: p.integer().primary(),
+    contact: () => p.embedded(Contact),
+  },
+});
+
+export class Contact extends ContactSchema.class {}
+ContactSchema.setClass(Contact);
+```
+
+  </TabItem>
+
+  <TabItem value="define-entity">
+
+```ts title="./entities/User.ts"
+export const Contact = defineEntity({
+  name: 'Contact',
+  embeddable: true,
+  properties: {
+    address: () => p.embedded(Address).prefix('addr_').prefixMode('absolute'),
+    address2: () => p.embedded(Address).prefix('addr2_').prefixMode('relative'),
+  },
+});
+
+export type IContact = InferEntity<typeof Contact>;
+
+export const User = defineEntity({
+  name: 'User',
+  properties: {
+    id: p.integer().primary(),
+    contact: () => p.embedded(Contact),
+  },
+});
+
+export type IUser = InferEntity<typeof User>;
+```
+
+  </TabItem>
   <TabItem value="reflect-metadata">
 
 ```ts title="./entities/User.ts"
@@ -354,64 +425,6 @@ export class User {
 ```
 
   </TabItem>
-  <TabItem value="define-entity">
-
-```ts title="./entities/User.ts"
-export const Contact = defineEntity({
-  name: 'Contact',
-  embeddable: true,
-  properties: {
-    address: () => p.embedded(Address).prefix('addr_').prefixMode('absolute'),
-    address2: () => p.embedded(Address).prefix('addr2_').prefixMode('relative'),
-  },
-});
-
-export type IContact = InferEntity<typeof Contact>;
-
-export const User = defineEntity({
-  name: 'User',
-  properties: {
-    id: p.integer().primary(),
-    contact: () => p.embedded(Contact),
-  },
-});
-
-export type IUser = InferEntity<typeof User>;
-```
-
-  </TabItem>
-  <TabItem value="entity-schema">
-
-```ts title="./entities/User.ts"
-export class Contact {
-  address!: Address;
-  address2!: Address;
-}
-
-export class User {
-  id!: number;
-  contact!: Contact;
-}
-
-export const ContactSchema = new EntitySchema({
-  class: Contact,
-  embeddable: true,
-  properties: {
-    address: { kind: 'embedded', entity: () => Address, prefix: 'addr_', prefixMode: 'absolute' },
-    address2: { kind: 'embedded', entity: () => Address, prefix: 'addr2_', prefixMode: 'relative' },
-  },
-});
-
-export const UserSchema = new EntitySchema({
-  class: User,
-  properties: {
-    id: { primary: true, type: 'number' },
-    contact: { kind: 'embedded', entity: () => Contact },
-  },
-});
-```
-
-  </TabItem>
 </Tabs>
 
 The default behavior can be overridden in the ORM configuration:
@@ -428,22 +441,32 @@ To have MikroORM drop the prefix and use the value object's property name direct
 
 <Tabs
   groupId="entity-def"
-  defaultValue="define-entity"
+  defaultValue="define-entity-class"
   values={[
+    {label: 'defineEntity + class', value: 'define-entity-class'},
     {label: 'defineEntity', value: 'define-entity'},
     {label: 'reflect-metadata', value: 'reflect-metadata'},
     {label: 'ts-morph', value: 'ts-morph'},
-    {label: 'EntitySchema', value: 'entity-schema'},
-  ]
-  }>
-  <TabItem value="reflect-metadata">
+]
+  }
+>
+  <TabItem value="define-entity-class">
 
 ```ts title="./entities/User.ts"
-@Embedded({ entity: () => Address, prefix: false })
-address!: Address;
+const UserSchema = defineEntity({
+  name: 'User',
+  properties: {
+    id: p.integer().primary(),
+    address: () => p.embedded(Address).prefix(false),
+  },
+});
+
+export class User extends UserSchema.class {}
+UserSchema.setClass(User);
 ```
 
   </TabItem>
+
   <TabItem value="define-entity">
 
 ```ts title="./entities/User.ts"
@@ -457,18 +480,19 @@ const User = defineEntity({
 ```
 
   </TabItem>
+  <TabItem value="reflect-metadata">
+
+```ts title="./entities/User.ts"
+@Embedded({ entity: () => Address, prefix: false })
+address!: Address;
+```
+
+  </TabItem>
   <TabItem value="ts-morph">
 
 ```ts title="./entities/User.ts"
 @Embedded({ prefix: false })
 address!: Address;
-```
-
-  </TabItem>
-  <TabItem value="entity-schema">
-
-```ts title="./entities/User.ts"@Entity()
-address: { kind: 'embedded', entity: () => Address, prefix: false },
 ```
 
   </TabItem>
@@ -480,30 +504,32 @@ You can also store the embeddable as an object instead of inlining its propertie
 
 <Tabs
   groupId="entity-def"
-  defaultValue="define-entity"
+  defaultValue="define-entity-class"
   values={[
+    {label: 'defineEntity + class', value: 'define-entity-class'},
     {label: 'defineEntity', value: 'define-entity'},
     {label: 'reflect-metadata', value: 'reflect-metadata'},
     {label: 'ts-morph', value: 'ts-morph'},
-    {label: 'EntitySchema', value: 'entity-schema'},
-  ]
-  }>
-  <TabItem value="reflect-metadata">
+]
+  }
+>
+  <TabItem value="define-entity-class">
 
 ```ts title="./entities/User.ts"
-@Embedded({ entity: () => Address, object: true })
-address!: Address;
+const UserSchema = defineEntity({
+  name: 'User',
+  properties: {
+    id: p.integer().primary(),
+    address: () => p.embedded(Address).object(),
+  },
+});
+
+export class User extends UserSchema.class {}
+UserSchema.setClass(User);
 ```
 
   </TabItem>
-  <TabItem value="ts-morph">
 
-```ts title="./entities/User.ts"
-@Embedded({ object: true })
-address!: Address;
-```
-
-  </TabItem>
   <TabItem value="define-entity">
 
 ```ts title="./entities/User.ts"
@@ -517,10 +543,19 @@ const User = defineEntity({
 ```
 
   </TabItem>
-  <TabItem value="entity-schema">
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/User.ts"
-address: { kind: 'embedded', entity: () => Address, object: true },
+@Embedded({ entity: () => Address, object: true })
+address!: Address;
+```
+
+  </TabItem>
+  <TabItem value="ts-morph">
+
+```ts title="./entities/User.ts"
+@Embedded({ object: true })
+address!: Address;
 ```
 
   </TabItem>
@@ -538,14 +573,45 @@ Embedded arrays are always stored as JSON. It is possible to use them inside nes
 
 <Tabs
   groupId="entity-def"
-  defaultValue="define-entity"
+  defaultValue="define-entity-class"
   values={[
+    {label: 'defineEntity + class', value: 'define-entity-class'},
     {label: 'defineEntity', value: 'define-entity'},
     {label: 'reflect-metadata', value: 'reflect-metadata'},
     {label: 'ts-morph', value: 'ts-morph'},
-    {label: 'EntitySchema', value: 'entity-schema'},
-  ]
-  }>
+]
+  }
+>
+  <TabItem value="define-entity-class">
+
+```ts title="./entities/User.ts"
+const UserSchema = defineEntity({
+  name: 'User',
+  properties: {
+    id: p.integer().primary(),
+    addresses: () => p.embedded(Address).array().onCreate(() => []),
+  },
+});
+
+export class User extends UserSchema.class {}
+UserSchema.setClass(User);
+```
+
+  </TabItem>
+
+  <TabItem value="define-entity">
+
+```ts title="./entities/User.ts"
+const User = defineEntity({
+  name: 'User',
+  properties: {
+    id: p.integer().primary(),
+    addresses: () => p.embedded(Address).array().onCreate(() => []),
+  },
+});
+```
+
+  </TabItem>
   <TabItem value="reflect-metadata">
 
 ```ts title="./entities/User.ts"
@@ -562,26 +628,6 @@ addresses: Address[] = [];
 ```
 
   </TabItem>
-  <TabItem value="define-entity">
-
-```ts title="./entities/User.ts"
-const User = defineEntity({
-  name: 'User',
-  properties: {
-    id: p.integer().primary(),
-    addresses: () => p.embedded(Address).array().onCreate(() => []),
-  },
-});
-```
-
-  </TabItem>
-  <TabItem value="entity-schema">
-
-```ts title="./entities/User.ts"
-address: { kind: 'embedded', entity: () => Address, onCreate: () => [], array: true },
-```
-
-  </TabItem>
 </Tabs>
 
 ## Nested embeddables
@@ -590,14 +636,89 @@ You can also nest embeddables, both in inline mode and object mode:
 
 <Tabs
   groupId="entity-def"
-  defaultValue="define-entity"
+  defaultValue="define-entity-class"
   values={[
+    {label: 'defineEntity + class', value: 'define-entity-class'},
     {label: 'defineEntity', value: 'define-entity'},
     {label: 'reflect-metadata', value: 'reflect-metadata'},
     {label: 'ts-morph', value: 'ts-morph'},
-    {label: 'EntitySchema', value: 'entity-schema'},
-  ]
-  }>
+]
+  }
+>
+  <TabItem value="define-entity-class">
+
+```ts title="./entities/User.ts"
+const UserSchema = defineEntity({
+  name: 'User',
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+    address: () => p.embedded(Address),
+  },
+});
+
+
+export const Profile = defineEntity({
+  name: 'Profile',
+  embeddable: true,
+  properties: {
+    username: p.string(),
+    identity: () => p.embedded(Identity),
+  },
+});
+
+
+export const Identity = defineEntity({
+  name: 'Identity',
+  embeddable: true,
+  properties: {
+    email: p.string(),
+  },
+});
+
+export class User extends UserSchema.class {}
+UserSchema.setClass(User);
+```
+
+  </TabItem>
+
+  <TabItem value="define-entity">
+
+```ts title="./entities/User.ts"
+export const User = defineEntity({
+  name: 'User',
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+    address: () => p.embedded(Address),
+  },
+});
+
+export type IUser = InferEntity<typeof User>;
+
+export const Profile = defineEntity({
+  name: 'Profile',
+  embeddable: true,
+  properties: {
+    username: p.string(),
+    identity: () => p.embedded(Identity),
+  },
+});
+
+export type IProfile = InferEntity<typeof Profile>;
+
+export const Identity = defineEntity({
+  name: 'Identity',
+  embeddable: true,
+  properties: {
+    email: p.string(),
+  },
+});
+
+export type IIdentity = InferEntity<typeof Identity>;
+```
+
+  </TabItem>
   <TabItem value="reflect-metadata">
 
 ```ts
@@ -696,93 +817,6 @@ export class Identity {
 ```
 
   </TabItem>
-  <TabItem value="define-entity">
-
-```ts title="./entities/User.ts"
-export const User = defineEntity({
-  name: 'User',
-  properties: {
-    id: p.integer().primary(),
-    name: p.string(),
-    address: () => p.embedded(Address),
-  },
-});
-
-export type IUser = InferEntity<typeof User>;
-
-export const Profile = defineEntity({
-  name: 'Profile',
-  embeddable: true,
-  properties: {
-    username: p.string(),
-    identity: () => p.embedded(Identity),
-  },
-});
-
-export type IProfile = InferEntity<typeof Profile>;
-
-export const Identity = defineEntity({
-  name: 'Identity',
-  embeddable: true,
-  properties: {
-    email: p.string(),
-  },
-});
-
-export type IIdentity = InferEntity<typeof Identity>;
-```
-
-  </TabItem>
-  <TabItem value="entity-schema">
-
-```ts
-import { EntitySchema } from '@mikro-orm/core';
-
-export class User {
-  id!: number;
-  name!: string;
-  profile?: Profile;
-}
-
-export class Profile {
-  constructor(
-    public username: string,
-    public identity: Identity,
-  ) {}
-}
-
-export class Identity {
-  constructor(public email: string) {}
-}
-
-export const UserSchema = new EntitySchema({
-  class: User,
-  properties: {
-    id: { primary: true, type: 'number' },
-    name: { type: 'string' },
-    address: { kind: 'embedded', entity: () => Address },
-  },
-});
-
-export const ProfileSchema = new EntitySchema({
-  class: Profile,
-  embeddable: true,
-  properties: {
-    username: { type: 'string' },
-    identity: { kind: 'embedded', entity: () => Identity },
-  },
-});
-
-export const IdentitySchema = new EntitySchema({
-  class: Identity,
-  embeddable: true,
-  properties: {
-    email: { type: 'string' },
-  },
-});
-```
-
-  </TabItem>
 </Tabs>
 
 ## Polymorphic embeddables
@@ -791,14 +825,127 @@ It is also possible to use polymorphic embeddables. This means you can define mu
 
 <Tabs
   groupId="entity-def"
-  defaultValue="define-entity"
+  defaultValue="define-entity-class"
   values={[
+    {label: 'defineEntity + class', value: 'define-entity-class'},
     {label: 'defineEntity', value: 'define-entity'},
     {label: 'reflect-metadata', value: 'reflect-metadata'},
     {label: 'ts-morph', value: 'ts-morph'},
-    {label: 'EntitySchema', value: 'entity-schema'},
-  ]
-  }>
+]
+  }
+>
+  <TabItem value="define-entity-class">
+
+```ts
+import { defineEntity, p, type InferEntity } from '@mikro-orm/core';
+
+export enum AnimalType {
+  CAT,
+  DOG,
+}
+
+const AnimalSchema = defineEntity({
+  name: 'Animal',
+  embeddable: true,
+  abstract: true,
+  discriminatorColumn: 'type',
+  properties: {
+    type: p.enum(() => AnimalType),
+    name: p.string(),
+  },
+});
+
+export const Cat = defineEntity({
+  name: 'Cat',
+  embeddable: true,
+  extends: Animal,
+  discriminatorValue: AnimalType.CAT,
+  properties: {
+    canMeow: p.boolean().nullable(),
+  },
+});
+
+export const Dog = defineEntity({
+  name: 'Dog',
+  embeddable: true,
+  extends: Animal,
+  discriminatorValue: AnimalType.DOG,
+  properties: {
+    canBark: p.boolean().nullable(),
+  },
+});
+
+export const Owner = defineEntity({
+  name: 'Owner',
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+    pet: () => p.embedded([Cat, Dog]),
+  },
+});
+
+export class Animal extends AnimalSchema.class {}
+AnimalSchema.setClass(Animal);
+```
+
+  </TabItem>
+
+  <TabItem value="define-entity">
+
+```ts
+import { defineEntity, p, type InferEntity } from '@mikro-orm/core';
+
+export enum AnimalType {
+  CAT,
+  DOG,
+}
+
+export const Animal = defineEntity({
+  name: 'Animal',
+  embeddable: true,
+  abstract: true,
+  discriminatorColumn: 'type',
+  properties: {
+    type: p.enum(() => AnimalType),
+    name: p.string(),
+  },
+});
+
+export const Cat = defineEntity({
+  name: 'Cat',
+  embeddable: true,
+  extends: Animal,
+  discriminatorValue: AnimalType.CAT,
+  properties: {
+    canMeow: p.boolean().nullable(),
+  },
+});
+
+export const Dog = defineEntity({
+  name: 'Dog',
+  embeddable: true,
+  extends: Animal,
+  discriminatorValue: AnimalType.DOG,
+  properties: {
+    canBark: p.boolean().nullable(),
+  },
+});
+
+export const Owner = defineEntity({
+  name: 'Owner',
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+    pet: () => p.embedded([Cat, Dog]),
+  },
+});
+
+export type Cat = InferEntity<typeof Cat>;
+export type Dog = InferEntity<typeof Dog>;
+export type Owner = InferEntity<typeof Owner>;
+```
+
+  </TabItem>
   <TabItem value="reflect-metadata">
 
 ```ts
@@ -926,145 +1073,6 @@ export class Owner {
   pet!: Cat | Dog;
 
 }
-```
-
-  </TabItem>
-  <TabItem value="define-entity">
-
-```ts
-import { defineEntity, p, type InferEntity } from '@mikro-orm/core';
-
-export enum AnimalType {
-  CAT,
-  DOG,
-}
-
-export const Animal = defineEntity({
-  name: 'Animal',
-  embeddable: true,
-  abstract: true,
-  discriminatorColumn: 'type',
-  properties: {
-    type: p.enum(() => AnimalType),
-    name: p.string(),
-  },
-});
-
-export const Cat = defineEntity({
-  name: 'Cat',
-  embeddable: true,
-  extends: Animal,
-  discriminatorValue: AnimalType.CAT,
-  properties: {
-    canMeow: p.boolean().nullable(),
-  },
-});
-
-export const Dog = defineEntity({
-  name: 'Dog',
-  embeddable: true,
-  extends: Animal,
-  discriminatorValue: AnimalType.DOG,
-  properties: {
-    canBark: p.boolean().nullable(),
-  },
-});
-
-export const Owner = defineEntity({
-  name: 'Owner',
-  properties: {
-    id: p.integer().primary(),
-    name: p.string(),
-    pet: () => p.embedded([Cat, Dog]),
-  },
-});
-
-export type Cat = InferEntity<typeof Cat>;
-export type Dog = InferEntity<typeof Dog>;
-export type Owner = InferEntity<typeof Owner>;
-```
-
-  </TabItem>
-  <TabItem value="entity-schema">
-
-```ts
-import { EntitySchema } from '@mikro-orm/core';
-
-export enum AnimalType {
-  CAT,
-  DOG,
-}
-
-export abstract class Animal {
-  type!: AnimalType;
-  name!: string;
-}
-
-export class Cat extends Animal {
-  canMeow? = true;
-
-  constructor(name: string) {
-    super();
-    this.type = AnimalType.CAT;
-    this.name = name;
-  }
-}
-
-export class Dog extends Animal {
-  canBark? = true;
-
-  constructor(name: string) {
-    super();
-    this.type = AnimalType.DOG;
-    this.name = name;
-  }
-}
-
-export class Owner {
-  id!: number;
-  name!: string;
-  pet!: Cat | Dog;
-}
-
-export const AnimalSchema = new EntitySchema({
-  class: Animal,
-  embeddable: true,
-  abstract: true,
-  discriminatorColumn: 'type',
-  properties: {
-    type: { enum: true, items: () => AnimalType },
-    name: { type: 'string' },
-  },
-});
-
-export const CatSchema = new EntitySchema({
-  class: Cat,
-  embeddable: true,
-  extends: Animal,
-  discriminatorValue: AnimalType.CAT,
-  properties: {
-    canMeow: { type: 'boolean', nullable: true },
-  },
-});
-
-export const DogSchema = new EntitySchema({
-  class: Dog,
-  embeddable: true,
-  extends: Animal,
-  discriminatorValue: AnimalType.DOG,
-  properties: {
-    canBark: { type: 'boolean', nullable: true },
-  },
-});
-
-export const OwnerSchema = new EntitySchema({
-  class: Owner,
-  properties: {
-    id: { primary: true, type: 'number' },
-    name: { type: 'string' },
-    pet: { kind: 'embedded', entity: () => [Cat, Dog] },
-  },
-});
 ```
 
   </TabItem>

--- a/docs/docs/indexes.md
+++ b/docs/docs/indexes.md
@@ -17,10 +17,10 @@ defaultValue="reflect-metadata"
 values={[
 {label: 'reflect-metadata', value: 'reflect-metadata'},
 {label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
 ]
-}>
-<TabItem value="reflect-metadata">
+}
+>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Author.ts"
 @Entity()
@@ -76,28 +76,6 @@ export class Author {
 ```
 
 </TabItem>
-<TabItem value="entity-schema">
-
-```ts title="./entities/Author.ts"
-export const AuthorSchema = new EntitySchema<Author>({
-  class: Author,
-  indexes: [
-    { properties: ['name', 'age'] },
-    { name: 'custom_idx_name', properties: ['name'] },
-  ],
-  uniques: [
-    { properties: ['name', 'email'] },
-  ],
-  properties: {
-    id: { type: Number, primary: true },
-    name: { type: String, index: true },
-    email: { type: String, unique: true },
-    age: { type: Number, nullable: true, index: 'age_idx' },
-  },
-});
-```
-
-</TabItem>
 </Tabs>
 
 ## Custom Index Expressions
@@ -109,10 +87,10 @@ groupId="entity-def"
 defaultValue="reflect-metadata"
 values={[
 {label: 'reflect-metadata', value: 'reflect-metadata'},
-{label: 'EntitySchema', value: 'entity-schema'},
 ]
-}>
-<TabItem value="reflect-metadata">
+}
+>
+  <TabItem value="reflect-metadata">
 
 ```ts title="./entities/Author.ts"
 @Entity()
@@ -136,30 +114,6 @@ export class Author {
   country!: string;
 
 }
-```
-
-</TabItem>
-<TabItem value="entity-schema">
-
-```ts title="./entities/Author.ts"
-export const AuthorSchema = new EntitySchema({
-  class: Author,
-  indexes: [
-    {
-      name: 'custom_index_expr',
-      expression: 'alter table `author` add index `custom_index_expr`(`title`)'
-    },
-    {
-      name: 'custom_index_country',
-      expression: (table, columns, indexName) =>
-        `create index \`${indexName}\` on \`${table.name}\` (\`${columns.country}\`)`
-    },
-  ],
-  properties: {
-    title: { type: String },
-    country: { type: String },
-  },
-});
 ```
 
 </TabItem>

--- a/docs/docs/inheritance-mapping.md
+++ b/docs/docs/inheritance-mapping.md
@@ -17,13 +17,92 @@ Mapped superclasses, just as regular, non-mapped classes, can appear in the midd
 
 <Tabs
   groupId="entity-def"
-  defaultValue="define-entity"
+  defaultValue="define-entity-class"
   values={[
+    {label: 'defineEntity + class', value: 'define-entity-class'},
     {label: 'defineEntity', value: 'define-entity'},
     {label: 'decorators', value: 'decorators'},
-    {label: 'EntitySchema', value: 'entity-schema'},
-  ]
-}>
+]
+}
+>
+  <TabItem value="define-entity-class">
+
+```ts
+const p = defineEntity.properties;
+
+// mapped superclass (abstract entity that won't have its own table)
+const PersonSchema = defineEntity({
+  name: 'Person',
+  abstract: true,
+  properties: {
+    mapped1: p.number(),
+    mapped2: p.string(),
+    toothbrush: () => p.oneToOne(Toothbrush),
+  },
+});
+
+export const Employee = defineEntity({
+  name: 'Employee',
+  extends: Person,
+  properties: {
+    id: p.number().primary(),
+    name: p.string(),
+  },
+});
+
+export const Toothbrush = defineEntity({
+  name: 'Toothbrush',
+  properties: {
+    id: p.number().primary(),
+    // ... more fields
+  },
+});
+
+export class Person extends PersonSchema.class {}
+PersonSchema.setClass(Person);
+```
+
+  </TabItem>
+
+  <TabItem value="define-entity">
+
+```ts
+const p = defineEntity.properties;
+
+// mapped superclass (abstract entity that won't have its own table)
+export const Person = defineEntity({
+  name: 'Person',
+  abstract: true,
+  properties: {
+    mapped1: p.number(),
+    mapped2: p.string(),
+    toothbrush: () => p.oneToOne(Toothbrush),
+  },
+});
+
+export const Employee = defineEntity({
+  name: 'Employee',
+  extends: Person,
+  properties: {
+    id: p.number().primary(),
+    name: p.string(),
+  },
+});
+
+export const Toothbrush = defineEntity({
+  name: 'Toothbrush',
+  properties: {
+    id: p.number().primary(),
+    // ... more fields
+  },
+});
+
+export type Person = InferEntity<typeof Person>;
+export type Employee = InferEntity<typeof Employee>;
+export type Toothbrush = InferEntity<typeof Toothbrush>;
+```
+
+  </TabItem>
   <TabItem value="decorators">
 
 ```ts
@@ -68,78 +147,6 @@ export class Toothbrush {
 ```
 
   </TabItem>
-  <TabItem value="define-entity">
-
-```ts
-const p = defineEntity.properties;
-
-// mapped superclass (abstract entity that won't have its own table)
-export const Person = defineEntity({
-  name: 'Person',
-  abstract: true,
-  properties: {
-    mapped1: p.number(),
-    mapped2: p.string(),
-    toothbrush: () => p.oneToOne(Toothbrush),
-  },
-});
-
-export const Employee = defineEntity({
-  name: 'Employee',
-  extends: Person,
-  properties: {
-    id: p.number().primary(),
-    name: p.string(),
-  },
-});
-
-export const Toothbrush = defineEntity({
-  name: 'Toothbrush',
-  properties: {
-    id: p.number().primary(),
-    // ... more fields
-  },
-});
-
-export type Person = InferEntity<typeof Person>;
-export type Employee = InferEntity<typeof Employee>;
-export type Toothbrush = InferEntity<typeof Toothbrush>;
-```
-
-  </TabItem>
-  <TabItem value="entity-schema">
-
-```ts
-// mapped superclass (abstract entity that won't have its own table)
-export const Person = new EntitySchema({
-  name: 'Person',
-  abstract: true,
-  properties: {
-    mapped1: { type: 'number' },
-    mapped2: { type: 'string' },
-    toothbrush: { kind: '1:1', entity: () => Toothbrush },
-  },
-});
-
-export const Employee = new EntitySchema({
-  name: 'Employee',
-  extends: Person,
-  properties: {
-    id: { type: 'number', primary: true },
-    name: { type: 'string' },
-  },
-});
-
-export const Toothbrush = new EntitySchema({
-  name: 'Toothbrush',
-  properties: {
-    id: { type: 'number', primary: true },
-    // ... more fields
-  },
-});
-```
-
-  </TabItem>
 </Tabs>
 
 The DDL for the corresponding database schema would look something like this (this is for SQLite):
@@ -163,31 +170,40 @@ As you can see from this DDL snippet, there is only a single table for the entit
 
 <Tabs
   groupId="entity-def"
-  defaultValue="define-entity"
+  defaultValue="define-entity-class"
   values={[
+    {label: 'defineEntity + class', value: 'define-entity-class'},
     {label: 'defineEntity', value: 'define-entity'},
     {label: 'decorators', value: 'decorators'},
-    {label: 'EntitySchema', value: 'entity-schema'},
-  ]
-}>
-  <TabItem value="decorators">
+]
+}
+>
+  <TabItem value="define-entity-class">
 
 ```ts
-@Entity({
+const PersonSchema = defineEntity({
+  name: 'Person',
   discriminatorColumn: 'discr',
   discriminatorMap: { person: 'Person', employee: 'Employee' },
-})
-export class Person {
-  // ...
-}
+  properties: {
+    // ...
+  },
+});
 
-@Entity()
-export class Employee extends Person {
-  // ...
-}
+export const Employee = defineEntity({
+  name: 'Employee',
+  extends: Person,
+  properties: {
+    // ...
+  },
+});
+
+export class Person extends PersonSchema.class {}
+PersonSchema.setClass(Person);
 ```
 
   </TabItem>
+
   <TabItem value="define-entity">
 
 ```ts
@@ -210,25 +226,21 @@ export const Employee = defineEntity({
 ```
 
   </TabItem>
-  <TabItem value="entity-schema">
+  <TabItem value="decorators">
 
 ```ts
-export const Person = new EntitySchema({
-  name: 'Person',
+@Entity({
   discriminatorColumn: 'discr',
   discriminatorMap: { person: 'Person', employee: 'Employee' },
-  properties: {
-    // ...
-  },
-});
+})
+export class Person {
+  // ...
+}
 
-export const Employee = new EntitySchema({
-  name: 'Employee',
-  extends: Person,
-  properties: {
-    // ...
-  },
-});
+@Entity()
+export class Employee extends Person {
+  // ...
+}
 ```
 
   </TabItem>
@@ -248,33 +260,41 @@ As noted above, the discriminator map can be auto-generated. In that case, you m
 
 <Tabs
   groupId="entity-def"
-  defaultValue="define-entity"
+  defaultValue="define-entity-class"
   values={[
+    {label: 'defineEntity + class', value: 'define-entity-class'},
     {label: 'defineEntity', value: 'define-entity'},
     {label: 'decorators', value: 'decorators'},
-    {label: 'EntitySchema', value: 'entity-schema'},
-  ]
-}>
-  <TabItem value="decorators">
+]
+}
+>
+  <TabItem value="define-entity-class">
 
 ```ts
-@Entity({
+const PersonSchema = defineEntity({
+  name: 'Person',
   discriminatorColumn: 'discr',
   discriminatorValue: 'person',
-})
-export class Person {
-  // ...
-}
+  properties: {
+    // ...
+  },
+});
 
-@Entity({
+export const Employee = defineEntity({
+  name: 'Employee',
+  extends: Person,
   discriminatorValue: 'employee',
-})
-export class Employee extends Person {
-  // ...
-}
+  properties: {
+    // ...
+  },
+});
+
+export class Person extends PersonSchema.class {}
+PersonSchema.setClass(Person);
 ```
 
   </TabItem>
+
   <TabItem value="define-entity">
 
 ```ts
@@ -298,26 +318,23 @@ export const Employee = defineEntity({
 ```
 
   </TabItem>
-  <TabItem value="entity-schema">
+  <TabItem value="decorators">
 
 ```ts
-export const Person = new EntitySchema({
-  name: 'Person',
+@Entity({
   discriminatorColumn: 'discr',
   discriminatorValue: 'person',
-  properties: {
-    // ...
-  },
-});
+})
+export class Person {
+  // ...
+}
 
-export const Employee = new EntitySchema({
-  name: 'Employee',
-  extends: Person,
+@Entity({
   discriminatorValue: 'employee',
-  properties: {
-    // ...
-  },
-});
+})
+export class Employee extends Person {
+  // ...
+}
 ```
 
   </TabItem>
@@ -336,39 +353,49 @@ Following example shows how you can define the discriminator explicitly, as well
 
 <Tabs
   groupId="entity-def"
-  defaultValue="define-entity"
+  defaultValue="define-entity-class"
   values={[
+    {label: 'defineEntity + class', value: 'define-entity-class'},
     {label: 'defineEntity', value: 'define-entity'},
     {label: 'decorators', value: 'decorators'},
-    {label: 'EntitySchema', value: 'entity-schema'},
-  ]
-}>
-  <TabItem value="decorators">
+]
+}
+>
+  <TabItem value="define-entity-class">
 
 ```ts
-@Entity({
+const BasePersonSchema = defineEntity({
+  name: 'BasePerson',
+  abstract: true,
   discriminatorColumn: 'type',
   discriminatorMap: { person: 'Person', employee: 'Employee' },
-})
-export abstract class BasePerson {
+  properties: {
+    type: p.enum(['person', 'employee'] as const),
+  },
+});
 
-  @Enum()
-  type!: 'person' | 'employee';
+export const Person = defineEntity({
+  name: 'Person',
+  extends: BasePerson,
+  properties: {
+    // ...
+  },
+});
 
-}
+export const Employee = defineEntity({
+  name: 'Employee',
+  extends: Person,
+  properties: {
+    // ...
+  },
+});
 
-@Entity()
-export class Person extends BasePerson {
-  // ...
-}
-
-@Entity()
-export class Employee extends Person {
-  // ...
-}
+export class BasePerson extends BasePersonSchema.class {}
+BasePersonSchema.setClass(BasePerson);
 ```
 
   </TabItem>
+
   <TabItem value="define-entity">
 
 ```ts
@@ -400,34 +427,29 @@ export const Employee = defineEntity({
 ```
 
   </TabItem>
-  <TabItem value="entity-schema">
+  <TabItem value="decorators">
 
 ```ts
-export const BasePerson = new EntitySchema({
-  name: 'BasePerson',
-  abstract: true,
+@Entity({
   discriminatorColumn: 'type',
   discriminatorMap: { person: 'Person', employee: 'Employee' },
-  properties: {
-    type: { enum: true, items: ['person', 'employee'] },
-  },
-});
+})
+export abstract class BasePerson {
 
-export const Person = new EntitySchema({
-  name: 'Person',
-  extends: BasePerson,
-  properties: {
-    // ...
-  },
-});
+  @Enum()
+  type!: 'person' | 'employee';
 
-export const Employee = new EntitySchema({
-  name: 'Employee',
-  extends: Person,
-  properties: {
-    // ...
-  },
-});
+}
+
+@Entity()
+export class Person extends BasePerson {
+  // ...
+}
+
+@Entity()
+export class Employee extends Person {
+  // ...
+}
 ```
 
   </TabItem>
@@ -437,13 +459,82 @@ If you want to use `discriminatorValue` with abstract entities, you need to mark
 
 <Tabs
   groupId="entity-def"
-  defaultValue="define-entity"
+  defaultValue="define-entity-class"
   values={[
+    {label: 'defineEntity + class', value: 'define-entity-class'},
     {label: 'defineEntity', value: 'define-entity'},
     {label: 'decorators', value: 'decorators'},
-    {label: 'EntitySchema', value: 'entity-schema'},
-  ]
-}>
+]
+}
+>
+  <TabItem value="define-entity-class">
+
+```ts
+const BasePersonSchema = defineEntity({
+  name: 'BasePerson',
+  abstract: true,
+  discriminatorColumn: 'type',
+  properties: {
+    type: p.enum(['person', 'employee'] as const),
+  },
+});
+
+export const Person = defineEntity({
+  name: 'Person',
+  extends: BasePerson,
+  discriminatorValue: 'person',
+  properties: {
+    // ...
+  },
+});
+
+export const Employee = defineEntity({
+  name: 'Employee',
+  extends: Person,
+  discriminatorValue: 'employee',
+  properties: {
+    // ...
+  },
+});
+
+export class BasePerson extends BasePersonSchema.class {}
+BasePersonSchema.setClass(BasePerson);
+```
+
+  </TabItem>
+
+  <TabItem value="define-entity">
+
+```ts
+export const BasePerson = defineEntity({
+  name: 'BasePerson',
+  abstract: true,
+  discriminatorColumn: 'type',
+  properties: {
+    type: p.enum(['person', 'employee'] as const),
+  },
+});
+
+export const Person = defineEntity({
+  name: 'Person',
+  extends: BasePerson,
+  discriminatorValue: 'person',
+  properties: {
+    // ...
+  },
+});
+
+export const Employee = defineEntity({
+  name: 'Employee',
+  extends: Person,
+  discriminatorValue: 'employee',
+  properties: {
+    // ...
+  },
+});
+```
+
+  </TabItem>
   <TabItem value="decorators">
 
 ```ts
@@ -467,70 +558,6 @@ export class Person extends BasePerson {
 export class Employee extends Person {
   // ...
 }
-```
-
-  </TabItem>
-  <TabItem value="define-entity">
-
-```ts
-export const BasePerson = defineEntity({
-  name: 'BasePerson',
-  abstract: true,
-  discriminatorColumn: 'type',
-  properties: {
-    type: p.enum(['person', 'employee'] as const),
-  },
-});
-
-export const Person = defineEntity({
-  name: 'Person',
-  extends: BasePerson,
-  discriminatorValue: 'person',
-  properties: {
-    // ...
-  },
-});
-
-export const Employee = defineEntity({
-  name: 'Employee',
-  extends: Person,
-  discriminatorValue: 'employee',
-  properties: {
-    // ...
-  },
-});
-```
-
-  </TabItem>
-  <TabItem value="entity-schema">
-
-```ts
-export const BasePerson = new EntitySchema({
-  name: 'BasePerson',
-  abstract: true,
-  discriminatorColumn: 'type',
-  properties: {
-    type: { enum: true, items: ['person', 'employee'] },
-  },
-});
-
-export const Person = new EntitySchema({
-  name: 'Person',
-  extends: BasePerson,
-  discriminatorValue: 'person',
-  properties: {
-    // ...
-  },
-});
-
-export const Employee = new EntitySchema({
-  name: 'Employee',
-  extends: Person,
-  discriminatorValue: 'employee',
-  properties: {
-    // ...
-  },
-});
 ```
 
   </TabItem>
@@ -576,45 +603,49 @@ Use `inheritance: 'tpt'` on the root entity of the hierarchy:
 
 <Tabs
   groupId="entity-def"
-  defaultValue="define-entity"
+  defaultValue="define-entity-class"
   values={[
+    {label: 'defineEntity + class', value: 'define-entity-class'},
     {label: 'defineEntity', value: 'define-entity'},
     {label: 'decorators', value: 'decorators'},
-    {label: 'EntitySchema', value: 'entity-schema'},
-  ]
-}>
-  <TabItem value="decorators">
+]
+}
+>
+  <TabItem value="define-entity-class">
 
 ```ts
-@Entity({ inheritance: 'tpt' })
-export abstract class Person {
+const PersonSchema = defineEntity({
+  name: 'Person',
+  abstract: true,
+  inheritance: 'tpt',
+  properties: {
+    id: p.number().primary(),
+    name: p.string(),
+  },
+});
 
-  @PrimaryKey()
-  id!: number;
+export const Employee = defineEntity({
+  name: 'Employee',
+  extends: Person,
+  properties: {
+    department: p.string(),
+  },
+});
 
-  @Property()
-  name!: string;
+export const Customer = defineEntity({
+  name: 'Customer',
+  extends: Person,
+  properties: {
+    loyaltyPoints: p.number(),
+  },
+});
 
-}
-
-@Entity()
-export class Employee extends Person {
-
-  @Property()
-  department!: string;
-
-}
-
-@Entity()
-export class Customer extends Person {
-
-  @Property()
-  loyaltyPoints!: number;
-
-}
+export class Person extends PersonSchema.class {}
+PersonSchema.setClass(Person);
 ```
 
   </TabItem>
+
   <TabItem value="define-entity">
 
 ```ts
@@ -646,34 +677,35 @@ export const Customer = defineEntity({
 ```
 
   </TabItem>
-  <TabItem value="entity-schema">
+  <TabItem value="decorators">
 
 ```ts
-export const Person = new EntitySchema({
-  name: 'Person',
-  abstract: true,
-  inheritance: 'tpt',
-  properties: {
-    id: { type: 'number', primary: true },
-    name: { type: 'string' },
-  },
-});
+@Entity({ inheritance: 'tpt' })
+export abstract class Person {
 
-export const Employee = new EntitySchema({
-  name: 'Employee',
-  extends: Person,
-  properties: {
-    department: { type: 'string' },
-  },
-});
+  @PrimaryKey()
+  id!: number;
 
-export const Customer = new EntitySchema({
-  name: 'Customer',
-  extends: Person,
-  properties: {
-    loyaltyPoints: { type: 'number' },
-  },
-});
+  @Property()
+  name!: string;
+
+}
+
+@Entity()
+export class Employee extends Person {
+
+  @Property()
+  department!: string;
+
+}
+
+@Entity()
+export class Customer extends Person {
+
+  @Property()
+  loyaltyPoints!: number;
+
+}
 ```
 
   </TabItem>
@@ -761,39 +793,49 @@ TPT supports deep inheritance hierarchies. Each level adds another table and joi
 
 <Tabs
   groupId="entity-def"
-  defaultValue="define-entity"
+  defaultValue="define-entity-class"
   values={[
+    {label: 'defineEntity + class', value: 'define-entity-class'},
     {label: 'defineEntity', value: 'define-entity'},
     {label: 'decorators', value: 'decorators'},
-    {label: 'EntitySchema', value: 'entity-schema'},
-  ]
-}>
-  <TabItem value="decorators">
+]
+}
+>
+  <TabItem value="define-entity-class">
 
 ```ts
-@Entity({ inheritance: 'tpt' })
-export abstract class Person {
-  @PrimaryKey()
-  id!: number;
+const PersonSchema = defineEntity({
+  name: 'Person',
+  abstract: true,
+  inheritance: 'tpt',
+  properties: {
+    id: p.number().primary(),
+    name: p.string(),
+  },
+});
 
-  @Property()
-  name!: string;
-}
+export const Employee = defineEntity({
+  name: 'Employee',
+  extends: Person,
+  properties: {
+    department: p.string(),
+  },
+});
 
-@Entity()
-export class Employee extends Person {
-  @Property()
-  department!: string;
-}
+export const Manager = defineEntity({
+  name: 'Manager',
+  extends: Employee,
+  properties: {
+    teamSize: p.number(),
+  },
+});
 
-@Entity()
-export class Manager extends Employee {
-  @Property()
-  teamSize!: number;
-}
+export class Person extends PersonSchema.class {}
+PersonSchema.setClass(Person);
 ```
 
   </TabItem>
+
   <TabItem value="define-entity">
 
 ```ts
@@ -825,34 +867,29 @@ export const Manager = defineEntity({
 ```
 
   </TabItem>
-  <TabItem value="entity-schema">
+  <TabItem value="decorators">
 
 ```ts
-export const Person = new EntitySchema({
-  name: 'Person',
-  abstract: true,
-  inheritance: 'tpt',
-  properties: {
-    id: { type: 'number', primary: true },
-    name: { type: 'string' },
-  },
-});
+@Entity({ inheritance: 'tpt' })
+export abstract class Person {
+  @PrimaryKey()
+  id!: number;
 
-export const Employee = new EntitySchema({
-  name: 'Employee',
-  extends: Person,
-  properties: {
-    department: { type: 'string' },
-  },
-});
+  @Property()
+  name!: string;
+}
 
-export const Manager = new EntitySchema({
-  name: 'Manager',
-  extends: Employee,
-  properties: {
-    teamSize: { type: 'number' },
-  },
-});
+@Entity()
+export class Employee extends Person {
+  @Property()
+  department!: string;
+}
+
+@Entity()
+export class Manager extends Employee {
+  @Property()
+  teamSize!: number;
+}
 ```
 
   </TabItem>

--- a/docs/docs/materialized-views.md
+++ b/docs/docs/materialized-views.md
@@ -13,14 +13,46 @@ To create a materialized view entity, use `view: { materialized: true }` in your
 
 <Tabs
   groupId="entity-def"
-  defaultValue="define-entity"
+  defaultValue="define-entity-class"
   values={[
+    {label: 'defineEntity + class', value: 'define-entity-class'},
     {label: 'defineEntity', value: 'define-entity'},
     {label: 'reflect-metadata', value: 'reflect-metadata'},
     {label: 'ts-morph', value: 'ts-morph'},
-    {label: 'EntitySchema', value: 'entity-schema'},
-  ]
-  }>
+]
+  }
+>
+  <TabItem value="define-entity-class">
+
+```ts title="./entities/AuthorStats.ts"
+import { defineEntity, p } from '@mikro-orm/postgresql';
+
+const AuthorStatsSchema = defineEntity({
+  name: 'AuthorStats',
+  tableName: 'author_stats_matview',
+  view: { materialized: true },
+  expression: `
+    select
+      a.id,
+      a.name,
+      count(b.id)::int as book_count
+    from author a
+    left join book b on b.author_id = a.id
+    group by a.id
+  `,
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+    bookCount: p.integer(),
+  },
+});
+
+export class AuthorStats extends AuthorStatsSchema.class {}
+AuthorStatsSchema.setClass(AuthorStats);
+```
+
+  </TabItem>
+
   <TabItem value="define-entity">
 
 ```ts title="./entities/AuthorStats.ts"
@@ -111,39 +143,6 @@ export class AuthorStats {
   bookCount!: number;
 
 }
-```
-
-  </TabItem>
-  <TabItem value="entity-schema">
-
-```ts title="./entities/AuthorStats.ts"
-import { EntitySchema } from '@mikro-orm/postgresql';
-
-export interface IAuthorStats {
-  id: number;
-  name: string;
-  bookCount: number;
-}
-
-export const AuthorStats = new EntitySchema<IAuthorStats>({
-  name: 'AuthorStats',
-  tableName: 'author_stats_matview',
-  view: { materialized: true },
-  expression: `
-    select
-      a.id,
-      a.name,
-      count(b.id)::int as book_count
-    from author a
-    left join book b on b.author_id = a.id
-    group by a.id
-  `,
-  properties: {
-    id: { type: 'number', primary: true },
-    name: { type: 'string' },
-    bookCount: { type: 'number' },
-  },
-});
 ```
 
   </TabItem>

--- a/docs/docs/multiple-schemas.md
+++ b/docs/docs/multiple-schemas.md
@@ -130,14 +130,46 @@ Reference attached databases using the `schema` option:
 
 <Tabs
   groupId="entity-def"
-  defaultValue="reflect-metadata"
+  defaultValue="define-entity-class"
   values={[
+    {label: 'defineEntity + class', value: 'define-entity-class'},
     {label: 'defineEntity', value: 'define-entity'},
     {label: 'reflect-metadata', value: 'reflect-metadata'},
     {label: 'ts-morph', value: 'ts-morph'},
-    {label: 'EntitySchema', value: 'entity-schema'},
-  ]
-  }>
+]
+  }
+>
+  <TabItem value="define-entity-class">
+
+```ts
+import { defineEntity, p } from '@mikro-orm/core';
+
+// Entity in the main database (schema is optional for main)
+const AuthorSchema = defineEntity({
+  name: 'Author',
+  schema: 'main',
+  properties: {
+    id: p.number().primary(),
+    name: p.string(),
+  },
+});
+
+// Entity in an attached database
+export const UserProfile = defineEntity({
+  name: 'UserProfile',
+  schema: 'users_db',
+  properties: {
+    id: p.number().primary(),
+    username: p.string(),
+  },
+});
+
+export class Author extends AuthorSchema.class {}
+AuthorSchema.setClass(Author);
+```
+
+  </TabItem>
+
   <TabItem value="define-entity">
 
 ```ts
@@ -220,41 +252,6 @@ class UserProfile {
   username!: string;
 
 }
-```
-
-  </TabItem>
-  <TabItem value="entity-schema">
-
-```ts
-export interface IAuthor {
-  id: number;
-  name: string;
-}
-
-export interface IUserProfile {
-  id: number;
-  username: string;
-}
-
-// Entity in the main database (schema is optional for main)
-export const Author = new EntitySchema<IAuthor>({
-  name: 'Author',
-  schema: 'main',
-  properties: {
-    id: { type: 'number', primary: true },
-    name: { type: 'string' },
-  },
-});
-
-// Entity in an attached database
-export const UserProfile = new EntitySchema<IUserProfile>({
-  name: 'UserProfile',
-  schema: 'users_db',
-  properties: {
-    id: { type: 'number', primary: true },
-    username: { type: 'string' },
-  },
-});
 ```
 
   </TabItem>

--- a/docs/docs/quick-start.md
+++ b/docs/docs/quick-start.md
@@ -116,13 +116,36 @@ Now you can start defining your entities. MikroORM supports multiple approaches:
 
 <Tabs
   groupId="entity-def"
-  defaultValue="define-entity"
+  defaultValue="define-entity-class"
   values={[
+    {label: 'defineEntity + class', value: 'define-entity-class'},
     {label: 'defineEntity', value: 'define-entity'},
     {label: 'decorators', value: 'decorators'},
-    {label: 'EntitySchema', value: 'entity-schema'},
-  ]
-}>
+]
+}
+>
+  <TabItem value="define-entity-class">
+
+The `defineEntity` helper with a class extension gives you clean named types and a natural place for custom methods:
+
+```ts title="./entities/Book.ts"
+import { defineEntity, p } from '@mikro-orm/core';
+
+const BookSchema = defineEntity({
+  name: 'Book',
+  properties: {
+    id: p.bigint().primary(),
+    title: p.string(),
+    author: () => p.manyToOne(Author),
+    tags: () => p.manyToMany(BookTag),
+  },
+});
+
+export class Book extends BookSchema.class {}
+BookSchema.setClass(Book);
+```
+
+  </TabItem>
   <TabItem value="define-entity">
 
 The `defineEntity` helper provides full type inference without decorators:
@@ -142,8 +165,6 @@ export const Book = defineEntity({
 
 export type Book = InferEntity<typeof Book>;
 ```
-
-To add custom methods, extend `Book.class` and register it with `Book.setClass(CustomBook)`. See the [EntitySchema docs](./entity-schema.md#adding-custom-methods) for details.
 
   </TabItem>
   <TabItem value="decorators">
@@ -169,32 +190,6 @@ export class Book {
   tags = new Collection<BookTag>(this);
 
 }
-```
-
-  </TabItem>
-  <TabItem value="entity-schema">
-
-`EntitySchema` allows programmatic definition without decorators:
-
-```ts title="./entities/Book.ts"
-import { EntitySchema, Collection } from '@mikro-orm/core';
-
-export interface IBook {
-  id: bigint;
-  title: string;
-  author: Author;
-  tags: Collection<BookTag>;
-}
-
-export const Book = new EntitySchema<IBook>({
-  name: 'Book',
-  properties: {
-    id: { type: 'bigint', primary: true },
-    title: { type: 'string' },
-    author: { kind: 'm:1', entity: () => Author },
-    tags: { kind: 'm:n', entity: () => BookTag },
-  },
-});
 ```
 
   </TabItem>

--- a/docs/docs/relationships.md
+++ b/docs/docs/relationships.md
@@ -25,14 +25,51 @@ There are multiple ways how to define the relationship, all of the following is 
 
 <Tabs
   groupId="entity-def"
-  defaultValue="define-entity"
+  defaultValue="define-entity-class"
   values={[
+    {label: 'defineEntity + class', value: 'define-entity-class'},
     {label: 'defineEntity', value: 'define-entity'},
     {label: 'reflect-metadata', value: 'reflect-metadata'},
     {label: 'ts-morph', value: 'ts-morph'},
-    {label: 'EntitySchema', value: 'entity-schema'},
-  ]
-  }>
+]
+  }
+>
+  <TabItem value="define-entity-class">
+
+```ts
+import { defineEntity, InferEntity, p } from '@mikro-orm/core';
+
+const BookSchema = defineEntity({
+  name: 'Book',
+  properties: {
+    id: p.integer().primary(),
+    author: () => p.manyToOne(Author),
+  },
+});
+
+export class Book extends BookSchema.class {}
+BookSchema.setClass(Book);
+```
+
+  </TabItem>
+
+  <TabItem value="define-entity">
+
+```ts
+import { defineEntity, InferEntity, p } from '@mikro-orm/core';
+
+export const Book = defineEntity({
+  name: 'Book',
+  properties: {
+    id: p.integer().primary(),
+    author: () => p.manyToOne(Author),
+  },
+});
+
+export type IBook = InferEntity<typeof Book>;
+```
+
+  </TabItem>
   <TabItem value="reflect-metadata">
 
 ```ts
@@ -65,41 +102,6 @@ export class Book {
 ```
 
   </TabItem>
-  <TabItem value="define-entity">
-
-```ts
-import { defineEntity, InferEntity, p } from '@mikro-orm/core';
-
-export const Book = defineEntity({
-  name: 'Book',
-  properties: {
-    id: p.integer().primary(),
-    author: () => p.manyToOne(Author),
-  },
-});
-
-export type IBook = InferEntity<typeof Book>;
-```
-
-  </TabItem>
-  <TabItem value="entity-schema">
-
-```ts
-export interface IBook {
-  id: number;
-  author: Author;
-}
-
-export const Book = new EntitySchema<IBook>({
-  name: 'Book',
-  properties: {
-    id: { type: 'number', primary: true },
-    author: { kind: 'm:1', entity: () => Author },
-  },
-});
-```
-
-  </TabItem>
 </Tabs>
 
 You can also specify how operations on given entity should [cascade](./cascading.md) to the referred entity.
@@ -112,14 +114,51 @@ Again, all of the following is equivalent:
 
 <Tabs
   groupId="entity-def"
-  defaultValue="define-entity"
+  defaultValue="define-entity-class"
   values={[
+    {label: 'defineEntity + class', value: 'define-entity-class'},
     {label: 'defineEntity', value: 'define-entity'},
     {label: 'reflect-metadata', value: 'reflect-metadata'},
     {label: 'ts-morph', value: 'ts-morph'},
-    {label: 'EntitySchema', value: 'entity-schema'},
-  ]
-  }>
+]
+  }
+>
+  <TabItem value="define-entity-class">
+
+```ts
+import { defineEntity, InferEntity, p } from '@mikro-orm/core';
+
+const AuthorSchema = defineEntity({
+  name: 'Author',
+  properties: {
+    id: p.integer().primary(),
+    books: () => p.oneToMany(Book).mappedBy('author'),
+  },
+});
+
+export class Author extends AuthorSchema.class {}
+AuthorSchema.setClass(Author);
+```
+
+  </TabItem>
+
+  <TabItem value="define-entity">
+
+```ts
+import { defineEntity, InferEntity, p } from '@mikro-orm/core';
+
+export const Author = defineEntity({
+  name: 'Author',
+  properties: {
+    id: p.integer().primary(),
+    books: () => p.oneToMany(Book).mappedBy('author'),
+  },
+});
+
+export type IAuthor = InferEntity<typeof Author>;
+```
+
+  </TabItem>
   <TabItem value="reflect-metadata">
 
 ```ts
@@ -155,41 +194,6 @@ export class Author {
 ```
 
   </TabItem>
-  <TabItem value="define-entity">
-
-```ts
-import { defineEntity, InferEntity, p } from '@mikro-orm/core';
-
-export const Author = defineEntity({
-  name: 'Author',
-  properties: {
-    id: p.integer().primary(),
-    books: () => p.oneToMany(Book).mappedBy('author'),
-  },
-});
-
-export type IAuthor = InferEntity<typeof Author>;
-```
-
-  </TabItem>
-  <TabItem value="entity-schema">
-
-```ts
-export interface IAuthor {
-  id: number;
-  books: Collection<Book>;
-}
-
-export const Author = new EntitySchema<IAuthor>({
-  name: 'Author',
-  properties: {
-    id: { type: 'number', primary: true },
-    books: { kind: '1:m', entity: () => Book, mappedBy: 'author' },
-  },
-});
-```
-
-  </TabItem>
 </Tabs>
 
 As you can see, OneToMany is the inverse side of ManyToOne (which is the owning side). More about how collections work can be found on [collections page](./collections.md).
@@ -206,58 +210,39 @@ This is a variant of ManyToOne, where there is always just one entity on both si
 
 <Tabs
   groupId="entity-def"
-  defaultValue="define-entity"
+  defaultValue="define-entity-class"
   values={[
+    {label: 'defineEntity + class', value: 'define-entity-class'},
     {label: 'defineEntity', value: 'define-entity'},
     {label: 'reflect-metadata', value: 'reflect-metadata'},
     {label: 'ts-morph', value: 'ts-morph'},
-    {label: 'EntitySchema', value: 'entity-schema'},
-  ]
-  }>
-  <TabItem value="reflect-metadata">
+]
+  }
+>
+  <TabItem value="define-entity-class">
 
 ```ts
-@Entity()
-export class User {
+import { defineEntity, InferEntity, p } from '@mikro-orm/core';
 
-  // when none of `owner/inversedBy/mappedBy` is provided, it will be considered owning side
-  @OneToOne()
-  bestFriend1!: User;
+const UserSchema = defineEntity({
+  name: 'User',
+  properties: {
+    id: p.integer().primary(),
+    // when none of `owner/inversedBy/mappedBy` is provided, it will be considered owning side
+    bestFriend1: () => p.oneToOne(User),
+    // side with `inversedBy` is the owning one, to define inverse side use `mappedBy`
+    bestFriend2: () => p.oneToOne(User).inversedBy('bestFriend1'),
+    // you need to specifically mark the owning side with `owner: true`
+    bestFriend3: () => p.oneToOne(User).owner(),
+  },
+});
 
-  // side with `inversedBy` is the owning one, to define inverse side use `mappedBy`
-  @OneToOne({ inversedBy: 'bestFriend1' })
-  bestFriend2!: User;
-
-  // when defining it like this, you need to specifically mark the owning side with `owner: true`
-  @OneToOne(() => User, user => user.bestFriend2, { owner: true })
-  bestFriend3!: User;
-
-}
+export class User extends UserSchema.class {}
+UserSchema.setClass(User);
 ```
 
   </TabItem>
-  <TabItem value="ts-morph">
 
-```ts
-@Entity()
-export class User {
-
-  // when none of `owner/inversedBy/mappedBy` is provided, it will be considered owning side
-  @OneToOne()
-  bestFriend1!: User;
-
-  // side with `inversedBy` is the owning one, to define inverse side use `mappedBy`
-  @OneToOne({ inversedBy: 'bestFriend1' })
-  bestFriend2!: User;
-
-  // when defining it like this, you need to specifically mark the owning side with `owner: true`
-  @OneToOne(() => User, user => user.bestFriend2, { owner: true })
-  bestFriend3!: User;
-
-}
-```
-
-  </TabItem>
   <TabItem value="define-entity">
 
 ```ts
@@ -280,28 +265,47 @@ export type IUser = InferEntity<typeof User>;
 ```
 
   </TabItem>
-  <TabItem value="entity-schema">
+  <TabItem value="reflect-metadata">
 
 ```ts
-export interface IUser {
-  id: number;
-  bestFriend1: User;
-  bestFriend2: User;
-  bestFriend3: User;
-}
+@Entity()
+export class User {
 
-export const User = new EntitySchema<IUser>({
-  name: 'User',
-  properties: {
-    id: { type: 'number', primary: true },
-    // when none of `owner/inversedBy/mappedBy` is provided, it will be considered owning side
-    bestFriend1: { kind: '1:1', entity: () => User },
-    // side with `inversedBy` is the owning one, to define inverse side use `mappedBy`
-    bestFriend2: { kind: '1:1', entity: () => User, inversedBy: 'bestFriend1' },
-    // you need to specifically mark the owning side with `owner: true`
-    bestFriend3: { kind: '1:1', entity: () => User, owner: true },
-  },
-});
+  // when none of `owner/inversedBy/mappedBy` is provided, it will be considered owning side
+  @OneToOne()
+  bestFriend1!: User;
+
+  // side with `inversedBy` is the owning one, to define inverse side use `mappedBy`
+  @OneToOne({ inversedBy: 'bestFriend1' })
+  bestFriend2!: User;
+
+  // when defining it like this, you need to specifically mark the owning side with `owner: true`
+  @OneToOne(() => User, user => user.bestFriend2, { owner: true })
+  bestFriend3!: User;
+
+}
+```
+
+  </TabItem>
+  <TabItem value="ts-morph">
+
+```ts
+@Entity()
+export class User {
+
+  // when none of `owner/inversedBy/mappedBy` is provided, it will be considered owning side
+  @OneToOne()
+  bestFriend1!: User;
+
+  // side with `inversedBy` is the owning one, to define inverse side use `mappedBy`
+  @OneToOne({ inversedBy: 'bestFriend1' })
+  bestFriend2!: User;
+
+  // when defining it like this, you need to specifically mark the owning side with `owner: true`
+  @OneToOne(() => User, user => user.bestFriend2, { owner: true })
+  bestFriend3!: User;
+
+}
 ```
 
   </TabItem>
@@ -311,14 +315,53 @@ export const User = new EntitySchema<IUser>({
 
 <Tabs
   groupId="entity-def"
-  defaultValue="define-entity"
+  defaultValue="define-entity-class"
   values={[
+    {label: 'defineEntity + class', value: 'define-entity-class'},
     {label: 'defineEntity', value: 'define-entity'},
     {label: 'reflect-metadata', value: 'reflect-metadata'},
     {label: 'ts-morph', value: 'ts-morph'},
-    {label: 'EntitySchema', value: 'entity-schema'},
-  ]
-  }>
+]
+  }
+>
+  <TabItem value="define-entity-class">
+
+```ts
+import { defineEntity, InferEntity, p } from '@mikro-orm/core';
+
+const UserSchema = defineEntity({
+  name: 'User',
+  properties: {
+    id: p.integer().primary(),
+    bestFriend1: () => p.oneToOne(User).mappedBy('bestFriend1').orphanRemoval(),
+    bestFriend2: () => p.oneToOne(User).mappedBy('bestFriend2').orphanRemoval(),
+  },
+});
+
+export class User extends UserSchema.class {}
+UserSchema.setClass(User);
+```
+
+  </TabItem>
+
+  <TabItem value="define-entity">
+
+```ts
+import { defineEntity, InferEntity, p } from '@mikro-orm/core';
+
+export const User = defineEntity({
+  name: 'User',
+  properties: {
+    id: p.integer().primary(),
+    bestFriend1: () => p.oneToOne(User).mappedBy('bestFriend1').orphanRemoval(),
+    bestFriend2: () => p.oneToOne(User).mappedBy('bestFriend2').orphanRemoval(),
+  },
+});
+
+export type IUser = InferEntity<typeof User>;
+```
+
+  </TabItem>
   <TabItem value="reflect-metadata">
 
 ```ts
@@ -351,44 +394,6 @@ export class User {
 ```
 
   </TabItem>
-  <TabItem value="define-entity">
-
-```ts
-import { defineEntity, InferEntity, p } from '@mikro-orm/core';
-
-export const User = defineEntity({
-  name: 'User',
-  properties: {
-    id: p.integer().primary(),
-    bestFriend1: () => p.oneToOne(User).mappedBy('bestFriend1').orphanRemoval(),
-    bestFriend2: () => p.oneToOne(User).mappedBy('bestFriend2').orphanRemoval(),
-  },
-});
-
-export type IUser = InferEntity<typeof User>;
-```
-
-  </TabItem>
-  <TabItem value="entity-schema">
-
-```ts
-export interface IUser {
-  id: number;
-  bestFriend1: User;
-  bestFriend2: User;
-}
-
-export const User = new EntitySchema<IUser>({
-  name: 'User',
-  properties: {
-    id: { type: 'number', primary: true },
-    bestFriend1: { kind: '1:1', entity: () => User, mappedBy: 'bestFriend1', orphanRemoval: true },
-    bestFriend2: { kind: '1:1', entity: () => User, mappedBy: 'bestFriend2', orphanRemoval: true },
-  },
-});
-```
-
-  </TabItem>
 </Tabs>
 
 As you can see, relationships can be also self-referencing (all of them. OneToOne also supports [Orphan Removal](./cascading.md#orphan-removal)).
@@ -403,14 +408,57 @@ Here are examples of how you can define ManyToMany relationship:
 
 <Tabs
   groupId="entity-def"
-  defaultValue="define-entity"
+  defaultValue="define-entity-class"
   values={[
+    {label: 'defineEntity + class', value: 'define-entity-class'},
     {label: 'defineEntity', value: 'define-entity'},
     {label: 'reflect-metadata', value: 'reflect-metadata'},
     {label: 'ts-morph', value: 'ts-morph'},
-    {label: 'EntitySchema', value: 'entity-schema'},
-  ]
-  }>
+]
+  }
+>
+  <TabItem value="define-entity-class">
+
+```ts
+import { defineEntity, InferEntity, p } from '@mikro-orm/core';
+
+const BookSchema = defineEntity({
+  name: 'Book',
+  properties: {
+    id: p.integer().primary(),
+    // when none of `owner/inversedBy/mappedBy` is provided, it will be considered owning side
+    tags: () => p.manyToMany(BookTag),
+    // to define uni-directional many to many, simply omit `mappedBy`
+    friends: () => p.manyToMany(Author),
+  },
+});
+
+export class Book extends BookSchema.class {}
+BookSchema.setClass(Book);
+```
+
+  </TabItem>
+
+  <TabItem value="define-entity">
+
+```ts
+import { defineEntity, InferEntity, p } from '@mikro-orm/core';
+
+export const Book = defineEntity({
+  name: 'Book',
+  properties: {
+    id: p.integer().primary(),
+    // when none of `owner/inversedBy/mappedBy` is provided, it will be considered owning side
+    tags: () => p.manyToMany(BookTag),
+    // to define uni-directional many to many, simply omit `mappedBy`
+    friends: () => p.manyToMany(Author),
+  },
+});
+
+export type IBook = InferEntity<typeof Book>;
+```
+
+  </TabItem>
   <TabItem value="reflect-metadata">
 
 ```ts
@@ -451,61 +499,59 @@ export class Book {
 ```
 
   </TabItem>
-  <TabItem value="define-entity">
-
-```ts
-import { defineEntity, InferEntity, p } from '@mikro-orm/core';
-
-export const Book = defineEntity({
-  name: 'Book',
-  properties: {
-    id: p.integer().primary(),
-    // when none of `owner/inversedBy/mappedBy` is provided, it will be considered owning side
-    tags: () => p.manyToMany(BookTag),
-    // to define uni-directional many to many, simply omit `mappedBy`
-    friends: () => p.manyToMany(Author),
-  },
-});
-
-export type IBook = InferEntity<typeof Book>;
-```
-
-  </TabItem>
-  <TabItem value="entity-schema">
-
-```ts
-export interface IBook {
-  id: number;
-  tags: Collection<BookTag>;
-  friends: Collection<Author>;
-}
-
-export const Book = new EntitySchema<IBook>({
-  name: 'Book',
-  properties: {
-    id: { type: 'number', primary: true },
-    tags: { kind: 'm:n', entity: () => BookTag },
-    // to define uni-directional many to many, simply omit `mappedBy`
-    friends: { kind: 'm:n', entity: () => Author },
-  },
-});
-```
-
-  </TabItem>
 </Tabs>
 
 ### Inverse Side
 
 <Tabs
   groupId="entity-def"
-  defaultValue="define-entity"
+  defaultValue="define-entity-class"
   values={[
+    {label: 'defineEntity + class', value: 'define-entity-class'},
     {label: 'defineEntity', value: 'define-entity'},
     {label: 'reflect-metadata', value: 'reflect-metadata'},
     {label: 'ts-morph', value: 'ts-morph'},
-    {label: 'EntitySchema', value: 'entity-schema'},
-  ]
-  }>
+]
+  }
+>
+  <TabItem value="define-entity-class">
+
+```ts
+import { defineEntity, InferEntity, p } from '@mikro-orm/core';
+
+const BookTagSchema = defineEntity({
+  name: 'BookTag',
+  properties: {
+    id: p.integer().primary(),
+    // inverse side has to point to the owning side via `mappedBy`
+    books: () => p.manyToMany(Book).mappedBy('tags'),
+  },
+});
+
+export class BookTag extends BookTagSchema.class {}
+BookTagSchema.setClass(BookTag);
+```
+
+  </TabItem>
+
+  <TabItem value="define-entity">
+
+```ts
+import { defineEntity, InferEntity, p } from '@mikro-orm/core';
+
+export const BookTag = defineEntity({
+  name: 'BookTag',
+  properties: {
+    id: p.integer().primary(),
+    // inverse side has to point to the owning side via `mappedBy`
+    books: () => p.manyToMany(Book).mappedBy('tags'),
+  },
+});
+
+export type IBookTag = InferEntity<typeof BookTag>;
+```
+
+  </TabItem>
   <TabItem value="reflect-metadata">
 
 ```ts
@@ -534,43 +580,6 @@ export class BookTag {
 ```
 
   </TabItem>
-  <TabItem value="define-entity">
-
-```ts
-import { defineEntity, InferEntity, p } from '@mikro-orm/core';
-
-export const BookTag = defineEntity({
-  name: 'BookTag',
-  properties: {
-    id: p.integer().primary(),
-    // inverse side has to point to the owning side via `mappedBy`
-    books: () => p.manyToMany(Book).mappedBy('tags'),
-  },
-});
-
-export type IBookTag = InferEntity<typeof BookTag>;
-```
-
-  </TabItem>
-  <TabItem value="entity-schema">
-
-```ts
-export interface IBookTag {
-  id: number;
-  books: Collection<Book>;
-}
-
-export const BookTag = new EntitySchema<IBookTag>({
-  name: 'BookTag',
-  properties: {
-    id: { type: 'number', primary: true },
-    // inverse side has to point to the owning side via `mappedBy`
-    books: { kind: 'm:n', entity: () => Book, mappedBy: 'tags' },
-  },
-});
-```
-
-  </TabItem>
 </Tabs>
 
 Again, more information about how collections work can be found on [collections page](./collections.md).
@@ -581,14 +590,74 @@ By default, ManyToOne and OneToOne relations reference the primary key of the ta
 
 <Tabs
   groupId="entity-def"
-  defaultValue="define-entity"
+  defaultValue="define-entity-class"
   values={[
+    {label: 'defineEntity + class', value: 'define-entity-class'},
     {label: 'defineEntity', value: 'define-entity'},
     {label: 'reflect-metadata', value: 'reflect-metadata'},
     {label: 'ts-morph', value: 'ts-morph'},
-    {label: 'EntitySchema', value: 'entity-schema'},
-  ]
-  }>
+]
+  }
+>
+  <TabItem value="define-entity-class">
+
+```ts
+import { defineEntity, InferEntity, p, Collection } from '@mikro-orm/core';
+
+const AuthorSchema = defineEntity({
+  name: 'Author',
+  properties: {
+    id: p.integer().primary(),
+    uuid: p.string().unique(),
+    books: () => p.oneToMany(Book).mappedBy('author'),
+  },
+});
+
+
+export const Book = defineEntity({
+  name: 'Book',
+  properties: {
+    id: p.integer().primary(),
+    // This relation references Author by uuid instead of id (PK)
+    author: () => p.manyToOne(Author).targetKey('uuid'),
+  },
+});
+
+export class Author extends AuthorSchema.class {}
+AuthorSchema.setClass(Author);
+```
+
+  </TabItem>
+
+  <TabItem value="define-entity">
+
+```ts
+import { defineEntity, InferEntity, p, Collection } from '@mikro-orm/core';
+
+export const Author = defineEntity({
+  name: 'Author',
+  properties: {
+    id: p.integer().primary(),
+    uuid: p.string().unique(),
+    books: () => p.oneToMany(Book).mappedBy('author'),
+  },
+});
+
+export type IAuthor = InferEntity<typeof Author>;
+
+export const Book = defineEntity({
+  name: 'Book',
+  properties: {
+    id: p.integer().primary(),
+    // This relation references Author by uuid instead of id (PK)
+    author: () => p.manyToOne(Author).targetKey('uuid'),
+  },
+});
+
+export type IBook = InferEntity<typeof Book>;
+```
+
+  </TabItem>
   <TabItem value="reflect-metadata">
 
 ```ts
@@ -653,69 +722,6 @@ export class Book {
 ```
 
   </TabItem>
-  <TabItem value="define-entity">
-
-```ts
-import { defineEntity, InferEntity, p, Collection } from '@mikro-orm/core';
-
-export const Author = defineEntity({
-  name: 'Author',
-  properties: {
-    id: p.integer().primary(),
-    uuid: p.string().unique(),
-    books: () => p.oneToMany(Book).mappedBy('author'),
-  },
-});
-
-export type IAuthor = InferEntity<typeof Author>;
-
-export const Book = defineEntity({
-  name: 'Book',
-  properties: {
-    id: p.integer().primary(),
-    // This relation references Author by uuid instead of id (PK)
-    author: () => p.manyToOne(Author).targetKey('uuid'),
-  },
-});
-
-export type IBook = InferEntity<typeof Book>;
-```
-
-  </TabItem>
-  <TabItem value="entity-schema">
-
-```ts
-export interface IAuthor {
-  id: number;
-  uuid: string;
-  books: Collection<Book>;
-}
-
-export const Author = new EntitySchema<IAuthor>({
-  name: 'Author',
-  properties: {
-    id: { type: 'number', primary: true },
-    uuid: { type: 'string', unique: true },
-    books: { kind: '1:m', entity: () => Book, mappedBy: 'author' },
-  },
-});
-
-export interface IBook {
-  id: number;
-  author: Author;
-}
-
-export const Book = new EntitySchema<IBook>({
-  name: 'Book',
-  properties: {
-    id: { type: 'number', primary: true },
-    // This relation references Author by uuid instead of id (PK)
-    author: { kind: 'm:1', entity: () => Author, targetKey: 'uuid' },
-  },
-});
-```
-
-  </TabItem>
 </Tabs>
 
 The target column must have a unique constraint. The FK column type will automatically match the type of the referenced column.
@@ -730,14 +736,54 @@ To get around them, use the `Rel` mapped type. It is an identity type, which dis
 
 <Tabs
   groupId="entity-def"
-  defaultValue="define-entity"
+  defaultValue="define-entity-class"
   values={[
+    {label: 'defineEntity + class', value: 'define-entity-class'},
     {label: 'defineEntity', value: 'define-entity'},
     {label: 'reflect-metadata', value: 'reflect-metadata'},
     {label: 'ts-morph', value: 'ts-morph'},
-    {label: 'EntitySchema', value: 'entity-schema'},
-  ]
-  }>
+]
+  }
+>
+  <TabItem value="define-entity-class">
+
+```ts
+import { defineEntity, p } from '@mikro-orm/core';
+
+const BookSchema = defineEntity({
+  name: 'Book',
+  properties: {
+    id: p.integer().primary(),
+    author: () => p.manyToOne(Author),
+  },
+});
+
+export class Book extends BookSchema.class {}
+BookSchema.setClass(Book);
+```
+
+> With `defineEntity`, circular dependencies are handled automatically, no need for `Rel` wrapper.
+
+  </TabItem>
+  <TabItem value="define-entity">
+
+```ts
+import { defineEntity, InferEntity, p } from '@mikro-orm/core';
+
+export const Book = defineEntity({
+  name: 'Book',
+  properties: {
+    id: p.integer().primary(),
+    author: () => p.manyToOne(Author),
+  },
+});
+
+export type IBook = InferEntity<typeof Book>;
+```
+
+> With `defineEntity`, circular dependencies are handled automatically, no need for `Rel` wrapper.
+
+  </TabItem>
   <TabItem value="reflect-metadata">
 
 ```ts
@@ -768,45 +814,6 @@ export class Book {
 ```
 
   </TabItem>
-  <TabItem value="define-entity">
-
-```ts
-import { defineEntity, InferEntity, p } from '@mikro-orm/core';
-
-export const Book = defineEntity({
-  name: 'Book',
-  properties: {
-    id: p.integer().primary(),
-    author: () => p.manyToOne(Author),
-  },
-});
-
-export type IBook = InferEntity<typeof Book>;
-```
-
-> With `defineEntity`, circular dependencies are handled automatically, no need for `Rel` wrapper.
-
-  </TabItem>
-  <TabItem value="entity-schema">
-
-```ts
-export interface IBook {
-  id: number;
-  author: Author;
-}
-
-export const Book = new EntitySchema<IBook>({
-  name: 'Book',
-  properties: {
-    id: { type: 'number', primary: true },
-    author: { kind: 'm:1', entity: () => Author },
-  },
-});
-```
-
-> With `EntitySchema`, circular dependencies are handled automatically via lazy references.
-
-  </TabItem>
 </Tabs>
 
 ## Custom foreign key constraint name
@@ -817,14 +824,51 @@ This name overrides the one automatically generated by the current [NamingStrate
 
 <Tabs
   groupId="entity-def"
-  defaultValue="define-entity"
+  defaultValue="define-entity-class"
   values={[
+    {label: 'defineEntity + class', value: 'define-entity-class'},
     {label: 'defineEntity', value: 'define-entity'},
     {label: 'reflect-metadata', value: 'reflect-metadata'},
     {label: 'ts-morph', value: 'ts-morph'},
-    {label: 'EntitySchema', value: 'entity-schema'},
-  ]
-  }>
+]
+  }
+>
+  <TabItem value="define-entity-class">
+
+```ts
+import { defineEntity, InferEntity, p } from '@mikro-orm/core';
+
+const BookSchema = defineEntity({
+  name: 'Book',
+  properties: {
+    id: p.integer().primary(),
+    author: () => p.manyToOne(Author).foreignKeyName('my_custom_name'),
+  },
+});
+
+export class Book extends BookSchema.class {}
+BookSchema.setClass(Book);
+```
+
+  </TabItem>
+
+  <TabItem value="define-entity">
+
+```ts
+import { defineEntity, InferEntity, p } from '@mikro-orm/core';
+
+export const Book = defineEntity({
+  name: 'Book',
+  properties: {
+    id: p.integer().primary(),
+    author: () => p.manyToOne(Author).foreignKeyName('my_custom_name'),
+  },
+});
+
+export type IBook = InferEntity<typeof Book>;
+```
+
+  </TabItem>
   <TabItem value="reflect-metadata">
 
 ```ts
@@ -851,6 +895,42 @@ export class Book {
 ```
 
   </TabItem>
+</Tabs>
+
+## Disabling foreign key constraint creation
+
+If you need to disable the creation of the underlying SQL foreign key constraint for a specific relation, you can set `createForeignKeyConstraint` to `false` on the relation on the owning side.
+
+<Tabs
+  groupId="entity-def"
+  defaultValue="define-entity-class"
+  values={[
+    {label: 'defineEntity + class', value: 'define-entity-class'},
+    {label: 'defineEntity', value: 'define-entity'},
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+]
+  }
+>
+  <TabItem value="define-entity-class">
+
+```ts
+import { defineEntity, InferEntity, p } from '@mikro-orm/core';
+
+const BookSchema = defineEntity({
+  name: 'Book',
+  properties: {
+    id: p.integer().primary(),
+    author: () => p.manyToOne(Author).createForeignKeyConstraint(false),
+  },
+});
+
+export class Book extends BookSchema.class {}
+BookSchema.setClass(Book);
+```
+
+  </TabItem>
+
   <TabItem value="define-entity">
 
 ```ts
@@ -860,7 +940,7 @@ export const Book = defineEntity({
   name: 'Book',
   properties: {
     id: p.integer().primary(),
-    author: () => p.manyToOne(Author).foreignKeyName('my_custom_name'),
+    author: () => p.manyToOne(Author).createForeignKeyConstraint(false),
   },
 });
 
@@ -868,40 +948,6 @@ export type IBook = InferEntity<typeof Book>;
 ```
 
   </TabItem>
-  <TabItem value="entity-schema">
-
-```ts
-export interface IBook {
-  id: number;
-  author: Author;
-}
-
-export const Book = new EntitySchema<IBook>({
-  name: 'Book',
-  properties: {
-    id: { type: 'number', primary: true },
-    author: { kind: 'm:1', entity: () => Author, foreignKeyName: 'my_custom_name' },
-  },
-});
-```
-
-  </TabItem>
-</Tabs>
-
-## Disabling foreign key constraint creation
-
-If you need to disable the creation of the underlying SQL foreign key constraint for a specific relation, you can set `createForeignKeyConstraint` to `false` on the relation on the owning side.
-
-<Tabs
-  groupId="entity-def"
-  defaultValue="define-entity"
-  values={[
-    {label: 'defineEntity', value: 'define-entity'},
-    {label: 'reflect-metadata', value: 'reflect-metadata'},
-    {label: 'ts-morph', value: 'ts-morph'},
-    {label: 'EntitySchema', value: 'entity-schema'},
-  ]
-  }>
   <TabItem value="reflect-metadata">
 
 ```ts
@@ -925,41 +971,6 @@ export class Book {
   author: Author;
 
 }
-```
-
-  </TabItem>
-  <TabItem value="define-entity">
-
-```ts
-import { defineEntity, InferEntity, p } from '@mikro-orm/core';
-
-export const Book = defineEntity({
-  name: 'Book',
-  properties: {
-    id: p.integer().primary(),
-    author: () => p.manyToOne(Author).createForeignKeyConstraint(false),
-  },
-});
-
-export type IBook = InferEntity<typeof Book>;
-```
-
-  </TabItem>
-  <TabItem value="entity-schema">
-
-```ts
-export interface IBook {
-  id: number;
-  author: Author;
-}
-
-export const Book = new EntitySchema<IBook>({
-  name: 'Book',
-  properties: {
-    id: { type: 'number', primary: true },
-    author: { kind: 'm:1', entity: () => Author, createForeignKeyConstraint: false },
-  },
-});
 ```
 
   </TabItem>
@@ -1006,14 +1017,57 @@ To define a polymorphic relation, pass an array of entity types to the `@ManyToO
 
 <Tabs
   groupId="entity-def"
-  defaultValue="define-entity"
+  defaultValue="define-entity-class"
   values={[
+    {label: 'defineEntity + class', value: 'define-entity-class'},
     {label: 'defineEntity', value: 'define-entity'},
     {label: 'reflect-metadata', value: 'reflect-metadata'},
     {label: 'ts-morph', value: 'ts-morph'},
-    {label: 'EntitySchema', value: 'entity-schema'},
-  ]
-  }>
+]
+  }
+>
+  <TabItem value="define-entity-class">
+
+```ts
+import { defineEntity, p, type InferEntity } from '@mikro-orm/core';
+
+const PostSchema = defineEntity({
+  name: 'Post',
+  properties: {
+    id: p.number().primary(),
+    title: p.string(),
+    // Inverse side of polymorphic relation
+    likes: () => p.oneToMany(UserLike).mappedBy('likeable'),
+  },
+});
+
+export interface IPost extends InferEntity<typeof Post> {}
+
+export const Comment = defineEntity({
+  name: 'Comment',
+  properties: {
+    id: p.number().primary(),
+    text: p.string(),
+    // Inverse side of polymorphic relation
+    likes: () => p.oneToMany(UserLike).mappedBy('likeable'),
+  },
+});
+
+export interface IComment extends InferEntity<typeof Comment> {}
+
+export const UserLike = defineEntity({
+  name: 'UserLike',
+  properties: {
+    id: p.number().primary(),
+    // Polymorphic relation - can point to either Post or Comment
+    likeable: () => p.manyToOne([Post, Comment]),
+  },
+});
+
+export interface IUserLike extends InferEntity<typeof UserLike> {}```
+
+  </TabItem>
+
   <TabItem value="define-entity">
 
 ```ts
@@ -1145,59 +1199,6 @@ export class UserLike {
   likeable!: Post | Comment;
 
 }
-```
-
-  </TabItem>
-  <TabItem value="entity-schema">
-
-```ts
-import { EntitySchema, Collection } from '@mikro-orm/core';
-
-export interface IPost {
-  id: number;
-  title: string;
-  likes: Collection<IUserLike>;
-}
-
-export const Post = new EntitySchema<IPost>({
-  name: 'Post',
-  properties: {
-    id: { type: 'number', primary: true },
-    title: { type: 'string' },
-    // Inverse side of polymorphic relation
-    likes: { kind: '1:m', entity: () => UserLike, mappedBy: 'likeable' },
-  },
-});
-
-export interface IComment {
-  id: number;
-  text: string;
-  likes: Collection<IUserLike>;
-}
-
-export const Comment = new EntitySchema<IComment>({
-  name: 'Comment',
-  properties: {
-    id: { type: 'number', primary: true },
-    text: { type: 'string' },
-    // Inverse side of polymorphic relation
-    likes: { kind: '1:m', entity: () => UserLike, mappedBy: 'likeable' },
-  },
-});
-
-export interface IUserLike {
-  id: number;
-  likeable: IPost | IComment;
-}
-
-export const UserLike = new EntitySchema<IUserLike>({
-  name: 'UserLike',
-  properties: {
-    id: { type: 'number', primary: true },
-    // Polymorphic relation - can point to either Post or Comment
-    likeable: { kind: 'm:1', entity: () => [Post, Comment] },
-  },
-});
 ```
 
   </TabItem>
@@ -1336,14 +1337,59 @@ To define a polymorphic M:N relation, use the `discriminator` option on `@ManyTo
 
 <Tabs
   groupId="entity-def"
-  defaultValue="define-entity"
+  defaultValue="define-entity-class"
   values={[
+    {label: 'defineEntity + class', value: 'define-entity-class'},
     {label: 'defineEntity', value: 'define-entity'},
     {label: 'reflect-metadata', value: 'reflect-metadata'},
     {label: 'ts-morph', value: 'ts-morph'},
-    {label: 'EntitySchema', value: 'entity-schema'},
-  ]
-  }>
+]
+  }
+>
+  <TabItem value="define-entity-class">
+
+```ts
+import { defineEntity, p, type InferEntity } from '@mikro-orm/core';
+
+const TagSchema = defineEntity({
+  name: 'Tag',
+  properties: {
+    id: p.number().primary(),
+    name: p.string(),
+    // Inverse sides - separate collections per entity type
+    posts: () => p.manyToMany(Post).mappedBy('tags'),
+    videos: () => p.manyToMany(Video).mappedBy('tags'),
+  },
+});
+
+export interface ITag extends InferEntity<typeof Tag> {}
+
+export const Post = defineEntity({
+  name: 'Post',
+  properties: {
+    id: p.number().primary(),
+    title: p.string(),
+    // Owner side - polymorphic M:N via shared pivot table
+    tags: () => p.manyToMany(Tag).pivotTable('taggables').discriminator('taggable'),
+  },
+});
+
+export interface IPost extends InferEntity<typeof Post> {}
+
+export const Video = defineEntity({
+  name: 'Video',
+  properties: {
+    id: p.number().primary(),
+    url: p.string(),
+    // Owner side - same pivot table, different discriminator value
+    tags: () => p.manyToMany(Tag).pivotTable('taggables').discriminator('taggable'),
+  },
+});
+
+export interface IVideo extends InferEntity<typeof Video> {}```
+
+  </TabItem>
+
   <TabItem value="define-entity">
 
 ```ts
@@ -1507,75 +1553,6 @@ export class Video {
 ```
 
   </TabItem>
-  <TabItem value="entity-schema">
-
-```ts
-import { EntitySchema, Collection } from '@mikro-orm/core';
-
-export interface ITag {
-  id: number;
-  name: string;
-  posts: Collection<IPost>;
-  videos: Collection<IVideo>;
-}
-
-export const Tag = new EntitySchema<ITag>({
-  name: 'Tag',
-  properties: {
-    id: { type: 'number', primary: true },
-    name: { type: 'string' },
-    // Inverse sides - separate collections per entity type
-    posts: { kind: 'm:n', entity: () => Post, mappedBy: 'tags' },
-    videos: { kind: 'm:n', entity: () => Video, mappedBy: 'tags' },
-  },
-});
-
-export interface IPost {
-  id: number;
-  title: string;
-  tags: Collection<ITag>;
-}
-
-export const Post = new EntitySchema<IPost>({
-  name: 'Post',
-  properties: {
-    id: { type: 'number', primary: true },
-    title: { type: 'string' },
-    // Owner side - polymorphic M:N via shared pivot table
-    tags: {
-      kind: 'm:n',
-      entity: () => Tag,
-      pivotTable: 'taggables',
-      discriminator: 'taggable',
-      owner: true,
-    },
-  },
-});
-
-export interface IVideo {
-  id: number;
-  url: string;
-  tags: Collection<ITag>;
-}
-
-export const Video = new EntitySchema<IVideo>({
-  name: 'Video',
-  properties: {
-    id: { type: 'number', primary: true },
-    url: { type: 'string' },
-    // Owner side - same pivot table, different discriminator value
-    tags: {
-      kind: 'm:n',
-      entity: () => Tag,
-      pivotTable: 'taggables',
-      discriminator: 'taggable',
-      owner: true,
-    },
-  },
-});
-```
-
-  </TabItem>
 </Tabs>
 
 #### Configuration Options
@@ -1601,13 +1578,49 @@ You can specify custom discriminator values using the `discriminatorMap` option.
 
 <Tabs
   groupId="entity-def-style"
-  defaultValue="reflect-metadata"
+  defaultValue="define-entity-class"
   values={[
+    {label: 'defineEntity + class', value: 'define-entity-class'},
     {label: 'defineEntity', value: 'define-entity'},
     {label: 'reflect-metadata', value: 'reflect-metadata'},
-    {label: 'EntitySchema', value: 'entity-schema'},
-  ]
-  }>
+]
+  }
+>
+  <TabItem value="define-entity-class">
+
+```ts
+const ArticleSchema = defineEntity({
+  name: 'Article',
+  properties: {
+    id: p.number().primary(),
+    categories: () => p.manyToMany(Category)
+      .inversedBy('articles')
+      .pivotTable('categorizables')
+      .discriminator('categorizable')
+      .discriminatorMap({ art: 'Article', prod: 'Product' })
+      .owner(),
+  },
+});
+
+export const Product = defineEntity({
+  name: 'Product',
+  properties: {
+    id: p.number().primary(),
+    categories: () => p.manyToMany(Category)
+      .inversedBy('products')
+      .pivotTable('categorizables')
+      .discriminator('categorizable')
+      .discriminatorMap({ art: 'Article', prod: 'Product' })
+      .owner(),
+  },
+});
+
+export class Article extends ArticleSchema.class {}
+ArticleSchema.setClass(Article);
+```
+
+  </TabItem>
+
   <TabItem value="define-entity">
 
 ```ts
@@ -1679,43 +1692,6 @@ export class Product {
   categories = new Collection<Category>(this);
 
 }
-```
-
-  </TabItem>
-  <TabItem value="entity-schema">
-
-```ts
-export const Article = new EntitySchema<IArticle>({
-  name: 'Article',
-  properties: {
-    id: { type: 'number', primary: true },
-    categories: {
-      kind: 'm:n',
-      entity: () => Category,
-      inversedBy: 'articles',
-      pivotTable: 'categorizables',
-      discriminator: 'categorizable',
-      discriminatorMap: { art: 'Article', prod: 'Product' },
-      owner: true,
-    },
-  },
-});
-
-export const Product = new EntitySchema<IProduct>({
-  name: 'Product',
-  properties: {
-    id: { type: 'number', primary: true },
-    categories: {
-      kind: 'm:n',
-      entity: () => Category,
-      inversedBy: 'products',
-      pivotTable: 'categorizables',
-      discriminator: 'categorizable',
-      discriminatorMap: { art: 'Article', prod: 'Product' },
-      owner: true,
-    },
-  },
-});
 ```
 
   </TabItem>

--- a/docs/docs/repositories.md
+++ b/docs/docs/repositories.md
@@ -50,14 +50,33 @@ And register the repository via the entity definition:
 
 <Tabs
 groupId="entity-def"
-defaultValue="define-entity"
+defaultValue="define-entity-class"
 values={[
+{label: 'defineEntity + class', value: 'define-entity-class'},
 {label: 'defineEntity', value: 'define-entity'},
 {label: 'reflect-metadata', value: 'reflect-metadata'},
 {label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
 ]
-}>
+}
+>
+  <TabItem value="define-entity-class">
+
+```ts
+const AuthorSchema = defineEntity({
+  name: 'Author',
+  repository: () => CustomAuthorRepository,
+  properties: {
+    id: p.integer().primary(),
+    // ...
+  },
+});
+
+export class Author extends AuthorSchema.class {}
+AuthorSchema.setClass(Author);
+```
+
+  </TabItem>
+
 <TabItem value="define-entity">
 
 ```ts
@@ -92,22 +111,6 @@ export class Author {
 ```
 
 </TabItem>
-<TabItem value="entity-schema">
-
-```ts
-export class Author {}
-
-export const AuthorSchema = new EntitySchema({
-  class: Author,
-  repository: () => CustomAuthorRepository,
-  properties: {
-    id: { type: 'number', primary: true },
-    // ...
-  },
-});
-```
-
-</TabItem>
 </Tabs>
 
 Note that you need to pass that repository reference inside a callback so you will not run into circular dependency issues when using entity references inside that repository.
@@ -120,14 +123,31 @@ To have the `em.getRepository()` method return correctly typed custom repository
 
 <Tabs
 groupId="entity-def"
-defaultValue="define-entity"
+defaultValue="define-entity-class"
 values={[
+{label: 'defineEntity + class', value: 'define-entity-class'},
 {label: 'defineEntity', value: 'define-entity'},
 {label: 'reflect-metadata', value: 'reflect-metadata'},
 {label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
 ]
-}>
+}
+>
+  <TabItem value="define-entity-class">
+
+```ts
+const AuthorSchema = defineEntity({
+  name: 'Author',
+  repository: () => AuthorRepository,
+  properties: {
+    id: p.integer().primary(),
+    // ...
+  },
+});
+
+const repo = em.getRepository(Author); // repo has type AuthorRepository```
+
+  </TabItem>
+
 <TabItem value="define-entity">
 
 ```ts
@@ -169,26 +189,6 @@ export class Author {
   [EntityRepositoryType]?: AuthorRepository;
 
 }
-
-const repo = em.getRepository(Author); // repo has type AuthorRepository
-```
-
-</TabItem>
-<TabItem value="entity-schema">
-
-```ts
-export class Author {
-  [EntityRepositoryType]?: AuthorRepository;
-}
-
-export const AuthorSchema = new EntitySchema({
-  class: Author,
-  repository: () => AuthorRepository,
-  properties: {
-    id: { type: 'number', primary: true },
-    // ...
-  },
-});
 
 const repo = em.getRepository(Author); // repo has type AuthorRepository
 ```
@@ -255,14 +255,32 @@ Register it the same way as any custom repository, via the entity definition:
 
 <Tabs
 groupId="entity-def"
-defaultValue="define-entity"
+defaultValue="define-entity-class"
 values={[
+{label: 'defineEntity + class', value: 'define-entity-class'},
 {label: 'defineEntity', value: 'define-entity'},
 {label: 'reflect-metadata', value: 'reflect-metadata'},
 {label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
 ]
-}>
+}
+>
+  <TabItem value="define-entity-class">
+
+```ts
+const AuthorSchema = defineEntity({
+  name: 'Author',
+  repository: () => AuthorRepository,
+  properties: {
+    id: p.integer().primary(),
+    // ...
+  },
+});
+
+// em.getRepository(Author) now returns AuthorRepository,
+// which has both BaseRepository methods and AuthorRepository methods.```
+
+  </TabItem>
+
 <TabItem value="define-entity">
 
 ```ts
@@ -312,27 +330,6 @@ export class Author {
 ```
 
 </TabItem>
-<TabItem value="entity-schema">
-
-```ts
-export class Author {
-  [EntityRepositoryType]?: AuthorRepository;
-}
-
-export const AuthorSchema = new EntitySchema({
-  class: Author,
-  repository: () => AuthorRepository,
-  properties: {
-    id: { type: 'number', primary: true },
-    // ...
-  },
-});
-
-// em.getRepository(Author) now returns AuthorRepository,
-// which has both BaseRepository methods and AuthorRepository methods.
-```
-
-</TabItem>
 </Tabs>
 
 Entities without a specific repository will still use the `BaseRepository` with its generic methods.
@@ -343,14 +340,32 @@ If you use a common base entity, you can set the `EntityRepositoryType` there so
 
 <Tabs
 groupId="entity-def"
-defaultValue="define-entity"
+defaultValue="define-entity-class"
 values={[
+{label: 'defineEntity + class', value: 'define-entity-class'},
 {label: 'defineEntity', value: 'define-entity'},
 {label: 'reflect-metadata', value: 'reflect-metadata'},
 {label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
 ]
-}>
+}
+>
+  <TabItem value="define-entity-class">
+
+```ts
+const BaseEntitySchema = defineEntity({
+  name: 'BaseEntity',
+  abstract: true,
+  properties: {
+    id: p.integer().primary(),
+  },
+});
+
+export class BaseEntity extends BaseEntitySchema.class {}
+BaseEntitySchema.setClass(BaseEntity);
+```
+
+  </TabItem>
+
 <TabItem value="define-entity">
 
 ```ts
@@ -395,23 +410,6 @@ export abstract class BaseEntity {
   id!: number;
 
 }
-```
-
-</TabItem>
-<TabItem value="entity-schema">
-
-```ts
-export abstract class BaseEntity {
-  [EntityRepositoryType]?: BaseRepository<this>;
-}
-
-export const BaseEntitySchema = new EntitySchema({
-  class: BaseEntity,
-  abstract: true,
-  properties: {
-    id: { type: 'number', primary: true },
-  },
-});
 ```
 
 </TabItem>

--- a/docs/docs/type-safe-relations.md
+++ b/docs/docs/type-safe-relations.md
@@ -43,14 +43,34 @@ Use the `Ref<T>` type and `ref: true` option to define a reference property:
 
 <Tabs
 groupId="entity-def"
-defaultValue="define-entity"
+defaultValue="define-entity-class"
 values={[
+{label: 'defineEntity + class', value: 'define-entity-class'},
 {label: 'defineEntity', value: 'define-entity'},
 {label: 'reflect-metadata', value: 'reflect-metadata'},
 {label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
 ]
-}>
+}
+>
+  <TabItem value="define-entity-class">
+
+```ts title="./entities/Book.ts"
+import { defineEntity, p } from '@mikro-orm/core';
+
+const BookSchema = defineEntity({
+  name: 'Book',
+  properties: {
+    id: p.integer().primary(),
+    author: p.manyToOne(() => Author).ref(),
+  },
+});
+
+export class Book extends BookSchema.class {}
+BookSchema.setClass(Book);
+```
+
+  </TabItem>
+
 <TabItem value="define-entity">
 
 ```ts title="./entities/Book.ts"
@@ -107,26 +127,6 @@ export class Book {
   }
 
 }
-```
-
-</TabItem>
-<TabItem value="entity-schema">
-
-```ts title="./entities/Book.ts"
-import { EntitySchema, Ref } from '@mikro-orm/core';
-
-export interface IBook {
-  id: number;
-  author: Ref<IAuthor>;
-}
-
-export const Book = new EntitySchema<IBook>({
-  name: 'Book',
-  properties: {
-    id: { type: Number, primary: true },
-    author: { entity: () => Author, ref: true },
-  },
-});
 ```
 
 </TabItem>
@@ -206,14 +206,35 @@ Given the following `User` entity:
 
 <Tabs
 groupId="entity-def"
-defaultValue="define-entity"
+defaultValue="define-entity-class"
 values={[
+{label: 'defineEntity + class', value: 'define-entity-class'},
 {label: 'defineEntity', value: 'define-entity'},
 {label: 'reflect-metadata', value: 'reflect-metadata'},
 {label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
 ]
-}>
+}
+>
+  <TabItem value="define-entity-class">
+
+```ts title="./entities/User.ts"
+import { defineEntity, p } from '@mikro-orm/core';
+
+const UserSchema = defineEntity({
+  name: 'User',
+  properties: {
+    id: p.integer().primary(),
+    identity: p.manyToOne(() => Identity).ref(),
+    friends: p.manyToMany(() => User),
+  },
+});
+
+export class User extends UserSchema.class {}
+UserSchema.setClass(User);
+```
+
+  </TabItem>
+
 <TabItem value="define-entity">
 
 ```ts title="./entities/User.ts"
@@ -277,28 +298,6 @@ export class User {
   }
 
 }
-```
-
-</TabItem>
-<TabItem value="entity-schema">
-
-```ts title="./entities/User.ts"
-import { EntitySchema, Collection, Ref } from '@mikro-orm/core';
-
-export interface IUser {
-  id: number;
-  identity: Ref<IIdentity>;
-  friends: Collection<IUser>;
-}
-
-export const User = new EntitySchema<IUser>({
-  name: 'User',
-  properties: {
-    id: { type: Number, primary: true },
-    identity: { entity: () => Identity, ref: true },
-    friends: { entity: () => User, kind: 'm:n' },
-  },
-});
 ```
 
 </TabItem>
@@ -391,14 +390,37 @@ You can create references inside entity constructors using `rel()`:
 
 <Tabs
 groupId="entity-def"
-defaultValue="define-entity"
+defaultValue="define-entity-class"
 values={[
+{label: 'defineEntity + class', value: 'define-entity-class'},
 {label: 'defineEntity', value: 'define-entity'},
 {label: 'reflect-metadata', value: 'reflect-metadata'},
 {label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
 ]
-}>
+}
+>
+  <TabItem value="define-entity-class">
+
+```ts title="./entities/Book.ts"
+import { defineEntity, p, rel } from '@mikro-orm/core';
+
+const BookSchema = defineEntity({
+  name: 'Book',
+  properties: {
+    id: p.integer().primary(),
+    author: p.manyToOne(() => Author).ref(),
+  },
+});
+
+// Usage: create book with author reference
+const book = em.create(Book, { author: rel(Author, authorId) });
+
+export class Book extends BookSchema.class {}
+BookSchema.setClass(Book);
+```
+
+  </TabItem>
+
 <TabItem value="define-entity">
 
 ```ts title="./entities/Book.ts"
@@ -461,29 +483,6 @@ export class Book {
 ```
 
 </TabItem>
-<TabItem value="entity-schema">
-
-```ts title="./entities/Book.ts"
-import { EntitySchema, Ref, rel } from '@mikro-orm/core';
-
-export interface IBook {
-  id: number;
-  author: Ref<IAuthor>;
-}
-
-export const Book = new EntitySchema<IBook>({
-  name: 'Book',
-  properties: {
-    id: { type: Number, primary: true },
-    author: { entity: () => Author, ref: true },
-  },
-});
-
-// Usage: create book with author reference
-const book = em.create(Book, { author: rel(Author, authorId) });
-```
-
-</TabItem>
 </Tabs>
 
 Another way is to use `toReference()` method available as part of the [`wrap()` helper](./wrap-helper.md):
@@ -506,14 +505,31 @@ MikroORM detects the PK property by checking for `_id`, `uuid`, or `id` in that 
 
 <Tabs
 groupId="entity-def"
-defaultValue="define-entity"
+defaultValue="define-entity-class"
 values={[
+{label: 'defineEntity + class', value: 'define-entity-class'},
 {label: 'defineEntity', value: 'define-entity'},
 {label: 'reflect-metadata', value: 'reflect-metadata'},
 {label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
 ]
-}>
+}
+>
+  <TabItem value="define-entity-class">
+
+```ts title="./entities/Author.ts"
+import { defineEntity, p, PrimaryKeyProp } from '@mikro-orm/core';
+
+const AuthorSchema = defineEntity({
+  name: 'Author',
+  properties: {
+    myPrimaryKey: p.integer().primary(),
+  },
+});
+
+// PrimaryKeyProp is inferred automatically with defineEntity```
+
+  </TabItem>
+
 <TabItem value="define-entity">
 
 ```ts title="./entities/Author.ts"
@@ -564,25 +580,6 @@ export class Author {
 ```
 
 </TabItem>
-<TabItem value="entity-schema">
-
-```ts title="./entities/Author.ts"
-import { EntitySchema, PrimaryKeyProp } from '@mikro-orm/core';
-
-export interface IAuthor {
-  myPrimaryKey: number;
-  [PrimaryKeyProp]?: 'myPrimaryKey';
-}
-
-export const Author = new EntitySchema<IAuthor>({
-  name: 'Author',
-  properties: {
-    myPrimaryKey: { type: Number, primary: true },
-  },
-});
-```
-
-</TabItem>
 </Tabs>
 
 ```ts
@@ -595,14 +592,35 @@ For MongoDB, both `id` (string) and `_id` (ObjectId) are available:
 
 <Tabs
 groupId="entity-def"
-defaultValue="define-entity"
+defaultValue="define-entity-class"
 values={[
+{label: 'defineEntity + class', value: 'define-entity-class'},
 {label: 'defineEntity', value: 'define-entity'},
 {label: 'reflect-metadata', value: 'reflect-metadata'},
 {label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
 ]
-}>
+}
+>
+  <TabItem value="define-entity-class">
+
+```ts title="./entities/Book.ts"
+import { defineEntity, p } from '@mikro-orm/core';
+
+const BookSchema = defineEntity({
+  name: 'Book',
+  properties: {
+    _id: p.type(ObjectId).primary(),
+    id: p.string().serializedPrimaryKey(),
+    author: p.manyToOne(() => Author).ref(),
+  },
+});
+
+export class Book extends BookSchema.class {}
+BookSchema.setClass(Book);
+```
+
+  </TabItem>
+
 <TabItem value="define-entity">
 
 ```ts title="./entities/Book.ts"
@@ -658,28 +676,6 @@ export class Book {
   author!: Ref<Author>;
 
 }
-```
-
-</TabItem>
-<TabItem value="entity-schema">
-
-```ts title="./entities/Book.ts"
-import { EntitySchema, Ref } from '@mikro-orm/core';
-
-export interface IBook {
-  _id: ObjectId;
-  id: string;
-  author: Ref<IAuthor>;
-}
-
-export const Book = new EntitySchema<IBook>({
-  name: 'Book',
-  properties: {
-    _id: { type: 'ObjectId', primary: true },
-    id: { type: String, serializedPrimaryKey: true },
-    author: { entity: () => Author, ref: true },
-  },
-});
 ```
 
 </TabItem>

--- a/docs/docs/view-entities.md
+++ b/docs/docs/view-entities.md
@@ -26,14 +26,42 @@ To define a view entity, set both `view: true` and provide an `expression`. The 
 
 <Tabs
   groupId="entity-def"
-  defaultValue="define-entity"
+  defaultValue="define-entity-class"
   values={[
+    {label: 'defineEntity + class', value: 'define-entity-class'},
     {label: 'defineEntity', value: 'define-entity'},
     {label: 'reflect-metadata', value: 'reflect-metadata'},
     {label: 'ts-morph', value: 'ts-morph'},
-    {label: 'EntitySchema', value: 'entity-schema'},
-  ]
-  }>
+]
+  }
+>
+  <TabItem value="define-entity-class">
+
+```ts title="./entities/AuthorStats.ts"
+import { defineEntity, p } from '@mikro-orm/core';
+
+const AuthorStatsSchema = defineEntity({
+  name: 'AuthorStats',
+  tableName: 'author_stats_view',
+  view: true,
+  expression: `
+    select a.name, count(b.id) as book_count
+    from author a
+    left join book b on b.author_id = a.id
+    group by a.id, a.name
+  `,
+  properties: {
+    name: p.string().primary(),
+    bookCount: p.integer(),
+  },
+});
+
+export class AuthorStats extends AuthorStatsSchema.class {}
+AuthorStatsSchema.setClass(AuthorStats);
+```
+
+  </TabItem>
+
   <TabItem value="define-entity">
 
 ```ts title="./entities/AuthorStats.ts"
@@ -107,32 +135,6 @@ export class AuthorStats {
 ```
 
   </TabItem>
-  <TabItem value="entity-schema">
-
-```ts title="./entities/AuthorStats.ts"
-export interface IAuthorStats {
-  name: string;
-  bookCount: number;
-}
-
-export const AuthorStats = new EntitySchema<IAuthorStats>({
-  name: 'AuthorStats',
-  tableName: 'author_stats_view',
-  view: true,
-  expression: `
-    select a.name, count(b.id) as book_count
-    from author a
-    left join book b on b.author_id = a.id
-    group by a.id, a.name
-  `,
-  properties: {
-    name: { type: 'string', primary: true },
-    bookCount: { type: 'number' },
-  },
-});
-```
-
-  </TabItem>
 </Tabs>
 
 ### Using QueryBuilder Expression
@@ -141,14 +143,41 @@ You can also use a callback that returns a QueryBuilder for type-safe view defin
 
 <Tabs
   groupId="entity-def"
-  defaultValue="define-entity"
+  defaultValue="define-entity-class"
   values={[
+    {label: 'defineEntity + class', value: 'define-entity-class'},
     {label: 'defineEntity', value: 'define-entity'},
     {label: 'reflect-metadata', value: 'reflect-metadata'},
     {label: 'ts-morph', value: 'ts-morph'},
-    {label: 'EntitySchema', value: 'entity-schema'},
-  ]
-  }>
+]
+  }
+>
+  <TabItem value="define-entity-class">
+
+```ts title="./entities/BookSummary.ts"
+import { defineEntity, p } from '@mikro-orm/core';
+
+const BookSummarySchema = defineEntity({
+  name: 'BookSummary',
+  tableName: 'book_summary_view',
+  view: true,
+  expression: (em: EntityManager) => {
+    return em.createQueryBuilder(Book, 'b')
+      .select(['b.title', 'a.name as author_name'])
+      .join('b.author', 'a');
+  },
+  properties: {
+    title: p.string().primary(),
+    authorName: p.string(),
+  },
+});
+
+export class BookSummary extends BookSummarySchema.class {}
+BookSummarySchema.setClass(BookSummary);
+```
+
+  </TabItem>
+
   <TabItem value="define-entity">
 
 ```ts title="./entities/BookSummary.ts"
@@ -216,31 +245,6 @@ export class BookSummary {
   authorName!: string;
 
 }
-```
-
-  </TabItem>
-  <TabItem value="entity-schema">
-
-```ts title="./entities/BookSummary.ts"
-export interface IBookSummary {
-  title: string;
-  authorName: string;
-}
-
-export const BookSummary = new EntitySchema<IBookSummary>({
-  name: 'BookSummary',
-  tableName: 'book_summary_view',
-  view: true,
-  expression: (em: EntityManager) => {
-    return em.createQueryBuilder(Book, 'b')
-      .select(['b.title', 'a.name as author_name'])
-      .join('b.author', 'a');
-  },
-  properties: {
-    title: { type: 'string', primary: true },
-    authorName: { type: 'string' },
-  },
-});
 ```
 
   </TabItem>

--- a/docs/docs/wrap-helper.md
+++ b/docs/docs/wrap-helper.md
@@ -34,14 +34,34 @@ There are two ways to access these helper methods:
 
 <Tabs
 groupId="entity-def"
-defaultValue="define-entity"
+defaultValue="define-entity-class"
 values={[
+{label: 'defineEntity + class', value: 'define-entity-class'},
 {label: 'defineEntity', value: 'define-entity'},
 {label: 'reflect-metadata', value: 'reflect-metadata'},
 {label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
 ]
-}>
+}
+>
+  <TabItem value="define-entity-class">
+
+```ts title="./entities/Book.ts"
+import { defineEntity, p } from '@mikro-orm/core';
+
+const BookSchema = defineEntity({
+  name: 'Book',
+  properties: {
+    id: p.integer().primary(),
+    title: p.string(),
+  },
+});
+
+export class Book extends BookSchema.class {}
+BookSchema.setClass(Book);
+```
+
+  </TabItem>
+
 <TabItem value="define-entity">
 
 ```ts title="./entities/Book.ts"
@@ -108,45 +128,41 @@ wrap(book).assign({ title: 'New Title' });
 ```
 
 </TabItem>
-<TabItem value="entity-schema">
-
-```ts title="./entities/Book.ts"
-import { EntitySchema } from '@mikro-orm/core';
-
-export interface IBook {
-  id: number;
-  title: string;
-}
-
-export const Book = new EntitySchema<IBook>({
-  name: 'Book',
-  properties: {
-    id: { type: Number, primary: true },
-    title: { type: String },
-  },
-});
-```
-
-```ts
-// Access helpers via wrap()
-wrap(book).assign({ title: 'New Title' });
-```
-
-</TabItem>
 </Tabs>
 
 **2. Extending `BaseEntity`** - methods available directly on the entity:
 
 <Tabs
 groupId="entity-def"
-defaultValue="define-entity"
+defaultValue="define-entity-class"
 values={[
+{label: 'defineEntity + class', value: 'define-entity-class'},
 {label: 'defineEntity', value: 'define-entity'},
 {label: 'reflect-metadata', value: 'reflect-metadata'},
 {label: 'ts-morph', value: 'ts-morph'},
-{label: 'EntitySchema', value: 'entity-schema'},
 ]
-}>
+}
+>
+  <TabItem value="define-entity-class">
+
+```ts title="./entities/Book.ts"
+import { defineEntity, p, BaseEntity } from '@mikro-orm/core';
+
+const BookSchema = defineEntity({
+  name: 'Book',
+  extends: BaseEntity,
+  properties: {
+    id: p.integer().primary(),
+    title: p.string(),
+  },
+});
+
+export class Book extends BookSchema.class {}
+BookSchema.setClass(Book);
+```
+
+  </TabItem>
+
 <TabItem value="define-entity">
 
 ```ts title="./entities/Book.ts"
@@ -206,32 +222,6 @@ export class Book extends BaseEntity {
   title!: string;
 
 }
-```
-
-```ts
-// Access helpers directly
-book.assign({ title: 'New Title' });
-```
-
-</TabItem>
-<TabItem value="entity-schema">
-
-```ts title="./entities/Book.ts"
-import { EntitySchema, BaseEntity } from '@mikro-orm/core';
-
-export interface IBook {
-  id: number;
-  title: string;
-}
-
-export const Book = new EntitySchema<IBook>({
-  name: 'Book',
-  extends: BaseEntity,
-  properties: {
-    id: { type: Number, primary: true },
-    title: { type: String },
-  },
-});
 ```
 
 ```ts


### PR DESCRIPTION
## Summary

- Replace all `EntitySchema` code tabs across 16 docs files (88 tab blocks) with a new **"defineEntity + class"** tab as the default/recommended approach
- Keep pure `defineEntity` as the second tab option for quick/simple use cases
- Rewrite `entity-schema.md` to lead with `defineEntity`, promote the `+class` pattern and its benefits (clean hover types, better perf, custom methods), and move raw `EntitySchema` to a "low-level API" section

The new default tab shows the hybrid class pattern:

```ts
const BookSchema = defineEntity({
  name: 'Book',
  properties: {
    id: p.integer().primary(),
    title: p.string(),
    author: () => p.manyToOne(Author),
  },
});

export class Book extends BookSchema.class {}
BookSchema.setClass(Book);
```

This gives users:
- **Clean hover types**: `Book` instead of complex intersection types
- **Better runtime performance**: real named class vs dynamically generated anonymous class
- **Custom methods**: natural place for domain logic on entities

## Test plan

- [ ] Verify docs site builds correctly with the new tab structure
- [ ] Check that tab sync (`groupId`) works across pages
- [ ] Review hybrid class examples for correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)