### PR TITLE
feat(core): auto-generated classes inherit from parent with defineEntity extends

### DIFF
--- a/docs/docs/define-entity.md
+++ b/docs/docs/define-entity.md
@@ -93,9 +93,13 @@ const book = em.create(Book, { title: 'My Book', author });
 await em.flush();
 ```
 
-### Reusing base properties via composition
+### Reusing base properties
 
-With `defineEntity`, use composition (shared property objects) instead of class inheritance for base properties:
+There are two ways to share common properties across entities with `defineEntity`:
+
+#### Via composition (shared property objects)
+
+The simplest approach — spread a shared property object into each entity's properties:
 
 ```ts
 const p = defineEntity.properties;
@@ -120,6 +124,52 @@ const BookSchema = defineEntity({
 export class Book extends BookSchema.class {}
 BookSchema.setClass(Book);
 ```
+
+#### Via `extends` with property initializers {#extends-initializers}
+
+When using the `defineEntity + class` pattern with `extends`, the auto-generated class inherits from the parent class at the JavaScript level. This means property initializers defined on the base class (like `id = v4()` or `createdAt = new Date()`) run automatically when constructing child entities via `new`:
+
+```ts
+const BaseSchema = defineEntity({
+  name: 'BaseEntity',
+  abstract: true,
+  properties: {
+    id: p.string().primary(),
+    createdAt: p.datetime(),
+    updatedAt: p.datetime(),
+  },
+});
+
+export class Base extends BaseSchema.class {
+  id = v4();
+  createdAt = new Date();
+  updatedAt = new Date();
+}
+
+BaseSchema.setClass(Base);
+
+const UserSchema = defineEntity({
+  name: 'User',
+  extends: BaseSchema,
+  properties: {
+    email: p.string().unique(),
+    name: p.string(),
+  },
+});
+
+export class User extends UserSchema.class {
+  name = '';
+}
+
+UserSchema.setClass(User);
+
+// id, createdAt, updatedAt are initialized from Base's property initializers
+const user = new User();
+console.log(user.id); // a UUID string
+console.log(user.createdAt); // current Date
+```
+
+> This approach is useful when you want constructor-level defaults that work without an `EntityManager` context (i.e., with plain `new`). If you only need defaults during persistence, you can use `onCreate` hooks instead — see [Mapped Superclasses](./inheritance-mapping.md#mapped-superclasses) for more details.
 
 ### Property types
 

--- a/docs/docs/entity-constructors.md
+++ b/docs/docs/entity-constructors.md
@@ -108,6 +108,10 @@ book.author = ref(Author, author);
 book.author = ref(author);
 ```
 
+## Property initializers with `defineEntity` and `extends`
+
+When using `defineEntity` with the `extends` option, property initializers from the base class are inherited and run automatically via `super()`. This allows you to define defaults like `id = v4()` or `createdAt = new Date()` on the base class and have them work in all child entities created via `new`. See [Reusing base properties via `extends`](./define-entity.md#extends-initializers) for a full example.
+
 ## Using native private properties
 
 If you want to use native private properties inside entities, the default approach of how MikroORM creates entity instances via `Object.create()` is not viable (more about this in the [issue](https://github.com/mikro-orm/mikro-orm/issues/1226)). To force usage of entity constructors, you can use [`forceEntityConstructor`](./configuration.md#using-native-private-properties) toggle.

--- a/docs/docs/inheritance-mapping.md
+++ b/docs/docs/inheritance-mapping.md
@@ -62,6 +62,8 @@ export class Person extends PersonSchema.class {}
 PersonSchema.setClass(Person);
 ```
 
+> When using `extends` with the `defineEntity + class` pattern, property initializers from the base class run automatically via `super()`. See [Reusing base properties via `extends`](./define-entity.md#extends-initializers) for details.
+
   </TabItem>
 
   <TabItem value="define-entity">

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -1089,8 +1089,15 @@ export class EntityMetadata<Entity = any, Class extends EntityCtor<Entity> = Ent
     const name = meta.className ?? meta.name;
 
     if (!this.class && name) {
-      const Class =
-        this.extends === BaseEntity ? { [name]: class extends BaseEntity {} }[name] : { [name]: class {} }[name];
+      let Parent: any;
+
+      if (typeof this.extends === 'function') {
+        Parent = this.extends;
+      } else if (this.extends != null && typeof (this.extends as any).class === 'function') {
+        Parent = (this.extends as any).class;
+      }
+
+      const Class = Parent ? { [name]: class extends Parent {} }[name] : { [name]: class {} }[name];
       this.class = Class as any;
     }
   }

--- a/tests/defineEntity.test.ts
+++ b/tests/defineEntity.test.ts
@@ -361,6 +361,67 @@ describe('defineEntity', () => {
     expect(UserSchema.meta.className).toBe('User');
   });
 
+  it('should inherit property initializers from parent class via extends', () => {
+    const BaseSchema = defineEntity({
+      name: 'BaseWithInit',
+      abstract: true,
+      properties: {
+        id: p.integer().primary(),
+        createdAt: p.datetime(),
+      },
+    });
+
+    class Base extends BaseSchema.class {
+      id = Math.floor(Math.random() * 1000000);
+      createdAt = new Date();
+    }
+
+    BaseSchema.setClass(Base);
+
+    const ChildSchema = defineEntity({
+      name: 'ChildWithInit',
+      extends: BaseSchema,
+      properties: {
+        name: p.string(),
+      },
+    });
+
+    class Child extends ChildSchema.class {
+      name = 'default';
+    }
+
+    ChildSchema.setClass(Child);
+
+    const autoClass = Object.getPrototypeOf(Child);
+    expect(autoClass.prototype).toBeInstanceOf(Base);
+
+    const child = new Child();
+    expect(child.id).toBeDefined();
+    expect(typeof child.id).toBe('number');
+    expect(child.createdAt).toBeInstanceOf(Date);
+    expect(child.name).toBe('default');
+  });
+
+  it('should inherit property initializers via extends with EntitySchema (no setClass)', () => {
+    const BaseSchema = defineEntity({
+      name: 'BaseNoSetClass',
+      properties: {
+        id: p.integer().primary(),
+      },
+    });
+
+    const ChildSchema = defineEntity({
+      name: 'ChildNoSetClass',
+      extends: BaseSchema,
+      properties: {
+        name: p.string(),
+      },
+    });
+
+    const ChildClass = ChildSchema.class as new () => any;
+    expect(new ChildClass()).toBeInstanceOf(BaseSchema.class);
+  });
+
   it('should define entity with json', () => {
     const Foo = defineEntity({
       name: 'Foo',


### PR DESCRIPTION
## Summary

- When `defineEntity` is used without an explicit `class` option and with `extends` pointing to another schema or class, the auto-generated class now extends the parent class at the JS level
- Previously only `BaseEntity` was special-cased — any other `extends` value produced a bare `class {}` with no prototype chain, so property initializers from the base class didn't run via `super()`
- Uses duck-typing to resolve `EntitySchema` parent classes (runtime import of `EntitySchema` in `typings.ts` is blocked by circular dependency)
- Added docs in `define-entity.md` (primary), `inheritance-mapping.md`, and `entity-constructors.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)