### PR TITLE
feat(postgresql): add NativeArrayType for typed native array columns

### DIFF
--- a/docs/docs/custom-types.md
+++ b/docs/docs/custom-types.md
@@ -515,6 +515,47 @@ export class CalendarDateArrayType extends ArrayType<CalendarDate> {
 favoriteDays!: CalendarDate[];
 ```
 
+### NativeArrayType (PostgreSQL)
+
+`NativeArrayType` is a PostgreSQL-specific type (from `@mikro-orm/postgresql`) that wraps any other type and produces a native PostgreSQL typed array column. Unlike the core `ArrayType` which always creates a `text[]` column and marshalls values to a delimited string, `NativeArrayType` derives the element column type from the inner type and appends `[]`, so you get columns like `integer[]`, `decimal(10,2)[]`, `boolean[]`, etc.
+
+Per-element conversion is delegated to the inner type, which means features such as `DecimalType`'s precision-aware comparison and custom `convertToJSValue` continue to work on each array element.
+
+The `nullable` option applies to the array column itself (the column may be `NULL`), while all other property options (e.g. `precision`, `scale`, `length`) are forwarded to the inner type when determining the element column type.
+
+```ts
+import { NativeArrayType } from '@mikro-orm/postgresql';
+import { types, DecimalType } from '@mikro-orm/core';
+
+// integer[] column
+@Property({ type: new NativeArrayType(types.integer) })
+ids!: number[];
+
+// decimal(10,2)[] column – precision and scale are forwarded to the inner DecimalType
+@Property({ type: new NativeArrayType(new DecimalType('number')), precision: 10, scale: 2 })
+prices!: number[];
+
+// nullable text[] column
+@Property({ type: new NativeArrayType(types.string), nullable: true })
+tags?: string[] | null;
+```
+
+With `defineEntity` you can use `p.type()` to attach the custom type:
+
+```ts
+import { defineEntity, p, types, DecimalType } from '@mikro-orm/core';
+import { NativeArrayType } from '@mikro-orm/postgresql';
+
+const Product = defineEntity({
+  name: 'Product',
+  properties: {
+    id: p.integer().primary(),
+    tagIds: p.type(new NativeArrayType(types.integer)),
+    prices: p.type(new NativeArrayType(new DecimalType('number'))).precision(10).scale(2),
+  },
+});
+```
+
 ### BigIntType
 
 Since v6, `bigint`s are represented by the native `BigInt` type, and as such, they don't require explicit type in the decorator options:

--- a/packages/postgresql/src/NativeArrayType.ts
+++ b/packages/postgresql/src/NativeArrayType.ts
@@ -1,0 +1,83 @@
+import type { Constructor, EntityProperty, Platform, TransformContext } from '@mikro-orm/core';
+import { Type } from '@mikro-orm/core';
+
+/**
+ * Maps a PostgreSQL native typed array column (e.g. `integer[]`, `decimal(10,2)[]`) to a JS array.
+ *
+ * Unlike the core `ArrayType` which always uses a `text[]` column and marshalls values to/from
+ * a delimited string, `NativeArrayType` derives the element column type from the supplied inner
+ * type and appends `[]`, producing a proper PostgreSQL typed array column. Per-element conversion
+ * is delegated to the inner type, so features like `DecimalType`'s precision-aware comparison
+ * continue to work on each element.
+ *
+ * The `nullable` decorator/defineEntity option applies to the array column itself (i.e. the
+ * column may be `NULL`), while all other property options (e.g. `precision`, `scale`) are
+ * forwarded to the inner type when determining the element column type.
+ *
+ * @example
+ * // integer[] column
+ * @Property({ type: new NativeArrayType(types.integer) })
+ * ids!: number[];
+ *
+ * @example
+ * // decimal(10,2)[] column
+ * @Property({ type: new NativeArrayType(new DecimalType('number')), precision: 10, scale: 2 })
+ * prices!: number[];
+ */
+export class NativeArrayType<InnerJsType, InnerDbType> extends Type<InnerJsType[] | null, InnerDbType[] | null> {
+  readonly #inner: Type<InnerJsType, InnerDbType>;
+
+  constructor(inner: Constructor<Type<InnerJsType, InnerDbType>> | Type<InnerJsType, InnerDbType>) {
+    super();
+    this.#inner = inner instanceof Type ? inner : new inner();
+
+    for (const key of ['platform', 'meta', 'prop'] as const) {
+      Object.defineProperty(this, key, {
+        get: () => this.#inner[key],
+        set: (value) => this.#inner.prop = key === 'prop' ? { ...value, autoincrement: false } : value,
+        enumerable: true,
+        configurable: true,
+      });
+    }
+  }
+
+  override getColumnType(prop: EntityProperty, platform: Platform): string {
+    const innerProp = { ...prop, autoincrement: false };
+    return `${this.#inner.getColumnType(innerProp, platform)}[]`;
+  }
+
+  override convertToDatabaseValue(
+    value: InnerJsType[] | null,
+    platform: Platform,
+    context?: TransformContext,
+  ): InnerDbType[] | null {
+    if (value == null) {
+      return value;
+    }
+
+    return value.map(item => this.#inner.convertToDatabaseValue(item, platform, context));
+  }
+
+  override convertToJSValue(
+    value: InnerDbType[] | null,
+    platform: Platform,
+  ): InnerJsType[] | null {
+    if (value == null) {
+      return value;
+    }
+
+    return value.map(item => this.#inner.convertToJSValue(item, platform));
+  }
+
+  override compareAsType(): string {
+    return 'array';
+  }
+
+  override toJSON(value: InnerJsType[] | null, platform: Platform): InnerJsType[] | InnerDbType[] | null {
+    if (value == null) {
+      return value;
+    }
+
+    return value.map(item => this.#inner.toJSON(item, platform)) as InnerJsType[] | InnerDbType[];
+  }
+}

--- a/packages/postgresql/src/index.ts
+++ b/packages/postgresql/src/index.ts
@@ -1,4 +1,5 @@
 export * from '@mikro-orm/sql';
+export * from './NativeArrayType.js';
 export * from './PostgreSqlConnection.js';
 export * from './PostgreSqlDriver.js';
 export * from './PostgreSqlPlatform.js';

--- a/tests/features/custom-types/NativeArrayType.postgres.test.ts
+++ b/tests/features/custom-types/NativeArrayType.postgres.test.ts
@@ -1,0 +1,113 @@
+import { DecimalType, IntegerType, BooleanType, StringType, OptionalProps } from '@mikro-orm/postgresql';
+import { MikroORM } from '@mikro-orm/postgresql';
+import { Entity, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+import { NativeArrayType } from '@mikro-orm/postgresql';
+import { mockLogger } from '../../helpers.js';
+
+@Entity()
+class Product {
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ type: new NativeArrayType(new IntegerType()) })
+  tagIds!: number[];
+
+  @Property({ type: new NativeArrayType(new DecimalType('number')), precision: 10, scale: 2 })
+  prices!: number[];
+
+  @Property({ type: new NativeArrayType(new BooleanType()) })
+  flags!: boolean[];
+
+  @Property({ type: new NativeArrayType(new StringType()), nullable: true })
+  labels?: string[] | null;
+
+  [OptionalProps]?: 'labels';
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    metadataProvider: ReflectMetadataProvider,
+    entities: [Product],
+    dbName: 'native_array_type',
+  });
+  await orm.schema.refresh();
+});
+
+afterAll(() => orm.close(true));
+
+test('getColumnType produces typed array columns', async () => {
+  const sql = await orm.schema.getCreateSchemaSQL();
+  expect(sql).toMatch('"tag_ids" int[]');
+  expect(sql).toMatch('"prices" numeric(10,2)[]');
+  expect(sql).toMatch('"flags" boolean[]');
+  expect(sql).toMatch('"labels" varchar(255)[]');
+});
+
+test('persist and retrieve entity with native array columns', async () => {
+  const product = orm.em.create(Product, {
+    id: 1,
+    tagIds: [1, 2, 3],
+    prices: [9.99, 19.99, 29.99],
+    flags: [true, false, true],
+    labels: ['foo', 'bar'],
+  });
+  await orm.em.flush();
+  orm.em.clear();
+
+  const found = await orm.em.findOneOrFail(Product, { id: 1 });
+  expect(found.tagIds).toStrictEqual([1, 2, 3]);
+  expect(found.prices).toStrictEqual([9.99, 19.99, 29.99]);
+  expect(found.flags).toStrictEqual([true, false, true]);
+  expect(found.labels).toStrictEqual(['foo', 'bar']);
+});
+
+test('nullable array column can store null', async () => {
+  const product = orm.em.create(Product, {
+    id: 2,
+    tagIds: [],
+    prices: [],
+    flags: [],
+    labels: null,
+  });
+  await orm.em.flush();
+  orm.em.clear();
+
+  const found = await orm.em.findOneOrFail(Product, { id: 2 });
+  expect(found.labels).toBeNull();
+});
+
+test('empty arrays roundtrip correctly', async () => {
+  const product = orm.em.create(Product, {
+    id: 3,
+    tagIds: [],
+    prices: [],
+    flags: [],
+    labels: [],
+  });
+  await orm.em.flush();
+  orm.em.clear();
+
+  const found = await orm.em.findOneOrFail(Product, { id: 3 });
+  expect(found.tagIds).toStrictEqual([]);
+  expect(found.prices).toStrictEqual([]);
+  expect(found.flags).toStrictEqual([]);
+  expect(found.labels).toStrictEqual([]);
+});
+
+test('no spurious update after loading entity', async () => {
+  const product = orm.em.create(Product, {
+    id: 4,
+    tagIds: [10, 20],
+    prices: [1.5],
+    flags: [false],
+  });
+  await orm.em.flush();
+  orm.em.clear();
+
+  await orm.em.findOneOrFail(Product, { id: 4 });
+  const mock = mockLogger(orm);
+  await orm.em.flush();
+  expect(mock).not.toHaveBeenCalled();
+});

--- a/tests/features/custom-types/NativeArrayType.test.ts
+++ b/tests/features/custom-types/NativeArrayType.test.ts
@@ -1,0 +1,119 @@
+import { DecimalType, IntegerType, StringType, BooleanType } from '@mikro-orm/core';
+import { NativeArrayType } from '@mikro-orm/postgresql';
+import { PostgreSqlPlatform } from '@mikro-orm/postgresql';
+
+const platform = new PostgreSqlPlatform();
+const prop = (overrides: Record<string, unknown> = {}) =>
+  ({ columnTypes: [], autoincrement: false, ...overrides }) as any;
+
+describe('NativeArrayType', () => {
+  describe('getColumnType', () => {
+    test('integer[] from IntegerType instance', () => {
+      const type = new NativeArrayType(new IntegerType());
+      expect(type.getColumnType(prop(), platform)).toBe('int[]');
+    });
+
+    test('integer[] from IntegerType constructor', () => {
+      const type = new NativeArrayType(IntegerType);
+      expect(type.getColumnType(prop(), platform)).toBe('int[]');
+    });
+
+    test('decimal(10,2)[] forwards precision and scale to inner type', () => {
+      const type = new NativeArrayType(new DecimalType());
+      expect(type.getColumnType(prop({ precision: 10, scale: 2 }), platform)).toBe('numeric(10,2)[]');
+    });
+
+    test('varchar(100)[] forwards length to inner type', () => {
+      const type = new NativeArrayType(new StringType());
+      expect(type.getColumnType(prop({ length: 100 }), platform)).toBe('varchar(100)[]');
+    });
+
+    test('strips autoincrement so inner type does not produce serial', () => {
+      const type = new NativeArrayType(new IntegerType());
+      expect(type.getColumnType(prop({ autoincrement: true }), platform)).toBe('int[]');
+    });
+  });
+
+  describe('convertToDatabaseValue', () => {
+    test('passes each item through the inner type', () => {
+      const inner = new DecimalType('number');
+      const type = new NativeArrayType(inner);
+      expect(type.convertToDatabaseValue([1.5, 2.5], platform)).toStrictEqual([1.5, 2.5]);
+    });
+
+    test('returns null as-is', () => {
+      const type = new NativeArrayType(new IntegerType());
+      expect(type.convertToDatabaseValue(null, platform)).toBeNull();
+    });
+
+    test('returns undefined as-is', () => {
+      const type = new NativeArrayType(new IntegerType());
+      expect(type.convertToDatabaseValue(undefined as any, platform)).toBeUndefined();
+    });
+
+    test('integer values pass through', () => {
+      const type = new NativeArrayType(new IntegerType());
+      expect(type.convertToDatabaseValue([1, 2, 3], platform)).toStrictEqual([1, 2, 3]);
+    });
+
+    test('boolean values pass through', () => {
+      const type = new NativeArrayType(new BooleanType());
+      expect(type.convertToDatabaseValue([true, false], platform)).toStrictEqual([true, false]);
+    });
+  });
+
+  describe('convertToJSValue', () => {
+    test('returns null as-is', () => {
+      const type = new NativeArrayType(new IntegerType());
+      expect(type.convertToJSValue(null, platform)).toBeNull();
+    });
+
+    test('returns undefined as-is', () => {
+      const type = new NativeArrayType(new IntegerType());
+      expect(type.convertToJSValue(undefined as any, platform)).toBeUndefined();
+    });
+
+    test('integer values pass through', () => {
+      const type = new NativeArrayType(new IntegerType());
+      expect(type.convertToJSValue([1, 2, 3], platform)).toStrictEqual([1, 2, 3]);
+    });
+
+    test('DecimalType convertToJSValue maps string elements to numbers in number mode', () => {
+      const inner = new DecimalType('number');
+      const type = new NativeArrayType(inner);
+      expect(type.convertToJSValue(['1.50', '2.75'] as any, platform)).toStrictEqual([1.5, 2.75]);
+    });
+  });
+
+  describe('compareAsType', () => {
+    test('returns "array"', () => {
+      expect(new NativeArrayType(new IntegerType()).compareAsType()).toBe('array');
+    });
+  });
+
+  describe('toJSON', () => {
+    test('returns null as-is', () => {
+      const type = new NativeArrayType(new IntegerType());
+      expect(type.toJSON(null, platform)).toBeNull();
+    });
+
+    test('returns array as-is for simple types', () => {
+      const type = new NativeArrayType(new IntegerType());
+      expect(type.toJSON([1, 2, 3], platform)).toStrictEqual([1, 2, 3]);
+    });
+  });
+
+  describe('roundtrip', () => {
+    test('integer array roundtrip', () => {
+      const type = new NativeArrayType(new IntegerType());
+      const original = [1, 2, 3];
+      const db = type.convertToDatabaseValue(original, platform);
+      expect(type.convertToJSValue(db, platform)).toStrictEqual(original);
+    });
+
+    test('nullable array roundtrip', () => {
+      const type = new NativeArrayType(new IntegerType());
+      expect(type.convertToJSValue(type.convertToDatabaseValue(null, platform), platform)).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
While Mikro ORM has an `ArrayType` in core, it defaults to using `text[]` in Postgres as its primary type. One can extend the `ArrayType` and override that behavior, but that is a lot of unnecessary  work which can be avoided.

This PR introduces `NativeArrayType` in the `postgres` package. It allows wrapping any other type and turning it into an array type. Props are automatically forwarded to the inner type, so the type stays fully configurable.

In theory one can even wrap multiple `NativeArrayType`s to get multi-dimensional arrays in postgres.

## Usage

```ts
// integer[] column
@Property({ type: new NativeArrayType(IntegerType) })
tagIds!: number[];

// decimal(10,2)[] — precision/scale forwarded to inner type
@Property({ type: new NativeArrayType(new DecimalType('number')), precision: 10, scale: 2 })
prices!: number[];

// nullable
@Property({ type: new NativeArrayType(StringType), nullable: true })
labels?: string[] | null;
```

This also works with `defineEntity()`:

```ts
{
  properties: {
    tagIds: p.type(new NativeArrayType(IntegerType)),
  },
}
```
