### PR TITLE
Add mention of dotenvx alongside dotenv.

### DIFF
--- a/docs/blog/2026-03-11-mikro-orm-7-released.md
+++ b/docs/blog/2026-03-11-mikro-orm-7-released.md
@@ -38,7 +38,7 @@ One of the headline features of v7 is that the `@mikro-orm/core` package now has
 
 This has huge implications for bundle size, cold start times (great news for serverless users!), and overall maintainability. Some of these dependencies are still available as optional peer dependencies - for instance, install `dataloader` if you want the dataloader integration, and `reflect-metadata` if you prefer the reflect-based metadata provider.
 
-> Dotenv support has been removed entirely. If you relied on automatic `.env` loading, you'll need to call `dotenv.config()` yourself before initializing the ORM.
+> Dotenv support has been removed entirely. If you relied on automatic `.env` loading, you'll need to call `dotenv.config()` yourself before initializing the ORM, or use [`@dotenvx/dotenvx`](https://github.com/dotenvx/dotenvx) (for added encryption–from the creator of dotenv).
 
 ## Knex replaced with Kysely
 

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -768,7 +768,7 @@ If you also set other environment variables, MikroORM will still search for a co
 
 ### Using `.env` file
 
-If you want to use a `.env` file, you can use the `dotenv` package to load it before initializing the ORM:
+If you want to use a `.env` file, you can use the `dotenv` or `@dotenvx/dotenvx` package to load it before initializing the ORM.
 
 ```ts
 import 'dotenv/config';

--- a/docs/docs/upgrading-v6-to-v7.md
+++ b/docs/docs/upgrading-v6-to-v7.md
@@ -481,7 +481,7 @@ npm install tinyglobby
 
 ## Dotenv file support removed
 
-If you want to use a `.env` file, you need to use the `dotenv` package directly (and install it explicitly):
+If you want to use a `.env` file, you need to use the `dotenv` or `@dotenvx/dotenvx` package directly (and install it explicitly):
 
 ```ts
 import 'dotenv/config';

--- a/docs/versioned_docs/version-7.0/configuration.md
+++ b/docs/versioned_docs/version-7.0/configuration.md
@@ -768,7 +768,7 @@ If you also set other environment variables, MikroORM will still search for a co
 
 ### Using `.env` file
 
-If you want to use a `.env` file, you can use the `dotenv` package to load it before initializing the ORM:
+If you want to use a `.env` file, you can use the `dotenv` or `@dotenvx/dotenvx` package to load it before initializing the ORM.
 
 ```ts
 import 'dotenv/config';

--- a/docs/versioned_docs/version-7.0/upgrading-v6-to-v7.md
+++ b/docs/versioned_docs/version-7.0/upgrading-v6-to-v7.md
@@ -481,7 +481,7 @@ npm install tinyglobby
 
 ## Dotenv file support removed
 
-If you want to use a `.env` file, you need to use the `dotenv` package directly (and install it explicitly):
+If you want to use a `.env` file, you need to use the `dotenv` or `@dotenvx/dotenvx` package directly (and install it explicitly):
 
 ```ts
 import 'dotenv/config';


### PR DESCRIPTION
Adds mention of dotenvx which adds encryption safety as well as default variable expansion out of the box. It's a drop-in replacement from me the creator of dotenv.