### PR TITLE
fix(core): respect partial loading fields hint in serialize() return type

### DIFF
--- a/packages/core/src/serialization/EntitySerializer.ts
+++ b/packages/core/src/serialization/EntitySerializer.ts
@@ -4,16 +4,15 @@ import type {
   AutoPath,
   CleanTypeConfig,
   Dictionary,
-  EntityDTO,
   EntityDTOProp,
+  ExtractFieldsHint,
+  FromEntityType,
   SerializeDTO,
   EntityKey,
   EntityMetadata,
   EntityProperty,
   EntityValue,
-  FromEntityType,
   IPrimaryKey,
-  Loaded,
   TypeConfig,
   UnboxArray,
 } from '../typings.js';
@@ -399,7 +398,7 @@ export function serialize<
   options?: Config & SerializeOptions<UnboxArray<Entity>, Populate, Exclude>,
 ): Naked extends object[]
   ? SerializeDTO<ArrayElement<Naked>, Populate, Exclude, CleanTypeConfig<Config>>[]
-  : SerializeDTO<Naked, Populate, Exclude, CleanTypeConfig<Config>>;
+  : SerializeDTO<Naked, Populate, Exclude, CleanTypeConfig<Config>, ExtractFieldsHint<Entity>>;
 
 /**
  * Converts entity instance to POJO, converting the `Collection`s to arrays and unwrapping the `Reference` wrapper, while respecting the serialization options.
@@ -423,8 +422,8 @@ export function serialize<
   entities: Entity | Entity[],
   options?: SerializeOptions<Entity, Populate, Exclude>,
 ):
-  | SerializeDTO<Naked, Populate, Exclude, CleanTypeConfig<Config>>
-  | SerializeDTO<Naked, Populate, Exclude, CleanTypeConfig<Config>>[] {
+  | SerializeDTO<Naked, Populate, Exclude, CleanTypeConfig<Config>, ExtractFieldsHint<Entity>>
+  | SerializeDTO<Naked, Populate, Exclude, CleanTypeConfig<Config>, ExtractFieldsHint<Entity>>[] {
   if (Array.isArray(entities)) {
     return entities.map(e => EntitySerializer.serialize(e, options)) as any;
   }

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -279,6 +279,9 @@ declare const __loadedType: unique symbol;
 // eslint-disable-next-line @typescript-eslint/naming-convention
 declare const __loadHint: unique symbol;
 
+// eslint-disable-next-line @typescript-eslint/naming-convention
+declare const __fieldsHint: unique symbol;
+
 /**
  * Expands a populate hint into all its prefixes.
  * e.g., Prefixes<'a.b.c'> = 'a' | 'a.b' | 'a.b.c'
@@ -821,29 +824,63 @@ export type EntityDTOFlat<T, C extends TypeConfig = never> = {
  */
 type SerializeTopHints<H extends string> = H extends `${infer Top}.${string}` ? Top : H;
 type SerializeSubHints<K extends string, H extends string> = H extends `${K}.${infer Rest}` ? Rest : never;
+type SerializeSubFields<K extends string, F extends string> = K extends F
+  ? '*'
+  : [F extends `${K & string}.${infer Rest}` ? Rest : never] extends [never]
+    ? '*'
+    : F extends `${K & string}.${infer Rest}`
+      ? Rest
+      : never;
+type SerializeFieldsFilter<T, K extends keyof T, F extends string> = K extends Prefix<T, F> | PrimaryProperty<T>
+  ? K
+  : never;
 type SerializePropValue<T, K extends keyof T, H extends string, C extends TypeConfig = never> =
   K & string extends SerializeTopHints<H>
     ? NonNullable<T[K]> extends CollectionShape<infer U>
       ? SerializeDTO<U & object, SerializeSubHints<K & string, H>, never, C>[]
       : SerializeDTO<ExpandProperty<T[K]>, SerializeSubHints<K & string, H>, never, C> | Extract<T[K], null | undefined>
     : EntityDTOProp<T, T[K], C>;
+type SerializePropValueWithFields<T, K extends keyof T, H extends string, C extends TypeConfig, F extends string> =
+  K & string extends SerializeTopHints<H>
+    ? NonNullable<T[K]> extends CollectionShape<infer U>
+      ? SerializeDTO<U & object, SerializeSubHints<K & string, H>, never, C, SerializeSubFields<K & string, F>>[]
+      :
+          | SerializeDTO<
+              ExpandProperty<T[K]>,
+              SerializeSubHints<K & string, H>,
+              never,
+              C,
+              SerializeSubFields<K & string, F>
+            >
+          | Extract<T[K], null | undefined>
+    : EntityDTOProp<T, T[K], C>;
 
 /**
  * Return type of `serialize()`. Combines Loaded + EntityDTO in a single pass for better performance.
- * Respects populate hints (`H`) and exclude hints (`E`).
+ * Respects populate hints (`H`), exclude hints (`E`), and fields hints (`F`).
  */
 export type SerializeDTO<
   T,
   H extends string = never,
   E extends string = never,
   C extends TypeConfig = never,
+  F extends string = '*',
 > = string extends H
   ? EntityDTOFlat<T, C>
-  : {
-      [K in keyof T as ExcludeHidden<T, K> & CleanKeys<T, K> & (IsNever<E> extends true ? K : Exclude<K, E>)]:
-        | SerializePropValue<T, K, H, C>
-        | Extract<T[K], null | undefined>;
-    };
+  : [F] extends ['*']
+    ? {
+        [K in keyof T as ExcludeHidden<T, K> & CleanKeys<T, K> & (IsNever<E> extends true ? K : Exclude<K, E>)]:
+          | SerializePropValue<T, K, H, C>
+          | Extract<T[K], null | undefined>;
+      }
+    : {
+        [K in keyof T as ExcludeHidden<T, K> &
+          CleanKeys<T, K> &
+          (IsNever<E> extends true ? K : Exclude<K, E>) &
+          SerializeFieldsFilter<T, K, F>]:
+          | SerializePropValueWithFields<T, K, H, C, F>
+          | Extract<T[K], null | undefined>;
+      };
 
 type TargetKeys<T> = T extends EntityClass<infer P> ? keyof P : keyof T;
 type PropertyName<T> = IsUnknown<T> extends false ? TargetKeys<T> : string;
@@ -1931,7 +1968,7 @@ export type Selected<T, L extends string = never, F extends string = '*'> = {
     : NonNullable<T[K]> extends Scalar
       ? T[K]
       : LoadedProp<NonNullable<T[K]>, Suffix<K, L, true>, Suffix<K, F, true>> | AddOptional<T[K]>;
-} & { [__selectedType]?: T };
+} & { [__selectedType]?: T; [__fieldsHint]?: (hint: F) => void };
 
 type LoadedEntityType<T> = { [__loadedType]?: T } | { [__selectedType]?: T };
 /** Accepts either a plain entity type or a `Loaded`/`Selected` wrapped version. */
@@ -1939,6 +1976,9 @@ export type EntityType<T> = T | LoadedEntityType<T>;
 
 /** Extracts the base entity type from a `Loaded`/`Selected` wrapper, or returns `T` as-is. */
 export type FromEntityType<T> = T extends LoadedEntityType<infer U> ? U : T;
+
+/** Extracts the fields hint (`F`) from a `Loaded`/`Selected` type, or returns `'*'` (all fields) for unwrapped entities. */
+export type ExtractFieldsHint<T> = T extends { [__fieldsHint]?: (hint: infer F extends string) => void } ? F : '*';
 
 type LoadedInternal<T, L extends string = never, F extends string = '*', E extends string = never> = [F] extends ['*']
   ? IsNever<E> extends true

--- a/tests/features/serialization/serialize-fields-hint.test.ts
+++ b/tests/features/serialization/serialize-fields-hint.test.ts
@@ -1,0 +1,76 @@
+import { defineEntity, MikroORM, p, quote, serialize } from '@mikro-orm/sqlite';
+
+const SupplierSchema = defineEntity({
+  name: 'Supplier',
+  forceObject: true,
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+    balance: p.float(),
+    remainingBalance: p.float(),
+    totalBalance: p
+      .float()
+      .formula(cols => quote`${cols.balance} + ${cols.remainingBalance}`)
+      .precision(10)
+      .scale(2),
+  },
+});
+
+class Supplier extends SupplierSchema.class {}
+
+SupplierSchema.setClass(Supplier);
+
+const ProductSchema = defineEntity({
+  name: 'Product',
+  forceObject: true,
+  properties: {
+    id: p.integer().primary(),
+    title: p.string(),
+    clientId: p.string(),
+    productId: p.string(),
+    supplier: () => p.manyToOne(Supplier),
+  },
+  uniques: [{ properties: ['clientId', 'productId'] }],
+});
+
+class Product extends ProductSchema.class {}
+
+ProductSchema.setClass(Product);
+
+describe('serialize respects partial loading type hint', () => {
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      dbName: ':memory:',
+      entities: [Product, Supplier],
+      serialization: { forceObject: true },
+    });
+    await orm.schema.refresh();
+  });
+
+  afterAll(() => orm.close(true));
+
+  it('explicit serialization respects fields hint from Loaded type', async () => {
+    const clientId = 'client-123';
+    const productId = 'product-456';
+    const supplier = orm.em.create(Supplier, { name: 'Supplier 1', balance: 100, remainingBalance: 50 });
+    const product = orm.em.create(Product, { title: 'Test', clientId, productId, supplier });
+
+    await orm.em.flush();
+    orm.em.clear();
+
+    const loaded = await orm.em.findOneOrFail(Product, product.id, {
+      fields: ['supplier.name'],
+      populate: ['supplier'],
+    });
+    // @ts-expect-error - balance is not in fields hint
+    expect(loaded.supplier.balance).toBeUndefined();
+    const serialized = serialize(loaded, { populate: ['supplier'] });
+
+    expect(serialized).toBeDefined();
+    expect(serialized.supplier.name).toBe('Supplier 1');
+    // @ts-expect-error - balance is not in fields hint, serialize should respect this
+    expect(serialized.supplier.balance).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- `serialize()` now respects the `fields` hint from `Loaded` entities in its return type
- When an entity is loaded with `fields: ['supplier.name']`, the serialized output type correctly narrows `supplier` to only include `name` (and PK), matching the runtime behavior
- The fields hint marker (`__fieldsHint`) is stored on `Selected` (not `Loaded`), so the common case (`F='*'`) has **zero type-level overhead**
- `SerializeDTO` branches on `[F] extends ['*']` to use the original code path when no fields restriction is active

🤖 Generated with [Claude Code](https://claude.com/claude-code)