### PR TITLE
chore: add JSDoc annotations across all packages

### DIFF
--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -99,7 +99,9 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
   static #counter = 1;
   /** @internal */
   readonly _id: number = EntityManager.#counter++;
+  /** Whether this is the global (root) EntityManager instance. */
   readonly global = false;
+  /** The context name of this EntityManager, derived from the ORM configuration. */
   readonly name: string;
   readonly #loaders: Partial<Record<'ref' | '1:m' | 'm:n', { load: (...args: unknown[]) => Promise<unknown> }>> = {};
   readonly #repositoryMap = new Map<EntityMetadata, EntityRepository<any>>();
@@ -428,6 +430,7 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
     return em.loggerContext as T;
   }
 
+  /** Sets the flush mode for this EntityManager. Pass `undefined` to reset to the global default. */
   setFlushMode(flushMode?: FlushMode | `${FlushMode}`): void {
     this.getContext(false).#flushMode = flushMode as FlushMode;
   }
@@ -2352,6 +2355,7 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
     return em;
   }
 
+  /** Gets the EventManager instance used by this EntityManager. */
   getEventManager(): EventManager {
     return this.eventManager;
   }

--- a/packages/core/src/MikroORM.ts
+++ b/packages/core/src/MikroORM.ts
@@ -105,7 +105,9 @@ export class MikroORM<
 > {
   /** The global EntityManager instance. If you are using `RequestContext` helper, it will automatically pick the request specific context under the hood */
   em!: EM & { '~entities'?: Entities };
+  /** The database driver instance used by this ORM. */
   readonly driver: Driver;
+  /** The ORM configuration instance. */
   readonly config: Configuration<Driver>;
   #metadata!: MetadataStorage;
   readonly #logger: Logger;

--- a/packages/core/src/cache/CacheAdapter.ts
+++ b/packages/core/src/cache/CacheAdapter.ts
@@ -1,3 +1,4 @@
+/** Interface for async-capable cache storage used by result cache and metadata cache. */
 export interface CacheAdapter {
   /**
    * Gets the items under `name` key from the cache.
@@ -25,6 +26,7 @@ export interface CacheAdapter {
   close?(): void | Promise<void>;
 }
 
+/** Synchronous variant of CacheAdapter, used for metadata cache where async access is not needed. */
 export interface SyncCacheAdapter extends CacheAdapter {
   /**
    * Gets the items under `name` key from the cache.

--- a/packages/core/src/cache/GeneratedCacheAdapter.ts
+++ b/packages/core/src/cache/GeneratedCacheAdapter.ts
@@ -1,6 +1,7 @@
 import type { CacheAdapter } from './CacheAdapter.js';
 import type { Dictionary } from '../typings.js';
 
+/** Cache adapter backed by pre-generated static data, typically produced by the CLI cache:generate command. */
 export class GeneratedCacheAdapter implements CacheAdapter {
   readonly #data: Map<string, { data: Dictionary }>;
 

--- a/packages/core/src/cache/MemoryCacheAdapter.ts
+++ b/packages/core/src/cache/MemoryCacheAdapter.ts
@@ -1,5 +1,6 @@
 import type { CacheAdapter } from './CacheAdapter.js';
 
+/** In-memory cache adapter with time-based expiration. Used as the default result cache. */
 export class MemoryCacheAdapter implements CacheAdapter {
   readonly #data = new Map<string, { data: any; expiration: number }>();
   readonly #options: { expiration: number };

--- a/packages/core/src/cache/NullCacheAdapter.ts
+++ b/packages/core/src/cache/NullCacheAdapter.ts
@@ -1,5 +1,6 @@
 import type { SyncCacheAdapter } from './CacheAdapter.js';
 
+/** No-op cache adapter that never stores or returns any data. Used to disable caching. */
 export class NullCacheAdapter implements SyncCacheAdapter {
   /**
    * @inheritDoc

--- a/packages/core/src/connections/Connection.ts
+++ b/packages/core/src/connections/Connection.ts
@@ -7,6 +7,7 @@ import type { Platform } from '../platforms/Platform.js';
 import type { TransactionEventBroadcaster } from '../events/TransactionEventBroadcaster.js';
 import type { IsolationLevel } from '../enums.js';
 
+/** Abstract base class for database connections, providing transaction and query execution support. */
 export abstract class Connection {
   protected metadata!: MetadataStorage;
   protected platform!: Platform;
@@ -107,6 +108,7 @@ export abstract class Connection {
     }
   }
 
+  /** Executes a callback inside a transaction, committing on success and rolling back on failure. */
   async transactional<T>(
     cb: (trx: Transaction) => Promise<T>,
     options?: {
@@ -120,6 +122,7 @@ export abstract class Connection {
     throw new Error(`Transactions are not supported by current driver`);
   }
 
+  /** Begins a new database transaction and returns the transaction context. */
   async begin(options?: {
     isolationLevel?: IsolationLevel | `${IsolationLevel}`;
     readOnly?: boolean;
@@ -130,6 +133,7 @@ export abstract class Connection {
     throw new Error(`Transactions are not supported by current driver`);
   }
 
+  /** Commits the given transaction. */
   async commit(
     ctx: Transaction,
     eventBroadcaster?: TransactionEventBroadcaster,
@@ -138,6 +142,7 @@ export abstract class Connection {
     throw new Error(`Transactions are not supported by current driver`);
   }
 
+  /** Rolls back the given transaction. */
   async rollback(
     ctx: Transaction,
     eventBroadcaster?: TransactionEventBroadcaster,
@@ -146,6 +151,7 @@ export abstract class Connection {
     throw new Error(`Transactions are not supported by current driver`);
   }
 
+  /** Executes a raw query and returns the result. */
   abstract execute<T>(
     query: string,
     params?: any[],
@@ -153,6 +159,7 @@ export abstract class Connection {
     ctx?: Transaction,
   ): Promise<QueryResult<T> | any | any[]>;
 
+  /** Parses and returns the resolved connection configuration (host, port, user, etc.). */
   getConnectionOptions(): ConnectionConfig {
     const ret: ConnectionConfig = {};
 
@@ -182,14 +189,17 @@ export abstract class Connection {
     return ret;
   }
 
+  /** Sets the metadata storage on this connection. */
   setMetadata(metadata: MetadataStorage): void {
     this.metadata = metadata;
   }
 
+  /** Sets the platform abstraction on this connection. */
   setPlatform(platform: Platform): void {
     this.platform = platform;
   }
 
+  /** Returns the platform abstraction for this connection. */
   getPlatform(): Platform {
     return this.platform;
   }
@@ -241,6 +251,7 @@ export abstract class Connection {
   }
 }
 
+/** Result of a native database query (insert, update, delete). */
 export interface QueryResult<T = { id: number }> {
   affectedRows: number;
   insertId: Primary<T>;
@@ -249,6 +260,7 @@ export interface QueryResult<T = { id: number }> {
   insertedIds?: Primary<T>[];
 }
 
+/** Resolved database connection parameters. */
 export interface ConnectionConfig {
   host?: string;
   port?: number;
@@ -258,4 +270,5 @@ export interface ConnectionConfig {
   schema?: string;
 }
 
+/** Opaque transaction context type, wrapping the driver-specific transaction object. */
 export type Transaction<T = any> = T & {};

--- a/packages/core/src/drivers/DatabaseDriver.ts
+++ b/packages/core/src/drivers/DatabaseDriver.ts
@@ -45,6 +45,7 @@ import { PolymorphicRef } from '../entity/PolymorphicRef.js';
 import { JsonType } from '../types/JsonType.js';
 import { MikroORM } from '../MikroORM.js';
 
+/** Abstract base class for all database drivers, implementing common driver logic. */
 export abstract class DatabaseDriver<C extends Connection> implements IDatabaseDriver<C> {
   [EntityManagerType]!: EntityManager<this>;
 
@@ -112,6 +113,7 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
     options?: CountOptions<T, P>,
   ): Promise<number>;
 
+  /** Creates a new EntityManager instance bound to this driver. */
   createEntityManager(useContext?: boolean): this[typeof EntityManagerType] {
     const EntityManagerClass = this.config.get('entityManager', EntityManager);
     return new EntityManagerClass(this.config, this, this.metadata, useContext);
@@ -179,6 +181,7 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
     }
   }
 
+  /** Maps raw database result to entity data, converting column names to property names. */
   mapResult<T extends object>(
     result: EntityDictionary<T>,
     meta?: EntityMetadata<T>,
@@ -191,6 +194,7 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
     return this.comparator.mapResult<T>(meta, result);
   }
 
+  /** Opens the primary connection and all read replicas. */
   async connect(options?: { skipOnConnect?: boolean }): Promise<C> {
     await this.connection.connect(options);
     await Promise.all(this.replicas.map(replica => replica.connect() as Promise<void>));
@@ -198,6 +202,7 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
     return this.connection;
   }
 
+  /** Closes all connections and re-establishes them. */
   async reconnect(options?: { skipOnConnect?: boolean }): Promise<C> {
     await this.close(true);
     await this.connect(options);
@@ -205,6 +210,7 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
     return this.connection;
   }
 
+  /** Returns the write connection or a random read replica. */
   getConnection(type: ConnectionType = 'write'): C {
     if (type === 'write' || this.replicas.length === 0) {
       return this.connection;
@@ -215,15 +221,18 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
     return this.replicas[rand];
   }
 
+  /** Closes the primary connection and all read replicas. */
   async close(force?: boolean): Promise<void> {
     await Promise.all(this.replicas.map(replica => replica.close(force)));
     await this.connection.close(force);
   }
 
+  /** Returns the database platform abstraction for this driver. */
   getPlatform(): Platform {
     return this.platform;
   }
 
+  /** Sets the metadata storage and initializes the comparator for all connections. */
   setMetadata(metadata: MetadataStorage): void {
     this.metadata = metadata;
     this.comparator = new EntityComparator(this.metadata, this.platform);
@@ -235,10 +244,12 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
     });
   }
 
+  /** Returns the metadata storage used by this driver. */
   getMetadata(): MetadataStorage {
     return this.metadata;
   }
 
+  /** Returns the names of native database dependencies required by this driver. */
   getDependencies(): string[] {
     return this.dependencies;
   }
@@ -675,6 +686,7 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
     return ret;
   }
 
+  /** Acquires a pessimistic lock on the given entity. */
   async lockPessimistic<T extends object>(entity: T, options: LockOptions): Promise<void> {
     throw new Error(`Pessimistic locks are not supported by ${this.constructor.name} driver`);
   }

--- a/packages/core/src/drivers/IDatabaseDriver.ts
+++ b/packages/core/src/drivers/IDatabaseDriver.ts
@@ -38,20 +38,27 @@ import type { MikroORM } from '../MikroORM.js';
 import type { LoggingOptions, LogContext } from '../logging/Logger.js';
 import type { Raw } from '../utils/RawQueryFragment.js';
 
+/** Symbol used to extract the EntityManager type from a driver instance. */
 export const EntityManagerType = Symbol('EntityManagerType');
 
+/** Interface defining the contract for all database drivers. */
 export interface IDatabaseDriver<C extends Connection = Connection> {
   [EntityManagerType]: EntityManager<this>;
   readonly config: Configuration;
 
+  /** Creates a new EntityManager instance for this driver. */
   createEntityManager(useContext?: boolean): this[typeof EntityManagerType];
 
+  /** Opens a connection to the database. */
   connect(options?: { skipOnConnect?: boolean }): Promise<C>;
 
+  /** Closes the database connection. */
   close(force?: boolean): Promise<void>;
 
+  /** Closes and re-establishes the database connection. */
   reconnect(options?: { skipOnConnect?: boolean }): Promise<C>;
 
+  /** Returns the underlying database connection (write or read replica). */
   getConnection(type?: ConnectionType): C;
 
   /**
@@ -72,24 +79,28 @@ export interface IDatabaseDriver<C extends Connection = Connection> {
     options?: FindOneOptions<T, P, F, E>,
   ): Promise<EntityData<T> | null>;
 
+  /** Finds entities backed by a virtual (expression-based) definition. */
   findVirtual<T extends object>(
     entityName: EntityName<T>,
     where: FilterQuery<T>,
     options: FindOptions<T, any, any, any>,
   ): Promise<EntityData<T>[]>;
 
+  /** Returns an async iterator that streams query results one entity at a time. */
   stream<T extends object>(
     entityName: EntityName<T>,
     where: FilterQuery<T>,
     options: StreamOptions<T>,
   ): AsyncIterableIterator<T>;
 
+  /** Inserts a single row into the database. */
   nativeInsert<T extends object>(
     entityName: EntityName<T>,
     data: EntityDictionary<T>,
     options?: NativeInsertUpdateOptions<T>,
   ): Promise<QueryResult<T>>;
 
+  /** Inserts multiple rows into the database in a single batch operation. */
   nativeInsertMany<T extends object>(
     entityName: EntityName<T>,
     data: EntityDictionary<T>[],
@@ -97,6 +108,7 @@ export interface IDatabaseDriver<C extends Connection = Connection> {
     transform?: (sql: string) => string,
   ): Promise<QueryResult<T>>;
 
+  /** Updates rows matching the given condition. */
   nativeUpdate<T extends object>(
     entityName: EntityName<T>,
     where: FilterQuery<T>,
@@ -104,6 +116,7 @@ export interface IDatabaseDriver<C extends Connection = Connection> {
     options?: NativeInsertUpdateOptions<T>,
   ): Promise<QueryResult<T>>;
 
+  /** Updates multiple rows with different payloads in a single batch operation. */
   nativeUpdateMany<T extends object>(
     entityName: EntityName<T>,
     where: FilterQuery<T>[],
@@ -111,25 +124,30 @@ export interface IDatabaseDriver<C extends Connection = Connection> {
     options?: NativeInsertUpdateManyOptions<T>,
   ): Promise<QueryResult<T>>;
 
+  /** Deletes rows matching the given condition. */
   nativeDelete<T extends object>(
     entityName: EntityName<T>,
     where: FilterQuery<T>,
     options?: NativeDeleteOptions<T>,
   ): Promise<QueryResult<T>>;
 
+  /** Persists changes to M:N collections (inserts/deletes pivot table rows). */
   syncCollections<T extends object, O extends object>(
     collections: Iterable<Collection<T, O>>,
     options?: DriverMethodOptions,
   ): Promise<void>;
 
+  /** Counts entities matching the given condition. */
   count<T extends object, P extends string = never>(
     entityName: EntityName<T>,
     where: FilterQuery<T>,
     options?: CountOptions<T, P>,
   ): Promise<number>;
 
+  /** Executes a MongoDB aggregation pipeline (MongoDB driver only). */
   aggregate(entityName: EntityName, pipeline: any[]): Promise<any[]>;
 
+  /** Maps raw database result to entity data, converting column names to property names. */
   mapResult<T extends object>(
     result: EntityDictionary<T>,
     meta: EntityMetadata<T>,
@@ -149,10 +167,13 @@ export interface IDatabaseDriver<C extends Connection = Connection> {
     pivotJoin?: boolean,
   ): Promise<Dictionary<T[]>>;
 
+  /** Returns the database platform abstraction for this driver. */
   getPlatform(): Platform;
 
+  /** Sets the metadata storage used by this driver. */
   setMetadata(metadata: MetadataStorage): void;
 
+  /** Returns the metadata storage used by this driver. */
   getMetadata(): MetadataStorage;
 
   /**
@@ -161,6 +182,7 @@ export interface IDatabaseDriver<C extends Connection = Connection> {
    */
   getDependencies(): string[];
 
+  /** Acquires a pessimistic lock on the given entity. */
   lockPessimistic<T extends object>(entity: T, options: LockOptions): Promise<void>;
 
   /**
@@ -179,13 +201,16 @@ export interface IDatabaseDriver<C extends Connection = Connection> {
   getORMClass(): Constructor<MikroORM>;
 }
 
+/** Represents a field selector for entity queries (property name or wildcard). */
 export type EntityField<T, P extends string = PopulatePath.ALL> =
   | keyof T
   | PopulatePath.ALL
   | AutoPath<T, P, `${PopulatePath.ALL}`>;
 
+/** Defines the ordering for query results, either a single order map or an array of them. */
 export type OrderDefinition<T> = (QueryOrderMap<T> & { 0?: never }) | QueryOrderMap<T>[];
 
+/** Options for `em.findAll()`, extends FindOptions with an optional `where` clause. */
 export interface FindAllOptions<
   T,
   P extends string = never,
@@ -195,6 +220,7 @@ export interface FindAllOptions<
   where?: FilterQuery<T>;
 }
 
+/** Options for streaming query results via `em.stream()`. */
 export interface StreamOptions<
   Entity,
   Populate extends string = never,
@@ -216,8 +242,10 @@ export interface StreamOptions<
   mergeResults?: boolean;
 }
 
+/** Configuration for enabling/disabling named filters on a query. */
 export type FilterOptions = Dictionary<boolean | Dictionary> | string[] | boolean;
 
+/** Specifies which relations to populate and which fields to select or exclude. */
 export interface LoadHint<
   Entity,
   Hint extends string = never,
@@ -229,6 +257,7 @@ export interface LoadHint<
   exclude?: readonly AutoPath<Entity, Excludes>[];
 }
 
+/** Options for `em.find()` queries, including population, ordering, pagination, and locking. */
 export interface FindOptions<
   Entity,
   Hint extends string = never,
@@ -345,6 +374,7 @@ export interface FindOptions<
   em?: EntityManager;
 }
 
+/** Options for cursor-based pagination via `em.findByCursor()`. */
 export interface FindByCursorOptions<
   T extends object,
   P extends string = never,
@@ -355,6 +385,7 @@ export interface FindByCursorOptions<
   includeCount?: I;
 }
 
+/** Options for `em.findOne()`, extends FindOptions with optimistic lock version support. */
 export interface FindOneOptions<
   T,
   P extends string = never,
@@ -365,6 +396,7 @@ export interface FindOneOptions<
   lockVersion?: number | Date;
 }
 
+/** Options for `em.findOneOrFail()`, adds a custom error handler for missing entities. */
 export interface FindOneOrFailOptions<
   T extends object,
   P extends string = never,
@@ -375,6 +407,7 @@ export interface FindOneOrFailOptions<
   strict?: boolean;
 }
 
+/** Options for native insert and update operations. */
 export interface NativeInsertUpdateOptions<T> {
   convertCustomTypes?: boolean;
   ctx?: Transaction;
@@ -391,10 +424,12 @@ export interface NativeInsertUpdateOptions<T> {
   em?: EntityManager;
 }
 
+/** Options for batch native insert and update operations. */
 export interface NativeInsertUpdateManyOptions<T> extends NativeInsertUpdateOptions<T> {
   processCollections?: boolean;
 }
 
+/** Options for `em.upsert()`, controlling conflict resolution behavior. */
 export interface UpsertOptions<Entity, Fields extends string = never> extends Omit<
   NativeInsertUpdateOptions<Entity>,
   'upsert'
@@ -407,10 +442,12 @@ export interface UpsertOptions<Entity, Fields extends string = never> extends Om
   disableIdentityMap?: boolean;
 }
 
+/** Options for `em.upsertMany()`, adds batch size control. */
 export interface UpsertManyOptions<Entity, Fields extends string = never> extends UpsertOptions<Entity, Fields> {
   batchSize?: number;
 }
 
+/** Options for `em.count()` queries. */
 export interface CountOptions<T extends object, P extends string = never> {
   filters?: FilterOptions;
   schema?: string;
@@ -443,6 +480,7 @@ export interface CountOptions<T extends object, P extends string = never> {
   em?: EntityManager;
 }
 
+/** Options for `em.qb().update()` operations. */
 export interface UpdateOptions<T> {
   filters?: FilterOptions;
   schema?: string;
@@ -453,6 +491,7 @@ export interface UpdateOptions<T> {
   unionWhereStrategy?: 'union-all' | 'union';
 }
 
+/** Options for `em.qb().delete()` operations. */
 export interface DeleteOptions<T> extends DriverMethodOptions {
   filters?: FilterOptions;
   /** sql only */
@@ -463,6 +502,7 @@ export interface DeleteOptions<T> extends DriverMethodOptions {
   em?: EntityManager;
 }
 
+/** Options for `em.nativeDelete()` operations. */
 export interface NativeDeleteOptions<T> extends DriverMethodOptions {
   filters?: FilterOptions;
   /** sql only */
@@ -473,6 +513,7 @@ export interface NativeDeleteOptions<T> extends DriverMethodOptions {
   em?: EntityManager;
 }
 
+/** Options for pessimistic and optimistic lock operations. */
 export interface LockOptions extends DriverMethodOptions {
   lockMode?: LockMode;
   lockVersion?: number | Date;
@@ -480,12 +521,14 @@ export interface LockOptions extends DriverMethodOptions {
   logging?: LoggingOptions;
 }
 
+/** Base options shared by all driver methods (transaction context, schema, logging). */
 export interface DriverMethodOptions {
   ctx?: Transaction;
   schema?: string;
   loggerContext?: LogContext;
 }
 
+/** MongoDB-style collation options for locale-aware string comparison. */
 export interface CollationOptions {
   locale: string;
   caseLevel?: boolean;
@@ -497,6 +540,7 @@ export interface CollationOptions {
   backwards?: boolean;
 }
 
+/** Options for `em.getReference()`, controlling wrapping and type conversion. */
 export interface GetReferenceOptions {
   wrapped?: boolean;
   convertCustomTypes?: boolean;

--- a/packages/core/src/entity/BaseEntity.ts
+++ b/packages/core/src/entity/BaseEntity.ts
@@ -19,15 +19,19 @@ import { helper } from './wrap.js';
 import type { FindOneOptions } from '../drivers/IDatabaseDriver.js';
 import type { PopulatePath } from '../enums.js';
 
+/** Base class for entities providing convenience methods like `assign()`, `toObject()`, and `populate()`. */
 export abstract class BaseEntity {
+  /** Returns whether the entity has been fully loaded from the database. */
   isInitialized(): boolean {
     return helper(this).__initialized;
   }
 
+  /** Marks the entity as populated or not for serialization purposes. */
   populated(populated = true): void {
     helper(this).populated(populated);
   }
 
+  /** Loads the specified relations on this entity. */
   async populate<Entity extends this = this, Hint extends string = never, Fields extends string = never>(
     populate: AutoPath<Entity, Hint, PopulatePath.ALL>[] | false,
     options: EntityLoaderOptions<Entity, Fields> = {},
@@ -35,6 +39,7 @@ export abstract class BaseEntity {
     return helper(this as Entity).populate(populate, options);
   }
 
+  /** Returns a Reference wrapper for this entity. */
   toReference<Entity extends this = this>(): Ref<Entity> & LoadedReference<Loaded<Entity, AddEager<Entity>>> {
     return Reference.create(this) as unknown as Ref<Entity> & LoadedReference<Loaded<Entity, AddEager<Entity>>>;
   }
@@ -109,10 +114,12 @@ export abstract class BaseEntity {
     return helper(this as Entity).toObject(ignoreFields!);
   }
 
+  /** Converts the entity to a plain object, including all properties regardless of serialization rules. */
   toPOJO<Entity extends this = this>(): EntityDTO<Entity> {
     return helper(this as Entity).toPOJO();
   }
 
+  /** Serializes the entity with control over which relations and fields to include or exclude. */
   serialize<
     Entity extends this = this,
     Naked extends FromEntityType<Entity> = FromEntityType<Entity>,
@@ -122,6 +129,7 @@ export abstract class BaseEntity {
     return EntitySerializer.serialize(this as unknown as Naked, options);
   }
 
+  /** Assigns the given data to this entity, updating its properties and relations. */
   assign<
     Entity extends this,
     Naked extends FromEntityType<Entity> = FromEntityType<Entity>,
@@ -136,6 +144,7 @@ export abstract class BaseEntity {
     return EntityAssigner.assign(this as Entity, data as any, options) as any;
   }
 
+  /** Initializes (refreshes) the entity by reloading it from the database. Returns null if not found. */
   init<
     Entity extends this = this,
     Hint extends string = never,
@@ -145,10 +154,12 @@ export abstract class BaseEntity {
     return helper(this as Entity).init(options);
   }
 
+  /** Returns the database schema this entity belongs to. */
   getSchema(): string | undefined {
     return helper(this).getSchema();
   }
 
+  /** Sets the database schema for this entity. */
   setSchema(schema?: string): void {
     helper(this).setSchema(schema);
   }

--- a/packages/core/src/entity/Collection.ts
+++ b/packages/core/src/entity/Collection.ts
@@ -25,12 +25,17 @@ import type { EntityLoaderOptions } from './EntityLoader.js';
 import { QueryHelper } from '../utils/QueryHelper.js';
 import { inspect } from '../logging/inspect.js';
 
+/** Options for the `Collection.matching()` method to query a subset of collection items from the database. */
 export interface MatchingOptions<T extends object, P extends string = never> extends FindOptions<T, P> {
+  /** Additional filtering conditions for the query. */
   where?: FilterQuery<T>;
+  /** Whether to store the matched items in the collection (makes it read-only). */
   store?: boolean;
+  /** Transaction context for the query. */
   ctx?: Transaction;
 }
 
+/** Represents a to-many relation (1:m or m:n) as an iterable, managed collection of entities. */
 export class Collection<T extends object, O extends object = object> {
   [k: number]: T;
 
@@ -148,6 +153,7 @@ export class Collection<T extends object, O extends object = object> {
     return count;
   }
 
+  /** Queries a subset of the collection items from the database with custom filtering, ordering, and pagination. */
   async matching<TT extends T, P extends string = never>(options: MatchingOptions<T, P>): Promise<Loaded<TT, P>[]> {
     const em = this.getEntityManager()!;
     const { where, ctx, ...opts } = options;
@@ -197,6 +203,7 @@ export class Collection<T extends object, O extends object = object> {
     return [...this.#items];
   }
 
+  /** Serializes the collection items to plain JSON objects. Returns an empty array if not initialized. */
   toJSON<TT extends T>(): EntityDTO<TT>[] {
     if (!this.isInitialized()) {
       return [];
@@ -205,6 +212,7 @@ export class Collection<T extends object, O extends object = object> {
     return this.toArray();
   }
 
+  /** Adds one or more items to the collection, propagating the change to the inverse side. Returns the number of items added. */
   add<TT extends T>(
     entity: TT | Reference<TT> | Iterable<TT | Reference<TT>>,
     ...entities: (TT | Reference<TT>)[]
@@ -297,6 +305,7 @@ export class Collection<T extends object, O extends object = object> {
     return removed;
   }
 
+  /** Checks whether the collection contains the given item. */
   contains<TT extends T>(item: TT | Reference<TT>, check = true): boolean {
     if (check) {
       this.checkInitialized();
@@ -306,16 +315,19 @@ export class Collection<T extends object, O extends object = object> {
     return this.#items.has(entity);
   }
 
+  /** Returns the number of items in the collection. Throws if the collection is not initialized. */
   count(): number {
     this.checkInitialized();
     return this.#items.size;
   }
 
+  /** Returns true if the collection has no items. Throws if the collection is not initialized. */
   isEmpty(): boolean {
     this.checkInitialized();
     return this.count() === 0;
   }
 
+  /** Returns whether this collection should be included in serialization based on its populated state. */
   shouldPopulate(populated?: boolean): boolean {
     if (!this.isInitialized(true)) {
       return false;
@@ -328,10 +340,12 @@ export class Collection<T extends object, O extends object = object> {
     return !!populated;
   }
 
+  /** Marks the collection as populated or not for serialization purposes. */
   populated(populated: boolean | undefined = true): void {
     this.#populated = populated;
   }
 
+  /** Initializes the collection by loading its items from the database. */
   async init<TT extends T, P extends string = never>(
     options: InitCollectionOptions<TT, P> = {},
   ): Promise<LoadedCollection<Loaded<TT, P>>> {
@@ -520,6 +534,7 @@ export class Collection<T extends object, O extends object = object> {
     }
   }
 
+  /** Converts all items in the collection to plain DTO objects. */
   toArray<TT extends T>(): EntityDTO<TT>[] {
     if (this.#items.size === 0) {
       return [];
@@ -528,6 +543,7 @@ export class Collection<T extends object, O extends object = object> {
     return this.map(item => wrap(item as TT).toJSON());
   }
 
+  /** Returns the primary key values (or a specific field) of all items in the collection. */
   getIdentifiers<U extends IPrimaryKey = Primary<T> & IPrimaryKey>(field?: string | string[]): U[] {
     const items = this.getItems();
     const targetMeta = this.property.targetMeta!;
@@ -569,6 +585,7 @@ export class Collection<T extends object, O extends object = object> {
     }
   }
 
+  /** Replaces all items in the collection with the given items. */
   set(items: Iterable<T | Reference<T>>): void {
     if (!this.#initialized) {
       this.#initialized = true;
@@ -793,6 +810,7 @@ export class Collection<T extends object, O extends object = object> {
     }, {} as any);
   }
 
+  /** Returns whether the collection has been initialized. Pass `fully = true` to also check that all items are initialized. */
   isInitialized(fully = false): boolean {
     if (!this.#initialized || !fully) {
       return this.#initialized;
@@ -811,6 +829,7 @@ export class Collection<T extends object, O extends object = object> {
     return this.#dirty;
   }
 
+  /** Returns whether the collection was partially loaded (propagation is disabled for partial collections). */
   isPartial(): boolean {
     return this.#partial;
   }
@@ -981,18 +1000,25 @@ Object.defineProperties(Collection.prototype, {
   __collection: { value: true, enumerable: false, writable: false },
 });
 
+/** Options for initializing a collection via `init()` or `load()`. */
 export interface InitCollectionOptions<
   T,
   P extends string = never,
   F extends string = '*',
   E extends string = never,
 > extends EntityLoaderOptions<T, F, E> {
+  /** Whether to use the dataloader for batching collection loads. */
   dataloader?: boolean;
+  /** Relations to populate on the loaded items. */
   populate?: Populate<T, P>;
-  ref?: boolean; // populate only references, works only with M:N collections that use pivot table
+  /** Populate only references (without loading full entities). Works only with M:N collections that use pivot table. */
+  ref?: boolean;
 }
 
+/** Options for the `Collection.loadCount()` method. */
 export interface LoadCountOptions<T extends object> extends CountOptions<T, '*'> {
+  /** Whether to reload the count from the database even if it is already cached. */
   refresh?: boolean;
+  /** Additional filtering conditions for the count query. */
   where?: FilterQuery<T>;
 }

--- a/packages/core/src/entity/EntityAssigner.ts
+++ b/packages/core/src/entity/EntityAssigner.ts
@@ -23,7 +23,9 @@ import { helper, wrap } from './wrap.js';
 import { EntityHelper } from './EntityHelper.js';
 import { ValidationError } from '../errors.js';
 
+/** Handles assigning data to entities, resolving relations, and propagating changes. */
 export class EntityAssigner {
+  /** Assigns the given data to the entity, resolving relations and handling custom types. */
   static assign<
     Entity extends object,
     Naked extends FromEntityType<Entity> = FromEntityType<Entity>,
@@ -389,6 +391,7 @@ export class EntityAssigner {
 
 export const assign = EntityAssigner.assign;
 
+/** Options controlling how data is assigned to an entity via `assign()`. */
 export interface AssignOptions<Convert extends boolean> {
   /**
    * Allows disabling processing of nested relations. When disabled, an object payload in place of a relation always

--- a/packages/core/src/entity/EntityFactory.ts
+++ b/packages/core/src/entity/EntityFactory.ts
@@ -26,21 +26,31 @@ import type { EventManager } from '../events/EventManager.js';
 import type { MetadataStorage } from '../metadata/MetadataStorage.js';
 import { JsonType } from '../types/JsonType.js';
 
+/** @internal Options for creating and merging entities via the EntityFactory. */
 export interface FactoryOptions {
+  /** Whether the entity should be marked as initialized. */
   initialized?: boolean;
+  /** Whether the entity is being newly created (uses constructor). */
   newEntity?: boolean;
   /**
    * Property `onCreate` hooks are normally executed during `flush` operation.
    * With this option, they will be processed early inside `em.create()` method.
    */
   processOnCreateHooksEarly?: boolean;
+  /** Whether to merge the entity into the identity map. */
   merge?: boolean;
+  /** Whether to refresh an already loaded entity with new data. */
   refresh?: boolean;
+  /** Whether to convert custom types during hydration. */
   convertCustomTypes?: boolean;
+  /** Whether to recompute the entity snapshot after creation. */
   recomputeSnapshot?: boolean;
-  schema?: string; // schema from FindOptions, overrides default schema
-  parentSchema?: string; // parent entity schema
-  normalizeAccessors?: boolean; // for `em.create`, we need to normalize accessors to the correct property names (this is normally handled via result mapper)
+  /** Schema from FindOptions, overrides default schema. */
+  schema?: string;
+  /** Parent entity schema for nested entity creation. */
+  parentSchema?: string;
+  /** Whether to normalize accessors to the correct property names (normally handled via result mapper). */
+  normalizeAccessors?: boolean;
   /**
    * Property name to use for identity map lookup instead of the primary key.
    * This is useful for creating references by unique non-PK properties.
@@ -48,6 +58,7 @@ export interface FactoryOptions {
   key?: string;
 }
 
+/** @internal Factory responsible for creating, merging, and hydrating entity instances. */
 export class EntityFactory {
   readonly #driver: IDatabaseDriver;
   readonly #platform: Platform;
@@ -69,6 +80,7 @@ export class EntityFactory {
     this.#comparator = this.#em.getComparator();
   }
 
+  /** Creates a new entity instance or returns an existing one from the identity map, hydrating it with the provided data. */
   create<T extends object, P extends string = string>(
     entityName: EntityName<T>,
     data: EntityData<T>,
@@ -178,6 +190,7 @@ export class EntityFactory {
     return entity as New<T, P>;
   }
 
+  /** Merges new data into an existing entity, preserving user-modified properties. */
   mergeData<T extends object>(
     meta: EntityMetadata<T>,
     entity: T,
@@ -285,6 +298,7 @@ export class EntityFactory {
     this.unitOfWork.normalizeEntityData(meta, originalEntityData);
   }
 
+  /** Creates or retrieves an uninitialized entity reference by its primary key or alternate key. */
   createReference<T extends object>(
     entityName: EntityName<T>,
     id: Primary<T> | Primary<T>[] | Record<string, Primary<T>>,
@@ -340,6 +354,7 @@ export class EntityFactory {
     return this.create<T>(entityName, id as EntityData<T>, { ...options, initialized: false }) as T;
   }
 
+  /** Creates an embeddable entity instance from the provided data. */
   createEmbeddable<T extends object>(
     entityName: EntityName<T>,
     data: EntityData<T>,
@@ -352,6 +367,7 @@ export class EntityFactory {
     return this.createEntity(data, meta2, options);
   }
 
+  /** Returns the EntityComparator instance used for diffing entities. */
   getComparator(): EntityComparator {
     return this.#comparator;
   }

--- a/packages/core/src/entity/EntityLoader.ts
+++ b/packages/core/src/entity/EntityLoader.ts
@@ -35,29 +35,47 @@ import type { LoggingOptions } from '../logging/Logger.js';
 import { expandDotPaths } from './utils.js';
 import { Raw } from '../utils/RawQueryFragment.js';
 
+/** Options for controlling how relations are loaded by the EntityLoader. */
 export interface EntityLoaderOptions<
   Entity,
   Fields extends string = PopulatePath.ALL,
   Excludes extends string = never,
 > {
+  /** Select specific fields to load (partial loading). */
   fields?: readonly AutoPath<Entity, Fields, `${PopulatePath.ALL}`>[];
+  /** Fields to exclude from loading. */
   exclude?: readonly AutoPath<Entity, Excludes>[];
+  /** Additional filtering conditions applied to populated relations. */
   where?: FilterQuery<Entity>;
+  /** Controls how `where` conditions are applied to populated relations. */
   populateWhere?: PopulateHint | `${PopulateHint}`;
+  /** Ordering for populated relations. */
   orderBy?: QueryOrderMap<Entity> | QueryOrderMap<Entity>[];
+  /** Whether to reload already loaded entities. */
   refresh?: boolean;
+  /** Whether to validate the populate hint against the entity metadata. */
   validate?: boolean;
+  /** Whether to look up eager-loaded relationships automatically. */
   lookup?: boolean;
+  /** Whether to convert custom types during hydration. */
   convertCustomTypes?: boolean;
+  /** Whether to skip loading lazy scalar properties. */
   ignoreLazyScalarProperties?: boolean;
+  /** Filter options to apply when loading relations. */
   filters?: FilterOptions;
+  /** Loading strategy to use (select-in, joined, or balanced). */
   strategy?: LoadStrategy | `${LoadStrategy}`;
+  /** Lock mode for the query (pessimistic locking). */
   lockMode?: Exclude<LockMode, LockMode.OPTIMISTIC>;
+  /** Database schema override. */
   schema?: string;
+  /** Connection type (read or write replica). */
   connectionType?: ConnectionType;
+  /** Logging options for the query. */
   logging?: LoggingOptions;
 }
 
+/** Responsible for batch-loading entity relations using either select-in or joined loading strategies. */
 export class EntityLoader {
   readonly #metadata: MetadataStorage;
   readonly #driver: IDatabaseDriver;
@@ -132,6 +150,7 @@ export class EntityLoader {
     }
   }
 
+  /** Normalizes populate hints into a structured array of PopulateOptions, expanding dot paths and eager relations. */
   normalizePopulate<Entity>(
     entityName: EntityName<Entity>,
     populate: (PopulateOptions<Entity> | boolean)[] | PopulateOptions<Entity> | boolean,

--- a/packages/core/src/entity/EntityRepository.ts
+++ b/packages/core/src/entity/EntityRepository.ts
@@ -40,6 +40,7 @@ import { ValidationError } from '../errors.js';
 import { Utils } from '../utils/Utils.js';
 import type { Cursor } from '../utils/Cursor.js';
 
+/** Repository class providing a type-safe API for querying and persisting a specific entity type. */
 export class EntityRepository<Entity extends object> {
   constructor(
     protected readonly em: EntityManager,
@@ -403,6 +404,7 @@ export class EntityRepository<Entity extends object> {
     return this.getEntityManager().count<Entity, Hint>(this.entityName, where as any, options);
   }
 
+  /** Returns the entity class name associated with this repository. */
   getEntityName(): string {
     return Utils.className(this.entityName);
   }

--- a/packages/core/src/entity/Reference.ts
+++ b/packages/core/src/entity/Reference.ts
@@ -19,6 +19,7 @@ import type { FindOneOptions, FindOneOrFailOptions } from '../drivers/IDatabaseD
 import { NotFoundError } from '../errors.js';
 import { inspect } from '../logging/inspect.js';
 
+/** Wrapper around an entity that provides lazy loading capabilities and identity-preserving reference semantics. */
 export class Reference<T extends object> {
   private property?: EntityProperty;
 
@@ -43,6 +44,7 @@ export class Reference<T extends object> {
     }
   }
 
+  /** Creates a Reference wrapper for the given entity, preserving identity if one already exists. */
   static create<T extends object>(entity: T | Ref<T>): Ref<T> {
     const unwrapped = Reference.unwrapReference(entity);
     const ref = helper(entity).toReference() as Reference<T>;
@@ -54,6 +56,7 @@ export class Reference<T extends object> {
     return ref as Ref<T>;
   }
 
+  /** Creates a Reference wrapper for an entity identified by its primary key, wrapped in a Ref. */
   static createFromPK<T extends object>(
     entityType: EntityClass<T>,
     pk: Primary<T>,
@@ -63,6 +66,7 @@ export class Reference<T extends object> {
     return helper(ref)?.toReference() ?? ref;
   }
 
+  /** Creates an uninitialized entity reference by primary key without wrapping it in a Reference. */
   static createNakedFromPK<T extends object>(
     entityType: EntityClass<T>,
     pk: Primary<T>,
@@ -180,10 +184,12 @@ export class Reference<T extends object> {
     delete helper(this.entity).__reference;
   }
 
+  /** Returns the underlying entity without checking initialization state. */
   unwrap(): T {
     return this.entity;
   }
 
+  /** Returns the underlying entity, throwing an error if the reference is not initialized. */
   getEntity(): T {
     if (!this.isInitialized()) {
       throw new Error(
@@ -194,10 +200,12 @@ export class Reference<T extends object> {
     return this.entity;
   }
 
+  /** Returns the value of a property on the underlying entity. Throws if the reference is not initialized. */
   getProperty<K extends keyof T>(prop: K): T[K] {
     return this.getEntity()[prop];
   }
 
+  /** Loads the entity if needed, then returns the value of the specified property. */
   async loadProperty<TT extends T, P extends string = never, K extends keyof TT = keyof TT>(
     prop: K,
     options?: LoadReferenceOrFailOptions<TT, P>,
@@ -206,14 +214,17 @@ export class Reference<T extends object> {
     return (this.getEntity() as TT)[prop] as Loaded<TT, P>[K];
   }
 
+  /** Returns whether the underlying entity has been fully loaded from the database. */
   isInitialized(): boolean {
     return helper(this.entity).__initialized;
   }
 
+  /** Marks the underlying entity as populated or not for serialization purposes. */
   populated(populated?: boolean): void {
     helper(this.entity).populated(populated);
   }
 
+  /** Serializes the underlying entity to a plain JSON object. */
   toJSON(...args: any[]): Dictionary {
     return wrap(this.entity as object).toJSON(...args);
   }
@@ -234,6 +245,7 @@ export class Reference<T extends object> {
   }
 }
 
+/** Wrapper for lazy scalar properties that provides on-demand loading from the database. */
 export class ScalarReference<Value> {
   private entity?: object;
   #property?: string;
@@ -286,21 +298,25 @@ export class ScalarReference<Value> {
     return ret;
   }
 
+  /** Sets the scalar value and marks the reference as initialized. */
   set(value: Value): void {
     this.value = value;
     this.#initialized = true;
   }
 
+  /** Binds this scalar reference to a specific entity and property for lazy loading support. */
   bind<Entity extends object>(entity: Entity, property: EntityKey<Entity>): void {
     this.entity = entity;
     this.#property = property;
     Object.defineProperty(this, 'entity', { enumerable: false, value: entity });
   }
 
+  /** Returns the current scalar value, or undefined if not yet loaded. */
   unwrap(): Value | undefined {
     return this.value;
   }
 
+  /** Returns whether the scalar value has been loaded. */
   isInitialized(): boolean {
     return this.#initialized;
   }
@@ -355,21 +371,25 @@ Object.defineProperties(ScalarReference.prototype, {
   },
 });
 
+/** Options for `Reference.load()` to control how the referenced entity is loaded. */
 export interface LoadReferenceOptions<
   T extends object,
   P extends string = never,
   F extends string = '*',
   E extends string = never,
 > extends FindOneOptions<T, P, F, E> {
+  /** Whether to use the dataloader for batching reference loads. */
   dataloader?: boolean;
 }
 
+/** Options for `Reference.loadOrFail()` which throws when the entity is not found. */
 export interface LoadReferenceOrFailOptions<
   T extends object,
   P extends string = never,
   F extends string = '*',
   E extends string = never,
 > extends FindOneOrFailOptions<T, P, F, E> {
+  /** Whether to use the dataloader for batching reference loads. */
   dataloader?: boolean;
 }
 

--- a/packages/core/src/entity/WrappedEntity.ts
+++ b/packages/core/src/entity/WrappedEntity.ts
@@ -38,6 +38,7 @@ import { expandDotPaths } from './utils.js';
 import type { Platform } from '../platforms/Platform.js';
 import type { Configuration } from '../utils/Configuration.js';
 
+/** @internal Wrapper attached to every managed entity, holding ORM state such as initialization flags, identity map references, and change tracking snapshots. */
 export class WrappedEntity<Entity extends object> {
   declare __initialized: boolean;
   declare __populated?: boolean;
@@ -92,18 +93,22 @@ export class WrappedEntity<Entity extends object> {
     this.__processing = false;
   }
 
+  /** Returns whether the entity has been fully loaded from the database. */
   isInitialized(): boolean {
     return this.__initialized;
   }
 
+  /** Returns whether the entity is managed by an EntityManager (tracked in the identity map). */
   isManaged(): boolean {
     return !!this.__managed;
   }
 
+  /** Marks the entity as populated or not for serialization purposes. */
   populated(populated: boolean | undefined = true): void {
     this.__populated = populated;
   }
 
+  /** Sets the serialization context with populate hints, field selections, and exclusions. */
   setSerializationContext<Hint extends string = never, Fields extends string = '*', Exclude extends string = never>(
     options: LoadHint<Entity, Hint, Fields, Exclude>,
   ): void {
@@ -122,30 +127,36 @@ export class WrappedEntity<Entity extends object> {
     }
   }
 
+  /** Returns a Reference wrapper for this entity, creating one if it does not already exist. */
   toReference(): Ref<Entity> & LoadedReference<Loaded<Entity, AddEager<Entity>>> {
     this.__reference ??= new Reference(this.entity);
     return this.__reference as Ref<Entity> & LoadedReference<Loaded<Entity, AddEager<Entity>>>;
   }
 
+  /** Converts the entity to a plain object representation, optionally excluding specified fields. */
   toObject<Ignored extends EntityKey<Entity> = never>(ignoreFields?: Ignored[]): Omit<EntityDTO<Entity>, Ignored> {
     return EntityTransformer.toObject(this.entity, ignoreFields);
   }
 
+  /** Serializes the entity with control over which relations and fields to include or exclude. */
   serialize<Hint extends string = never, Exclude extends string = never>(
     options?: SerializeOptions<Entity, Hint, Exclude>,
   ): SerializeDTO<Entity, Hint, Exclude> {
     return EntitySerializer.serialize(this.entity, options);
   }
 
+  /** Converts the entity to a plain object, including all properties regardless of serialization rules. */
   toPOJO(): EntityDTO<Entity> {
     return EntityTransformer.toObject(this.entity, [], true) as EntityDTO<Entity>;
   }
 
+  /** Serializes the entity using its `toJSON` method (supports `JSON.stringify`). */
   toJSON(...args: any[]): EntityDictionary<Entity> {
     // toJSON methods is added to the prototype during discovery to support automatic serialization via JSON.stringify()
     return (this.entity as Dictionary).toJSON(...args);
   }
 
+  /** Assigns the given data to this entity, updating its properties and relations. */
   assign<
     Naked extends FromEntityType<Entity> = FromEntityType<Entity>,
     Convert extends boolean = false,
@@ -163,6 +174,7 @@ export class WrappedEntity<Entity extends object> {
     return EntityAssigner.assign(this.entity, data as any, options) as any;
   }
 
+  /** Initializes (refreshes) the entity by reloading it from the database. Returns null if not found. */
   async init<Hint extends string = never, Fields extends string = '*', Excludes extends string = never>(
     options?: FindOneOptions<Entity, Hint, Fields, Excludes>,
   ): Promise<Loaded<Entity, Hint, Fields, Excludes> | null> {
@@ -177,6 +189,7 @@ export class WrappedEntity<Entity extends object> {
     });
   }
 
+  /** Loads the specified relations on this entity. */
   async populate<Hint extends string = never, Fields extends string = never>(
     populate: AutoPath<Entity, Hint, PopulatePath.ALL>[] | false,
     options: EntityLoaderOptions<Entity, Fields> = {},
@@ -191,11 +204,13 @@ export class WrappedEntity<Entity extends object> {
     return this.entity as Loaded<Entity, Hint>;
   }
 
+  /** Returns whether this entity has a primary key value set. */
   hasPrimaryKey(): boolean {
     const pk = this.getPrimaryKey();
     return pk != null;
   }
 
+  /** Returns the primary key value, optionally converting custom types to their database representation. */
   getPrimaryKey(convertCustomTypes = false): Primary<Entity> | null {
     const prop = this.__meta.getPrimaryProps()[0];
 
@@ -223,7 +238,8 @@ export class WrappedEntity<Entity extends object> {
     return this.__pk ?? this.pkGetter!(this.entity);
   }
 
-  // this method is currently used only in `Driver.syncCollection` and can be probably removed
+  /** Returns all primary key values as an array. Used internally for composite key handling. */
+  // TODO: currently used only in `Driver.syncCollection` — candidate for removal
   getPrimaryKeys(convertCustomTypes = false): Primary<Entity>[] | null {
     const pk = this.getPrimaryKey(convertCustomTypes);
 
@@ -249,19 +265,23 @@ export class WrappedEntity<Entity extends object> {
     return [pk];
   }
 
+  /** Returns the database schema this entity belongs to. */
   getSchema(): string | undefined {
     return this.__schema;
   }
 
+  /** Sets the database schema for this entity. */
   setSchema(schema?: string): void {
     this.__schema = schema;
   }
 
+  /** Sets the primary key value on the entity. */
   setPrimaryKey(id: Primary<Entity> | null) {
     this.entity[this.__meta.primaryKeys[0]] = id as EntityValue<Entity>;
     this.__pk = id!;
   }
 
+  /** Returns the primary key serialized as a string suitable for identity map lookups. */
   getSerializedPrimaryKey(): string {
     return this.pkSerializer!(this.entity);
   }

--- a/packages/core/src/entity/defineEntity.ts
+++ b/packages/core/src/entity/defineEntity.ts
@@ -55,6 +55,7 @@ import { EntitySchema } from '../metadata/EntitySchema.js';
 import type { Collection } from './Collection.js';
 import type { FilterOptions } from '../drivers/IDatabaseDriver.js';
 
+/** Union of all option keys supported across all property definition types (scalar, enum, embedded, relations). */
 export type UniversalPropertyKeys =
   | keyof PropertyOptions<any>
   | keyof EnumOptions<any>
@@ -970,6 +971,7 @@ export class UniversalPropertyOptionsBuilder<Value, Options, IncludeKeys extends
   }
 }
 
+/** Empty options object used as the initial state for property builders. */
 export interface EmptyOptions extends Partial<Record<UniversalPropertyKeys, unknown>> {}
 
 /** @internal */
@@ -1095,6 +1097,7 @@ const propertyBuilders: PropertyBuilders = {
 
 type PropertyBuildersOverrideKeys = 'bigint' | 'array' | 'decimal' | 'json' | 'datetime' | 'time' | 'enum';
 
+/** Map of factory functions for creating type-safe property builders (scalars, enums, embeddables, and relations). */
 export type PropertyBuilders = {
   [K in Exclude<keyof typeof types, PropertyBuildersOverrideKeys>]: () => UniversalPropertyOptionsBuilder<
     InferPropertyValueType<(typeof types)[K]>,
@@ -1172,6 +1175,7 @@ function getBuilderOptions(builder: any) {
 /** Own keys + base entity keys (when TBase is not `never`). Guards against `keyof never = string | number | symbol`. */
 type AllKeys<TProperties, TBase> = keyof TProperties | (IsNever<TBase> extends true ? never : keyof TBase);
 
+/** Metadata descriptor for `defineEntity()`, combining entity options with property definitions. */
 export interface EntityMetadataWithProperties<
   TName extends string,
   TTableName extends string,
@@ -1234,6 +1238,7 @@ export interface EntityMetadataWithProperties<
   }[];
 }
 
+/** Defines an entity schema using property builders, with full type inference from the property definitions. */
 export function defineEntity<
   const TName extends string,
   const TTableName extends string,
@@ -1252,6 +1257,7 @@ export function defineEntity<
   TProperties
 >;
 
+/** Defines an entity schema for an existing class, combining the class with property builders. */
 export function defineEntity<
   const TEntity = any,
   const TProperties extends Record<string, any> = Record<string, any>,
@@ -1311,10 +1317,12 @@ export function defineEntity(
 }
 
 defineEntity.properties = propertyBuilders;
+/** Shorthand alias for `defineEntity.properties` - the property builders for use in `defineEntity()`. */
 export { propertyBuilders as p };
 
 type EntityHookValue<T, K extends keyof EventSubscriber<T>> = (keyof T | NonNullable<EventSubscriber<T>[K]>)[];
 
+/** Lifecycle hook definitions for entities created via `defineEntity()`. */
 export interface DefineEntityHooks<T = any> {
   onInit?: EntityHookValue<T, 'onInit'>;
   onLoad?: EntityHookValue<T, 'onLoad'>;
@@ -1416,6 +1424,7 @@ type InferColumnType<T extends string> = T extends
 // before the Base in the intersection — TypeScript picks earlier overloads first.
 type BaseEntityMethodKeys = 'toObject' | 'toPOJO' | 'serialize' | 'assign' | 'populate' | 'init' | 'toReference';
 
+/** Infers the entity type from a `defineEntity()` properties map, resolving builders, base classes, and primary keys. */
 export type InferEntityFromProperties<
   Properties extends Record<string, any>,
   PK extends (keyof Properties)[] | undefined = undefined,
@@ -1465,6 +1474,7 @@ type CombinePrimaryKeys<ChildPK, BasePK> = [ChildPK] extends [never]
       : ChildPK
     : ChildPK | BasePK;
 
+/** Extracts the primary key property names from a properties map by finding builders with `primary: true`. */
 export type InferPrimaryKey<Properties extends Record<string, any>> = {
   [K in keyof Properties]: MaybeReturnType<Properties[K]> extends { '~options': { primary: true } } ? K : never;
 }[keyof Properties];

--- a/packages/core/src/enums.ts
+++ b/packages/core/src/enums.ts
@@ -2,6 +2,7 @@ import type { EntityKey, ExpandProperty } from './typings.js';
 import type { Transaction } from './connections/Connection.js';
 import type { LogContext } from './logging/Logger.js';
 
+/** Controls when the `EntityManager` flushes pending changes to the database. */
 export enum FlushMode {
   /** The `EntityManager` delays the flush until the current Transaction is committed. */
   COMMIT = 'commit',
@@ -11,46 +12,81 @@ export enum FlushMode {
   ALWAYS = 'always',
 }
 
+/** Controls how populate hints are resolved when using `FindOptions.populateWhere`. */
 export enum PopulateHint {
+  /** Infer population hints from the `where` condition. */
   INFER = 'infer',
+  /** Apply population hints to all relations. */
   ALL = 'all',
 }
 
+/** Special tokens used as populate path values in `FindOptions.populate`. */
 export enum PopulatePath {
+  /** Infer which relations to populate based on fields accessed in the `where` or `orderBy` clause. */
   INFER = '$infer',
+  /** Populate all relations. */
   ALL = '*',
 }
 
+/** Logical grouping operators for combining query conditions. */
 export enum GroupOperator {
+  /** Logical AND — all conditions must match. */
   $and = 'and',
+  /** Logical OR — at least one condition must match. */
   $or = 'or',
 }
 
+/** Comparison and filtering operators used in query conditions. */
 export enum QueryOperator {
+  /** Equal. */
   $eq = '=',
+  /** Included in the given list. */
   $in = 'in',
+  /** Not included in the given list. */
   $nin = 'not in',
+  /** Greater than. */
   $gt = '>',
+  /** Greater than or equal to. */
   $gte = '>=',
+  /** Less than. */
   $lt = '<',
+  /** Less than or equal to. */
   $lte = '<=',
+  /** Not equal. */
   $ne = '!=',
+  /** Negation wrapper. */
   $not = 'not',
+  /** SQL LIKE pattern matching. */
   $like = 'like',
+  /** Regular expression matching. */
   $re = 'regexp',
+  /** Full-text search. */
   $fulltext = 'fulltext',
+  /** Checks that the value is not null (i.e., exists). */
   $exists = 'not null',
+  /** Case-insensitive LIKE (PostgreSQL only). */
   $ilike = 'ilike', // postgres only
+  /** Array overlap operator (PostgreSQL only). */
   $overlap = '&&', // postgres only
+  /** Array/JSON contains operator (PostgreSQL only). */
   $contains = '@>', // postgres only
+  /** Array/JSON contained-by operator (PostgreSQL only). */
   $contained = '<@', // postgres only
+  /** No element in the collection matches (SQL only). */
   $none = 'none', // collection operators, sql only
+  /** At least one element in the collection matches (SQL only). */
   $some = 'some', // collection operators, sql only
+  /** Every element in the collection matches (SQL only). */
   $every = 'every', // collection operators, sql only
+  /** Matches collections by their size (SQL only). */
   $size = 'size', // collection operators, sql only
+  /** JSON object has the given key (PostgreSQL only). */
   $hasKey = '?', // postgres only, json
+  /** JSON object has all of the given keys (PostgreSQL only). */
   $hasKeys = '?&', // postgres only, json
+  /** JSON object has at least one of the given keys (PostgreSQL only). */
   $hasSomeKeys = '?|', // postgres only, json
+  /** Matches an element inside a JSON array (SQL only). */
   $elemMatch = 'elemMatch', // json array element matching, sql only
 }
 
@@ -58,23 +94,39 @@ export const ARRAY_OPERATORS = ['$eq', '$gt', '$gte', '$lt', '$lte', '$ne', '$ov
 
 export const JSON_KEY_OPERATORS = ['$hasKey', '$hasKeys', '$hasSomeKeys'];
 
+/** Sort direction for query results. Both upper- and lower-case variants are accepted. */
 export enum QueryOrder {
+  /** Ascending order. */
   ASC = 'ASC',
+  /** Ascending order with nulls sorted last. */
   ASC_NULLS_LAST = 'ASC NULLS LAST',
+  /** Ascending order with nulls sorted first. */
   ASC_NULLS_FIRST = 'ASC NULLS FIRST',
+  /** Descending order. */
   DESC = 'DESC',
+  /** Descending order with nulls sorted last. */
   DESC_NULLS_LAST = 'DESC NULLS LAST',
+  /** Descending order with nulls sorted first. */
   DESC_NULLS_FIRST = 'DESC NULLS FIRST',
+  /** Ascending order (lower-case variant). */
   asc = 'asc',
+  /** Ascending order with nulls sorted last (lower-case variant). */
   asc_nulls_last = 'asc nulls last',
+  /** Ascending order with nulls sorted first (lower-case variant). */
   asc_nulls_first = 'asc nulls first',
+  /** Descending order (lower-case variant). */
   desc = 'desc',
+  /** Descending order with nulls sorted last (lower-case variant). */
   desc_nulls_last = 'desc nulls last',
+  /** Descending order with nulls sorted first (lower-case variant). */
   desc_nulls_first = 'desc nulls first',
 }
 
+/** Numeric sort direction, compatible with MongoDB-style ordering. */
 export enum QueryOrderNumeric {
+  /** Ascending order. */
   ASC = 1,
+  /** Descending order. */
   DESC = -1,
 }
 
@@ -89,18 +141,31 @@ export interface FlatQueryOrderMap {
   [x: string]: QueryOrderKeysFlat;
 }
 
+/** Flags that modify query builder behavior. */
 export enum QueryFlag {
+  /** Add a DISTINCT clause to the SELECT statement. */
   DISTINCT = 'DISTINCT',
+  /** Enable result pagination via a sub-query for the primary keys. */
   PAGINATE = 'PAGINATE',
+  /** Disable the automatic pagination sub-query. */
   DISABLE_PAGINATE = 'DISABLE_PAGINATE',
+  /** Wrap UPDATE statements in a sub-query. */
   UPDATE_SUB_QUERY = 'UPDATE_SUB_QUERY',
+  /** Wrap DELETE statements in a sub-query. */
   DELETE_SUB_QUERY = 'DELETE_SUB_QUERY',
+  /** Convert values through custom type mappings when reading results. */
   CONVERT_CUSTOM_TYPES = 'CONVERT_CUSTOM_TYPES',
+  /** Include lazy formula properties in the SELECT clause. */
   INCLUDE_LAZY_FORMULAS = 'INCLUDE_LAZY_FORMULAS',
+  /** Automatically join the owning side of one-to-one relations. */
   AUTO_JOIN_ONE_TO_ONE_OWNER = 'AUTO_JOIN_ONE_TO_ONE_OWNER',
+  /** Infer the populate hint from the query fields. */
   INFER_POPULATE = 'INFER_POPULATE',
+  /** Prevent nested conditions from being promoted to INNER JOINs. */
   DISABLE_NESTED_INNER_JOIN = 'DISABLE_NESTED_INNER_JOIN',
+  /** Enable IDENTITY_INSERT for explicit PK values (MSSQL only). */
   IDENTITY_INSERT = 'IDENTITY_INSERT', // mssql only
+  /** Use an OUTPUT...INTO temp table for returning rows (MSSQL only). */
   OUTPUT_TABLE = 'OUTPUT_TABLE', // mssql only
 }
 
@@ -115,19 +180,31 @@ export const SCALAR_TYPES: Set<string> = new Set([
   'RegExp',
 ]);
 
+/** Describes the kind of relationship a property represents. */
 export enum ReferenceKind {
+  /** A plain scalar property (not a relation). */
   SCALAR = 'scalar',
+  /** A one-to-one relation. */
   ONE_TO_ONE = '1:1',
+  /** A one-to-many relation (inverse side of a many-to-one). */
   ONE_TO_MANY = '1:m',
+  /** A many-to-one relation (owning side). */
   MANY_TO_ONE = 'm:1',
+  /** A many-to-many relation. */
   MANY_TO_MANY = 'm:n',
+  /** An embedded entity (inline object stored within the parent). */
   EMBEDDED = 'embedded',
 }
 
+/** Cascade operations that propagate from a parent entity to its relations. */
 export enum Cascade {
+  /** Cascade persist — new related entities are automatically persisted. */
   PERSIST = 'persist',
+  /** Cascade merge — detached related entities are merged into the identity map. */
   MERGE = 'merge',
+  /** Cascade remove — removing the parent also removes related entities. */
   REMOVE = 'remove',
+  /** Enable all cascade operations (persist, merge, remove). */
   ALL = 'all',
 
   /** @internal */
@@ -136,57 +213,101 @@ export enum Cascade {
   CANCEL_ORPHAN_REMOVAL = 'cancel_orphan_removal',
 }
 
+/** Strategy used to load related entities when populating. */
 export enum LoadStrategy {
+  /** Load relations with a separate SELECT ... WHERE pk IN (...) query. */
   SELECT_IN = 'select-in',
+  /** Load relations via SQL JOINs in a single query. */
   JOINED = 'joined',
+  /** Use joined strategy for to-one relations and select-in for to-many. */
   BALANCED = 'balanced',
 }
 
+/** Controls which relation types use the dataloader for batched loading. */
 export enum DataloaderType {
+  /** Dataloader is disabled. */
   NONE = 0,
+  /** Use the dataloader for Reference (to-one) relations only. */
   REFERENCE = 1,
+  /** Use the dataloader for Collection (to-many) relations only. */
   COLLECTION = 2,
+  /** Use the dataloader for both Reference and Collection relations. */
   ALL = 3,
 }
 
+/** Locking strategy for concurrency control. */
 export enum LockMode {
+  /** No locking. */
   NONE = 0,
+  /** Optimistic locking via a version column. */
   OPTIMISTIC = 1,
+  /** Pessimistic shared lock (FOR SHARE). */
   PESSIMISTIC_READ = 2,
+  /** Pessimistic exclusive lock (FOR UPDATE). */
   PESSIMISTIC_WRITE = 3,
+  /** Pessimistic exclusive lock that skips already-locked rows (FOR UPDATE SKIP LOCKED). */
   PESSIMISTIC_PARTIAL_WRITE = 4,
+  /** Pessimistic exclusive lock that fails immediately if the row is locked (FOR UPDATE NOWAIT). */
   PESSIMISTIC_WRITE_OR_FAIL = 5,
+  /** Pessimistic shared lock that skips already-locked rows (FOR SHARE SKIP LOCKED). */
   PESSIMISTIC_PARTIAL_READ = 6,
+  /** Pessimistic shared lock that fails immediately if the row is locked (FOR SHARE NOWAIT). */
   PESSIMISTIC_READ_OR_FAIL = 7,
 }
 
+/** Transaction isolation levels as defined by the SQL standard (plus vendor extensions). */
 export enum IsolationLevel {
+  /** Allows dirty reads, non-repeatable reads, and phantom reads. */
   READ_UNCOMMITTED = 'read uncommitted',
+  /** Prevents dirty reads; non-repeatable and phantom reads are still possible. */
   READ_COMMITTED = 'read committed',
+  /** Snapshot isolation — each transaction sees a consistent snapshot of the database (MSSQL). */
   SNAPSHOT = 'snapshot',
+  /** Prevents dirty and non-repeatable reads; phantom reads are still possible. */
   REPEATABLE_READ = 'repeatable read',
+  /** Full isolation — transactions are executed as if they were run sequentially. */
   SERIALIZABLE = 'serializable',
 }
 
+/** Lifecycle and transaction events emitted by the ORM. */
 export enum EventType {
+  /** Fired when an entity instance is created (via constructor or `em.create`). */
   onInit = 'onInit',
+  /** Fired after an entity is loaded from the database. */
   onLoad = 'onLoad',
+  /** Fired before a new entity is inserted into the database. */
   beforeCreate = 'beforeCreate',
+  /** Fired after a new entity has been inserted into the database. */
   afterCreate = 'afterCreate',
+  /** Fired before an existing entity is updated in the database. */
   beforeUpdate = 'beforeUpdate',
+  /** Fired after an existing entity has been updated in the database. */
   afterUpdate = 'afterUpdate',
+  /** Fired before an upsert operation. */
   beforeUpsert = 'beforeUpsert',
+  /** Fired after an upsert operation. */
   afterUpsert = 'afterUpsert',
+  /** Fired before an entity is deleted from the database. */
   beforeDelete = 'beforeDelete',
+  /** Fired after an entity has been deleted from the database. */
   afterDelete = 'afterDelete',
+  /** Fired at the very beginning of `em.flush()`, before change detection. */
   beforeFlush = 'beforeFlush',
+  /** Fired during `em.flush()` after change detection but before database writes. */
   onFlush = 'onFlush',
+  /** Fired after `em.flush()` has completed all database writes. */
   afterFlush = 'afterFlush',
+  /** Fired before a new database transaction is started. */
   beforeTransactionStart = 'beforeTransactionStart',
+  /** Fired after a new database transaction has been started. */
   afterTransactionStart = 'afterTransactionStart',
+  /** Fired before a database transaction is committed. */
   beforeTransactionCommit = 'beforeTransactionCommit',
+  /** Fired after a database transaction has been committed. */
   afterTransactionCommit = 'afterTransactionCommit',
+  /** Fired before a database transaction is rolled back. */
   beforeTransactionRollback = 'beforeTransactionRollback',
+  /** Fired after a database transaction has been rolled back. */
   afterTransactionRollback = 'afterTransactionRollback',
 }
 
@@ -206,13 +327,21 @@ export type TransactionEventType =
   | EventType.beforeTransactionRollback
   | EventType.afterTransactionRollback;
 
+/** Controls how a transactional operation interacts with an existing transaction. */
 export enum TransactionPropagation {
+  /** Join the current transaction or create a new one if none exists. */
   REQUIRED = 'required',
+  /** Always create a new transaction, suspending the current one if it exists. */
   REQUIRES_NEW = 'requires_new',
+  /** Create a nested savepoint within the current transaction, or a new transaction if none exists. */
   NESTED = 'nested',
+  /** Execute non-transactionally, suspending the current transaction if one exists. */
   NOT_SUPPORTED = 'not_supported',
+  /** Join the current transaction if one exists, otherwise execute non-transactionally. */
   SUPPORTS = 'supports',
+  /** Join the current transaction; throw if no transaction is active. */
   MANDATORY = 'mandatory',
+  /** Execute non-transactionally; throw if a transaction is active. */
   NEVER = 'never',
 }
 
@@ -229,8 +358,11 @@ export interface TransactionOptions {
 
 export abstract class PlainObject {}
 
+/** Constraint deferral mode for database constraints (e.g., foreign keys, unique). */
 export enum DeferMode {
+  /** The constraint is checked immediately by default, but can be deferred within a transaction. */
   INITIALLY_IMMEDIATE = 'immediate',
+  /** The constraint is deferred until the transaction is committed. */
   INITIALLY_DEFERRED = 'deferred',
 }
 

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -10,6 +10,7 @@ import type {
 import { inspect } from './logging/inspect.js';
 import { Utils } from './utils/Utils.js';
 
+/** Base error class for ORM validation errors such as invalid entity state or incorrect usage. */
 export class ValidationError<T extends AnyEntity = AnyEntity> extends Error {
   constructor(
     message: string,
@@ -190,6 +191,7 @@ export class ValidationError<T extends AnyEntity = AnyEntity> extends Error {
   }
 }
 
+/** Error thrown when cursor-based pagination encounters missing or invalid cursor values. */
 export class CursorError<T extends AnyEntity = AnyEntity> extends ValidationError<T> {
   static entityNotPopulated(entity: AnyEntity, prop: string): ValidationError {
     return new CursorError(`Cannot create cursor, value for '${entity.constructor.name}.${prop}' is missing.`);
@@ -200,6 +202,7 @@ export class CursorError<T extends AnyEntity = AnyEntity> extends ValidationErro
   }
 }
 
+/** Error thrown when an optimistic lock conflict is detected during entity persistence. */
 export class OptimisticLockError<T extends AnyEntity = AnyEntity> extends ValidationError<T> {
   static notVersioned(meta: EntityMetadata): OptimisticLockError {
     return new OptimisticLockError(`Cannot obtain optimistic lock on unversioned entity ${meta.className}`);
@@ -227,6 +230,7 @@ export class OptimisticLockError<T extends AnyEntity = AnyEntity> extends Valida
   }
 }
 
+/** Error thrown when entity metadata is invalid, incomplete, or inconsistent. */
 export class MetadataError<T extends AnyEntity = AnyEntity> extends ValidationError<T> {
   static fromMissingPrimaryKey(meta: EntityMetadata): MetadataError {
     return new MetadataError(`${meta.className} entity is missing @PrimaryKey()`);
@@ -453,6 +457,7 @@ export class MetadataError<T extends AnyEntity = AnyEntity> extends ValidationEr
   }
 }
 
+/** Error thrown when an entity lookup fails to find the expected result. */
 export class NotFoundError<T extends AnyEntity = AnyEntity> extends ValidationError<T> {
   static findOneFailed(name: string, where: Dictionary | IPrimaryKey): NotFoundError {
     return new NotFoundError(`${name} not found (${inspect(where)})`);
@@ -470,6 +475,7 @@ export class NotFoundError<T extends AnyEntity = AnyEntity> extends ValidationEr
   }
 }
 
+/** Error thrown when a transaction propagation requirement is not satisfied. */
 export class TransactionStateError extends ValidationError {
   static requiredTransactionNotFound(propagation: string): TransactionStateError {
     return new TransactionStateError(

--- a/packages/core/src/events/EventManager.ts
+++ b/packages/core/src/events/EventManager.ts
@@ -3,6 +3,7 @@ import type { EventArgs, EventSubscriber, FlushEventArgs, TransactionEventArgs }
 import { Utils } from '../utils/Utils.js';
 import { EventType, EventTypeMap, type TransactionEventType } from '../enums.js';
 
+/** Manages event subscribers and dispatches entity/flush/transaction lifecycle events. */
 export class EventManager {
   readonly #listeners: { [K in EventType]?: Set<EventSubscriber> } = {};
   readonly #entities = new Map<EventSubscriber, Set<string>>();
@@ -15,6 +16,7 @@ export class EventManager {
     }
   }
 
+  /** Registers an event subscriber and indexes its subscribed entities and event types. */
   registerSubscriber(subscriber: EventSubscriber): void {
     if (this.#subscribers.has(subscriber)) {
       return;
@@ -31,6 +33,7 @@ export class EventManager {
       });
   }
 
+  /** Returns the set of all registered event subscribers. */
   getSubscribers(): Set<EventSubscriber> {
     return this.#subscribers;
   }
@@ -88,6 +91,7 @@ export class EventManager {
     return Utils.runSerial(listeners, listener => listener(args));
   }
 
+  /** Checks whether there are any listeners (hooks or subscribers) for the given event type and entity. */
   hasListeners<T>(event: EventType, meta: EntityMetadata<T>): boolean {
     const cacheKey = meta._id + EventTypeMap[event];
 
@@ -115,6 +119,7 @@ export class EventManager {
     return false;
   }
 
+  /** Creates a new EventManager with the same set of subscribers. */
   clone(): EventManager {
     return new EventManager(this.#subscribers);
   }

--- a/packages/core/src/events/EventSubscriber.ts
+++ b/packages/core/src/events/EventSubscriber.ts
@@ -4,6 +4,7 @@ import type { UnitOfWork } from '../unit-of-work/UnitOfWork.js';
 import type { ChangeSet } from '../unit-of-work/ChangeSet.js';
 import type { Transaction } from '../connections/Connection.js';
 
+/** Arguments passed to entity lifecycle event hooks. */
 export interface EventArgs<T> {
   entity: T;
   em: EntityManager;
@@ -11,15 +12,18 @@ export interface EventArgs<T> {
   changeSet?: ChangeSet<T & {}>;
 }
 
+/** Arguments passed to flush lifecycle event hooks (beforeFlush, onFlush, afterFlush). */
 export interface FlushEventArgs extends Omit<EventArgs<any>, 'entity' | 'changeSet' | 'meta'> {
   uow: UnitOfWork;
 }
 
+/** Arguments passed to transaction lifecycle event hooks (start, commit, rollback). */
 export interface TransactionEventArgs extends Omit<EventArgs<any>, 'entity' | 'meta' | 'changeSet'> {
   transaction?: Transaction & { savepointName?: string };
   uow?: UnitOfWork;
 }
 
+/** Interface for subscribing to entity and transaction lifecycle events. */
 export interface EventSubscriber<T = any> {
   getSubscribedEntities?(): EntityName<T>[];
   onInit?(args: EventArgs<T>): void;

--- a/packages/core/src/events/TransactionEventBroadcaster.ts
+++ b/packages/core/src/events/TransactionEventBroadcaster.ts
@@ -2,12 +2,14 @@ import type { Transaction } from '../connections/Connection.js';
 import type { EntityManager } from '../EntityManager.js';
 import type { TransactionEventType } from '../enums.js';
 
+/** Broadcasts transaction lifecycle events (start, commit, rollback) through the EventManager. */
 export class TransactionEventBroadcaster {
   constructor(
     private readonly em: EntityManager,
     readonly context?: { topLevelTransaction?: boolean },
   ) {}
 
+  /** Dispatches a transaction lifecycle event to the EventManager. */
   async dispatchEvent(event: TransactionEventType, transaction?: Transaction) {
     await this.em.getEventManager().dispatchEvent(event, {
       em: this.em,

--- a/packages/core/src/hydration/Hydrator.ts
+++ b/packages/core/src/hydration/Hydrator.ts
@@ -4,6 +4,7 @@ import type { Platform } from '../platforms/Platform.js';
 import type { MetadataStorage } from '../metadata/MetadataStorage.js';
 import type { Configuration } from '../utils/Configuration.js';
 
+/** Abstract base class for hydrating entity instances from raw database data. */
 /* v8 ignore next */
 export abstract class Hydrator implements IHydrator {
   protected running = false;
@@ -58,6 +59,7 @@ export abstract class Hydrator implements IHydrator {
     this.running = false;
   }
 
+  /** Returns whether the hydrator is currently in the middle of hydrating an entity. */
   isRunning(): boolean {
     return this.running;
   }

--- a/packages/core/src/hydration/ObjectHydrator.ts
+++ b/packages/core/src/hydration/ObjectHydrator.ts
@@ -20,6 +20,7 @@ type EntityHydrator<T extends object> = (
   normalizeAccessors?: boolean,
 ) => void;
 
+/** @internal JIT-compiled hydrator that converts raw database rows into entity instances with optimized generated code. */
 export class ObjectHydrator extends Hydrator {
   readonly #hydrators = {
     'full~true': new Map<EntityName, EntityHydrator<any>>(),

--- a/packages/core/src/logging/DefaultLogger.ts
+++ b/packages/core/src/logging/DefaultLogger.ts
@@ -2,6 +2,7 @@ import type { Logger, LoggerNamespace, LogContext, LoggerOptions } from './Logge
 import { colors } from './colors.js';
 import type { Highlighter } from '../typings.js';
 
+/** Default logger implementation with colored output, query formatting, and namespace-based filtering. */
 export class DefaultLogger implements Logger {
   debugMode: boolean | LoggerNamespace[];
   readonly writer: (message: string) => void;
@@ -62,6 +63,7 @@ export class DefaultLogger implements Logger {
     this.debugMode = debugMode;
   }
 
+  /** Checks whether logging is enabled for the given namespace, considering context overrides. */
   isEnabled(namespace: LoggerNamespace, context?: LogContext): boolean {
     if (context?.enabled !== undefined) {
       return context.enabled;
@@ -113,6 +115,7 @@ export class DefaultLogger implements Logger {
     return this.log(namespace, msg, context);
   }
 
+  /** Factory method for creating a new DefaultLogger instance. */
   static create(this: void, options: LoggerOptions): DefaultLogger {
     return new DefaultLogger(options);
   }

--- a/packages/core/src/logging/Logger.ts
+++ b/packages/core/src/logging/Logger.ts
@@ -1,5 +1,6 @@
 import type { AnyString, Dictionary, Highlighter } from '../typings.js';
 
+/** Interface for ORM logging, supporting namespaced log levels and query logging. */
 export interface Logger {
   /**
    * Logs a message inside given namespace.
@@ -26,11 +27,14 @@ export interface Logger {
    */
   setDebugMode(debugMode: boolean | LoggerNamespace[]): void;
 
+  /** Checks whether logging is enabled for the given namespace. */
   isEnabled(namespace: LoggerNamespace, context?: LogContext): boolean;
 }
 
+/** Available logging namespaces that can be individually enabled or disabled. */
 export type LoggerNamespace = 'query' | 'query-params' | 'schema' | 'discovery' | 'info' | 'deprecated' | 'slow-query';
 
+/** Contextual metadata passed alongside log messages, including query details and timing. */
 export interface LogContext extends Dictionary {
   query?: string;
   label?: string;
@@ -48,6 +52,7 @@ export interface LogContext extends Dictionary {
   };
 }
 
+/** Options for constructing a Logger instance. */
 export interface LoggerOptions {
   writer: (message: string) => void;
   debugMode?: boolean | LoggerNamespace[];

--- a/packages/core/src/metadata/EntitySchema.ts
+++ b/packages/core/src/metadata/EntitySchema.ts
@@ -44,6 +44,7 @@ type TypeType =
   | Type<any>;
 type TypeDef<Target> = { type: TypeType } | { entity: () => EntityName<Target> | EntityName[] };
 type EmbeddedTypeDef<Target> = { type: TypeType } | { entity: () => EntityName<Target> | EntityName[] };
+/** Union type representing all possible property definition shapes in an EntitySchema. */
 export type EntitySchemaProperty<Target, Owner> =
   | ({ kind: ReferenceKind.MANY_TO_ONE | 'm:1' } & TypeDef<Target> & ManyToOneOptions<Owner, Target>)
   | ({ kind: ReferenceKind.ONE_TO_ONE | '1:1' } & TypeDef<Target> & OneToOneOptions<Owner, Target>)
@@ -55,6 +56,7 @@ export type EntitySchemaProperty<Target, Owner> =
   | ({ enum: true } & EnumOptions<Owner>)
   | (TypeDef<Target> & PropertyOptions<Owner>);
 type OmitBaseProps<Entity, Base> = IsNever<Base> extends true ? Entity : Omit<Entity, keyof Base>;
+/** Configuration object for defining an entity via EntitySchema. */
 export type EntitySchemaMetadata<Entity, Base = never, Class extends EntityCtor = EntityCtor<Entity>> = Omit<
   Partial<EntityMetadata<Entity>>,
   'name' | 'properties' | 'extends'
@@ -68,6 +70,7 @@ export type EntitySchemaMetadata<Entity, Base = never, Class extends EntityCtor 
     };
   } & { inheritance?: 'tpt' };
 
+/** Class-less entity definition that provides a programmatic API for defining entities without decorators. */
 export class EntitySchema<Entity = any, Base = never, Class extends EntityCtor = EntityCtor<Entity>> {
   /**
    * When schema links the entity class via `class` option, this registry allows the lookup from opposite side,
@@ -113,6 +116,7 @@ export class EntitySchema<Entity = any, Base = never, Class extends EntityCtor =
     return item != null && typeof item === 'object' && item.constructor?.name === 'EntitySchema' && 'meta' in item;
   }
 
+  /** Creates an EntitySchema from existing EntityMetadata (used internally). */
   static fromMetadata<T = AnyEntity, U = never>(
     meta: EntityMetadata<T> | DeepPartial<EntityMetadata<T>>,
   ): EntitySchema<T, U> {
@@ -122,6 +126,7 @@ export class EntitySchema<Entity = any, Base = never, Class extends EntityCtor =
     return schema;
   }
 
+  /** Adds a scalar property to the entity schema. */
   addProperty(
     name: EntityKey<Entity>,
     type?: TypeType,
@@ -151,6 +156,7 @@ export class EntitySchema<Entity = any, Base = never, Class extends EntityCtor =
     this._meta.properties[name] = prop;
   }
 
+  /** Adds an enum property to the entity schema. */
   addEnum(name: EntityKey<Entity>, type?: TypeType, options: EnumOptions<Entity> = {}): void {
     if (options.items instanceof Function) {
       options.items = Utils.extractEnumValues(options.items());
@@ -176,14 +182,17 @@ export class EntitySchema<Entity = any, Base = never, Class extends EntityCtor =
     this.addProperty(name, this.internal ? type : type || 'enum', prop);
   }
 
+  /** Adds a version property for optimistic locking. */
   addVersion(name: EntityKey<Entity>, type: TypeType, options: PropertyOptions<Entity> = {}): void {
     this.addProperty(name, type, { version: true, ...options });
   }
 
+  /** Adds a primary key property to the entity schema. */
   addPrimaryKey(name: EntityKey<Entity>, type: TypeType, options: PrimaryKeyOptions<Entity> = {}): void {
     this.addProperty(name, type, { primary: true, ...options });
   }
 
+  /** Adds a serialized primary key property (e.g. for MongoDB ObjectId). */
   addSerializedPrimaryKey(
     name: EntityKey<Entity>,
     type: TypeType,
@@ -193,6 +202,7 @@ export class EntitySchema<Entity = any, Base = never, Class extends EntityCtor =
     this.addProperty(name, type, { serializedPrimaryKey: true, ...options });
   }
 
+  /** Adds an embedded property to the entity schema. */
   addEmbedded<Target = AnyEntity>(name: EntityKey<Entity>, options: EmbeddedOptions<Entity, Target>): void {
     this.renameCompositeOptions(name, options);
     Utils.defaultValue(options, 'prefix', true);
@@ -209,6 +219,7 @@ export class EntitySchema<Entity = any, Base = never, Class extends EntityCtor =
     } as EntityProperty<Entity>;
   }
 
+  /** Adds a many-to-one relation to the entity schema. */
   addManyToOne<Target = AnyEntity>(
     name: EntityKey<Entity>,
     type: TypeType,
@@ -231,6 +242,7 @@ export class EntitySchema<Entity = any, Base = never, Class extends EntityCtor =
     this.addProperty(name, type, prop);
   }
 
+  /** Adds a many-to-many relation to the entity schema. */
   addManyToMany<Target = AnyEntity>(
     name: EntityKey<Entity>,
     type: TypeType,
@@ -253,6 +265,7 @@ export class EntitySchema<Entity = any, Base = never, Class extends EntityCtor =
     this.addProperty(name, type, prop);
   }
 
+  /** Adds a one-to-many relation to the entity schema. */
   addOneToMany<Target = AnyEntity>(
     name: EntityKey<Entity>,
     type: TypeType,
@@ -262,6 +275,7 @@ export class EntitySchema<Entity = any, Base = never, Class extends EntityCtor =
     this.addProperty(name, type, prop);
   }
 
+  /** Adds a one-to-one relation to the entity schema. */
   addOneToOne<Target = AnyEntity>(
     name: EntityKey<Entity>,
     type: TypeType,
@@ -291,22 +305,27 @@ export class EntitySchema<Entity = any, Base = never, Class extends EntityCtor =
     this.addProperty(name, type, prop);
   }
 
+  /** Adds an index definition to the entity schema. */
   addIndex<Key extends string>(options: IndexOptions<Entity, Key>): void {
     this._meta.indexes.push(options as any);
   }
 
+  /** Adds a unique constraint definition to the entity schema. */
   addUnique<Key extends string>(options: UniqueOptions<Entity, Key>): void {
     this._meta.uniques.push(options as any);
   }
 
+  /** Sets a custom repository class for this entity. */
   setCustomRepository(repository: () => Constructor): void {
     this._meta.repository = repository as () => Constructor<EntityRepository<any>>;
   }
 
+  /** Sets the base entity that this schema extends. */
   setExtends(base: EntityName): void {
     this._meta.extends = base;
   }
 
+  /** Sets or replaces the entity class associated with this schema. */
   setClass(cls: Class) {
     const oldClass = this._meta.class;
     const sameClass = this._meta.class === cls;
@@ -338,14 +357,17 @@ export class EntitySchema<Entity = any, Base = never, Class extends EntityCtor =
     }
   }
 
+  /** Returns the underlying EntityMetadata. */
   get meta(): EntityMetadata<Entity, Class> {
     return this._meta;
   }
 
+  /** Returns the entity class name. */
   get name(): string | EntityName<Entity> {
     return this._meta.className;
   }
 
+  /** Returns the database table name. */
   get tableName(): string {
     return this._meta.tableName;
   }

--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -26,6 +26,7 @@ import { raw, Raw } from '../utils/RawQueryFragment.js';
 import type { Logger } from '../logging/Logger.js';
 import { BaseEntity } from '../entity/BaseEntity.js';
 
+/** Discovers, validates, and processes entity metadata from configured sources. */
 export class MetadataDiscovery {
   readonly #namingStrategy: NamingStrategy;
   readonly #metadataProvider: MetadataProvider;
@@ -48,6 +49,7 @@ export class MetadataDiscovery {
     this.#schemaHelper = this.#platform.getSchemaHelper();
   }
 
+  /** Discovers all entities asynchronously and returns the populated MetadataStorage. */
   async discover(preferTs = true): Promise<MetadataStorage> {
     this.#discovered.length = 0;
     const startTime = Date.now();
@@ -78,6 +80,7 @@ export class MetadataDiscovery {
     return storage;
   }
 
+  /** Discovers all entities synchronously and returns the populated MetadataStorage. */
   discoverSync(): MetadataStorage {
     this.#discovered.length = 0;
     const startTime = Date.now();
@@ -169,6 +172,7 @@ export class MetadataDiscovery {
     }
   }
 
+  /** Processes discovered entities: initializes relations, embeddables, indexes, and inheritance. */
   processDiscoveredEntities(discovered: EntityMetadata[]): EntityMetadata[] {
     for (const meta of discovered) {
       let i = 1;

--- a/packages/core/src/metadata/MetadataProvider.ts
+++ b/packages/core/src/metadata/MetadataProvider.ts
@@ -13,9 +13,11 @@ export interface IConfiguration {
   getPlatform(): Platform;
 }
 
+/** Base metadata provider that resolves entity type information and manages metadata caching. */
 export class MetadataProvider {
   constructor(protected readonly config: IConfiguration) {}
 
+  /** Resolves entity references and type information for all properties in the given metadata. */
   loadEntityMetadata(meta: EntityMetadata): void {
     for (const prop of meta.props) {
       /* v8 ignore next */
@@ -36,6 +38,7 @@ export class MetadataProvider {
     }
   }
 
+  /** Merges cached metadata into the given entity metadata, preserving function expressions. */
   loadFromCache(meta: EntityMetadata, cache: EntityMetadata): void {
     Object.values(cache.properties).forEach(prop => {
       const metaProp = meta.properties[prop.name];
@@ -73,10 +76,12 @@ export class MetadataProvider {
     }
   }
 
+  /** Whether this provider class uses metadata caching by default. */
   static useCache(): boolean {
     return false;
   }
 
+  /** Whether metadata caching is enabled for this instance. */
   useCache(): boolean {
     return this.config.get('metadataCache').enabled ?? MetadataProvider.useCache();
   }
@@ -85,6 +90,7 @@ export class MetadataProvider {
     //
   }
 
+  /** Attempts to load metadata from cache, returning undefined if not available. */
   getCachedMetadata<T>(
     meta: Pick<EntityMetadata<T>, 'className' | 'path' | 'root'>,
     root: EntityMetadata<T>,
@@ -103,6 +109,7 @@ export class MetadataProvider {
     return cache;
   }
 
+  /** Combines individual metadata cache entries into a single file. */
   combineCache(): void {
     const path = this.config.getMetadataCacheAdapter().combine?.();
 
@@ -112,6 +119,7 @@ export class MetadataProvider {
     }
   }
 
+  /** Returns the cache key for the given entity metadata. */
   getCacheKey(meta: Pick<EntityMetadata, 'className' | 'path'>): string {
     return meta.className;
   }

--- a/packages/core/src/metadata/MetadataStorage.ts
+++ b/packages/core/src/metadata/MetadataStorage.ts
@@ -12,6 +12,7 @@ function getGlobalStorage(namespace: string): Dictionary {
   return globalThis[key];
 }
 
+/** Registry that stores and provides access to entity metadata by class, name, or id. */
 export class MetadataStorage {
   static readonly PATH_SYMBOL = Symbol.for('@mikro-orm/core/MetadataStorage.PATH_SYMBOL');
 
@@ -33,6 +34,7 @@ export class MetadataStorage {
     }
   }
 
+  /** Returns the global metadata dictionary, or a specific entry by entity name and path. */
   static getMetadata(): Dictionary<EntityMetadata>;
   static getMetadata<T = any>(entity: string, path: string): EntityMetadata<T>;
   static getMetadata<T = any>(entity?: string, path?: string): Dictionary<EntityMetadata> | EntityMetadata<T> {
@@ -49,18 +51,22 @@ export class MetadataStorage {
     return MetadataStorage.#metadata;
   }
 
+  /** Checks whether an entity with the given class name exists in the global metadata. */
   static isKnownEntity(name: string): boolean {
     return !!Object.values(this.#metadata).find(meta => meta.className === name);
   }
 
+  /** Clears all entries from the global metadata registry. */
   static clear(): void {
     Object.keys(this.#metadata).forEach(k => delete this.#metadata[k]);
   }
 
+  /** Returns the map of all registered entity metadata. */
   getAll(): Map<EntityName, EntityMetadata> {
     return this.#metadataMap;
   }
 
+  /** Returns metadata for the given entity, optionally initializing it if not found. */
   get<T = any>(entityName: EntityName<T>, init = false): EntityMetadata<T> {
     const exists = this.find(entityName);
 
@@ -80,6 +86,7 @@ export class MetadataStorage {
     return meta;
   }
 
+  /** Finds metadata for the given entity, returning undefined if not registered. */
   find<T = any>(entityName: EntityName<T>): EntityMetadata<T> | undefined {
     if (!entityName) {
       return;
@@ -98,10 +105,12 @@ export class MetadataStorage {
     return this.#classNameMap[Utils.className(entityName)];
   }
 
+  /** Checks whether metadata exists for the given entity. */
   has<T>(entityName: EntityName<T>): boolean {
     return this.#metadataMap.has(entityName);
   }
 
+  /** Registers metadata for the given entity. */
   set<T>(entityName: EntityName<T>, meta: EntityMetadata): EntityMetadata {
     this.#metadataMap.set(entityName, meta);
     this.#idMap[meta._id] = meta;
@@ -111,6 +120,7 @@ export class MetadataStorage {
     return meta;
   }
 
+  /** Removes metadata for the given entity from all internal maps. */
   reset<T>(entityName: EntityName<T>): void {
     const meta = this.find(entityName);
 
@@ -122,6 +132,7 @@ export class MetadataStorage {
     }
   }
 
+  /** Decorates all entity prototypes with helper methods (e.g. init, toJSON). */
   decorate(em: EntityManager): void {
     [...this.#metadataMap.values()].filter(meta => meta.prototype).forEach(meta => EntityHelper.decorate(meta, em));
   }
@@ -132,10 +143,12 @@ export class MetadataStorage {
     }
   }
 
+  /** Returns metadata by its internal numeric id. */
   getById<T>(id: number): EntityMetadata<T> {
     return this.#idMap[id];
   }
 
+  /** Returns metadata by class name, optionally throwing if not found. */
   getByClassName<T = any, V extends boolean = true>(
     className: string,
     validate = true as V,
@@ -143,6 +156,7 @@ export class MetadataStorage {
     return this.validate(this.#classNameMap[className], className, validate);
   }
 
+  /** Returns metadata by unique name, optionally throwing if not found. */
   getByUniqueName<T = any, V extends boolean = true>(
     uniqueName: string,
     validate = true as V,

--- a/packages/core/src/naming-strategy/AbstractNamingStrategy.ts
+++ b/packages/core/src/naming-strategy/AbstractNamingStrategy.ts
@@ -3,6 +3,7 @@ import { PopulatePath, type ReferenceKind } from '../enums.js';
 
 const populatePathMembers = Object.values(PopulatePath);
 
+/** Base class for naming strategies, providing default implementations for common naming conventions. */
 export abstract class AbstractNamingStrategy implements NamingStrategy {
   getClassName(file: string, separator = '-'): string {
     const name = file.split('.')[0];

--- a/packages/core/src/naming-strategy/MongoNamingStrategy.ts
+++ b/packages/core/src/naming-strategy/MongoNamingStrategy.ts
@@ -1,5 +1,6 @@
 import { AbstractNamingStrategy } from './AbstractNamingStrategy.js';
 
+/** Naming strategy for MongoDB that uses camelCase property names and hyphenated collection names. */
 export class MongoNamingStrategy extends AbstractNamingStrategy {
   classToTableName(entityName: string, tableName?: string): string {
     return tableName ?? entityName.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase();

--- a/packages/core/src/naming-strategy/UnderscoreNamingStrategy.ts
+++ b/packages/core/src/naming-strategy/UnderscoreNamingStrategy.ts
@@ -1,5 +1,6 @@
 import { AbstractNamingStrategy } from './AbstractNamingStrategy.js';
 
+/** Naming strategy that converts camelCase names to snake_case for table and column names. */
 export class UnderscoreNamingStrategy extends AbstractNamingStrategy {
   classToTableName(entityName: string, tableName?: string): string {
     return tableName ?? this.underscore(entityName);

--- a/packages/core/src/platforms/ExceptionConverter.ts
+++ b/packages/core/src/platforms/ExceptionConverter.ts
@@ -1,6 +1,7 @@
 import type { Dictionary } from '../typings.js';
 import { DriverException } from '../exceptions.js';
 
+/** Converts native database errors into standardized DriverException instances. */
 export class ExceptionConverter {
   /* v8 ignore next */
   convertException(exception: Error & Dictionary): DriverException {

--- a/packages/core/src/platforms/Platform.ts
+++ b/packages/core/src/platforms/Platform.ts
@@ -52,38 +52,47 @@ import type { MikroORM } from '../MikroORM.js';
 import type { TransformContext } from '../types/Type.js';
 import { Raw } from '../utils/RawQueryFragment.js';
 
+/** Symbol used to tag cloned embeddable data for JSON serialization handling. */
 export const JsonProperty = Symbol('JsonProperty');
 
+/** Abstract base class providing database-specific behavior and SQL dialect differences. */
 export abstract class Platform {
   protected readonly exceptionConverter: ExceptionConverter = new ExceptionConverter();
   protected config!: Configuration;
   protected namingStrategy!: NamingStrategy;
   protected timezone?: string;
 
+  /** Whether this driver uses pivot tables for M:N relations (SQL drivers do, MongoDB does not). */
   usesPivotTable(): boolean {
     return false;
   }
 
+  /** Whether this driver supports database transactions. */
   supportsTransactions(): boolean {
     return !this.config.get('disableTransactions');
   }
 
+  /** Whether the driver wraps operations in implicit transactions by default. */
   usesImplicitTransactions(): boolean {
     return true;
   }
 
+  /** Returns the default naming strategy constructor for this platform. */
   getNamingStrategy(): { new (): NamingStrategy } {
     return UnderscoreNamingStrategy;
   }
 
+  /** Whether the driver supports RETURNING clause (e.g. PostgreSQL). */
   usesReturningStatement(): boolean {
     return false;
   }
 
+  /** Whether the driver supports OUTPUT clause (e.g. MSSQL). */
   usesOutputStatement(): boolean {
     return false;
   }
 
+  /** Whether DELETE statements require explicit CASCADE keyword. */
   usesCascadeStatement(): boolean {
     return false;
   }
@@ -98,14 +107,17 @@ export abstract class Platform {
     return false;
   }
 
+  /** Whether this platform supports materialized views. */
   supportsMaterializedViews(): boolean {
     return false;
   }
 
+  /** Returns the schema helper instance for this platform, or undefined if not supported. */
   getSchemaHelper(): unknown {
     return undefined;
   }
 
+  /** Whether the platform automatically creates indexes on foreign key columns. */
   indexForeignKeys(): boolean {
     return false;
   }
@@ -124,6 +136,7 @@ export abstract class Platform {
     return true;
   }
 
+  /** Whether the platform supports the DEFAULT keyword in INSERT statements. */
   usesDefaultKeyword(): boolean {
     return true;
   }
@@ -149,34 +162,42 @@ export abstract class Platform {
     return 'current_timestamp' + (length ? `(${length})` : '');
   }
 
+  /** Returns the SQL type declaration for datetime columns. */
   getDateTimeTypeDeclarationSQL(column: { length?: number }): string {
     return 'datetime' + (column.length ? `(${column.length})` : '');
   }
 
+  /** Returns the default fractional seconds precision for datetime columns. */
   getDefaultDateTimeLength(): number {
     return 0;
   }
 
+  /** Returns the default length for varchar columns. */
   getDefaultVarcharLength(): number {
     return 255;
   }
 
+  /** Returns the default length for char columns. */
   getDefaultCharLength(): number {
     return 1;
   }
 
+  /** Returns the SQL type declaration for date columns. */
   getDateTypeDeclarationSQL(length?: number): string {
     return 'date' + (length ? `(${length})` : '');
   }
 
+  /** Returns the SQL type declaration for time columns. */
   getTimeTypeDeclarationSQL(length?: number): string {
     return 'time' + (length ? `(${length})` : '');
   }
 
+  /** Returns the SQL operator used for regular expression matching. */
   getRegExpOperator(val?: unknown, flags?: string): string {
     return 'regexp';
   }
 
+  /** Builds the SQL clause and parameters for a regular expression condition. */
   mapRegExpCondition(mappedKey: string, value: { $re: string; $flags?: string }): { sql: string; params: unknown[] } {
     const operator = this.getRegExpOperator(value.$re, value.$flags);
     const quotedKey = this.quoteIdentifier(mappedKey);
@@ -184,6 +205,7 @@ export abstract class Platform {
     return { sql: `${quotedKey} ${operator} ?`, params: [value.$re] };
   }
 
+  /** Converts a JavaScript RegExp into a platform-specific regex representation. */
   getRegExpValue(val: RegExp): { $re: string; $flags?: string } {
     if (val.flags.includes('i')) {
       return { $re: `(?i)${val.source}` };
@@ -192,10 +214,12 @@ export abstract class Platform {
     return { $re: val.source };
   }
 
+  /** Whether the given operator is allowed at the top level of a query condition. */
   isAllowedTopLevelOperator(operator: string): boolean {
     return operator === '$not';
   }
 
+  /** Converts a version field value for comparison in optimistic locking queries. */
   convertVersionValue(
     value: Date | number,
     prop: EntityProperty,
@@ -203,26 +227,32 @@ export abstract class Platform {
     return value;
   }
 
+  /** Returns the default fractional seconds precision for version timestamp columns. */
   getDefaultVersionLength(): number {
     return 3;
   }
 
+  /** Whether the platform supports tuple comparison in WHERE clauses. */
   allowsComparingTuples(): boolean {
     return true;
   }
 
+  /** Whether the given property maps to a bigint database column. */
   isBigIntProperty(prop: EntityProperty): boolean {
     return prop.columnTypes?.[0] === 'bigint';
   }
 
+  /** Returns the default schema name for this platform (e.g. "public" for PostgreSQL). */
   getDefaultSchemaName(): string | undefined {
     return undefined;
   }
 
+  /** Returns the SQL type declaration for boolean columns. */
   getBooleanTypeDeclarationSQL(): string {
     return 'boolean';
   }
 
+  /** Returns the SQL type declaration for integer columns. */
   getIntegerTypeDeclarationSQL(column: { length?: number; unsigned?: boolean; autoincrement?: boolean }): string {
     return 'int';
   }
@@ -293,6 +323,7 @@ export abstract class Platform {
     return this.getVarcharTypeDeclarationSQL(column);
   }
 
+  /** Extracts the base type name from a full SQL type declaration (e.g. "varchar(255)" -> "varchar"). */
   extractSimpleType(type: string): string {
     return /[^(), ]+/.exec(type.toLowerCase())![0];
   }
@@ -304,11 +335,13 @@ export abstract class Platform {
     return type.toLowerCase();
   }
 
+  /** Returns the mapped Type instance for a given SQL/runtime type string. */
   getMappedType(type: string): Type<unknown> {
     const mappedType = this.config.get('discovery').getMappedType?.(type, this);
     return mappedType ?? this.getDefaultMappedType(type);
   }
 
+  /** Returns the default mapped Type for a given type string when no custom mapping is configured. */
   getDefaultMappedType(type: string): Type<unknown> {
     if (type.endsWith('[]')) {
       return Type.getType(ArrayType);
@@ -371,6 +404,7 @@ export abstract class Platform {
     }
   }
 
+  /** Whether the platform supports multiple cascade paths to the same table. */
   supportsMultipleCascadePaths(): boolean {
     return true;
   }
@@ -383,22 +417,27 @@ export abstract class Platform {
     return true;
   }
 
+  /** Whether the connection supports executing multiple SQL statements in a single call. */
   supportsMultipleStatements(): boolean {
     return this.config.get('multipleStatements');
   }
 
+  /** Whether the platform supports the UNION WHERE optimization for multi-branch queries. */
   supportsUnionWhere(): boolean {
     return false;
   }
 
+  /** Returns the SQL type declaration used for array storage. */
   getArrayDeclarationSQL(): string {
     return 'text';
   }
 
+  /** Serializes a string array into its database storage format. */
   marshallArray(values: string[]): string {
     return values.join(',');
   }
 
+  /** Deserializes a database-stored array string back into a string array. */
   unmarshallArray(value: string): string[] {
     if (value === '') {
       return [];
@@ -483,14 +522,17 @@ export abstract class Platform {
     throw new Error('Full text searching is not supported by this driver.');
   }
 
+  /** Whether the driver automatically parses JSON columns into JS objects. */
   convertsJsonAutomatically(): boolean {
     return true;
   }
 
+  /** Converts a JS value to its JSON database representation (typically JSON.stringify). */
   convertJsonToDatabaseValue(value: unknown, context?: TransformContext): unknown {
     return JSON.stringify(value);
   }
 
+  /** Converts a database JSON value to its JS representation. */
   convertJsonToJSValue(value: unknown, context?: TransformContext): unknown {
     return parseJsonSafe(value);
   }
@@ -527,6 +569,7 @@ export abstract class Platform {
     return value;
   }
 
+  /** Parses a string or numeric value into a Date object. */
   parseDate(value: string | number): Date {
     const date = new Date(value);
 
@@ -538,14 +581,17 @@ export abstract class Platform {
     return date;
   }
 
+  /** Returns the default EntityRepository class used by this platform. */
   getRepositoryClass<T extends object>(): Constructor<EntityRepository<T>> {
     return EntityRepository;
   }
 
+  /** Returns the default character set for this platform. */
   getDefaultCharset(): string {
     return 'utf8';
   }
 
+  /** Returns the exception converter for translating native errors to driver exceptions. */
   getExceptionConverter(): ExceptionConverter {
     return this.exceptionConverter;
   }
@@ -562,6 +608,7 @@ export abstract class Platform {
     this.lookupExtensions(orm);
   }
 
+  /** Retrieves a registered extension (e.g. SchemaGenerator, Migrator), throwing if not found. */
   getExtension<T>(extensionName: string, extensionKey: string, moduleName: string, em: EntityManager): T {
     const extension = this.config.getExtension<T>(extensionKey);
 
@@ -580,10 +627,12 @@ export abstract class Platform {
     throw new Error(`${driver.constructor.name} does not support SchemaGenerator`);
   }
 
+  /** Processes a date value before persisting, applying timezone or format conversions. */
   processDateProperty(value: unknown): string | number | Date {
     return value as string;
   }
 
+  /** Wraps a table or column identifier with the platform-specific quote character. */
   quoteIdentifier(id: string | { toString: () => string }, quote = '`'): string {
     const raw = Raw.getKnownFragment(id);
 
@@ -594,6 +643,7 @@ export abstract class Platform {
     return `${quote}${id.toString().replace('.', `${quote}.${quote}`)}${quote}`;
   }
 
+  /** Quotes a literal value for safe embedding in SQL. */
   quoteValue(value: any): string {
     return value;
   }
@@ -603,6 +653,7 @@ export abstract class Platform {
     return value;
   }
 
+  /** Replaces `?` placeholders in SQL with quoted parameter values. */
   formatQuery(sql: string, params: readonly any[]): string {
     if (params.length === 0) {
       return sql;
@@ -646,6 +697,7 @@ export abstract class Platform {
     return ret;
   }
 
+  /** Deep-clones embeddable data and tags it for JSON serialization. */
   cloneEmbeddable<T>(data: T): T {
     const copy = clone(data);
     // tag the copy so we know it should be stringified when quoting (so we know how to treat JSON arrays)
@@ -654,6 +706,7 @@ export abstract class Platform {
     return copy;
   }
 
+  /** Initializes the platform with the ORM configuration. */
   setConfig(config: Configuration): void {
     this.config = config;
     this.namingStrategy = config.getNamingStrategy();
@@ -665,23 +718,28 @@ export abstract class Platform {
     }
   }
 
+  /** Returns the current ORM configuration. */
   getConfig(): Configuration {
     return this.config;
   }
 
+  /** Returns the configured timezone, or undefined if not set. */
   getTimezone(): string | undefined {
     return this.timezone;
   }
 
+  /** Whether the given property represents a numeric database column. */
   isNumericProperty(prop: EntityProperty, ignoreCustomType = false): boolean {
     const numericMappedType = prop.columnTypes?.[0] && this.isNumericColumn(this.getMappedType(prop.columnTypes[0]));
     return numericMappedType || prop.type === 'number' || this.isBigIntProperty(prop);
   }
 
+  /** Whether the given mapped type represents a numeric column. */
   isNumericColumn(mappedType: Type<unknown>): boolean {
     return [IntegerType, SmallIntType, BigIntType, TinyIntType].some(t => mappedType instanceof t);
   }
 
+  /** Whether the platform supports unsigned integer columns. */
   supportsUnsigned(): boolean {
     return false;
   }
@@ -697,18 +755,22 @@ export abstract class Platform {
     return this.namingStrategy.indexName(tableName, columns, type);
   }
 
+  /** Returns the default primary key constraint name. */
   getDefaultPrimaryName(tableName: string, columns: string[]): string {
     return 'primary';
   }
 
+  /** Whether the platform supports custom names for primary key constraints. */
   supportsCustomPrimaryKeyNames(): boolean {
     return false;
   }
 
+  /** Whether the given property key is included in the populate hint. */
   isPopulated<T>(key: string, populate: readonly PopulateOptions<T>[] | boolean): boolean {
     return populate === true || (populate !== false && populate.some(p => p.field === key || p.all));
   }
 
+  /** Whether the given property should be included as a column in the SELECT query. */
   shouldHaveColumn<T>(
     prop: EntityProperty<T>,
     populate: readonly PopulateOptions<T>[] | boolean,
@@ -750,14 +812,17 @@ export abstract class Platform {
   /**
    * Currently not supported due to how knex does complex sqlite diffing (always based on current schema)
    */
+  /** Whether the platform supports generating down migrations. */
   supportsDownMigrations(): boolean {
     return true;
   }
 
+  /** Whether the platform supports deferred unique constraints. */
   supportsDeferredUniqueConstraints(): boolean {
     return true;
   }
 
+  /** Platform-specific validation of entity metadata. */
   validateMetadata(meta: EntityMetadata): void {
     return;
   }

--- a/packages/core/src/serialization/EntitySerializer.ts
+++ b/packages/core/src/serialization/EntitySerializer.ts
@@ -68,7 +68,9 @@ function isPopulated(propName: string, options: SerializeOptions<any, any, any>)
   return false;
 }
 
+/** Converts entity instances to plain DTOs via `serialize()`, with fine-grained control over populate, exclude, and serialization groups. */
 export class EntitySerializer {
+  /** Serializes an entity to a plain DTO, with fine-grained control over population, exclusion, groups, and custom types. */
   static serialize<T extends object, P extends string = never, E extends string = never>(
     entity: T,
     options: SerializeOptions<T, P, E> = {},

--- a/packages/core/src/serialization/EntityTransformer.ts
+++ b/packages/core/src/serialization/EntityTransformer.ts
@@ -29,7 +29,9 @@ function isVisible<Entity extends object>(
   return visible && !prefixed && !ignoreFields.includes(propName);
 }
 
+/** Converts entity instances to plain objects via `toObject()`, respecting populate hints, hidden fields, and serialization context. */
 export class EntityTransformer {
+  /** Converts an entity to a plain object, respecting populate hints, hidden fields, and custom serializers. */
   static toObject<Entity extends object, Ignored extends EntityKey<Entity> = never>(
     entity: Entity,
     ignoreFields: Ignored[] = [],

--- a/packages/core/src/serialization/SerializationContext.ts
+++ b/packages/core/src/serialization/SerializationContext.ts
@@ -39,6 +39,7 @@ export class SerializationContext<T extends object> {
     return false;
   }
 
+  /** Removes the last entry from the visit path after processing a property. */
   leave(entityName: EntityName, prop: string) {
     const last = this.path.pop();
 
@@ -48,6 +49,7 @@ export class SerializationContext<T extends object> {
     }
   }
 
+  /** Cleans up the serialization context by removing root references from all tracked entities. */
   close() {
     for (const entity of this.#entities) {
       delete helper(entity).__serializationContext.root;
@@ -90,6 +92,7 @@ export class SerializationContext<T extends object> {
     }
   }
 
+  /** Checks whether a property is explicitly listed in the populate hints for the current path. */
   isMarkedAsPopulated(entityName: EntityName, prop: string): boolean {
     let populate: PopulateOptions<T>[] = this.#populate ?? [];
 
@@ -117,6 +120,7 @@ export class SerializationContext<T extends object> {
     return !!populate?.some(p => p.field === prop);
   }
 
+  /** Checks whether a property is excluded from serialization via the exclude list. */
   isExcluded(entityName: EntityName, prop: string): boolean {
     if (!this.#exclude || this.#exclude.length === 0) {
       return false;
@@ -127,6 +131,7 @@ export class SerializationContext<T extends object> {
     return this.#exclude.includes(fullPath);
   }
 
+  /** Checks whether a property is included in the partial fields selection for the current path. */
   isPartiallyLoaded(entityName: EntityName, prop: string): boolean {
     if (!this.#fields) {
       return true;

--- a/packages/core/src/types/ArrayType.ts
+++ b/packages/core/src/types/ArrayType.ts
@@ -3,6 +3,7 @@ import type { EntityProperty } from '../typings.js';
 import type { Platform } from '../platforms/Platform.js';
 import { ValidationError } from '../errors.js';
 
+/** Maps a database text/array column to a JS array, using platform-specific marshalling (e.g., PostgreSQL arrays or comma-separated strings). */
 export class ArrayType<T = string> extends Type<T[] | null, string | null> {
   constructor(
     private readonly toJsValue: (i: string) => T = i => i as T,

--- a/packages/core/src/types/BlobType.ts
+++ b/packages/core/src/types/BlobType.ts
@@ -2,6 +2,7 @@ import { Uint8ArrayType } from './Uint8ArrayType.js';
 import type { Platform } from '../platforms/Platform.js';
 import type { EntityProperty } from '../typings.js';
 
+/** Maps a database BLOB/BYTEA column to a Node.js `Buffer`. */
 export class BlobType extends Uint8ArrayType {
   override convertToJSValue(value: Buffer): Buffer | null {
     if ((value as unknown) instanceof Buffer || !value) {

--- a/packages/core/src/types/BooleanType.ts
+++ b/packages/core/src/types/BooleanType.ts
@@ -2,6 +2,7 @@ import { Type } from './Type.js';
 import type { Platform } from '../platforms/Platform.js';
 import type { EntityProperty } from '../typings.js';
 
+/** Maps a database BOOLEAN/TINYINT(1) column to a JS `boolean`. */
 export class BooleanType extends Type<boolean | null | undefined, boolean | null | undefined> {
   override getColumnType(prop: EntityProperty, platform: Platform): string {
     return platform.getBooleanTypeDeclarationSQL();

--- a/packages/core/src/types/CharacterType.ts
+++ b/packages/core/src/types/CharacterType.ts
@@ -2,6 +2,7 @@ import { StringType } from './StringType.js';
 import type { Platform } from '../platforms/Platform.js';
 import type { EntityProperty } from '../typings.js';
 
+/** Maps a database CHAR (fixed-length) column to a JS `string`. */
 export class CharacterType extends StringType {
   override getColumnType(prop: EntityProperty, platform: Platform): string {
     return platform.getCharTypeDeclarationSQL(prop);

--- a/packages/core/src/types/DateTimeType.ts
+++ b/packages/core/src/types/DateTimeType.ts
@@ -2,6 +2,7 @@ import { Type } from './Type.js';
 import type { Platform } from '../platforms/Platform.js';
 import type { EntityProperty } from '../typings.js';
 
+/** Maps a database DATETIME/TIMESTAMP column to a JS `Date` object. */
 export class DateTimeType extends Type<Date, string> {
   override getColumnType(prop: EntityProperty, platform: Platform): string {
     return platform.getDateTimeTypeDeclarationSQL({ length: prop.length });

--- a/packages/core/src/types/DateType.ts
+++ b/packages/core/src/types/DateType.ts
@@ -2,6 +2,7 @@ import { Type } from './Type.js';
 import type { Platform } from '../platforms/Platform.js';
 import type { EntityProperty } from '../typings.js';
 
+/** Maps a database DATE column (date without time) to a JS `string` in YYYY-MM-DD format. */
 export class DateType extends Type<string | null | undefined, string | null | undefined> {
   override compareAsType(): string {
     return 'string';

--- a/packages/core/src/types/EnumArrayType.ts
+++ b/packages/core/src/types/EnumArrayType.ts
@@ -12,6 +12,7 @@ function mapHydrator<T>(items: T[] | undefined, hydrate: (i: string) => T): (i: 
   return hydrate;
 }
 
+/** Maps a database array column to a JS array of enum values, with validation against allowed enum items. */
 export class EnumArrayType<T extends string | number = string> extends ArrayType<T> {
   constructor(
     private readonly owner: string,

--- a/packages/core/src/types/EnumType.ts
+++ b/packages/core/src/types/EnumType.ts
@@ -2,6 +2,7 @@ import { Type } from './Type.js';
 import type { Platform } from '../platforms/Platform.js';
 import type { EntityProperty } from '../typings.js';
 
+/** Maps a database ENUM or equivalent column to a JS string. Supports native database enums when available. */
 export class EnumType extends Type<string | null | undefined> {
   override getColumnType(prop: EntityProperty, platform: Platform): string {
     if (prop.nativeEnumName) {

--- a/packages/core/src/types/FloatType.ts
+++ b/packages/core/src/types/FloatType.ts
@@ -2,6 +2,7 @@ import { Type } from './Type.js';
 import type { Platform } from '../platforms/Platform.js';
 import type { EntityProperty } from '../typings.js';
 
+/** Maps a database FLOAT column to a JS `number`. */
 export class FloatType extends Type<number | null | undefined, number | null | undefined> {
   override getColumnType(prop: EntityProperty, platform: Platform): string {
     return platform.getFloatDeclarationSQL();

--- a/packages/core/src/types/IntegerType.ts
+++ b/packages/core/src/types/IntegerType.ts
@@ -2,6 +2,7 @@ import { Type } from './Type.js';
 import type { Platform } from '../platforms/Platform.js';
 import type { EntityProperty } from '../typings.js';
 
+/** Maps a database INTEGER/INT column to a JS `number`. */
 export class IntegerType extends Type<number | null | undefined, number | null | undefined> {
   override getColumnType(prop: EntityProperty, platform: Platform): string {
     return platform.getIntegerTypeDeclarationSQL(prop);

--- a/packages/core/src/types/IntervalType.ts
+++ b/packages/core/src/types/IntervalType.ts
@@ -2,6 +2,7 @@ import { Type } from './Type.js';
 import type { Platform } from '../platforms/Platform.js';
 import type { EntityProperty } from '../typings.js';
 
+/** Maps a database INTERVAL column (PostgreSQL) to a JS `string`. */
 export class IntervalType extends Type<string | null | undefined, string | null | undefined> {
   override getColumnType(prop: EntityProperty, platform: Platform): string {
     return platform.getIntervalTypeDeclarationSQL(prop);

--- a/packages/core/src/types/JsonType.ts
+++ b/packages/core/src/types/JsonType.ts
@@ -2,6 +2,7 @@ import { Type, type TransformContext } from './Type.js';
 import type { Platform } from '../platforms/Platform.js';
 import type { EntityMetadata, EntityProperty } from '../typings.js';
 
+/** Maps a database JSON/JSONB column to a JS object, handling serialization and deserialization. */
 export class JsonType extends Type<unknown, string | null> {
   override convertToDatabaseValue(value: unknown, platform: Platform, context?: TransformContext): string | null {
     if (value == null) {

--- a/packages/core/src/types/MediumIntType.ts
+++ b/packages/core/src/types/MediumIntType.ts
@@ -2,6 +2,7 @@ import type { Platform } from '../platforms/Platform.js';
 import type { EntityProperty } from '../typings.js';
 import { IntegerType } from './IntegerType.js';
 
+/** Maps a database MEDIUMINT column to a JS `number`. */
 export class MediumIntType extends IntegerType {
   override getColumnType(prop: EntityProperty, platform: Platform): string {
     return platform.getMediumIntTypeDeclarationSQL(prop);

--- a/packages/core/src/types/SmallIntType.ts
+++ b/packages/core/src/types/SmallIntType.ts
@@ -2,6 +2,7 @@ import { Type } from './Type.js';
 import type { Platform } from '../platforms/Platform.js';
 import type { EntityProperty } from '../typings.js';
 
+/** Maps a database SMALLINT column to a JS `number`. */
 export class SmallIntType extends Type<number | null | undefined, number | null | undefined> {
   override getColumnType(prop: EntityProperty, platform: Platform): string {
     return platform.getSmallIntTypeDeclarationSQL(prop);

--- a/packages/core/src/types/StringType.ts
+++ b/packages/core/src/types/StringType.ts
@@ -2,6 +2,7 @@ import { Type } from './Type.js';
 import type { Platform } from '../platforms/Platform.js';
 import type { EntityProperty } from '../typings.js';
 
+/** Maps a database VARCHAR column to a JS `string`. */
 export class StringType extends Type<string | null | undefined, string | null | undefined> {
   override getColumnType(prop: EntityProperty, platform: Platform): string {
     return platform.getVarcharTypeDeclarationSQL(prop);

--- a/packages/core/src/types/TextType.ts
+++ b/packages/core/src/types/TextType.ts
@@ -2,6 +2,7 @@ import { Type } from './Type.js';
 import type { Platform } from '../platforms/Platform.js';
 import type { EntityProperty } from '../typings.js';
 
+/** Maps a database TEXT column (unbounded length) to a JS `string`. */
 export class TextType extends Type<string | null | undefined, string | null | undefined> {
   override getColumnType(prop: EntityProperty, platform: Platform): string {
     return platform.getTextTypeDeclarationSQL(prop);

--- a/packages/core/src/types/TimeType.ts
+++ b/packages/core/src/types/TimeType.ts
@@ -3,6 +3,7 @@ import type { Platform } from '../platforms/Platform.js';
 import type { EntityProperty } from '../typings.js';
 import { ValidationError } from '../errors.js';
 
+/** Maps a database TIME column to a JS `string` in HH:MM:SS format. */
 export class TimeType extends Type {
   override convertToDatabaseValue(value: any, platform: Platform): string {
     if (value && !value.toString().match(/^\d{2,}:(?:[0-5]\d):(?:[0-5]\d)$/)) {

--- a/packages/core/src/types/TinyIntType.ts
+++ b/packages/core/src/types/TinyIntType.ts
@@ -2,6 +2,7 @@ import { Type } from './Type.js';
 import type { Platform } from '../platforms/Platform.js';
 import type { EntityProperty } from '../typings.js';
 
+/** Maps a database TINYINT column to a JS `number`. */
 export class TinyIntType extends Type<number | null | undefined, number | null | undefined> {
   override getColumnType(prop: EntityProperty, platform: Platform): string {
     return platform.getTinyIntTypeDeclarationSQL(prop);

--- a/packages/core/src/types/Type.ts
+++ b/packages/core/src/types/Type.ts
@@ -5,6 +5,7 @@ import { inspect } from '../logging/inspect.js';
 /** @internal */
 export const ORM_TYPE = Symbol.for('@mikro-orm/type');
 
+/** Context passed to type conversion methods, indicating the conversion mode and source. */
 export interface TransformContext {
   fromQuery?: boolean;
   force?: boolean;
@@ -12,12 +13,14 @@ export interface TransformContext {
   mode?: 'hydration' | 'query' | 'query-data' | 'discovery' | 'serialization';
 }
 
+/** Branded type helper for mapping between JS runtime, database raw, and JSON serialized representations. */
 export type IType<Runtime, Raw, Serialized = Raw> = Runtime & {
   __raw?: Raw;
   __runtime?: Runtime;
   __serialized?: Serialized;
 };
 
+/** Abstract base class for custom property types that handle conversion between JS and database representations. */
 export abstract class Type<JSType = string, DBType = JSType> {
   private static readonly types = new Map();
 

--- a/packages/core/src/types/Uint8ArrayType.ts
+++ b/packages/core/src/types/Uint8ArrayType.ts
@@ -2,6 +2,7 @@ import { Type } from './Type.js';
 import type { Platform } from '../platforms/Platform.js';
 import type { EntityProperty } from '../typings.js';
 
+/** Maps a database BLOB/BYTEA column to a JS `Uint8Array`. */
 export class Uint8ArrayType extends Type<Uint8Array | null> {
   override convertToDatabaseValue(value: Uint8Array): Buffer {
     if (!value) {

--- a/packages/core/src/types/UnknownType.ts
+++ b/packages/core/src/types/UnknownType.ts
@@ -2,6 +2,7 @@ import type { EntityProperty } from '../typings.js';
 import type { Platform } from '../platforms/Platform.js';
 import { Type } from './Type.js';
 
+/** Passthrough type that performs no conversion, used when the column type is unknown or unrecognized. */
 export class UnknownType extends Type<unknown | null | undefined, unknown | null | undefined> {
   override getColumnType(prop: EntityProperty, platform: Platform): string {
     return prop.columnTypes?.[0] ?? platform.getVarcharTypeDeclarationSQL(prop);

--- a/packages/core/src/types/UuidType.ts
+++ b/packages/core/src/types/UuidType.ts
@@ -2,6 +2,7 @@ import { Type } from './Type.js';
 import type { Platform } from '../platforms/Platform.js';
 import type { EntityProperty } from '../typings.js';
 
+/** Maps a database UUID column to a JS `string`, with platform-specific normalization. */
 export class UuidType extends Type<string | null | undefined> {
   override getColumnType(prop: EntityProperty, platform: Platform): string {
     return platform.getUuidTypeDeclarationSQL(prop);

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -53,6 +53,7 @@ export {
   CharacterType,
 };
 
+/** Registry of all built-in type constructors, keyed by their short name (e.g., `types.integer`, `types.uuid`). */
 export const types = {
   date: DateType,
   time: TimeType,
@@ -80,6 +81,7 @@ export const types = {
   unknown: UnknownType,
 } as const;
 
+/** Shorthand alias for the `types` registry. */
 export const t = types;
 
 /**

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -35,16 +35,36 @@ import type { FilterOptions, FindOneOptions, FindOptions, LoadHint } from './dri
 import { BaseEntity } from './entity/BaseEntity.js';
 
 export type { Raw };
+
+/** Generic constructor type. Matches any class that can be instantiated with `new`. */
 export type Constructor<T = unknown> = new (...args: any[]) => T;
+
+/** Simple string-keyed object type. Use instead of `Record<string, T>` for convenience. */
 export type Dictionary<T = any> = { [k: string]: T };
+
+/** Record of compiled functions, used internally for hydration and comparison. */
 export type CompiledFunctions = Record<string, (...args: any[]) => any>;
-// `EntityKey<T, true>` will skip scalar properties (and some other scalar like types like Date or Buffer)
+
+/**
+ * Extracts string property keys from an entity, excluding symbols, functions, and internal keys.
+ * Pass `B = true` to also exclude scalar properties (useful for getting only relation keys).
+ */
 export type EntityKey<T = unknown, B extends boolean = false> = string &
   { [K in keyof T]-?: CleanKeys<T, K, B> extends never ? never : K }[keyof T];
+
+/** Resolves to the value type of entity properties (keyed by `EntityKey<T>`). */
 export type EntityValue<T> = T[EntityKey<T>];
+
+/** Resolves to the value type within `EntityData<T>` (the data shape used for create/update). */
 export type EntityDataValue<T> = EntityData<T>[EntityKey<T>];
+
+/** Extracts valid keys for `FilterQuery<T>`. */
 export type FilterKey<T> = keyof FilterQuery<T>;
+
+/** A function type that accepts a dictionary argument and returns a Promise. */
 export type AsyncFunction<R = any, T = Dictionary> = (args: T) => Promise<T>;
+
+/** Identity mapped type that forces TypeScript to eagerly evaluate and flatten `T`. */
 export type Compute<T> = { [K in keyof T]: T[K] } & {};
 type InternalKeys =
   | 'EntityRepositoryType'
@@ -54,6 +74,7 @@ type InternalKeys =
   | 'HiddenProps'
   | '__selectedType'
   | '__loadedType';
+/** Filters out function, symbol, and internal keys from an entity type. When `B = true`, also excludes scalar keys. */
 export type CleanKeys<T, K extends keyof T, B extends boolean = false> = T[K] & {} extends Function
   ? never
   : K extends symbol | InternalKeys
@@ -63,11 +84,23 @@ export type CleanKeys<T, K extends keyof T, B extends boolean = false> = T[K] & 
         ? never
         : K
       : K;
+
+/** Extracts keys of `T` whose values are functions. */
 export type FunctionKeys<T, K extends keyof T> = T[K] extends Function ? K : never;
+
+/** Conditional cast: returns `T` if it extends `R`, otherwise returns `R`. */
 export type Cast<T, R> = T extends R ? T : R;
+
+/** Evaluates to `true` if `T` is the `unknown` type. */
 export type IsUnknown<T> = T extends unknown ? (unknown extends T ? true : never) : never;
+
+/** Evaluates to `true` if `T` is `any`. */
 export type IsAny<T> = 0 extends 1 & T ? true : false;
+
+/** Evaluates to `True` if `T` is `never`, otherwise `False`. */
 export type IsNever<T, True = true, False = false> = [T] extends [never] ? True : False;
+
+/** Represents a value that may be synchronous or wrapped in a Promise. */
 export type MaybePromise<T> = T | Promise<T>;
 
 /**
@@ -118,17 +151,19 @@ type LoadedReferenceShape<T = any> = ReferenceShape & { $: T };
  */
 type LoadableShape = CollectionShape | ReferenceShape | readonly any[];
 
-// Get all keys from all union members (distributes over union)
+/** Gets all keys from all members of a union type (distributes over the union). */
 export type UnionKeys<T> = T extends any ? keyof T : never;
 
-// Get the type of property from all union members that have it
+/** Gets the type of a property from all union members that have it (distributes over the union). */
 export type UnionPropertyType<T, K extends PropertyKey> = T extends any ? (K extends keyof T ? T[K] : never) : never;
 
 // Check if T is a union type (non-distributing check)
 type IsUnion<T, U = T> = T extends any ? ([U] extends [T] ? false : true) : false;
 
-// Merge all union member properties into a single object for filtering
-// Optimized: for non-union types, just returns T directly to avoid expensive key iteration
+/**
+ * Merges all members of a union type into a single object with all their properties.
+ * For non-union types, returns `T` directly to avoid expensive key iteration.
+ */
 export type MergeUnion<T> = [T] extends [object]
   ? T extends Scalar
     ? T
@@ -137,6 +172,7 @@ export type MergeUnion<T> = [T] extends [object]
       : T
   : T;
 
+/** Recursively makes all properties of `T` optional, including nested objects and arrays. */
 export type DeepPartial<T> = T & {
   [P in keyof T]?: T[P] extends (infer U)[]
     ? DeepPartial<U>[]
@@ -145,17 +181,35 @@ export type DeepPartial<T> = T & {
       : DeepPartial<T[P]>;
 };
 
+/** Symbol used to declare a custom repository type on an entity class (e.g., `[EntityRepositoryType]?: BookRepository`). */
 export const EntityRepositoryType = Symbol('EntityRepositoryType');
+
+/** Symbol used to declare the primary key property name(s) on an entity (e.g., `[PrimaryKeyProp]?: 'id'`). */
 export const PrimaryKeyProp = Symbol('PrimaryKeyProp');
+
+/** Symbol used to declare which properties are optional in `em.create()` (e.g., `[OptionalProps]?: 'createdAt'`). */
 export const OptionalProps = Symbol('OptionalProps');
+
+/** Symbol used to declare which relation properties should be eagerly loaded (e.g., `[EagerProps]?: 'author'`). */
 export const EagerProps = Symbol('EagerProps');
+
+/** Symbol used to declare which properties are hidden from serialization (e.g., `[HiddenProps]?: 'password'`). */
 export const HiddenProps = Symbol('HiddenProps');
+
+/** Symbol used to declare type-level configuration on an entity (e.g., `[Config]?: DefineConfig<{ forceObject: true }>`). */
 export const Config = Symbol('Config');
+
+/** Symbol used to declare the entity name as a string literal type (used by `defineEntity`). */
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const EntityName = Symbol('EntityName');
 
+/** Extracts the entity name string literal from an entity type that declares `[EntityName]`. */
 export type InferEntityName<T> = T extends { [EntityName]?: infer Name } ? (Name extends string ? Name : never) : never;
 
+/**
+ * Branded type that marks a property as optional in `em.create()`.
+ * Use as a property type wrapper: `createdAt: Opt<Date>` instead of listing in `[OptionalProps]`.
+ */
 export type Opt<T = unknown> = T & Opt.Brand;
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export declare namespace Opt {
@@ -166,6 +220,10 @@ export declare namespace Opt {
   }
 }
 
+/**
+ * Branded type that marks a nullable property as required in `em.create()`.
+ * By default, nullable properties are treated as optional; this forces them to be explicitly provided.
+ */
 export type RequiredNullable<T = never> = (T & RequiredNullable.Brand) | null;
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export declare namespace RequiredNullable {
@@ -176,6 +234,10 @@ export declare namespace RequiredNullable {
   }
 }
 
+/**
+ * Branded type that marks a property as hidden from serialization.
+ * Use as a property type wrapper: `password: Hidden<string>` instead of listing in `[HiddenProps]`.
+ */
 export type Hidden<T = unknown> = T & Hidden.Brand;
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export declare namespace Hidden {
@@ -186,6 +248,10 @@ export declare namespace Hidden {
   }
 }
 
+/**
+ * Branded type for entity-level configuration (e.g., `[Config]?: DefineConfig<{ forceObject: true }>`).
+ * Controls type-level behavior such as forcing object representation for primary keys in DTOs.
+ */
 export type DefineConfig<T extends TypeConfig> = T & DefineConfig.Brand;
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export declare namespace DefineConfig {
@@ -196,8 +262,10 @@ export declare namespace DefineConfig {
   }
 }
 
+/** Extracts only the `TypeConfig` keys from a branded config type, stripping the brand. */
 export type CleanTypeConfig<T> = Compute<Pick<T, Extract<keyof T, keyof TypeConfig>>>;
 
+/** Configuration options that can be set on an entity via the `[Config]` symbol. */
 export interface TypeConfig {
   forceObject?: boolean;
 }
@@ -223,6 +291,7 @@ export type Prefixes<S extends string> = S extends '*'
     ? H | `${H}.${Prefixes<T>}`
     : S;
 
+/** Unwraps a value to its primary key type. Scalars pass through; References are unwrapped first. */
 export type UnwrapPrimary<T> = T extends Scalar ? T : T extends ReferenceShape<infer U> ? Primary<U> : Primary<T>;
 
 type PrimaryPropToType<T, Keys extends (keyof T)[]> = {
@@ -231,6 +300,10 @@ type PrimaryPropToType<T, Keys extends (keyof T)[]> = {
 
 type ReadonlyPrimary<T> = T extends any[] ? Readonly<T> : T;
 
+/**
+ * Resolves the primary key type for an entity. Uses `[PrimaryKeyProp]` if declared,
+ * otherwise falls back to `_id`, `id`, or `uuid` properties. For composite keys, returns a tuple.
+ */
 export type Primary<T> =
   IsAny<T> extends true
     ? any
@@ -267,9 +340,13 @@ export type PrimaryProperty<T> = T extends { [PrimaryKeyProp]?: infer PK }
         ? 'uuid'
         : never;
 
+/** Union of all allowed primary key value types (number, string, bigint, Date, ObjectId-like). */
 export type IPrimaryKeyValue = number | string | bigint | Date | { toHexString(): string };
+
+/** Alias for a primary key value, constrained to `IPrimaryKeyValue`. */
 export type IPrimaryKey<T extends IPrimaryKeyValue = IPrimaryKeyValue> = T;
 
+/** Union of types considered "scalar" (non-entity) values. Used to distinguish entity relations from plain values. */
 export type Scalar =
   | boolean
   | number
@@ -284,6 +361,7 @@ export type Scalar =
 // Primitive types that don't extend object - used for Hidden brand detection
 type Primitive = boolean | number | string | bigint | symbol;
 
+/** Expands a scalar type to include alternative representations accepted in queries (e.g., `Date | string`). */
 export type ExpandScalar<T> =
   | null
   | (T extends string ? T | RegExp : T extends Date ? Date | string : T extends bigint ? bigint | string | number : T);
@@ -293,6 +371,7 @@ export interface Subquery {
   readonly __subquery: true;
 }
 
+/** Map of query operators (`$eq`, `$gt`, `$in`, etc.) available for filtering a value of type `T`. */
 export type OperatorMap<T> = {
   $and?: ExpandQuery<T>[];
   $or?: ExpandQuery<T>[];
@@ -322,7 +401,10 @@ export type OperatorMap<T> = {
   $hasSomeKeys?: readonly string[];
 };
 
+/** A single filter value: the raw value, its expanded scalar form, its primary key, or a raw SQL expression. */
 export type FilterItemValue<T> = T | ExpandScalar<T> | Primary<T> | Raw;
+
+/** A complete filter value: an operator map, a single value, an array of values, or null. */
 export type FilterValue<T> = OperatorMap<FilterItemValue<T>> | FilterItemValue<T> | FilterItemValue<T>[] | null;
 
 type FilterObjectProp<T, K extends PropertyKey> = K extends keyof MergeUnion<T>
@@ -352,6 +434,7 @@ type ElemMatchFilter<T> = T extends readonly (infer E)[]
     : never
   : never;
 
+/** Object form of a filter query, mapping entity keys to their filter conditions. */
 export type FilterObject<T> = {
   -readonly [K in EntityKey<T>]?:
     | ExpandQuery<ExpandProperty<FilterObjectProp<T, K>>>
@@ -361,16 +444,26 @@ export type FilterObject<T> = {
     | null;
 };
 
+/** Recursively expands a type into its `FilterQuery` form for nested object filtering. */
 export type ExpandQuery<T> = T extends object ? (T extends Scalar ? never : FilterQuery<T>) : FilterValue<T>;
 
+/** Partial entity shape with all entity properties optional. */
 export type EntityProps<T> = { -readonly [K in EntityKey<T>]?: T[K] };
+
+/** Object-based query filter combining operator maps with property-level filters. */
 export type ObjectQuery<T> = OperatorMap<T> & FilterObject<T>;
+
+/**
+ * The main query filter type used in `em.find()`, `em.findOne()`, etc.
+ * Accepts an object query, a primary key value, entity props with operators, or an array of filters.
+ */
 export type FilterQuery<T> =
   | ObjectQuery<T>
   | NonNullable<ExpandScalar<Primary<T>>>
   | NonNullable<EntityProps<T> & OperatorMap<T>>
   | FilterQuery<T>[];
 
+/** Public interface for the entity wrapper, accessible via `wrap(entity)`. Provides helper methods for entity state management. */
 export interface IWrappedEntity<Entity extends object> {
   isInitialized(): boolean;
   isManaged(): boolean;
@@ -412,6 +505,7 @@ export interface IWrappedEntity<Entity extends object> {
   setSchema(schema?: string): void;
 }
 
+/** @internal Extended wrapper interface with internal state used by the ORM runtime. */
 export interface IWrappedEntityInternal<Entity extends object> extends IWrappedEntity<Entity> {
   hasPrimaryKey(): boolean;
   getPrimaryKey(convertCustomTypes?: boolean): Primary<Entity> | null;
@@ -445,11 +539,16 @@ export interface IWrappedEntityInternal<Entity extends object> extends IWrappedE
   };
 }
 
+/** Loose entity type used in generic contexts. Equivalent to `Partial<T>`. */
 export type AnyEntity<T = any> = Partial<T>;
+
+/** A class (function with prototype) whose instances are of type `T`. */
 export type EntityClass<T = any> = Function & { prototype: T };
+
+/** Any valid entity name reference: a class, abstract constructor, or EntitySchema. */
 export type EntityName<T = any> = EntityClass<T> | EntityCtor<T> | EntitySchema<T, any>;
 
-// we need to restrict the type in the generic argument, otherwise inference don't work, so we use two types here
+/** Resolves the custom repository type for an entity (from `[EntityRepositoryType]`), or falls back to `Fallback`. */
 export type GetRepository<
   Entity extends { [k: PropertyKey]: any },
   Fallback,
@@ -469,6 +568,7 @@ type PolymorphicPrimaryInner<T> = T extends object
  */
 export type PolymorphicPrimary<T> = true extends IsUnion<T> ? PolymorphicPrimaryInner<T> : never;
 
+/** Allowed value types when assigning to an entity data property: the entity itself, its PK, or a polymorphic PK tuple. */
 export type EntityDataPropValue<T> = T | Primary<T> | PolymorphicPrimary<T>;
 type ExpandEntityProp<T, C extends boolean = false> =
   T extends Record<string, any>
@@ -498,6 +598,7 @@ type ExpandRequiredEntityPropObject<T, I = never, C extends boolean = false> = {
 
 type NonArrayObject = object & { [Symbol.iterator]?: never };
 
+/** Resolves the allowed input type for a single entity property in `EntityData`. Handles scalars, references, collections, and nested entities. */
 export type EntityDataProp<T, C extends boolean> = T extends Date
   ? string | Date
   : T extends Scalar
@@ -518,6 +619,7 @@ export type EntityDataProp<T, C extends boolean> = T extends Date
                 : U[] | EntityDataNested<U, C>[]
               : EntityDataNested<T, C>;
 
+/** Like `EntityDataProp` but used in `RequiredEntityData` context with required/optional key distinction. */
 export type RequiredEntityDataProp<T, O, C extends boolean> = T extends Date
   ? string | Date
   : Exclude<T, null> extends RequiredNullable.Brand
@@ -540,6 +642,7 @@ export type RequiredEntityDataProp<T, O, C extends boolean> = T extends Date
                   : U[] | RequiredEntityDataNested<U, O, C>[]
                 : RequiredEntityDataNested<T, O, C>;
 
+/** Nested entity data shape for embedded or related entities within `EntityData`. */
 export type EntityDataNested<T, C extends boolean = false> = T extends undefined
   ? never
   : T extends any[]
@@ -550,6 +653,7 @@ type EntityDataItem<T, C extends boolean> = C extends false
   ? UnwrapScalarRef<T> | EntityDataProp<T, C> | Raw | null
   : EntityDataProp<T, C> | Raw | null;
 
+/** Nested entity data shape used within `RequiredEntityData` for embedded or related entities. */
 export type RequiredEntityDataNested<T, O, C extends boolean> = T extends any[]
   ? Readonly<T>
   : RequiredEntityData<T, O> | ExpandRequiredEntityProp<T, O, C>;
@@ -575,7 +679,14 @@ type IsOptional<T, K extends keyof T, I> = T[K] extends CollectionShape
       : false;
 type RequiredKeys<T, K extends keyof T, I> = IsOptional<T, K, I> extends false ? CleanKeys<T, K> : never;
 type OptionalKeys<T, K extends keyof T, I> = IsOptional<T, K, I> extends false ? never : CleanKeys<T, K>;
+/** Data shape for creating or updating entities. All properties are optional. Used in `em.create()` and `em.assign()`. */
 export type EntityData<T, C extends boolean = false> = { [K in EntityKey<T>]?: EntityDataItem<T[K] & {}, C> };
+
+/**
+ * Data shape for `em.create()` with required/optional distinction based on entity metadata.
+ * Properties with defaults, nullable types, `Opt` brand, or `[OptionalProps]` declaration are optional.
+ * `I` excludes additional types from being required (used for inverse side of relations).
+ */
 export type RequiredEntityData<T, I = never, C extends boolean = false> = {
   [K in keyof T as RequiredKeys<T, K, I>]:
     | T[K]
@@ -592,6 +703,7 @@ export type RequiredEntityData<T, I = never, C extends boolean = false> = {
     | Raw
     | null;
 };
+/** `EntityData<T>` extended with an index signature, allowing arbitrary additional properties. */
 export type EntityDictionary<T> = EntityData<T> & Record<any, any>;
 
 type ExtractEagerProps<T> = T extends { [EagerProps]?: infer PK } ? PK : never;
@@ -640,6 +752,7 @@ type DTOWrapper<T, C extends TypeConfig, Flat extends boolean> = Flat extends tr
   ? EntityDTOFlat<T, C>
   : EntityDTO<T, C>;
 
+/** Resolves the serialized (DTO) type for a single entity property. Unwraps references, collections, and custom serialized types. */
 export type EntityDTOProp<E, T, C extends TypeConfig = never, Flat extends boolean = false> = T extends Scalar
   ? T
   : T extends ScalarReference<infer U>
@@ -680,6 +793,10 @@ type DTORequiredKeys<T, K extends keyof T> =
 type DTOOptionalKeys<T, K extends keyof T> =
   DTOIsOptional<T, K> extends false ? never : ExcludeHidden<T, K> & CleanKeys<T, K>;
 
+/**
+ * Plain object (DTO) representation of an entity as returned by `toObject()` / `toPOJO()`.
+ * Unwraps references to PKs, collections to arrays, and respects hidden properties.
+ */
 export type EntityDTO<T, C extends TypeConfig = never> = {
   [K in keyof T as DTORequiredKeys<T, K>]: EntityDTOProp<T, T[K], C> | AddOptional<T[K]>;
 } & {
@@ -711,6 +828,10 @@ type SerializePropValue<T, K extends keyof T, H extends string, C extends TypeCo
       : SerializeDTO<ExpandProperty<T[K]>, SerializeSubHints<K & string, H>, never, C> | Extract<T[K], null | undefined>
     : EntityDTOProp<T, T[K], C>;
 
+/**
+ * Return type of `serialize()`. Combines Loaded + EntityDTO in a single pass for better performance.
+ * Respects populate hints (`H`) and exclude hints (`E`).
+ */
 export type SerializeDTO<
   T,
   H extends string = never,
@@ -726,6 +847,7 @@ export type SerializeDTO<
 
 type TargetKeys<T> = T extends EntityClass<infer P> ? keyof P : keyof T;
 type PropertyName<T> = IsUnknown<T> extends false ? TargetKeys<T> : string;
+/** Table reference object passed to formula callbacks, including alias and schema information. */
 export type FormulaTable = {
   alias: string;
   name: string;
@@ -759,24 +881,32 @@ export type FormulaColumns<T> = Record<PropertyName<T>, string> & { toString(): 
  */
 export type SchemaColumns<T> = Record<PropertyName<T>, string>;
 
+/** Callback for custom index expressions. Receives column mappings, table info, and the index name. */
 export type IndexCallback<T> = (
   columns: Record<PropertyName<T>, string>,
   table: SchemaTable,
   indexName: string,
 ) => string | Raw;
+/** Callback for computed (formula) properties. Receives column mappings and table info, returns a SQL expression. */
 export type FormulaCallback<T> = (columns: FormulaColumns<T>, table: FormulaTable) => string | Raw;
 
+/** Callback for CHECK constraint expressions. Receives column mappings and table info. */
 export type CheckCallback<T> = (columns: Record<PropertyName<T>, string>, table: SchemaTable) => string | Raw;
+
+/** Callback for generated (computed) column expressions. Receives column mappings and table info. */
 export type GeneratedColumnCallback<T> = (columns: Record<PropertyName<T>, string>, table: SchemaTable) => string | Raw;
 
+/** Definition of a CHECK constraint on a table or property. */
 export interface CheckConstraint<T = any> {
   name?: string;
   property?: string;
   expression: string | Raw | CheckCallback<T>;
 }
 
+/** Branded string that accepts any string value while preserving autocompletion for known literals. */
 export type AnyString = string & {};
 
+/** Describes a single property (column, relation, or embedded) within an entity's metadata. */
 export interface EntityProperty<Owner = any, Target = any> {
   name: EntityKey<Owner>;
   entity: () => EntityName<Owner>;
@@ -881,6 +1011,10 @@ export interface EntityProperty<Owner = any, Target = any> {
   foreignKeyName?: string;
 }
 
+/**
+ * Runtime metadata for an entity, holding its properties, relations, indexes, hooks, and more.
+ * Created during metadata discovery and used throughout the ORM lifecycle.
+ */
 export class EntityMetadata<Entity = any, Class extends EntityCtor<Entity> = EntityCtor<Entity>> {
   private static counter = 0;
   readonly _id: number = 1000 * EntityMetadata.counter++; // keep the id >= 1000 to allow computing cache keys by simple addition
@@ -1196,11 +1330,13 @@ export class EntityMetadata<Entity = any, Class extends EntityCtor<Entity> = Ent
   }
 }
 
+/** Minimal column metadata with just a name and database type. */
 export interface SimpleColumnMeta {
   name: string;
   type: string;
 }
 
+/** Abstract constructor type that matches both abstract and concrete entity classes. */
 export type EntityCtor<T = any> = abstract new (...args: any[]) => T;
 
 export interface EntityMetadata<Entity = any, Class extends EntityCtor<Entity> = EntityCtor<Entity>> {
@@ -1320,23 +1456,27 @@ export interface EntityMetadata<Entity = any, Class extends EntityCtor<Entity> =
   readonly _id: number;
 }
 
+/** Options for `ISchemaGenerator.create()`. */
 export interface CreateSchemaOptions {
   wrap?: boolean;
   schema?: string;
 }
 
+/** Options for `ISchemaGenerator.clear()` to truncate/clear database tables. */
 export interface ClearDatabaseOptions {
   schema?: string;
   truncate?: boolean;
   clearIdentityMap?: boolean;
 }
 
+/** Options for `ISchemaGenerator.ensureDatabase()` which creates and optionally clears the database. */
 export interface EnsureDatabaseOptions extends CreateSchemaOptions, ClearDatabaseOptions {
   clear?: boolean;
   create?: boolean;
   forceCheck?: boolean;
 }
 
+/** Options for `ISchemaGenerator.drop()`. */
 export interface DropSchemaOptions {
   wrap?: boolean;
   dropMigrationsTable?: boolean;
@@ -1345,6 +1485,7 @@ export interface DropSchemaOptions {
   schema?: string;
 }
 
+/** Options for `ISchemaGenerator.update()` to apply incremental schema changes. */
 export interface UpdateSchemaOptions<DatabaseSchema = unknown> {
   wrap?: boolean;
   safe?: boolean;
@@ -1354,12 +1495,14 @@ export interface UpdateSchemaOptions<DatabaseSchema = unknown> {
   fromSchema?: DatabaseSchema;
 }
 
+/** Options for `ISchemaGenerator.refresh()` which drops and recreates the schema. */
 export interface RefreshDatabaseOptions extends CreateSchemaOptions {
   ensureIndexes?: boolean;
   dropDb?: boolean;
   createSchema?: boolean;
 }
 
+/** Interface for the schema generator, responsible for creating, updating, and dropping database schemas. */
 export interface ISchemaGenerator {
   create(options?: CreateSchemaOptions): Promise<void>;
   update(options?: UpdateSchemaOptions): Promise<void>;
@@ -1377,6 +1520,7 @@ export interface ISchemaGenerator {
   ensureIndexes(): Promise<void>;
 }
 
+/** Custom resolver for import paths in the entity generator. Returns a path/name pair or undefined to use the default. */
 export type ImportsResolver = (
   alias: string,
   basePath: string,
@@ -1384,6 +1528,7 @@ export type ImportsResolver = (
   originFileName: string,
 ) => { path: string; name: string } | undefined;
 
+/** Options for the entity generator (`IEntityGenerator.generate()`). Controls output format, filtering, and style. */
 export interface GenerateOptions {
   path?: string;
   save?: boolean;
@@ -1415,18 +1560,25 @@ export interface GenerateOptions {
   onProcessedMetadata?: MetadataProcessor;
 }
 
+/** Interface for the entity generator, which reverse-engineers database schema into entity source files. */
 export interface IEntityGenerator {
   generate(options?: GenerateOptions): Promise<string[]>;
 }
 
+/** Basic migration descriptor with a name and optional file path. */
 export type MigrationInfo = { name: string; path?: string };
+
+/** Options for controlling which migrations to run (range, specific list, or transaction). */
 export type MigrateOptions = {
   from?: string | number;
   to?: string | number;
   migrations?: string[];
   transaction?: Transaction;
 };
+/** Result of creating a new migration file, including the generated code and schema diff. */
 export type MigrationResult = { fileName: string; code: string; diff: MigrationDiff };
+
+/** A row from the migrations tracking table, representing an executed migration. */
 export type MigrationRow = { id: number; name: string; executed_at: Date };
 
 /**
@@ -1453,6 +1605,7 @@ export interface IMigratorStorage {
   getTableName?(): { schemaName?: string; tableName: string };
 }
 
+/** Interface for the migrator, responsible for creating and executing database migrations. */
 export interface IMigrator {
   /**
    * Checks current schema for changes, generates new migration if there are any.
@@ -1508,13 +1661,16 @@ export interface IMigrator {
   getStorage(): IMigratorStorage;
 }
 
+/** Events emitted by the migrator during migration execution. */
 export type MigratorEvent = 'migrating' | 'migrated' | 'reverting' | 'reverted';
 
+/** The up and down SQL statements representing a schema diff for a migration. */
 export interface MigrationDiff {
   up: string[];
   down: string[];
 }
 
+/** Interface for generating migration file contents from schema diffs. */
 export interface IMigrationGenerator {
   /**
    * Generates the full contents of migration file. Uses `generateMigrationFile` to get the file contents.
@@ -1532,6 +1688,7 @@ export interface IMigrationGenerator {
   generateMigrationFile(className: string, diff: MigrationDiff): MaybePromise<string>;
 }
 
+/** Interface that all migration classes must implement. */
 export interface Migration {
   up(): Promise<void> | void;
   down(): Promise<void> | void;
@@ -1541,6 +1698,7 @@ export interface Migration {
   getQueries?(): any[];
 }
 
+/** A named migration class reference, used for inline migration registration. */
 export interface MigrationObject {
   name: string;
   class: Constructor<Migration>;
@@ -1565,12 +1723,15 @@ type FilterDefResolved<T extends object = any> = {
   strict?: boolean;
 };
 
+/** Definition of a query filter that can be registered globally or per-entity via `@Filter()`. */
 export type FilterDef<T extends EntityName | readonly EntityName[] = any> = FilterDefResolved<EntityFromInput<T>> & {
   entity?: T;
 };
 
+/** Type for the `populate` option in find methods. An array of relation paths to eagerly load, or `false` to disable. */
 export type Populate<T, P extends string = never> = readonly AutoPath<T, P, `${PopulatePath}`>[] | false;
 
+/** Parsed populate hint for a single relation, including strategy and nested children. */
 export type PopulateOptions<T> = {
   field: EntityKey<T>;
   strategy?: LoadStrategy;
@@ -1582,6 +1743,7 @@ export type PopulateOptions<T> = {
   dataOnly?: boolean;
 };
 
+/** Inline options that can be appended to populate hint strings (e.g., strategy, join type). */
 export type PopulateHintOptions = {
   strategy?: LoadStrategy.JOINED | LoadStrategy.SELECT_IN | 'joined' | 'select-in';
   joinType?: 'inner join' | 'left join';
@@ -1616,6 +1778,10 @@ type Prev = [never, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
 // all relation keys (collections + to-one) - uses CleanKeys with scalar exclusion for efficiency
 type RelationKeys<T> = T extends object ? { [K in keyof T]-?: CleanKeys<T, K, true> }[keyof T] & {} : never;
 
+/**
+ * Autocomplete-friendly type for dot-separated relation paths (e.g., `'author.books'`).
+ * Validates each segment against entity keys and provides IDE suggestions. Depth-limited to prevent infinite recursion.
+ */
 export type AutoPath<
   O,
   P extends string | boolean,
@@ -1643,9 +1809,13 @@ export type AutoPath<
         : never
       : never;
 
+/** Unwraps an array type to its element type; non-arrays pass through unchanged. */
 export type UnboxArray<T> = T extends any[] ? ArrayElement<T> : T;
+
+/** Extracts the element type from an array type. */
 export type ArrayElement<ArrayType extends unknown[]> = ArrayType extends (infer ElementType)[] ? ElementType : never;
 
+/** Unwraps a property type from its wrapper (Reference, Collection, or array) to the inner entity type. */
 export type ExpandProperty<T> =
   T extends ReferenceShape<infer U>
     ? NonNullable<U>
@@ -1673,6 +1843,7 @@ type IsTrue<T> = IsNever<T> extends true ? false : T extends boolean ? (T extend
 type StringLiteral<T> = T extends string ? (string extends T ? never : T) : never;
 type Prefix<T, K> = K extends `${infer S}.${string}` ? S : K extends '*' ? keyof T : K;
 type IsPrefixedExclude<T, K extends keyof T, E extends string> = K extends E ? never : K;
+/** Checks whether a key `K` is included in the populate/fields hints. Used to filter entity keys in `Loaded`/`Selected`. */
 export type IsPrefixed<T, K extends keyof T, L extends string, E extends string = never> =
   IsNever<E> extends false
     ? IsPrefixedExclude<T, K, E>
@@ -1703,6 +1874,7 @@ type Suffix<Key, Hint extends string, All = true | '*'> = Hint extends `${infer 
     ? Hint
     : never;
 
+/** Validates that `U` is a subset of `T`. Returns `{}` if valid, or a mapped type with `never` values to cause a type error. */
 export type IsSubset<T, U> = keyof U extends keyof T
   ? {}
   : string extends keyof U // If U has an index signature (like Dictionary), allow it
@@ -1731,6 +1903,7 @@ export type MergeSelected<T, U, F extends string> = IsLoadedType<T> extends true
 export type MergeLoaded<T, U, P extends string, F extends string, E extends string, R extends boolean = false> =
   IsLoadedType<T> extends true ? T & Loaded<U, P, F, E> : Loaded<T, P, F, E>;
 
+/** Extracts the nullability modifiers (`null`, `undefined`, or both) from a type `T`. */
 export type AddOptional<T> = undefined | null extends T
   ? null | undefined
   : null extends T
@@ -1742,9 +1915,16 @@ type LoadedProp<T, L extends string = never, F extends string = '*', E extends s
   T,
   Loaded<ExtractType<T>, L, F, E>
 >;
+/** Extracts the eager-loaded property names declared via `[EagerProps]` as a string union. */
 export type AddEager<T> = ExtractEagerProps<T> & string;
+
+/** Combines an explicit populate hint `L` with the entity's eagerly loaded properties. */
 export type ExpandHint<T, L extends string> = L | AddEager<T>;
 
+/**
+ * Entity type narrowed to only the selected fields (`F`) and populated relations (`L`).
+ * Used as the return type when `fields` option is specified in find methods.
+ */
 export type Selected<T, L extends string = never, F extends string = '*'> = {
   [K in keyof T as IsPrefixed<T, K, L | F | AddEager<T>> | FunctionKeys<T, K>]: T[K] extends Function
     ? T[K]
@@ -1754,7 +1934,10 @@ export type Selected<T, L extends string = never, F extends string = '*'> = {
 } & { [__selectedType]?: T };
 
 type LoadedEntityType<T> = { [__loadedType]?: T } | { [__selectedType]?: T };
+/** Accepts either a plain entity type or a `Loaded`/`Selected` wrapped version. */
 export type EntityType<T> = T | LoadedEntityType<T>;
+
+/** Extracts the base entity type from a `Loaded`/`Selected` wrapper, or returns `T` as-is. */
 export type FromEntityType<T> = T extends LoadedEntityType<infer U> ? U : T;
 
 type LoadedInternal<T, L extends string = never, F extends string = '*', E extends string = never> = [F] extends ['*']
@@ -1785,28 +1968,34 @@ export type Loaded<T, L extends string = never, F extends string = '*', E extend
   [__loadHint]?: (hint: Prefixes<L>) => void;
 };
 
+/** A `Reference<T>` that is guaranteed to be loaded, providing synchronous access via `$` and `get()`. */
 export interface LoadedReference<T> extends Reference<NonNullable<T>> {
   $: NonNullable<T>;
   get(): NonNullable<T>;
 }
 
+/** A `ScalarReference<T>` that is guaranteed to be loaded, providing synchronous access via `$` and `get()`. */
 export interface LoadedScalarReference<T> extends ScalarReference<T> {
   $: T;
   get(): T;
 }
 
+/** A `Collection<T>` that is guaranteed to be loaded, providing synchronous access via `$`, `get()`, and `getItems()`. */
 export interface LoadedCollection<T extends object> extends Collection<T> {
   $: Collection<T>;
   get(): Collection<T>;
   getItems(check?: boolean): T[];
 }
 
+/** Alias for `Loaded<T, P>`. Represents a newly created entity with all specified relations populated. */
 export type New<T, P extends string = string> = Loaded<T, P>;
 
+/** Interface for SQL/code syntax highlighters used in logging output. */
 export interface Highlighter {
   highlight(text: string): string;
 }
 
+/** Interface for the metadata storage, which holds `EntityMetadata` for all discovered entities. */
 export interface IMetadataStorage {
   getAll(): Map<EntityName, EntityMetadata>;
   get<T = any>(entity: EntityName<T>, init?: boolean, validate?: boolean): EntityMetadata<T>;
@@ -1816,6 +2005,7 @@ export interface IMetadataStorage {
   reset<T>(entity: EntityName<T>): void;
 }
 
+/** Interface for entity hydrators, which populate entity instances from raw database data. */
 export interface IHydrator {
   /**
    * Hydrates the whole entity. This process handles custom type conversions, creating missing Collection instances,
@@ -1851,10 +2041,12 @@ export interface IHydrator {
   isRunning(): boolean;
 }
 
+/** Constructor signature for hydrator implementations. */
 export interface HydratorConstructor {
   new (metadata: MetadataStorage, platform: Platform, config: Configuration): IHydrator;
 }
 
+/** Interface for the seed manager, which runs database seeders. */
 export interface ISeedManager {
   seed(...classNames: Constructor<Seeder>[]): Promise<void>;
   /** @internal */
@@ -1862,21 +2054,30 @@ export interface ISeedManager {
   create(className: string): Promise<string>;
 }
 
+/** Interface that all seeder classes must implement. The `run` method receives an EntityManager. */
 export interface Seeder<T extends Dictionary = Dictionary> {
   run(em: EntityManager, context?: T): void | Promise<void>;
 }
 
+/** A named seeder class reference, used for inline seeder registration. */
 export interface SeederObject {
   name: string;
   class: Constructor<Seeder>;
 }
 
+/** Discriminator for read vs write database connections in read-replica setups. */
 export type ConnectionType = 'read' | 'write';
 
+/** Callback for processing entity metadata during discovery or entity generation. */
 export type MetadataProcessor = (metadata: EntityMetadata[], platform: Platform) => MaybePromise<void>;
 
+/** Extracts the return type if `T` is a function, otherwise returns `T` as-is. */
 export type MaybeReturnType<T> = T extends (...args: any[]) => infer R ? R : T;
 
+/**
+ * Extended `EntitySchema` interface that carries additional type-level metadata (entity name, properties, table name).
+ * Returned by `defineEntity()` to provide strong type inference without explicit generics.
+ */
 export interface EntitySchemaWithMeta<
   TName extends string = string,
   TTableName extends string = string,
@@ -1892,7 +2093,10 @@ export interface EntitySchemaWithMeta<
   readonly '~entity': TEntity;
 }
 
-// Fast path: direct property access avoids pattern matching against 6-parameter generic
+/**
+ * Extracts the entity type from an `EntitySchema`, `EntitySchemaWithMeta`, or entity class.
+ * Uses a fast-path direct property access when available, falling back to generic inference.
+ */
 export type InferEntity<Schema> = Schema extends { '~entity': infer E }
   ? E
   : Schema extends EntitySchema<infer Entity>

--- a/packages/core/src/unit-of-work/ChangeSet.ts
+++ b/packages/core/src/unit-of-work/ChangeSet.ts
@@ -3,6 +3,7 @@ import { helper } from '../entity/wrap.js';
 import { Utils } from '../utils/Utils.js';
 import { inspect } from '../logging/inspect.js';
 
+/** Represents a pending change (create, update, or delete) for a single entity. */
 export class ChangeSet<T extends object> {
   private primaryKey?: Primary<T> | null;
   private serializedPrimaryKey?: string;
@@ -18,6 +19,7 @@ export class ChangeSet<T extends object> {
     this.schema = helper(entity).__schema ?? meta.root.schema;
   }
 
+  /** Returns the primary key of the entity, optionally as an object for composite keys. */
   getPrimaryKey(object = false): Primary<T> | null {
     if (!this.originalEntity) {
       this.primaryKey ??= helper(this.entity).getPrimaryKey(true);
@@ -45,6 +47,7 @@ export class ChangeSet<T extends object> {
     return this.primaryKey ?? null;
   }
 
+  /** Returns the serialized (string) form of the primary key. */
   getSerializedPrimaryKey(): string | null {
     this.serializedPrimaryKey ??= helper(this.entity).getSerializedPrimaryKey();
     return this.serializedPrimaryKey;
@@ -76,6 +79,7 @@ export interface ChangeSet<T> {
   tptChangeSets?: ChangeSet<T>[];
 }
 
+/** Enumeration of change set operation types. */
 export enum ChangeSetType {
   CREATE = 'create',
   UPDATE = 'update',

--- a/packages/core/src/unit-of-work/ChangeSetComputer.ts
+++ b/packages/core/src/unit-of-work/ChangeSetComputer.ts
@@ -14,6 +14,7 @@ import type { Platform } from '../platforms/Platform.js';
 import { ReferenceKind } from '../enums.js';
 import type { EntityManager } from '../EntityManager.js';
 
+/** @internal Computes change sets by comparing entity state against original snapshots. */
 export class ChangeSetComputer {
   readonly #comparator: EntityComparator;
   readonly #metadata: MetadataStorage;
@@ -32,6 +33,7 @@ export class ChangeSetComputer {
     this.#comparator = this.#config.getComparator(this.#metadata);
   }
 
+  /** Computes a change set for the given entity by diffing against its original state. */
   computeChangeSet<T extends object>(entity: T): ChangeSet<T> | null {
     const meta = this.#metadata.get((entity as AnyEntity).constructor);
 

--- a/packages/core/src/unit-of-work/ChangeSetPersister.ts
+++ b/packages/core/src/unit-of-work/ChangeSetPersister.ts
@@ -28,6 +28,7 @@ import { ReferenceKind } from '../enums.js';
 import type { Platform } from '../platforms/Platform.js';
 import type { EntityManager } from '../EntityManager.js';
 
+/** @internal Executes change sets against the database, handling inserts, updates, and deletes. */
 export class ChangeSetPersister {
   readonly #platform: Platform;
   readonly #comparator: EntityComparator;
@@ -52,6 +53,7 @@ export class ChangeSetPersister {
     this.#usesReturningStatement = this.#platform.usesReturningStatement() || this.#platform.usesOutputStatement();
   }
 
+  /** Executes all pending INSERT change sets, using batch inserts when possible. */
   async executeInserts<T extends object>(
     changeSets: ChangeSet<T>[],
     options?: DriverMethodOptions,
@@ -73,6 +75,7 @@ export class ChangeSetPersister {
     }
   }
 
+  /** Executes all pending UPDATE change sets, using batch updates when possible. */
   async executeUpdates<T extends object>(
     changeSets: ChangeSet<T>[],
     batched: boolean,
@@ -104,6 +107,7 @@ export class ChangeSetPersister {
     }
   }
 
+  /** Executes all pending DELETE change sets in batches. */
   async executeDeletes<T extends object>(
     changeSets: ChangeSet<T>[],
     options?: DriverMethodOptions,

--- a/packages/core/src/unit-of-work/IdentityMap.ts
+++ b/packages/core/src/unit-of-work/IdentityMap.ts
@@ -1,5 +1,6 @@
 import type { AnyEntity, EntityCtor, EntityMetadata } from '../typings.js';
 
+/** @internal Stores managed entity instances keyed by their primary key hash, ensuring each row is loaded once. */
 export class IdentityMap {
   readonly #defaultSchema?: string;
   readonly #registry = new Map<EntityCtor, Map<string, AnyEntity>>();
@@ -10,6 +11,7 @@ export class IdentityMap {
     this.#defaultSchema = defaultSchema;
   }
 
+  /** Stores an entity in the identity map under its primary key hash. */
   store<T>(item: T) {
     this.getStore((item as AnyEntity).__meta!.root).set(this.getPkHash(item), item);
   }
@@ -32,6 +34,7 @@ export class IdentityMap {
     keys.add(hash);
   }
 
+  /** Removes an entity and its alternate key entries from the identity map. */
   delete<T>(item: T) {
     const meta = (item as AnyEntity).__meta!.root;
     const store = this.getStore(meta);
@@ -49,11 +52,13 @@ export class IdentityMap {
     }
   }
 
+  /** Retrieves an entity by its hash key from the identity map. */
   getByHash<T>(meta: EntityMetadata<T>, hash: string): T | undefined {
     const store = this.getStore(meta);
     return store.has(hash) ? store.get(hash) : undefined;
   }
 
+  /** Returns (or creates) the per-entity-class store within the identity map. */
   getStore<T>(meta: EntityMetadata<T>): Map<string, T> {
     const store = this.#registry.get(meta.class) as Map<string, T>;
 
@@ -71,6 +76,7 @@ export class IdentityMap {
     this.#registry.clear();
   }
 
+  /** Returns all entities currently in the identity map. */
   values(): AnyEntity[] {
     const ret: AnyEntity[] = [];
 
@@ -89,6 +95,7 @@ export class IdentityMap {
     }
   }
 
+  /** Returns all hash keys currently in the identity map. */
   keys(): string[] {
     const ret: string[] = [];
 

--- a/packages/core/src/unit-of-work/UnitOfWork.ts
+++ b/packages/core/src/unit-of-work/UnitOfWork.ts
@@ -39,6 +39,7 @@ import type { Platform } from '../platforms/Platform.js';
 // to deal with validation for flush inside flush hooks and `Promise.all`
 const insideFlush = createAsyncContext<boolean>();
 
+/** Implements the Unit of Work pattern: tracks entity changes, computes change sets, and flushes them to the database. */
 export class UnitOfWork {
   /** map of references to managed entities */
   readonly #identityMap: IdentityMap;
@@ -81,6 +82,7 @@ export class UnitOfWork {
     this.#changeSetPersister = new ChangeSetPersister(this.#em);
   }
 
+  /** Merges an entity into the identity map, taking a snapshot of its current state. */
   merge<T extends object>(entity: T, visited?: Set<AnyEntity>): void {
     const wrapped = helper(entity);
     wrapped.__em = this.#em;
@@ -310,6 +312,7 @@ export class UnitOfWork {
     this.#identityMap.storeByKey(entity, key, '' + value, schema);
   }
 
+  /** Attempts to extract a primary key from the where condition and look up the entity in the identity map. */
   tryGetById<T extends object>(
     entityName: EntityName<T>,
     where: FilterQuery<T>,
@@ -339,22 +342,27 @@ export class UnitOfWork {
     return helper(entity).__originalEntityData;
   }
 
+  /** Returns the set of entities scheduled for persistence. */
   getPersistStack(): Set<AnyEntity> {
     return this.#persistStack;
   }
 
+  /** Returns the set of entities scheduled for removal. */
   getRemoveStack(): Set<AnyEntity> {
     return this.#removeStack;
   }
 
+  /** Returns all computed change sets for the current flush. */
   getChangeSets(): ChangeSet<AnyEntity>[] {
     return [...this.#changeSets.values()];
   }
 
+  /** Returns all M:N collections that need synchronization. */
   getCollectionUpdates(): Collection<AnyEntity>[] {
     return [...this.#collectionUpdates];
   }
 
+  /** Returns extra updates needed for relations that could not be resolved in the initial pass. */
   getExtraUpdates(): Set<
     [
       AnyEntity,
@@ -367,6 +375,7 @@ export class UnitOfWork {
     return this.#extraUpdates;
   }
 
+  /** Checks whether an auto-flush is needed before querying the given entity type. */
   shouldAutoFlush<T extends object>(meta: EntityMetadata<T>): boolean {
     if (insideFlush.getStore()) {
       return false;
@@ -383,10 +392,12 @@ export class UnitOfWork {
     return false;
   }
 
+  /** Clears the queue of entity types that triggered auto-flush detection. */
   clearActionsQueue(): void {
     this.#queuedActions.clear();
   }
 
+  /** Computes and registers a change set for the given entity. */
   computeChangeSet<T extends object>(entity: T, type?: ChangeSetType): void {
     const wrapped = helper(entity);
 
@@ -412,6 +423,7 @@ export class UnitOfWork {
     wrapped.__originalEntityData = this.#comparator.prepareEntity(entity);
   }
 
+  /** Recomputes and merges the change set for an already-tracked entity. */
   recomputeSingleChangeSet<T extends object>(entity: T): void {
     const changeSet = this.#changeSets.get(entity);
 
@@ -427,6 +439,7 @@ export class UnitOfWork {
     }
   }
 
+  /** Marks an entity for persistence, cascading to related entities. */
   persist<T extends object>(
     entity: T,
     visited?: Set<AnyEntity>,
@@ -452,6 +465,7 @@ export class UnitOfWork {
     }
   }
 
+  /** Marks an entity for removal, cascading to related entities. */
   remove<T extends object>(entity: T, visited?: Set<AnyEntity>, options: { cascade?: boolean } = {}): void {
     // allow removing not managed entities if they are not part of the persist stack
     if (helper(entity).__managed || !this.#persistStack.has(entity)) {
@@ -488,6 +502,7 @@ export class UnitOfWork {
     }
   }
 
+  /** Flushes all pending changes to the database within a transaction. */
   async commit(): Promise<void> {
     if (this.#working) {
       if (insideFlush.getStore()) {

--- a/packages/core/src/utils/Configuration.ts
+++ b/packages/core/src/utils/Configuration.ts
@@ -165,6 +165,7 @@ const DEFAULTS = {
   dynamicImportProvider: /* v8 ignore next */ (id: string) => import(id),
 } as const;
 
+/** Holds and validates all ORM configuration options, providing access to drivers, loggers, cache adapters, and other services. */
 export class Configuration<
   D extends IDatabaseDriver = IDatabaseDriver,
   EM extends EntityManager<D> = D[typeof EntityManagerType] & EntityManager<D>,
@@ -214,6 +215,7 @@ export class Configuration<
     }
   }
 
+  /** Returns the database platform instance. */
   getPlatform(): ReturnType<D['getPlatform']> {
     return this.#platform;
   }
@@ -229,6 +231,7 @@ export class Configuration<
     return defaultValue as U;
   }
 
+  /** Returns all configuration options. */
   getAll(): Options<D, EM> {
     return this.#options;
   }
@@ -271,6 +274,7 @@ export class Configuration<
     return this.#slowQueryLogger;
   }
 
+  /** Returns the configured dataloader type, normalizing boolean values. */
   getDataloaderType(): DataloaderType {
     if (typeof this.#options.dataloader === 'boolean') {
       return this.#options.dataloader ? DataloaderType.ALL : DataloaderType.NONE;
@@ -279,6 +283,7 @@ export class Configuration<
     return this.#options.dataloader;
   }
 
+  /** Returns the configured schema name, optionally skipping the platform's default schema. */
   getSchema(skipDefaultSchema = false): string | undefined {
     if (skipDefaultSchema && this.#options.schema === this.#platform.getDefaultSchemaName()) {
       return undefined;
@@ -294,10 +299,12 @@ export class Configuration<
     return this.#driver;
   }
 
+  /** Registers a lazily-initialized extension by name. */
   registerExtension(name: string, cb: () => unknown): void {
     this.#extensions.set(name, cb);
   }
 
+  /** Returns a previously registered extension by name, initializing it on first access. */
   getExtension<T>(name: string): T | undefined {
     if (this.#cache.has(name)) {
       return this.#cache.get(name);
@@ -393,6 +400,7 @@ export class Configuration<
     return this.#cache.get(cls.name);
   }
 
+  /** Clears the cached service instances, forcing re-creation on next access. */
   resetServiceCache(): void {
     this.#cache.clear();
   }

--- a/packages/core/src/utils/EntityComparator.ts
+++ b/packages/core/src/utils/EntityComparator.ts
@@ -34,6 +34,7 @@ type PkGetter<T> = (entity: T) => Primary<T>;
 type PkSerializer<T> = (entity: T) => string;
 type CompositeKeyPart = string | CompositeKeyPart[];
 
+/** @internal Generates and caches JIT-compiled functions for comparing, snapshotting, and mapping entity data. */
 export class EntityComparator {
   readonly #comparators = new Map<EntityMetadata, Comparator<any>>();
   readonly #mappers = new Map<EntityMetadata, ResultMapper<any>>();
@@ -65,6 +66,7 @@ export class EntityComparator {
     return Utils.callCompiledFunction(comparator, a as T, b as T, options);
   }
 
+  /** Returns true if two entity snapshots are identical (no differences). */
   matching<T extends object>(entityName: EntityName<T>, a: EntityData<T>, b: EntityData<T>): boolean {
     const diff = this.diffEntities(entityName, a, b);
     return Utils.getObjectKeysSize(diff) === 0;

--- a/packages/core/src/utils/NullHighlighter.ts
+++ b/packages/core/src/utils/NullHighlighter.ts
@@ -1,5 +1,6 @@
 import type { Highlighter } from '../typings.js';
 
+/** No-op highlighter that returns SQL text unchanged. Used as the default when no syntax highlighting is configured. */
 export class NullHighlighter implements Highlighter {
   highlight(text: string): string {
     return text;

--- a/packages/core/src/utils/RawQueryFragment.ts
+++ b/packages/core/src/utils/RawQueryFragment.ts
@@ -3,10 +3,12 @@ import type { AnyString, Dictionary, EntityKey } from '../typings.js';
 
 declare const rawFragmentSymbolBrand: unique symbol;
 
+/** Branded symbol type used as a unique key for tracking raw SQL fragments in object properties. */
 export type RawQueryFragmentSymbol = symbol & {
   readonly [rawFragmentSymbolBrand]: true;
 };
 
+/** Represents a raw SQL fragment with optional parameters, usable as both a value and an object key via Symbol coercion. */
 export class RawQueryFragment<Alias extends string = string> {
   static #rawQueryReferences = new WeakMap<RawQueryFragmentSymbol, RawQueryFragment>();
   #key?: RawQueryFragmentSymbol;
@@ -18,6 +20,7 @@ export class RawQueryFragment<Alias extends string = string> {
     readonly params: unknown[] = [],
   ) {}
 
+  /** Returns a unique symbol key for this fragment, creating and caching it on first access. */
   get key(): RawQueryFragmentSymbol {
     if (!this.#key) {
       this.#key = Symbol(this.toJSON()) as RawQueryFragmentSymbol;
@@ -27,6 +30,7 @@ export class RawQueryFragment<Alias extends string = string> {
     return this.#key;
   }
 
+  /** Creates a new fragment with an alias appended via `as ??`. */
   as<A extends string>(alias: A): RawQueryFragment<A> {
     return new RawQueryFragment<A>(`${this.sql} as ??`, [...this.params, alias]);
   }
@@ -54,10 +58,12 @@ export class RawQueryFragment<Alias extends string = string> {
     return this;
   }
 
+  /** Checks whether the given value is a symbol that maps to a known raw query fragment. */
   static isKnownFragmentSymbol(key: unknown): key is RawQueryFragmentSymbol {
     return typeof key === 'symbol' && this.#rawQueryReferences.has(key as RawQueryFragmentSymbol);
   }
 
+  /** Checks whether an object has any symbol keys that are known raw query fragments. */
   static hasObjectFragments(object: unknown): boolean {
     return (
       Utils.isPlainObject(object) &&
@@ -65,6 +71,7 @@ export class RawQueryFragment<Alias extends string = string> {
     );
   }
 
+  /** Checks whether the given value is a RawQueryFragment instance or a known fragment symbol. */
   static isKnownFragment(key: unknown): key is RawQueryFragment | symbol {
     if (key instanceof RawQueryFragment) {
       return true;
@@ -73,6 +80,7 @@ export class RawQueryFragment<Alias extends string = string> {
     return this.isKnownFragmentSymbol(key);
   }
 
+  /** Retrieves the RawQueryFragment associated with the given key (instance or symbol). */
   static getKnownFragment(key: unknown): RawQueryFragment | undefined {
     if (key instanceof RawQueryFragment) {
       return key;
@@ -102,6 +110,7 @@ Object.defineProperties(RawQueryFragment.prototype, {
   __raw: { value: true, enumerable: false },
 });
 
+/** Checks whether the given value is a `RawQueryFragment` instance. */
 export function isRaw(value: unknown): value is RawQueryFragment {
   return typeof value === 'object' && value !== null && '__raw' in value;
 }
@@ -225,6 +234,7 @@ export function sql<R = RawQueryFragment & symbol>(sql: readonly string[], ...va
   return raw<R>(sql.join('?'), values);
 }
 
+/** Creates a raw SQL function expression wrapping the given key (e.g., `lower(name)`). */
 export function createSqlFunction<R = RawQueryFragment & symbol, T extends object = any>(
   func: string,
   key: string | ((alias: string) => string),

--- a/packages/core/src/utils/RequestContext.ts
+++ b/packages/core/src/utils/RequestContext.ts
@@ -74,6 +74,7 @@ export class RequestContext {
   }
 }
 
+/** Options for creating a new RequestContext, allowing schema and logger overrides. */
 export interface CreateContextOptions {
   schema?: string;
   loggerContext?: LoggingOptions;

--- a/packages/core/src/utils/TransactionContext.ts
+++ b/packages/core/src/utils/TransactionContext.ts
@@ -1,6 +1,7 @@
 import type { EntityManager } from '../EntityManager.js';
 import { createAsyncContext } from './AsyncContext.js';
 
+/** Uses `AsyncLocalStorage` to maintain a transaction-scoped EntityManager context across async operations. */
 export class TransactionContext {
   private static storage = createAsyncContext<TransactionContext>();
   readonly id: number;

--- a/packages/core/src/utils/Utils.ts
+++ b/packages/core/src/utils/Utils.ts
@@ -33,6 +33,7 @@ function compareConstructors(a: any, b: any) {
   return false;
 }
 
+/** Deeply compares two objects for equality, handling dates, regexes, and raw fragments. */
 export function compareObjects(a: any, b: any): boolean {
   if (a === b || (a == null && b == null)) {
     return true;
@@ -91,6 +92,7 @@ export function compareObjects(a: any, b: any): boolean {
   return true;
 }
 
+/** Compares two arrays element-by-element for deep equality. */
 export function compareArrays(a: any[] | string, b: any[] | string): boolean {
   const length = a.length;
 
@@ -108,6 +110,7 @@ export function compareArrays(a: any[] | string, b: any[] | string): boolean {
   return true;
 }
 
+/** Compares two boolean values, treating numeric 0/1 as false/true. */
 export function compareBooleans(a: unknown, b: unknown): boolean {
   a = typeof a === 'number' ? Boolean(a) : a;
   b = typeof b === 'number' ? Boolean(b) : b;
@@ -115,6 +118,7 @@ export function compareBooleans(a: unknown, b: unknown): boolean {
   return a === b;
 }
 
+/** Compares two byte arrays element-by-element. */
 export function compareBuffers(a: Uint8Array, b: Uint8Array): boolean {
   const length = a.length;
 
@@ -156,6 +160,7 @@ export function equals(a: any, b: any): boolean {
 
 const equalsFn = equals;
 
+/** Parses a JSON string safely, returning the original value if parsing fails. */
 export function parseJsonSafe<T = unknown>(value: unknown): T {
   if (typeof value === 'string') {
     /* v8 ignore next */
@@ -170,6 +175,7 @@ export function parseJsonSafe<T = unknown>(value: unknown): T {
   return value as T;
 }
 
+/** Collection of general-purpose utility methods used throughout the ORM. */
 export class Utils {
   static readonly PK_SEPARATOR = '~~~';
   static readonly #ORM_VERSION = '[[MIKRO_ORM_VERSION]]';

--- a/packages/decorators/src/es/Check.ts
+++ b/packages/decorators/src/es/Check.ts
@@ -1,5 +1,6 @@
 import { type CheckConstraint, type EntityMetadata } from '@mikro-orm/core';
 
+/** Defines a database check constraint on a property (TC39 decorator). */
 export function Check<T>(
   options: CheckConstraint<T>,
 ): (value: unknown, context: ClassFieldDecoratorContext<T>) => void {

--- a/packages/decorators/src/es/CreateRequestContext.ts
+++ b/packages/decorators/src/es/CreateRequestContext.ts
@@ -1,6 +1,7 @@
 import { RequestContext, TransactionContext } from '@mikro-orm/core';
 import { type ContextProvider, resolveContextProvider } from '../utils.js';
 
+/** Wraps an async method in a new RequestContext, forking the EntityManager (TC39 decorator). */
 export function CreateRequestContext<T extends object>(
   contextProvider?: ContextProvider<T>,
   respectExistingContext = false,
@@ -43,6 +44,7 @@ export function CreateRequestContext<T extends object>(
   };
 }
 
+/** Like `@CreateRequestContext`, but reuses an existing RequestContext if one is available (TC39 decorator). */
 export function EnsureRequestContext<T extends object>(
   context?: ContextProvider<T>,
 ): (

--- a/packages/decorators/src/es/Embeddable.ts
+++ b/packages/decorators/src/es/Embeddable.ts
@@ -1,6 +1,7 @@
 import { type Constructor, type EmbeddableOptions, type EntityClass, Utils } from '@mikro-orm/core';
 import { getMetadataFromDecorator } from '../utils.js';
 
+/** Marks a class as an embeddable type (TC39 decorator). */
 export function Embeddable<Owner extends EntityClass<unknown> & Constructor>(
   options: EmbeddableOptions<Owner> = {},
 ): (target: Owner, context: ClassDecoratorContext<Owner>) => Owner {

--- a/packages/decorators/src/es/Embedded.ts
+++ b/packages/decorators/src/es/Embedded.ts
@@ -8,6 +8,7 @@ import {
 } from '@mikro-orm/core';
 import { prepareMetadataContext } from '../utils.js';
 
+/** Defines an embedded property on an entity (TC39 decorator). */
 export function Embedded<Owner extends object, Target>(
   type: EmbeddedOptions<Owner, Target> | (() => EntityName<Target> | EntityName[]) = {},
   options: EmbeddedOptions<Owner, Target> = {},

--- a/packages/decorators/src/es/Entity.ts
+++ b/packages/decorators/src/es/Entity.ts
@@ -1,6 +1,7 @@
 import { type Constructor, type EntityOptions, type EntityClass, Utils } from '@mikro-orm/core';
 import { getMetadataFromDecorator } from '../utils.js';
 
+/** Marks a class as a MikroORM entity (TC39 decorator). */
 export function Entity<Owner extends EntityClass<unknown> & Constructor>(
   options: EntityOptions<Owner> = {},
 ): (target: Owner, context: ClassDecoratorContext<Owner>) => void {

--- a/packages/decorators/src/es/Enum.ts
+++ b/packages/decorators/src/es/Enum.ts
@@ -8,6 +8,7 @@ import {
 } from '@mikro-orm/core';
 import { prepareMetadataContext } from '../utils.js';
 
+/** Defines an enum property on an entity (TC39 decorator). */
 export function Enum<Owner extends object>(
   options: EnumOptions<AnyEntity> | (() => Dictionary) = {},
 ): (target: unknown, context: ClassFieldDecoratorContext<Owner>) => void {

--- a/packages/decorators/src/es/Filter.ts
+++ b/packages/decorators/src/es/Filter.ts
@@ -1,6 +1,7 @@
 import { type FilterDef, type EntityClass } from '@mikro-orm/core';
 import { getMetadataFromDecorator } from '../utils.js';
 
+/** Registers a named filter on an entity class (TC39 decorator). */
 export function Filter<T extends EntityClass<unknown>>(options: FilterDef<T>): (target: T) => void {
   return function (target: T): void {
     const meta = getMetadataFromDecorator(target);

--- a/packages/decorators/src/es/Formula.ts
+++ b/packages/decorators/src/es/Formula.ts
@@ -7,6 +7,7 @@ import {
 } from '@mikro-orm/core';
 import { prepareMetadataContext } from '../utils.js';
 
+/** Defines a computed SQL formula property on an entity (TC39 decorator). */
 export function Formula<Owner extends object>(
   formula: string | FormulaCallback<Owner>,
   options: PropertyOptions<Owner> = {},

--- a/packages/decorators/src/es/Indexed.ts
+++ b/packages/decorators/src/es/Indexed.ts
@@ -17,12 +17,14 @@ function createDecorator<T extends object>(options: IndexOptions<T> | UniqueOpti
   };
 }
 
+/** Defines a database index on a property or entity class (TC39 decorator). */
 export function Index<T extends object, H extends string>(
   options: IndexOptions<T, H> = {},
 ): (value: unknown, context: ClassDecoratorContext<T & Constructor> | ClassFieldDecoratorContext<T>) => any {
   return createDecorator(options, false);
 }
 
+/** Defines a unique constraint on a property or entity class (TC39 decorator). */
 export function Unique<T extends object, H extends string>(
   options: UniqueOptions<T, H> = {},
 ): (value: unknown, context: ClassDecoratorContext<T & Constructor> | ClassFieldDecoratorContext<T>) => any {

--- a/packages/decorators/src/es/ManyToMany.ts
+++ b/packages/decorators/src/es/ManyToMany.ts
@@ -9,6 +9,7 @@ import {
 } from '@mikro-orm/core';
 import { prepareMetadataContext, processDecoratorParameters } from '../utils.js';
 
+/** Defines a many-to-many relationship (TC39 decorator). */
 export function ManyToMany<Target extends object, Owner extends object>(
   entity?: ManyToManyOptions<Owner, Target> | string | (() => EntityName<Target>),
   mappedBy?: (string & keyof Target) | ((e: Target) => any),

--- a/packages/decorators/src/es/ManyToOne.ts
+++ b/packages/decorators/src/es/ManyToOne.ts
@@ -9,6 +9,7 @@ import {
 } from '@mikro-orm/core';
 import { prepareMetadataContext, processDecoratorParameters } from '../utils.js';
 
+/** Defines a many-to-one relationship (TC39 decorator). */
 export function ManyToOne<Target extends object, Owner extends object>(
   entity: ManyToOneOptions<Owner, Target> | ((e?: Owner) => EntityName<Target> | EntityName[]) = {},
   options: Partial<ManyToOneOptions<Owner, Target>> = {},

--- a/packages/decorators/src/es/OneToMany.ts
+++ b/packages/decorators/src/es/OneToMany.ts
@@ -9,6 +9,7 @@ import {
 } from '@mikro-orm/core';
 import { prepareMetadataContext, processDecoratorParameters } from '../utils.js';
 
+/** Defines a one-to-many relationship (TC39 decorator). */
 export function OneToMany<Target extends object, Owner extends object>(
   entity: string | ((e?: Owner) => EntityName<Target>),
   mappedBy: (string & keyof Target) | ((e: Target) => any),

--- a/packages/decorators/src/es/OneToOne.ts
+++ b/packages/decorators/src/es/OneToOne.ts
@@ -9,6 +9,7 @@ import {
 } from '@mikro-orm/core';
 import { prepareMetadataContext, processDecoratorParameters } from '../utils.js';
 
+/** Defines a one-to-one relationship (TC39 decorator). */
 export function OneToOne<Target extends object, Owner extends object>(
   entity?: OneToOneOptions<Owner, Target> | string | ((e: Owner) => EntityName<Target> | EntityName[]),
   mappedByOrOptions?: (string & keyof Target) | ((e: Target) => any) | Partial<OneToOneOptions<Owner, Target>>,

--- a/packages/decorators/src/es/PrimaryKey.ts
+++ b/packages/decorators/src/es/PrimaryKey.ts
@@ -23,12 +23,14 @@ function createDecorator<T extends object>(
   };
 }
 
+/** Marks a property as the primary key of an entity (TC39 decorator). */
 export function PrimaryKey<T extends object>(
   options: PrimaryKeyOptions<T> = {},
 ): (value: unknown, context: ClassFieldDecoratorContext<T>) => void {
   return createDecorator(options, false);
 }
 
+/** Marks a property as the serialized form of the primary key, e.g. for MongoDB ObjectId (TC39 decorator). */
 export function SerializedPrimaryKey<T extends object>(
   options: SerializedPrimaryKeyOptions<T> = {},
 ): (value: unknown, context: ClassFieldDecoratorContext<T>) => void {

--- a/packages/decorators/src/es/Property.ts
+++ b/packages/decorators/src/es/Property.ts
@@ -1,6 +1,7 @@
 import { type EntityKey, type EntityProperty, type PropertyOptions, ReferenceKind, Utils } from '@mikro-orm/core';
 import { prepareMetadataContext } from '../utils.js';
 
+/** Defines a scalar property on an entity (TC39 decorator). */
 export function Property<T extends object>(
   options: PropertyOptions<T> = {},
 ): (

--- a/packages/decorators/src/es/hooks.ts
+++ b/packages/decorators/src/es/hooks.ts
@@ -9,34 +9,42 @@ function hook<Owner extends object>(type: EventType) {
   };
 }
 
+/** Called before a new entity is persisted to the database (TC39 decorator). */
 export function BeforeCreate(): (value: (...args: any[]) => unknown, context: ClassMethodDecoratorContext) => void {
   return hook(EventType.beforeCreate);
 }
 
+/** Called after a new entity has been persisted to the database (TC39 decorator). */
 export function AfterCreate(): (value: (...args: any[]) => unknown, context: ClassMethodDecoratorContext) => void {
   return hook(EventType.afterCreate);
 }
 
+/** Called before an existing entity is updated in the database (TC39 decorator). */
 export function BeforeUpdate(): (value: (...args: any[]) => unknown, context: ClassMethodDecoratorContext) => void {
   return hook(EventType.beforeUpdate);
 }
 
+/** Called after an existing entity has been updated in the database (TC39 decorator). */
 export function AfterUpdate(): (value: (...args: any[]) => unknown, context: ClassMethodDecoratorContext) => void {
   return hook(EventType.afterUpdate);
 }
 
+/** Called before an entity is upserted (TC39 decorator). */
 export function BeforeUpsert(): (value: (...args: any[]) => unknown, context: ClassMethodDecoratorContext) => void {
   return hook(EventType.beforeUpsert);
 }
 
+/** Called after an entity has been upserted (TC39 decorator). */
 export function AfterUpsert(): (value: (...args: any[]) => unknown, context: ClassMethodDecoratorContext) => void {
   return hook(EventType.afterUpsert);
 }
 
+/** Called when an entity is instantiated by the EntityManager (TC39 decorator). */
 export function OnInit(): (value: (...args: any[]) => unknown, context: ClassMethodDecoratorContext) => void {
   return hook(EventType.onInit);
 }
 
+/** Called after an entity is loaded from the database (TC39 decorator). */
 export function OnLoad(): (value: (...args: any[]) => unknown, context: ClassMethodDecoratorContext) => void {
   return hook(EventType.onLoad);
 }

--- a/packages/decorators/src/legacy/Check.ts
+++ b/packages/decorators/src/legacy/Check.ts
@@ -1,6 +1,7 @@
 import { type CheckConstraint, type Dictionary, type EntityClass } from '@mikro-orm/core';
 import { getMetadataFromDecorator } from '../utils.js';
 
+/** Defines a database check constraint on a property or entity class (legacy TypeScript decorator). */
 export function Check<T>(
   options: CheckConstraint<T>,
 ): (target: T, propertyName?: T extends EntityClass<unknown> ? undefined : keyof T) => any {

--- a/packages/decorators/src/legacy/CreateRequestContext.ts
+++ b/packages/decorators/src/legacy/CreateRequestContext.ts
@@ -1,6 +1,7 @@
 import { RequestContext, TransactionContext } from '@mikro-orm/core';
 import { resolveContextProvider, type ContextProvider } from '../utils.js';
 
+/** Wraps an async method in a new RequestContext, forking the EntityManager (legacy TypeScript decorator). */
 export function CreateRequestContext<T extends object>(
   context?: ContextProvider<T>,
   respectExistingContext = false,
@@ -40,6 +41,7 @@ export function CreateRequestContext<T extends object>(
   };
 }
 
+/** Like `@CreateRequestContext`, but reuses an existing RequestContext if one is available (legacy TypeScript decorator). */
 export function EnsureRequestContext<T extends object>(context?: ContextProvider<T>): MethodDecorator {
   return CreateRequestContext(context, true);
 }

--- a/packages/decorators/src/legacy/Embeddable.ts
+++ b/packages/decorators/src/legacy/Embeddable.ts
@@ -1,6 +1,7 @@
 import { type Constructor, type Dictionary, type EmbeddableOptions } from '@mikro-orm/core';
 import { getMetadataFromDecorator } from '../utils.js';
 
+/** Marks a class as an embeddable type (legacy TypeScript decorator). */
 export function Embeddable<T>(options: EmbeddableOptions<T> = {}): (target: T) => T {
   return function (target: T): T {
     const meta = getMetadataFromDecorator(target as T & Dictionary);

--- a/packages/decorators/src/legacy/Embedded.ts
+++ b/packages/decorators/src/legacy/Embedded.ts
@@ -9,6 +9,7 @@ import {
 } from '@mikro-orm/core';
 import { validateSingleDecorator, getMetadataFromDecorator } from '../utils.js';
 
+/** Defines an embedded property on an entity (legacy TypeScript decorator). */
 export function Embedded<Owner extends object, Target>(
   type: EmbeddedOptions<Owner, Target> | (() => EntityName<Target> | EntityName[]) = {},
   options: EmbeddedOptions<Owner, Target> = {},

--- a/packages/decorators/src/legacy/Entity.ts
+++ b/packages/decorators/src/legacy/Entity.ts
@@ -1,6 +1,7 @@
 import { Utils, type EntityClass, type EntityOptions } from '@mikro-orm/core';
 import { getMetadataFromDecorator } from '../utils.js';
 
+/** Marks a class as a MikroORM entity (legacy TypeScript decorator). */
 export function Entity<T extends EntityClass<unknown>>(options: EntityOptions<T> = {}): (target: T) => void {
   return function (target: T): void {
     const meta = getMetadataFromDecorator(target);

--- a/packages/decorators/src/legacy/Enum.ts
+++ b/packages/decorators/src/legacy/Enum.ts
@@ -8,6 +8,7 @@ import {
 } from '@mikro-orm/core';
 import { getMetadataFromDecorator } from '../utils.js';
 
+/** Defines an enum property on an entity (legacy TypeScript decorator). */
 export function Enum<T extends object>(
   options: EnumOptions<AnyEntity> | (() => Dictionary) = {},
 ): (target: T, propertyName: string) => void {

--- a/packages/decorators/src/legacy/Filter.ts
+++ b/packages/decorators/src/legacy/Filter.ts
@@ -1,6 +1,7 @@
 import { type FilterDef, type EntityClass } from '@mikro-orm/core';
 import { getMetadataFromDecorator } from '../utils.js';
 
+/** Registers a named filter on an entity class (legacy TypeScript decorator). */
 export function Filter<T extends EntityClass<unknown>>(options: FilterDef<T>): (target: T) => void {
   return function (target: T): void {
     const meta = getMetadataFromDecorator(target);

--- a/packages/decorators/src/legacy/Formula.ts
+++ b/packages/decorators/src/legacy/Formula.ts
@@ -7,6 +7,7 @@ import {
 } from '@mikro-orm/core';
 import { getMetadataFromDecorator } from '../utils.js';
 
+/** Defines a computed SQL formula property on an entity (legacy TypeScript decorator). */
 export function Formula<T extends object>(
   formula: string | FormulaCallback<T>,
   options: PropertyOptions<T> = {},

--- a/packages/decorators/src/legacy/Indexed.ts
+++ b/packages/decorators/src/legacy/Indexed.ts
@@ -16,12 +16,14 @@ function createDecorator<T extends object>(options: IndexOptions<T> | UniqueOpti
   };
 }
 
+/** Defines a database index on a property or entity class (legacy TypeScript decorator). */
 export function Index<T extends object, H extends string>(
   options: IndexOptions<T, H> = {},
 ): (target: T, propertyName?: T extends EntityClass<unknown> ? undefined : keyof T) => any {
   return createDecorator(options, false);
 }
 
+/** Defines a unique constraint on a property or entity class (legacy TypeScript decorator). */
 export function Unique<T extends object, H extends string>(
   options: UniqueOptions<T, H> = {},
 ): (target: T, propertyName?: T extends EntityClass<unknown> ? undefined : keyof T) => any {

--- a/packages/decorators/src/legacy/ManyToMany.ts
+++ b/packages/decorators/src/legacy/ManyToMany.ts
@@ -7,6 +7,7 @@ import {
 } from '@mikro-orm/core';
 import { processDecoratorParameters, validateSingleDecorator, getMetadataFromDecorator } from '../utils.js';
 
+/** Defines a many-to-many relationship (legacy TypeScript decorator). */
 export function ManyToMany<Target extends object, Owner extends object>(
   entity: () => EntityName<Target>,
   mappedBy?: (string & keyof Target) | ((e: Target) => any),

--- a/packages/decorators/src/legacy/ManyToOne.ts
+++ b/packages/decorators/src/legacy/ManyToOne.ts
@@ -7,6 +7,7 @@ import {
 } from '@mikro-orm/core';
 import { processDecoratorParameters, validateSingleDecorator, getMetadataFromDecorator } from '../utils.js';
 
+/** Defines a many-to-one relationship (legacy TypeScript decorator). */
 export function ManyToOne<Target extends object, Owner extends object>(
   entity: (e?: any) => EntityName<Target> | EntityName[],
   options?: Partial<ManyToOneOptions<Owner, Target>>,

--- a/packages/decorators/src/legacy/OneToMany.ts
+++ b/packages/decorators/src/legacy/OneToMany.ts
@@ -7,6 +7,7 @@ import {
 } from '@mikro-orm/core';
 import { processDecoratorParameters, validateSingleDecorator, getMetadataFromDecorator } from '../utils.js';
 
+/** Defines a one-to-many relationship (legacy TypeScript decorator). */
 export function OneToMany<Target extends object, Owner extends object>(
   entity: (e?: any) => EntityName<Target>,
   mappedBy: (string & keyof Target) | ((e: Target) => any),

--- a/packages/decorators/src/legacy/OneToOne.ts
+++ b/packages/decorators/src/legacy/OneToOne.ts
@@ -8,6 +8,7 @@ import {
 } from '@mikro-orm/core';
 import { processDecoratorParameters, validateSingleDecorator, getMetadataFromDecorator } from '../utils.js';
 
+/** Defines a one-to-one relationship (legacy TypeScript decorator). */
 export function OneToOne<Target, Owner>(
   entity: (e: Owner) => EntityName<Target> | EntityName[],
   mappedByOrOptions?: (string & keyof Target) | ((e: Target) => any) | Partial<OneToOneOptions<Owner, Target>>,

--- a/packages/decorators/src/legacy/PrimaryKey.ts
+++ b/packages/decorators/src/legacy/PrimaryKey.ts
@@ -24,12 +24,14 @@ function createDecorator<T extends object>(
   };
 }
 
+/** Marks a property as the primary key of an entity (legacy TypeScript decorator). */
 export function PrimaryKey<T extends object>(
   options: PrimaryKeyOptions<T> = {},
 ): (target: T, propertyName: string) => void {
   return createDecorator(options, false);
 }
 
+/** Marks a property as the serialized form of the primary key, e.g. for MongoDB ObjectId (legacy TypeScript decorator). */
 export function SerializedPrimaryKey<T extends object>(
   options: SerializedPrimaryKeyOptions<T> = {},
 ): (target: T, propertyName: string) => void {

--- a/packages/decorators/src/legacy/Property.ts
+++ b/packages/decorators/src/legacy/Property.ts
@@ -1,6 +1,7 @@
 import { Utils, ReferenceKind, type EntityProperty, type EntityKey, type PropertyOptions } from '@mikro-orm/core';
 import { validateSingleDecorator, getMetadataFromDecorator } from '../utils.js';
 
+/** Defines a scalar property on an entity (legacy TypeScript decorator). */
 export function Property<T extends object>(
   options: PropertyOptions<T> = {},
 ): (target: T, propertyName: string) => void {

--- a/packages/decorators/src/legacy/ReflectMetadataProvider.ts
+++ b/packages/decorators/src/legacy/ReflectMetadataProvider.ts
@@ -9,6 +9,7 @@ import {
   Utils,
 } from '@mikro-orm/core';
 
+/** Metadata provider that uses `reflect-metadata` to infer property types from TypeScript's emitted design:type metadata. */
 export class ReflectMetadataProvider extends MetadataProvider {
   override loadEntityMetadata(meta: EntityMetadata): void {
     // load types and column names

--- a/packages/decorators/src/legacy/hooks.ts
+++ b/packages/decorators/src/legacy/hooks.ts
@@ -9,34 +9,42 @@ function hook(type: EventType) {
   };
 }
 
+/** Called before a new entity is persisted to the database (legacy TypeScript decorator). */
 export function BeforeCreate(): (target: any, method: string) => void {
   return hook(EventType.beforeCreate);
 }
 
+/** Called after a new entity has been persisted to the database (legacy TypeScript decorator). */
 export function AfterCreate(): (target: any, method: string) => void {
   return hook(EventType.afterCreate);
 }
 
+/** Called before an existing entity is updated in the database (legacy TypeScript decorator). */
 export function BeforeUpdate(): (target: any, method: string) => void {
   return hook(EventType.beforeUpdate);
 }
 
+/** Called after an existing entity has been updated in the database (legacy TypeScript decorator). */
 export function AfterUpdate(): (target: any, method: string) => void {
   return hook(EventType.afterUpdate);
 }
 
+/** Called before an entity is upserted (legacy TypeScript decorator). */
 export function BeforeUpsert(): (target: any, method: string) => void {
   return hook(EventType.beforeUpsert);
 }
 
+/** Called after an entity has been upserted (legacy TypeScript decorator). */
 export function AfterUpsert(): (target: any, method: string) => void {
   return hook(EventType.afterUpsert);
 }
 
+/** Called when an entity is instantiated by the EntityManager (legacy TypeScript decorator). */
 export function OnInit(): (target: any, method: string) => void {
   return hook(EventType.onInit);
 }
 
+/** Called after an entity is loaded from the database (legacy TypeScript decorator). */
 export function OnLoad(): (target: any, method: string) => void {
   return hook(EventType.onLoad);
 }

--- a/packages/decorators/src/utils.ts
+++ b/packages/decorators/src/utils.ts
@@ -175,6 +175,7 @@ export function lookupPathFromDecorator(name: string, stack?: string[]): string 
   }
 }
 
+/** Retrieves or creates the metadata object for a decorated entity class. */
 export function getMetadataFromDecorator<T = any>(
   target: T & Dictionary & { [MetadataStorage.PATH_SYMBOL]?: string },
 ): EntityMetadata<T> {

--- a/packages/entity-generator/src/EntityGenerator.ts
+++ b/packages/entity-generator/src/EntityGenerator.ts
@@ -26,6 +26,7 @@ import { EntitySchemaSourceFile } from './EntitySchemaSourceFile.js';
 import { NativeEnumSourceFile } from './NativeEnumSourceFile.js';
 import { SourceFile } from './SourceFile.js';
 
+/** Generates entity source files by introspecting an existing database schema. */
 export class EntityGenerator {
   readonly #config: Configuration;
   readonly #driver: AbstractSqlDriver;

--- a/packages/libsql/src/LibSqlConnection.ts
+++ b/packages/libsql/src/LibSqlConnection.ts
@@ -2,6 +2,7 @@ import { BaseSqliteConnection, type Dictionary } from '@mikro-orm/sql';
 import Database, { type Options } from 'libsql';
 import { LibSqlDialect } from './LibSqlDialect.js';
 
+/** libSQL database connection supporting both local and remote databases. */
 export class LibSqlConnection extends BaseSqliteConnection {
   private database!: Database.Database;
 

--- a/packages/libsql/src/LibSqlDialect.ts
+++ b/packages/libsql/src/LibSqlDialect.ts
@@ -135,6 +135,7 @@ class LibSqlKyselyDriver extends SqliteDriver {
   }
 }
 
+/** Kysely dialect adapter for libSQL. */
 export class LibSqlDialect extends SqliteDialect {
   readonly #config: SqliteDialectConfig;
 

--- a/packages/libsql/src/LibSqlDriver.ts
+++ b/packages/libsql/src/LibSqlDriver.ts
@@ -3,6 +3,7 @@ import { AbstractSqlDriver, SqlitePlatform } from '@mikro-orm/sql';
 import { LibSqlConnection } from './LibSqlConnection.js';
 import { LibSqlMikroORM } from './LibSqlMikroORM.js';
 
+/** Database driver for libSQL (Turso). */
 export class LibSqlDriver extends AbstractSqlDriver<LibSqlConnection> {
   constructor(config: Configuration) {
     super(config, new SqlitePlatform(), LibSqlConnection, ['kysely', 'libsql']);

--- a/packages/libsql/src/LibSqlMikroORM.ts
+++ b/packages/libsql/src/LibSqlMikroORM.ts
@@ -12,6 +12,7 @@ import {
 import type { SqlEntityManager } from '@mikro-orm/sql';
 import { LibSqlDriver } from './LibSqlDriver.js';
 
+/** Configuration options for the libSQL driver. */
 export type LibSqlOptions<
   EM extends SqlEntityManager<LibSqlDriver> = SqlEntityManager<LibSqlDriver>,
   Entities extends (string | EntityClass<AnyEntity> | EntitySchema)[] = (
@@ -21,6 +22,7 @@ export type LibSqlOptions<
   )[],
 > = Partial<Options<LibSqlDriver, EM, Entities>>;
 
+/** Creates a type-safe configuration object for the libSQL driver. */
 export function defineLibSqlConfig<
   EM extends SqlEntityManager<LibSqlDriver> = SqlEntityManager<LibSqlDriver>,
   Entities extends (string | EntityClass<AnyEntity> | EntitySchema)[] = (

--- a/packages/mariadb/src/MariaDbDriver.ts
+++ b/packages/mariadb/src/MariaDbDriver.ts
@@ -13,6 +13,7 @@ import { MariaDbPlatform } from './MariaDbPlatform.js';
 import { MariaDbQueryBuilder } from './MariaDbQueryBuilder.js';
 import { MariaDbMikroORM } from './MariaDbMikroORM.js';
 
+/** Database driver for MariaDB, extending the MySQL driver with MariaDB-specific behavior. */
 export class MariaDbDriver extends MySqlDriver {
   declare readonly platform: MariaDbPlatform;
 

--- a/packages/mariadb/src/MariaDbMikroORM.ts
+++ b/packages/mariadb/src/MariaDbMikroORM.ts
@@ -12,6 +12,7 @@ import {
 import type { SqlEntityManager } from '@mikro-orm/mysql';
 import { MariaDbDriver } from './MariaDbDriver.js';
 
+/** Configuration options for the MariaDB driver. */
 export type MariaDbOptions<
   EM extends SqlEntityManager<MariaDbDriver> = SqlEntityManager<MariaDbDriver>,
   Entities extends (string | EntityClass<AnyEntity> | EntitySchema)[] = (
@@ -21,6 +22,7 @@ export type MariaDbOptions<
   )[],
 > = Partial<Options<MariaDbDriver, EM, Entities>>;
 
+/** Creates a type-safe configuration object for the MariaDB driver. */
 export function defineMariaDbConfig<
   EM extends SqlEntityManager<MariaDbDriver> = SqlEntityManager<MariaDbDriver>,
   Entities extends (string | EntityClass<AnyEntity> | EntitySchema)[] = (

--- a/packages/mariadb/src/MariaDbPlatform.ts
+++ b/packages/mariadb/src/MariaDbPlatform.ts
@@ -1,6 +1,7 @@
 import { MySqlPlatform, type TransformContext } from '@mikro-orm/mysql';
 import { MariaDbSchemaHelper } from './MariaDbSchemaHelper.js';
 
+/** Platform implementation for MariaDB. */
 export class MariaDbPlatform extends MySqlPlatform {
   protected override readonly schemaHelper: MariaDbSchemaHelper = new MariaDbSchemaHelper(this);
 

--- a/packages/mariadb/src/MariaDbSchemaHelper.ts
+++ b/packages/mariadb/src/MariaDbSchemaHelper.ts
@@ -10,6 +10,7 @@ import {
 } from '@mikro-orm/mysql';
 import { type Dictionary, type Type } from '@mikro-orm/core';
 
+/** Schema introspection helper for MariaDB. */
 export class MariaDbSchemaHelper extends MySqlSchemaHelper {
   protected override appendMySqlIndexSuffix(sql: string, index: IndexDef): string {
     // MariaDB uses IGNORED instead of MySQL's INVISIBLE keyword

--- a/packages/migrations-mongodb/src/JSMigrationGenerator.ts
+++ b/packages/migrations-mongodb/src/JSMigrationGenerator.ts
@@ -1,5 +1,6 @@
 import { MigrationGenerator } from './MigrationGenerator.js';
 
+/** Generates MongoDB migration files in CommonJS JavaScript format. */
 export class JSMigrationGenerator extends MigrationGenerator {
   /**
    * @inheritDoc

--- a/packages/migrations-mongodb/src/Migration.ts
+++ b/packages/migrations-mongodb/src/Migration.ts
@@ -2,6 +2,7 @@ import type { Configuration, Transaction, EntityName } from '@mikro-orm/core';
 import type { MongoDriver } from '@mikro-orm/mongodb';
 import type { Collection, ClientSession, Document, Db } from 'mongodb';
 
+/** Base class for MongoDB migrations. Extend this class and implement `up()` (and optionally `down()`). */
 export abstract class Migration {
   protected ctx?: Transaction<ClientSession>;
 

--- a/packages/migrations-mongodb/src/MigrationGenerator.ts
+++ b/packages/migrations-mongodb/src/MigrationGenerator.ts
@@ -6,6 +6,7 @@ import {
 } from '@mikro-orm/core';
 import type { MongoDriver } from '@mikro-orm/mongodb';
 
+/** Base class for generating MongoDB migration source files. */
 export abstract class MigrationGenerator implements IMigrationGenerator {
   constructor(
     protected readonly driver: MongoDriver,

--- a/packages/migrations-mongodb/src/MigrationRunner.ts
+++ b/packages/migrations-mongodb/src/MigrationRunner.ts
@@ -2,6 +2,7 @@ import type { MigrationsOptions, Transaction } from '@mikro-orm/core';
 import type { MongoDriver, MongoConnection } from '@mikro-orm/mongodb';
 import type { Migration } from './Migration.js';
 
+/** Executes individual MongoDB migration files within optional transaction contexts. */
 export class MigrationRunner {
   private readonly connection: MongoConnection;
   private masterTransaction?: Transaction;

--- a/packages/migrations-mongodb/src/MigrationStorage.ts
+++ b/packages/migrations-mongodb/src/MigrationStorage.ts
@@ -9,6 +9,7 @@ import {
 import type { MongoDriver } from '@mikro-orm/mongodb';
 import type { MigrationRow } from './typings.js';
 
+/** Tracks executed MongoDB migrations in a collection. */
 export class MigrationStorage {
   private masterTransaction?: Transaction;
 

--- a/packages/migrations-mongodb/src/Migrator.ts
+++ b/packages/migrations-mongodb/src/Migrator.ts
@@ -7,6 +7,7 @@ import type { MigrationResult } from './typings.js';
 import { TSMigrationGenerator } from './TSMigrationGenerator.js';
 import { JSMigrationGenerator } from './JSMigrationGenerator.js';
 
+/** Manages MongoDB migrations: creation, execution, and rollback. */
 export class Migrator extends AbstractMigrator<MongoDriver> {
   static register(orm: MikroORM): void {
     orm.config.registerExtension('@mikro-orm/migrator', () => new Migrator(orm.em as EntityManager));

--- a/packages/migrations-mongodb/src/TSMigrationGenerator.ts
+++ b/packages/migrations-mongodb/src/TSMigrationGenerator.ts
@@ -1,5 +1,6 @@
 import { MigrationGenerator } from './MigrationGenerator.js';
 
+/** Generates MongoDB migration files in TypeScript format. */
 export class TSMigrationGenerator extends MigrationGenerator {
   /**
    * @inheritDoc

--- a/packages/migrations/src/JSMigrationGenerator.ts
+++ b/packages/migrations/src/JSMigrationGenerator.ts
@@ -1,5 +1,6 @@
 import { MigrationGenerator } from './MigrationGenerator.js';
 
+/** Generates migration files in CommonJS JavaScript format. */
 export class JSMigrationGenerator extends MigrationGenerator {
   /**
    * @inheritDoc

--- a/packages/migrations/src/Migration.ts
+++ b/packages/migrations/src/Migration.ts
@@ -7,8 +7,10 @@ import {
 } from '@mikro-orm/core';
 import type { AbstractSqlDriver, EntityManager, NativeQueryBuilder } from '@mikro-orm/sql';
 
+/** A migration query: raw SQL string, a native query builder instance, or a `raw()` SQL fragment. */
 export type Query = string | NativeQueryBuilder | RawQueryFragment;
 
+/** Base class for SQL database migrations. Extend this class and implement `up()` (and optionally `down()`). */
 export abstract class Migration {
   readonly #queries: Query[] = [];
   protected ctx?: Transaction;

--- a/packages/migrations/src/MigrationGenerator.ts
+++ b/packages/migrations/src/MigrationGenerator.ts
@@ -6,6 +6,7 @@ import {
 } from '@mikro-orm/core';
 import type { AbstractSqlDriver } from '@mikro-orm/sql';
 
+/** Base class for generating migration source files from schema diffs. */
 export abstract class MigrationGenerator implements IMigrationGenerator {
   constructor(
     protected readonly driver: AbstractSqlDriver,

--- a/packages/migrations/src/MigrationRunner.ts
+++ b/packages/migrations/src/MigrationRunner.ts
@@ -2,6 +2,7 @@ import { type Configuration, type MigrationsOptions, type Transaction, Utils } f
 import type { AbstractSqlConnection, AbstractSqlDriver, SchemaHelper } from '@mikro-orm/sql';
 import type { Migration } from './Migration.js';
 
+/** Executes individual migration files within optional transaction contexts. */
 export class MigrationRunner {
   readonly #connection: AbstractSqlConnection;
   readonly #helper: SchemaHelper;

--- a/packages/migrations/src/MigrationStorage.ts
+++ b/packages/migrations/src/MigrationStorage.ts
@@ -9,6 +9,7 @@ import {
 } from '@mikro-orm/sql';
 import type { MigrationRow } from './typings.js';
 
+/** Tracks executed migrations in a database table. */
 export class MigrationStorage {
   readonly #connection: AbstractSqlConnection;
   readonly #helper: SchemaHelper;

--- a/packages/migrations/src/Migrator.ts
+++ b/packages/migrations/src/Migrator.ts
@@ -24,6 +24,7 @@ import type { MigrationResult } from './typings.js';
 import { TSMigrationGenerator } from './TSMigrationGenerator.js';
 import { JSMigrationGenerator } from './JSMigrationGenerator.js';
 
+/** Manages SQL database migrations: creation, execution, and rollback of schema changes. */
 export class Migrator extends AbstractMigrator<AbstractSqlDriver> {
   readonly #schemaGenerator: SqlSchemaGenerator;
   #snapshotPath?: string;

--- a/packages/migrations/src/TSMigrationGenerator.ts
+++ b/packages/migrations/src/TSMigrationGenerator.ts
@@ -1,5 +1,6 @@
 import { MigrationGenerator } from './MigrationGenerator.js';
 
+/** Generates migration files in TypeScript format. */
 export class TSMigrationGenerator extends MigrationGenerator {
   /**
    * @inheritDoc

--- a/packages/mongodb/src/MongoConnection.ts
+++ b/packages/mongodb/src/MongoConnection.ts
@@ -43,6 +43,7 @@ import {
   ValidationError,
 } from '@mikro-orm/core';
 
+/** MongoDB database connection using the official `mongodb` driver. */
 export class MongoConnection extends Connection {
   #client?: MongoClient;
   #db?: Db;
@@ -661,6 +662,7 @@ export class MongoConnection extends Connection {
   }
 }
 
+/** Options shared across MongoDB query operations. */
 export interface MongoQueryOptions {
   collation?: CollationOptions;
   indexHint?: string | Dictionary;
@@ -668,6 +670,7 @@ export interface MongoQueryOptions {
   allowDiskUse?: boolean;
 }
 
+/** Options for MongoDB find operations. */
 export interface MongoFindOptions<T extends object> extends MongoQueryOptions {
   orderBy?: QueryOrderMap<T> | QueryOrderMap<T>[];
   limit?: number;
@@ -677,6 +680,7 @@ export interface MongoFindOptions<T extends object> extends MongoQueryOptions {
   loggerContext?: LoggingOptions;
 }
 
+/** Options for MongoDB count operations. */
 export interface MongoCountOptions extends Omit<MongoQueryOptions, 'allowDiskUse'> {
   ctx?: Transaction<ClientSession>;
   loggerContext?: LoggingOptions;

--- a/packages/mongodb/src/MongoDriver.ts
+++ b/packages/mongodb/src/MongoDriver.ts
@@ -33,6 +33,7 @@ import { MongoPlatform } from './MongoPlatform.js';
 import { MongoEntityManager } from './MongoEntityManager.js';
 import { MongoMikroORM } from './MongoMikroORM.js';
 
+/** Database driver for MongoDB. */
 export class MongoDriver extends DatabaseDriver<MongoConnection> {
   override [EntityManagerType]!: MongoEntityManager<this>;
 

--- a/packages/mongodb/src/MongoEntityRepository.ts
+++ b/packages/mongodb/src/MongoEntityRepository.ts
@@ -2,6 +2,7 @@ import { EntityRepository, type EntityName } from '@mikro-orm/core';
 import type { Collection } from 'mongodb';
 import type { MongoEntityManager } from './MongoEntityManager.js';
 
+/** Entity repository with MongoDB-specific methods such as `aggregate()`. */
 export class MongoEntityRepository<T extends object> extends EntityRepository<T> {
   constructor(
     protected override readonly em: MongoEntityManager,

--- a/packages/mongodb/src/MongoExceptionConverter.ts
+++ b/packages/mongodb/src/MongoExceptionConverter.ts
@@ -6,6 +6,7 @@ import {
   type DriverException,
 } from '@mikro-orm/core';
 
+/** Converts MongoDB native errors into typed MikroORM driver exceptions. */
 export class MongoExceptionConverter extends ExceptionConverter {
   /**
    * @see https://gist.github.com/rluvaton/a97a8da46ab6541a3e5702e83b9d357b

--- a/packages/mongodb/src/MongoMikroORM.ts
+++ b/packages/mongodb/src/MongoMikroORM.ts
@@ -13,6 +13,7 @@ import {
 import { MongoDriver } from './MongoDriver.js';
 import type { MongoEntityManager } from './MongoEntityManager.js';
 
+/** Configuration options for the MongoDB driver. */
 export type MongoOptions<
   EM extends MongoEntityManager = MongoEntityManager,
   Entities extends (string | EntityClass<AnyEntity> | EntitySchema)[] = (
@@ -22,6 +23,7 @@ export type MongoOptions<
   )[],
 > = Partial<Options<MongoDriver, EM, Entities>>;
 
+/** Creates a type-safe configuration object for the MongoDB driver. */
 export function defineMongoConfig<
   EM extends MongoEntityManager = MongoEntityManager,
   Entities extends (string | EntityClass<AnyEntity> | EntitySchema)[] = (

--- a/packages/mongodb/src/MongoPlatform.ts
+++ b/packages/mongodb/src/MongoPlatform.ts
@@ -23,6 +23,7 @@ import { MongoExceptionConverter } from './MongoExceptionConverter.js';
 import { MongoEntityRepository } from './MongoEntityRepository.js';
 import { MongoSchemaGenerator } from './MongoSchemaGenerator.js';
 
+/** Platform implementation for MongoDB. */
 export class MongoPlatform extends Platform {
   protected override readonly exceptionConverter: MongoExceptionConverter = new MongoExceptionConverter();
 

--- a/packages/mongodb/src/MongoSchemaGenerator.ts
+++ b/packages/mongodb/src/MongoSchemaGenerator.ts
@@ -13,6 +13,7 @@ import { AbstractSchemaGenerator } from '@mikro-orm/core/schema';
 import type { MongoDriver } from './MongoDriver.js';
 import type { MongoEntityManager } from './MongoEntityManager.js';
 
+/** Schema generator for MongoDB that manages collections and indexes. */
 export class MongoSchemaGenerator extends AbstractSchemaGenerator<MongoDriver> {
   static register(orm: MikroORM): void {
     orm.config.registerExtension(
@@ -301,6 +302,7 @@ export interface MongoCreateSchemaOptions extends CreateSchemaOptions {
   ensureIndexes?: boolean;
 }
 
+/** Options for the `ensureIndexes()` method of `MongoSchemaGenerator`. */
 export interface EnsureIndexesOptions {
   ensureCollections?: boolean;
   retry?: boolean | string[];

--- a/packages/mssql/src/MsSqlConnection.ts
+++ b/packages/mssql/src/MsSqlConnection.ts
@@ -4,6 +4,7 @@ import type { ConnectionConfiguration } from 'tedious';
 import * as Tedious from 'tedious';
 import * as Tarn from 'tarn';
 
+/** Microsoft SQL Server database connection using the `tedious` driver. */
 export class MsSqlConnection extends AbstractSqlConnection {
   override createKyselyDialect(overrides: ConnectionConfiguration): MssqlDialect {
     const options = this.mapOptions(overrides);

--- a/packages/mssql/src/MsSqlDriver.ts
+++ b/packages/mssql/src/MsSqlDriver.ts
@@ -21,6 +21,7 @@ import { MsSqlPlatform } from './MsSqlPlatform.js';
 import { MsSqlQueryBuilder } from './MsSqlQueryBuilder.js';
 import { MsSqlMikroORM } from './MsSqlMikroORM.js';
 
+/** Database driver for Microsoft SQL Server. */
 export class MsSqlDriver extends AbstractSqlDriver<MsSqlConnection> {
   constructor(config: Configuration) {
     super(config, new MsSqlPlatform(), MsSqlConnection, ['kysely', 'tedious']);

--- a/packages/mssql/src/MsSqlExceptionConverter.ts
+++ b/packages/mssql/src/MsSqlExceptionConverter.ts
@@ -11,6 +11,7 @@ import {
   type DriverException,
 } from '@mikro-orm/core';
 
+/** Converts MSSQL native errors into typed MikroORM driver exceptions. */
 export class MsSqlExceptionConverter extends ExceptionConverter {
   /**
    * @see https://docs.microsoft.com/en-us/sql/relational-databases/errors-events/mssqlserver-511-database-engine-error?view=sql-server-ver15

--- a/packages/mssql/src/MsSqlMikroORM.ts
+++ b/packages/mssql/src/MsSqlMikroORM.ts
@@ -12,6 +12,7 @@ import {
 import type { SqlEntityManager } from '@mikro-orm/sql';
 import { MsSqlDriver } from './MsSqlDriver.js';
 
+/** Configuration options for the MSSQL driver. */
 export type MsSqlOptions<
   EM extends SqlEntityManager<MsSqlDriver> = SqlEntityManager<MsSqlDriver>,
   Entities extends (string | EntityClass<AnyEntity> | EntitySchema)[] = (
@@ -21,6 +22,7 @@ export type MsSqlOptions<
   )[],
 > = Partial<Options<MsSqlDriver, EM, Entities>>;
 
+/** Creates a type-safe configuration object for the MSSQL driver. */
 export function defineMsSqlConfig<
   EM extends SqlEntityManager<MsSqlDriver> = SqlEntityManager<MsSqlDriver>,
   Entities extends (string | EntityClass<AnyEntity> | EntitySchema)[] = (

--- a/packages/mssql/src/MsSqlPlatform.ts
+++ b/packages/mssql/src/MsSqlPlatform.ts
@@ -25,6 +25,7 @@ import { UnicodeCharacterType } from './UnicodeCharacterType.js';
 import { UnicodeString, UnicodeStringType } from './UnicodeStringType.js';
 import type { MsSqlDriver } from './MsSqlDriver.js';
 
+/** Platform implementation for Microsoft SQL Server. */
 export class MsSqlPlatform extends AbstractSqlPlatform {
   protected override readonly schemaHelper: MsSqlSchemaHelper = new MsSqlSchemaHelper(this);
   protected override readonly exceptionConverter: MsSqlExceptionConverter = new MsSqlExceptionConverter();

--- a/packages/mssql/src/MsSqlQueryBuilder.ts
+++ b/packages/mssql/src/MsSqlQueryBuilder.ts
@@ -1,6 +1,7 @@
 import { type AnyEntity, QueryFlag, type RequiredEntityData, Utils } from '@mikro-orm/core';
 import { type InsertQueryBuilder, QueryBuilder } from '@mikro-orm/sql';
 
+/** Query builder with MSSQL-specific behavior such as identity insert handling. */
 export class MsSqlQueryBuilder<
   Entity extends object = AnyEntity,
   RootAlias extends string = never,

--- a/packages/mssql/src/MsSqlSchemaGenerator.ts
+++ b/packages/mssql/src/MsSqlSchemaGenerator.ts
@@ -1,6 +1,7 @@
 import { type ClearDatabaseOptions, type DropSchemaOptions, type MikroORM, SchemaGenerator } from '@mikro-orm/sql';
 import type { MsSqlDriver } from './MsSqlDriver.js';
 
+/** Schema generator with MSSQL-specific behavior for clearing and dropping schemas. */
 export class MsSqlSchemaGenerator extends SchemaGenerator {
   static override register(orm: MikroORM<MsSqlDriver>): void {
     orm.config.registerExtension('@mikro-orm/schema-generator', () => new MsSqlSchemaGenerator(orm.em));

--- a/packages/mssql/src/MsSqlSchemaHelper.ts
+++ b/packages/mssql/src/MsSqlSchemaHelper.ts
@@ -19,6 +19,7 @@ import {
 } from '@mikro-orm/sql';
 import { UnicodeStringType } from './UnicodeStringType.js';
 
+/** Schema introspection helper for Microsoft SQL Server. */
 export class MsSqlSchemaHelper extends SchemaHelper {
   static readonly DEFAULT_VALUES = {
     true: ['1'],

--- a/packages/mssql/src/UnicodeCharacterType.ts
+++ b/packages/mssql/src/UnicodeCharacterType.ts
@@ -2,6 +2,7 @@ import type { Platform, EntityProperty } from '@mikro-orm/core';
 
 import { UnicodeStringType } from './UnicodeStringType.js';
 
+/** Custom type for MSSQL nchar (fixed-length Unicode character) columns. */
 export class UnicodeCharacterType extends UnicodeStringType {
   override getColumnType(prop: EntityProperty, platform: Platform) {
     const length = prop.length === -1 ? 'max' : (prop.length ?? this.getDefaultLength(platform));

--- a/packages/mssql/src/UnicodeStringType.ts
+++ b/packages/mssql/src/UnicodeStringType.ts
@@ -1,5 +1,6 @@
 import { type Platform, Type } from '@mikro-orm/core';
 
+/** Wrapper for string values that should be stored as Unicode (nvarchar) in MSSQL. */
 export class UnicodeString {
   constructor(readonly value: string) {}
 
@@ -20,6 +21,7 @@ export class UnicodeString {
   }
 }
 
+/** Custom type for MSSQL nvarchar columns with automatic Unicode string wrapping. */
 export class UnicodeStringType extends Type<string | null, string | null> {
   override getColumnType(prop: { length?: number }, platform: Platform): string {
     const length = prop.length === -1 ? 'max' : (prop.length ?? this.getDefaultLength(platform));

--- a/packages/mysql/src/MySqlConnection.ts
+++ b/packages/mysql/src/MySqlConnection.ts
@@ -2,6 +2,7 @@ import { type ControlledTransaction, MysqlDialect } from 'kysely';
 import { createPool, type PoolOptions } from 'mysql2';
 import { type ConnectionConfig, Utils, AbstractSqlConnection, type TransactionEventBroadcaster } from '@mikro-orm/sql';
 
+/** MySQL database connection using the `mysql2` driver. */
 export class MySqlConnection extends AbstractSqlConnection {
   override createKyselyDialect(overrides: PoolOptions): MysqlDialect {
     const options = this.mapOptions(overrides);

--- a/packages/mysql/src/MySqlDriver.ts
+++ b/packages/mysql/src/MySqlDriver.ts
@@ -16,6 +16,7 @@ import { MySqlConnection } from './MySqlConnection.js';
 import { MySqlMikroORM } from './MySqlMikroORM.js';
 import { MySqlPlatform } from './MySqlPlatform.js';
 
+/** Database driver for MySQL. */
 export class MySqlDriver extends AbstractSqlDriver<MySqlConnection, MySqlPlatform> {
   private autoIncrementIncrement?: number;
 

--- a/packages/mysql/src/MySqlMikroORM.ts
+++ b/packages/mysql/src/MySqlMikroORM.ts
@@ -12,6 +12,7 @@ import {
 import type { SqlEntityManager } from '@mikro-orm/sql';
 import { MySqlDriver } from './MySqlDriver.js';
 
+/** Configuration options for the MySQL driver. */
 export type MySqlOptions<
   EM extends SqlEntityManager<MySqlDriver> = SqlEntityManager<MySqlDriver>,
   Entities extends (string | EntityClass<AnyEntity> | EntitySchema)[] = (
@@ -21,6 +22,7 @@ export type MySqlOptions<
   )[],
 > = Partial<Options<MySqlDriver, EM, Entities>>;
 
+/** Creates a type-safe configuration object for the MySQL driver. */
 export function defineMySqlConfig<
   EM extends SqlEntityManager<MySqlDriver> = SqlEntityManager<MySqlDriver>,
   Entities extends (string | EntityClass<AnyEntity> | EntitySchema)[] = (

--- a/packages/mysql/src/MySqlPlatform.ts
+++ b/packages/mysql/src/MySqlPlatform.ts
@@ -1,6 +1,7 @@
 import SqlString from 'sqlstring';
 import { BaseMySqlPlatform } from '@mikro-orm/sql';
 
+/** Platform implementation for MySQL. */
 export class MySqlPlatform extends BaseMySqlPlatform {
   override escape(value: any): string {
     return SqlString.escape(value, true, this.timezone);

--- a/packages/oracledb/src/OracleConnection.ts
+++ b/packages/oracledb/src/OracleConnection.ts
@@ -15,6 +15,7 @@ import {
 import { CompiledQuery } from 'kysely';
 import oracledb, { type ExecuteOptions, type PoolAttributes } from 'oracledb';
 
+/** Oracle database connection using the `oracledb` driver. */
 export class OracleConnection extends AbstractSqlConnection {
   override async createKyselyDialect(overrides: PoolAttributes): Promise<OracleDialect> {
     const options = this.mapOptions(overrides);

--- a/packages/oracledb/src/OracleDriver.ts
+++ b/packages/oracledb/src/OracleDriver.ts
@@ -24,6 +24,7 @@ import { OracleMikroORM } from './OracleMikroORM.js';
 import { OracleQueryBuilder } from './OracleQueryBuilder.js';
 import { OraclePlatform } from './OraclePlatform.js';
 
+/** Database driver for Oracle. */
 export class OracleDriver extends AbstractSqlDriver<OracleConnection, OraclePlatform> {
   constructor(config: Configuration) {
     super(config, new OraclePlatform(), OracleConnection, ['kysely', 'oracledb']);

--- a/packages/oracledb/src/OracleExceptionConverter.ts
+++ b/packages/oracledb/src/OracleExceptionConverter.ts
@@ -19,6 +19,7 @@ import {
 } from '@mikro-orm/core';
 
 /* v8 ignore start */
+/** Converts Oracle native errors into typed MikroORM driver exceptions. */
 export class OracleExceptionConverter extends ExceptionConverter {
   /**
    * @link https://docs.oracle.com/cd/B28359_01/server.111/b28278/toc.htm

--- a/packages/oracledb/src/OracleMikroORM.ts
+++ b/packages/oracledb/src/OracleMikroORM.ts
@@ -12,6 +12,7 @@ import {
 import type { SqlEntityManager } from '@mikro-orm/sql';
 import { OracleDriver } from './OracleDriver.js';
 
+/** Configuration options for the Oracle driver. */
 export type OracleOptions<
   EM extends SqlEntityManager<OracleDriver> = SqlEntityManager<OracleDriver>,
   Entities extends (string | EntityClass<AnyEntity> | EntitySchema)[] = (
@@ -21,6 +22,7 @@ export type OracleOptions<
   )[],
 > = Partial<Options<OracleDriver, EM, Entities>>;
 
+/** Creates a type-safe configuration object for the Oracle driver. */
 export function defineOracleConfig<
   EM extends SqlEntityManager<OracleDriver> = SqlEntityManager<OracleDriver>,
   Entities extends (string | EntityClass<AnyEntity> | EntitySchema)[] = (

--- a/packages/oracledb/src/OraclePlatform.ts
+++ b/packages/oracledb/src/OraclePlatform.ts
@@ -33,6 +33,7 @@ const ORACLE_TYPE_MAP: Record<string, unknown> = {
   out: oracledb.BIND_OUT,
 };
 
+/** Platform implementation for Oracle Database. */
 export class OraclePlatform extends AbstractSqlPlatform {
   protected override readonly schemaHelper: OracleSchemaHelper = new OracleSchemaHelper(this);
   protected override readonly exceptionConverter: OracleExceptionConverter = new OracleExceptionConverter();

--- a/packages/oracledb/src/OracleQueryBuilder.ts
+++ b/packages/oracledb/src/OracleQueryBuilder.ts
@@ -10,6 +10,7 @@ import {
 } from '@mikro-orm/core';
 import { type InsertQueryBuilder, type NativeQueryBuilder, type Field, QueryBuilder, QueryType } from '@mikro-orm/sql';
 
+/** Query builder with Oracle-specific behavior such as RETURNING clause handling and lock table conversion. */
 export class OracleQueryBuilder<
   Entity extends object = AnyEntity,
   RootAlias extends string = never,

--- a/packages/oracledb/src/OracleSchemaGenerator.ts
+++ b/packages/oracledb/src/OracleSchemaGenerator.ts
@@ -14,6 +14,7 @@ import {
 import type { OracleSchemaHelper } from './OracleSchemaHelper.js';
 import type { OracleConnection } from './OracleConnection.js';
 
+/** Schema generator with Oracle-specific behavior for multi-schema support and privilege management. */
 export class OracleSchemaGenerator extends SchemaGenerator {
   declare protected helper: OracleSchemaHelper;
   declare protected connection: OracleConnection;

--- a/packages/oracledb/src/OracleSchemaHelper.ts
+++ b/packages/oracledb/src/OracleSchemaHelper.ts
@@ -18,6 +18,7 @@ import {
   Utils,
 } from '@mikro-orm/sql';
 
+/** Schema introspection helper for Oracle Database. */
 export class OracleSchemaHelper extends SchemaHelper {
   static readonly DEFAULT_VALUES: Record<string, string[]> = {
     true: ['1'],

--- a/packages/postgresql/src/PostgreSqlConnection.ts
+++ b/packages/postgresql/src/PostgreSqlConnection.ts
@@ -4,6 +4,7 @@ import { PostgresDialect } from 'kysely';
 import array from 'postgres-array';
 import { AbstractSqlConnection, Utils } from '@mikro-orm/sql';
 
+/** PostgreSQL database connection using the `pg` driver. */
 export class PostgreSqlConnection extends AbstractSqlConnection {
   override createKyselyDialect(overrides: PoolConfig): PostgresDialect {
     const options = this.mapOptions(overrides);

--- a/packages/postgresql/src/PostgreSqlDriver.ts
+++ b/packages/postgresql/src/PostgreSqlDriver.ts
@@ -5,6 +5,7 @@ import { PostgreSqlPlatform } from './PostgreSqlPlatform.js';
 import { PostgreSqlMikroORM } from './PostgreSqlMikroORM.js';
 import { PostgreSqlEntityManager } from './PostgreSqlEntityManager.js';
 
+/** Database driver for PostgreSQL. */
 export class PostgreSqlDriver extends AbstractSqlDriver<PostgreSqlConnection> {
   override [EntityManagerType]!: PostgreSqlEntityManager<this>;
 

--- a/packages/postgresql/src/PostgreSqlMikroORM.ts
+++ b/packages/postgresql/src/PostgreSqlMikroORM.ts
@@ -12,6 +12,7 @@ import {
 import { PostgreSqlDriver } from './PostgreSqlDriver.js';
 import type { PostgreSqlEntityManager } from './PostgreSqlEntityManager.js';
 
+/** Configuration options for the PostgreSQL driver. */
 export type PostgreSqlOptions<
   EM extends PostgreSqlEntityManager = PostgreSqlEntityManager,
   Entities extends (string | EntityClass<AnyEntity> | EntitySchema)[] = (
@@ -21,6 +22,7 @@ export type PostgreSqlOptions<
   )[],
 > = Partial<Options<PostgreSqlDriver, EM, Entities>>;
 
+/** Creates a type-safe configuration object for the PostgreSQL driver. */
 export function definePostgreSqlConfig<
   EM extends PostgreSqlEntityManager = PostgreSqlEntityManager,
   Entities extends (string | EntityClass<AnyEntity> | EntitySchema)[] = (

--- a/packages/postgresql/src/PostgreSqlPlatform.ts
+++ b/packages/postgresql/src/PostgreSqlPlatform.ts
@@ -4,6 +4,7 @@ import parseDate from 'postgres-date';
 import PostgresInterval, { type IPostgresInterval } from 'postgres-interval';
 import { BasePostgreSqlPlatform, Utils } from '@mikro-orm/sql';
 
+/** Platform implementation for PostgreSQL. */
 export class PostgreSqlPlatform extends BasePostgreSqlPlatform {
   override convertIntervalToJSValue(value: string): unknown {
     return PostgresInterval(value);

--- a/packages/reflection/src/TsMorphMetadataProvider.ts
+++ b/packages/reflection/src/TsMorphMetadataProvider.ts
@@ -23,6 +23,7 @@ import {
 } from '@mikro-orm/core';
 import { fs } from '@mikro-orm/core/fs-utils';
 
+/** Metadata provider that uses ts-morph to infer property types from TypeScript source files or declaration files. */
 export class TsMorphMetadataProvider extends MetadataProvider {
   private project!: Project;
   private sources!: SourceFile[];

--- a/packages/seeder/src/Factory.ts
+++ b/packages/seeder/src/Factory.ts
@@ -1,5 +1,6 @@
 import type { RequiredEntityData, EntityData, EntityManager, Constructor } from '@mikro-orm/core';
 
+/** Base class for entity factories used in seeding. Provides methods to create and persist test entities. */
 export abstract class Factory<TEntity extends object, TInput = EntityData<TEntity>> {
   abstract readonly model: Constructor<TEntity>;
   private eachFunction?: (entity: TEntity, index: number) => void;

--- a/packages/seeder/src/SeedManager.ts
+++ b/packages/seeder/src/SeedManager.ts
@@ -9,6 +9,7 @@ import {
 } from '@mikro-orm/core';
 import type { Seeder } from './Seeder.js';
 
+/** Manages discovery and execution of database seeders. */
 export class SeedManager implements ISeedManager {
   readonly #config: Configuration;
   readonly #options: SeederOptions;

--- a/packages/seeder/src/Seeder.ts
+++ b/packages/seeder/src/Seeder.ts
@@ -1,5 +1,6 @@
 import type { Dictionary, EntityManager } from '@mikro-orm/core';
 
+/** Base class for database seeders. Extend this class and implement `run()` to populate the database with data. */
 export abstract class Seeder<T extends Dictionary = Dictionary> {
   abstract run(em: EntityManager, context?: T): void | Promise<void>;
 

--- a/packages/sql/src/AbstractSqlConnection.ts
+++ b/packages/sql/src/AbstractSqlConnection.ts
@@ -18,12 +18,15 @@ import {
 import type { AbstractSqlPlatform } from './AbstractSqlPlatform.js';
 import { NativeQueryBuilder } from './query/NativeQueryBuilder.js';
 
+/** Base class for SQL database connections, built on top of Kysely. */
 export abstract class AbstractSqlConnection extends Connection {
   declare protected platform: AbstractSqlPlatform;
   #client?: Kysely<any>;
 
+  /** Creates a Kysely dialect instance with driver-specific configuration. */
   abstract createKyselyDialect(overrides: Dictionary): MaybePromise<Dialect>;
 
+  /** Establishes the database connection and runs the onConnect hook. */
   async connect(options?: { skipOnConnect?: boolean }): Promise<void> {
     await this.initClient();
     this.connected = true;
@@ -33,6 +36,7 @@ export abstract class AbstractSqlConnection extends Connection {
     }
   }
 
+  /** Initializes the Kysely client from driver options or a user-provided Kysely instance. */
   createKysely(): MaybePromise<void> {
     let driverOptions = this.options.driverOptions ?? this.config.get('driverOptions');
 
@@ -93,6 +97,7 @@ export abstract class AbstractSqlConnection extends Connection {
     }
   }
 
+  /** Returns the underlying Kysely client, creating it synchronously if needed. */
   getClient<T = any>(): Kysely<T> {
     if (!this.#client) {
       const maybePromise = this.createKysely();
@@ -108,12 +113,14 @@ export abstract class AbstractSqlConnection extends Connection {
     return this.#client!;
   }
 
+  /** Ensures the Kysely client is initialized, creating it asynchronously if needed. */
   async initClient(): Promise<void> {
     if (!this.#client) {
       await this.createKysely();
     }
   }
 
+  /** Executes a callback within a transaction, committing on success and rolling back on error. */
   override async transactional<T>(
     cb: (trx: Transaction<ControlledTransaction<any, any>>) => Promise<T>,
     options: {
@@ -137,6 +144,7 @@ export abstract class AbstractSqlConnection extends Connection {
     }
   }
 
+  /** Begins a new transaction or creates a savepoint if a transaction context already exists. */
   override async begin(
     options: {
       isolationLevel?: IsolationLevel;
@@ -192,6 +200,7 @@ export abstract class AbstractSqlConnection extends Connection {
     return trx;
   }
 
+  /** Commits the transaction or releases the savepoint. */
   override async commit(
     ctx: ControlledTransaction<any, any>,
     eventBroadcaster?: TransactionEventBroadcaster,
@@ -214,6 +223,7 @@ export abstract class AbstractSqlConnection extends Connection {
     await eventBroadcaster?.dispatchEvent(EventType.afterTransactionCommit, ctx);
   }
 
+  /** Rolls back the transaction or rolls back to the savepoint. */
   override async rollback(
     ctx: ControlledTransaction<any, any>,
     eventBroadcaster?: TransactionEventBroadcaster,
@@ -250,6 +260,7 @@ export abstract class AbstractSqlConnection extends Connection {
     return { query, params, formatted };
   }
 
+  /** Executes a SQL query and returns the result based on the method: `'all'` for rows, `'get'` for single row, `'run'` for affected count. */
   async execute<T extends QueryResult | EntityData<AnyEntity> | EntityData<AnyEntity>[] = EntityData<AnyEntity>[]>(
     query: string | NativeQueryBuilder | RawQueryFragment,
     params: readonly unknown[] = [],
@@ -272,6 +283,7 @@ export abstract class AbstractSqlConnection extends Connection {
     );
   }
 
+  /** Executes a SQL query and returns an async iterable that yields results row by row. */
   async *stream<T extends EntityData<AnyEntity>>(
     query: string | NativeQueryBuilder | RawQueryFragment,
     params: readonly unknown[] = [],

--- a/packages/sql/src/AbstractSqlDriver.ts
+++ b/packages/sql/src/AbstractSqlDriver.ts
@@ -69,6 +69,7 @@ import { SqlEntityManager } from './SqlEntityManager.js';
 import type { InternalField } from './typings.js';
 import { PivotCollectionPersister } from './PivotCollectionPersister.js';
 
+/** Base class for SQL database drivers, implementing find/insert/update/delete using QueryBuilder. */
 export abstract class AbstractSqlDriver<
   Connection extends AbstractSqlConnection = AbstractSqlConnection,
   Platform extends AbstractSqlPlatform = AbstractSqlPlatform,

--- a/packages/sql/src/AbstractSqlPlatform.ts
+++ b/packages/sql/src/AbstractSqlPlatform.ts
@@ -18,6 +18,7 @@ import { type SchemaHelper } from './schema/SchemaHelper.js';
 import type { IndexDef } from './typings.js';
 import { NativeQueryBuilder } from './query/NativeQueryBuilder.js';
 
+/** Base class for SQL database platforms, providing SQL generation and quoting utilities. */
 export abstract class AbstractSqlPlatform extends Platform {
   static readonly #JSON_PROPERTY_NAME_RE = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
 

--- a/packages/sql/src/SqlEntityManager.ts
+++ b/packages/sql/src/SqlEntityManager.ts
@@ -20,7 +20,9 @@ import type { Kysely } from 'kysely';
 import type { InferClassEntityDB, InferKyselyDB } from './typings.js';
 import { MikroKyselyPlugin, type MikroKyselyPluginOptions } from './plugin/index.js';
 
+/** Options for `SqlEntityManager.getKysely()`. */
 export interface GetKyselyOptions extends MikroKyselyPluginOptions {
+  /** Connection type to use (`'read'` or `'write'`). */
   type?: ConnectionType;
 }
 
@@ -84,6 +86,7 @@ export class SqlEntityManager<Driver extends AbstractSqlDriver = AbstractSqlDriv
     return kysely;
   }
 
+  /** Executes a raw SQL query, using the current transaction context if available. */
   async execute<T extends QueryResult | EntityData<AnyEntity> | EntityData<AnyEntity>[] = EntityData<AnyEntity>[]>(
     query: string | NativeQueryBuilder | RawQueryFragment,
     params: any[] = [],

--- a/packages/sql/src/SqlEntityRepository.ts
+++ b/packages/sql/src/SqlEntityRepository.ts
@@ -2,6 +2,7 @@ import { EntityRepository, type EntityName } from '@mikro-orm/core';
 import type { SqlEntityManager } from './SqlEntityManager.js';
 import type { QueryBuilder } from './query/QueryBuilder.js';
 
+/** SQL-specific entity repository with QueryBuilder support. */
 export class SqlEntityRepository<Entity extends object> extends EntityRepository<Entity> {
   constructor(
     protected override readonly em: SqlEntityManager,

--- a/packages/sql/src/plugin/index.ts
+++ b/packages/sql/src/plugin/index.ts
@@ -22,6 +22,7 @@ interface QueryTransformCache {
   entityMap: Map<string, EntityMetadata>;
 }
 
+/** Configuration options for the MikroKyselyPlugin. */
 export interface MikroKyselyPluginOptions {
   /**
    * Use database table names ('table') or entity names ('entity') in queries.
@@ -55,6 +56,7 @@ export interface MikroKyselyPluginOptions {
   convertValues?: boolean;
 }
 
+/** Kysely plugin that transforms queries and results to use MikroORM entity/property naming conventions. */
 export class MikroKyselyPlugin implements KyselyPlugin {
   static #queryNodeCache = new WeakMap<any, QueryTransformCache>();
 

--- a/packages/sql/src/query/NativeQueryBuilder.ts
+++ b/packages/sql/src/query/NativeQueryBuilder.ts
@@ -10,7 +10,9 @@ import {
 import { QueryType } from './enums.js';
 import type { AbstractSqlPlatform } from '../AbstractSqlPlatform.js';
 
+/** Options for Common Table Expression (CTE) definitions. */
 export interface CteOptions {
+  /** Column names for the CTE. */
   columns?: string[];
   /** PostgreSQL: MATERIALIZED / NOT MATERIALIZED */
   materialized?: boolean;
@@ -48,6 +50,7 @@ interface Options {
   ctes?: CteClause[];
 }
 
+/** Options for specifying the target table in FROM/INTO clauses. */
 export interface TableOptions {
   schema?: string;
   indexHint?: string;

--- a/packages/sql/src/query/enums.ts
+++ b/packages/sql/src/query/enums.ts
@@ -1,3 +1,4 @@
+/** Type of SQL query to be generated. */
 export enum QueryType {
   TRUNCATE = 'TRUNCATE',
   SELECT = 'SELECT',
@@ -11,6 +12,7 @@ export enum QueryType {
 /** Operators that apply to the embedded array column itself, not to individual elements. */
 export const EMBEDDABLE_ARRAY_OPS = ['$contains', '$contained', '$overlap'];
 
+/** Type of SQL JOIN clause. */
 export enum JoinType {
   leftJoin = 'left join',
   innerJoin = 'inner join',

--- a/packages/sql/src/schema/SchemaHelper.ts
+++ b/packages/sql/src/schema/SchemaHelper.ts
@@ -5,9 +5,11 @@ import type { CheckDef, Column, ForeignKey, IndexDef, Table, TableDifference } f
 import type { DatabaseSchema } from './DatabaseSchema.js';
 import type { DatabaseTable } from './DatabaseTable.js';
 
+/** Base class for database-specific schema helpers. Provides SQL generation for DDL operations. */
 export abstract class SchemaHelper {
   constructor(protected readonly platform: AbstractSqlPlatform) {}
 
+  /** Returns SQL to prepend to schema migration scripts (e.g., disabling FK checks). */
   getSchemaBeginning(_charset: string, disableForeignKeys?: boolean): string {
     if (disableForeignKeys) {
       return `${this.disableForeignKeysSQL()}\n`;
@@ -16,14 +18,17 @@ export abstract class SchemaHelper {
     return '';
   }
 
+  /** Returns SQL to disable foreign key checks. */
   disableForeignKeysSQL(): string {
     return '';
   }
 
+  /** Returns SQL to re-enable foreign key checks. */
   enableForeignKeysSQL(): string {
     return '';
   }
 
+  /** Returns SQL to append to schema migration scripts (e.g., re-enabling FK checks). */
   getSchemaEnd(disableForeignKeys?: boolean): string {
     if (disableForeignKeys) {
       return `${this.enableForeignKeysSQL()}\n`;
@@ -90,6 +95,7 @@ export abstract class SchemaHelper {
     throw new Error('Not supported by given driver');
   }
 
+  /** Loads table metadata (columns, indexes, foreign keys) from the database information schema. */
   abstract loadInformationSchema(
     schema: DatabaseSchema,
     connection: AbstractSqlConnection,
@@ -97,10 +103,12 @@ export abstract class SchemaHelper {
     schemas?: string[],
   ): Promise<void>;
 
+  /** Returns the SQL query to list all tables in the database. */
   getListTablesSQL(): string {
     throw new Error('Not supported by given driver');
   }
 
+  /** Retrieves all tables from the database. */
   async getAllTables(connection: AbstractSqlConnection, schemas?: string[]): Promise<Table[]> {
     return connection.execute<Table[]>(this.getListTablesSQL());
   }
@@ -113,6 +121,7 @@ export abstract class SchemaHelper {
     throw new Error('Not supported by given driver');
   }
 
+  /** Returns SQL to rename a column in a table. */
   getRenameColumnSQL(tableName: string, oldColumnName: string, to: Column, schemaName?: string): string {
     tableName = this.quote(tableName);
     oldColumnName = this.quote(oldColumnName);
@@ -124,6 +133,7 @@ export abstract class SchemaHelper {
     return `alter table ${tableReference} rename column ${oldColumnName} to ${columnName}`;
   }
 
+  /** Returns SQL to create an index on a table. */
   getCreateIndexSQL(tableName: string, index: IndexDef): string {
     /* v8 ignore next */
     if (index.expression) {
@@ -202,6 +212,7 @@ export abstract class SchemaHelper {
     return index.columnNames.map(c => this.quote(c)).join(', ');
   }
 
+  /** Returns SQL to drop an index. */
   getDropIndexSQL(tableName: string, index: IndexDef): string {
     return `drop index ${this.quote(index.keyName)}`;
   }
@@ -213,6 +224,7 @@ export abstract class SchemaHelper {
     ];
   }
 
+  /** Returns SQL statements to apply a table difference (add/drop/alter columns, indexes, foreign keys). */
   alterTable(diff: TableDifference, safe?: boolean): string[] {
     const ret: string[] = [];
     const [schemaName, tableName] = this.splitTableName(diff.name);
@@ -355,6 +367,7 @@ export abstract class SchemaHelper {
     return ret;
   }
 
+  /** Returns SQL to add columns to an existing table. */
   getAddColumnsSQL(table: DatabaseTable, columns: Column[]): string[] {
     const adds = columns
       .map(column => {
@@ -633,6 +646,7 @@ export abstract class SchemaHelper {
     }
   }
 
+  /** Returns SQL statements to create a table with all its columns, primary key, indexes, and checks. */
   createTable(table: DatabaseTable, alter?: boolean): string[] {
     let sql = `create table ${table.getQuotedName()} (`;
 
@@ -685,6 +699,7 @@ export abstract class SchemaHelper {
     return `alter table ${table.getQuotedName()} comment = ${this.platform.quoteValue(comment ?? '')}`;
   }
 
+  /** Returns SQL to create a foreign key constraint on a table. */
   createForeignKey(table: DatabaseTable, foreignKey: ForeignKey, alterTable = true, inline = false): string {
     if (!this.options.createForeignKeyConstraints) {
       return '';
@@ -829,6 +844,7 @@ export abstract class SchemaHelper {
     return `alter table ${this.quote(table)} drop constraint ${this.quote(name)}`;
   }
 
+  /** Returns SQL to drop a table if it exists. */
   dropTableIfExists(name: string, schema?: string): string {
     let sql = `drop table if exists ${this.quote(this.getTableName(name, schema))}`;
 

--- a/packages/sql/src/schema/SqlSchemaGenerator.ts
+++ b/packages/sql/src/schema/SqlSchemaGenerator.ts
@@ -22,6 +22,7 @@ import { SchemaComparator } from './SchemaComparator.js';
 import type { SchemaHelper } from './SchemaHelper.js';
 import type { SqlEntityManager } from '../SqlEntityManager.js';
 
+/** Generates and manages SQL database schemas based on entity metadata. Supports create, update, and drop operations. */
 export class SqlSchemaGenerator extends AbstractSchemaGenerator<AbstractSqlDriver> implements ISchemaGenerator {
   protected readonly helper: SchemaHelper = this.platform.getSchemaHelper()!;
   protected readonly options: NonNullable<Options['schemaGenerator']> = this.config.get('schemaGenerator');

--- a/packages/sqlite/src/SqliteConnection.ts
+++ b/packages/sqlite/src/SqliteConnection.ts
@@ -2,6 +2,7 @@ import { BaseSqliteConnection, type Dictionary } from '@mikro-orm/sql';
 import { type Dialect, SqliteDialect } from 'kysely';
 import Database from 'better-sqlite3';
 
+/** SQLite database connection using the `better-sqlite3` driver. */
 export class SqliteConnection extends BaseSqliteConnection {
   private database!: Database.Database;
 

--- a/packages/sqlite/src/SqliteDriver.ts
+++ b/packages/sqlite/src/SqliteDriver.ts
@@ -3,6 +3,7 @@ import { AbstractSqlDriver, SqlitePlatform } from '@mikro-orm/sql';
 import { SqliteConnection } from './SqliteConnection.js';
 import { SqliteMikroORM } from './SqliteMikroORM.js';
 
+/** Database driver for SQLite using better-sqlite3. */
 export class SqliteDriver extends AbstractSqlDriver<SqliteConnection> {
   constructor(config: Configuration) {
     super(config, new SqlitePlatform(), SqliteConnection, ['kysely', 'better-sqlite3']);

--- a/packages/sqlite/src/SqliteMikroORM.ts
+++ b/packages/sqlite/src/SqliteMikroORM.ts
@@ -12,6 +12,7 @@ import {
 import type { SqlEntityManager } from '@mikro-orm/sql';
 import { SqliteDriver } from './SqliteDriver.js';
 
+/** Configuration options for the SQLite driver. */
 export type SqliteOptions<
   EM extends SqlEntityManager<SqliteDriver> = SqlEntityManager<SqliteDriver>,
   Entities extends (string | EntityClass<AnyEntity> | EntitySchema)[] = (
@@ -21,6 +22,7 @@ export type SqliteOptions<
   )[],
 > = Partial<Options<SqliteDriver, EM, Entities>>;
 
+/** Creates a type-safe configuration object for the SQLite driver. */
 export function defineSqliteConfig<
   EM extends SqlEntityManager<SqliteDriver> = SqlEntityManager<SqliteDriver>,
   Entities extends (string | EntityClass<AnyEntity> | EntitySchema)[] = (


### PR DESCRIPTION
## Summary
- Add JSDoc comments to public APIs, enums, type aliases, interfaces, and key methods across all 19 packages
- Mark truly internal classes with `@internal` tags (`ChangeSetComputer`, `ChangeSetPersister`, `IdentityMap`, `EntityFactory`, `FactoryOptions`, `ObjectHydrator`, `EntityComparator`, `WrappedEntity`)
- Remove tautological comments (e.g. `isDirty`, `setDirty`, `length`, `clear`)
- Fix duplicate JSDoc on `ChangeSetPersister.mapReturnedValues`
- Preserve tech-debt TODO on `WrappedEntity.getPrimaryKeys`
- User-facing types exposed via events (e.g. `ChangeSet`) and extension points (e.g. `Hydrator`, `UnitOfWork`) are intentionally **not** marked `@internal`

## Test plan
- [ ] `yarn build` passes (additive JSDoc only, no behavioral changes)
- [ ] `yarn lint` passes
- [ ] Verify IDE hover shows new docs on public APIs

🤖 Generated with [Claude Code](https://claude.com/claude-code)