### PR TITLE
feat(cli): add oxc as a TS loader option via `@oxc-node/core`

### DIFF
--- a/docs/docs/quick-start.md
+++ b/docs/docs/quick-start.md
@@ -311,7 +311,7 @@ Another way to control these CLI-related settings is with the environment variab
 
 - `MIKRO_ORM_CLI_CONFIG`: the path to ORM config file
 - `MIKRO_ORM_CLI_PREFER_TS`: enforce use of the TS paths (e.g. `entitiesTs` or `pathTs`)
-- `MIKRO_ORM_CLI_TS_LOADER`: set preferred TS loader (one of `swc`, `tsx`, `jiti`, `tsimp`)
+- `MIKRO_ORM_CLI_TS_LOADER`: set preferred TS loader (one of `oxc`, `swc`, `tsx`, `jiti`, `tsimp`)
 - `MIKRO_ORM_CLI_TS_CONFIG_PATH`: path to the tsconfig.json (for TS support)
 - `MIKRO_ORM_CLI_ALWAYS_ALLOW_TS`: enable `.ts` files to use without detected TS support
 - `MIKRO_ORM_CLI_VERBOSE`: enable verbose logging (e.g. print queries used in seeder or schema diffing)

--- a/docs/docs/upgrading-v6-to-v7.md
+++ b/docs/docs/upgrading-v6-to-v7.md
@@ -133,6 +133,7 @@ Also, the `checkDuplicateEntities` discovery option is removed, since it is no l
 
 TypeScript support was previously provided by `ts-node`. In v7, the CLI supports various TS loaders:
 
+- `oxc` via `@oxc-node/core`, supports metadata reflection
 - `swc` via `@swc-node/register`, supports metadata reflection
 - `tsx`
 - `jiti`

--- a/docs/versioned_docs/version-7.0/quick-start.md
+++ b/docs/versioned_docs/version-7.0/quick-start.md
@@ -311,7 +311,7 @@ Another way to control these CLI-related settings is with the environment variab
 
 - `MIKRO_ORM_CLI_CONFIG`: the path to ORM config file
 - `MIKRO_ORM_CLI_PREFER_TS`: enforce use of the TS paths (e.g. `entitiesTs` or `pathTs`)
-- `MIKRO_ORM_CLI_TS_LOADER`: set preferred TS loader (one of `swc`, `tsx`, `jiti`, `tsimp`)
+- `MIKRO_ORM_CLI_TS_LOADER`: set preferred TS loader (one of `oxc`, `swc`, `tsx`, `jiti`, `tsimp`)
 - `MIKRO_ORM_CLI_TS_CONFIG_PATH`: path to the tsconfig.json (for TS support)
 - `MIKRO_ORM_CLI_ALWAYS_ALLOW_TS`: enable `.ts` files to use without detected TS support
 - `MIKRO_ORM_CLI_VERBOSE`: enable verbose logging (e.g. print queries used in seeder or schema diffing)

--- a/docs/versioned_docs/version-7.0/upgrading-v6-to-v7.md
+++ b/docs/versioned_docs/version-7.0/upgrading-v6-to-v7.md
@@ -133,6 +133,7 @@ Also, the `checkDuplicateEntities` discovery option is removed, since it is no l
 
 TypeScript support was previously provided by `ts-node`. In v7, the CLI supports various TS loaders:
 
+- `oxc` via `@oxc-node/core`, supports metadata reflection
 - `swc` via `@swc-node/register`, supports metadata reflection
 - `tsx`
 - `jiti`

--- a/packages/cli/src/CLIHelper.ts
+++ b/packages/cli/src/CLIHelper.ts
@@ -371,13 +371,13 @@ export class CLIHelper {
   }
 
   /**
-   * Tries to register TS support in the following order: swc, tsx, jiti, tsimp
+   * Tries to register TS support in the following order: oxc, swc, tsx, jiti, tsimp
    * Use `MIKRO_ORM_CLI_TS_LOADER` env var to set the loader explicitly.
    * This method is used only in CLI context.
    */
   static async registerTypeScriptSupport(
     configPath = 'tsconfig.json',
-    tsLoader?: 'swc' | 'tsx' | 'jiti' | 'tsimp' | 'auto',
+    tsLoader?: 'oxc' | 'swc' | 'tsx' | 'jiti' | 'tsimp' | 'auto',
   ): Promise<boolean> {
     /* v8 ignore if */
     if (process.versions.bun) {
@@ -393,6 +393,7 @@ export class CLIHelper {
       return ((globalThis as any).dynamicImportProvider = (id: string) => import(id).then(mod => mod?.default ?? mod));
     };
     const loaders = {
+      oxc: { esm: '@oxc-node/core/register', cjs: '@oxc-node/core/register' },
       swc: { esm: '@swc-node/register/esm-register', cjs: '@swc-node/register' },
       tsx: { esm: 'tsx/esm/api', cjs: 'tsx/cjs/api', cb: (tsx: any) => tsx.register({ tsconfig: configPath }) },
       jiti: { cjs: 'jiti/register', cb: setEsmImportProvider },
@@ -418,7 +419,7 @@ export class CLIHelper {
 
     // eslint-disable-next-line no-console
     console.warn(
-      'Neither `swc`, `tsx`, `jiti` nor `tsimp` found in the project dependencies, support for working with TypeScript files might not work. To use `swc`, you need to install both `@swc-node/register` and `@swc/core`.',
+      'Neither `oxc`, `swc`, `tsx`, `jiti` nor `tsimp` found in the project dependencies, support for working with TypeScript files might not work. To use `oxc`, install `@oxc-node/core`. To use `swc`, install both `@swc-node/register` and `@swc/core`.',
     );
 
     return false;
@@ -440,7 +441,7 @@ export class CLIHelper {
 export interface Settings {
   verbose?: boolean;
   preferTs?: boolean;
-  tsLoader?: 'swc' | 'tsx' | 'jiti' | 'tsimp' | 'auto';
+  tsLoader?: 'oxc' | 'swc' | 'tsx' | 'jiti' | 'tsimp' | 'auto';
   tsConfigPath?: string;
   configPaths?: string[];
 }

--- a/packages/core/src/utils/Utils.ts
+++ b/packages/core/src/utils/Utils.ts
@@ -734,8 +734,9 @@ export class Utils {
         return (
           arg.includes('ts-node') || // check for ts-node loader
           arg.includes('@swc-node/register') || // check for swc-node/register loader
-          arg.includes('node_modules/tsx/')
-        ); // check for tsx loader
+          arg.includes('node_modules/tsx/') || // check for tsx loader
+          arg.includes('@oxc-node/core') // check for oxc-node loader
+        );
       })
     );
   }

--- a/tests/features/cli/CLIHelper.test.ts
+++ b/tests/features/cli/CLIHelper.test.ts
@@ -112,6 +112,7 @@ describe('CLIHelper', () => {
   });
 
   test.each([
+    ['oxc', '@oxc-node/core/register'],
     ['swc', '@swc-node/register/esm-register'],
     ['tsx', 'tsx/esm/api'],
     ['jiti', 'jiti/register'],
@@ -153,7 +154,7 @@ describe('CLIHelper', () => {
     });
     const cli = (await configure()) as any;
     expect(cli.$0).toBe('mikro-orm');
-    expect(tryImportMock).toHaveBeenCalledTimes(1);
+    expect(tryImportMock).toHaveBeenCalledTimes(2);
     expect(tryImportMock).toHaveBeenCalledWith({ module: '@swc-node/register/esm-register' });
     pkg['mikro-orm'].preferTs = false;
   });
@@ -165,13 +166,14 @@ describe('CLIHelper', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(i => i);
     const cli = (await configure()) as any;
     expect(cli.$0).toBe('mikro-orm');
-    expect(tryImportMock).toHaveBeenCalledTimes(4);
+    expect(tryImportMock).toHaveBeenCalledTimes(5);
+    expect(tryImportMock).toHaveBeenCalledWith({ module: '@oxc-node/core/register' });
     expect(tryImportMock).toHaveBeenCalledWith({ module: '@swc-node/register/esm-register' });
     expect(tryImportMock).toHaveBeenCalledWith({ module: 'tsx/esm/api' });
     expect(tryImportMock).toHaveBeenCalledWith({ module: 'jiti/register' });
     expect(tryImportMock).toHaveBeenCalledWith({ module: 'tsimp/import' });
     const warning =
-      'Neither `swc`, `tsx`, `jiti` nor `tsimp` found in the project dependencies, support for working with TypeScript files might not work. To use `swc`, you need to install both `@swc-node/register` and `@swc/core`.';
+      'Neither `oxc`, `swc`, `tsx`, `jiti` nor `tsimp` found in the project dependencies, support for working with TypeScript files might not work. To use `oxc`, install `@oxc-node/core`. To use `swc`, install both `@swc-node/register` and `@swc/core`.';
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining(warning));
     pkg['mikro-orm'].preferTs = false;
   });
@@ -200,7 +202,7 @@ describe('CLIHelper', () => {
     });
     const cli = (await configure()) as any;
     expect(cli.$0).toBe('mikro-orm');
-    expect(tryImportMock).toHaveBeenCalledTimes(1);
+    expect(tryImportMock).toHaveBeenCalledTimes(2);
     expect(tryImportMock).toHaveBeenCalledWith({ module: '@swc-node/register/esm-register' });
 
     delete pkg['mikro-orm'].preferTs;


### PR DESCRIPTION
## Summary

- Add `oxc` (via `@oxc-node/core`) as a TS loader option in the CLI, first in the auto-detection order before swc/tsx/jiti/tsimp
- Support explicit selection via `MIKRO_ORM_CLI_TS_LOADER=oxc`
- Detect `@oxc-node/core` in process argv for `isTypeScript()` checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)