### PR TITLE
fix(core): preserve function expression indexes through metadata cache round-trip

### DIFF
--- a/packages/core/src/metadata/MetadataProvider.ts
+++ b/packages/core/src/metadata/MetadataProvider.ts
@@ -23,7 +23,27 @@ export abstract class MetadataProvider {
       }
     });
 
+    // Preserve function expressions from indexes/uniques — they can't survive JSON cache serialization
+    const expressionMap = new Map<string, Function>();
+
+    for (const idx of [...(meta.indexes ?? []), ...(meta.uniques ?? [])]) {
+      if (typeof idx.expression === 'function' && idx.name) {
+        expressionMap.set(idx.name, idx.expression);
+      }
+    }
+
     Utils.mergeConfig(meta, cache);
+
+    // Restore function expressions that were lost during JSON serialization
+    if (expressionMap.size > 0) {
+      for (const idx of [...(meta.indexes ?? []), ...(meta.uniques ?? [])]) {
+        const fn = idx.name && expressionMap.get(idx.name);
+
+        if (fn && typeof idx.expression !== 'function') {
+          idx.expression = fn as any;
+        }
+      }
+    }
   }
 
   useCache(): boolean {

--- a/tests/features/schema-generator/index-expression-diffing.postgres.test.ts
+++ b/tests/features/schema-generator/index-expression-diffing.postgres.test.ts
@@ -1,0 +1,144 @@
+import { Entity, Index, ManyToOne, MikroORM, PrimaryKey, Property, ReflectMetadataProvider, quote, type Ref } from '@mikro-orm/postgresql';
+import { Migrator } from '@mikro-orm/migrations';
+import { rm } from 'node:fs/promises';
+
+@Entity({ tableName: 'organizations' })
+@Index({
+  name: 'organizations_name_ui',
+  expression: (table, columns, indexName) => quote`create unique index ${indexName} on ${table}(${columns.name}) where ${columns.deletedAt} is null`,
+})
+class Organization {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @Property({ nullable: true })
+  deletedAt?: Date;
+
+}
+
+@Entity({ tableName: 'users' })
+@Index({
+  name: 'users_organization_id_ui',
+  expression: (table, columns, indexName) => quote`create unique index ${indexName} on ${table}(${columns.organization}) where ${columns.deletedAt} is null`,
+})
+class User {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @ManyToOne(() => Organization, { ref: true })
+  organization!: Ref<Organization>;
+
+  @Property({ nullable: true })
+  deletedAt?: Date;
+
+}
+
+const migrationsPath = process.cwd() + '/temp/migrations-gh7238';
+const cachePath = process.cwd() + '/temp/cache-gh7238';
+
+describe('expression-based index diffing (GH #7238)', () => {
+
+  afterAll(async () => {
+    await rm(migrationsPath, { recursive: true, force: true });
+    await rm(cachePath, { recursive: true, force: true });
+  });
+
+  test('function expression indexes survive when metadata cache is disabled', async () => {
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      entities: [Organization, User],
+      dbName: 'mikro_orm_test_gh_7238',
+      metadataCache: { enabled: false },
+    });
+
+    const meta = orm.getMetadata().get('Organization');
+    const idx = meta.indexes.find(i => i.name === 'organizations_name_ui');
+    expect(idx).toBeDefined();
+    expect(typeof idx!.expression).toBe('function');
+
+    await orm.close();
+  });
+
+  test('function expression indexes should survive metadata cache round-trip', async () => {
+    await rm(cachePath, { recursive: true, force: true });
+
+    // First init: populate the cache
+    const orm1 = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      entities: [Organization, User],
+      dbName: 'mikro_orm_test_gh_7238',
+      metadataCache: { enabled: true, options: { cacheDir: cachePath } },
+    });
+
+    const meta1 = orm1.getMetadata().get('Organization');
+    const idx1 = meta1.indexes.find(i => i.name === 'organizations_name_ui');
+    expect(idx1).toBeDefined();
+    expect(typeof idx1!.expression).toBe('function');
+
+    await orm1.close();
+
+    // Second init: load from cache — expression functions must survive
+    const orm2 = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      entities: [Organization, User],
+      dbName: 'mikro_orm_test_gh_7238',
+      metadataCache: { enabled: true, options: { cacheDir: cachePath } },
+    });
+
+    const meta2 = orm2.getMetadata().get('Organization');
+    const idx2 = meta2.indexes.find(i => i.name === 'organizations_name_ui');
+    expect(idx2).toBeDefined();
+    expect(typeof idx2!.expression).toBe('function');
+
+    const meta2u = orm2.getMetadata().get('User');
+    const idx2u = meta2u.indexes.find(i => i.name === 'users_organization_id_ui');
+    expect(idx2u).toBeDefined();
+    expect(typeof idx2u!.expression).toBe('function');
+
+    await orm2.close();
+    await rm(cachePath, { recursive: true, force: true });
+  });
+
+  test('schema diff should be clean after cache round-trip', async () => {
+    await rm(cachePath, { recursive: true, force: true });
+    await rm(migrationsPath, { recursive: true, force: true });
+
+    // First init: populate cache + create schema
+    const orm1 = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      entities: [Organization, User],
+      dbName: 'mikro_orm_test_gh_7238',
+      metadataCache: { enabled: true, options: { cacheDir: cachePath } },
+      migrations: { path: migrationsPath, snapshot: true },
+      extensions: [Migrator],
+    });
+    await orm1.schema.refreshDatabase();
+    await orm1.close();
+
+    // Second init: load from cache — should still produce clean diffs
+    const orm2 = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      entities: [Organization, User],
+      dbName: 'mikro_orm_test_gh_7238',
+      metadataCache: { enabled: true, options: { cacheDir: cachePath } },
+      migrations: { path: migrationsPath, snapshot: true },
+      extensions: [Migrator],
+    });
+
+    const updateSQL = await orm2.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(updateSQL).toBe('');
+
+    await orm2.close();
+    await rm(cachePath, { recursive: true, force: true });
+    await rm(migrationsPath, { recursive: true, force: true });
+  });
+
+});


### PR DESCRIPTION
## Summary
- Backport of the master fix (3fc87169a) to the 6.x branch
- When metadata is cached via JSON serialization (e.g. with TsMorphMetadataProvider), function expressions on `@Index`/`@Unique` decorators are silently dropped because `JSON.stringify` cannot serialize functions
- On the next init, `loadFromCache()` overwrites the decorator-applied indexes (with functions) with the cached version (without functions), causing the schema differ to emit spurious `DROP INDEX` statements
- The fix saves function expressions by index name before the cache merge in `MetadataProvider.loadFromCache()` and restores them afterward

Closes #7238

## Test plan
- [x] Added test: function expression indexes survive when metadata cache is disabled
- [x] Added test: function expression indexes survive cache round-trip (write + load)
- [x] Added test: schema diff is clean after cache round-trip (no spurious DROP INDEX)
- [x] `yarn build` (core package) passes
- [x] `yarn lint` passes
- [x] `yarn tsc-check-tests` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)