### PR TITLE
fix(core): provide intellisense for `fields` hint in find options

### DIFF
--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -192,7 +192,7 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
   async find<
     Entity extends object,
     Hint extends string = never,
-    Fields extends string = PopulatePath.ALL,
+    Fields extends string = never,
     Excludes extends string = never,
   >(
     entityName: EntityName<Entity>,
@@ -307,7 +307,7 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
   async *stream<
     Entity extends object,
     Hint extends string = never,
-    Fields extends string = '*',
+    Fields extends string = never,
     Excludes extends string = never,
   >(
     entityName: EntityName<Entity>,
@@ -357,7 +357,7 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
   async findAll<
     Entity extends object,
     Hint extends string = never,
-    Fields extends string = '*',
+    Fields extends string = never,
     Excludes extends string = never,
   >(
     entityName: EntityName<Entity>,
@@ -438,7 +438,7 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
   protected async processWhere<
     Entity extends object,
     Hint extends string = never,
-    Fields extends string = '*',
+    Fields extends string = never,
     Excludes extends string = never,
   >(
     entityName: EntityName<Entity>,
@@ -737,7 +737,7 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
   async findAndCount<
     Entity extends object,
     Hint extends string = never,
-    Fields extends string = '*',
+    Fields extends string = never,
     Excludes extends string = never,
   >(
     entityName: EntityName<Entity>,
@@ -813,7 +813,7 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
   async findByCursor<
     Entity extends object,
     Hint extends string = never,
-    Fields extends string = '*',
+    Fields extends string = never,
     Excludes extends string = never,
     IncludeCount extends boolean = true,
   >(
@@ -849,7 +849,7 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
     Entity extends object,
     Naked extends FromEntityType<Entity> = FromEntityType<Entity>,
     Hint extends string = never,
-    Fields extends string = '*',
+    Fields extends string = never,
     Excludes extends string = never,
   >(
     entity: Entity,
@@ -876,7 +876,7 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
     Entity extends object,
     Naked extends FromEntityType<Entity> = FromEntityType<Entity>,
     Hint extends string = never,
-    Fields extends string = '*',
+    Fields extends string = never,
     Excludes extends string = never,
   >(
     entity: Entity,
@@ -930,7 +930,7 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
   async findOne<
     Entity extends object,
     Hint extends string = never,
-    Fields extends string = '*',
+    Fields extends string = never,
     Excludes extends string = never,
   >(
     entityName: EntityName<Entity>,
@@ -1038,7 +1038,7 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
   async findOneOrFail<
     Entity extends object,
     Hint extends string = never,
-    Fields extends string = '*',
+    Fields extends string = never,
     Excludes extends string = never,
   >(
     entityName: EntityName<Entity>,
@@ -2437,7 +2437,7 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
   private async lockAndPopulate<
     T extends object,
     P extends string = never,
-    F extends string = '*',
+    F extends string = never,
     E extends string = never,
   >(
     meta: EntityMetadata<T>,
@@ -2616,11 +2616,12 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
    * when the entity is found in identity map, we check if it was partially loaded or we are trying to populate
    * some additional lazy properties, if so, we reload and merge the data from database
    */
-  protected shouldRefresh<T extends object, P extends string = never, F extends string = '*', E extends string = never>(
-    meta: EntityMetadata<T>,
-    entity: T,
-    options: FindOneOptions<T, P, F, E>,
-  ): boolean {
+  protected shouldRefresh<
+    T extends object,
+    P extends string = never,
+    F extends string = never,
+    E extends string = never,
+  >(meta: EntityMetadata<T>, entity: T, options: FindOneOptions<T, P, F, E>): boolean {
     if (!helper(entity).__initialized || options.refresh) {
       return true;
     }

--- a/packages/core/src/drivers/DatabaseDriver.ts
+++ b/packages/core/src/drivers/DatabaseDriver.ts
@@ -60,13 +60,13 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
     protected readonly dependencies: string[],
   ) {}
 
-  abstract find<T extends object, P extends string = never, F extends string = '*', E extends string = never>(
+  abstract find<T extends object, P extends string = never, F extends string = never, E extends string = never>(
     entityName: EntityName<T>,
     where: FilterQuery<T>,
     options?: FindOptions<T, P, F, E>,
   ): Promise<EntityData<T>[]>;
 
-  abstract findOne<T extends object, P extends string = never, F extends string = '*', E extends string = never>(
+  abstract findOne<T extends object, P extends string = never, F extends string = never, E extends string = never>(
     entityName: EntityName<T>,
     where: FilterQuery<T>,
     options?: FindOneOptions<T, P, F, E>,

--- a/packages/core/src/drivers/IDatabaseDriver.ts
+++ b/packages/core/src/drivers/IDatabaseDriver.ts
@@ -64,7 +64,7 @@ export interface IDatabaseDriver<C extends Connection = Connection> {
   /**
    * Finds selection of entities
    */
-  find<T extends object, P extends string = never, F extends string = '*', E extends string = never>(
+  find<T extends object, P extends string = never, F extends string = never, E extends string = never>(
     entityName: EntityName<T>,
     where: FilterQuery<T>,
     options?: FindOptions<T, P, F, E>,
@@ -73,7 +73,7 @@ export interface IDatabaseDriver<C extends Connection = Connection> {
   /**
    * Finds single entity (table row, document)
    */
-  findOne<T extends object, P extends string = never, F extends string = '*', E extends string = never>(
+  findOne<T extends object, P extends string = never, F extends string = never, E extends string = never>(
     entityName: EntityName<T>,
     where: FilterQuery<T>,
     options?: FindOneOptions<T, P, F, E>,
@@ -214,7 +214,7 @@ export type OrderDefinition<T> = (QueryOrderMap<T> & { 0?: never }) | QueryOrder
 export interface FindAllOptions<
   T,
   P extends string = never,
-  F extends string = '*',
+  F extends string = never,
   E extends string = never,
 > extends FindOptions<T, P, F, E> {
   where?: FilterQuery<T>;
@@ -224,7 +224,7 @@ export interface FindAllOptions<
 export interface StreamOptions<
   Entity,
   Populate extends string = never,
-  Fields extends string = '*',
+  Fields extends string = never,
   Exclude extends string = never,
 > extends Omit<
   FindAllOptions<Entity, Populate, Fields, Exclude>,
@@ -249,7 +249,7 @@ export type FilterOptions = Dictionary<boolean | Dictionary> | string[] | boolea
 export interface LoadHint<
   Entity,
   Hint extends string = never,
-  Fields extends string = PopulatePath.ALL,
+  Fields extends string = never,
   Excludes extends string = never,
 > {
   populate?: Populate<Entity, Hint>;
@@ -261,7 +261,7 @@ export interface LoadHint<
 export interface FindOptions<
   Entity,
   Hint extends string = never,
-  Fields extends string = PopulatePath.ALL,
+  Fields extends string = never,
   Excludes extends string = never,
 > extends LoadHint<Entity, Hint, Fields, Excludes> {
   /**
@@ -378,7 +378,7 @@ export interface FindOptions<
 export interface FindByCursorOptions<
   T extends object,
   P extends string = never,
-  F extends string = '*',
+  F extends string = never,
   E extends string = never,
   I extends boolean = true,
 > extends Omit<FindAllOptions<T, P, F, E>, 'limit' | 'offset'> {
@@ -389,7 +389,7 @@ export interface FindByCursorOptions<
 export interface FindOneOptions<
   T,
   P extends string = never,
-  F extends string = '*',
+  F extends string = never,
   E extends string = never,
 > extends Omit<FindOptions<T, P, F, E>, 'limit' | 'lockMode'> {
   lockMode?: LockMode;
@@ -400,7 +400,7 @@ export interface FindOneOptions<
 export interface FindOneOrFailOptions<
   T extends object,
   P extends string = never,
-  F extends string = '*',
+  F extends string = never,
   E extends string = never,
 > extends FindOneOptions<T, P, F, E> {
   failHandler?: (entityName: string, where: Dictionary | IPrimaryKey | any) => Error;

--- a/packages/core/src/entity/BaseEntity.ts
+++ b/packages/core/src/entity/BaseEntity.ts
@@ -148,7 +148,7 @@ export abstract class BaseEntity {
   init<
     Entity extends this = this,
     Hint extends string = never,
-    Fields extends string = '*',
+    Fields extends string = never,
     Excludes extends string = never,
   >(options?: FindOneOptions<Entity, Hint, Fields, Excludes>): Promise<Loaded<Entity, Hint, Fields, Excludes> | null> {
     return helper(this as Entity).init(options);

--- a/packages/core/src/entity/Collection.ts
+++ b/packages/core/src/entity/Collection.ts
@@ -1004,7 +1004,7 @@ Object.defineProperties(Collection.prototype, {
 export interface InitCollectionOptions<
   T,
   P extends string = never,
-  F extends string = '*',
+  F extends string = never,
   E extends string = never,
 > extends EntityLoaderOptions<T, F, E> {
   /** Whether to use the dataloader for batching collection loads. */

--- a/packages/core/src/entity/EntityLoader.ts
+++ b/packages/core/src/entity/EntityLoader.ts
@@ -36,11 +36,7 @@ import { expandDotPaths } from './utils.js';
 import { Raw } from '../utils/RawQueryFragment.js';
 
 /** Options for controlling how relations are loaded by the EntityLoader. */
-export interface EntityLoaderOptions<
-  Entity,
-  Fields extends string = PopulatePath.ALL,
-  Excludes extends string = never,
-> {
+export interface EntityLoaderOptions<Entity, Fields extends string = never, Excludes extends string = never> {
   /** Select specific fields to load (partial loading). */
   fields?: readonly AutoPath<Entity, Fields, `${PopulatePath.ALL}`>[];
   /** Fields to exclude from loading. */
@@ -91,7 +87,7 @@ export class EntityLoader {
    * Loads specified relations in batch.
    * This will execute one query for each relation, that will populate it on all the specified entities.
    */
-  async populate<Entity extends object, Fields extends string = PopulatePath.ALL>(
+  async populate<Entity extends object, Fields extends string = never>(
     entityName: EntityName<Entity>,
     entities: Entity[],
     populate: PopulateOptions<Entity>[] | boolean,
@@ -182,7 +178,7 @@ export class EntityLoader {
     return this.mergeNestedPopulate(normalized);
   }
 
-  private setSerializationContext<Entity extends object, Fields extends string = PopulatePath.ALL>(
+  private setSerializationContext<Entity extends object, Fields extends string = never>(
     entities: Entity[],
     populate: PopulateOptions<Entity>[] | boolean,
     options: EntityLoaderOptions<Entity, Fields>,

--- a/packages/core/src/entity/EntityRepository.ts
+++ b/packages/core/src/entity/EntityRepository.ts
@@ -50,7 +50,7 @@ export class EntityRepository<Entity extends object> {
   /**
    * Finds first entity matching your `where` query.
    */
-  async findOne<Hint extends string = never, Fields extends string = '*', Excludes extends string = never>(
+  async findOne<Hint extends string = never, Fields extends string = never, Excludes extends string = never>(
     where: FilterQuery<Entity>,
     options?: FindOneOptions<Entity, Hint, Fields, Excludes>,
   ): Promise<Loaded<Entity, Hint, Fields, Excludes> | null> {
@@ -62,7 +62,7 @@ export class EntityRepository<Entity extends object> {
    * You can override the factory for creating this method via `options.failHandler` locally
    * or via `Configuration.findOneOrFailHandler` globally.
    */
-  async findOneOrFail<Hint extends string = never, Fields extends string = '*', Excludes extends string = never>(
+  async findOneOrFail<Hint extends string = never, Fields extends string = never, Excludes extends string = never>(
     where: FilterQuery<Entity>,
     options?: FindOneOrFailOptions<Entity, Hint, Fields, Excludes>,
   ): Promise<Loaded<Entity, Hint, Fields, Excludes>> {
@@ -137,7 +137,7 @@ export class EntityRepository<Entity extends object> {
   /**
    * Finds all entities matching your `where` query. You can pass additional options via the `options` parameter.
    */
-  async find<Hint extends string = never, Fields extends string = '*', Excludes extends string = never>(
+  async find<Hint extends string = never, Fields extends string = never, Excludes extends string = never>(
     where: FilterQuery<Entity>,
     options?: FindOptions<Entity, Hint, Fields, Excludes>,
   ): Promise<Loaded<Entity, Hint, Fields, Excludes>[]> {
@@ -148,7 +148,7 @@ export class EntityRepository<Entity extends object> {
    * Calls `em.find()` and `em.count()` with the same arguments (where applicable) and returns the results as tuple
    * where first element is the array of entities, and the second is the count.
    */
-  async findAndCount<Hint extends string = never, Fields extends string = '*', Excludes extends string = never>(
+  async findAndCount<Hint extends string = never, Fields extends string = never, Excludes extends string = never>(
     where: FilterQuery<Entity>,
     options?: FindOptions<Entity, Hint, Fields, Excludes>,
   ): Promise<[Loaded<Entity, Hint, Fields, Excludes>[], number]> {
@@ -160,7 +160,7 @@ export class EntityRepository<Entity extends object> {
    */
   async findByCursor<
     Hint extends string = never,
-    Fields extends string = '*',
+    Fields extends string = never,
     Excludes extends string = never,
     IncludeCount extends boolean = true,
   >(
@@ -172,7 +172,7 @@ export class EntityRepository<Entity extends object> {
   /**
    * Finds all entities of given type. You can pass additional options via the `options` parameter.
    */
-  async findAll<Hint extends string = never, Fields extends string = '*', Excludes extends string = never>(
+  async findAll<Hint extends string = never, Fields extends string = never, Excludes extends string = never>(
     options?: FindAllOptions<Entity, Hint, Fields, Excludes>,
   ): Promise<Loaded<Entity, Hint, Fields, Excludes>[]> {
     return this.getEntityManager().findAll(this.entityName, options);
@@ -181,7 +181,7 @@ export class EntityRepository<Entity extends object> {
   /**
    * @inheritDoc EntityManager.stream
    */
-  async *stream<Hint extends string = never, Fields extends string = '*', Excludes extends string = never>(
+  async *stream<Hint extends string = never, Fields extends string = never, Excludes extends string = never>(
     options?: StreamOptions<Entity, Hint, Fields, Excludes>,
   ): AsyncIterableIterator<Loaded<Entity, Hint, Fields, Excludes>> {
     yield* this.getEntityManager().stream(this.entityName, options);

--- a/packages/core/src/entity/Reference.ts
+++ b/packages/core/src/entity/Reference.ts
@@ -129,7 +129,7 @@ export class Reference<T extends object> {
    * If the entity is not found in the database (e.g. it was deleted in the meantime, or currently active filters disallow loading of it)
    * the method returns `null`. Use `loadOrFail()` if you want an error to be thrown in such a case.
    */
-  async load<TT extends T, P extends string = never, F extends string = '*', E extends string = never>(
+  async load<TT extends T, P extends string = never, F extends string = never, E extends string = never>(
     options: LoadReferenceOptions<TT, P, F, E> = {},
   ): Promise<Loaded<TT, P, F, E> | null> {
     const wrapped = helper(this.entity as TT & object);
@@ -163,7 +163,7 @@ export class Reference<T extends object> {
    * Ensures the underlying entity is loaded first (without reloading it if it already is loaded).
    * Returns the entity or throws an error just like `em.findOneOrFail()` (and respects the same config options).
    */
-  async loadOrFail<TT extends T, P extends string = never, F extends string = '*', E extends string = never>(
+  async loadOrFail<TT extends T, P extends string = never, F extends string = never, E extends string = never>(
     options: LoadReferenceOrFailOptions<TT, P, F, E> = {},
   ): Promise<Loaded<TT, P, F, E>> {
     const ret = await this.load(options);
@@ -375,7 +375,7 @@ Object.defineProperties(ScalarReference.prototype, {
 export interface LoadReferenceOptions<
   T extends object,
   P extends string = never,
-  F extends string = '*',
+  F extends string = never,
   E extends string = never,
 > extends FindOneOptions<T, P, F, E> {
   /** Whether to use the dataloader for batching reference loads. */
@@ -386,7 +386,7 @@ export interface LoadReferenceOptions<
 export interface LoadReferenceOrFailOptions<
   T extends object,
   P extends string = never,
-  F extends string = '*',
+  F extends string = never,
   E extends string = never,
 > extends FindOneOrFailOptions<T, P, F, E> {
   /** Whether to use the dataloader for batching reference loads. */

--- a/packages/core/src/entity/WrappedEntity.ts
+++ b/packages/core/src/entity/WrappedEntity.ts
@@ -109,7 +109,7 @@ export class WrappedEntity<Entity extends object> {
   }
 
   /** Sets the serialization context with populate hints, field selections, and exclusions. */
-  setSerializationContext<Hint extends string = never, Fields extends string = '*', Exclude extends string = never>(
+  setSerializationContext<Hint extends string = never, Fields extends string = never, Exclude extends string = never>(
     options: LoadHint<Entity, Hint, Fields, Exclude>,
   ): void {
     const exclude = (options.exclude as readonly string[]) ?? [];
@@ -175,7 +175,7 @@ export class WrappedEntity<Entity extends object> {
   }
 
   /** Initializes (refreshes) the entity by reloading it from the database. Returns null if not found. */
-  async init<Hint extends string = never, Fields extends string = '*', Excludes extends string = never>(
+  async init<Hint extends string = never, Fields extends string = never, Excludes extends string = never>(
     options?: FindOneOptions<Entity, Hint, Fields, Excludes>,
   ): Promise<Loaded<Entity, Hint, Fields, Excludes> | null> {
     if (!this.__em) {

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -472,7 +472,7 @@ export interface IWrappedEntity<Entity extends object> {
     populate: readonly AutoPath<Entity, Hint, PopulatePath.ALL>[] | false,
     options?: EntityLoaderOptions<Entity, Fields>,
   ): Promise<Loaded<Entity, Hint>>;
-  init<Hint extends string = never, Fields extends string = '*', Exclude extends string = never>(
+  init<Hint extends string = never, Fields extends string = never, Exclude extends string = never>(
     options?: FindOneOptions<Entity, Hint, Fields, Exclude>,
   ): Promise<Loaded<Entity, Hint, Fields, Exclude> | null>;
   toReference(): Ref<Entity> & LoadedReference<Loaded<Entity, AddEager<Entity>>>;
@@ -488,7 +488,7 @@ export interface IWrappedEntity<Entity extends object> {
   >(
     options?: SerializeOptions<Naked, Hint, Exclude>,
   ): SerializeDTO<Naked, Hint, Exclude>;
-  setSerializationContext<Hint extends string = never, Fields extends string = '*', Exclude extends string = never>(
+  setSerializationContext<Hint extends string = never, Fields extends string = never, Exclude extends string = never>(
     options: LoadHint<Entity, Hint, Fields, Exclude>,
   ): void;
   assign<

--- a/packages/core/src/utils/Cursor.ts
+++ b/packages/core/src/utils/Cursor.ts
@@ -58,7 +58,7 @@ import { inspect } from '../logging/inspect.js';
 export class Cursor<
   Entity extends object,
   Hint extends string = never,
-  Fields extends string = '*',
+  Fields extends string = never,
   Excludes extends string = never,
   IncludeCount extends boolean = true,
 > {

--- a/packages/mongodb/src/MongoDriver.ts
+++ b/packages/mongodb/src/MongoDriver.ts
@@ -85,7 +85,7 @@ export class MongoDriver extends DatabaseDriver<MongoConnection> {
     }
   }
 
-  async find<T extends object, P extends string = never, F extends string = '*', E extends string = never>(
+  async find<T extends object, P extends string = never, F extends string = never, E extends string = never>(
     entityName: EntityName<T>,
     where: FilterQuery<T>,
     options: FindOptions<T, P, F, E> = {},
@@ -154,12 +154,7 @@ export class MongoDriver extends DatabaseDriver<MongoConnection> {
     return res.map(r => this.mapResult<T>(r, this.metadata.find<T>(entityName))!);
   }
 
-  async findOne<
-    T extends object,
-    P extends string = never,
-    F extends string = PopulatePath.ALL,
-    E extends string = never,
-  >(
+  async findOne<T extends object, P extends string = never, F extends string = never, E extends string = never>(
     entityName: EntityName<T>,
     where: FilterQuery<T>,
     options: FindOneOptions<T, P, F, E> = { populate: [], orderBy: {} },

--- a/packages/mongodb/src/MongoEntityManager.ts
+++ b/packages/mongodb/src/MongoEntityManager.ts
@@ -36,7 +36,7 @@ export class MongoEntityManager<Driver extends MongoDriver = MongoDriver> extend
   override async *stream<
     Entity extends object,
     Hint extends string = never,
-    Fields extends string = '*',
+    Fields extends string = never,
     Excludes extends string = never,
   >(
     entityName: EntityName<Entity>,

--- a/packages/sql/src/AbstractSqlDriver.ts
+++ b/packages/sql/src/AbstractSqlDriver.ts
@@ -206,7 +206,7 @@ export abstract class AbstractSqlDriver<
     return qb;
   }
 
-  async find<T extends object, P extends string = never, F extends string = PopulatePath.ALL, E extends string = never>(
+  async find<T extends object, P extends string = never, F extends string = never, E extends string = never>(
     entityName: EntityName<T>,
     where: ObjectQuery<T>,
     options: FindOptions<T, P, F, E> = {},
@@ -232,12 +232,7 @@ export abstract class AbstractSqlDriver<
     return result;
   }
 
-  async findOne<
-    T extends object,
-    P extends string = never,
-    F extends string = PopulatePath.ALL,
-    E extends string = never,
-  >(
+  async findOne<T extends object, P extends string = never, F extends string = never, E extends string = never>(
     entityName: EntityName<T>,
     where: ObjectQuery<T>,
     options?: FindOneOptions<T, P, F, E>,


### PR DESCRIPTION
## Summary
- The `fields` option in find methods (`em.find`, `em.findOne`, etc.) was not providing IDE autocomplete/intellisense suggestions for entity property names
- Root cause: the `Fields` type parameter defaulted to `PopulatePath.ALL` (`'*'`), which made TypeScript resolve `AutoPath<Entity, '*', '*'>` to just `'*'` instead of entity property suggestions
- Changed the default from `'*'` to `never` in all option interfaces and method signatures, matching how `Hint` (for `populate`) already works — this makes TypeScript fall back to evaluating `AutoPath<Entity, string, '*'>` which correctly produces the entity's property names
- The `QueryBuilder`'s `Fields` parameter retains the `'*'` default since it tracks selected fields through method chains where `'*'` means "all fields"
- Return type behavior is unchanged: `[never] extends ['*']` is `true` in TypeScript's non-distributive check, so `LoadedInternal` still returns the full entity type when no fields are specified

## Test plan
- [x] `yarn build` passes
- [x] `yarn tsc-check-tests` passes (no type regressions)
- [ ] Verify IDE autocomplete now suggests entity properties when typing inside `fields: ['']`

🤖 Generated with [Claude Code](https://claude.com/claude-code)