### PR TITLE
fix(knex): handle $not operator inside relation filters

### DIFF
--- a/packages/knex/src/query/ObjectCriteriaNode.ts
+++ b/packages/knex/src/query/ObjectCriteriaNode.ts
@@ -167,7 +167,14 @@ export class ObjectCriteriaNode<T extends object> extends CriteriaNode<T> {
   override shouldInline(payload: any): boolean {
     const customExpression = RawQueryFragment.isKnownFragment(this.key!);
     const scalar = Utils.isPrimaryKey(payload) || payload as unknown instanceof RegExp || payload as unknown instanceof Date || customExpression;
-    const operator = Utils.isObject(payload) && Object.keys(payload).every(k => Utils.isOperator(k, false));
+    const operator = Utils.isObject(payload) && Object.keys(payload).every(k => {
+      if (k === '$not' && Utils.isPlainObject(payload[k])) {
+        // $not wrapping non-operator conditions (entity props) should be inlined
+        return Object.keys(payload[k]).every(ik => Utils.isOperator(ik, false));
+      }
+
+      return Utils.isOperator(k, false);
+    });
 
     return !!this.prop && this.prop.kind !== ReferenceKind.SCALAR && !scalar && !operator;
   }
@@ -195,7 +202,10 @@ export class ObjectCriteriaNode<T extends object> extends CriteriaNode<T> {
     const prop = this.metadata.find<T>(this.entityName)!.properties[field];
 
     for (const k of Object.keys(payload)) {
-      if (Utils.isOperator(k, false)) {
+      if (k === '$not' && Utils.isPlainObject(payload[k]) && Object.keys(payload[k]).some(ik => !Utils.isOperator(ik, false))) {
+        // $not wraps entity conditions (from auto-join), inline at current level
+        this.inlineCondition(k, o, payload[k]);
+      } else if (Utils.isOperator(k, false)) {
         const tmp = payload[k];
         delete payload[k];
         o[this.aliased(field, alias)] = { [k]: tmp, ...o[this.aliased(field, alias)] };
@@ -248,7 +258,19 @@ export class ObjectCriteriaNode<T extends object> extends CriteriaNode<T> {
     const meta = this.metadata.find(this.entityName)!;
     const embeddable = this.prop.kind === ReferenceKind.EMBEDDED;
     const knownKey = [ReferenceKind.SCALAR, ReferenceKind.MANY_TO_ONE, ReferenceKind.EMBEDDED].includes(this.prop.kind) || (this.prop.kind === ReferenceKind.ONE_TO_ONE && this.prop.owner);
-    const operatorKeys = knownKey && keys.every(key => Utils.isOperator(key, false));
+    const operatorKeys = knownKey && keys.every(key => {
+      if (key === '$not') {
+        // $not wraps conditions like $and/$or, check if it wraps entity property conditions (needs auto-join)
+        // vs simple operator conditions on the FK (doesn't need auto-join)
+        const childPayload = (this.payload[key] as CriteriaNode<T>).payload;
+
+        if (Utils.isPlainObject(childPayload)) {
+          return Object.keys(childPayload).every(k => Utils.isOperator(k, false));
+        }
+      }
+
+      return Utils.isOperator(key, false);
+    });
     const primaryKeys = knownKey && keys.every(key => {
       if (!meta.primaryKeys.includes(key)) {
         return false;

--- a/tests/QueryBuilder.test.ts
+++ b/tests/QueryBuilder.test.ts
@@ -2040,6 +2040,51 @@ describe('QueryBuilder', () => {
       'where (`e1`.`name` = ? or not (`e1`.`name` = ?))');
   });
 
+  test('select with auto-joining and $not inside relation (GH slack report)', async () => {
+    const qb1 = orm.em.createQueryBuilder(Book2, 'a');
+    qb1.select('*').where({
+      author: {
+        $not: {
+          email: 'test',
+        },
+      },
+    });
+    expect(qb1.getQuery()).toEqual('select `a`.*, `a`.price * 1.19 as `price_taxed` ' +
+      'from `book2` as `a` ' +
+      'inner join `author2` as `e1` on `a`.`author_id` = `e1`.`id` ' +
+      'where not (`e1`.`email` = ?)');
+
+    // $not with multiple conditions inside relation
+    const qb2 = orm.em.createQueryBuilder(Book2, 'a');
+    qb2.select('*').where({
+      author: {
+        $not: {
+          name: 'foo',
+          email: 'bar',
+        },
+      },
+    });
+    expect(qb2.getQuery()).toEqual('select `a`.*, `a`.price * 1.19 as `price_taxed` ' +
+      'from `book2` as `a` ' +
+      'inner join `author2` as `e1` on `a`.`author_id` = `e1`.`id` ' +
+      'where not (`e1`.`name` = ? and `e1`.`email` = ?)');
+
+    // $not combined with regular conditions inside relation
+    const qb3 = orm.em.createQueryBuilder(Book2, 'a');
+    qb3.select('*').where({
+      author: {
+        name: 'test',
+        $not: {
+          email: 'bar',
+        },
+      },
+    });
+    expect(qb3.getQuery()).toEqual('select `a`.*, `a`.price * 1.19 as `price_taxed` ' +
+      'from `book2` as `a` ' +
+      'inner join `author2` as `e1` on `a`.`author_id` = `e1`.`id` ' +
+      'where `e1`.`name` = ? and not (`e1`.`email` = ?)');
+  });
+
   test('select with auto-joining and alias replacement via expr()', async () => {
     const qb1 = orm.em.createQueryBuilder(Book2, 'a');
     qb1.select('*').where({


### PR DESCRIPTION
## Summary

Backport of #7226 to 6.x.

- Fixes `$not` operator used inside relation filters (e.g. `{ author: { $not: { email: 'test' } } }`) which previously produced `DriverException: The operator "not" is not permitted`
- The root cause is that `$not` is in `QueryOperator` (unlike `$and`/`$or` in `GroupOperator`), so the auto-join, inline, and child payload logic all treated it as a simple FK operator
- Three changes in `ObjectCriteriaNode`: `shouldAutoJoin`, `shouldInline`, and `inlineChildPayload` now handle `$not` as a group-like operator when it wraps entity property conditions

## Test plan

- [x] Added test for `$not` with single condition inside relation
- [x] Added test for `$not` with multiple conditions inside relation
- [x] Added test for `$not` combined with regular conditions inside relation
- [x] All 169 QueryBuilder tests pass
- [x] All 597 EntityManager tests pass
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)