### PR TITLE
fix(schema): escape single quotes in enum CHECK constraints

### DIFF
--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -1929,7 +1929,7 @@ export class MetadataDiscovery {
         let expression: string | null = null;
 
         if (prop.enum) {
-          expression = `${this.#platform.quoteIdentifier(prop.fieldNames[0])} in ('${prop.items.join("', '")}')`;
+          expression = this.#platform.getEnumCheckConstraintExpression(prop.fieldNames[0], prop.items as string[]);
         } else if (prop.array) {
           expression = this.#platform.getEnumArrayCheckConstraintExpression(prop.fieldNames[0], prop.items as string[]);
         }

--- a/packages/core/src/platforms/Platform.ts
+++ b/packages/core/src/platforms/Platform.ts
@@ -107,6 +107,11 @@ export abstract class Platform {
     return false;
   }
 
+  /** Returns the check constraint expression for an enum column. */
+  getEnumCheckConstraintExpression(column: string, items: string[]): string {
+    return `${this.quoteIdentifier(column)} in (${items.map(v => this.quoteValue(v)).join(', ')})`;
+  }
+
   /** Returns the check constraint expression for an enum array column, or null if unsupported. */
   getEnumArrayCheckConstraintExpression(column: string, items: string[]): string | null {
     return null;

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -1253,7 +1253,9 @@ export class EntityMetadata<Entity = any, Class extends EntityCtor<Entity> = Ent
           this.checks.push({
             name,
             property: prop.name,
-            expression: `${config.getPlatform().quoteIdentifier(prop.fieldNames[0])} in ('${prop.items.join("', '")}')`,
+            expression: config
+              .getPlatform()
+              .getEnumCheckConstraintExpression(prop.fieldNames[0], prop.items as string[]),
           });
         }
       }

--- a/packages/sql/src/dialects/postgresql/BasePostgreSqlPlatform.ts
+++ b/packages/sql/src/dialects/postgresql/BasePostgreSqlPlatform.ts
@@ -45,7 +45,7 @@ export class BasePostgreSqlPlatform extends AbstractSqlPlatform {
   }
 
   override getEnumArrayCheckConstraintExpression(column: string, items: string[]): string {
-    return `${this.quoteIdentifier(column)} <@ array[${items.map(item => `'${item}'::text`).join(', ')}]`;
+    return `${this.quoteIdentifier(column)} <@ array[${items.map(item => `${this.quoteValue(item)}::text`).join(', ')}]`;
   }
 
   override supportsMaterializedViews(): boolean {

--- a/packages/sql/src/dialects/postgresql/PostgreSqlSchemaHelper.ts
+++ b/packages/sql/src/dialects/postgresql/PostgreSqlSchemaHelper.ts
@@ -658,21 +658,15 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
         const m2 = item.definition?.match(/\(array\[(.*)]\)/i) || item.definition?.match(/ = (.*)\)/i);
 
         if (item.columnName && m1 && m2) {
-          const m3 = m2[1].match(/('[^']*'::text)/g);
-          let items: (string | undefined)[];
-
           /* v8 ignore next */
-          if (m3) {
-            items = m3.map((item: string) => /^\(?'(.*)'/.exec(item.trim())?.[1]);
-          } else {
-            items = m2[1].split(',').map((item: string) => /^\(?'(.*)'/.exec(item.trim())?.[1]);
-          }
+          const parts = m2[1].match(/('(?:[^']|'')*'::\w[\w ]*)/g) ?? m2[1].split(',');
+          let items = parts.map((item: string) => /^\(?'((?:[^']|'')*)'/.exec(item.trim())?.[1]?.replace(/''/g, "'"));
 
           items = items.filter(item => item !== undefined);
 
           if (items.length > 0) {
             o[item.columnName] = items as string[];
-            item.expression = `${this.quote(item.columnName)} in ('${items.join("', '")}')`;
+            item.expression = this.platform.getEnumCheckConstraintExpression(item.columnName, items as string[]);
             item.definition = `check (${item.expression})`;
           }
         }

--- a/packages/sql/src/dialects/sqlite/SqliteSchemaHelper.ts
+++ b/packages/sql/src/dialects/sqlite/SqliteSchemaHelper.ts
@@ -443,7 +443,9 @@ export class SqliteSchemaHelper extends SchemaHelper {
 
         /* v8 ignore next */
         if (match) {
-          o[match[1]] = match[2].split(',').map((item: string) => /^\(?'(.*)'/.exec(item.trim())![1]);
+          o[match[1]] = match[2]
+            .split(/,(?=\s*'(?:[^']|'')*'(?:\s*\)|$))/)
+            .map((item: string) => /^\(?'((?:[^']|'')*)'/.exec(item.trim())![1].replace(/''/g, "'"));
         }
 
         return o;

--- a/tests/features/schema-generator/GH7395.test.ts
+++ b/tests/features/schema-generator/GH7395.test.ts
@@ -1,0 +1,43 @@
+import { MikroORM } from '@mikro-orm/postgresql';
+import { Entity, Enum, PrimaryKey, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+
+enum Status {
+  ItsComplicated = "it's complicated",
+  Active = 'active',
+}
+
+@Entity()
+class GH7395 {
+  @PrimaryKey()
+  id!: number;
+
+  @Enum({ items: () => Status })
+  status!: Status;
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    metadataProvider: ReflectMetadataProvider,
+    entities: [GH7395],
+    dbName: 'mikro_orm_test_gh_7395',
+  });
+  await orm.schema.refresh();
+});
+
+afterAll(async () => {
+  await orm.schema.drop();
+  await orm.close(true);
+});
+
+test('GH #7395 - enum CHECK constraint with single quotes in values', async () => {
+  const createSQL = await orm.schema.getCreateSchemaSQL({ wrap: false });
+  // Single quotes must be escaped as '' in SQL
+  expect(createSQL).toContain(`check ("status" in ('it''s complicated', 'active'))`);
+  expect(createSQL).not.toContain(`check ("status" in ('it's complicated', 'active'))`);
+
+  // Ensure no diff is generated (schema is in sync)
+  const diff = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+  expect(diff).toBe('');
+});


### PR DESCRIPTION
## Summary

- Use `platform.quoteValue()` instead of raw string interpolation when building enum CHECK constraint SQL, fixing invalid syntax when enum values contain single quotes (e.g. `it's complicated`)
- Extract `getEnumCheckConstraintExpression()` on `Platform` to centralize the expression building (mirrors existing `getEnumArrayCheckConstraintExpression`)
- Fix PostgreSQL and SQLite CHECK constraint parsers to handle escaped quotes (`''`) when reading constraints back from the database

Closes #7395

🤖 Generated with [Claude Code](https://claude.com/claude-code)