### PR TITLE
docs: remove string references from entity definitions examples

### DIFF
--- a/docs/docs/relationships.md
+++ b/docs/docs/relationships.md
@@ -79,11 +79,8 @@ export class Book {
   @ManyToOne(() => Author) // you need to specify type via callback
   author1!: Author;
 
-  @ManyToOne('Author') // or as a string
-  author2!: Author;
-
   @ManyToOne({ entity: () => Author }) // or use options object
-  author3!: Author;
+  author2!: Author;
 
 }
 ```

--- a/docs/versioned_docs/version-7.0/relationships.md
+++ b/docs/versioned_docs/version-7.0/relationships.md
@@ -79,11 +79,8 @@ export class Book {
   @ManyToOne(() => Author) // you need to specify type via callback
   author1!: Author;
 
-  @ManyToOne('Author') // or as a string
-  author2!: Author;
-
   @ManyToOne({ entity: () => Author }) // or use options object
-  author3!: Author;
+  author2!: Author;
 
 }
 ```


### PR DESCRIPTION
String references are no longer supported in v7.