### PR TITLE
fix(sql): use column name mapping for decorator entities in `getKysely` types

### DIFF
--- a/packages/sql/src/typings.ts
+++ b/packages/sql/src/typings.ts
@@ -399,7 +399,7 @@ export type InferClassEntityDB<TEntities, TOptions extends MikroKyselyPluginOpti
   ClassEntityDBMap<TEntities, TOptions> extends infer R ? ([keyof R] extends [never] ? unknown : R) : never;
 
 type ClassEntityDBMap<TEntities, TOptions extends MikroKyselyPluginOptions = {}> = {
-  [T in TEntities as ClassEntityTableName<T, TOptions>]: ClassEntityColumns<T>;
+  [T in TEntities as ClassEntityTableName<T, TOptions>]: ClassEntityColumns<T, TOptions>;
 };
 
 type ClassEntityTableName<T, TOptions extends MikroKyselyPluginOptions = {}> = T extends abstract new (
@@ -408,16 +408,29 @@ type ClassEntityTableName<T, TOptions extends MikroKyselyPluginOptions = {}> = T
   ? TransformName<InferEntityName<Instance>, TOptions['tableNamingStrategy'] extends 'entity' ? 'entity' : 'underscore'>
   : never;
 
-type ClassEntityColumns<T> = T extends abstract new (...args: any[]) => infer Instance
-  ? { [K in keyof Instance as ClassEntityColumnName<K, Instance[K]>]: ClassEntityColumnValue<Instance[K]> }
+type ClassEntityColumns<T, TOptions extends MikroKyselyPluginOptions = {}> = T extends abstract new (
+  ...args: any[]
+) => infer Instance
+  ? { [K in keyof Instance as ClassEntityColumnName<K, Instance[K], TOptions>]: ClassEntityColumnValue<Instance[K]> }
   : never;
 
-type ClassEntityColumnName<K, V> = K extends symbol
+type ClassEntityColumnName<K, V, TOptions extends MikroKyselyPluginOptions = {}> = K extends symbol
   ? never
-  : NonNullable<V> extends Scalar
-    ? K
-    : NonNullable<V> extends { [k: number]: any; readonly owner: object }
+  : NonNullable<V> extends infer NV
+    ? NV extends { [k: number]: any; readonly owner: object }
       ? never
-      : K;
+      : TOptions['columnNamingStrategy'] extends 'property'
+        ? K
+        : NV extends Scalar
+          ? K extends string
+            ? SnakeCase<K>
+            : never
+          : K extends string
+            ? ClassEntityJoinColumnName<SnakeCase<K>, NV>
+            : never
+    : never;
+
+type ClassEntityJoinColumnName<TName extends string, V> =
+  PrimaryProperty<V> extends string ? `${TName}_${SnakeCase<PrimaryProperty<V>>}` : never;
 
 type ClassEntityColumnValue<V> = NonNullable<V> extends Scalar ? V : Primary<NonNullable<V>>;

--- a/tests/features/get-kysely.test.ts
+++ b/tests/features/get-kysely.test.ts
@@ -5,6 +5,7 @@ import {
   EntityName,
   Collection,
   Opt,
+  Rel,
   MikroORM,
   InferClassEntityDB,
   InferDBFromKysely,
@@ -654,20 +655,27 @@ describe('InferClassEntityDB', () => {
   });
 
   test('InferClassEntityDB type utility', () => {
+    // default: column name mapping (snake_case + FK suffix)
     type DB = InferClassEntityDB<typeof Author | typeof Post>;
 
     expectTypeOf<DB>().toHaveProperty('author');
     expectTypeOf<DB>().toHaveProperty('post');
     expectTypeOf<DB['author']['id']>().toEqualTypeOf<number>();
-    expectTypeOf<DB['author']['firstName']>().toEqualTypeOf<string>();
+    expectTypeOf<DB['author']['first_name']>().toEqualTypeOf<string>();
     expectTypeOf<DB['post']['title']>().toEqualTypeOf<string>();
+    expectTypeOf<DB['post']>().toHaveProperty('created_at');
 
-    // collections are excluded, FK columns are inferred for relations
+    // collections are excluded, FK columns are inferred with column names
     type AuthorKeys = keyof DB['author'];
     expectTypeOf<'posts'>().not.toMatchTypeOf<AuthorKeys>();
-    // post has author FK column with PK type
-    expectTypeOf<DB['post']>().toHaveProperty('author');
-    expectTypeOf<DB['post']['author']>().toEqualTypeOf<number>();
+    // post has author_id FK column with PK type
+    expectTypeOf<DB['post']>().toHaveProperty('author_id');
+    expectTypeOf<DB['post']['author_id']>().toEqualTypeOf<number>();
+
+    // property naming strategy
+    type DBProp = InferClassEntityDB<typeof Author | typeof Post, { columnNamingStrategy: 'property' }>;
+    expectTypeOf<DBProp['author']['firstName']>().toEqualTypeOf<string>();
+    expectTypeOf<DBProp['post']['author']>().toEqualTypeOf<number>();
 
     // entity naming strategy
     type DBEntity = InferClassEntityDB<typeof Author | typeof Post, { tableNamingStrategy: 'entity' }>;
@@ -696,14 +704,74 @@ describe('InferClassEntityDB', () => {
       entities: [Book7367, Author7367],
       dbName: ':memory:',
     });
-    await orm.schema.create();
 
+    // default column naming: FK uses column name (author_id)
     const db = orm.em.getKysely();
-
     db.selectFrom('book7367').select('book7367.title');
-    db.selectFrom('book7367').select('book7367.author');
+    db.selectFrom('book7367').select('book7367.author_id');
+
+    // property naming: FK uses property name (author)
+    const db2 = orm.em.getKysely({ columnNamingStrategy: 'property' });
+    db2.selectFrom('book7367').select('book7367.author');
 
     await orm.close(true);
+  });
+
+  test('decorator and defineEntity produce consistent column naming', () => {
+    @Entity()
+    class AuthorDec {
+      [EntityName]?: 'AuthorDec';
+      @PrimaryKey({ type: 'uuid' }) id!: string;
+      @Property() name!: string;
+    }
+
+    @Entity()
+    class BookDec {
+      [EntityName]?: 'BookDec';
+      @PrimaryKey({ type: 'uuid' }) id!: string;
+      @Property() title!: string;
+      @ManyToOne(() => AuthorDec) author!: Rel<AuthorDec>;
+    }
+
+    const AuthorDE = defineEntity({
+      name: 'AuthorDE',
+      properties: {
+        id: p.uuid().primary(),
+        name: p.string(),
+      },
+    });
+
+    const BookDE = defineEntity({
+      name: 'BookDE',
+      properties: {
+        id: p.uuid().primary(),
+        title: p.string(),
+        author: () => p.manyToOne(AuthorDE),
+      },
+    });
+
+    // decorator entities: default column naming (snake_case + FK suffix)
+    type DBDec = InferClassEntityDB<typeof AuthorDec | typeof BookDec>;
+    expectTypeOf<DBDec['author_dec']>().toHaveProperty('id');
+    expectTypeOf<DBDec['author_dec']>().toHaveProperty('name');
+    expectTypeOf<DBDec['book_dec']>().toHaveProperty('id');
+    expectTypeOf<DBDec['book_dec']>().toHaveProperty('title');
+    expectTypeOf<DBDec['book_dec']>().toHaveProperty('author_id');
+    expectTypeOf<DBDec['book_dec']['author_id']>().toEqualTypeOf<string>();
+
+    // defineEntity: same column naming
+    type DBDE = InferKyselyDB<typeof AuthorDE | typeof BookDE>;
+    expectTypeOf<DBDE['author_de']>().toHaveProperty('id');
+    expectTypeOf<DBDE['author_de']>().toHaveProperty('name');
+    expectTypeOf<DBDE['book_de']>().toHaveProperty('id');
+    expectTypeOf<DBDE['book_de']>().toHaveProperty('title');
+    expectTypeOf<DBDE['book_de']>().toHaveProperty('author_id');
+    expectTypeOf<DBDE['book_de']['author_id']>().toEqualTypeOf<string>();
+
+    // property naming strategy: use property names as-is
+    type DBProp = InferClassEntityDB<typeof AuthorDec | typeof BookDec, { columnNamingStrategy: 'property' }>;
+    expectTypeOf<DBProp['book_dec']>().toHaveProperty('author');
+    expectTypeOf<DBProp['book_dec']['author']>().toEqualTypeOf<string>();
   });
 
   test('entities without EntityName are excluded from inference', () => {


### PR DESCRIPTION
## Summary

- `InferClassEntityDB` now applies snake_case transformation and FK column suffixes by default, matching `defineEntity` behavior (e.g. `author` property → `author_id` column, `firstName` → `first_name`)
- Supports `columnNamingStrategy: 'property'` option to use property names as-is
- Hoisted Collection check and used `infer` to deduplicate `NonNullable<V>` in `ClassEntityColumnName`

Closes #7367

🤖 Generated with [Claude Code](https://claude.com/claude-code)