### PR TITLE
fix(core): preserve explicit entity name in defineEntity + setClass during discovery

### DIFF
--- a/packages/core/src/metadata/EntitySchema.ts
+++ b/packages/core/src/metadata/EntitySchema.ts
@@ -92,7 +92,11 @@ export class EntitySchema<Entity = any, Base = never, Class extends EntityCtor =
   private initialized = false;
 
   constructor(meta: EntitySchemaMetadata<Entity, Base, Class>) {
-    meta.name = meta.class ? meta.class.name : meta.name;
+    // Skip for internal schemas (fromMetadata) — the name was already resolved,
+    // re-deriving it from class.name would break defineEntity + setClass with a different name (GH #7391).
+    if (!(meta as Dictionary).internal) {
+      meta.name = meta.class ? meta.class.name : meta.name;
+    }
 
     if (meta.name) {
       meta.abstract ??= false;

--- a/tests/features/define-entity-setclass.sqlite.test.ts
+++ b/tests/features/define-entity-setclass.sqlite.test.ts
@@ -151,4 +151,40 @@ describe('defineEntity with setClass (SQLite)', () => {
       expect(book).toBeInstanceOf(Book);
     }
   });
+
+  test('entity name different from class name does not cause duplicates (GH #7391)', async () => {
+    // When defineEntity name differs from the class name, discovery should
+    // not treat the auto-generated parent class as a separate entity.
+    const TagSchema = defineEntity({
+      name: 'TagEntity',
+      properties: {
+        id: p.integer().primary(),
+        label: p.string(),
+      },
+    });
+
+    class Tag extends TagSchema.class {}
+    TagSchema.setClass(Tag);
+
+    const testOrm = await MikroORM.init({
+      entities: [Tag],
+      dbName: ':memory:',
+    });
+
+    const metadata = [...testOrm.getMetadata().getAll().values()];
+    expect(metadata).toHaveLength(1);
+    expect(metadata[0].className).toBe('TagEntity');
+    expect(metadata[0].class).toBe(Tag);
+
+    await testOrm.schema.create();
+    testOrm.em.create(Tag, { label: 'test' });
+    await testOrm.em.flush();
+    testOrm.em.clear();
+
+    const tag = await testOrm.em.findOneOrFail(Tag, { label: 'test' });
+    expect(tag).toBeInstanceOf(Tag);
+    expect(tag.label).toBe('test');
+
+    await testOrm.close(true);
+  });
 });


### PR DESCRIPTION
## Summary

- When `defineEntity({ name: 'Foo' })` is used with `setClass(Bar)` where the class name differs from the schema name, `fromMetadata` re-enters the `EntitySchema` constructor which unconditionally overwrites `meta.name` with `class.name`, causing the auto-generated parent class to be discovered as a separate entity
- Skip the name derivation for internal schemas created by `fromMetadata`, since their name was already correctly resolved

Closes #7391

🤖 Generated with [Claude Code](https://claude.com/claude-code)