### PR TITLE
fix(core): preserve user changes on references during initialization

### DIFF
--- a/packages/core/src/entity/EntityFactory.ts
+++ b/packages/core/src/entity/EntityFactory.ts
@@ -113,12 +113,37 @@ export class EntityFactory {
     let wrapped = exists && helper(exists);
 
     if (wrapped && !options.refresh) {
+      const wasInitialized = wrapped.isInitialized();
       wrapped.__processing = true;
       Utils.dropUndefinedProperties(data);
       this.mergeData(meta2, exists!, data, options);
       wrapped.__processing = false;
+      wrapped.__initialized ||= !!options.initialized;
 
       if (wrapped.isInitialized()) {
+        if (!wasInitialized) {
+          if (meta.root.inheritanceType && !(exists instanceof meta2.class)) {
+            Object.setPrototypeOf(exists, meta2.prototype as object);
+          }
+
+          if (options.merge && wrapped.hasPrimaryKey()) {
+            this.unitOfWork.register(exists!, data, { loaded: options.initialized });
+
+            // ensure all data keys are tracked as loaded for shouldRefresh checks,
+            // but don't overwrite __originalEntityData — mergeData already set it
+            // with DB values for non-user-modified keys, leaving user changes detectable
+            for (const key of Utils.keys(data)) {
+              if (meta2.properties[key]) {
+                wrapped.__loadedProperties.add(key as string);
+              }
+            }
+          }
+
+          if (this.#eventManager.hasListeners(EventType.onInit, meta2)) {
+            this.#eventManager.dispatchEvent(EventType.onInit, { entity: exists, meta: meta2, em: this.#em });
+          }
+        }
+
         return exists as New<T, P>;
       }
     }
@@ -215,8 +240,17 @@ export class EntityFactory {
 
     const diff2 = this.#comparator.diffEntities(meta.class, existsData, data, { includeInverseSides: true });
 
-    // do not override values changed by user
-    Utils.keys(diff).forEach(key => delete diff2[key]);
+    // do not override values changed by user; for uninitialized entities,
+    // the diff may include stale snapshot entries (value is undefined) — skip those
+    if (helper(entity).__initialized) {
+      Utils.keys(diff).forEach(key => delete diff2[key]);
+    } else {
+      Utils.keys(diff).forEach(key => {
+        if (diff[key] !== undefined) {
+          delete diff2[key];
+        }
+      });
+    }
 
     Utils.keys(diff2)
       .filter(key => {

--- a/tests/features/custom-types/json-hydration.postgres.test.ts
+++ b/tests/features/custom-types/json-hydration.postgres.test.ts
@@ -89,10 +89,7 @@ test('json property hydration 1/2', async () => {
   Page.log = [];
   const results = await orm.em.find(Course, {}, { populate: ['*'] });
   expect(results[0].published?.page.attestations).toEqual(['attestation1', 'attestation2']);
-  expect(Page.log).toEqual([
-    ['attestation1', 'attestation2'],
-    ['attestation1', 'attestation2'],
-  ]);
+  expect(Page.log).toEqual([['attestation1', 'attestation2']]);
 
   const mock = mockLogger(orm);
   await orm.em.flush();

--- a/tests/issues/GHx33.test.ts
+++ b/tests/issues/GHx33.test.ts
@@ -1,0 +1,109 @@
+import { defineEntity, EventArgs, EventSubscriber, MikroORM, p, wrap } from '@mikro-orm/sqlite';
+
+const Item = defineEntity({
+  name: 'Item',
+  properties: {
+    id: p.integer().primary().autoincrement(),
+    name: p.string(),
+    url: p.string(),
+    note: p.string().nullable(),
+  },
+});
+
+class FindOneInHookSubscriber implements EventSubscriber {
+  async beforeUpdate(args: EventArgs<any>): Promise<void> {
+    // loading the same entity inside beforeUpdate should not overwrite pending changes
+    await args.em.findOne(args.meta!.class, args.entity);
+  }
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    dbName: ':memory:',
+    entities: [Item],
+    subscribers: [new FindOneInHookSubscriber()],
+  });
+  await orm.schema.create();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+test('findOne in beforeUpdate subscriber should not overwrite pending changes on loaded entity', async () => {
+  const em = orm.em.fork();
+  const item = em.create(Item, { name: 'Name', url: 'any' });
+  await em.flush();
+
+  wrap(item).assign({ name: 'New name' });
+  await em.flush();
+
+  // clear and reload from DB to verify the update was persisted
+  em.clear();
+  const reloaded = await em.findOneOrFail(Item, item.id);
+  expect(reloaded.name).toBe('New name');
+});
+
+test('findOne in beforeUpdate subscriber should not overwrite pending changes on reference', async () => {
+  const em = orm.em.fork();
+  const item = em.create(Item, { name: 'Name', url: 'any' });
+  await em.flush();
+
+  em.clear();
+
+  const reference = em.getReference(Item, item.id);
+  wrap(reference).assign({ name: 'New name' });
+  await em.flush();
+
+  // clear and reload from DB to verify the update was persisted
+  em.clear();
+  const reloaded = await em.findOneOrFail(Item, item.id);
+  expect(reloaded.name).toBe('New name');
+});
+
+test('user changes on reference are persisted after findOne re-initializes it', async () => {
+  const em = orm.em.fork();
+  const item = em.create(Item, { name: 'Name', url: 'any' });
+  await em.flush();
+
+  em.clear();
+
+  // get a reference, modify it, then findOne before flushing
+  const reference = em.getReference(Item, item.id);
+  wrap(reference).assign({ name: 'New name' });
+
+  // findOne loads full data — should not lose the pending change
+  const loaded = await em.findOne(Item, item.id);
+  expect(loaded).toBe(reference);
+  expect(loaded!.name).toBe('New name');
+
+  // the change should still be persisted on flush
+  await em.flush();
+  em.clear();
+  const reloaded = await em.findOneOrFail(Item, item.id);
+  expect(reloaded.name).toBe('New name');
+});
+
+test('mergeData preserves user setting a property to undefined (forceUndefined)', async () => {
+  await orm.close();
+  orm = await MikroORM.init({
+    dbName: ':memory:',
+    entities: [Item],
+    forceUndefined: true,
+  });
+  await orm.schema.create();
+
+  const em = orm.em.fork();
+  const item = em.create(Item, { name: 'Name', url: 'any', note: 'some note' });
+  await em.flush();
+
+  // user explicitly unsets the note
+  item.note = undefined;
+  await em.flush();
+
+  em.clear();
+  const reloaded = await em.findOneOrFail(Item, item.id);
+  expect(reloaded.note).toBeUndefined();
+});


### PR DESCRIPTION
## Summary

- User modifications on uninitialized references (created via `getReference`) were silently lost when the reference was later initialized with DB data (via `findOne`, `populate`, joined loading, or any path through `EntityFactory.create`).
- Root cause was twofold: (1) after `mergeData` correctly preserved user changes, the entity remained uninitialized, causing a fall-through to full unprotected hydration that overwrote everything; (2) even without the fall-through, the snapshot (`__originalEntityData`) was set from the entity's current state (including user modifications), making the changeset computer unable to detect them as dirty.
- Fix: after `mergeData`, mark the entity as initialized when full data was provided, handle the reference→initialized transition properly (prototype fixup, `onLoad` registration, `onInit` event), and let `mergeData`'s snapshot stand (which correctly has DB values for non-user-modified keys, leaving user changes detectable by the changeset computer).
- Also fix `mergeData`'s diff to skip stale snapshot entries (`diff[key] === undefined` on uninitialized entities) while preserving `forceUndefined` semantics for initialized entities.

Reproduction: https://github.com/thaivlinh/mikro-orm-reproduction/blob/1ed1f2bb/src/example.test.ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)