### PR TITLE
feat(core): add `em.countBy()` for grouped counting

### DIFF
--- a/docs/docs/entity-manager.md
+++ b/docs/docs/entity-manager.md
@@ -452,6 +452,30 @@ order by (point(loc_latitude, loc_longitude) <@> point(0, 0)) asc
 
 Read more about this in [Using raw SQL query fragments](./raw-queries.md) section.
 
+### Counting by group
+
+Use `em.countBy()` to count entities grouped by one or more properties. Instead of N individual count queries, it issues a single `GROUP BY` query on SQL drivers and an aggregation pipeline on MongoDB:
+
+```ts
+// Count books per author
+const counts = await em.countBy(Book, 'author');
+// { '1': 2, '2': 1, '3': 3 }
+
+// Count with a filter
+const counts = await em.countBy(Book, 'author', { where: { active: true } });
+// { '1': 1, '3': 2 }
+
+// Composite groupBy — keys joined with ~~~
+const counts = await em.countBy(Order, ['status', 'country']);
+// { 'pending~~~US': 5, 'shipped~~~DE': 3 }
+```
+
+The same method is available on the repository:
+
+```ts
+const counts = await em.getRepository(Book).countBy('author');
+```
+
 ### Query Options
 
 The `em.find()` and `em.count()` methods accept several driver-specific query options:

--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -15,6 +15,7 @@ import { helper } from './entity/wrap.js';
 import { ChangeSet, ChangeSetType } from './unit-of-work/ChangeSet.js';
 import { UnitOfWork } from './unit-of-work/UnitOfWork.js';
 import type {
+  CountByOptions,
   CountOptions,
   DeleteOptions,
   EntityField,
@@ -2236,6 +2237,34 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
     await em.storeCache(options.cache, cached!, () => +count);
 
     return +count;
+  }
+
+  /**
+   * Counts entities grouped by one or more properties. Returns a dictionary keyed by the grouped
+   * field value(s), with counts as values. For composite `groupBy`, keys are joined with `~~~`.
+   *
+   * SQL drivers issue a single `GROUP BY` query; MongoDB uses an aggregation pipeline.
+   *
+   * @example
+   * ```ts
+   * // Count books per author
+   * const counts = await em.countBy(Book, 'author');
+   * // { '1': 2, '2': 1, '3': 3 }
+   *
+   * // Count with a filter
+   * const counts = await em.countBy(Book, 'author', { where: { active: true } });
+   *
+   * // Composite groupBy — keys joined with ~~~
+   * const counts = await em.countBy(Order, ['status', 'country']);
+   * // { 'pending~~~US': 5, 'shipped~~~DE': 3 }
+   * ```
+   */
+  async countBy<Entity extends object>(
+    entityName: EntityName<Entity>,
+    groupBy: EntityKey<Entity> | readonly EntityKey<Entity>[],
+    options?: CountByOptions<Entity>,
+  ): Promise<Dictionary<number>> {
+    throw new Error(`${this.constructor.name}.countBy() is not supported by the current driver`);
   }
 
   /**

--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -2931,7 +2931,11 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
   }
 
   protected prepareOptions(
-    options: FindOptions<any, any, any, any> | FindOneOptions<any, any, any, any> | CountOptions<any, any>,
+    options:
+      | FindOptions<any, any, any, any>
+      | FindOneOptions<any, any, any, any>
+      | CountOptions<any, any>
+      | CountByOptions<any>,
   ): void {
     if (!Utils.isEmpty((options as FindOptions<any>).fields) && !Utils.isEmpty((options as FindOptions<any>).exclude)) {
       throw new ValidationError(`Cannot combine 'fields' and 'exclude' option.`);

--- a/packages/core/src/drivers/IDatabaseDriver.ts
+++ b/packages/core/src/drivers/IDatabaseDriver.ts
@@ -508,11 +508,14 @@ export interface CountOptions<T extends object, P extends string = never> {
 }
 
 /** Options for `em.countBy()` queries. */
-export interface CountByOptions<T extends object, P extends string = never> extends Omit<
-  CountOptions<T, P>,
-  'groupBy'
-> {
+export interface CountByOptions<T extends object> {
   where?: FilterQuery<T>;
+  filters?: FilterOptions;
+  having?: FilterQuery<T>;
+  schema?: string;
+  flushMode?: FlushMode | `${FlushMode}`;
+  loggerContext?: LogContext;
+  logging?: LoggingOptions;
 }
 
 /** Options for `em.qb().update()` operations. */

--- a/packages/core/src/drivers/IDatabaseDriver.ts
+++ b/packages/core/src/drivers/IDatabaseDriver.ts
@@ -507,6 +507,14 @@ export interface CountOptions<T extends object, P extends string = never> {
   em?: EntityManager;
 }
 
+/** Options for `em.countBy()` queries. */
+export interface CountByOptions<T extends object, P extends string = never> extends Omit<
+  CountOptions<T, P>,
+  'groupBy'
+> {
+  where?: FilterQuery<T>;
+}
+
 /** Options for `em.qb().update()` operations. */
 export interface UpdateOptions<T> {
   filters?: FilterOptions;

--- a/packages/core/src/entity/EntityRepository.ts
+++ b/packages/core/src/entity/EntityRepository.ts
@@ -2,12 +2,14 @@ import type { PopulatePath } from '../enums.js';
 import type { CreateOptions, EntityManager, MergeOptions } from '../EntityManager.js';
 import type { AssignOptions } from './EntityAssigner.js';
 import type {
+  Dictionary,
   EntityData,
-  EntityName,
-  Primary,
-  Loaded,
-  FilterQuery,
   EntityDictionary,
+  EntityKey,
+  EntityName,
+  FilterQuery,
+  Loaded,
+  Primary,
   AutoPath,
   RequiredEntityData,
   Ref,
@@ -22,6 +24,7 @@ import type {
   WithUsingOptions,
 } from '../typings.js';
 import type {
+  CountByOptions,
   CountOptions,
   DeleteOptions,
   FindAllOptions,
@@ -431,6 +434,22 @@ export class EntityRepository<Entity extends object> {
     options: CountOptions<Entity, Hint> = {},
   ): Promise<number> {
     return this.getEntityManager().count<Entity, Hint>(this.entityName, where as any, options);
+  }
+
+  /**
+   * Counts entities grouped by one or more properties.
+   *
+   * @example
+   * ```ts
+   * const counts = await repo.countBy('status');
+   * // { 'active': 5, 'inactive': 2 }
+   * ```
+   */
+  async countBy(
+    groupBy: EntityKey<Entity> | readonly EntityKey<Entity>[],
+    options?: CountByOptions<Entity>,
+  ): Promise<Dictionary<number>> {
+    return this.getEntityManager().countBy<Entity>(this.entityName, groupBy, options);
   }
 
   /** Returns the entity class name associated with this repository. */

--- a/packages/mongodb/src/MongoDriver.ts
+++ b/packages/mongodb/src/MongoDriver.ts
@@ -492,7 +492,8 @@ export class MongoDriver extends DatabaseDriver<MongoConnection> {
     return ret;
   }
 
-  private renameFields<T extends object>(
+  /** @internal */
+  renameFields<T extends object>(
     entityName: EntityName<T>,
     data: T,
     dotPaths = false,

--- a/packages/mongodb/src/MongoEntityManager.ts
+++ b/packages/mongodb/src/MongoEntityManager.ts
@@ -6,6 +6,7 @@ import {
   type EntityKey,
   type EntityName,
   type EntityRepository,
+  type FilterQuery,
   type GetRepository,
   type Loaded,
   type StreamOptions,
@@ -73,7 +74,10 @@ export class MongoEntityManager<Driver extends MongoDriver = MongoDriver> extend
     const em = this.getContext(false) as MongoEntityManager;
     const meta = em.getMetadata().find(entityName)!;
     const fields = Utils.asArray(groupBy);
-    const { where, ...countOptions } = options;
+    await em.tryFlush(entityName, options);
+    const rawWhere = options.where;
+    const where = await em.processWhere(entityName, rawWhere ?? ({} as FilterQuery<Entity>), options as any, 'read');
+    const renamedWhere = em.getDriver().renameFields(meta.class, where as Entity, true);
 
     const fieldNames = fields.map(f => meta.properties[f as EntityKey<Entity>]?.fieldNames?.[0] ?? f);
     const groupId =
@@ -81,14 +85,13 @@ export class MongoEntityManager<Driver extends MongoDriver = MongoDriver> extend
 
     const pipeline: Dictionary[] = [];
 
-    if (where && Object.keys(where).length > 0) {
-      pipeline.push({ $match: where });
+    if (renamedWhere && Object.keys(renamedWhere).length > 0) {
+      pipeline.push({ $match: renamedWhere });
     }
 
     pipeline.push({ $group: { _id: groupId, count: { $sum: 1 } } });
 
-    const collection = em.getCollection(meta.collection);
-    const rows = await collection.aggregate(pipeline).toArray();
+    const rows = await em.getDriver().aggregate(meta.class, pipeline, em.getTransactionContext());
     const results: Dictionary<number> = {};
 
     for (const row of rows) {

--- a/packages/mongodb/src/MongoEntityManager.ts
+++ b/packages/mongodb/src/MongoEntityManager.ts
@@ -72,8 +72,15 @@ export class MongoEntityManager<Driver extends MongoDriver = MongoDriver> extend
     options: CountByOptions<Entity> = {},
   ): Promise<Dictionary<number>> {
     const em = this.getContext(false) as MongoEntityManager;
+    options = { ...options };
+    em.prepareOptions(options);
     const meta = em.getMetadata().find(entityName)!;
     const fields = Utils.asArray(groupBy);
+
+    if (options.having) {
+      throw new Error('The `having` option is not supported for MongoDB in `countBy`.');
+    }
+
     await em.tryFlush(entityName, options);
     const rawWhere = options.where;
     const where = await em.processWhere(entityName, rawWhere ?? ({} as FilterQuery<Entity>), options as any, 'read');

--- a/packages/mongodb/src/MongoEntityManager.ts
+++ b/packages/mongodb/src/MongoEntityManager.ts
@@ -1,12 +1,15 @@
 import {
   EntityManager,
   Utils,
+  type CountByOptions,
+  type Dictionary,
+  type EntityKey,
   type EntityName,
   type EntityRepository,
   type GetRepository,
-  type TransactionOptions,
-  type StreamOptions,
   type Loaded,
+  type StreamOptions,
+  type TransactionOptions,
   type WithUsingOptions,
 } from '@mikro-orm/core';
 import type { Collection, Document, TransactionOptions as MongoTransactionOptions } from 'mongodb';
@@ -57,6 +60,44 @@ export class MongoEntityManager<Driver extends MongoDriver = MongoDriver> extend
 
   getCollection<T extends Document>(entityOrCollectionName: EntityName<T> | string): Collection<T> {
     return this.getConnection().getCollection(entityOrCollectionName);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  override async countBy<Entity extends object>(
+    entityName: EntityName<Entity>,
+    groupBy: EntityKey<Entity> | readonly EntityKey<Entity>[],
+    options: CountByOptions<Entity> = {},
+  ): Promise<Dictionary<number>> {
+    const em = this.getContext(false) as MongoEntityManager;
+    const meta = em.getMetadata().find(entityName)!;
+    const fields = Utils.asArray(groupBy);
+    const { where, ...countOptions } = options;
+
+    const fieldNames = fields.map(f => meta.properties[f as EntityKey<Entity>]?.fieldNames?.[0] ?? f);
+    const groupId =
+      fieldNames.length === 1 ? `$${fieldNames[0]}` : Object.fromEntries(fieldNames.map(f => [f, `$${f}`]));
+
+    const pipeline: Dictionary[] = [];
+
+    if (where && Object.keys(where).length > 0) {
+      pipeline.push({ $match: where });
+    }
+
+    pipeline.push({ $group: { _id: groupId, count: { $sum: 1 } } });
+
+    const collection = em.getCollection(meta.collection);
+    const rows = await collection.aggregate(pipeline).toArray();
+    const results: Dictionary<number> = {};
+
+    for (const row of rows) {
+      const key =
+        fieldNames.length === 1 ? String(row._id) : fieldNames.map(f => String(row._id[f])).join(Utils.PK_SEPARATOR);
+      results[key] = +row.count;
+    }
+
+    return results;
   }
 
   /**

--- a/packages/sql/src/SqlEntityManager.ts
+++ b/packages/sql/src/SqlEntityManager.ts
@@ -1,15 +1,20 @@
 import {
   type EntitySchemaWithMeta,
   EntityManager,
+  raw,
+  Utils,
   type AnyEntity,
   type ConnectionType,
+  type CountByOptions,
+  type Dictionary,
   type EntityData,
+  type EntityKey,
   type EntityName,
   type EntityRepository,
-  type GetRepository,
-  type QueryResult,
   type FilterQuery,
+  type GetRepository,
   type LoggingOptions,
+  type QueryResult,
   type RawQueryFragment,
 } from '@mikro-orm/core';
 import type { AbstractSqlDriver } from './AbstractSqlDriver.js';
@@ -100,6 +105,48 @@ export class SqlEntityManager<Driver extends AbstractSqlDriver = AbstractSqlDriv
       this.getContext(false).getTransactionContext(),
       loggerContext,
     );
+  }
+
+  /**
+   * @inheritDoc
+   */
+  override async countBy<Entity extends object>(
+    entityName: EntityName<Entity>,
+    groupBy: EntityKey<Entity> | readonly EntityKey<Entity>[],
+    options: CountByOptions<Entity> = {},
+  ): Promise<Dictionary<number>> {
+    const em = this.getContext(false) as SqlEntityManager;
+    const meta = em.getMetadata().find(entityName)!;
+    const fields = Utils.asArray(groupBy);
+    const { where, ...countOptions } = options;
+    const qb = em.createQueryBuilder(meta.class);
+
+    (qb as any)
+      .select([...fields, raw('count(*) as "cnt"')])
+      .where(where ?? {})
+      .groupBy(fields as string[]);
+
+    if (countOptions.having) {
+      (qb as any).having(countOptions.having);
+    }
+
+    if (countOptions.schema) {
+      qb.withSchema(countOptions.schema);
+    }
+
+    const rows: any[] = await qb.execute('all', { mapResults: false });
+    const results: Dictionary<number> = {};
+
+    for (const row of rows) {
+      const keyParts = fields.map(f => {
+        const col = meta.properties[f as EntityKey<Entity>]?.fieldNames?.[0] ?? f;
+        return String(row[col]);
+      });
+      const key = keyParts.join(Utils.PK_SEPARATOR);
+      results[key] = +row.cnt;
+    }
+
+    return results;
   }
 
   override getRepository<T extends object, U extends EntityRepository<T> = SqlEntityRepository<T>>(

--- a/packages/sql/src/SqlEntityManager.ts
+++ b/packages/sql/src/SqlEntityManager.ts
@@ -118,12 +118,16 @@ export class SqlEntityManager<Driver extends AbstractSqlDriver = AbstractSqlDriv
     const em = this.getContext(false) as SqlEntityManager;
     const meta = em.getMetadata().find(entityName)!;
     const fields = Utils.asArray(groupBy);
-    const { where, ...countOptions } = options;
+    const { where: rawWhere, ...countOptions } = options;
+
+    await em.tryFlush(entityName, options);
+    const where = await em.processWhere(entityName, rawWhere ?? ({} as FilterQuery<Entity>), options as any, 'read');
+
     const qb = em.createQueryBuilder(meta.class);
 
     (qb as any)
-      .select([...fields, raw('count(*) as "cnt"')])
-      .where(where ?? {})
+      .select([...fields, raw('count(*) as cnt')])
+      .where(where)
       .groupBy(fields as string[]);
 
     if (countOptions.having) {

--- a/packages/sql/src/SqlEntityManager.ts
+++ b/packages/sql/src/SqlEntityManager.ts
@@ -116,6 +116,8 @@ export class SqlEntityManager<Driver extends AbstractSqlDriver = AbstractSqlDriv
     options: CountByOptions<Entity> = {},
   ): Promise<Dictionary<number>> {
     const em = this.getContext(false) as SqlEntityManager;
+    options = { ...options };
+    em.prepareOptions(options);
     const meta = em.getMetadata().find(entityName)!;
     const fields = Utils.asArray(groupBy);
     const { where: rawWhere, ...countOptions } = options;

--- a/tests/features/count-by.test.ts
+++ b/tests/features/count-by.test.ts
@@ -1,0 +1,177 @@
+import { Collection, MikroORM, Ref, ref } from '@mikro-orm/sqlite';
+import {
+  Entity,
+  Filter,
+  ManyToOne,
+  OneToMany,
+  PrimaryKey,
+  Property,
+  ReflectMetadataProvider,
+} from '@mikro-orm/decorators/legacy';
+
+@Filter({ name: 'active', cond: { active: true }, default: true })
+@Entity()
+class Author {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name: string;
+
+  @Property()
+  active: boolean;
+
+  @OneToMany(() => Book, book => book.author)
+  books = new Collection<Book>(this);
+
+  constructor({ id, name, active = true }: { id?: number; name: string; active?: boolean }) {
+    if (id) {
+      this.id = id;
+    }
+    this.name = name;
+    this.active = active;
+  }
+}
+
+@Filter({ name: 'published', cond: { published: true }, default: true })
+@Entity()
+class Book {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  title: string;
+
+  @Property()
+  published: boolean;
+
+  @ManyToOne(() => Author, { ref: true })
+  author: Ref<Author>;
+
+  @ManyToOne(() => Publisher, { ref: true, nullable: true })
+  publisher!: Ref<Publisher> | null;
+
+  constructor({
+    id,
+    title,
+    author,
+    published = true,
+  }: {
+    id?: number;
+    title: string;
+    author: Author | Ref<Author>;
+    published?: boolean;
+  }) {
+    if (id) {
+      this.id = id;
+    }
+    this.title = title;
+    this.published = published;
+    this.author = ref(author);
+  }
+}
+
+@Entity()
+class Publisher {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name: string;
+
+  @OneToMany(() => Book, book => book.publisher)
+  books = new Collection<Book, Publisher>(this);
+
+  constructor({ id, name = 'asd' }: { id?: number; name?: string }) {
+    if (id) {
+      this.id = id;
+    }
+    this.name = name;
+  }
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    metadataProvider: ReflectMetadataProvider,
+    dbName: ':memory:',
+    entities: [Author, Book, Publisher],
+  });
+  await orm.schema.create();
+
+  const em = orm.em.fork();
+  const authors = [
+    new Author({ id: 1, name: 'a' }),
+    new Author({ id: 2, name: 'b' }),
+    new Author({ id: 3, name: 'c' }),
+  ];
+  em.persist(authors);
+
+  const publishers = [new Publisher({ id: 1, name: 'AAA' }), new Publisher({ id: 2, name: 'BBB' })];
+  em.persist(publishers);
+
+  const books = [
+    new Book({ id: 1, title: 'One', author: authors[0] }),
+    new Book({ id: 2, title: 'Two', author: authors[0] }),
+    new Book({ id: 3, title: 'Three', author: authors[1] }),
+    new Book({ id: 4, title: 'Four', author: authors[2] }),
+    new Book({ id: 5, title: 'Five', author: authors[2] }),
+    new Book({ id: 6, title: 'Six', author: authors[2] }),
+    new Book({ id: 7, title: 'Draft', author: authors[2], published: false }),
+  ];
+  books[0].publisher = ref(publishers[0]);
+  books[1].publisher = ref(publishers[1]);
+  books[2].publisher = ref(publishers[1]);
+  books[3].publisher = ref(publishers[1]);
+  books[4].publisher = ref(publishers[1]);
+  books[5].publisher = ref(publishers[1]);
+  em.persist(books);
+
+  await em.flush();
+});
+
+afterAll(async () => orm.close(true));
+
+test('em.countBy (single field)', async () => {
+  const em = orm.em.fork();
+  const counts = await em.countBy(Book, 'author');
+  // author 1 has 2 published books, author 2 has 1, author 3 has 3 (draft filtered out)
+  expect(counts).toEqual({ '1': 2, '2': 1, '3': 3 });
+});
+
+test('em.countBy (composite groupBy with ~~~ separator)', async () => {
+  const em = orm.em.fork();
+  const counts = await em.countBy(Book, ['author', 'publisher']);
+  expect(counts['1~~~1']).toBe(1);
+  expect(counts['1~~~2']).toBe(1);
+  expect(counts['2~~~2']).toBe(1);
+  expect(counts['3~~~2']).toBe(3);
+});
+
+test('em.countBy with where filter', async () => {
+  const em = orm.em.fork();
+  const counts = await em.countBy(Book, 'author', { where: { title: ['One', 'Six'] } as any });
+  expect(counts).toEqual({ '1': 1, '3': 1 });
+});
+
+test('em.countBy with empty result', async () => {
+  const em = orm.em.fork();
+  const counts = await em.countBy(Book, 'author', { where: { title: 'nonexistent' } as any });
+  expect(counts).toEqual({});
+});
+
+test('em.countBy with entity filter disabled', async () => {
+  const em = orm.em.fork();
+  // With filter disabled, the unpublished draft should be included
+  const counts = await em.countBy(Book, 'author', { filters: false });
+  // author 3 now has 4 books (3 published + 1 draft)
+  expect(counts).toEqual({ '1': 2, '2': 1, '3': 4 });
+});
+
+test('repo.countBy', async () => {
+  const em = orm.em.fork();
+  const repo = em.getRepository(Book);
+  const counts = await repo.countBy('author');
+  expect(counts).toEqual({ '1': 2, '2': 1, '3': 3 });
+});

--- a/tests/features/count-by.test.ts
+++ b/tests/features/count-by.test.ts
@@ -169,6 +169,16 @@ test('em.countBy with entity filter disabled', async () => {
   expect(counts).toEqual({ '1': 2, '2': 1, '3': 4 });
 });
 
+test('em.countBy with nullable groupBy column', async () => {
+  const em = orm.em.fork();
+  // Book 7 (Draft) has null publisher, but default filter excludes it
+  // With filters disabled, null publisher appears as key "null"
+  const counts = await em.countBy(Book, 'publisher', { filters: false });
+  expect(counts['1']).toBe(1);
+  expect(counts['2']).toBe(5);
+  expect(counts['null']).toBe(1);
+});
+
 test('repo.countBy', async () => {
   const em = orm.em.fork();
   const repo = em.getRepository(Book);

--- a/tests/features/count-by.test.ts
+++ b/tests/features/count-by.test.ts
@@ -1,4 +1,5 @@
-import { Collection, MikroORM, Ref, ref } from '@mikro-orm/sqlite';
+import { Collection, MikroORM, raw, Ref, ref } from '@mikro-orm/sqlite';
+import { EntityManager as CoreEntityManager } from '@mikro-orm/core';
 import {
   Entity,
   Filter,
@@ -183,5 +184,36 @@ test('repo.countBy', async () => {
   const em = orm.em.fork();
   const repo = em.getRepository(Book);
   const counts = await repo.countBy('author');
+  expect(counts).toEqual({ '1': 2, '2': 1, '3': 3 });
+});
+
+test('em.countBy with having filters groups', async () => {
+  const em = orm.em.fork();
+  // keep only authors with 2+ published books (author 1 has 2, author 3 has 3)
+  const counts = await em.countBy(Book, 'author', {
+    having: { [raw('count(*)')]: { $gte: 2 } } as any,
+  });
+  expect(counts).toEqual({ '1': 2, '3': 3 });
+});
+
+test('em.countBy accepts schema option', async () => {
+  const em = orm.em.fork();
+  // SQLite ignores schema, but the option path must be exercised without breaking the query
+  const counts = await em.countBy(Book, 'author', { schema: 'main' });
+  expect(counts).toEqual({ '1': 2, '2': 1, '3': 3 });
+});
+
+test('base EntityManager.countBy throws for unsupported drivers', async () => {
+  const em = orm.em.fork();
+  // force-invoke the base implementation to cover the "not supported" fallback
+  const base = (CoreEntityManager.prototype as any).countBy as (...args: any[]) => Promise<unknown>;
+  await expect(base.call(em, Book, 'author')).rejects.toThrow('countBy() is not supported by the current driver');
+});
+
+test('em.countBy falls back to the raw column name when grouping by a non-property key', async () => {
+  const em = orm.em.fork();
+  // `author_id` is the resolved column name, not an entity property — `meta.properties['author_id']` is undefined,
+  // so the implementation falls back to using the raw column name as both the SELECT/GROUP BY target and the result key.
+  const counts = await em.countBy(Book, 'author_id' as any);
   expect(counts).toEqual({ '1': 2, '2': 1, '3': 3 });
 });

--- a/tests/features/dataloader/dataloader.test.ts
+++ b/tests/features/dataloader/dataloader.test.ts
@@ -833,4 +833,42 @@ describe('Dataloader', () => {
 
     await orm.close(true);
   });
+
+  test('em.countBy (single field)', async () => {
+    const em = orm.em.fork();
+    const counts = await em.countBy(Book, 'author');
+    // author 1 has 2 books, author 2 has 1, author 3 has 3
+    expect(counts).toEqual({ '1': 2, '2': 1, '3': 3 });
+  });
+
+  test('em.countBy (composite groupBy with ~~~ separator)', async () => {
+    const em = orm.em.fork();
+    const counts = await em.countBy(Book, ['author', 'publisher']);
+    // book 1: author=1, publisher=1; book 2: author=1, publisher=2;
+    // book 3: author=2, publisher=2; books 4-6: author=3, publisher=2
+    expect(counts['1~~~1']).toBe(1);
+    expect(counts['1~~~2']).toBe(1);
+    expect(counts['2~~~2']).toBe(1);
+    expect(counts['3~~~2']).toBe(3);
+  });
+
+  test('em.countBy with where filter', async () => {
+    const em = orm.em.fork();
+    const counts = await em.countBy(Book, 'author', { where: { title: ['One', 'Six'] } as any });
+    // Only "One" (author 1) and "Six" (author 3) match
+    expect(counts).toEqual({ '1': 1, '3': 1 });
+  });
+
+  test('em.countBy with empty result', async () => {
+    const em = orm.em.fork();
+    const counts = await em.countBy(Book, 'author', { where: { title: 'nonexistent' } as any });
+    expect(counts).toEqual({});
+  });
+
+  test('repo.countBy', async () => {
+    const em = orm.em.fork();
+    const repo = em.getRepository(Book);
+    const counts = await repo.countBy('author');
+    expect(counts).toEqual({ '1': 2, '2': 1, '3': 3 });
+  });
 });

--- a/tests/features/dataloader/dataloader.test.ts
+++ b/tests/features/dataloader/dataloader.test.ts
@@ -833,42 +833,4 @@ describe('Dataloader', () => {
 
     await orm.close(true);
   });
-
-  test('em.countBy (single field)', async () => {
-    const em = orm.em.fork();
-    const counts = await em.countBy(Book, 'author');
-    // author 1 has 2 books, author 2 has 1, author 3 has 3
-    expect(counts).toEqual({ '1': 2, '2': 1, '3': 3 });
-  });
-
-  test('em.countBy (composite groupBy with ~~~ separator)', async () => {
-    const em = orm.em.fork();
-    const counts = await em.countBy(Book, ['author', 'publisher']);
-    // book 1: author=1, publisher=1; book 2: author=1, publisher=2;
-    // book 3: author=2, publisher=2; books 4-6: author=3, publisher=2
-    expect(counts['1~~~1']).toBe(1);
-    expect(counts['1~~~2']).toBe(1);
-    expect(counts['2~~~2']).toBe(1);
-    expect(counts['3~~~2']).toBe(3);
-  });
-
-  test('em.countBy with where filter', async () => {
-    const em = orm.em.fork();
-    const counts = await em.countBy(Book, 'author', { where: { title: ['One', 'Six'] } as any });
-    // Only "One" (author 1) and "Six" (author 3) match
-    expect(counts).toEqual({ '1': 1, '3': 1 });
-  });
-
-  test('em.countBy with empty result', async () => {
-    const em = orm.em.fork();
-    const counts = await em.countBy(Book, 'author', { where: { title: 'nonexistent' } as any });
-    expect(counts).toEqual({});
-  });
-
-  test('repo.countBy', async () => {
-    const em = orm.em.fork();
-    const repo = em.getRepository(Book);
-    const counts = await repo.countBy('author');
-    expect(counts).toEqual({ '1': 2, '2': 1, '3': 3 });
-  });
 });

--- a/tests/features/entity-manager/EntityManager.mongo.test.ts
+++ b/tests/features/entity-manager/EntityManager.mongo.test.ts
@@ -553,6 +553,48 @@ describe('EntityManagerMongo', () => {
     ).rejects.toThrow('Collation option for MongoDB must be a CollationOptions object');
   });
 
+  test('em.countBy (single field)', async () => {
+    const god = new Author('God', 'hello@heaven.god');
+    const bible = new Book('Bible', god);
+    const bible2 = new Book('Bible pt. 2', god);
+    const author2 = new Author('Author2', 'a2@test.com');
+    const book3 = new Book('Book3', author2);
+    await orm.em.persist([god, author2, bible, bible2, book3]).flush();
+    orm.em.clear();
+
+    const counts = await orm.em.countBy(Book, 'author');
+    expect(counts[String(god._id)]).toBe(2);
+    expect(counts[String(author2._id)]).toBe(1);
+  });
+
+  test('em.countBy with where filter', async () => {
+    const god = new Author('God', 'hello@heaven.god');
+    const bible = new Book('Bible', god);
+    const bible2 = new Book('Bible pt. 2', god);
+    await orm.em.persist([god, bible, bible2]).flush();
+    orm.em.clear();
+
+    const counts = await orm.em.countBy(Book, 'author', { where: { title: 'Bible' } as any });
+    expect(counts[String(god._id)]).toBe(1);
+  });
+
+  test('em.countBy with empty result', async () => {
+    const counts = await orm.em.countBy(Book, 'author', { where: { title: 'nonexistent' } as any });
+    expect(counts).toEqual({});
+  });
+
+  test('repo.countBy', async () => {
+    const god = new Author('God', 'hello@heaven.god');
+    const bible = new Book('Bible', god);
+    const bible2 = new Book('Bible pt. 2', god);
+    await orm.em.persist([god, bible, bible2]).flush();
+    orm.em.clear();
+
+    const repo = orm.em.getRepository(Book);
+    const counts = await repo.countBy('author');
+    expect(counts[String(god._id)]).toBe(2);
+  });
+
   test('should throw when trying to merge entity without id', async () => {
     const author = new Author('test', 'test');
     expect(() => orm.em.merge(author)).toThrow(`You cannot merge entity 'Author' without identifier!`);

--- a/tests/features/entity-manager/EntityManager.mongo.test.ts
+++ b/tests/features/entity-manager/EntityManager.mongo.test.ts
@@ -595,6 +595,41 @@ describe('EntityManagerMongo', () => {
     expect(counts[String(god._id)]).toBe(2);
   });
 
+  test('em.countBy (composite groupBy with ~~~ separator)', async () => {
+    const god = new Author('God', 'hello@heaven.god');
+    const author2 = new Author('Author2', 'a2@test.com');
+    const bible = new Book('Bible', god);
+    const bible2 = new Book('Bible pt. 2', god);
+    const biblea2 = new Book('Bible', author2);
+    await orm.em.persist([god, author2, bible, bible2, biblea2]).flush();
+    orm.em.clear();
+
+    const counts = await orm.em.countBy(Book, ['author', 'title']);
+    expect(counts[`${String(god._id)}~~~Bible`]).toBe(1);
+    expect(counts[`${String(god._id)}~~~Bible pt. 2`]).toBe(1);
+    expect(counts[`${String(author2._id)}~~~Bible`]).toBe(1);
+  });
+
+  test('em.countBy throws when having option is passed for MongoDB', async () => {
+    await expect(orm.em.countBy(Book, 'author', { having: { title: 'Bible' } as any })).rejects.toThrow(
+      'The `having` option is not supported for MongoDB in `countBy`.',
+    );
+  });
+
+  test('em.countBy falls back to the raw field name when grouping by a non-property key', async () => {
+    const god = new Author('God', 'hello@heaven.god');
+    const bible = new Book('Bible', god);
+    const bible2 = new Book('Bible pt. 2', god);
+    await orm.em.persist([god, bible, bible2]).flush();
+    orm.em.clear();
+
+    // `nonExistentField` is not an entity property — `meta.properties[...]` is undefined,
+    // so the implementation falls back to using the raw field name. Mongo groups by missing fields
+    // under `_id: null`, yielding a single bucket for the stored documents.
+    const counts = await orm.em.countBy(Book, 'nonExistentField' as any);
+    expect(counts.null).toBeGreaterThanOrEqual(2);
+  });
+
   test('should throw when trying to merge entity without id', async () => {
     const author = new Author('test', 'test');
     expect(() => orm.em.merge(author)).toThrow(`You cannot merge entity 'Author' without identifier!`);


### PR DESCRIPTION
## Summary

- Adds `em.countBy(entityName, groupBy, options?)` — counts entities grouped by one or more properties, returning `Dictionary<number>`
- Type-safe `groupBy` parameter (`EntityKey<Entity> | readonly EntityKey<Entity>[]`)
- For composite `groupBy`, result keys are joined with `~~~` (`Utils.PK_SEPARATOR`)
- SQL: single `GROUP BY` query via QueryBuilder
- MongoDB: aggregation pipeline with `$group` + `$sum`
- Also available on `EntityRepository` via `repo.countBy(groupBy, options?)`
- New `CountByOptions` type extends `CountOptions` (without `groupBy`) and adds `where`

```ts
const counts = await em.countBy(Book, 'author');
// { '1': 2, '2': 1, '3': 3 }

const counts = await em.countBy(Order, ['status', 'country']);
// { 'pending~~~US': 5, 'shipped~~~DE': 3 }
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)