### PR TITLE
fix(core): share EntitySchema.REGISTRY across CJS/ESM module boundaries

### DIFF
--- a/packages/core/src/metadata/EntitySchema.ts
+++ b/packages/core/src/metadata/EntitySchema.ts
@@ -75,8 +75,14 @@ export class EntitySchema<Entity = any, Base = never, Class extends EntityCtor =
   /**
    * When schema links the entity class via `class` option, this registry allows the lookup from opposite side,
    * so we can use the class in `entities` option just like the EntitySchema instance.
+   *
+   * Stored on `globalThis` via `Symbol.for` to survive the CJS/ESM dual-package hazard
+   * (e.g. when `tsx` loads the same package in both module systems).
    */
-  static REGISTRY: Map<AnyEntity, EntitySchema> = new Map();
+  static get REGISTRY(): Map<AnyEntity, EntitySchema> {
+    const key = Symbol.for('@mikro-orm/core/EntitySchema.REGISTRY');
+    return ((globalThis as any)[key] ??= new Map());
+  }
 
   /** @internal Type-level marker for fast entity type inference */
   declare readonly '~entity': Entity;


### PR DESCRIPTION
## Summary
- Store `EntitySchema.REGISTRY` on `globalThis` via `Symbol.for` (same pattern as `MetadataStorage` and `Type` branding) so the map is shared when the same package is evaluated in both CJS and ESM module graphs.
- Fixes the "Only abstract entities were discovered" error when using `defineEntity` + `setClass` in a CJS project with the CLI (tsx loads `@mikro-orm/core` twice — once as ESM for the CLI, once as CJS for user code).

Closes #7376

🤖 Generated with [Claude Code](https://claude.com/claude-code)