### PR TITLE
feat(postgresql): generate check constraints for enum array columns

### DIFF
--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -1921,17 +1921,24 @@ export class MetadataDiscovery {
 
     if (this.#platform.usesEnumCheckConstraints() && !meta.embeddable) {
       for (const prop of meta.props) {
-        if (
-          prop.enum &&
-          prop.persist !== false &&
-          !prop.nativeEnumName &&
-          prop.items?.every(item => typeof item === 'string')
-        ) {
-          this.initFieldName(prop);
+        if (prop.persist === false || prop.nativeEnumName || !prop.items?.every(item => typeof item === 'string')) {
+          continue;
+        }
+
+        this.initFieldName(prop);
+        let expression: string | null = null;
+
+        if (prop.enum) {
+          expression = `${this.#platform.quoteIdentifier(prop.fieldNames[0])} in ('${prop.items.join("', '")}')`;
+        } else if (prop.array) {
+          expression = this.#platform.getEnumArrayCheckConstraintExpression(prop.fieldNames[0], prop.items as string[]);
+        }
+
+        if (expression) {
           meta.checks.push({
             name: this.#namingStrategy.indexName(meta.tableName, prop.fieldNames, 'check'),
             property: prop.name,
-            expression: `${this.#platform.quoteIdentifier(prop.fieldNames[0])} in ('${prop.items.join("', '")}')`,
+            expression,
           });
         }
       }

--- a/packages/core/src/platforms/Platform.ts
+++ b/packages/core/src/platforms/Platform.ts
@@ -107,6 +107,11 @@ export abstract class Platform {
     return false;
   }
 
+  /** Returns the check constraint expression for an enum array column, or null if unsupported. */
+  getEnumArrayCheckConstraintExpression(column: string, items: string[]): string | null {
+    return null;
+  }
+
   /** Whether this platform supports materialized views. */
   supportsMaterializedViews(): boolean {
     return false;

--- a/packages/sql/src/dialects/postgresql/BasePostgreSqlPlatform.ts
+++ b/packages/sql/src/dialects/postgresql/BasePostgreSqlPlatform.ts
@@ -44,6 +44,10 @@ export class BasePostgreSqlPlatform extends AbstractSqlPlatform {
     return true;
   }
 
+  override getEnumArrayCheckConstraintExpression(column: string, items: string[]): string {
+    return `${this.quoteIdentifier(column)} <@ array[${items.map(item => `'${item}'::text`).join(', ')}]`;
+  }
+
   override supportsMaterializedViews(): boolean {
     return true;
   }

--- a/tests/features/reflection/GH7352.test.ts
+++ b/tests/features/reflection/GH7352.test.ts
@@ -14,7 +14,7 @@ class Sample {
   porosity: Porosity[] | null = null;
 }
 
-test('GH #7352 - enum array should not generate check constraints', async () => {
+test('GH #7352 - enum array generates proper check constraint for postgres', async () => {
   const orm = await MikroORM.init({
     metadataProvider: TsMorphMetadataProvider,
     metadataCache: { enabled: false },
@@ -23,7 +23,13 @@ test('GH #7352 - enum array should not generate check constraints', async () => 
   });
 
   const meta = orm.getMetadata().get(Sample);
-  expect(meta.checks).toEqual([]);
+  expect(meta.checks).toEqual([
+    {
+      name: 'sample_porosity_check',
+      property: 'porosity',
+      expression: `"porosity" <@ array['meso'::text, 'macro'::text, 'micro'::text]`,
+    },
+  ]);
 
   await orm.schema.refresh();
   const diff = await orm.schema.getUpdateSchemaSQL({ wrap: false });

--- a/tests/features/schema-generator/enum-array.postgres.test.ts
+++ b/tests/features/schema-generator/enum-array.postgres.test.ts
@@ -1,6 +1,7 @@
-import { MikroORM } from '@mikro-orm/postgresql';
+import { EntitySchema, MikroORM } from '@mikro-orm/postgresql';
 
 import { Entity, Enum, PrimaryKey, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+
 enum AdminPermission {
   ROOT = 'ROOT',
   ACCESS = 'ACCESS',
@@ -26,10 +27,109 @@ test('enum array diffing', async () => {
     dbName: `mikro_orm_test_enum_array_diffing`,
   });
 
+  const createSQL = await orm.schema.getCreateSchemaSQL({ wrap: false });
+  expect(createSQL).toContain(
+    `alter table "admin" add constraint "admin_permissions_check" check ("permissions" <@ array['ROOT'::text, 'ACCESS'::text]);`,
+  );
+
   await orm.schema.refresh();
 
   const diff = await orm.schema.getUpdateSchemaSQL({ wrap: false });
   expect(diff).toBe('');
 
   await orm.close(true);
+});
+
+describe('enum array check constraint diffing', () => {
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      entities: [Admin],
+      dbName: `mikro_orm_test_enum_array_diffing`,
+    });
+
+    await orm.schema.refresh();
+  });
+
+  afterAll(() => orm.close(true));
+
+  test('add enum item updates check constraint', async () => {
+    const meta = orm.getMetadata().get(Admin);
+    const prop = meta.properties.permissions;
+    prop.items = ['ROOT', 'ACCESS', 'MANAGE'];
+    meta.checks = [
+      {
+        name: 'admin_permissions_check',
+        property: 'permissions',
+        expression: `"permissions" <@ array['ROOT'::text, 'ACCESS'::text, 'MANAGE'::text]`,
+      },
+    ];
+
+    const diff = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(diff).toContain('alter table "admin" drop constraint "admin_permissions_check"');
+    expect(diff).toContain(
+      `alter table "admin" add constraint "admin_permissions_check" check ("permissions" <@ array['ROOT'::text, 'ACCESS'::text, 'MANAGE'::text])`,
+    );
+    await orm.schema.execute(diff);
+
+    const diff2 = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(diff2).toBe('');
+  });
+
+  test('remove enum item updates check constraint', async () => {
+    const meta = orm.getMetadata().get(Admin);
+    const prop = meta.properties.permissions;
+    prop.items = ['ROOT'];
+    meta.checks = [
+      {
+        name: 'admin_permissions_check',
+        property: 'permissions',
+        expression: `"permissions" <@ array['ROOT'::text]`,
+      },
+    ];
+
+    const diff = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(diff).toContain('alter table "admin" drop constraint "admin_permissions_check"');
+    expect(diff).toContain(
+      `alter table "admin" add constraint "admin_permissions_check" check ("permissions" <@ array['ROOT'::text])`,
+    );
+    await orm.schema.execute(diff);
+
+    const diff2 = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(diff2).toBe('');
+  });
+
+  test('remove check constraint', async () => {
+    const meta = orm.getMetadata().get(Admin);
+    meta.checks = [];
+
+    const diff = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(diff).toContain('alter table "admin" drop constraint "admin_permissions_check"');
+    await orm.schema.execute(diff);
+
+    const diff2 = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(diff2).toBe('');
+  });
+
+  test('add check constraint back', async () => {
+    const meta = orm.getMetadata().get(Admin);
+    meta.checks = [
+      {
+        name: 'admin_permissions_check',
+        property: 'permissions',
+        expression: `"permissions" <@ array['ROOT'::text, 'ACCESS'::text]`,
+      },
+    ];
+
+    const diff = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(diff).toContain(
+      `alter table "admin" add constraint "admin_permissions_check" check ("permissions" <@ array['ROOT'::text, 'ACCESS'::text])`,
+    );
+    await orm.schema.execute(diff);
+
+    const diff2 = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(diff2).toBe('');
+  });
 });

--- a/tests/issues/__snapshots__/GH6688.test.ts.snap
+++ b/tests/issues/__snapshots__/GH6688.test.ts.snap
@@ -28,6 +28,7 @@ exports[`default array values [postgresql] > database default when using arrays 
 "set names 'utf8';
 
 create table "a" ("id" serial primary key, "languages" text[] not null default '{en}', "accounts" jsonb not null default '[]', "items" text[] not null default '{}');
+alter table "a" add constraint "a_items_check" check ("items" <@ array['a'::text, 'b'::text, 'c'::text]);
 "
 `;
 


### PR DESCRIPTION
## Summary
- Add `<@` array check constraints for enum array columns on PostgreSQL (e.g. `"col" <@ array['a'::text, 'b'::text]`)
- Add `Platform.getEnumArrayCheckConstraintExpression()` hook for dialect-specific array constraint expressions
- Only PostgreSQL implements this since other dialects store arrays as comma-separated text where such constraints aren't feasible

Closes #7352

🤖 Generated with [Claude Code](https://claude.com/claude-code)