### PR TITLE
fix(postgres): handle native enum arrays in non-default schemas

### DIFF
--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -2222,13 +2222,13 @@ export class MetadataDiscovery {
 
     if (prop.kind === ReferenceKind.SCALAR && !(mappedType instanceof t.unknown)) {
       if (
-        !prop.columnTypes &&
         prop.nativeEnumName &&
         meta.schema !== this.#platform.getDefaultSchemaName() &&
         meta.schema &&
         !prop.nativeEnumName.includes('.')
       ) {
-        prop.columnTypes = [`${meta.schema}.${prop.nativeEnumName}`];
+        const suffix = prop.columnTypes?.[0]?.endsWith('[]') ? '[]' : '';
+        prop.columnTypes = [`${meta.schema}.${prop.nativeEnumName}${suffix}`];
       } else {
         prop.columnTypes ??= [mappedType.getColumnType(prop, this.#platform)];
       }

--- a/packages/sql/src/dialects/postgresql/PostgreSqlSchemaHelper.ts
+++ b/packages/sql/src/dialects/postgresql/PostgreSqlSchemaHelper.ts
@@ -424,10 +424,38 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
         comment: col.column_comment,
       };
 
-      if (nativeEnums?.[column.type]) {
+      let enumKey = column.type;
+      let enumEntry = nativeEnums?.[enumKey];
+
+      // for array enum columns, strip the [] suffix and try the base type,
+      // try schema-qualified key first for non-default schemas to avoid
+      // ambiguity when multiple schemas have enums with the same name
+      if (!enumEntry && enumKey.endsWith('[]')) {
+        const baseType = enumKey.slice(0, -2);
+
+        if (col.udt_schema && col.udt_schema !== this.platform.getDefaultSchemaName()) {
+          const schemaKey = `${col.udt_schema}.${baseType}`;
+          enumEntry = nativeEnums?.[schemaKey];
+
+          if (enumEntry) {
+            enumKey = schemaKey;
+            column.type = `${schemaKey}[]`;
+          }
+        }
+
+        if (!enumEntry) {
+          enumEntry = nativeEnums?.[baseType];
+
+          if (enumEntry) {
+            enumKey = baseType;
+          }
+        }
+      }
+
+      if (enumEntry) {
         column.mappedType = Type.getType(EnumType);
-        column.nativeEnumName = column.type;
-        column.enumItems = nativeEnums[column.type]?.items;
+        column.nativeEnumName = enumKey;
+        column.enumItems = enumEntry.items;
       }
 
       ret[key].push(column);

--- a/tests/features/native-postgres-enums/GH7318.test.ts
+++ b/tests/features/native-postgres-enums/GH7318.test.ts
@@ -1,0 +1,58 @@
+import { MikroORM } from '@mikro-orm/postgresql';
+import { Entity, Enum, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+
+enum CompanyTag {
+  foo = 'foo',
+  bar = 'bar',
+}
+
+@Entity({ tableName: 'company', schema: 'company' })
+class Company {
+  @PrimaryKey({ type: 'integer' })
+  id!: number;
+
+  @Property({ type: 'text' })
+  name!: string;
+
+  @Enum({
+    items: () => CompanyTag,
+    nativeEnumName: 'company_tag',
+    default: [],
+    array: true,
+  })
+  tags: CompanyTag[] = [];
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    metadataProvider: ReflectMetadataProvider,
+    entities: [Company],
+    dbName: '7318',
+  });
+
+  await orm.schema.ensureDatabase();
+  await orm.schema.execute('drop schema if exists company cascade');
+});
+
+afterAll(() => orm.close());
+
+test('GH #7318 - enum arrays with non-default schema', async () => {
+  const sql = await orm.schema.getCreateSchemaSQL();
+  expect(sql).toContain(`create schema if not exists "company";`);
+  expect(sql).toContain(`create type "company"."company_tag" as enum ('foo', 'bar');`);
+  expect(sql).toContain(`"tags" "company"."company_tag"[] not null`);
+
+  // this used to fail with: type "company_tag[]" does not exist
+  await orm.schema.execute(sql);
+
+  // update should produce no diff
+  const diff = await orm.schema.getUpdateSchemaSQL();
+  expect(diff).toBe('');
+});
+
+test('GH #7318 - refresh with enum arrays in non-default schema', async () => {
+  // this used to fail with: type "company_tag[]" does not exist
+  await orm.schema.refresh();
+});


### PR DESCRIPTION
## Summary
- Fix schema-qualified column type generation for native enum arrays in non-default schemas (`"company"."company_tag"[]` instead of `"company_tag"[]`)
- Fix schema introspection to correctly resolve enum arrays in non-default schemas for diff computation
- Remove stale `!prop.columnTypes` guard in `MetadataDiscovery` that prevented schema-prefixing when `columnTypes` was already set by `EnumArrayType`

Closes #7318

## Test plan
- [x] New test `GH7318.test.ts` verifying DDL generation, execution, update diff (empty), and schema refresh
- [x] All 11 existing native enum tests pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)