### PR TITLE
fix(core): discover `defineEntity` classes via glob when only class is exported

### DIFF
--- a/packages/core/src/metadata/discover-entities.ts
+++ b/packages/core/src/metadata/discover-entities.ts
@@ -27,10 +27,18 @@ async function getEntityClassOrSchema(
   }
 
   for (const item of targets) {
-    const validTarget = EntitySchema.is(item) || (item instanceof Function && MetadataStorage.isKnownEntity(item.name));
+    if (EntitySchema.is(item)) {
+      if (!allTargets.has(item)) {
+        allTargets.set(item, path);
+      }
+    } else if (item instanceof Function) {
+      const schema = EntitySchema.REGISTRY.get(item);
 
-    if (validTarget && !allTargets.has(item)) {
-      allTargets.set(item, path);
+      if (schema && !allTargets.has(schema)) {
+        allTargets.set(schema, path);
+      } else if (!schema && MetadataStorage.isKnownEntity(item.name) && !allTargets.has(item)) {
+        allTargets.set(item, path);
+      }
     }
   }
 }

--- a/tests/MikroORM.test.ts
+++ b/tests/MikroORM.test.ts
@@ -164,7 +164,23 @@ describe('MikroORM', () => {
       'AbstractClass',
       'ClassA',
       'ClassB',
+      'User',
     ]);
+  });
+
+  test('should discover defineEntity class via glob when only class is exported', async () => {
+    const orm = await MikroORM.init({
+      driver: SqliteDriver,
+      dbName: ':memory:',
+      baseDir: BASE_DIR,
+      entities: ['complex-entities/define-entity-class-only.entity.js'],
+      entitiesTs: ['complex-entities/define-entity-class-only.entity.ts'],
+    });
+
+    expect(orm).toBeInstanceOf(MikroORM);
+    expect([...orm.getMetadata().getAll().keys()].map(k => k.name).sort()).toEqual(['User']);
+
+    await orm.close();
   });
 
   test('should NOT throw when multiple entities with same file name discovered', async () => {

--- a/tests/complex-entities/define-entity-class-only.entity.ts
+++ b/tests/complex-entities/define-entity-class-only.entity.ts
@@ -1,0 +1,16 @@
+import { defineEntity, p } from '@mikro-orm/core';
+
+// Only the class is exported, not the schema.
+// Glob discovery should still find this entity via EntitySchema.REGISTRY.
+const UserSchema = defineEntity({
+  name: 'User',
+  properties: {
+    id: p.integer().primary(),
+    fullName: p.string(),
+    email: p.string(),
+  },
+});
+
+export class User extends UserSchema.class {}
+
+UserSchema.setClass(User);


### PR DESCRIPTION
## Summary

- Glob-based entity discovery failed when using `defineEntity` + `setClass()` if only the class was exported but not the schema (`MetadataError: No entities were discovered`)
- The discovery now checks `EntitySchema.REGISTRY` for exported classes, resolving them to their associated schema to naturally deduplicate against schemas that may also be exported

Reproducer: https://github.com/jscheel/mikro-orm-entity-glob-discovery-issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)