### PR TITLE
fix(sql): infer Kysely table names for classes extending defineEntity().class

### DIFF
--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -2133,6 +2133,8 @@ export interface EntitySchemaWithMeta<
   readonly tableName: TTableName;
   /** @internal Direct entity type access - avoids expensive pattern matching */
   readonly '~entity': TEntity;
+  /** @internal */
+  readonly class: TClass & { '~entityName'?: TName };
 }
 
 /**

--- a/packages/sql/src/typings.ts
+++ b/packages/sql/src/typings.ts
@@ -293,11 +293,12 @@ export type MapTableName<
     : PreferStringLiteral<NonNullable<P['tableName']>, P['name']>]: P;
 };
 
+type ResolveTableNaming<TOptions extends MikroKyselyPluginOptions> = TOptions['tableNamingStrategy'] extends 'entity'
+  ? 'entity'
+  : 'underscore';
+
 export type MapValueAsTable<TMap extends Record<string, any>, TOptions extends MikroKyselyPluginOptions = {}> = {
-  [K in keyof TMap as TransformName<
-    K,
-    TOptions['tableNamingStrategy'] extends 'entity' ? 'entity' : 'underscore'
-  >]: InferKyselyTable<TMap[K], TOptions>;
+  [K in keyof TMap as TransformName<K, ResolveTableNaming<TOptions>>]: InferKyselyTable<TMap[K], TOptions>;
 };
 
 export type InferKyselyTable<
@@ -404,11 +405,13 @@ type ClassEntityDBMap<TEntities, TOptions extends MikroKyselyPluginOptions = {}>
   [T in TEntities as ClassEntityTableName<T, TOptions>]: ClassEntityColumns<T, TOptions>;
 };
 
-type ClassEntityTableName<T, TOptions extends MikroKyselyPluginOptions = {}> = T extends abstract new (
-  ...args: any[]
-) => infer Instance
-  ? TransformName<InferEntityName<Instance>, TOptions['tableNamingStrategy'] extends 'entity' ? 'entity' : 'underscore'>
-  : never;
+type ClassEntityTableName<T, TOptions extends MikroKyselyPluginOptions = {}> = T extends {
+  '~entityName'?: infer Name extends string;
+}
+  ? TransformName<Name, ResolveTableNaming<TOptions>>
+  : T extends abstract new (...args: any[]) => infer Instance
+    ? TransformName<InferEntityName<Instance>, ResolveTableNaming<TOptions>>
+    : never;
 
 type ClassEntityColumns<T, TOptions extends MikroKyselyPluginOptions = {}> = T extends abstract new (
   ...args: any[]

--- a/tests/features/get-kysely.test.ts
+++ b/tests/features/get-kysely.test.ts
@@ -783,6 +783,27 @@ describe('InferClassEntityDB', () => {
     type DB = InferClassEntityDB<typeof NoName>;
     expectTypeOf<DB>().toEqualTypeOf<unknown>();
   });
+
+  test('class extending defineEntity().class is inferred via ~entityName brand (GH #7423)', () => {
+    const FooSchema = defineEntity({
+      name: 'Foo7423',
+      properties: {
+        id: p.integer().primary(),
+        name: p.string(),
+      },
+    });
+
+    class Foo7423 extends FooSchema.class {}
+    FooSchema.setClass(Foo7423);
+
+    type DB = InferClassEntityDB<typeof Foo7423>;
+    expectTypeOf<DB>().toHaveProperty('foo7423');
+    expectTypeOf<DB['foo7423']>().toHaveProperty('id');
+    expectTypeOf<DB['foo7423']>().toHaveProperty('name');
+
+    type DBEntity = InferClassEntityDB<typeof Foo7423, { tableNamingStrategy: 'entity' }>;
+    expectTypeOf<DBEntity>().toHaveProperty('Foo7423');
+  });
 });
 
 interface Generated<T> {


### PR DESCRIPTION
## Summary

- When a class is created via `class Foo extends Schema.class {}` (from `defineEntity`) and passed in the `entities` array, `getKysely().selectFrom('Foo')` didn't recognize it as a valid table name
- Root cause: `InferClassEntityDB` only checked for `[EntityName]` on the instance type (the pattern used by decorator classes), which isn't present on classes derived from `defineEntity`
- Fix: brand `EntitySchemaWithMeta.class` with `'~entityName'` on the constructor's static side, and check for it first in `ClassEntityTableName`

Closes #7423

🤖 Generated with [Claude Code](https://claude.com/claude-code)