### PR TITLE
feat(logger): added support for slow query logging

### DIFF
--- a/packages/core/src/connections/Connection.ts
+++ b/packages/core/src/connections/Connection.ts
@@ -13,12 +13,14 @@ export abstract class Connection {
   protected platform!: Platform;
   protected readonly options: ConnectionOptions;
   protected readonly logger: Logger;
+  protected readonly slowQueryLogger: Logger;
   protected connected = false;
 
   constructor(protected readonly config: Configuration,
               options?: ConnectionOptions,
               protected readonly type: ConnectionType = 'write') {
     this.logger = this.config.getLogger();
+    this.slowQueryLogger = this.config.getSlowQueryLogger();
     this.platform = this.config.getPlatform();
 
     if (options) {
@@ -150,12 +152,27 @@ export abstract class Connection {
 
     try {
       const res = await cb();
+      const took = Date.now() - now;
+      const threshold = this.config.getSlowQueryThreshold();
+      
       this.logQuery(query, {
         ...context,
-        took: Date.now() - now,
+        took,
         results: Array.isArray(res) ? res.length : undefined,
         affected: Utils.isPlainObject<QueryResult>(res) ? res.affectedRows : undefined,
       });
+
+      if (threshold && took >= threshold) {
+        this.slowQueryLogger.warn('slow-query', `${query} [took ${took} ms]`, {
+          ...context,
+          took,
+          connection: {
+            type: this.type,
+            name: this.options.name || this.config.get('name') || this.options.host,
+          },
+          query,
+        });
+      }
 
       return res;
     } catch (e) {

--- a/packages/core/src/logging/DefaultLogger.ts
+++ b/packages/core/src/logging/DefaultLogger.ts
@@ -67,6 +67,7 @@ export class DefaultLogger implements Logger {
 
   isEnabled(namespace: LoggerNamespace, context?: LogContext) {
     if (context?.enabled !== undefined) { return context.enabled; }
+    if (namespace === 'slow-query') { return true; }
     const debugMode = context?.debugMode ?? this.debugMode;
 
     if (namespace === 'deprecated') {

--- a/packages/core/src/logging/Logger.ts
+++ b/packages/core/src/logging/Logger.ts
@@ -31,7 +31,7 @@ export interface Logger {
 
 }
 
-export type LoggerNamespace = 'query' | 'query-params' | 'schema' | 'discovery' | 'info' | 'deprecated';
+export type LoggerNamespace = 'query' | 'query-params' | 'schema' | 'discovery' | 'info' | 'deprecated' | 'slow-query';
 
 export interface LogContext extends Dictionary {
   query?: string;

--- a/packages/core/src/utils/Configuration.ts
+++ b/packages/core/src/utils/Configuration.ts
@@ -167,6 +167,7 @@ export class Configuration<D extends IDatabaseDriver = IDatabaseDriver, EM exten
 
   private readonly options: RequiredOptions<D, EM>;
   private readonly logger: Logger;
+  private readonly slowQueryLogger: Logger;
   private readonly driver!: D;
   private readonly platform!: ReturnType<D['getPlatform']>;
   private readonly cache = new Map<string, any>();
@@ -191,6 +192,16 @@ export class Configuration<D extends IDatabaseDriver = IDatabaseDriver, EM exten
       highlighter: this.options.highlighter,
       writer: this.options.logger,
     });
+
+    const slowQueryLoggerFactory = this.options.slowQueryLogger;
+    this.slowQueryLogger = slowQueryLoggerFactory
+      ? slowQueryLoggerFactory({
+        debugMode: this.options.debug,
+        ignoreDeprecations: this.options.ignoreDeprecations,
+        usesReplicas: (this.options.replicas?.length ?? 0) > 0,
+        highlighter: this.options.highlighter,
+        writer: this.options.logger,
+      }) : this.logger;
 
     const cf = this.options.compiledFunctions as Record<string, unknown> | undefined;
 
@@ -248,6 +259,22 @@ export class Configuration<D extends IDatabaseDriver = IDatabaseDriver, EM exten
    */
   getLogger(): Logger {
     return this.logger;
+  }
+
+  /**
+   * Gets the logger instance for slow queries.
+   * Falls back to the main logger if no custom slow query logger is configured.
+   */
+  getSlowQueryLogger(): Logger {
+    return this.slowQueryLogger;
+  }
+
+  /**
+   * Gets the slow query threshold in milliseconds.
+   * Returns undefined if not configured.
+   */
+  getSlowQueryThreshold(): number | undefined {
+    return this.options.slowQueryThreshold;
   }
 
   getDataloaderType(): DataloaderType {
@@ -1027,6 +1054,18 @@ export interface Options<
    * @default console.log
    */
   logger?: (message: string) => void;
+  /**
+   * Threshold in milliseconds for logging slow queries.
+   * Queries taking longer than this value will be logged via the 'slow-query' namespace at warning level.
+   * @default undefined (slow query logging disabled)
+   */
+  slowQueryThreshold?: number;
+  /**
+   * Factory function to create a custom logger instance for slow queries.
+   * When not provided, the main logger instance is used.
+   * @default undefined (falls back to main logger)
+   */
+  slowQueryLogger?: (options: LoggerOptions) => Logger;
   /**
    * Enable colored output in logs.
    * @default true

--- a/tests/features/logging/logging.test.ts
+++ b/tests/features/logging/logging.test.ts
@@ -152,4 +152,60 @@ describe('logging', () => {
     expect(logSpy.mock.calls[1][2]).toMatchObject({ id: em.id, label: 'foo', bar: 123 });
   });
 
+  describe('slow query logging', () => {
+    let slowOrm: MikroORM;
+    let slowLoggerMock: Mock;
+  
+    beforeAll(async () => {
+      slowLoggerMock = vi.fn();
+  
+      slowOrm = await MikroORM.init({
+        metadataProvider: ReflectMetadataProvider,
+        entities: [Example],
+        dbName: ':memory:',
+        loggerFactory: opts => new DefaultLogger(opts),
+        slowQueryThreshold: 1, // enable slow query logging
+        slowQueryLogger: opts => new DefaultLogger({
+          ...opts,
+          writer: slowLoggerMock,
+        }),
+      });
+  
+      await slowOrm.schema.create();
+    });
+  
+    afterAll(async () => {
+      await slowOrm.close(true);
+    });
+  
+    beforeEach(async () => {
+      await slowOrm.schema.clear();
+      const example = new Example();
+      example.id = 1;
+      await slowOrm.em.persist(example).flush();
+      slowOrm.em.clear();
+      vi.clearAllMocks();
+    });
+  
+    it('logs slow queries via slow-query namespace when threshold is exceeded', async () => {
+      const nowSpy = vi.spyOn(Date, 'now');
+      nowSpy
+        .mockImplementationOnce(() => 0)
+        .mockImplementationOnce(() => 5);
+
+      const em = slowOrm.em.fork();
+  
+      await em.findOneOrFail(Example, { id: 1 });
+  
+      expect(slowLoggerMock).toHaveBeenCalled();
+  
+      expect(slowLoggerMock.mock.calls).toHaveLength(1);
+      const firstCallMsg = slowLoggerMock.mock.calls[0][0] as string;
+      expect(firstCallMsg).toContain('[slow-query]');
+      expect(firstCallMsg).toContain('[took 5 ms]');
+
+      nowSpy.mockRestore();
+    });
+  
+  });
 });


### PR DESCRIPTION
closes #4695 

- Introduced two slow query options into the Mikro ORM config [Both optional].
  - `slowQueryThreshold` - Threshold in milliseconds for logging slow queries. 
  - `slowQueryLogger` - Factory function to create a custom logger instance for slow queries.
- Introduced a new logger namespace - `slow-query` [To easily identify the slow-query logs. ]
- Added logic in the `executeQuery` method to log slow queries at the warning level if the query time exceeds the slowQuery threshold. 


This is my first contribution to Mikro ORM. I do not have a lot of experience with TypeScript either; I tried to do this while learning it. So please feel free to let me know if I missed some nuances; I'm happy to address the feedback. 