### PR TITLE
fix(core): resolve entity name from registry in MetadataProvider

### DIFF
--- a/packages/core/src/metadata/MetadataProvider.ts
+++ b/packages/core/src/metadata/MetadataProvider.ts
@@ -27,15 +27,33 @@ export class MetadataProvider {
         const tmp = prop.entity() as EntityClass;
         prop.type = Array.isArray(tmp)
           ? tmp
-              .map(t => Utils.className(t))
+              .map(t => this.resolveEntityName(t))
               .sort()
               .join(' | ')
-          : Utils.className(tmp);
+          : this.resolveEntityName(tmp);
         prop.target = EntitySchema.is(tmp) ? tmp.meta.class : tmp;
       } else if (!prop.type && !((prop.enum || prop.array) && (prop.items?.length ?? 0) > 0)) {
         throw new Error(`Please provide either 'type' or 'entity' attribute in ${meta.className}.${prop.name}.`);
       }
     }
+  }
+
+  /**
+   * Resolves the entity name for a given class or schema, respecting explicit names
+   * set via `defineEntity({ name })` + `setClass()`.
+   */
+  private resolveEntityName(entity: EntityClass): string {
+    if (EntitySchema.is(entity)) {
+      return entity.meta.className;
+    }
+
+    const schema = EntitySchema.REGISTRY.get(entity);
+
+    if (schema) {
+      return schema.name as string;
+    }
+
+    return Utils.className(entity);
   }
 
   /** Merges cached metadata into the given entity metadata, preserving function expressions. */

--- a/tests/issues/GHx32.test.ts
+++ b/tests/issues/GHx32.test.ts
@@ -1,0 +1,62 @@
+import { defineEntity, MikroORM, p } from '@mikro-orm/sqlite';
+
+const ClientSettingsSchema = defineEntity({
+  name: 'ClientSetting',
+  tableName: 'ClientSettings',
+  properties: {
+    id: p.integer().primary(),
+    storeAlias: p.string().length(80),
+    isAutoDelistUnusedProductsEnabled: p.boolean().default(false),
+    client: () => p.oneToOne(Client).owner().deleteRule('cascade'),
+  },
+});
+
+export class ClientSettings extends ClientSettingsSchema.class {}
+ClientSettingsSchema.setClass(ClientSettings);
+
+const ClientSchema = defineEntity({
+  name: 'Client',
+  tableName: 'Clients',
+  properties: {
+    id: p.integer().primary(),
+    name: p.string().length(80),
+    settings: () =>
+      p
+        .oneToOne(ClientSettings)
+        .mappedBy(settings => settings.client)
+        .nullable(),
+  },
+});
+
+export class Client extends ClientSchema.class {}
+ClientSchema.setClass(Client);
+
+describe('onCreate', () => {
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      dbName: ':memory:',
+      entities: [Client, ClientSettings],
+      serialization: { forceObject: true },
+    });
+    await orm.schema.refresh();
+  });
+
+  afterAll(() => orm.close(true));
+
+  it('should create a client', async () => {
+    const client = orm.em.create(Client, {
+      name: 'Test Client',
+    });
+    orm.em.create(ClientSettings, {
+      storeAlias: 'test-store',
+      client,
+    });
+
+    await orm.em.flush();
+
+    expect(client.id).toBeDefined();
+    expect(client.settings).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- When `defineEntity({ name: 'ClientSetting' })` + `setClass(ClientSettings)` is used (class name differs from explicit entity name), `MetadataProvider.loadEntityMetadata` resolved `prop.type` via `Utils.className()` returning `'ClientSettings'` instead of the schema's canonical name `'ClientSetting'`, causing validation to fail with "entity was not discovered"
- Added `resolveEntityName()` helper that checks `EntitySchema.REGISTRY` first and uses the schema's name when available
- This is a regression from fca6e6b2c which correctly preserved explicit names during discovery but didn't update the reference resolution path

🤖 Generated with [Claude Code](https://claude.com/claude-code)