### PR TITLE
fix(core): use EntitySchema.is() instead of instanceof for CJS/ESM dual-package hazard

### DIFF
--- a/packages/core/src/metadata/EntitySchema.ts
+++ b/packages/core/src/metadata/EntitySchema.ts
@@ -406,7 +406,7 @@ export class EntitySchema<Entity = any, Base = never, Class extends EntityCtor =
     let parent = this._meta.extends;
 
     while (parent) {
-      const parentSchema = parent instanceof EntitySchema ? parent : EntitySchema.REGISTRY.get(parent as any);
+      const parentSchema = EntitySchema.is(parent) ? parent : EntitySchema.REGISTRY.get(parent as any);
 
       if (!parentSchema) {
         break;
@@ -500,7 +500,7 @@ export class EntitySchema<Entity = any, Base = never, Class extends EntityCtor =
               .sort()
               .join(' | ')
           : Utils.className(tmp);
-        const target = tmp instanceof EntitySchema ? tmp.meta.class : tmp;
+        const target = EntitySchema.is(tmp) ? tmp.meta.class : tmp;
         return { type, target };
       }
     }

--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -304,7 +304,7 @@ export class MetadataDiscovery {
 
   private tryDiscoverTargets(targets: EntityClass[]): void {
     for (const target of targets) {
-      const schema = target instanceof EntitySchema ? target : undefined;
+      const schema = EntitySchema.is(target) ? target : undefined;
       const isDiscoverable = typeof target === 'function' || schema;
 
       if (isDiscoverable && target.name) {
@@ -337,7 +337,7 @@ export class MetadataDiscovery {
     for (const meta of this.#metadata) {
       let parent = meta.extends as any;
 
-      if (parent instanceof EntitySchema && !this.#metadata.has(parent.init().meta.class)) {
+      if (EntitySchema.is(parent) && !this.#metadata.has(parent.init().meta.class)) {
         this.discoverReferences([parent], false);
       }
 
@@ -394,24 +394,26 @@ export class MetadataDiscovery {
       entity = EntitySchema.REGISTRY.get(entity)!;
     }
 
-    if (entity instanceof EntitySchema) {
+    if (EntitySchema.is(entity)) {
       const meta = Utils.copy(entity.meta, false);
       return EntitySchema.fromMetadata(meta);
     }
 
-    const path = entity[MetadataStorage.PATH_SYMBOL];
+    // After the EntitySchema check, entity must be an EntityClass
+    const cls = entity as EntityClass<T> & { [MetadataStorage.PATH_SYMBOL]?: string };
+    const path = cls[MetadataStorage.PATH_SYMBOL];
 
     if (path) {
-      const meta = Utils.copy(MetadataStorage.getMetadata(entity.name, path), false);
+      const meta = Utils.copy(MetadataStorage.getMetadata(cls.name, path), false);
       meta.path = path;
-      this.#metadata.set(entity, meta);
+      this.#metadata.set(cls, meta);
     }
 
-    const exists = this.#metadata.has(entity);
-    const meta = this.#metadata.get<T>(entity, true);
+    const exists = this.#metadata.has(cls);
+    const meta = this.#metadata.get<T>(cls, true);
     meta.abstract ??= !(exists && meta.name);
     const schema = EntitySchema.fromMetadata(meta);
-    schema.setClass(entity as EntityCtor<T>);
+    schema.setClass(cls as EntityCtor<T>);
 
     return schema;
   }
@@ -1863,7 +1865,7 @@ export class MetadataDiscovery {
     return metadata.find(m => {
       const ext = meta.extends!;
 
-      if (ext instanceof EntitySchema) {
+      if (EntitySchema.is(ext)) {
         return m.class === ext.meta.class || m.className === ext.meta.className;
       }
 

--- a/packages/core/src/metadata/MetadataProvider.ts
+++ b/packages/core/src/metadata/MetadataProvider.ts
@@ -29,7 +29,7 @@ export class MetadataProvider {
               .sort()
               .join(' | ')
           : Utils.className(tmp);
-        prop.target = tmp instanceof EntitySchema ? tmp.meta.class : tmp;
+        prop.target = EntitySchema.is(tmp) ? tmp.meta.class : tmp;
       } else if (!prop.type && !((prop.enum || prop.array) && (prop.items?.length ?? 0) > 0)) {
         throw new Error(`Please provide either 'type' or 'entity' attribute in ${meta.className}.${prop.name}.`);
       }

--- a/packages/core/src/metadata/MetadataStorage.ts
+++ b/packages/core/src/metadata/MetadataStorage.ts
@@ -91,7 +91,7 @@ export class MetadataStorage {
       return meta;
     }
 
-    if (entityName instanceof EntitySchema) {
+    if (EntitySchema.is(entityName)) {
       return this.#metadataMap.get(entityName.meta.class) ?? entityName.meta;
     }
 

--- a/packages/decorators/src/legacy/ReflectMetadataProvider.ts
+++ b/packages/decorators/src/legacy/ReflectMetadataProvider.ts
@@ -26,7 +26,7 @@ export class ReflectMetadataProvider extends MetadataProvider {
               .sort()
               .join(' | ')
           : Utils.className(tmp);
-        prop.target = tmp instanceof EntitySchema ? tmp.meta.class : tmp;
+        prop.target = EntitySchema.is(tmp) ? tmp.meta.class : tmp;
       } else {
         this.initPropertyType(meta, prop);
       }

--- a/packages/reflection/src/TsMorphMetadataProvider.ts
+++ b/packages/reflection/src/TsMorphMetadataProvider.ts
@@ -78,7 +78,7 @@ export class TsMorphMetadataProvider extends MetadataProvider {
     }
 
     const tmp = prop.entity() as EntityClass;
-    const target = tmp instanceof EntitySchema ? tmp.meta.class : tmp;
+    const target = EntitySchema.is(tmp) ? tmp.meta.class : tmp;
 
     return { type: Utils.className(target), target };
   }


### PR DESCRIPTION
## Summary
- Replaced all `instanceof EntitySchema` checks with `EntitySchema.is()` (duck-typing fallback) across 6 files
- Fixes CLI commands (migrations, seeders) and app startup crashing with `TypeError: Cannot read properties of undefined (reading 'className')` when using `tsx` or `@swc-node/register` in `"type": "commonjs"` projects with `defineEntity`

## Root cause
When the CLI (ESM) loads user entity files via CJS `require()` in a CJS project, `tsx` creates separate CJS and ESM module instances. `instanceof EntitySchema` fails across this boundary, causing `MetadataDiscovery.getSchema()` to treat EntitySchema instances as plain classes and crash in `setClass()`.

`EntitySchema.is()` already existed with duck-typing support for exactly this scenario — it just wasn't being used consistently.

## Test plan
- [x] All 5266 existing tests pass
- [x] Verified against [reproduction repo](https://github.com/MubbashirAliMinhas/mikro-orm-v7-test) with local builds:
  - [x] SWC branch: `mikro-orm debug`, `migration:create`, `seeder:run`, `dev1` app — all pass discovery
  - [x] TSX branch: `mikro-orm debug`, `migration:create`, `seeder:run`, `dev` app — all pass discovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)