### PR TITLE
fix(core): preserve nullability in Opt/Hidden branded types for defineEntity

### DIFF
--- a/packages/core/src/entity/defineEntity.ts
+++ b/packages/core/src/entity/defineEntity.ts
@@ -1526,10 +1526,12 @@ type MaybeOpt<Value, Options> = Options extends { mapToPk: true }
         | { persist: false }
         | { version: true }
         | { formula: string | ((...args: any[]) => any) }
-    ? Opt<Value>
+    ? Opt<NonNullable<Value>> | Extract<Value, null | undefined>
     : Value;
 
-type MaybeHidden<Value, Options> = Options extends { hidden: true } ? Hidden<Value> : Value;
+type MaybeHidden<Value, Options> = Options extends { hidden: true }
+  ? Hidden<NonNullable<Value>> | Extract<Value, null | undefined>
+  : Value;
 
 type ValueOf<T extends Dictionary> = T[keyof T];
 

--- a/tests/defineEntity.test.ts
+++ b/tests/defineEntity.test.ts
@@ -600,6 +600,45 @@ describe('defineEntity', () => {
     expect(Foo.meta).toEqual(asSnapshot(FooSchema.meta));
   });
 
+  // GH #7291
+  it('should define entity with nullable many to one with formula', () => {
+    const Bar = defineEntity({
+      name: 'Bar',
+      properties: {
+        id: p.integer().primary().autoincrement(),
+        phone: p.string(),
+      },
+    });
+
+    const Foo = defineEntity({
+      name: 'Foo',
+      properties: {
+        id: p.integer().primary().autoincrement(),
+        phone: p.string(),
+        // nullable via .nullable()
+        barNullable: () =>
+          p
+            .manyToOne(Bar)
+            .formula(cols => cols.phone)
+            .nullable(),
+        // nullable via .$type
+        barTyped: () =>
+          p
+            .manyToOne(Bar)
+            .formula(cols => cols.phone)
+            .$type<InferEntity<typeof Bar> | null>(),
+        // non-nullable with formula (should be Opt, not nullable)
+        barRequired: () => p.manyToOne(Bar).formula(cols => cols.phone),
+      },
+    });
+
+    type IBar = InferEntity<typeof Bar>;
+    type IFoo = InferEntity<typeof Foo>;
+    assert<IsExact<IFoo['barNullable'], Opt<IBar> | null | undefined>>(true);
+    assert<IsExact<IFoo['barTyped'], Opt<IBar> | null>>(true);
+    assert<IsExact<IFoo['barRequired'], Opt<IBar>>>(true);
+  });
+
   it('should define entity with one to many relation', () => {
     const Folder = defineEntity({
       name: 'Folder',


### PR DESCRIPTION
## Summary
- `Opt<T>` and `Hidden<T>` use `T & Brand` intersection, which erases `null | undefined` from union types (`null & Brand = never`)
- Changes `MaybeOpt` and `MaybeHidden` to apply the brand only to the non-nullable part: `Opt<NonNullable<Value>> | Extract<Value, null | undefined>`
- Fixes both `.nullable()` and `.$type<T | null>()` on relations with `formula`, `default`, `onCreate`, etc.

Closes #7291

## Test plan
- [x] Added type assertions for `manyToOne().formula().nullable()`, `.$type<T | null>()`, and non-nullable formula
- [x] Verified assertions fail without the fix, pass with it
- [x] `yarn tsc-check-tests` passes
- [x] `yarn build` passes
- [x] All 44 defineEntity tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)