### PR TITLE
fix(decorators): polyfill metadata symbol if not available

### DIFF
--- a/packages/decorators/src/es/index.ts
+++ b/packages/decorators/src/es/index.ts
@@ -1,17 +1,7 @@
 // Polyfill Symbol.metadata for runtimes that do not support it natively
-// (e.g. current Node.js).
-//
-// TypeScript's ES-decorator output uses `Symbol.metadata` as the key to share
-// one metadata object across all decorators in a class:
-//
-//   const _metadata = typeof Symbol === "function" && Symbol.metadata
-//     ? Object.create(null)
-//     : void 0;
-//
-// When the symbol is absent, the runtime sets `_metadata = void 0` and every
-// decorator context receives `metadata: undefined`, making it impossible to
-// propagate field-level metadata to the class decorator. Installing the symbol
-// first ensures `_metadata` is always a proper object.
+// (e.g. current Node.js). Without it, TypeScript's ES-decorator output sets
+// `_metadata = void 0` and decorator contexts receive `metadata: undefined`,
+// making it impossible to propagate field-level metadata to the class decorator.
 /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
 (Symbol as any).metadata ??= Symbol('Symbol.metadata');
 

--- a/tests/features/decorators/es/GH7312.test.ts
+++ b/tests/features/decorators/es/GH7312.test.ts
@@ -1,0 +1,30 @@
+import { MikroORM } from '@mikro-orm/sqlite';
+import { Entity, PrimaryKey, Property } from '@mikro-orm/decorators/es';
+
+@Entity()
+class Bar7312 {
+  @PrimaryKey({ type: 'integer' })
+  id!: number;
+
+  @Property({ type: 'string' })
+  name!: string;
+}
+
+test('GH #7312 - Symbol.metadata polyfill is present', () => {
+  expect((Symbol as any).metadata).toBeDefined();
+  expect(typeof (Symbol as any).metadata).toBe('symbol');
+});
+
+test('GH #7312 - ES decorators propagate metadata to class decorator', async () => {
+  const orm = await MikroORM.init({
+    dbName: ':memory:',
+    entities: [Bar7312],
+  });
+
+  const meta = orm.getMetadata().get(Bar7312);
+  expect(meta.properties.id).toBeDefined();
+  expect(meta.properties.name).toBeDefined();
+  expect(meta.class).toBe(Bar7312);
+
+  await orm.close(true);
+});


### PR DESCRIPTION
Polyfill `Symbol.metadata` for runtimes that do not support it natively (e.g. current Node.js).

TypeScript's ES-decorator output uses `Symbol.metadata` as the key to share one metadata object across all decorators in a class:

```js
const _metadata = typeof Symbol === "function" && Symbol.metadata
  ? Object.create(null)
  : void 0;
```

When the symbol is absent, the runtime sets `_metadata = void 0` and every decorator context receives `metadata: undefined`, making it impossible to propagate field-level metadata to the class decorator. Installing the symbol first ensures `_metadata` is always a proper object.