### PR TITLE
fix(schema): handle SELECT * expansion in view schema diffing

### DIFF
--- a/packages/sql/src/schema/SchemaComparator.ts
+++ b/packages/sql/src/schema/SchemaComparator.ts
@@ -173,7 +173,7 @@ export class SchemaComparator {
       } else {
         const fromView = fromSchema.getView(toView.name) ?? fromSchema.getView(viewName);
 
-        if (fromView && this.diffExpression(fromView.definition, toView.definition)) {
+        if (fromView && this.diffViewExpression(fromView.definition, toView.definition)) {
           diff.changedViews[viewName] = { from: fromView, to: toView };
           this.log(`view ${viewName} changed`);
         }
@@ -848,6 +848,31 @@ export class SchemaComparator {
       );
     };
     return simplify(expr1) !== simplify(expr2);
+  }
+
+  /**
+   * Compares two view expressions, with special handling for SELECT *.
+   * Databases like PostgreSQL and MySQL expand `SELECT *` to explicit column names
+   * in their stored view definitions, which makes diffExpression always detect changes.
+   * When SELECT * is present, we strip the first SELECT...FROM column list from both
+   * sides and compare only the structural parts (FROM clause onwards).
+   * Note: this means changes *within* subqueries in the SELECT list of a SELECT * view
+   * may not be detected — an acceptable tradeoff since SELECT * views are inherently
+   * column-list-agnostic.
+   * @see https://github.com/mikro-orm/mikro-orm/issues/7308
+   */
+  private diffViewExpression(fromDef: string, toDef: string): boolean {
+    if (!this.diffExpression(fromDef, toDef)) {
+      return false;
+    }
+
+    // If either expression uses SELECT *, the diff may be due to * expansion
+    if (/\bselect\s+\*/i.test(fromDef) || /\bselect\s+\*/i.test(toDef)) {
+      const stripColumns = (s: string) => s.replace(/\bselect\b[\s\S]*?\bfrom\b/i, 'select from');
+      return this.diffExpression(stripColumns(fromDef), stripColumns(toDef));
+    }
+
+    return true;
   }
 
   parseJsonDefault(defaultValue?: string | null): Dictionary | string | null {

--- a/tests/features/view-entities/__snapshots__/view-entities.postgres.test.ts.snap
+++ b/tests/features/view-entities/__snapshots__/view-entities.postgres.test.ts.snap
@@ -177,6 +177,17 @@ alter table "configuration2" add constraint "configuration2_test_id_foreign" for
 alter table "test2_bars" add constraint "test2_bars_test2_id_foreign" foreign key ("test2_id") references "test2" ("id") on update cascade on delete cascade;
 alter table "test2_bars" add constraint "test2_bars_foo_bar2_id_foreign" foreign key ("foo_bar2_id") references "foo_bar2" ("id") on update cascade on delete cascade;
 
+create view "select_star_view" as 
+    SELECT
+    *
+    FROM author2;
+
+create view "multiline_author_stats_view" as 
+    SELECT
+    name, (select count(*)::int from book2 b where b.author_id = a.id) as book_count
+    FROM author2 a
+    GROUP BY a.id;
+
 create view "book_summary_view" as select min(b.title) as "title", min(a.name) as "author_name" from "book2" as "b" inner join "author2" as "a" on "b"."author_id" = "a"."id" group by "b"."uuid_pk";
 
 create view "author_stats_view" as select min(name) as name, (select count(*)::int from book2 b where b.author_id = a.id) as book_count from author2 a group by a.id;

--- a/tests/features/view-entities/view-entities.postgres.test.ts
+++ b/tests/features/view-entities/view-entities.postgres.test.ts
@@ -51,6 +51,39 @@ const BookSummary = defineEntity({
   },
 });
 
+// GH #7308 - multiline view expression (without SELECT *)
+const multilineViewSQL = `
+    SELECT
+    name, (select count(*)::int from book2 b where b.author_id = a.id) as book_count
+    FROM author2 a
+    GROUP BY a.id`;
+
+const MultilineAuthorStats = defineEntity({
+  name: 'MultilineAuthorStats',
+  tableName: 'multiline_author_stats_view',
+  view: true,
+  expression: multilineViewSQL,
+  properties: {
+    name: p.string().primary(),
+    bookCount: p.integer(),
+  },
+});
+
+// GH #7308 - view with SELECT * (PostgreSQL expands * to explicit column names)
+const SelectStarView = defineEntity({
+  name: 'SelectStarView',
+  tableName: 'select_star_view',
+  view: true,
+  expression: `
+    SELECT
+    *
+    FROM author2`,
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+  },
+});
+
 // View depending on another view (for testing dependency ordering)
 // This view references author_stats_view
 const ProlificAuthors = defineEntity({
@@ -184,6 +217,8 @@ describe('View entities (postgres)', () => {
         Address2,
         Configuration2,
         AuthorStats,
+        MultilineAuthorStats,
+        SelectStarView,
         BookSummary,
         ProlificAuthors,
       ],
@@ -233,6 +268,7 @@ describe('View entities (postgres)', () => {
     expect(summaries.map(s => s.title).sort()).toEqual(['Book 1', 'Book 2']);
   });
 
+  // GH #7308 - multiline and SELECT * views should not cause perpetual schema changes
   test('updateSchema detects no changes for unchanged views', async () => {
     const sql = await orm.schema.getUpdateSchemaSQL();
     expect(sql).toBe('');
@@ -301,6 +337,46 @@ describe('View entities (postgres)', () => {
     try {
       const sql = await orm2.schema.getUpdateSchemaSQL();
       expect(typeof sql).toBe('string');
+    } finally {
+      await orm2.close();
+    }
+  });
+
+  // GH #7308 - actual changes to SELECT * views should still be detected
+  test('updateSchema detects changes to SELECT * views', async () => {
+    const ModifiedStarView = defineEntity({
+      name: 'ModifiedStarView',
+      tableName: 'select_star_view',
+      view: true,
+      expression: `SELECT * FROM author2 WHERE age > 18`,
+      properties: {
+        id: p.integer().primary(),
+        name: p.string(),
+      },
+    });
+
+    const orm2 = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      entities: [
+        Author2,
+        Book2,
+        BookTag2,
+        Publisher2,
+        Test2,
+        FooBar2,
+        FooBaz2,
+        AuthorStats,
+        MultilineAuthorStats,
+        ModifiedStarView,
+        BookSummary,
+        ProlificAuthors,
+      ],
+      dbName: 'mikro_orm_test_views',
+    });
+
+    try {
+      const sql = await orm2.schema.getUpdateSchemaSQL();
+      expect(sql).toContain('select_star_view');
     } finally {
       await orm2.close();
     }


### PR DESCRIPTION
## Summary

- Databases like PostgreSQL and MySQL expand `SELECT *` to explicit column names in stored view definitions (`information_schema.views`). The existing `diffExpression` simplify function strips `*`, making `selectfromtable` vs `selectcol1,col2fromtable` irreconcilable — causing `migration:check` to perpetually detect changes and `migration:create` to regenerate the same view every time.
- Adds `diffViewExpression()` in `SchemaComparator` that falls back to structure-only comparison (stripping the first `SELECT...FROM` column list from both sides) when `SELECT *` is detected in either expression.
- Actual changes to `SELECT *` views (e.g. adding a `WHERE` clause) are still correctly detected.

Closes #7308

## Test plan

- [x] Added `SelectStarView` entity with multiline `SELECT *` expression
- [x] Added `MultilineAuthorStats` entity with multiline expression (without `*`)
- [x] Test verifying `getUpdateSchemaSQL()` returns empty for unchanged views including `SELECT *`
- [x] Test verifying changes to `SELECT *` views (adding `WHERE` clause) are still detected
- [x] All 75 view entity tests pass (5 files)
- [x] All 249 schema generator tests pass
- [x] Full test suite passes (5275 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)