### PR TITLE
fix(schema): escape single quotes in enum CHECK constraints

### DIFF
--- a/packages/knex/src/MonkeyPatchable.ts
+++ b/packages/knex/src/MonkeyPatchable.ts
@@ -23,11 +23,15 @@ import PostgresDialectTableCompiler from 'knex/lib/dialects/postgres/schema/pg-t
 // @ts-ignore
 import PostgresQueryCompiler from 'knex/lib/dialects/postgres/query/pg-querycompiler';
 // @ts-ignore
+import PostgresColumnCompiler from 'knex/lib/dialects/postgres/schema/pg-columncompiler';
+// @ts-ignore
 import Sqlite3Dialect from 'knex/lib/dialects/sqlite3';
 // @ts-ignore
 import BetterSqlite3Dialect from 'knex/lib/dialects/better-sqlite3';
 // @ts-ignore
 import Sqlite3DialectTableCompiler from 'knex/lib/dialects/sqlite3/schema/sqlite-tablecompiler';
+// @ts-ignore
+import Sqlite3ColumnCompiler from 'knex/lib/dialects/sqlite3/schema/sqlite-columncompiler';
 // @ts-ignore
 import TableCompiler from 'knex/lib/schema/tablecompiler';
 
@@ -48,8 +52,10 @@ export const MonkeyPatchable = {
   PostgresDialect,
   PostgresDialectTableCompiler,
   PostgresQueryCompiler,
+  PostgresColumnCompiler,
   Sqlite3Dialect,
   Sqlite3DialectTableCompiler,
+  Sqlite3ColumnCompiler,
   BetterSqlite3Dialect,
   TableCompiler,
 };

--- a/packages/knex/src/dialects/mssql/MsSqlColumnCompiler.ts
+++ b/packages/knex/src/dialects/mssql/MsSqlColumnCompiler.ts
@@ -3,7 +3,7 @@ import { MonkeyPatchable } from '../../MonkeyPatchable';
 export class MsSqlColumnCompiler extends MonkeyPatchable.MsSqlColumnCompiler {
 
   enu(this: any, allowed: unknown[]) {
-    return `nvarchar(100) check (${this.formatter.wrap(this.args[0])} in ('${(allowed.join("', '"))}'))`;
+    return `nvarchar(100) check (${this.formatter.wrap(this.args[0])} in (${allowed.map(v => `'${String(v).replace(/'/g, "''")}'`).join(', ')}))`;
   }
 
 }

--- a/packages/knex/src/dialects/postgresql/PostgreSqlColumnCompiler.ts
+++ b/packages/knex/src/dialects/postgresql/PostgreSqlColumnCompiler.ts
@@ -1,0 +1,16 @@
+import { MonkeyPatchable } from '../../MonkeyPatchable';
+
+export class PostgreSqlColumnCompiler extends MonkeyPatchable.PostgresColumnCompiler {
+
+  enu(this: any, allowed: unknown[], options: any) {
+    options = options || {};
+
+    if (options.useNative) {
+      return super.enu(allowed, options);
+    }
+
+    const values = allowed.map(v => `'${String(v).replace(/'/g, "''")}'`).join(', ');
+    return `text check (${this.formatter.wrap(this.args[0])} in (${values}))`;
+  }
+
+}

--- a/packages/knex/src/dialects/postgresql/PostgreSqlKnexDialect.ts
+++ b/packages/knex/src/dialects/postgresql/PostgreSqlKnexDialect.ts
@@ -1,6 +1,7 @@
 import type { Configuration } from '@mikro-orm/core';
 import { PostgreSqlTableCompiler } from './PostgreSqlTableCompiler';
 import { PostgreSqlQueryCompiler } from './PostgreSqlQueryCompiler';
+import { PostgreSqlColumnCompiler } from './PostgreSqlColumnCompiler';
 import { MonkeyPatchable } from '../../MonkeyPatchable';
 
 export class PostgreSqlKnexDialect extends MonkeyPatchable.PostgresDialect {
@@ -18,6 +19,11 @@ export class PostgreSqlKnexDialect extends MonkeyPatchable.PostgresDialect {
   queryCompiler() {
     // eslint-disable-next-line prefer-rest-params
     return new (PostgreSqlQueryCompiler as any)(this, ...arguments);
+  }
+
+  columnCompiler() {
+    // eslint-disable-next-line prefer-rest-params
+    return new (PostgreSqlColumnCompiler as any)(this, ...arguments);
   }
 
 }

--- a/packages/knex/src/dialects/sqlite/BaseSqliteSchemaHelper.ts
+++ b/packages/knex/src/dialects/sqlite/BaseSqliteSchemaHelper.ts
@@ -114,7 +114,9 @@ export abstract class BaseSqliteSchemaHelper extends SchemaHelper {
 
       /* istanbul ignore else */
       if (match) {
-        o[match[1]] = match[2].split(',').map((item: string) => item.trim().match(/^\(?'(.*)'/)![1]);
+        o[match[1]] = match[2]
+          .split(/,(?=\s*'(?:[^']|'')*'(?:\s*\)|$))/)
+          .map((item: string) => item.trim().match(/^\(?'((?:[^']|'')*)'/)![1].replace(/''/g, "'"));
       }
 
       return o;

--- a/packages/knex/src/dialects/sqlite/BetterSqliteKnexDialect.ts
+++ b/packages/knex/src/dialects/sqlite/BetterSqliteKnexDialect.ts
@@ -1,4 +1,5 @@
 import { SqliteTableCompiler } from './SqliteTableCompiler';
+import { SqliteColumnCompiler } from './SqliteColumnCompiler';
 import { MonkeyPatchable } from '../../MonkeyPatchable';
 
 export class BetterSqliteKnexDialect extends MonkeyPatchable.BetterSqlite3Dialect {
@@ -10,6 +11,11 @@ export class BetterSqliteKnexDialect extends MonkeyPatchable.BetterSqlite3Dialec
   tableCompiler() {
     // eslint-disable-next-line prefer-rest-params
     return new (SqliteTableCompiler as any)(this, ...arguments);
+  }
+
+  columnCompiler() {
+    // eslint-disable-next-line prefer-rest-params
+    return new (SqliteColumnCompiler as any)(this, ...arguments);
   }
 
 }

--- a/packages/knex/src/dialects/sqlite/LibSqlKnexDialect.ts
+++ b/packages/knex/src/dialects/sqlite/LibSqlKnexDialect.ts
@@ -1,4 +1,5 @@
 import { SqliteTableCompiler } from './SqliteTableCompiler';
+import { SqliteColumnCompiler } from './SqliteColumnCompiler';
 import { MonkeyPatchable } from '../../MonkeyPatchable';
 
 export class LibSqlKnexDialect extends MonkeyPatchable.BetterSqlite3Dialect {
@@ -47,6 +48,11 @@ export class LibSqlKnexDialect extends MonkeyPatchable.BetterSqlite3Dialect {
   tableCompiler() {
     // eslint-disable-next-line prefer-rest-params
     return new (SqliteTableCompiler as any)(this, ...arguments);
+  }
+
+  columnCompiler() {
+    // eslint-disable-next-line prefer-rest-params
+    return new (SqliteColumnCompiler as any)(this, ...arguments);
   }
 
   validateConnection(connection: any) {

--- a/packages/knex/src/dialects/sqlite/SqliteColumnCompiler.ts
+++ b/packages/knex/src/dialects/sqlite/SqliteColumnCompiler.ts
@@ -1,0 +1,10 @@
+import { MonkeyPatchable } from '../../MonkeyPatchable';
+
+export class SqliteColumnCompiler extends MonkeyPatchable.Sqlite3ColumnCompiler {
+
+  enu(this: any, allowed: unknown[]) {
+    const values = allowed.map(v => `'${String(v).replace(/'/g, "''")}'`).join(', ');
+    return `text check (${this.formatter.wrap(this.args[0])} in (${values}))`;
+  }
+
+}

--- a/packages/knex/src/dialects/sqlite/SqliteKnexDialect.ts
+++ b/packages/knex/src/dialects/sqlite/SqliteKnexDialect.ts
@@ -1,4 +1,5 @@
 import { SqliteTableCompiler } from './SqliteTableCompiler';
+import { SqliteColumnCompiler } from './SqliteColumnCompiler';
 import { MonkeyPatchable } from '../../MonkeyPatchable';
 
 export class SqliteKnexDialect extends MonkeyPatchable.Sqlite3Dialect {
@@ -6,6 +7,11 @@ export class SqliteKnexDialect extends MonkeyPatchable.Sqlite3Dialect {
   tableCompiler() {
     // eslint-disable-next-line prefer-rest-params
     return new (SqliteTableCompiler as any)(this, ...arguments);
+  }
+
+  columnCompiler() {
+    // eslint-disable-next-line prefer-rest-params
+    return new (SqliteColumnCompiler as any)(this, ...arguments);
   }
 
   processResponse(obj: any, runner: any) {

--- a/packages/mssql/src/MsSqlSchemaHelper.ts
+++ b/packages/mssql/src/MsSqlSchemaHelper.ts
@@ -249,7 +249,7 @@ export class MsSqlSchemaHelper extends SchemaHelper {
       const hasItems = (items?.length ?? 0) > 0;
 
       if (item.columnName && hasItems) {
-        items = items!.map(val => val.trim().replace(`[${item.columnName}]=`, '').match(/^\(?'(.*)'/)?.[1]).filter(Boolean) as string[];
+        items = items!.map(val => val.trim().replace(`[${item.columnName}]=`, '').match(/^\(?'((?:[^']|'')*)'/)?.[1]?.replace(/''/g, "'")).filter(Boolean) as string[];
 
         if (items.length > 0) {
           o[item.columnName] = items.reverse();
@@ -429,7 +429,7 @@ export class MsSqlSchemaHelper extends SchemaHelper {
       const checkName = this.platform.getConfig().getNamingStrategy().indexName(fromTable.name, [column.name], 'check');
 
       if (changedProperties.has('enumItems')) {
-        table.check(`${this.platform.quoteIdentifier(column.name)} in ('${(column.enumItems.join("', '"))}')`, {}, this.platform.quoteIdentifier(checkName));
+        table.check(`${this.platform.quoteIdentifier(column.name)} in (${column.enumItems.map(v => this.platform.quoteValue(v)).join(', ')})`, {}, this.platform.quoteIdentifier(checkName));
       }
 
       /* istanbul ignore next */

--- a/packages/postgresql/src/PostgreSqlSchemaHelper.ts
+++ b/packages/postgresql/src/PostgreSqlSchemaHelper.ts
@@ -393,15 +393,9 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
       const m2 = item.definition?.match(/\(array\[(.*)]\)/i) || item.definition?.match(/ = (.*)\)/i);
 
       if (item.columnName && m1 && m2) {
-        const m3 = m2[1].match(/('[^']*'::text)/g);
-        let items: (string | undefined)[];
-
-        /* istanbul ignore else */
-        if (m3) {
-          items = m3.map((item: string) => item.trim().match(/^\(?'(.*)'/)?.[1]);
-        } else {
-          items = m2[1].split(',').map((item: string) => item.trim().match(/^\(?'(.*)'/)?.[1]);
-        }
+        /* istanbul ignore next */
+        const parts = m2[1].match(/('(?:[^']|'')*'::\w[\w ]*)/g) ?? m2[1].split(',');
+        let items = parts.map((item: string) => item.trim().match(/^\(?'((?:[^']|'')*)'/)?.[1]?.replace(/''/g, "'"));
 
         items = items.filter(item => item !== undefined);
 
@@ -454,7 +448,7 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
       const checkName = this.platform.getConfig().getNamingStrategy().indexName(fromTable.name, [column.name], 'check');
 
       if (changedProperties.has('enumItems') || (!column.nativeEnumName && fromTable.getColumn(column.name)?.nativeEnumName)) {
-        table.check(`${this.platform.quoteIdentifier(column.name)} in ('${(column.enumItems.join("', '"))}')`, {}, this.platform.quoteIdentifier(checkName));
+        table.check(`${this.platform.quoteIdentifier(column.name)} in (${column.enumItems.map(v => this.platform.quoteValue(v)).join(', ')})`, {}, this.platform.quoteIdentifier(checkName));
       }
 
       if (changedProperties.has('type')) {

--- a/tests/features/schema-generator/GH7395.test.ts
+++ b/tests/features/schema-generator/GH7395.test.ts
@@ -1,0 +1,75 @@
+import { Entity, Enum, PrimaryKey } from '@mikro-orm/core';
+import { MikroORM as PostgresMikroORM } from '@mikro-orm/postgresql';
+import { MikroORM as SqliteMikroORM } from '@mikro-orm/libsql';
+import { MikroORM as MsSqlMikroORM } from '@mikro-orm/mssql';
+
+enum Status {
+  ItsComplicated = "it's complicated",
+  Active = 'active',
+}
+
+@Entity()
+class GH7395 {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Enum({ items: () => Status })
+  status!: Status;
+
+}
+
+describe('GH #7395 - enum CHECK constraint with single quotes', () => {
+
+  test('postgres', async () => {
+    const orm = await PostgresMikroORM.init({
+      entities: [GH7395],
+      dbName: 'mikro_orm_test_gh_7395',
+    });
+    await orm.schema.refreshDatabase();
+
+    const createSQL = await orm.schema.getCreateSchemaSQL({ wrap: false });
+    expect(createSQL).toContain(`check ("status" in ('it''s complicated', 'active'))`);
+
+    const diff = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(diff).toBe('');
+
+    await orm.schema.dropDatabase();
+    await orm.close(true);
+  });
+
+  test('sqlite', async () => {
+    const orm = await SqliteMikroORM.init({
+      entities: [GH7395],
+      dbName: ':memory:',
+    });
+    await orm.schema.refreshDatabase();
+
+    const createSQL = await orm.schema.getCreateSchemaSQL({ wrap: false });
+    expect(createSQL).toContain(`check (\`status\` in ('it''s complicated', 'active'))`);
+
+    const diff = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(diff).toBe('');
+
+    await orm.close(true);
+  });
+
+  test('mssql', async () => {
+    const orm = await MsSqlMikroORM.init({
+      entities: [GH7395],
+      dbName: 'mikro_orm_test_gh_7395',
+      password: 'Root.Root',
+    });
+    await orm.schema.refreshDatabase();
+
+    const createSQL = await orm.schema.getCreateSchemaSQL({ wrap: false });
+    expect(createSQL).toContain(`check ([status] in ('it''s complicated', 'active'))`);
+
+    const diff = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(diff).toBe('');
+
+    await orm.schema.dropSchema();
+    await orm.close(true);
+  });
+
+});


### PR DESCRIPTION
## Summary

Backport of #7396 to 6.x.

- Use `platform.quoteValue()` instead of raw string interpolation when building enum CHECK constraint SQL, fixing invalid syntax when enum values contain single quotes (e.g. `it's complicated`)
- Replace knex's `table.enum()` (which doesn't escape quotes internally) with `table.specificType('text')` + `table.check()` using properly quoted values for PostgreSQL
- Fix PostgreSQL and SQLite CHECK constraint parsers to handle escaped quotes (`''`) when reading constraints back from the database
- Fix MSSQL column compiler's `enu()` to escape single quotes in enum values

Closes #7395

🤖 Generated with [Claude Code](https://claude.com/claude-code)