### PR TITLE
fix(core): allow base entity properties in defineEntity indexes/uniques with extends

### DIFF
--- a/packages/core/src/entity/defineEntity.ts
+++ b/packages/core/src/entity/defineEntity.ts
@@ -1224,26 +1224,26 @@ export interface EntityMetadataWithProperties<
   concurrencyCheckKeys?: Set<AllKeys<TProperties, TBase>>;
   serializedPrimaryKey?: AllKeys<TProperties, TBase>;
   indexes?: {
-    properties?: keyof TProperties | (keyof TProperties)[];
+    properties?: NoInfer<AllKeys<TProperties, TBase>> | NoInfer<AllKeys<TProperties, TBase>>[];
     name?: string;
     type?: string;
     options?: Dictionary;
     expression?: string | IndexCallback<InferEntityFromProperties<TProperties, TPK, TBase>>;
     columns?: IndexColumnOptions[];
-    include?: keyof TProperties | (keyof TProperties)[];
+    include?: NoInfer<AllKeys<TProperties, TBase>> | NoInfer<AllKeys<TProperties, TBase>>[];
     fillFactor?: number;
     invisible?: boolean;
     disabled?: boolean;
     clustered?: boolean;
   }[];
   uniques?: {
-    properties?: keyof TProperties | (keyof TProperties)[];
+    properties?: NoInfer<AllKeys<TProperties, TBase>> | NoInfer<AllKeys<TProperties, TBase>>[];
     name?: string;
     options?: Dictionary;
     expression?: string | IndexCallback<InferEntityFromProperties<TProperties, TPK, TBase>>;
     deferMode?: DeferMode | `${DeferMode}`;
     columns?: IndexColumnOptions[];
-    include?: keyof TProperties | (keyof TProperties)[];
+    include?: NoInfer<AllKeys<TProperties, TBase>> | NoInfer<AllKeys<TProperties, TBase>>[];
     fillFactor?: number;
     disabled?: boolean;
   }[];

--- a/tests/defineEntity.test.ts
+++ b/tests/defineEntity.test.ts
@@ -1144,20 +1144,31 @@ describe('defineEntity', () => {
           columns: [{ name: 'email', sort: 'DESC' }],
           fillFactor: 90,
         },
+        {
+          // base entity properties should be allowed in indexes/uniques
+          properties: ['createdAt', 'email'],
+        },
       ],
       uniques: [
         {
           properties: ['email'],
           include: ['name'],
         },
+        {
+          properties: ['createdAt', 'email'],
+          include: ['id'],
+        },
       ],
     });
 
-    expect(Child.meta.indexes).toHaveLength(1);
+    expect(Child.meta.indexes).toHaveLength(2);
     expect(Child.meta.indexes[0].columns).toEqual([{ name: 'email', sort: 'DESC' }]);
     expect(Child.meta.indexes[0].fillFactor).toBe(90);
-    expect(Child.meta.uniques).toHaveLength(1);
+    expect(Child.meta.indexes[1].properties).toEqual(['createdAt', 'email']);
+    expect(Child.meta.uniques).toHaveLength(2);
     expect(Child.meta.uniques[0].include).toEqual(['name']);
+    expect(Child.meta.uniques[1].properties).toEqual(['createdAt', 'email']);
+    expect(Child.meta.uniques[1].include).toEqual(['id']);
   });
 
   it('supports entity inference for hooks', () => {


### PR DESCRIPTION
## Summary

- `defineEntity` with `extends` now allows referencing base entity properties in `indexes[].properties`, `indexes[].include`, `uniques[].properties`, and `uniques[].include`
- Uses `NoInfer<AllKeys<TProperties, TBase>>` to include base keys while preserving circular type inference for self-referencing entities
- Zero type performance regression (all `bench:types` baselines unchanged at 0.00% delta)

Example that now works:
```ts
const BaseSchema = defineEntity({
  name: 'Base',
  abstract: true,
  properties: {
    id: p.uuid().primary().defaultRaw('uuidv7()'),
    createdAt: p.datetime().defaultRaw('now()'),
  },
});

const StaffSchema = defineEntity({
  name: 'Staff',
  extends: BaseSchema,
  uniques: [{ properties: ['createdAt', 'email'] }], // ✅ 'createdAt' from base now accepted
  properties: {
    email: p.text(),
    enabled: p.boolean().default(true),
  },
});
```

## Test plan

- [x] `yarn tsc-check-tests` — 0 errors (including self-referencing Category entity)
- [x] `yarn test defineEntity.test.ts` — 46/46 pass
- [x] `yarn bench:types` — all baselines at 0.00% delta
- [x] `yarn build` — passes


🤖 Generated with [Claude Code](https://claude.com/claude-code)