### PR TITLE
fix(mongo): fix support for deno by handling `TypedArray` when cloning

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -351,10 +351,15 @@ jobs:
         with:
           cache: yarn
 
-      - name: Install & build
+      - name: Install & build & pull docker images
         run: |
+          docker compose pull mongo &
           yarn
           yarn build
+          wait
+
+      - name: Init docker
+        run: docker compose up -d mongo --wait
 
       - name: Setup Deno
         uses: denoland/setup-deno@v2
@@ -363,6 +368,9 @@ jobs:
 
       - name: Test (Deno + node:sqlite)
         run: deno run --allow-read --allow-write --allow-env --allow-ffi --node-modules-dir=manual tests/deno/sqlite.test.ts
+
+      - name: Test (Deno + mongodb)
+        run: deno run --allow-read --allow-write --allow-env --allow-net --allow-sys --node-modules-dir=manual tests/deno/mongodb.test.ts
 
   release:
     name: Release

--- a/packages/core/src/utils/clone.ts
+++ b/packages/core/src/utils/clone.ts
@@ -25,6 +25,8 @@ function getPropertyDescriptor<T>(obj: T, prop: keyof T): PropertyDescriptor | n
   return null;
 }
 
+const TypedArray = Object.getPrototypeOf(Uint8Array);
+
 export function clone<T>(parent: T, respectCustomCloneMethod = true): T {
   const allParents: unknown[] = [];
   const allChildren: unknown[] = [];
@@ -81,6 +83,9 @@ export function clone<T>(parent: T, respectCustomCloneMethod = true): T {
     } else if (Buffer.isBuffer(parent)) {
       child = Buffer.allocUnsafe(parent.length);
       parent.copy(child as Buffer);
+      return child;
+    } else if (parent instanceof TypedArray) {
+      child = parent.copyWithin(0);
       return child;
     } else if (parent instanceof Error) {
       child = new (parent as any).constructor(parent.message);

--- a/tests/Utils.win.test.ts
+++ b/tests/Utils.win.test.ts
@@ -175,6 +175,19 @@ describe('Utils', () => {
       expect(copied).toBeInstanceOf(Child);
       expect(copied.name).toBe(expected);
     });
+
+    describe('should copy TypedArray', () => {
+      test('should copy Uint8Array', () => {
+        const a = new Uint8Array([1, 2, 3]);
+        const b = Utils.copy(a);
+        expect(b.toString()).toBe(a.toString());
+      });
+      test('should copy Int8Array', () => {
+        const a = new Uint8Array([-1, 1]);
+        const b = Utils.copy(a);
+        expect(b.toString()).toBe(a.toString());
+      });
+    });
   });
 
   test('getConstructorParams', () => {

--- a/tests/deno/mongodb.test.ts
+++ b/tests/deno/mongodb.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Deno integration test — validates MikroORM works on Deno with node:sqlite.
+ *
+ * Run: deno run --allow-read --allow-write --allow-env --allow-net --allow-sys --node-modules-dir=manual tests/deno/mongodb.test.ts
+ */
+import { MikroORM } from '@mikro-orm/core';
+import { MongoDriver, defineEntity, p } from '@mikro-orm/mongodb';
+import { ObjectId } from 'mongodb';
+
+// ---------------------------------------------------------------------------
+// 1. Entity definitions
+// ---------------------------------------------------------------------------
+const Author = defineEntity({
+  name: 'Author',
+  collection: 'author',
+  properties: {
+    _id: p.type(ObjectId).primary(),
+    name: p.string(),
+    email: p.string(),
+  },
+});
+
+const Book = defineEntity({
+  name: 'Book',
+  collection: 'book',
+  properties: {
+    _id: p.type(ObjectId).primary(),
+    title: p.string(),
+    author: () => p.manyToOne(Author),
+  },
+});
+
+// ---------------------------------------------------------------------------
+// 2. Test runner
+// ---------------------------------------------------------------------------
+let passed = 0;
+let failed = 0;
+
+function assert(condition: boolean, message: string) {
+  if (condition) {
+    passed++;
+  } else {
+    failed++;
+    console.error(`  FAIL: ${message}`);
+  }
+}
+
+const orm = await MikroORM.init({
+  driver: MongoDriver,
+  entities: [Author, Book],
+  clientUrl: 'mongodb://localhost:27017/mikro-orm-test',
+});
+
+// create schema
+await orm.schema.create();
+
+// insert
+const em1 = orm.em.fork();
+const author = em1.create(Author, { name: 'John', email: 'john@example.com' });
+em1.create(Book, { title: 'Book 1', author });
+em1.create(Book, { title: 'Book 2', author });
+await em1.flush();
+assert(author._id !== undefined, 'Author should have an id after flush');
+
+// query
+const em2 = orm.em.fork();
+const authors = await em2.findAll(Author);
+assert(authors.length === 1, `Expected 1 author, got ${authors.length}`);
+assert(authors[0].name === 'John', `Expected 'John', got '${authors[0].name}'`);
+
+const books = await em2.findAll(Book, { populate: ['author'] });
+assert(books.length === 2, `Expected 2 books, got ${books.length}`);
+assert(books[0].author.name === 'John', 'Book should have author populated');
+
+// update
+authors[0].name = 'John Updated';
+await em2.flush();
+
+const em3 = orm.em.fork();
+const updated = await em3.findOne(Author, { name: 'John Updated' });
+assert(updated !== null, 'Should find updated author');
+
+// delete
+const em4 = orm.em.fork();
+const toDelete = await em4.findAll(Book);
+toDelete.forEach(b => em4.remove(b));
+await em4.flush();
+
+const remaining = await em4.findAll(Book);
+assert(remaining.length === 0, `Expected 0 books after delete, got ${remaining.length}`);
+
+// schema drop
+await orm.schema.drop();
+await orm.close();
+
+// report
+console.log(`\nDeno MongoDB test: ${passed} passed, ${failed} failed`);
+
+if (failed > 0) {
+  // deno-lint-ignore no-process-globals
+  process.exit(1);
+}


### PR DESCRIPTION
This PR fixes the usage of `@mikro-orm/mongodb` with Deno.

## Issue

Using the newly added reproduction test case in `tests/deno/mongodb.test.ts`, and running it with no additional code change results in the following error:

```
> deno run --allow-read --allow-write --allow-env --allow-net --allow-sys --node-modules-dir=manual tests/deno/mongodb.test.ts
error: Uncaught (in promise) TypeError: this is not a typed array.
    at Uint8Array.values (<anonymous>)
    at Array.from (<anonymous>)
    at Object.toHex (file:///.../mikro-orm/node_modules/bson/lib/bson.cjs:481:22)
    at ObjectId.toHexString (file:///.../mikro-orm/node_modules/bson/lib/bson.cjs:2672:37)
    at eval (eval at createFunction (file:///.../mikro-orm/packages/core/src/utils/Utils.ts:900:14), <anonymous>:13:68)
    at ChangeSetComputer.computePayload (file:///.../mikro-orm/packages/core/src/unit-of-work/ChangeSetComputer.ts:145:20)
    at ChangeSetComputer.computeChangeSet (file:///.../mikro-orm/packages/core/src/unit-of-work/ChangeSetComputer.ts:61:56)
    at UnitOfWork.findNewEntities (file:///.../mikro-orm/packages/core/src/unit-of-work/UnitOfWork.ts:780:46)
    at UnitOfWork.computeChangeSets (file:///.../mikro-orm/packages/core/src/unit-of-work/UnitOfWork.ts:634:12)
    at UnitOfWork.doCommit (file:///.../mikro-orm/packages/core/src/unit-of-work/UnitOfWork.ts:514:12)
```

## Investigation

Why is this bug appearing with Deno? The behavior is different because of [this line of code in the `bson` package](https://github.com/mongodb/js-bson/blob/0712bb15653093766a80bbd4ba104353cd4581e3/src/utils/byte_utils.ts#L69):
- with Node.js, `Buffer.prototype?._isBuffer` is `undefined` ; so `ByteUtils` is using `nodeJsByteUtils`
- with Deno, `Buffer.prototype?._isBuffer` is `true` ; so `ByteUtils` is using `webByteUtils`

The content of the `fromHex` method is different in both implementations:
- With `nodeJsByteUtils`, [it uses `Buffer.from`](https://github.com/mongodb/js-bson/blob/0712bb15653093766a80bbd4ba104353cd4581e3/src/utils/node_byte_utils.ts#L150)
- with `webByteUtils`, [it uses `Uint8Array.from`](https://github.com/mongodb/js-bson/blob/0712bb15653093766a80bbd4ba104353cd4581e3/src/utils/web_byte_utils.ts#L258)

The issue is that our `clone` function in `packages/core/src/utils/clone.ts` does not handle cloning of `Uint8Array` properly.

For instance, whit the following `Uint8Array` array:
```
Uint8Array(12) [
  105, 172, 10
]
```
Cloning it with our util function will result in:
```
Uint8Array {
  "0": 105,
  "1": 172,
  "2": 10
}
```

## Fix

In this PR, we add proper support for cloning [all `TypedArray` subtypes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#typedarray_objects).