### PR TITLE
ci: prepare CI for v7 stable release [skip ci]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,7 +137,7 @@ jobs:
       - name: Bump version
         run: |
           PREID=${{ inputs.dist-tag == 'rc' && 'rc' || 'dev' }}
-          yarn lerna run copy -- -- --canary=major --preid=$PREID
+          yarn lerna run copy -- -- --canary=patch --preid=$PREID
           git commit -am 'chore: bump ${{ inputs.dist-tag }} versions [skip ci]'
           git fetch --depth=1 origin +refs/tags/*:refs/tags/*
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,9 +2,9 @@ name: tests
 
 on:
   push:
-    branches: [ master, v7, renovate/** ]
+    branches: [ master, renovate/** ]
   pull_request:
-    branches: [ master, v7 ]
+    branches: [ master ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
@@ -380,7 +380,7 @@ jobs:
 
   release:
     name: Release
-    if: (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/v7') && github.repository_owner == 'mikro-orm'
+    if: github.ref == 'refs/heads/master' && github.repository_owner == 'mikro-orm'
     runs-on: ubuntu-latest
     needs: [ build, typecheck, test, lint, docs ]
     steps:

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "build": "yarn workspaces foreach -Ap --topological-dev run build",
     "publish:prod": "lerna publish from-package --contents dist --force-publish",
     "release:prod": "yarn build && yarn publish:prod",
-    "publish:next": "lerna publish from-package --contents dist --dist-tag v7 --force-publish",
+    "publish:next": "lerna publish from-package --contents dist --dist-tag next --force-publish",
     "publish:rc": "lerna publish from-package --contents dist --dist-tag rc --force-publish",
     "publish:jsr": "node scripts/publish-jsr.mjs",
     "release:next": "yarn workspaces foreach -Ap run compile && yarn publish:next",


### PR DESCRIPTION
## Summary

- Canary bump strategy: `major` → `patch` (so post-release canaries are `7.0.1-dev.X`, not `8.0.0-dev.X`)
- Canary npm dist-tag: `v7` → `next` (v7 becomes `latest`, canaries go to `next`)
- Remove `v7` branch from test/release workflow triggers (no longer needed)

## Release day sequence

1. Squash-merge this PR with `[skip ci]` in the commit message
2. Trigger Release workflow: `version: major`, `dist-tag: prod` → publishes 7.0.0
3. Next regular commit → canary publishes as `7.0.1-dev.X` on `next` tag
4. Create v7 docs snapshot
5. Merge #7260 
6. Merge #7194 
7. Merge https://github.com/mikro-orm/nestjs/pull/241
8. Release v7 of nestjs adapter

🤖 Generated with [Claude Code](https://claude.com/claude-code)