### PR TITLE
fix(migrations): normalize snapshots and write on both up/down

### DIFF
--- a/packages/migrations/src/Migrator.ts
+++ b/packages/migrations/src/Migrator.ts
@@ -141,13 +141,14 @@ export class Migrator extends AbstractMigrator<AbstractSqlDriver> {
   protected override async runMigrations(method: 'up' | 'down', options?: string | string[] | MigrateOptions): Promise<MigrationInfo[]> {
     const result = await super.runMigrations(method, options);
 
-    // Only update the snapshot after `down` — after reverting, the DB state
-    // diverges from what was stored during `create`, so we need to refresh it.
-    // For `up`, the snapshot is already up to date (written during `create`),
-    // and writing it would break read-only production environments (GH #7232).
-    if (method === 'down' && result.length > 0 && this.options.snapshot) {
+    if (result.length > 0 && this.options.snapshot) {
       const schema = await DatabaseSchema.create(this.em.getConnection(), this.em.getPlatform(), this.config);
-      await this.storeCurrentSchema(schema);
+
+      try {
+        await this.storeCurrentSchema(schema);
+      } catch {
+        // Silently ignore for read-only filesystems (production).
+      }
     }
 
     return result;

--- a/packages/sql/src/schema/DatabaseTable.ts
+++ b/packages/sql/src/schema/DatabaseTable.ts
@@ -1067,9 +1067,45 @@ export class DatabaseTable {
   toJSON(): Dictionary {
     const { platform, columns, ...rest } = this;
     const columnsMapped = Utils.keys(columns).reduce((o, col) => {
-      const { mappedType, ...restCol } = columns[col];
-      o[col] = restCol;
-      o[col].mappedType = Utils.keys(t).find(k => t[k] === mappedType.constructor);
+      const c = columns[col];
+      const normalized: Dictionary = {
+        name: c.name,
+        type: c.type,
+        unsigned: !!c.unsigned,
+        autoincrement: !!c.autoincrement,
+        primary: !!c.primary,
+        nullable: !!c.nullable,
+        unique: !!c.unique,
+        length: c.length ?? null,
+        precision: c.precision ?? null,
+        scale: c.scale ?? null,
+        default: c.default ?? null,
+        comment: c.comment ?? null,
+        enumItems: c.enumItems ?? [],
+        mappedType: Utils.keys(t).find(k => t[k] === c.mappedType.constructor),
+      };
+
+      if (c.generated) {
+        normalized.generated = c.generated;
+      }
+
+      if (c.nativeEnumName) {
+        normalized.nativeEnumName = c.nativeEnumName;
+      }
+
+      if (c.extra) {
+        normalized.extra = c.extra;
+      }
+
+      if (c.ignoreSchemaChanges) {
+        normalized.ignoreSchemaChanges = c.ignoreSchemaChanges;
+      }
+
+      if (c.defaultConstraint) {
+        normalized.defaultConstraint = c.defaultConstraint;
+      }
+
+      o[col] = normalized;
 
       return o;
     }, {} as Dictionary);

--- a/packages/sql/src/schema/SchemaComparator.ts
+++ b/packages/sql/src/schema/SchemaComparator.ts
@@ -550,7 +550,7 @@ export class SchemaComparator {
       }
     }
 
-    if (fromColumn.nullable !== toColumn.nullable && !fromColumn.generated && !toColumn.generated) {
+    if (!!fromColumn.nullable !== !!toColumn.nullable && !fromColumn.generated && !toColumn.generated) {
       log(`'nullable' changed for column ${fromTable.name}.${fromColumn.name}`, { fromColumn, toColumn });
       changedProperties.add('nullable');
     }
@@ -565,7 +565,7 @@ export class SchemaComparator {
       changedProperties.add('autoincrement');
     }
 
-    if (fromColumn.unsigned !== toColumn.unsigned && this.platform.supportsUnsigned()) {
+    if (!!fromColumn.unsigned !== !!toColumn.unsigned && this.platform.supportsUnsigned()) {
       log(`'unsigned' changed for column ${fromTable.name}.${fromColumn.name}`, { fromColumn, toColumn });
       changedProperties.add('unsigned');
     }

--- a/tests/features/migrations/Migrator.postgres.test.ts
+++ b/tests/features/migrations/Migrator.postgres.test.ts
@@ -173,7 +173,7 @@ describe('Migrator (postgres)', () => {
     migrations.snapshot = false;
   });
 
-  test('migration:down should update the snapshot to reflect current DB state', async () => {
+  test('migration:up and migration:down both update the snapshot to reflect current DB state', async () => {
     const migrations = orm.config.get('migrations');
     migrations.snapshot = true;
 
@@ -204,9 +204,14 @@ describe('Migrator (postgres)', () => {
 
     try {
       await orm.migrator.up(migration1.fileName);
+
+      // after up, snapshot should be updated via DB introspection
+      const snapshotAfterUp = readFileSync(snapshotPath, 'utf8');
+      expect(snapshotAfterUp).not.toEqual(snapshotAfterCreate);
+
       await orm.migrator.down(migration1.fileName);
 
-      // after down, snapshot should be updated to reflect current DB state
+      // after down, snapshot should also be updated to reflect current DB state
       const snapshotAfterDown = readFileSync(snapshotPath, 'utf8');
       expect(snapshotAfterDown).not.toEqual(snapshotAfterCreate);
 

--- a/tests/features/migrations/Migrator.sqlite.test.ts
+++ b/tests/features/migrations/Migrator.sqlite.test.ts
@@ -2,8 +2,7 @@ process.env.FORCE_COLOR = '0';
 import { MetadataStorage, MikroORM, raw } from '@mikro-orm/core';
 import { ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
 import { Migration, MigrationStorage, Migrator } from '@mikro-orm/migrations';
-import type { DatabaseTable } from '@mikro-orm/sqlite';
-import { DatabaseSchema, SqliteDriver } from '@mikro-orm/sqlite';
+import { DatabaseSchema, DatabaseTable, SqliteDriver } from '@mikro-orm/sqlite';
 import { rm } from 'node:fs/promises';
 import { initORMSqlite, mockLogger, TEMP_DIR } from '../../bootstrap.js';
 import { BaseEntity5, FooBar4, FooBaz4 } from '../../entities-schema/index.js';
@@ -106,7 +105,7 @@ describe('Migrator (sqlite)', () => {
     migrations.snapshot = false;
   });
 
-  test('migration up should not write the snapshot (GH #7232)', async () => {
+  test('migration up and down both write the snapshot', async () => {
     const migrations = orm.config.get('migrations');
     migrations.snapshot = true;
 
@@ -127,7 +126,7 @@ describe('Migrator (sqlite)', () => {
     const migration2 = await migrator.create();
     expect(migration2.diff).toEqual({ down: [], up: [] });
 
-    // spy on storeCurrentSchema to verify up does not call it
+    // spy on storeCurrentSchema to verify both up and down call it
     const storeSchemaSpy = vi.spyOn(migrator as any, 'storeCurrentSchema');
 
     // mock the down method so we don't need real SQL
@@ -135,22 +134,117 @@ describe('Migrator (sqlite)', () => {
     migratorMock.mockImplementation(async () => void 0);
 
     try {
-      // run the migration up — snapshot should NOT be written (read-only FS safe)
+      // run the migration up — snapshot SHOULD be written
       await migrator.up(migration1.fileName);
-      expect(storeSchemaSpy).not.toHaveBeenCalled();
-      // snapshot file should still exist unchanged from create
-      const snapshotAfterUp = readFileSync(snapshotPath, 'utf8');
-      expect(snapshotAfterUp).toBe(snapshotAfterCreate);
-
-      // run the migration down — snapshot SHOULD be updated
-      await migrator.down(migration1.fileName);
       expect(storeSchemaSpy).toHaveBeenCalledTimes(1);
+      const snapshotAfterUp = readFileSync(snapshotPath, 'utf8');
+      expect(snapshotAfterUp).toBeDefined();
+
+      // run the migration down — snapshot SHOULD also be updated
+      await migrator.down(migration1.fileName);
+      expect(storeSchemaSpy).toHaveBeenCalledTimes(2);
       const snapshotAfterDown = readFileSync(snapshotPath, 'utf8');
       expect(snapshotAfterDown).toBeDefined();
     } finally {
       await rm(path + '/' + migration1.fileName);
       await rm(snapshotPath, { force: true });
       storeSchemaSpy.mockRestore();
+      migratorMock.mockRestore();
+      migrations.snapshot = false;
+    }
+  });
+
+  test('migration up/down succeed on read-only filesystem', async () => {
+    const migrations = orm.config.get('migrations');
+    migrations.snapshot = true;
+
+    const dateMock = vi.spyOn(Date.prototype, 'toISOString');
+    dateMock.mockReturnValue('2019-10-13T21:48:13.382Z');
+    const path = process.cwd() + '/temp/migrations-3';
+    const migrator = new Migrator(orm.em);
+
+    // create a blank migration, this stores the snapshot
+    const migration1 = await migrator.create(path, true);
+    expect(migration1.diff).toEqual({ up: ['select 1'], down: ['select 1'] });
+
+    // mock storeCurrentSchema to throw (simulating read-only FS)
+    const storeSchemaSpy = vi.spyOn(migrator as any, 'storeCurrentSchema');
+    storeSchemaSpy.mockRejectedValue(new Error('EROFS: read-only file system'));
+
+    // mock the down method so we don't need real SQL
+    const migratorMock = vi.spyOn(Migration.prototype, 'down');
+    migratorMock.mockImplementation(async () => void 0);
+
+    try {
+      // up should succeed despite storeCurrentSchema throwing
+      await expect(migrator.up(migration1.fileName)).resolves.not.toThrow();
+      // down should also succeed
+      await expect(migrator.down(migration1.fileName)).resolves.not.toThrow();
+    } finally {
+      const snapshotPath = path + '/.snapshot-memory.json';
+      await rm(path + '/' + migration1.fileName);
+      await rm(snapshotPath, { force: true });
+      storeSchemaSpy.mockRestore();
+      migratorMock.mockRestore();
+      migrations.snapshot = false;
+    }
+  });
+
+  test('snapshot from create and up have identical column fields and consistent primary flag (GH #7234)', async () => {
+    const migrations = orm.config.get('migrations');
+    migrations.snapshot = true;
+
+    const { readFileSync } = await import('node:fs');
+    const dateMock = vi.spyOn(Date.prototype, 'toISOString');
+    dateMock.mockReturnValue('2019-10-13T21:48:13.382Z');
+    const path = process.cwd() + '/temp/migrations-3';
+    const migrator = new Migrator(orm.em);
+
+    // create a blank migration — snapshot is written from metadata (getTargetSchema)
+    const migration1 = await migrator.create(path, true);
+    const snapshotPath = path + '/.snapshot-memory.json';
+    const snapshotAfterCreate = JSON.parse(readFileSync(snapshotPath, 'utf8'));
+
+    // mock the down method so we don't need real SQL
+    const migratorMock = vi.spyOn(Migration.prototype, 'down');
+    migratorMock.mockImplementation(async () => void 0);
+
+    try {
+      // run up — snapshot is now written from DB introspection (DatabaseSchema.create)
+      await migrator.up(migration1.fileName);
+      const snapshotAfterUp = JSON.parse(readFileSync(snapshotPath, 'utf8'));
+
+      // both snapshots should have the same tables
+      expect(snapshotAfterUp.tables.length).toBe(snapshotAfterCreate.tables.length);
+
+      for (const createTable of snapshotAfterCreate.tables) {
+        const upTable = snapshotAfterUp.tables.find((t: any) => t.name === createTable.name);
+        expect(upTable).toBeDefined();
+
+        for (const [colName, createCol] of Object.entries<any>(createTable.columns)) {
+          const upCol = upTable.columns[colName];
+          expect(upCol).toBeDefined();
+
+          // both paths must produce the same set of fields (structural consistency)
+          expect(Object.keys(upCol).sort()).toEqual(Object.keys(createCol).sort());
+
+          // boolean fields must be proper booleans, not 0/1/undefined
+          for (const boolField of ['primary', 'nullable', 'unsigned', 'autoincrement', 'unique']) {
+            expect(typeof createCol[boolField]).toBe('boolean');
+            expect(typeof upCol[boolField]).toBe('boolean');
+          }
+
+          // non-composite PK columns must have primary: true in both paths
+          // (composite PK columns have primary: false in metadata path — by design,
+          // as the column-level primary flag controls DDL generation)
+          if (createCol.primary) {
+            expect(upCol.primary).toBe(true);
+          }
+        }
+      }
+    } finally {
+      await rm(path + '/' + migration1.fileName);
+      await rm(snapshotPath, { force: true });
       migratorMock.mockRestore();
       migrations.snapshot = false;
     }
@@ -363,6 +457,55 @@ describe('Migrator (sqlite)', () => {
     });
     await expect(orm.migrator.create()).resolves.not.toThrow();
     await orm.close();
+  });
+
+  test('toJSON serializes optional column fields (generated, nativeEnumName, extra, ignoreSchemaChanges, defaultConstraint)', () => {
+    const platform = orm.em.getPlatform();
+    const table = new DatabaseTable(platform, 'test_json');
+
+    table.addColumn({
+      name: 'gen_col',
+      type: 'text',
+      generated: '(col1 || col2) stored',
+      mappedType: platform.getMappedType('text'),
+    });
+    table.addColumn({
+      name: 'enum_col',
+      type: 'user_status',
+      nativeEnumName: 'user_status',
+      mappedType: platform.getMappedType('string'),
+    });
+    table.addColumn({
+      name: 'extra_col',
+      type: 'timestamp',
+      extra: 'on update current_timestamp',
+      mappedType: platform.getMappedType('datetime'),
+    });
+    table.addColumn({
+      name: 'ignore_col',
+      type: 'text',
+      ignoreSchemaChanges: ['type', 'extra'],
+      mappedType: platform.getMappedType('text'),
+    });
+    table.addColumn({
+      name: 'dc_col',
+      type: 'int',
+      defaultConstraint: 'DF_test_col1',
+      mappedType: platform.getMappedType('integer'),
+    });
+
+    const json = table.toJSON();
+    expect(json.columns.gen_col.generated).toBe('(col1 || col2) stored');
+    expect(json.columns.enum_col.nativeEnumName).toBe('user_status');
+    expect(json.columns.extra_col.extra).toBe('on update current_timestamp');
+    expect(json.columns.ignore_col.ignoreSchemaChanges).toEqual(['type', 'extra']);
+    expect(json.columns.dc_col.defaultConstraint).toBe('DF_test_col1');
+
+    // fields should not appear when not set
+    expect(json.columns.gen_col).not.toHaveProperty('nativeEnumName');
+    expect(json.columns.gen_col).not.toHaveProperty('extra');
+    expect(json.columns.gen_col).not.toHaveProperty('ignoreSchemaChanges');
+    expect(json.columns.gen_col).not.toHaveProperty('defaultConstraint');
   });
 
 });


### PR DESCRIPTION
## Summary

- **Normalize column serialization** in `DatabaseTable.toJSON()` to use a canonical form with explicit defaults (same fields, same order, same defaults) — eliminates JSON diff noise between metadata-based (`create`) and introspection-based (`up`/`down`) snapshot paths
- **Re-enable snapshot write on `migration:up`** (reverts c5ebd0a84) wrapped in `try/catch` so read-only filesystems (production) still work silently
- **Defensive `!!` coercion** for `nullable` and `unsigned` comparisons in `SchemaComparator.diffColumn()` for backward compat with pre-normalization snapshots

## Test plan

- [x] `yarn build` (packages/sql + packages/migrations)
- [x] `yarn lint` passes
- [x] `yarn tsc-check-tests` passes
- [x] `yarn test Migrator.sqlite.test.ts` — 16/16 tests pass (includes new read-only FS test)
- [x] `yarn test Migrator.postgres.test.ts` — 19/19 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)