### PR TITLE
feat(core): add `strictNullable()` property builder

### DIFF
--- a/packages/core/src/entity/defineEntity.ts
+++ b/packages/core/src/entity/defineEntity.ts
@@ -66,7 +66,7 @@ export type UniversalPropertyKeys =
   | keyof OneToOneOptions<any, any>
   | keyof ManyToManyOptions<any, any>;
 
-type BuilderExtraKeys = '~options' | '~type' | '$type';
+type BuilderExtraKeys = '~options' | '~type' | '$type' | 'strictNullable';
 type ExcludeKeys = 'entity' | 'items';
 type BuilderKeys = Exclude<UniversalPropertyKeys, ExcludeKeys> | BuilderExtraKeys;
 
@@ -98,6 +98,10 @@ export interface PropertyChain<Value, Options> {
 
   // Always-available methods (PropertyOptions keys)
   nullable(): PropertyChain<Value, Omit<Options, 'nullable'> & { nullable: true }>;
+  strictNullable(): PropertyChain<
+    Value,
+    Omit<Options, 'nullable' | 'strictNullable'> & { nullable: true; strictNullable: true }
+  >;
   ref(): PropertyChain<Value, Omit<Options, 'ref'> & { ref: true }>;
   primary(): PropertyChain<Value, Omit<Options, 'primary'> & { primary: true }>;
   hidden(): PropertyChain<Value, Omit<Options, 'hidden'> & { hidden: true }>;
@@ -505,6 +509,21 @@ export class UniversalPropertyOptionsBuilder<Value, Options, IncludeKeys extends
    */
   nullable(): Pick<
     UniversalPropertyOptionsBuilder<Value, Omit<Options, 'nullable'> & { nullable: true }, IncludeKeys>,
+    IncludeKeys
+  > {
+    return this.assignOptions({ nullable: true });
+  }
+
+  /**
+   * Set column as nullable without adding `| undefined` to the type.
+   * Use this when the property is always explicitly set (e.g. in constructor) but can be `null`.
+   */
+  strictNullable(): Pick<
+    UniversalPropertyOptionsBuilder<
+      Value,
+      Omit<Options, 'nullable' | 'strictNullable'> & { nullable: true; strictNullable: true },
+      IncludeKeys
+    >,
     IncludeKeys
   > {
     return this.assignOptions({ nullable: true });
@@ -1496,7 +1515,11 @@ type MaybeArray<Value, Options> = Options extends { array: true } ? Value[] : Va
 
 type MaybeMapToPk<Value, Options> = Options extends { mapToPk: true } ? Primary<Value> : Value;
 
-type MaybeNullable<Value, Options> = Options extends { nullable: true } ? Value | null | undefined : Value;
+type MaybeNullable<Value, Options> = Options extends { nullable: true }
+  ? Options extends { strictNullable: true }
+    ? Value | null
+    : Value | null | undefined
+  : Value;
 
 type MaybeRelationRef<Value, Options> = Options extends { mapToPk: true }
   ? Value

--- a/tests/bench/types/defineEntity-extends.ts
+++ b/tests/bench/types/defineEntity-extends.ts
@@ -270,7 +270,7 @@ bench('realistic entity (~20 props, relations, extends)', () => {
       tags: () => p.manyToMany(Tag),
     },
   });
-}).types([7249, 'instantiations']);
+}).types([7311, 'instantiations']);
 
 bench('realistic entity - InferEntity usage', () => {
   const base = defineEntity({
@@ -350,7 +350,7 @@ bench('realistic entity - InferEntity usage', () => {
 
   // Force evaluation of all entity types
   const _check: [IAuthor, IBook, ITag, IPublisher] = {} as any;
-}).types([7341, 'instantiations']);
+}).types([7403, 'instantiations']);
 
 bench('realistic entity - setClass pattern', () => {
   const BaseSchema = defineEntity({
@@ -436,4 +436,4 @@ bench('realistic entity - setClass pattern', () => {
   PublisherSchema.setClass(Publisher);
   AuthorSchema.setClass(Author);
   BookSchema.setClass(Book);
-}).types([7357, 'instantiations']);
+}).types([7419, 'instantiations']);

--- a/tests/bench/types/defineEntity.ts
+++ b/tests/bench/types/defineEntity.ts
@@ -15,9 +15,11 @@ bench('defineEntity with relations', () => {
       toOnePkNullable: () => p.oneToOne(Foo).mapToPk().nullable(),
       scalarRef: p.string().ref(),
       scalarRefNullable: p.string().ref().nullable(),
+      strictNullName: p.string().strictNullable(),
+      strictNullRef: () => p.oneToOne(Foo).strictNullable(),
     },
   });
-}).types([6532, 'instantiations']);
+}).types([7118, 'instantiations']);
 
 bench('defineEntity with ref and nullable', () => {
   const Foo = defineEntity({
@@ -34,7 +36,7 @@ bench('defineEntity with ref and nullable', () => {
       scalarRefNullable: p.string().ref().nullable(),
     },
   });
-}).types([6546, 'instantiations']);
+}).types([6608, 'instantiations']);
 
 bench('defineEntity only with ref and nullable', () => {
   const Foo = defineEntity({
@@ -86,7 +88,7 @@ bench('defineEntity with relations using class', () => {
       scalarRefNullable: p.string().ref().nullable(),
     },
   });
-}).types([7044, 'instantiations']);
+}).types([7106, 'instantiations']);
 
 bench('defineEntity with ref and nullable using class', () => {
   class Foo {
@@ -118,7 +120,7 @@ bench('defineEntity with ref and nullable using class', () => {
       scalarRefNullable: p.string().ref().nullable(),
     },
   });
-}).types([7044, 'instantiations']);
+}).types([7106, 'instantiations']);
 
 bench('defineEntity only with ref and nullable using class', () => {
   class Foo {
@@ -239,4 +241,4 @@ bench('defineEntity with setClass pattern (circular relations)', () => {
 
   AuthorSchema.setClass(Author);
   BookSchema.setClass(Book);
-}).types([5505, 'instantiations']);
+}).types([5567, 'instantiations']);

--- a/tests/defineEntity.test.ts
+++ b/tests/defineEntity.test.ts
@@ -385,6 +385,42 @@ describe('defineEntity', () => {
     expect(Foo.meta).toEqual(asSnapshot(FooSchema.meta));
   });
 
+  it('should define entity with strictNullable property', () => {
+    const Foo = defineEntity({
+      name: 'Foo',
+      properties: p => ({
+        id: p.integer().primary().autoincrement(),
+        name: p.string().strictNullable(),
+        settings: p.json<{ theme: string }>().strictNullable(),
+      }),
+    });
+
+    type IFoo = InferEntity<typeof Foo>;
+    assert<
+      IsExact<
+        IFoo,
+        {
+          id: Opt<number>;
+          name: string | null;
+          settings: { theme: string } | null;
+          [PrimaryKeyProp]?: 'id';
+        }
+      >
+    >(true);
+
+    const FooSchema = new EntitySchema({
+      name: 'Foo',
+      properties: {
+        id: { type: types.integer, primary: true, autoincrement: true },
+        name: { type: types.string, nullable: true },
+        settings: { type: types.json, nullable: true },
+      },
+    });
+
+    // strictNullable sets nullable: true in metadata, same as nullable()
+    expect(Foo.meta).toEqual(asSnapshot(FooSchema.meta));
+  });
+
   it('should define entity with reference scalar property', () => {
     const p = defineEntity.properties;
 

--- a/tests/issues/GH7307.test.ts
+++ b/tests/issues/GH7307.test.ts
@@ -1,0 +1,190 @@
+import { defineEntity, MikroORM, p, type Opt, type InferEntity } from '@mikro-orm/sqlite';
+import { v7 } from 'uuid';
+import { IsExact, assert } from 'conditional-type-checks';
+
+// --- Issue (a): Property initializers for default values ---
+
+const ItemSchema = defineEntity({
+  name: 'Item7307',
+  properties: {
+    id: p.uuid().primary(),
+    label: p.string(),
+    createdAt: p.datetime(),
+  },
+});
+
+class Item7307 extends ItemSchema.class {
+  id = v7();
+  createdAt = new Date();
+}
+
+ItemSchema.setClass(Item7307);
+
+// --- Issue (c): nullable() vs strictNullable() ---
+
+const ProfileSchema = defineEntity({
+  name: 'Profile7307',
+  properties: {
+    id: p.integer().primary().autoincrement(),
+    // nullable() produces T | null | undefined (backwards-compatible)
+    nickname: p.string().nullable(),
+    // strictNullable() produces T | null (no undefined)
+    bio: p.string().strictNullable(),
+    // strictNullable() with relations
+    title: p.string().strictNullable(),
+  },
+});
+
+type IProfile = InferEntity<typeof ProfileSchema>;
+
+// nullable() keeps current behavior: T | null | undefined
+assert<IsExact<IProfile['nickname'], string | null | undefined>>(true);
+
+// strictNullable() produces T | null without | undefined
+assert<IsExact<IProfile['bio'], string | null>>(true);
+assert<IsExact<IProfile['bio'], string | null | undefined>>(false);
+
+// strictNullable() still makes the property optional in em.create()
+assert<IsExact<IProfile['title'], string | null>>(true);
+
+// --- strictNullable with relations and other builders ---
+
+const RelSchema = defineEntity({
+  name: 'Rel7307',
+  properties: {
+    id: p.integer().primary().autoincrement(),
+    // strictNullable with m:1 relation
+    profile: () => p.manyToOne(ProfileSchema).strictNullable(),
+    // strictNullable with formula (produces Opt)
+    computed: () =>
+      p
+        .manyToOne(ProfileSchema)
+        .formula(cols => cols.id)
+        .strictNullable(),
+  },
+});
+
+type IRel = InferEntity<typeof RelSchema>;
+
+// m:1 strictNullable relation
+assert<IsExact<IRel['profile'], IProfile | null>>(true);
+assert<IsExact<IRel['profile'], IProfile | null | undefined>>(false);
+
+// formula + strictNullable produces Opt<T> | null (not | undefined)
+assert<IsExact<IRel['computed'], Opt<IProfile> | null>>(true);
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    entities: [ItemSchema, ProfileSchema, RelSchema],
+    dbName: ':memory:',
+  });
+  await orm.schema.create();
+});
+
+afterAll(() => orm.close(true));
+
+beforeEach(async () => {
+  await orm.schema.clear();
+});
+
+describe('GH #7307', () => {
+  test('(a) property initializers provide default values when using new', async () => {
+    const item = new Item7307();
+    item.label = 'test-item';
+
+    expect(item.id).toBeDefined();
+    expect(typeof item.id).toBe('string');
+    expect(item.createdAt).toBeInstanceOf(Date);
+
+    orm.em.persist(item);
+    await orm.em.flush();
+    orm.em.clear();
+
+    const loaded = await orm.em.findOneOrFail(Item7307, item.id);
+    expect(loaded.id).toBe(item.id);
+    expect(loaded.label).toBe('test-item');
+    expect(loaded.createdAt).toBeInstanceOf(Date);
+  });
+
+  test('(a) multiple entities with property initializers get unique ids', async () => {
+    const item1 = new Item7307();
+    item1.label = 'item-1';
+    const item2 = new Item7307();
+    item2.label = 'item-2';
+
+    expect(item1.id).not.toBe(item2.id);
+
+    orm.em.persist([item1, item2]);
+    await orm.em.flush();
+    orm.em.clear();
+
+    const items = await orm.em.findAll(Item7307, { orderBy: { label: 'asc' } });
+    expect(items).toHaveLength(2);
+    expect(items[0].label).toBe('item-1');
+    expect(items[1].label).toBe('item-2');
+  });
+
+  test('(c) strictNullable properties work at runtime', async () => {
+    const profileNull = orm.em.create(ProfileSchema, {
+      bio: null,
+      title: null,
+    });
+
+    const profileWithValues = orm.em.create(ProfileSchema, {
+      nickname: 'Nick',
+      bio: 'A short bio',
+      title: 'Mr',
+    });
+
+    await orm.em.flush();
+    orm.em.clear();
+
+    const loadedNull = await orm.em.findOneOrFail(ProfileSchema, profileNull.id);
+    expect(loadedNull.nickname).toBeNull();
+    expect(loadedNull.bio).toBeNull();
+    expect(loadedNull.title).toBeNull();
+
+    const loadedWithValues = await orm.em.findOneOrFail(ProfileSchema, profileWithValues.id);
+    expect(loadedWithValues.nickname).toBe('Nick');
+    expect(loadedWithValues.bio).toBe('A short bio');
+    expect(loadedWithValues.title).toBe('Mr');
+  });
+
+  test('(c) strictNullable properties can be omitted in em.create()', async () => {
+    const profile = orm.em.create(ProfileSchema, {});
+    await orm.em.flush();
+    orm.em.clear();
+
+    const loaded = await orm.em.findOneOrFail(ProfileSchema, profile.id);
+    expect(loaded.nickname).toBeNull();
+    expect(loaded.bio).toBeNull();
+  });
+
+  test('(c) strictNullable properties can be updated from null to value and back', async () => {
+    const profile = orm.em.create(ProfileSchema, {
+      bio: 'Initial bio',
+      title: 'Dr',
+    });
+    await orm.em.flush();
+
+    profile.bio = null;
+    profile.title = null;
+    await orm.em.flush();
+    orm.em.clear();
+
+    const loadedNull = await orm.em.findOneOrFail(ProfileSchema, profile.id);
+    expect(loadedNull.bio).toBeNull();
+    expect(loadedNull.title).toBeNull();
+
+    loadedNull.bio = 'Updated bio';
+    loadedNull.title = 'Prof';
+    await orm.em.flush();
+    orm.em.clear();
+
+    const loadedUpdated = await orm.em.findOneOrFail(ProfileSchema, profile.id);
+    expect(loadedUpdated.bio).toBe('Updated bio');
+    expect(loadedUpdated.title).toBe('Prof');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `strictNullable()` method to the `defineEntity` property builder that produces `T | null` without `| undefined`
- The existing `nullable()` is unchanged (`T | null | undefined`) for backwards compatibility

## Motivation
When using `defineEntity` with class extension and constructors, properties are always explicitly initialized — they're never `undefined`. Having `| undefined` in the type forces unnecessary null/undefined checks downstream. `strictNullable()` lets users express "this can be null but is always set" ([Discussion #7307](https://github.com/mikro-orm/mikro-orm/discussions/7307)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)