### PR TITLE
fix(schema): handle multiline view expressions in SQLite schema diffing

### DIFF
--- a/packages/sql/src/dialects/sqlite/SqliteSchemaHelper.ts
+++ b/packages/sql/src/dialects/sqlite/SqliteSchemaHelper.ts
@@ -351,7 +351,7 @@ export class SqliteSchemaHelper extends SchemaHelper {
    * Extracts the SELECT part from a CREATE VIEW statement.
    */
   private extractViewDefinition(viewDefinition: string): string {
-    const match = /create\s+view\s+[`"']?\w+[`"']?\s+as\s+(.*)/i.exec(viewDefinition);
+    const match = /create\s+view\s+[`"']?\w+[`"']?\s+as\s+(.*)/is.exec(viewDefinition);
     /* v8 ignore next - fallback for non-standard view definitions */
     return match ? match[1] : viewDefinition;
   }

--- a/tests/features/view-entities/__snapshots__/view-entities.sqlite.test.ts.snap
+++ b/tests/features/view-entities/__snapshots__/view-entities.sqlite.test.ts.snap
@@ -33,6 +33,11 @@ create table \`publisher4_tests\` (\`id\` integer not null primary key autoincre
 create index \`publisher4_tests_publisher4_id_index\` on \`publisher4_tests\` (\`publisher4_id\`);
 create index \`publisher4_tests_test4_id_index\` on \`publisher4_tests\` (\`test4_id\`);
 
+create view \`multiline_author_stats_view\` as 
+    SELECT
+    name, (select count(*) from book4 b where b.author_id = a.id) as book_count
+    FROM author4 a;
+
 create view \`book_summary_view\` as select \`b\`.\`title\`, \`a\`.\`name\` as \`author_name\` from \`book4\` as \`b\` inner join \`author4\` as \`a\` on \`b\`.\`author_id\` = \`a\`.\`id\`;
 
 create view \`author_stats_view\` as select name, (select count(*) from book4 b where b.author_id = a.id) as book_count from author4 a;

--- a/tests/features/view-entities/view-entities.sqlite.test.ts
+++ b/tests/features/view-entities/view-entities.sqlite.test.ts
@@ -22,11 +22,29 @@ class AuthorStats {
 
 const authorStatsSQL = `select name, (select count(*) from book4 b where b.author_id = a.id) as book_count from author4 a`;
 
+// View entity with multiline expression (GH #7292)
+const multilineViewSQL = `
+    SELECT
+    name, (select count(*) from book4 b where b.author_id = a.id) as book_count
+    FROM author4 a`;
+
 const AuthorStatsSchema = defineEntity({
   class: AuthorStats,
   tableName: 'author_stats_view',
   view: true,
   expression: authorStatsSQL,
+  properties: {
+    name: p.string().primary(),
+    bookCount: p.integer(),
+  },
+});
+
+// GH #7292 - multiline expression should not cause perpetual schema diff
+const MultilineAuthorStats = defineEntity({
+  name: 'MultilineAuthorStats',
+  tableName: 'multiline_author_stats_view',
+  view: true,
+  expression: multilineViewSQL,
   properties: {
     name: p.string().primary(),
     bookCount: p.integer(),
@@ -80,6 +98,7 @@ describe('View entities (sqlite)', () => {
         BaseEntity5,
         IdentitySchema,
         AuthorStatsSchema,
+        MultilineAuthorStats,
         BookSummary,
         ProlificAuthors,
       ],
@@ -142,6 +161,13 @@ describe('View entities (sqlite)', () => {
   });
 
   test('updateSchema detects no changes for unchanged views', async () => {
+    const sql = await orm.schema.getUpdateSchemaSQL();
+    expect(sql).toBe('');
+  });
+
+  // GH #7292
+  test('multiline view expressions do not cause perpetual schema changes', async () => {
+    // After creating the schema, the multiline view should not be detected as changed
     const sql = await orm.schema.getUpdateSchemaSQL();
     expect(sql).toBe('');
   });


### PR DESCRIPTION
## Summary
- Adds the `s` (dotAll) flag to the regex in `SqliteSchemaHelper.extractViewDefinition()` so `.` matches newline characters
- Fixes multiline view expressions being truncated to just the first line when loaded from the database, causing `migration:check` to perpetually detect changes

Closes #7292

## Test plan
- [x] Added multiline view expression entity to SQLite view entity tests
- [x] Added test verifying `getUpdateSchemaSQL()` returns empty for multiline views
- [x] All 571 SQLite tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)