### PR TITLE
fix(core): handle `check` constraint in `defineEntity`

### DIFF
--- a/packages/core/src/metadata/EntitySchema.ts
+++ b/packages/core/src/metadata/EntitySchema.ts
@@ -153,6 +153,11 @@ export class EntitySchema<Entity = any, Base = never, Class extends EntityCtor =
       prop.persist ??= false;
     }
 
+    if ((prop as any).check) {
+      this._meta.checks.push({ property: prop.name, expression: (prop as any).check });
+      delete (prop as any).check;
+    }
+
     this._meta.properties[name] = prop;
   }
 

--- a/tests/features/check-constraint.test.ts
+++ b/tests/features/check-constraint.test.ts
@@ -1,0 +1,46 @@
+import { CheckConstraintViolationException, defineEntity, MikroORM, p, quote } from '@mikro-orm/sqlite';
+
+const ProductSchema = defineEntity({
+  name: 'Product',
+  properties: {
+    id: p.integer().primary(),
+    title: p.string(),
+    barcodes: p.array(String).default([]),
+    plu: p.array(String).default([]),
+    price: p.decimal('number').default(0),
+    stock: p
+      .decimal('number')
+      .default(0)
+      .check(columns => quote`${columns.stock} >= 0`),
+  },
+});
+class Product extends ProductSchema.class {}
+ProductSchema.setClass(Product);
+
+describe('check constraint', () => {
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      dbName: ':memory:',
+      entities: [Product],
+      serialization: { forceObject: true },
+    });
+    await orm.schema.refresh();
+  });
+
+  afterAll(() => orm.close(true));
+
+  it('should throw on invalid check constraint', async () => {
+    const product = orm.em.create(Product, {
+      title: 'Test Product Valid',
+      barcodes: ['TEST183828'],
+      plu: ['TEST943'],
+      stock: -10,
+      price: -5,
+    });
+
+    await expect(orm.em.flush()).rejects.toThrowError(CheckConstraintViolationException);
+    expect(product.id).not.toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

- The `@Property` decorator extracts the `check` option and pushes it to `meta.checks`, but `EntitySchema.addProperty()` (used by `defineEntity`) did not — the constraint was silently dropped from the generated DDL.
- Adds the missing extraction in `addProperty` so `defineEntity` properties with `.check()` now generate the correct check constraints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)