### PR TITLE
fix(core): strip `persist: false` properties from upsert data

### DIFF
--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -1163,6 +1163,14 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
           return em.assign(exists, data as any) as any;
         }
       }
+
+      for (const key of Object.keys(data!)) {
+        const prop = meta.properties[key as EntityKey<Entity>];
+
+        if (prop?.persist === false) {
+          delete data![key as EntityKey<Entity>];
+        }
+      }
     }
 
     where = getWhereCondition(meta, options.onConflictFields, data as EntityData<Entity>, where).where;
@@ -1339,6 +1347,14 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
             entities.set(exists, row);
             entitiesByData.set(row, exists);
             continue;
+          }
+        }
+
+        for (const key of Object.keys(row)) {
+          const prop = meta.properties[key as EntityKey<Entity>];
+
+          if (prop?.persist === false) {
+            delete row[key as EntityKey<Entity>];
           }
         }
       }

--- a/tests/features/upsert/GH7344.test.ts
+++ b/tests/features/upsert/GH7344.test.ts
@@ -1,0 +1,76 @@
+import { MikroORM, SimpleLogger } from '@mikro-orm/sqlite';
+import { Entity, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+import { mockLogger } from '../../helpers.js';
+
+@Entity()
+class ExampleEntity {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @Property({ persist: false })
+  virtualField?: string;
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    metadataProvider: ReflectMetadataProvider,
+    dbName: ':memory:',
+    entities: [ExampleEntity],
+    loggerFactory: SimpleLogger.create,
+  });
+  await orm.schema.refresh();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+test('GH #7344 - upsert should ignore persist: false properties', async () => {
+  const mock = mockLogger(orm);
+
+  const e1 = await orm.em.upsert(ExampleEntity, {
+    id: 1,
+    name: 'test',
+    virtualField: 'should not be persisted',
+  });
+  expect(e1.id).toBe(1);
+  expect(e1.name).toBe('test');
+  expect(mock.mock.calls[0][0]).not.toMatch(/virtualField/);
+  expect(mock.mock.calls[0][0]).not.toMatch(/virtual_field/);
+
+  mock.mockReset();
+
+  // update via upsert
+  const e2 = await orm.em.upsert(ExampleEntity, {
+    id: 1,
+    name: 'updated',
+    virtualField: 'still should not be persisted',
+  });
+  expect(e2.id).toBe(1);
+  expect(e2.name).toBe('updated');
+  expect(mock.mock.calls[0][0]).not.toMatch(/virtualField/);
+  expect(mock.mock.calls[0][0]).not.toMatch(/virtual_field/);
+});
+
+test('GH #7344 - upsertMany should ignore persist: false properties', async () => {
+  orm.em.clear();
+  const mock = mockLogger(orm);
+
+  const entities = await orm.em.upsertMany(ExampleEntity, [
+    { id: 10, name: 'first', virtualField: 'nope' },
+    { id: 11, name: 'second', virtualField: 'nope' },
+  ]);
+  expect(entities).toHaveLength(2);
+  expect(entities[0].name).toBe('first');
+  expect(entities[1].name).toBe('second');
+
+  for (const call of mock.mock.calls) {
+    expect(call[0]).not.toMatch(/virtualField/);
+    expect(call[0]).not.toMatch(/virtual_field/);
+  }
+});


### PR DESCRIPTION
## Summary
- `em.upsert()` and `em.upsertMany()` now strip `persist: false` properties from plain-object data before generating SQL
- The entity-instance path already handled this via `prepareEntity()` / `comparableProps`, but the plain-object path included non-persistent fields in the query
- Test verifies via `mockLogger` that virtual fields are absent from generated SQL

Closes #7344

🤖 Generated with [Claude Code](https://claude.com/claude-code)