### PR TITLE
fix(migrations): normalize snapshots and write on both up/down

### DIFF
--- a/packages/knex/src/schema/DatabaseTable.ts
+++ b/packages/knex/src/schema/DatabaseTable.ts
@@ -108,14 +108,15 @@ export class DatabaseTable {
         }
       }
 
-      const primary = !meta.compositePK && !!prop.primary && prop.kind === ReferenceKind.SCALAR && this.platform.isNumericColumn(mappedType);
+      const primary = !!prop.primary;
+      const autoincrement = !meta.compositePK && primary && prop.kind === ReferenceKind.SCALAR && this.platform.isNumericColumn(mappedType);
       this.columns[field] = {
         name: prop.fieldNames[idx],
         type: prop.columnTypes[idx],
         generated: prop.generated as string,
         mappedType,
         unsigned: prop.unsigned && this.platform.isNumericColumn(mappedType),
-        autoincrement: prop.autoincrement ?? primary,
+        autoincrement: prop.autoincrement ?? autoincrement,
         primary,
         nullable: this.columns[field]?.nullable ?? !!prop.nullable,
         nativeEnumName: prop.nativeEnumName,
@@ -990,9 +991,41 @@ export class DatabaseTable {
   toJSON(): Dictionary {
     const { platform, columns, ...rest } = this;
     const columnsMapped = Utils.keys(columns).reduce((o, col) => {
-      const { mappedType, ...restCol } = columns[col];
-      o[col] = restCol;
-      o[col].mappedType = Utils.keys(t).find(k => t[k] === mappedType.constructor);
+      const c = columns[col];
+      const normalized: Dictionary = {
+        name: c.name,
+        type: c.type,
+        unsigned: !!c.unsigned,
+        autoincrement: !!c.autoincrement,
+        primary: !!c.primary,
+        nullable: !!c.nullable,
+        unique: !!c.unique,
+        length: c.length ?? null,
+        precision: c.precision ?? null,
+        scale: c.scale ?? null,
+        default: c.default ?? null,
+        comment: c.comment ?? null,
+        enumItems: c.enumItems ?? [],
+        mappedType: Utils.keys(t).find(k => t[k] === c.mappedType.constructor),
+      };
+
+      if (c.generated) {
+        normalized.generated = c.generated;
+      }
+
+      if (c.nativeEnumName) {
+        normalized.nativeEnumName = c.nativeEnumName;
+      }
+
+      if (c.extra) {
+        normalized.extra = c.extra;
+      }
+
+      if (c.ignoreSchemaChanges) {
+        normalized.ignoreSchemaChanges = c.ignoreSchemaChanges;
+      }
+
+      o[col] = normalized;
 
       return o;
     }, {} as Dictionary);

--- a/packages/knex/src/schema/SchemaComparator.ts
+++ b/packages/knex/src/schema/SchemaComparator.ts
@@ -516,7 +516,7 @@ export class SchemaComparator {
       }
     }
 
-    if (fromColumn.nullable !== toColumn.nullable && !fromColumn.generated && !toColumn.generated) {
+    if (!!fromColumn.nullable !== !!toColumn.nullable && !fromColumn.generated && !toColumn.generated) {
       log(`'nullable' changed for column ${tableName}.${fromColumn.name}`, { fromColumn, toColumn });
       changedProperties.add('nullable');
     }
@@ -531,7 +531,7 @@ export class SchemaComparator {
       changedProperties.add('autoincrement');
     }
 
-    if (fromColumn.unsigned !== toColumn.unsigned && this.platform.supportsUnsigned()) {
+    if (!!fromColumn.unsigned !== !!toColumn.unsigned && this.platform.supportsUnsigned()) {
       log(`'unsigned' changed for column ${tableName}.${fromColumn.name}`, { fromColumn, toColumn });
       changedProperties.add('unsigned');
     }

--- a/packages/migrations/src/Migrator.ts
+++ b/packages/migrations/src/Migrator.ts
@@ -439,13 +439,14 @@ export class Migrator implements IMigrator {
       result = await this.driver.getConnection().transactional(trx => this.runInTransaction(trx, method, options));
     }
 
-    // Only update the snapshot after `down` — after reverting, the DB state
-    // diverges from what was stored during `create`, so we need to refresh it.
-    // For `up`, the snapshot is already up to date (written during `create`),
-    // and writing it would break read-only production environments (GH #7232).
-    if (method === 'down' && result.length > 0 && this.options.snapshot) {
+    if (result.length > 0 && this.options.snapshot) {
       const schema = await DatabaseSchema.create(this.em.getConnection(), this.em.getPlatform(), this.config);
-      await this.storeCurrentSchema(schema);
+
+      try {
+        await this.storeCurrentSchema(schema);
+      } catch {
+        // Silently ignore for read-only filesystems (production).
+      }
     }
 
     return result;

--- a/tests/features/migrations/Migrator.postgres.test.ts
+++ b/tests/features/migrations/Migrator.postgres.test.ts
@@ -182,7 +182,7 @@ describe('Migrator (postgres)', () => {
     migrations.snapshot = false;
   });
 
-  test('migration:down should update the snapshot to reflect current DB state', async () => {
+  test('migration:up and migration:down both update the snapshot to reflect current DB state', async () => {
     const migrations = orm.config.get('migrations');
     migrations.snapshot = true;
 
@@ -214,9 +214,14 @@ describe('Migrator (postgres)', () => {
 
     try {
       await orm.migrator.up(migration1.fileName);
+
+      // after up, snapshot should be updated via DB introspection
+      const snapshotAfterUp = readFileSync(snapshotPath, 'utf8');
+      expect(snapshotAfterUp).not.toEqual(snapshotAfterCreate);
+
       await orm.migrator.down(migration1.fileName);
 
-      // after down, snapshot should be updated to reflect current DB state
+      // after down, snapshot should also be updated to reflect current DB state
       const snapshotAfterDown = readFileSync(snapshotPath, 'utf8');
       expect(snapshotAfterDown).not.toEqual(snapshotAfterCreate);
 

--- a/tests/features/migrations/Migrator.sqlite.test.ts
+++ b/tests/features/migrations/Migrator.sqlite.test.ts
@@ -2,8 +2,7 @@
 import { Umzug } from 'umzug';
 import { MetadataStorage, MikroORM } from '@mikro-orm/core';
 import { Migration, MigrationStorage, Migrator } from '@mikro-orm/migrations';
-import type { DatabaseTable } from '@mikro-orm/sqlite';
-import { DatabaseSchema, SqliteDriver } from '@mikro-orm/sqlite';
+import { DatabaseSchema, DatabaseTable, SqliteDriver } from '@mikro-orm/sqlite';
 import { remove } from 'fs-extra';
 import { initORMSqlite2, mockLogger, TEMP_DIR } from '../../bootstrap';
 import { BaseEntity5, FooBar4, FooBaz4 } from '../../entities-schema';
@@ -107,7 +106,7 @@ describe('Migrator (sqlite)', () => {
     migrations.snapshot = false;
   });
 
-  test('migration up should not write the snapshot (GH #7232)', async () => {
+  test('migration up and down both write the snapshot', async () => {
     const migrations = orm.config.get('migrations');
     migrations.snapshot = true;
 
@@ -128,7 +127,7 @@ describe('Migrator (sqlite)', () => {
     const migration2 = await migrator.createMigration();
     expect(migration2.diff).toEqual({ down: [], up: [] });
 
-    // spy on storeCurrentSchema to verify up does not call it
+    // spy on storeCurrentSchema to verify both up and down call it
     const storeSchemaSpy = jest.spyOn(migrator as any, 'storeCurrentSchema');
 
     // mock the down method so we don't need real SQL
@@ -136,22 +135,116 @@ describe('Migrator (sqlite)', () => {
     migratorMock.mockImplementation(async () => void 0);
 
     try {
-      // run the migration up — snapshot should NOT be written (read-only FS safe)
+      // run the migration up — snapshot SHOULD be written
       await migrator.up(migration1.fileName);
-      expect(storeSchemaSpy).not.toHaveBeenCalled();
-      // snapshot file should still exist unchanged from create
-      const snapshotAfterUp = readFileSync(snapshotPath, 'utf8');
-      expect(snapshotAfterUp).toBe(snapshotAfterCreate);
-
-      // run the migration down — snapshot SHOULD be updated
-      await migrator.down(migration1.fileName);
       expect(storeSchemaSpy).toHaveBeenCalledTimes(1);
+      const snapshotAfterUp = readFileSync(snapshotPath, 'utf8');
+      expect(snapshotAfterUp).toBeDefined();
+
+      // run the migration down — snapshot SHOULD also be updated
+      await migrator.down(migration1.fileName);
+      expect(storeSchemaSpy).toHaveBeenCalledTimes(2);
       const snapshotAfterDown = readFileSync(snapshotPath, 'utf8');
       expect(snapshotAfterDown).toBeDefined();
     } finally {
       await remove(path + '/' + migration1.fileName);
       await remove(snapshotPath);
       storeSchemaSpy.mockRestore();
+      migratorMock.mockRestore();
+      migrations.snapshot = false;
+    }
+  });
+
+  test('migration up/down succeed on read-only filesystem', async () => {
+    const migrations = orm.config.get('migrations');
+    migrations.snapshot = true;
+
+    const dateMock = jest.spyOn(Date.prototype, 'toISOString');
+    dateMock.mockReturnValue('2019-10-13T21:48:13.382Z');
+    const path = process.cwd() + '/temp/migrations-3';
+    const migrator = new Migrator(orm.em);
+
+    // create a blank migration, this stores the snapshot
+    const migration1 = await migrator.createMigration(path, true);
+    expect(migration1.diff).toEqual({ up: ['select 1'], down: ['select 1'] });
+
+    // mock storeCurrentSchema to throw (simulating read-only FS)
+    const storeSchemaSpy = jest.spyOn(migrator as any, 'storeCurrentSchema');
+    storeSchemaSpy.mockRejectedValue(new Error('EROFS: read-only file system'));
+
+    // mock the down method so we don't need real SQL
+    const migratorMock = jest.spyOn(Migration.prototype, 'down');
+    migratorMock.mockImplementation(async () => void 0);
+
+    try {
+      // up should succeed despite storeCurrentSchema throwing
+      await expect(migrator.up(migration1.fileName)).resolves.not.toThrow();
+      // down should also succeed
+      await expect(migrator.down(migration1.fileName)).resolves.not.toThrow();
+    } finally {
+      const snapshotPath = path + '/.snapshot-:memory:.json';
+      await remove(path + '/' + migration1.fileName);
+      await remove(snapshotPath);
+      storeSchemaSpy.mockRestore();
+      migratorMock.mockRestore();
+      migrations.snapshot = false;
+    }
+  });
+
+  test('snapshot from create and up have identical column fields and consistent primary flag (GH #7234)', async () => {
+    const migrations = orm.config.get('migrations');
+    migrations.snapshot = true;
+
+    const { readFileSync } = await import('node:fs');
+    const dateMock = jest.spyOn(Date.prototype, 'toISOString');
+    dateMock.mockReturnValue('2019-10-13T21:48:13.382Z');
+    const path = process.cwd() + '/temp/migrations-3';
+    const migrator = new Migrator(orm.em);
+
+    // create a blank migration — snapshot is written from metadata (getTargetSchema)
+    const migration1 = await migrator.createMigration(path, true);
+    const snapshotPath = path + '/.snapshot-:memory:.json';
+    const snapshotAfterCreate = JSON.parse(readFileSync(snapshotPath, 'utf8'));
+
+    // mock the down method so we don't need real SQL
+    const migratorMock = jest.spyOn(Migration.prototype, 'down');
+    migratorMock.mockImplementation(async () => void 0);
+
+    try {
+      // run up — snapshot is now written from DB introspection (DatabaseSchema.create)
+      await migrator.up(migration1.fileName);
+      const snapshotAfterUp = JSON.parse(readFileSync(snapshotPath, 'utf8'));
+
+      // both snapshots should have the same tables
+      expect(snapshotAfterUp.tables.length).toBe(snapshotAfterCreate.tables.length);
+
+      for (const createTable of snapshotAfterCreate.tables) {
+        const upTable = snapshotAfterUp.tables.find((t: any) => t.name === createTable.name);
+        expect(upTable).toBeDefined();
+
+        for (const [colName, createCol] of Object.entries<any>(createTable.columns)) {
+          const upCol = upTable.columns[colName];
+          expect(upCol).toBeDefined();
+
+          // both paths must produce the same set of fields (structural consistency)
+          expect(Object.keys(upCol).sort()).toEqual(Object.keys(createCol).sort());
+
+          // boolean fields must be proper booleans, not 0/1/undefined
+          for (const boolField of ['primary', 'nullable', 'unsigned', 'autoincrement', 'unique']) {
+            expect(typeof createCol[boolField]).toBe('boolean');
+            expect(typeof upCol[boolField]).toBe('boolean');
+          }
+
+          // PK columns must have primary: true in both paths
+          if (createCol.primary || upCol.primary) {
+            expect(createCol.primary).toBe(true);
+            expect(upCol.primary).toBe(true);
+          }
+        }
+      }
+    } finally {
+      await remove(path + '/' + migration1.fileName);
+      await remove(snapshotPath);
       migratorMock.mockRestore();
       migrations.snapshot = false;
     }
@@ -372,6 +465,47 @@ describe('Migrator (sqlite)', () => {
     await remove(TEMP_DIR + '/migrations/' + migration.fileName);
     await remove(snapshotPath);
     await orm.close();
+  });
+
+  test('toJSON serializes optional column fields (generated, nativeEnumName, extra, ignoreSchemaChanges)', () => {
+    const platform = orm.em.getPlatform();
+    const table = new DatabaseTable(platform, 'test_json');
+
+    table.addColumn({
+      name: 'gen_col',
+      type: 'text',
+      generated: '(col1 || col2) stored',
+      mappedType: platform.getMappedType('text'),
+    });
+    table.addColumn({
+      name: 'enum_col',
+      type: 'user_status',
+      nativeEnumName: 'user_status',
+      mappedType: platform.getMappedType('string'),
+    });
+    table.addColumn({
+      name: 'extra_col',
+      type: 'timestamp',
+      extra: 'on update current_timestamp',
+      mappedType: platform.getMappedType('datetime'),
+    });
+    table.addColumn({
+      name: 'ignore_col',
+      type: 'text',
+      ignoreSchemaChanges: ['type', 'extra'],
+      mappedType: platform.getMappedType('text'),
+    });
+
+    const json = table.toJSON();
+    expect(json.columns.gen_col.generated).toBe('(col1 || col2) stored');
+    expect(json.columns.enum_col.nativeEnumName).toBe('user_status');
+    expect(json.columns.extra_col.extra).toBe('on update current_timestamp');
+    expect(json.columns.ignore_col.ignoreSchemaChanges).toEqual(['type', 'extra']);
+
+    // fields should not appear when not set
+    expect(json.columns.gen_col).not.toHaveProperty('nativeEnumName');
+    expect(json.columns.gen_col).not.toHaveProperty('extra');
+    expect(json.columns.gen_col).not.toHaveProperty('ignoreSchemaChanges');
   });
 
 });

--- a/tests/features/schema-generator/serial-property.postgres.test.ts
+++ b/tests/features/schema-generator/serial-property.postgres.test.ts
@@ -145,7 +145,7 @@ test('schema generator works with non-pk autoincrement columns (serial)', async 
   expect(mock.mock.calls[5][0]).toMatch(`column public.something._id removed`);
   expect(mock.mock.calls[6][0]).toMatch(`column public.something._id of type serial added`);
   expect(mock.mock.calls[7][0]).toMatch(`'type' changed for column public.something.id { fromColumnType: 'int', toColumnType: 'varchar(255)' }`);
-  expect(mock.mock.calls[8][0]).toMatch(`'autoincrement' changed for column public.something.id { fromColumn: { name: 'id', type: 'int4', mappedType: IntegerType {}, length: null, precision: 32, scale: 0, nullable: false, default: null, unsigned: true, autoincrement: true, comment: null, primary: true, unique: false, enumItems: [] }, toColumn: { name: 'id', type: 'varchar(255)', mappedType: StringType {}, unsigned: false, autoincrement: false, primary: false, nullable: false, length: 255 }}`);
+  expect(mock.mock.calls[8][0]).toMatch(`'autoincrement' changed for column public.something.id { fromColumn: { name: 'id', type: 'int4', mappedType: IntegerType {}, length: null, precision: 32, scale: 0, nullable: false, default: null, unsigned: true, autoincrement: true, comment: null, primary: true, unique: false, enumItems: [] }, toColumn: { name: 'id', type: 'varchar(255)', mappedType: StringType {}, unsigned: false, autoincrement: false, primary: true, nullable: false, length: 255 }}`);
   expect(mock.mock.calls[9][0]).toMatch(`column public.something.id changed { changedProperties: Set(2) { 'type', 'autoincrement' } }`);
 });
 


### PR DESCRIPTION
## Summary

Backport of #7235 to 6.x, plus a root cause fix for the `primary` flag bug.

- **Fix `addColumnFromProperty`**: The `primary` flag was conflated with autoincrement eligibility — text PKs and composite PK columns got `primary: false` in metadata. Separated the two concerns so `primary` is always `!!prop.primary`.
- **Normalize column serialization** in `DatabaseTable.toJSON()` to a canonical form with `!!` coercion for booleans (handles SQLite returning `0`/`1` instead of `false`/`true`) and explicit null defaults for optional fields.
- **Re-enable snapshot write on `migration:up`** wrapped in `try/catch` so read-only filesystems still work.
- **Defensive `!!` coercion** for `nullable` and `unsigned` comparisons in `SchemaComparator.diffColumn()`.

Closes #7234

## Test plan

- [x] `yarn build` (packages/knex + packages/migrations)
- [x] `yarn test -- --testPathPattern Migrator.sqlite.test.ts` — 17/17 pass (includes integration test verifying snapshots from metadata and introspection produce identical column fields and consistent `primary` flag)
- [x] `yarn test -- --testPathPattern Migrator.postgres.test.ts` — 19/19 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)