### PR TITLE
fix(sql): prune redundant joins in pagination outer query

### DIFF
--- a/packages/mariadb/src/MariaDbQueryBuilder.ts
+++ b/packages/mariadb/src/MariaDbQueryBuilder.ts
@@ -94,7 +94,7 @@ export class MariaDbQueryBuilder<
     const populatePaths = this.getPopulatePaths();
 
     // Remove joins that are not used for population or ordering
-    this.pruneJoinsForPagination(meta, populatePaths);
+    this.pruneJoinsForPagination();
 
     // Transfer WHERE conditions to ORDER BY joins (GH #6160)
     this.transferConditionsForOrderByJoins(meta, originalCond, populatePaths);

--- a/packages/sql/src/query/QueryBuilder.ts
+++ b/packages/sql/src/query/QueryBuilder.ts
@@ -3820,7 +3820,7 @@ export class QueryBuilder<
     const populatePaths = this.getPopulatePaths();
 
     if (!this.#state.fields!.some(field => isRaw(field))) {
-      this.pruneJoinsForPagination(meta, populatePaths);
+      this.pruneJoinsForPagination();
     }
 
     // Transfer WHERE conditions to ORDER BY joins (GH #6160)
@@ -3893,29 +3893,59 @@ export class QueryBuilder<
   /**
    * Removes joins that are not used for population or ordering to improve performance.
    */
-  protected pruneJoinsForPagination(meta: EntityMetadata, populatePaths: Set<string>): void {
-    const orderByAliases = this.#state.orderBy.flatMap(hint => Object.keys(hint)).map(k => k.split('.')[0]);
-
+  protected pruneJoinsForPagination(): void {
     const joins = Object.entries(this.#state.joins);
     const rootAlias = this.alias;
+    const keptAliases = new Set<string>();
 
-    function addParentAlias(alias: string): void {
-      const join = joins.find(j => j[1].alias === alias);
-
-      if (join && join[1].ownerAlias !== rootAlias) {
-        orderByAliases.push(join[1].ownerAlias);
-        addParentAlias(join[1].ownerAlias);
+    // Collect aliases needed for ORDER BY
+    for (const hint of this.#state.orderBy) {
+      for (const k of Object.keys(hint)) {
+        if (!RawQueryFragment.isKnownFragmentSymbol(k)) {
+          keptAliases.add(k.split('.')[0]);
+        }
       }
     }
 
-    for (const orderByAlias of orderByAliases) {
-      addParentAlias(orderByAlias);
+    // Collect aliases needed for population (joined strategy):
+    // 1. Joins tracked in populateMap (OneToOne inverse from processPopulateHint)
+    // 2. Joins tracked in joinedProps (manual joinAndSelect calls)
+    // 3. Joins whose alias is referenced in SELECT fields (JOINED strategy populate fields)
+    for (const [key, join] of joins) {
+      if (key in this.#state.populateMap || this.#state.joinedProps.has(join.alias)) {
+        keptAliases.add(join.alias);
+      }
+    }
+
+    // Check SELECT fields for alias references - keeps joins needed for data loading
+    if (this.#state.fields) {
+      for (const field of this.#state.fields) {
+        const fieldStr = typeof field === 'string' ? field : isRaw(field) ? field.sql : '';
+
+        for (const [, join] of joins) {
+          if (fieldStr.includes(`${join.alias}.`) || fieldStr.includes(`${join.alias}__`)) {
+            keptAliases.add(join.alias);
+          }
+        }
+      }
+    }
+
+    // Also keep parent joins of all kept aliases (e.g. pivot tables for M:N)
+    function addParentAliases(alias: string): void {
+      const join = joins.find(j => j[1].alias === alias);
+
+      if (join && join[1].ownerAlias !== rootAlias && !keptAliases.has(join[1].ownerAlias)) {
+        keptAliases.add(join[1].ownerAlias);
+        addParentAliases(join[1].ownerAlias);
+      }
+    }
+
+    for (const alias of [...keptAliases]) {
+      addParentAliases(alias);
     }
 
     for (const [key, join] of joins) {
-      const path = this.normalizeJoinPath(join, meta);
-
-      if (!populatePaths.has(path) && !orderByAliases.includes(join.alias)) {
+      if (!keptAliases.has(join.alias)) {
         delete this.#state.joins[key];
       }
     }

--- a/tests/issues/GH6681.test.ts
+++ b/tests/issues/GH6681.test.ts
@@ -1,0 +1,212 @@
+import { Collection, LoadStrategy, MikroORM } from '@mikro-orm/sqlite';
+import {
+  Entity,
+  ManyToMany,
+  ManyToOne,
+  OneToMany,
+  PrimaryKey,
+  Property,
+  ReflectMetadataProvider,
+} from '@mikro-orm/decorators/legacy';
+import { mockLogger } from '../helpers.js';
+
+@Entity()
+class Tag {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name: string;
+
+  constructor(name: string) {
+    this.name = name;
+  }
+}
+
+@Entity()
+class User {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name: string;
+
+  @ManyToMany(() => Tag)
+  tags = new Collection<Tag>(this);
+
+  @OneToMany(() => Comment, comment => comment.user)
+  comments = new Collection<Comment>(this);
+
+  constructor(name: string) {
+    this.name = name;
+  }
+}
+
+@Entity()
+class Comment {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  text: string;
+
+  @ManyToOne(() => User)
+  user!: User;
+
+  constructor(text: string) {
+    this.text = text;
+  }
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    metadataProvider: ReflectMetadataProvider,
+    dbName: ':memory:',
+    entities: [User, Tag, Comment],
+  });
+  await orm.schema.refresh();
+
+  const tag1 = orm.em.create(Tag, { name: 'tag1' });
+  const tag2 = orm.em.create(Tag, { name: 'tag2' });
+  const user1 = orm.em.create(User, { name: 'User1' });
+  user1.tags.add(tag1, tag2);
+  const user2 = orm.em.create(User, { name: 'User2' });
+  user2.tags.add(tag1);
+  orm.em.create(Comment, { text: 'comment1', user: user1 });
+  orm.em.create(Comment, { text: 'comment2', user: user1 });
+  orm.em.create(Comment, { text: 'comment3', user: user2 });
+  await orm.em.flush();
+  orm.em.clear();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+test('GH6681 - findAndCount with M:N filter and limit should not have redundant joins in outer query', async () => {
+  const mock = mockLogger(orm);
+
+  const [users, count] = await orm.em.fork().findAndCount(User, { tags: { name: 'tag1' } }, { limit: 1 });
+
+  expect(count).toBe(2);
+  expect(users).toHaveLength(1);
+
+  // The outer query should not have redundant joins on the M:N pivot table and related entity
+  const dataQuery = mock.mock.calls.find(
+    call => call[0]?.includes('select') && call[0]?.includes('in (select'),
+  )?.[0] as string;
+  expect(dataQuery).toBeDefined();
+  // The outer query should only join the root table, not the pivot and tag tables
+  const outerQuery = dataQuery.split('where')[0];
+  expect(outerQuery).not.toContain('join');
+});
+
+test('GH6681 - find with M:N filter and limit should not have redundant joins', async () => {
+  const mock = mockLogger(orm);
+
+  const users = await orm.em.fork().find(User, { tags: { name: 'tag1' } }, { limit: 1 });
+
+  expect(users).toHaveLength(1);
+
+  const dataQuery = mock.mock.calls.find(
+    call => call[0]?.includes('select') && call[0]?.includes('in (select'),
+  )?.[0] as string;
+  expect(dataQuery).toBeDefined();
+  const outerQuery = dataQuery.split('where')[0];
+  expect(outerQuery).not.toContain('join');
+});
+
+test('GH6681 - results are still correct with the optimization', async () => {
+  // With limit
+  const [users1, count1] = await orm.em
+    .fork()
+    .findAndCount(User, { tags: { name: 'tag1' } }, { limit: 1, orderBy: { id: 'asc' } });
+  expect(count1).toBe(2);
+  expect(users1).toHaveLength(1);
+  expect(users1[0].name).toBe('User1');
+
+  // With limit and offset
+  const [users2, count2] = await orm.em
+    .fork()
+    .findAndCount(User, { tags: { name: 'tag1' } }, { limit: 1, offset: 1, orderBy: { id: 'asc' } });
+  expect(count2).toBe(2);
+  expect(users2).toHaveLength(1);
+  expect(users2[0].name).toBe('User2');
+
+  // Without limit - should work the same as before
+  const [users3, count3] = await orm.em.fork().findAndCount(User, { tags: { name: 'tag1' } });
+  expect(count3).toBe(2);
+  expect(users3).toHaveLength(2);
+});
+
+test('GH6681 - JOINED populate with M:N + limit keeps necessary joins in outer query', async () => {
+  const mock = mockLogger(orm);
+
+  const [users, count] = await orm.em
+    .fork()
+    .findAndCount(
+      User,
+      { tags: { name: 'tag1' } },
+      { populate: ['tags'], strategy: LoadStrategy.JOINED, limit: 1, orderBy: { id: 'asc' } },
+    );
+
+  expect(count).toBe(2);
+  expect(users).toHaveLength(1);
+  expect(users[0].name).toBe('User1');
+  expect(users[0].tags.isInitialized()).toBe(true);
+  expect(users[0].tags).toHaveLength(2);
+
+  // The outer query must keep the M:N joins for population
+  const dataQuery = mock.mock.calls.find(
+    call => call[0]?.includes('select') && call[0]?.includes('in (select'),
+  )?.[0] as string;
+  expect(dataQuery).toBeDefined();
+  const outerQuery = dataQuery.split('where')[0];
+  expect(outerQuery).toContain('join');
+});
+
+test('GH6681 - JOINED populate with OneToMany + limit keeps necessary joins in outer query', async () => {
+  const mock = mockLogger(orm);
+
+  const [users, count] = await orm.em
+    .fork()
+    .findAndCount(
+      User,
+      {},
+      { populate: ['comments'], strategy: LoadStrategy.JOINED, limit: 1, orderBy: { id: 'asc' } },
+    );
+
+  expect(count).toBe(2);
+  expect(users).toHaveLength(1);
+  expect(users[0].name).toBe('User1');
+  expect(users[0].comments.isInitialized()).toBe(true);
+  expect(users[0].comments).toHaveLength(2);
+
+  // The outer query must keep the OneToMany join for population
+  const dataQuery = mock.mock.calls.find(
+    call => call[0]?.includes('select') && call[0]?.includes('in (select'),
+  )?.[0] as string;
+  expect(dataQuery).toBeDefined();
+  const outerQuery = dataQuery.split('where')[0];
+  expect(outerQuery).toContain('join');
+});
+
+test('GH6681 - ORDER BY on joined relation + limit keeps the join', async () => {
+  const mock = mockLogger(orm);
+
+  const users = await orm.em
+    .fork()
+    .find(User, { tags: { name: 'tag1' } }, { limit: 1, orderBy: { tags: { name: 'asc' } } });
+
+  expect(users).toHaveLength(1);
+
+  // The outer query must keep the join used for ORDER BY
+  const dataQuery = mock.mock.calls.find(
+    call => call[0]?.includes('select') && call[0]?.includes('in (select'),
+  )?.[0] as string;
+  expect(dataQuery).toBeDefined();
+  const outerQuery = dataQuery.split('where')[0];
+  expect(outerQuery).toContain('join');
+});


### PR DESCRIPTION
## Summary

- When using relation filters (e.g. M:N `{ tags: { name: 'tag1' } }`) with `limit`, the pagination outer query kept joins that only served the WHERE clause in the inner subquery, causing unnecessary work
- Rewrites `pruneJoinsForPagination` to determine kept joins from direct evidence — ORDER BY aliases, `populateMap`, `joinedProps`, and SELECT field references — instead of path-normalization heuristics
- Updates `MariaDbQueryBuilder` to match the new parameterless signature

Closes #6681

🤖 Generated with [Claude Code](https://claude.com/claude-code)