### PR TITLE
feat(core): support `array` option on scalar properties

### DIFF
--- a/packages/core/src/entity/defineEntity.ts
+++ b/packages/core/src/entity/defineEntity.ts
@@ -201,10 +201,13 @@ export interface PropertyChain<Value, Options> {
     fixedOrderColumn: string,
   ): HasKind<Options, 'm:n'> extends true ? PropertyChain<Value, Options> : never;
 
+  array(): Options extends { kind: infer K extends string }
+    ? K extends 'embedded' | 'enum'
+      ? PropertyChain<Value, Omit<Options, 'array'> & { array: true }>
+      : never
+    : PropertyChain<Value, Omit<Options, 'array'> & { array: true }>;
+
   // Embedded-only methods
-  array(): HasKind<Options, 'embedded' | 'enum'> extends true
-    ? PropertyChain<Value, Omit<Options, 'array'> & { array: true }>
-    : never;
   prefix(prefix: string | boolean): HasKind<Options, 'embedded'> extends true ? PropertyChain<Value, Options> : never;
   prefixMode(
     prefixMode: EmbeddedPrefixMode,

--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -2114,7 +2114,13 @@ export class MetadataDiscovery {
       });
 
       if (type) {
-        prop.type = type === 'datetime' ? 'Date' : type;
+        if (prop.array) {
+          // built-in type + array: true — force-create instance for ArrayType wrapping
+          prop.customType = new (prop.type as Constructor<Type>)();
+          prop.type = prop.customType.constructor.name;
+        } else {
+          prop.type = type === 'datetime' ? 'Date' : type;
+        }
       } else {
         prop.customType = new (prop.type as Constructor<Type>)();
         prop.type = prop.customType.constructor.name;
@@ -2123,6 +2129,38 @@ export class MetadataDiscovery {
 
     if (simple) {
       return;
+    }
+
+    if (
+      prop.array &&
+      prop.customType &&
+      !(prop.customType instanceof t.array) &&
+      !(prop.customType instanceof t.enumArray) &&
+      prop.kind === ReferenceKind.SCALAR
+    ) {
+      const innerType = prop.customType;
+      innerType.platform = this.#platform;
+      innerType.meta = meta;
+      innerType.prop = prop;
+
+      if (!prop.columnTypes) {
+        const arrayDecl = this.#platform.getArrayDeclarationSQL();
+
+        if (arrayDecl.endsWith('[]')) {
+          // native array support (e.g. postgres) — use inner type's column type with [] suffix
+          prop.columnTypes = [innerType.getColumnType(prop, this.#platform) + '[]'];
+        } else {
+          // non-native (e.g. mysql, sqlite) — store as text/clob
+          prop.columnTypes = [arrayDecl];
+        }
+      }
+
+      const platform = this.#platform;
+      prop.customType = new t.array(
+        v => innerType.convertToJSValue(v, platform),
+        v => innerType.convertToDatabaseValue(v, platform),
+      );
+      prop.type = prop.customType.constructor.name;
     }
 
     if (!prop.customType && ['json', 'jsonb'].includes(prop.type?.toLowerCase())) {

--- a/packages/core/src/metadata/types.ts
+++ b/packages/core/src/metadata/types.ts
@@ -230,6 +230,12 @@ export interface PropertyOptions<Owner> {
    */
   lazy?: boolean;
   /**
+   * Marks this property as an array. When used with a custom type, the type is automatically
+   * wrapped in an `ArrayType` that delegates element conversion to the inner type.
+   * The column type is inferred as `innerType[]` (e.g. `int[]`, `time[]`).
+   */
+  array?: boolean;
+  /**
    * Set true to define entity's unique primary key identifier.
    * Alias for `@PrimaryKey()` decorator
    *

--- a/tests/defineEntity.test.ts
+++ b/tests/defineEntity.test.ts
@@ -1082,6 +1082,40 @@ describe('defineEntity', () => {
     assert<IsExact<LoadedBar['paymentMethods'], ('CASH' | 'CARD' | 'CRYPTO')[]>>(true);
   });
 
+  it('should allow .array() on scalar typed properties', () => {
+    const Foo = defineEntity({
+      name: 'Foo',
+      properties: p => ({
+        id: p.integer().primary().autoincrement(),
+        integers: p.integer().array(),
+        booleans: p.boolean().array(),
+        strings: p.string().array(),
+        decimals: p.decimal('number').array().nullable(),
+        bigints: p.type(new types.bigint('string')).array(),
+      }),
+    });
+
+    type IFoo = InferEntity<typeof Foo>;
+    assert<IsExact<IFoo['integers'], number[]>>(true);
+    assert<IsExact<IFoo['booleans'], boolean[]>>(true);
+    assert<IsExact<IFoo['strings'], string[]>>(true);
+    assert<IsExact<IFoo['decimals'], number[] | null | undefined>>(true);
+    assert<IsExact<IFoo['bigints'], string[]>>(true);
+
+    // Loaded<> preserves array types
+    type LoadedFoo = Loaded<IFoo>;
+    assert<IsExact<LoadedFoo['integers'], number[]>>(true);
+    assert<IsExact<LoadedFoo['booleans'], boolean[]>>(true);
+    assert<IsExact<LoadedFoo['strings'], string[]>>(true);
+    assert<IsExact<LoadedFoo['decimals'], number[] | null | undefined>>(true);
+    assert<IsExact<LoadedFoo['bigints'], string[]>>(true);
+
+    // array option is set on metadata
+    expect(Foo.meta.properties.integers.array).toBe(true);
+    expect(Foo.meta.properties.decimals.array).toBe(true);
+    expect(Foo.meta.properties.bigints.array).toBe(true);
+  });
+
   it('should define entity with decimal property', () => {
     const Foo = defineEntity({
       name: 'Foo',

--- a/tests/features/custom-types/scalar-array-option.mongo.test.ts
+++ b/tests/features/custom-types/scalar-array-option.mongo.test.ts
@@ -1,0 +1,88 @@
+import { MikroORM, Type, defineEntity } from '@mikro-orm/mongodb';
+import { ObjectId } from 'bson';
+import { mockLogger } from '../../helpers.js';
+
+class HexIntType extends Type<number, string> {
+  override convertToJSValue(value: string): number {
+    return parseInt(String(value), 16);
+  }
+
+  override convertToDatabaseValue(value: number): string {
+    return value.toString(16);
+  }
+
+  override getColumnType(): string {
+    return 'text';
+  }
+
+  override ensureComparable(): boolean {
+    return true;
+  }
+}
+
+const TypedArrayEntity = defineEntity({
+  name: 'TypedArrayEntity',
+  properties: p => ({
+    _id: p.type(ObjectId).primary(),
+    hexValues: p.type(new HexIntType()).array(),
+    optionalHexValues: p.type(new HexIntType()).array().nullable(),
+  }),
+});
+
+describe('scalar array option [mongo]', () => {
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      entities: [TypedArrayEntity],
+      dbName: 'scalar_array_option',
+      clientUrl: 'mongodb://localhost:27017',
+    });
+    await orm.schema.refresh();
+  });
+
+  afterAll(() => orm.close(true));
+
+  test('persist and retrieve custom type array', async () => {
+    const entity = orm.em.create(TypedArrayEntity, {
+      hexValues: [255, 16, 0],
+    });
+    await orm.em.persist(entity).flush();
+    orm.em.clear();
+
+    const loaded = await orm.em.findOneOrFail(TypedArrayEntity, entity._id);
+    expect(loaded.hexValues).toEqual([255, 16, 0]);
+  });
+
+  test('nullable array', async () => {
+    const entity = orm.em.create(TypedArrayEntity, {
+      hexValues: [42],
+      optionalHexValues: [10, 20],
+    });
+    await orm.em.persist(entity).flush();
+    orm.em.clear();
+
+    const loaded = await orm.em.findOneOrFail(TypedArrayEntity, entity._id);
+    expect(loaded.optionalHexValues).toEqual([10, 20]);
+
+    loaded.optionalHexValues = null;
+    await orm.em.flush();
+    orm.em.clear();
+
+    const loaded2 = await orm.em.findOneOrFail(TypedArrayEntity, entity._id);
+    expect(loaded2.optionalHexValues).toBeNull();
+  });
+
+  test('no spurious update after loading', async () => {
+    const entity = orm.em.create(TypedArrayEntity, {
+      hexValues: [255],
+    });
+    await orm.em.persist(entity).flush();
+    orm.em.clear();
+
+    await orm.em.findOneOrFail(TypedArrayEntity, entity._id);
+    const mock = mockLogger(orm);
+    await orm.em.flush();
+    expect(mock.mock.calls).toHaveLength(0);
+  });
+});

--- a/tests/features/custom-types/scalar-array-option.postgres.test.ts
+++ b/tests/features/custom-types/scalar-array-option.postgres.test.ts
@@ -1,0 +1,175 @@
+import { defineEntity, IntegerType, BooleanType, MikroORM, Type } from '@mikro-orm/postgresql';
+import { Entity, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+import { mockLogger } from '../../helpers.js';
+
+// Custom type: stores number as hex string in the DB, converts to/from number in JS
+class HexIntType extends Type<number, string> {
+  override convertToJSValue(value: string): number {
+    return parseInt(String(value), 16);
+  }
+
+  override convertToDatabaseValue(value: number): string {
+    return value.toString(16);
+  }
+
+  override getColumnType(): string {
+    return 'text';
+  }
+
+  override ensureComparable(): boolean {
+    return true;
+  }
+}
+
+describe('scalar array option', () => {
+  describe('decorators', () => {
+    @Entity()
+    class TypedArrayEntity {
+      @PrimaryKey()
+      id!: number;
+
+      @Property({ type: IntegerType, array: true })
+      integers!: number[];
+
+      @Property({ type: BooleanType, array: true })
+      flags!: boolean[];
+
+      @Property({ type: new HexIntType(), array: true })
+      hexValues!: number[];
+
+      @Property({ type: new HexIntType(), array: true, nullable: true })
+      optionalHexValues?: number[] | null;
+    }
+
+    let orm: MikroORM;
+
+    beforeAll(async () => {
+      orm = await MikroORM.init({
+        metadataProvider: ReflectMetadataProvider,
+        entities: [TypedArrayEntity],
+        dbName: 'mikro_orm_scalar_array_decorators',
+      });
+      await orm.schema.refresh();
+    });
+
+    afterAll(() => orm.close(true));
+
+    test('schema produces correct column types', async () => {
+      const sql = await orm.schema.getCreateSchemaSQL();
+      expect(sql).toContain('"integers" int[]');
+      expect(sql).toContain('"flags" boolean[]');
+      expect(sql).toContain('"hex_values" text[]');
+      expect(sql).toContain('"optional_hex_values" text[]');
+    });
+
+    test('persist and retrieve custom type array', async () => {
+      const entity = orm.em.create(TypedArrayEntity, {
+        integers: [1, 2, 3],
+        flags: [true, false],
+        hexValues: [255, 16, 0],
+      });
+      await orm.em.persist(entity).flush();
+      orm.em.clear();
+
+      const loaded = await orm.em.findOneOrFail(TypedArrayEntity, entity.id);
+      expect(loaded.integers).toEqual([1, 2, 3]);
+      expect(loaded.flags).toEqual([true, false]);
+      expect(loaded.hexValues).toEqual([255, 16, 0]);
+    });
+
+    test('nullable array', async () => {
+      const entity = orm.em.create(TypedArrayEntity, {
+        integers: [1],
+        flags: [true],
+        hexValues: [42],
+        optionalHexValues: [10, 20],
+      });
+      await orm.em.persist(entity).flush();
+      orm.em.clear();
+
+      const loaded = await orm.em.findOneOrFail(TypedArrayEntity, entity.id);
+      expect(loaded.optionalHexValues).toEqual([10, 20]);
+
+      loaded.optionalHexValues = null;
+      await orm.em.flush();
+      orm.em.clear();
+
+      const loaded2 = await orm.em.findOneOrFail(TypedArrayEntity, entity.id);
+      expect(loaded2.optionalHexValues).toBeNull();
+    });
+
+    test('no spurious update after loading', async () => {
+      const entity = orm.em.create(TypedArrayEntity, {
+        integers: [10, 20],
+        flags: [true],
+        hexValues: [255],
+      });
+      await orm.em.persist(entity).flush();
+      orm.em.clear();
+
+      await orm.em.findOneOrFail(TypedArrayEntity, entity.id);
+      const mock = mockLogger(orm);
+      await orm.em.flush();
+      expect(mock.mock.calls).toHaveLength(0);
+    });
+  });
+
+  describe('defineEntity', () => {
+    const TypedArrayDE = defineEntity({
+      name: 'TypedArrayDE',
+      properties: pr => ({
+        id: pr.integer().primary().autoincrement(),
+        integers: pr.integer().array(),
+        hexValues: pr.type(new HexIntType()).array(),
+        decimals: pr.decimal('number').array().nullable().precision(10).scale(2),
+      }),
+    });
+
+    let orm: MikroORM;
+
+    beforeAll(async () => {
+      orm = await MikroORM.init({
+        entities: [TypedArrayDE],
+        dbName: 'mikro_orm_scalar_array_define_entity',
+      });
+      await orm.schema.refresh();
+    });
+
+    afterAll(() => orm.close(true));
+
+    test('schema produces correct column types', async () => {
+      const sql = await orm.schema.getCreateSchemaSQL();
+      expect(sql).toContain('"integers" int[]');
+      expect(sql).toContain('"hex_values" text[]');
+      expect(sql).toContain('"decimals" numeric(10,2)[]');
+    });
+
+    test('persist and retrieve', async () => {
+      const entity = orm.em.create(TypedArrayDE, {
+        integers: [10, 20, 30],
+        hexValues: [255, 16],
+        decimals: [1.5, 2.5],
+      });
+      await orm.em.persist(entity).flush();
+      orm.em.clear();
+
+      const loaded = await orm.em.findOneOrFail(TypedArrayDE, entity.id);
+      expect(loaded.integers).toEqual([10, 20, 30]);
+      expect(loaded.hexValues).toEqual([255, 16]);
+      expect(loaded.decimals).toEqual([1.5, 2.5]);
+    });
+
+    test('empty arrays roundtrip correctly', async () => {
+      const entity = orm.em.create(TypedArrayDE, {
+        integers: [],
+        hexValues: [],
+      });
+      await orm.em.persist(entity).flush();
+      orm.em.clear();
+
+      const loaded = await orm.em.findOneOrFail(TypedArrayDE, entity.id);
+      expect(loaded.integers).toEqual([]);
+      expect(loaded.hexValues).toEqual([]);
+    });
+  });
+});

--- a/tests/features/custom-types/scalar-array-option.test.ts
+++ b/tests/features/custom-types/scalar-array-option.test.ts
@@ -1,0 +1,107 @@
+import { MikroORM, Utils, Type, defineEntity } from '@mikro-orm/sql';
+import type { AbstractSqlDriver } from '@mikro-orm/sql';
+import { PLATFORMS } from '../../bootstrap.js';
+import { mockLogger } from '../../helpers.js';
+
+class HexIntType extends Type<number, string> {
+  override convertToJSValue(value: string): number {
+    return parseInt(String(value), 16);
+  }
+
+  override convertToDatabaseValue(value: number): string {
+    return value.toString(16);
+  }
+
+  override getColumnType(): string {
+    return 'text';
+  }
+
+  override ensureComparable(): boolean {
+    return true;
+  }
+}
+
+const TypedArrayEntity = defineEntity({
+  name: 'TypedArrayEntity',
+  properties: p => ({
+    id: p.integer().primary().autoincrement(),
+    hexValues: p.type(new HexIntType()).array(),
+    optionalHexValues: p.type(new HexIntType()).array().nullable(),
+  }),
+});
+
+const options = {
+  sqlite: { dbName: ':memory:' },
+  libsql: { dbName: ':memory:' },
+  mysql: { dbName: 'scalar_array_option', port: 3308 },
+  mariadb: { dbName: 'scalar_array_option', port: 3309 },
+};
+
+describe.each(Utils.keys(options))('scalar array option [%s]', type => {
+  let orm: MikroORM<AbstractSqlDriver>;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init<AbstractSqlDriver>({
+      entities: [TypedArrayEntity],
+      driver: PLATFORMS[type],
+      ...options[type],
+    });
+    await orm.schema.refresh();
+  });
+
+  afterAll(() => orm.close(true));
+
+  test('persist and retrieve custom type array', async () => {
+    const entity = orm.em.create(TypedArrayEntity, {
+      hexValues: [255, 16, 0],
+    });
+    await orm.em.persist(entity).flush();
+    orm.em.clear();
+
+    const loaded = await orm.em.findOneOrFail(TypedArrayEntity, entity.id);
+    expect(loaded.hexValues).toEqual([255, 16, 0]);
+  });
+
+  test('nullable array', async () => {
+    const entity = orm.em.create(TypedArrayEntity, {
+      hexValues: [42],
+      optionalHexValues: [10, 20],
+    });
+    await orm.em.persist(entity).flush();
+    orm.em.clear();
+
+    const loaded = await orm.em.findOneOrFail(TypedArrayEntity, entity.id);
+    expect(loaded.optionalHexValues).toEqual([10, 20]);
+
+    loaded.optionalHexValues = null;
+    await orm.em.flush();
+    orm.em.clear();
+
+    const loaded2 = await orm.em.findOneOrFail(TypedArrayEntity, entity.id);
+    expect(loaded2.optionalHexValues).toBeNull();
+  });
+
+  test('no spurious update after loading', async () => {
+    const entity = orm.em.create(TypedArrayEntity, {
+      hexValues: [255],
+    });
+    await orm.em.persist(entity).flush();
+    orm.em.clear();
+
+    await orm.em.findOneOrFail(TypedArrayEntity, entity.id);
+    const mock = mockLogger(orm);
+    await orm.em.flush();
+    expect(mock.mock.calls).toHaveLength(0);
+  });
+
+  test('empty arrays roundtrip correctly', async () => {
+    const entity = orm.em.create(TypedArrayEntity, {
+      hexValues: [],
+    });
+    await orm.em.persist(entity).flush();
+    orm.em.clear();
+
+    const loaded = await orm.em.findOneOrFail(TypedArrayEntity, entity.id);
+    expect(loaded.hexValues).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- Expose `array: true` on `PropertyOptions` so scalar properties can use it via `@Property({ type: IntegerType, array: true })` or `p.integer().array()`
- During discovery, when `array: true` is set on a scalar with a custom type, the type is automatically wrapped in an `ArrayType` that delegates element conversion to the inner type's `convertToJSValue`/`convertToDatabaseValue`
- Column type is inferred as `innerType.getColumnType() + '[]'` (e.g. `int[]`, `text[]`, `numeric(10,2)[]`)

Relates to #7363 — provides a simpler alternative without introducing a new type class.

### Usage

```ts
// defineEntity
integers: p.integer().array()
decimals: p.decimal('number').array().precision(10).scale(2)
custom:   p.type(new PlainTimeType()).array()

// decorators
@Property({ type: IntegerType, array: true })
integers!: number[];
```


🤖 Generated with [Claude Code](https://claude.com/claude-code)