### PR TITLE
fix(core): apply onCreate hooks in em.upsert and em.upsertMany

### DIFF
--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -1151,6 +1151,7 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
       }
 
       where = helper(entity).getPrimaryKey() as FilterQuery<Entity>;
+      em.#entityFactory.assignDefaultValues(entity, meta);
       data = em.#comparator.prepareEntity(entity);
     } else {
       data = Utils.copy(QueryHelper.processParams(data));
@@ -1163,6 +1164,8 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
           return em.assign(exists, data as any) as any;
         }
       }
+
+      em.#entityFactory.assignDefaultValues(data as Entity, meta, true);
 
       for (const key of Object.keys(data!)) {
         const prop = meta.properties[key as EntityKey<Entity>];
@@ -1334,6 +1337,7 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
         }
 
         where = helper(entity).getPrimaryKey() as FilterQuery<Entity>;
+        em.#entityFactory.assignDefaultValues(entity, meta);
         row = em.#comparator.prepareEntity(entity);
       } else {
         row = data[i] = Utils.copy(QueryHelper.processParams(row));
@@ -1349,6 +1353,8 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
             continue;
           }
         }
+
+        em.#entityFactory.assignDefaultValues(row as Entity, meta, true);
 
         for (const key of Object.keys(row)) {
           const prop = meta.properties[key as EntityKey<Entity>];

--- a/packages/core/src/entity/EntityFactory.ts
+++ b/packages/core/src/entity/EntityFactory.ts
@@ -434,7 +434,8 @@ export class EntityFactory {
     return entity;
   }
 
-  private assignDefaultValues<T extends object>(entity: T, meta: EntityMetadata<T>): void {
+  /** @internal */
+  assignDefaultValues<T extends object>(entity: T, meta: EntityMetadata<T>, onCreateOnly?: boolean): void {
     for (const prop of meta.props) {
       if (prop.embedded || [ReferenceKind.MANY_TO_ONE, ReferenceKind.ONE_TO_ONE].includes(prop.kind)) {
         continue;
@@ -442,7 +443,7 @@ export class EntityFactory {
 
       if (prop.onCreate) {
         entity[prop.name] ??= prop.onCreate(entity, this.#em);
-      } else if (prop.default != null && !isRaw(prop.default) && entity[prop.name] === undefined) {
+      } else if (!onCreateOnly && prop.default != null && !isRaw(prop.default) && entity[prop.name] === undefined) {
         entity[prop.name] = prop.default as EntityValue<T>;
       }
 
@@ -450,7 +451,7 @@ export class EntityFactory {
         const items = prop.array ? (entity[prop.name] as T[]) : [entity[prop.name] as T];
 
         for (const item of items) {
-          this.assignDefaultValues(item, prop.targetMeta! as EntityMetadata<T>);
+          this.assignDefaultValues(item, prop.targetMeta! as EntityMetadata<T>, onCreateOnly);
         }
       }
     }

--- a/tests/features/upsert/GH7399.test.ts
+++ b/tests/features/upsert/GH7399.test.ts
@@ -1,0 +1,149 @@
+import { v4 } from 'uuid';
+import { MikroORM, SimpleLogger } from '@mikro-orm/sqlite';
+import { Entity, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+import { mockLogger } from '../../helpers.js';
+
+@Entity()
+class User {
+  @PrimaryKey()
+  id: string = v4();
+
+  @Property()
+  createdAt: Date = new Date();
+
+  @Property({ onUpdate: () => new Date() })
+  updatedAt: Date = new Date();
+
+  @Property({ unique: true })
+  email!: string;
+
+  @Property()
+  name: string = '';
+}
+
+@Entity()
+class User2 {
+  @PrimaryKey({ onCreate: () => v4() })
+  id!: string;
+
+  @Property({ onCreate: () => new Date() })
+  createdAt!: Date;
+
+  @Property({ onCreate: () => new Date(), onUpdate: () => new Date() })
+  updatedAt!: Date;
+
+  @Property({ unique: true })
+  email!: string;
+
+  @Property()
+  name: string = '';
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    entities: [User, User2],
+    metadataProvider: ReflectMetadataProvider,
+    dbName: ':memory:',
+    loggerFactory: SimpleLogger.create,
+  });
+  await orm.schema.refresh();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+beforeEach(() => orm.em.clear());
+
+test('GH #7399 - upsert with entity instance having constructor defaults', async () => {
+  const mock = mockLogger(orm);
+
+  const user = new User();
+  user.email = 'foo@bar.com';
+  user.name = 'test';
+  await orm.em.upsert(user);
+
+  expect(user.id).toBeDefined();
+  expect(user.createdAt).toBeInstanceOf(Date);
+  expect(user.updatedAt).toBeInstanceOf(Date);
+
+  // The insert query should include id, created_at, updated_at
+  const insertQuery = mock.mock.calls.find(c => c[0].includes('insert'));
+  expect(insertQuery).toBeDefined();
+  expect(insertQuery![0]).toContain('`id`');
+  expect(insertQuery![0]).toContain('`created_at`');
+  expect(insertQuery![0]).toContain('`updated_at`');
+});
+
+test('GH #7399 - upsert with entity instance having onCreate hooks', async () => {
+  const mock = mockLogger(orm);
+
+  const user = new User2();
+  user.email = 'bar@bar.com';
+  user.name = 'test';
+  // id, createdAt, updatedAt rely on onCreate hooks
+  await orm.em.upsert(user);
+
+  expect(user.id).toBeDefined();
+  expect(user.createdAt).toBeInstanceOf(Date);
+  expect(user.updatedAt).toBeInstanceOf(Date);
+
+  // The insert query should include id, created_at, updated_at
+  const insertQuery = mock.mock.calls.find(c => c[0].includes('insert'));
+  expect(insertQuery).toBeDefined();
+  expect(insertQuery![0]).toContain('`id`');
+  expect(insertQuery![0]).toContain('`created_at`');
+  expect(insertQuery![0]).toContain('`updated_at`');
+});
+
+test('GH #7399 - upsertMany with entity instances having onCreate hooks', async () => {
+  const user1 = new User2();
+  user1.email = 'many1@bar.com';
+  user1.name = 'test1';
+
+  const user2 = new User2();
+  user2.email = 'many2@bar.com';
+  user2.name = 'test2';
+
+  await orm.em.upsertMany(User2, [user1, user2]);
+
+  expect(user1.id).toBeDefined();
+  expect(user1.createdAt).toBeInstanceOf(Date);
+  expect(user2.id).toBeDefined();
+  expect(user2.createdAt).toBeInstanceOf(Date);
+});
+
+test('GH #7399 - upsert with plain data applies onCreate hooks', async () => {
+  const mock = mockLogger(orm);
+
+  const user = await orm.em.upsert(User2, {
+    email: 'pojo@bar.com',
+    name: 'test',
+  } as any);
+
+  expect(user.id).toBeDefined();
+  expect(user.createdAt).toBeInstanceOf(Date);
+  expect(user.updatedAt).toBeInstanceOf(Date);
+
+  const insertQuery = mock.mock.calls.find(c => c[0].includes('insert'));
+  expect(insertQuery).toBeDefined();
+  expect(insertQuery![0]).toContain('`id`');
+  expect(insertQuery![0]).toContain('`created_at`');
+  expect(insertQuery![0]).toContain('`updated_at`');
+  // should NOT include `name` default (empty string) since it was explicitly provided
+  // only onCreate hooks should fire, not prop.default
+});
+
+test('GH #7399 - upsertMany with plain data applies onCreate hooks', async () => {
+  const [user1, user2] = await orm.em.upsertMany(User2, [
+    { email: 'pojo-many1@bar.com', name: 'test1' } as any,
+    { email: 'pojo-many2@bar.com', name: 'test2' } as any,
+  ]);
+
+  expect(user1.id).toBeDefined();
+  expect(user1.createdAt).toBeInstanceOf(Date);
+  expect(user2.id).toBeDefined();
+  expect(user2.createdAt).toBeInstanceOf(Date);
+});


### PR DESCRIPTION
## Summary

- `em.upsert()` and `em.upsertMany()` now run `onCreate` property hooks before building the INSERT query, fixing NOT NULL constraint violations for properties like auto-generated UUIDs and timestamps
- Works for both entity instances (full `assignDefaultValues`) and plain data objects (`onCreate` hooks only, skipping `prop.default` since those have database-level defaults)
- Made `EntityFactory.assignDefaultValues` accessible (`@internal`) with an `onCreateOnly` flag to control whether `prop.default` values are applied

Closes #7399

🤖 Generated with [Claude Code](https://claude.com/claude-code)