### PR TITLE
fix(sql): pass transaction context through schema introspection to avoid deadlock

### DIFF
--- a/packages/mariadb/src/MariaDbSchemaHelper.ts
+++ b/packages/mariadb/src/MariaDbSchemaHelper.ts
@@ -8,7 +8,7 @@ import {
   type Table,
   MySqlSchemaHelper,
 } from '@mikro-orm/mysql';
-import { type Dictionary, type Type } from '@mikro-orm/core';
+import { type Dictionary, type Transaction, type Type } from '@mikro-orm/core';
 
 /** Schema introspection helper for MariaDB. */
 export class MariaDbSchemaHelper extends MySqlSchemaHelper {
@@ -32,17 +32,19 @@ export class MariaDbSchemaHelper extends MySqlSchemaHelper {
     schema: DatabaseSchema,
     connection: AbstractSqlConnection,
     tables: Table[],
+    schemas?: string[],
+    ctx?: Transaction,
   ): Promise<void> {
     /* v8 ignore next */
     if (tables.length === 0) {
       return;
     }
 
-    const columns = await this.getAllColumns(connection, tables);
-    const indexes = await this.getAllIndexes(connection, tables);
-    const checks = await this.getAllChecks(connection, tables, columns);
-    const fks = await this.getAllForeignKeys(connection, tables);
-    const enums = await this.getAllEnumDefinitions(connection, tables);
+    const columns = await this.getAllColumns(connection, tables, ctx);
+    const indexes = await this.getAllIndexes(connection, tables, ctx);
+    const checks = await this.getAllChecks(connection, tables, ctx, columns);
+    const fks = await this.getAllForeignKeys(connection, tables, ctx);
+    const enums = await this.getAllEnumDefinitions(connection, tables, ctx);
 
     for (const t of tables) {
       const key = this.getTableKey(t);
@@ -52,12 +54,16 @@ export class MariaDbSchemaHelper extends MySqlSchemaHelper {
     }
   }
 
-  override async getAllIndexes(connection: AbstractSqlConnection, tables: Table[]): Promise<Dictionary<IndexDef[]>> {
+  override async getAllIndexes(
+    connection: AbstractSqlConnection,
+    tables: Table[],
+    ctx?: Transaction,
+  ): Promise<Dictionary<IndexDef[]>> {
     const sql = `select table_name as table_name, nullif(table_schema, schema()) as schema_name, index_name as index_name, non_unique as non_unique, column_name as column_name, index_type as index_type, sub_part as sub_part, collation as sort_order /*M!100600 , ignored as ignored */
         from information_schema.statistics where table_schema = database()
         and table_name in (${tables.map(t => this.platform.quoteValue(t.table_name)).join(', ')})
         order by schema_name, table_name, index_name, seq_in_index`;
-    const allIndexes = await connection.execute<any[]>(sql);
+    const allIndexes = await connection.execute<any[]>(sql, [], 'all', ctx);
     const ret = {} as Dictionary;
 
     for (const index of allIndexes) {
@@ -106,7 +112,11 @@ export class MariaDbSchemaHelper extends MySqlSchemaHelper {
     return ret;
   }
 
-  override async getAllColumns(connection: AbstractSqlConnection, tables: Table[]): Promise<Dictionary<Column[]>> {
+  override async getAllColumns(
+    connection: AbstractSqlConnection,
+    tables: Table[],
+    ctx?: Transaction,
+  ): Promise<Dictionary<Column[]>> {
     const sql = `select table_name as table_name,
       nullif(table_schema, schema()) as schema_name,
       column_name as column_name,
@@ -123,7 +133,7 @@ export class MariaDbSchemaHelper extends MySqlSchemaHelper {
       ifnull(datetime_precision, character_maximum_length) length
       from information_schema.columns where table_schema = database() and table_name in (${tables.map(t => this.platform.quoteValue(t.table_name)).join(', ')})
       order by ordinal_position`;
-    const allColumns = await connection.execute<any[]>(sql);
+    const allColumns = await connection.execute<any[]>(sql, [], 'all', ctx);
     const str = (val?: string | number | null) => (val != null ? '' + val : val);
     const extra = (val: string) =>
       val.replace(/auto_increment|default_generated|(stored|virtual) generated/i, '').trim() || undefined;
@@ -170,13 +180,13 @@ export class MariaDbSchemaHelper extends MySqlSchemaHelper {
   override async getAllChecks(
     connection: AbstractSqlConnection,
     tables: Table[],
+    ctx?: Transaction,
     columns?: Dictionary<Column[]>,
   ): Promise<Dictionary<CheckDef[]>> {
     const sql = this.getChecksSQL(tables);
-    const allChecks =
-      await connection.execute<
-        { name: string; column_name: string; schema_name: string; table_name: string; expression: string }[]
-      >(sql);
+    const allChecks = await connection.execute<
+      { name: string; column_name: string; schema_name: string; table_name: string; expression: string }[]
+    >(sql, [], 'all', ctx);
     const ret = {} as Dictionary;
 
     for (const check of allChecks) {

--- a/packages/migrations/src/Migrator.ts
+++ b/packages/migrations/src/Migrator.ts
@@ -6,6 +6,7 @@ import {
   type MigrateOptions,
   type MigrationInfo,
   type MikroORM,
+  Utils,
   t,
   Type,
   UnknownType,
@@ -145,7 +146,18 @@ export class Migrator extends AbstractMigrator<AbstractSqlDriver> {
     const result = await super.runMigrations(method, options);
 
     if (result.length > 0 && this.options.snapshot) {
-      const schema = await DatabaseSchema.create(this.em.getConnection(), this.em.getPlatform(), this.config);
+      const ctx = Utils.isObject<MigrateOptions>(options) ? options.transaction : undefined;
+      const schema = await DatabaseSchema.create(
+        this.em.getConnection(),
+        this.em.getPlatform(),
+        this.config,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        ctx,
+      );
 
       try {
         await this.storeCurrentSchema(schema);

--- a/packages/mssql/src/MsSqlSchemaHelper.ts
+++ b/packages/mssql/src/MsSqlSchemaHelper.ts
@@ -14,6 +14,7 @@ import {
   type Table,
   type TableDifference,
   TextType,
+  type Transaction,
   type Type,
   Utils,
 } from '@mikro-orm/sql';
@@ -63,9 +64,17 @@ export class MsSqlSchemaHelper extends SchemaHelper {
       order by schema_name(v.schema_id), v.name`;
   }
 
-  override async loadViews(schema: DatabaseSchema, connection: AbstractSqlConnection): Promise<void> {
+  override async loadViews(
+    schema: DatabaseSchema,
+    connection: AbstractSqlConnection,
+    schemaName?: string,
+    ctx?: Transaction,
+  ): Promise<void> {
     const views = await connection.execute<{ view_name: string; schema_name: string; view_definition: string }[]>(
       this.getListViewsSQL(),
+      [],
+      'all',
+      ctx,
     );
 
     for (const view of views) {
@@ -80,9 +89,9 @@ export class MsSqlSchemaHelper extends SchemaHelper {
     }
   }
 
-  override async getNamespaces(connection: AbstractSqlConnection): Promise<string[]> {
+  override async getNamespaces(connection: AbstractSqlConnection, ctx?: Transaction): Promise<string[]> {
     const sql = `select name as schema_name from sys.schemas order by name`;
-    const res = await connection.execute<{ schema_name: string }[]>(sql);
+    const res = await connection.execute<{ schema_name: string }[]>(sql, [], 'all', ctx);
     return res.map(row => row.schema_name);
   }
 
@@ -116,6 +125,7 @@ export class MsSqlSchemaHelper extends SchemaHelper {
   async getAllColumns(
     connection: AbstractSqlConnection,
     tablesBySchemas: Map<string | undefined, Table[]>,
+    ctx?: Transaction,
   ): Promise<Dictionary<Column[]>> {
     const sql = `select table_name as table_name,
       table_schema as schema_name,
@@ -139,7 +149,7 @@ export class MsSqlSchemaHelper extends SchemaHelper {
       left join sys.default_constraints t5 on sc.default_object_id = t5.object_id
       where (${[...tablesBySchemas.entries()].map(([schema, tables]) => `(ic.table_name in (${tables.map(t => this.platform.quoteValue(t.table_name)).join(',')}) and ic.table_schema = '${schema}')`).join(' or ')})
       order by ordinal_position`;
-    const allColumns = await connection.execute<any[]>(sql);
+    const allColumns = await connection.execute<any[]>(sql, [], 'all', ctx);
     const str = (val?: string | number) => (val != null ? '' + val : val);
     const ret = {} as Dictionary;
 
@@ -200,6 +210,7 @@ export class MsSqlSchemaHelper extends SchemaHelper {
   async getAllIndexes(
     connection: AbstractSqlConnection,
     tablesBySchemas: Map<string | undefined, Table[]>,
+    ctx?: Transaction,
   ): Promise<Dictionary<IndexDef[]>> {
     const sql = `select t.name as table_name,
       ind.name as index_name,
@@ -220,7 +231,7 @@ export class MsSqlSchemaHelper extends SchemaHelper {
       where
       (${[...tablesBySchemas.entries()].map(([schema, tables]) => `(t.name in (${tables.map(t => this.platform.quoteValue(t.table_name)).join(',')}) and schema_name(t.schema_id) = '${schema}')`).join(' OR ')})
       order by t.name, ind.name, ic.is_included_column, ic.key_ordinal`;
-    const allIndexes = await connection.execute<any[]>(sql);
+    const allIndexes = await connection.execute<any[]>(sql, [], 'all', ctx);
     const ret = {} as Dictionary;
 
     for (const index of allIndexes) {
@@ -290,6 +301,7 @@ export class MsSqlSchemaHelper extends SchemaHelper {
   async getAllForeignKeys(
     connection: AbstractSqlConnection,
     tablesBySchemas: Map<string | undefined, Table[]>,
+    ctx?: Transaction,
   ): Promise<Dictionary<Dictionary<ForeignKey>>> {
     const sql = `select ccu.constraint_name, ccu.table_name, ccu.table_schema schema_name, ccu.column_name,
       kcu.constraint_schema referenced_schema_name,
@@ -302,7 +314,7 @@ export class MsSqlSchemaHelper extends SchemaHelper {
       inner join information_schema.key_column_usage kcu on kcu.constraint_name = rc.unique_constraint_name and rc.unique_constraint_schema = kcu.constraint_schema
       where (${[...tablesBySchemas.entries()].map(([schema, tables]) => `(ccu.table_name in (${tables.map(t => this.platform.quoteValue(t.table_name)).join(',')}) and ccu.table_schema = '${schema}')`).join(' or ')})
       order by kcu.table_schema, kcu.table_name, kcu.ordinal_position, kcu.constraint_name`;
-    const allFks = await connection.execute<any[]>(sql);
+    const allFks = await connection.execute<any[]>(sql, [], 'all', ctx);
     const ret = {} as Dictionary;
 
     for (const fk of allFks) {
@@ -362,12 +374,12 @@ export class MsSqlSchemaHelper extends SchemaHelper {
   async getAllChecks(
     connection: AbstractSqlConnection,
     tablesBySchemas: Map<string | undefined, Table[]>,
+    ctx?: Transaction,
   ): Promise<Dictionary<CheckDef[]>> {
     const sql = this.getChecksSQL(tablesBySchemas);
-    const allChecks =
-      await connection.execute<
-        { name: string; column_name: string; schema_name: string; table_name: string; expression: string }[]
-      >(sql);
+    const allChecks = await connection.execute<
+      { name: string; column_name: string; schema_name: string; table_name: string; expression: string }[]
+    >(sql, [], 'all', ctx);
     const ret = {} as Dictionary;
 
     for (const check of allChecks) {
@@ -389,16 +401,18 @@ export class MsSqlSchemaHelper extends SchemaHelper {
     schema: DatabaseSchema,
     connection: AbstractSqlConnection,
     tables: Table[],
+    schemas?: string[],
+    ctx?: Transaction,
   ): Promise<void> {
     if (tables.length === 0) {
       return;
     }
 
     const tablesBySchema = this.getTablesGroupedBySchemas(tables);
-    const columns = await this.getAllColumns(connection, tablesBySchema);
-    const indexes = await this.getAllIndexes(connection, tablesBySchema);
-    const checks = await this.getAllChecks(connection, tablesBySchema);
-    const fks = await this.getAllForeignKeys(connection, tablesBySchema);
+    const columns = await this.getAllColumns(connection, tablesBySchema, ctx);
+    const indexes = await this.getAllIndexes(connection, tablesBySchema, ctx);
+    const checks = await this.getAllChecks(connection, tablesBySchema, ctx);
+    const fks = await this.getAllForeignKeys(connection, tablesBySchema, ctx);
 
     for (const t of tables) {
       const key = this.getTableKey(t);

--- a/packages/oracledb/src/OracleSchemaHelper.ts
+++ b/packages/oracledb/src/OracleSchemaHelper.ts
@@ -14,6 +14,7 @@ import {
   type Table,
   type TableDifference,
   TextType,
+  type Transaction,
   type Type,
   Utils,
 } from '@mikro-orm/sql';
@@ -31,9 +32,13 @@ export class OracleSchemaHelper extends SchemaHelper {
     return `select 1 from all_users where username = ${this.platform.quoteValue(name)}`;
   }
 
-  override async getAllTables(connection: AbstractSqlConnection, schemas?: string[]): Promise<Table[]> {
+  override async getAllTables(
+    connection: AbstractSqlConnection,
+    schemas?: string[],
+    ctx?: Transaction,
+  ): Promise<Table[]> {
     if (!schemas || schemas.length === 0) {
-      return connection.execute<Table[]>(this.getListTablesSQL());
+      return connection.execute<Table[]>(this.getListTablesSQL(), [], 'all', ctx);
     }
 
     const conditions = schemas.map(s => `at.owner = ${this.platform.quoteValue(s)}`).join(' or ');
@@ -42,7 +47,7 @@ export class OracleSchemaHelper extends SchemaHelper {
       left join all_tab_comments atc on at.owner = atc.owner and at.table_name = atc.table_name
       where (${conditions})
       order by schema_name, at.table_name`;
-    return connection.execute<Table[]>(sql);
+    return connection.execute<Table[]>(sql, [], 'all', ctx);
   }
 
   override getListTablesSQL(schemaName?: string): string {
@@ -74,9 +79,17 @@ export class OracleSchemaHelper extends SchemaHelper {
       order by view_name`;
   }
 
-  override async loadViews(schema: DatabaseSchema, connection: AbstractSqlConnection): Promise<void> {
+  override async loadViews(
+    schema: DatabaseSchema,
+    connection: AbstractSqlConnection,
+    schemaName?: string,
+    ctx?: Transaction,
+  ): Promise<void> {
     const views = await connection.execute<{ view_name: string; schema_name: string; view_definition: string }[]>(
       this.getListViewsSQL(),
+      [],
+      'all',
+      ctx,
     );
 
     for (const view of views) {
@@ -90,9 +103,9 @@ export class OracleSchemaHelper extends SchemaHelper {
     }
   }
 
-  override async getNamespaces(connection: AbstractSqlConnection): Promise<string[]> {
+  override async getNamespaces(connection: AbstractSqlConnection, ctx?: Transaction): Promise<string[]> {
     const sql = `select username as schema_name from all_users where ${this.getIgnoredNamespacesConditionSQL()} order by username`;
-    const res = await connection.execute<{ schema_name: string }[]>(sql);
+    const res = await connection.execute<{ schema_name: string }[]>(sql, [], 'all', ctx);
     return res.map(row => row.schema_name);
   }
 
@@ -158,6 +171,7 @@ export class OracleSchemaHelper extends SchemaHelper {
   async getAllColumns(
     connection: AbstractSqlConnection,
     tablesBySchemas: Map<string | undefined, Table[]>,
+    ctx?: Transaction,
   ): Promise<Dictionary<Column[]>> {
     const sql = `select
       atc.owner as schema_name,
@@ -181,7 +195,7 @@ export class OracleSchemaHelper extends SchemaHelper {
       where atc.hidden_column = 'NO'
       and (${[...tablesBySchemas.entries()].map(([schema, tables]) => `(atc.table_name in (${tables.map(t => this.platform.quoteValue(t.table_name)).join(', ')}) and atc.owner = ${this.platform.quoteValue(schema)})`).join(' or ')})
       order by atc.owner, atc.table_name, atc.column_id`;
-    const allColumns = await connection.execute<any[]>(sql);
+    const allColumns = await connection.execute<any[]>(sql, [], 'all', ctx);
     const str = (val?: string | number) => (val != null ? '' + val : val);
     const ret = {} as Dictionary;
 
@@ -247,6 +261,7 @@ export class OracleSchemaHelper extends SchemaHelper {
   async getAllIndexes(
     connection: AbstractSqlConnection,
     tablesBySchemas: Map<string | undefined, Table[]>,
+    ctx?: Transaction,
   ): Promise<Dictionary<IndexDef[]>> {
     // Query indexes and join with constraints to identify which indexes back PRIMARY KEY or UNIQUE constraints
     // Also join with all_ind_expressions to get function-based index expressions
@@ -262,7 +277,7 @@ export class OracleSchemaHelper extends SchemaHelper {
       left join all_ind_expressions aie on ind.owner = aie.index_owner and ind.index_name = aie.index_name and aic.column_position = aie.column_position
       where (${[...tablesBySchemas.entries()].map(([schema, tables]) => `(ind.table_name in (${tables.map(t => this.platform.quoteValue(t.table_name)).join(', ')}) and ind.table_owner = ${this.platform.quoteValue(schema)})`).join(' or ')})
       order by ind.table_name, ind.index_name, aic.column_position`;
-    const allIndexes = await connection.execute<any[]>(sql);
+    const allIndexes = await connection.execute<any[]>(sql, [], 'all', ctx);
     const ret = {} as Dictionary;
 
     for (const index of allIndexes) {
@@ -335,6 +350,7 @@ export class OracleSchemaHelper extends SchemaHelper {
   async getAllForeignKeys(
     connection: AbstractSqlConnection,
     tablesBySchemas: Map<string | undefined, Table[]>,
+    ctx?: Transaction,
   ): Promise<Dictionary<Dictionary<ForeignKey>>> {
     const sql = `select fk_cons.constraint_name, fk_cons.table_name, fk_cons.owner as schema_name, fk_cols.column_name,
       fk_cons.r_owner as referenced_schema_name,
@@ -349,7 +365,7 @@ export class OracleSchemaHelper extends SchemaHelper {
       where fk_cons.constraint_type = 'R'
       and (${[...tablesBySchemas.entries()].map(([schema, tables]) => `(fk_cons.table_name in (${tables.map(t => this.platform.quoteValue(t.table_name)).join(', ')}) and fk_cons.owner = ${this.platform.quoteValue(schema)})`).join(' or ')})
       order by fk_cons.owner, fk_cons.table_name, fk_cons.constraint_name, pk_cols.position`;
-    const allFks = await connection.execute<any[]>(sql);
+    const allFks = await connection.execute<any[]>(sql, [], 'all', ctx);
     const ret = {} as Dictionary;
 
     for (const fk of allFks) {
@@ -421,12 +437,12 @@ export class OracleSchemaHelper extends SchemaHelper {
   async getAllChecks(
     connection: AbstractSqlConnection,
     tablesBySchemas: Map<string | undefined, Table[]>,
+    ctx?: Transaction,
   ): Promise<Dictionary<CheckDef[]>> {
     const sql = this.getChecksSQL(tablesBySchemas);
-    const allChecks =
-      await connection.execute<
-        { name: string; column_name: string; schema_name: string; table_name: string; expression: string }[]
-      >(sql);
+    const allChecks = await connection.execute<
+      { name: string; column_name: string; schema_name: string; table_name: string; expression: string }[]
+    >(sql, [], 'all', ctx);
     const ret = {} as Dictionary;
 
     for (const check of allChecks) {
@@ -448,16 +464,18 @@ export class OracleSchemaHelper extends SchemaHelper {
     schema: DatabaseSchema,
     connection: AbstractSqlConnection,
     tables: Table[],
+    schemas?: string[],
+    ctx?: Transaction,
   ): Promise<void> {
     if (tables.length === 0) {
       return;
     }
 
     const tablesBySchema = this.getTablesGroupedBySchemas(tables);
-    const columns = await this.getAllColumns(connection, tablesBySchema);
-    const indexes = await this.getAllIndexes(connection, tablesBySchema);
-    const checks = await this.getAllChecks(connection, tablesBySchema);
-    const fks = await this.getAllForeignKeys(connection, tablesBySchema);
+    const columns = await this.getAllColumns(connection, tablesBySchema, ctx);
+    const indexes = await this.getAllIndexes(connection, tablesBySchema, ctx);
+    const checks = await this.getAllChecks(connection, tablesBySchema, ctx);
+    const fks = await this.getAllForeignKeys(connection, tablesBySchema, ctx);
 
     for (const t of tables) {
       const key = this.getTableKey(t);

--- a/packages/sql/src/dialects/mysql/MySqlSchemaHelper.ts
+++ b/packages/sql/src/dialects/mysql/MySqlSchemaHelper.ts
@@ -1,4 +1,4 @@
-import { type Dictionary, EnumType, StringType, TextType, type Type } from '@mikro-orm/core';
+import { type Dictionary, EnumType, StringType, TextType, type Transaction, type Type } from '@mikro-orm/core';
 import type { CheckDef, Column, ForeignKey, IndexDef, Table, TableDifference } from '../../typings.js';
 import type { AbstractSqlConnection } from '../../AbstractSqlConnection.js';
 import { SchemaHelper } from '../../schema/SchemaHelper.js';
@@ -58,10 +58,11 @@ export class MySqlSchemaHelper extends SchemaHelper {
     schema: DatabaseSchema,
     connection: AbstractSqlConnection,
     schemaName?: string,
+    ctx?: Transaction,
   ): Promise<void> {
     const views = await connection.execute<
       { view_name: string; schema_name: string | null; view_definition?: string }[]
-    >(this.getListViewsSQL());
+    >(this.getListViewsSQL(), [], 'all', ctx);
 
     for (const view of views) {
       // MySQL information_schema.views.view_definition requires SHOW VIEW privilege
@@ -71,6 +72,9 @@ export class MySqlSchemaHelper extends SchemaHelper {
       if (!definition) {
         const createView = await connection.execute<{ View: string; 'Create View': string }[]>(
           `show create view \`${view.view_name}\``,
+          [],
+          'all',
+          ctx,
         );
         if (createView[0]?.['Create View']) {
           // Extract SELECT statement from CREATE VIEW ... AS SELECT ...
@@ -89,16 +93,18 @@ export class MySqlSchemaHelper extends SchemaHelper {
     schema: DatabaseSchema,
     connection: AbstractSqlConnection,
     tables: Table[],
+    schemas?: string[],
+    ctx?: Transaction,
   ): Promise<void> {
     if (tables.length === 0) {
       return;
     }
 
-    const columns = await this.getAllColumns(connection, tables);
-    const indexes = await this.getAllIndexes(connection, tables);
-    const checks = await this.getAllChecks(connection, tables);
-    const fks = await this.getAllForeignKeys(connection, tables);
-    const enums = await this.getAllEnumDefinitions(connection, tables);
+    const columns = await this.getAllColumns(connection, tables, ctx);
+    const indexes = await this.getAllIndexes(connection, tables, ctx);
+    const checks = await this.getAllChecks(connection, tables, ctx);
+    const fks = await this.getAllForeignKeys(connection, tables, ctx);
+    const enums = await this.getAllEnumDefinitions(connection, tables, ctx);
 
     for (const t of tables) {
       const key = this.getTableKey(t);
@@ -108,12 +114,16 @@ export class MySqlSchemaHelper extends SchemaHelper {
     }
   }
 
-  async getAllIndexes(connection: AbstractSqlConnection, tables: Table[]): Promise<Dictionary<IndexDef[]>> {
+  async getAllIndexes(
+    connection: AbstractSqlConnection,
+    tables: Table[],
+    ctx?: Transaction,
+  ): Promise<Dictionary<IndexDef[]>> {
     const sql = `select table_name as table_name, nullif(table_schema, schema()) as schema_name, index_name as index_name, non_unique as non_unique, column_name as column_name, index_type as index_type, sub_part as sub_part, collation as sort_order /*!80013 , expression as expression, is_visible as is_visible */
         from information_schema.statistics where table_schema = database()
         and table_name in (${tables.map(t => this.platform.quoteValue(t.table_name)).join(', ')})
         order by schema_name, table_name, index_name, seq_in_index`;
-    const allIndexes = await connection.execute<any[]>(sql);
+    const allIndexes = await connection.execute<any[]>(sql, [], 'all', ctx);
     const ret = {} as Dictionary;
 
     for (const index of allIndexes) {
@@ -251,7 +261,11 @@ export class MySqlSchemaHelper extends SchemaHelper {
     return sql;
   }
 
-  async getAllColumns(connection: AbstractSqlConnection, tables: Table[]): Promise<Dictionary<Column[]>> {
+  async getAllColumns(
+    connection: AbstractSqlConnection,
+    tables: Table[],
+    ctx?: Transaction,
+  ): Promise<Dictionary<Column[]>> {
     const sql = `select table_name as table_name,
       nullif(table_schema, schema()) as schema_name,
       column_name as column_name,
@@ -268,7 +282,7 @@ export class MySqlSchemaHelper extends SchemaHelper {
       ifnull(datetime_precision, character_maximum_length) length
       from information_schema.columns where table_schema = database() and table_name in (${tables.map(t => this.platform.quoteValue(t.table_name))})
       order by ordinal_position`;
-    const allColumns = await connection.execute<any[]>(sql);
+    const allColumns = await connection.execute<any[]>(sql, [], 'all', ctx);
     const str = (val?: string | number) => (val != null ? '' + val : val);
     const extra = (val: string) =>
       val.replace(/auto_increment|default_generated|(stored|virtual) generated/i, '').trim() || undefined;
@@ -313,17 +327,20 @@ export class MySqlSchemaHelper extends SchemaHelper {
     return ret;
   }
 
-  async getAllChecks(connection: AbstractSqlConnection, tables: Table[]): Promise<Dictionary<CheckDef[]>> {
+  async getAllChecks(
+    connection: AbstractSqlConnection,
+    tables: Table[],
+    ctx?: Transaction,
+  ): Promise<Dictionary<CheckDef[]>> {
     /* v8 ignore next */
-    if (!(await this.supportsCheckConstraints(connection))) {
+    if (!(await this.supportsCheckConstraints(connection, ctx))) {
       return {};
     }
 
     const sql = this.getChecksSQL(tables);
-    const allChecks =
-      await connection.execute<
-        { name: string; column_name: string; schema_name: string; table_name: string; expression: string }[]
-      >(sql);
+    const allChecks = await connection.execute<
+      { name: string; column_name: string; schema_name: string; table_name: string; expression: string }[]
+    >(sql, [], 'all', ctx);
     const ret = {} as Dictionary;
 
     for (const check of allChecks) {
@@ -343,6 +360,7 @@ export class MySqlSchemaHelper extends SchemaHelper {
   async getAllForeignKeys(
     connection: AbstractSqlConnection,
     tables: Table[],
+    ctx?: Transaction,
   ): Promise<Dictionary<Dictionary<ForeignKey>>> {
     const sql = `select k.constraint_name as constraint_name, nullif(k.table_schema, schema()) as schema_name, k.table_name as table_name, k.column_name as column_name, k.referenced_table_name as referenced_table_name, k.referenced_column_name as referenced_column_name, c.update_rule as update_rule, c.delete_rule as delete_rule
         from information_schema.key_column_usage k
@@ -350,7 +368,7 @@ export class MySqlSchemaHelper extends SchemaHelper {
         where k.table_name in (${tables.map(t => this.platform.quoteValue(t.table_name)).join(', ')})
         and k.table_schema = database() and c.constraint_schema = database() and k.referenced_column_name is not null
         order by constraint_name, k.ordinal_position`;
-    const allFks = await connection.execute<any[]>(sql);
+    const allFks = await connection.execute<any[]>(sql, [], 'all', ctx);
     const ret = {} as Dictionary;
 
     for (const fk of allFks) {
@@ -430,11 +448,12 @@ export class MySqlSchemaHelper extends SchemaHelper {
   async getAllEnumDefinitions(
     connection: AbstractSqlConnection,
     tables: Table[],
+    ctx?: Transaction,
   ): Promise<Dictionary<Dictionary<string[]>>> {
     const sql = `select column_name as column_name, column_type as column_type, table_name as table_name
       from information_schema.columns
       where data_type = 'enum' and table_name in (${tables.map(t => `'${t.table_name}'`).join(', ')}) and table_schema = database()`;
-    const enums = await connection.execute<any[]>(sql);
+    const enums = await connection.execute<any[]>(sql, [], 'all', ctx);
 
     return enums.reduce(
       (o, item) => {
@@ -449,13 +468,13 @@ export class MySqlSchemaHelper extends SchemaHelper {
     );
   }
 
-  private async supportsCheckConstraints(connection: AbstractSqlConnection): Promise<boolean> {
+  private async supportsCheckConstraints(connection: AbstractSqlConnection, ctx?: Transaction): Promise<boolean> {
     if (this.#cache.supportsCheckConstraints != null) {
       return this.#cache.supportsCheckConstraints;
     }
 
     const sql = `select 1 from information_schema.tables where table_name = 'CHECK_CONSTRAINTS' and table_schema = 'information_schema'`;
-    const res = await connection.execute(sql);
+    const res = await connection.execute(sql, [], 'all', ctx);
 
     return (this.#cache.supportsCheckConstraints = res.length > 0);
   }

--- a/packages/sql/src/dialects/postgresql/PostgreSqlSchemaHelper.ts
+++ b/packages/sql/src/dialects/postgresql/PostgreSqlSchemaHelper.ts
@@ -4,6 +4,7 @@ import {
   type EntityProperty,
   EnumType,
   type IndexColumnOptions,
+  type Transaction,
   Type,
   Utils,
 } from '@mikro-orm/core';
@@ -66,9 +67,17 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
     );
   }
 
-  override async loadViews(schema: DatabaseSchema, connection: AbstractSqlConnection): Promise<void> {
+  override async loadViews(
+    schema: DatabaseSchema,
+    connection: AbstractSqlConnection,
+    schemaName?: string,
+    ctx?: Transaction,
+  ): Promise<void> {
     const views = await connection.execute<{ view_name: string; schema_name: string; view_definition: string }[]>(
       this.getListViewsSQL(),
+      [],
+      'all',
+      ctx,
     );
 
     for (const view of views) {
@@ -93,6 +102,7 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
     schema: DatabaseSchema,
     connection: AbstractSqlConnection,
     schemaName?: string,
+    ctx?: Transaction,
   ): Promise<void> {
     const views = await connection.execute<
       {
@@ -101,14 +111,14 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
         view_definition: string;
         is_populated: boolean;
       }[]
-    >(this.getListMaterializedViewsSQL());
+    >(this.getListMaterializedViewsSQL(), [], 'all', ctx);
 
     if (views.length === 0) {
       return;
     }
 
     const tables = views.map(v => ({ table_name: v.view_name, schema_name: v.schema_name }) as Table);
-    const indexes = await this.getAllIndexes(connection, tables);
+    const indexes = await this.getAllIndexes(connection, tables, ctx);
 
     for (let i = 0; i < views.length; i++) {
       const definition = views[i].view_definition?.trim().replace(/;$/, '') ?? '';
@@ -148,12 +158,12 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
     return `refresh materialized view${concurrent} ${this.quote(this.getTableName(name, schema))}`;
   }
 
-  override async getNamespaces(connection: AbstractSqlConnection): Promise<string[]> {
+  override async getNamespaces(connection: AbstractSqlConnection, ctx?: Transaction): Promise<string[]> {
     const sql =
       `select schema_name from information_schema.schemata ` +
       `where ${this.getIgnoredNamespacesConditionSQL()} ` +
       `order by schema_name`;
-    const res = await connection.execute<{ schema_name: string }[]>(sql);
+    const res = await connection.execute<{ schema_name: string }[]>(sql, [], 'all', ctx);
 
     return res.map(row => row.schema_name);
   }
@@ -179,9 +189,10 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
     connection: AbstractSqlConnection,
     tables: Table[],
     schemas?: string[],
+    ctx?: Transaction,
   ): Promise<void> {
     schemas ??= tables.length === 0 ? [schema.name] : tables.map(t => t.schema_name!);
-    const nativeEnums = await this.getNativeEnumDefinitions(connection, schemas);
+    const nativeEnums = await this.getNativeEnumDefinitions(connection, schemas, ctx);
     schema.setNativeEnums(nativeEnums);
 
     if (tables.length === 0) {
@@ -190,10 +201,10 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
 
     const tablesBySchema = this.getTablesGroupedBySchemas(tables);
 
-    const columns = await this.getAllColumns(connection, tablesBySchema, nativeEnums);
-    const indexes = await this.getAllIndexes(connection, tables);
-    const checks = await this.getAllChecks(connection, tablesBySchema);
-    const fks = await this.getAllForeignKeys(connection, tablesBySchema);
+    const columns = await this.getAllColumns(connection, tablesBySchema, nativeEnums, ctx);
+    const indexes = await this.getAllIndexes(connection, tables, ctx);
+    const checks = await this.getAllChecks(connection, tablesBySchema, ctx);
+    const fks = await this.getAllForeignKeys(connection, tablesBySchema, ctx);
 
     for (const t of tables) {
       const key = this.getTableKey(t);
@@ -207,10 +218,14 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
     }
   }
 
-  async getAllIndexes(connection: AbstractSqlConnection, tables: Table[]): Promise<Dictionary<IndexDef[]>> {
+  async getAllIndexes(
+    connection: AbstractSqlConnection,
+    tables: Table[],
+    ctx?: Transaction,
+  ): Promise<Dictionary<IndexDef[]>> {
     const sql = this.getIndexesSQL(tables);
     const unquote = (str: string) => str.replace(/['"`]/g, '');
-    const allIndexes = await connection.execute<any[]>(sql);
+    const allIndexes = await connection.execute<any[]>(sql, [], 'all', ctx);
     const ret = {} as Dictionary;
 
     for (const index of allIndexes) {
@@ -364,6 +379,7 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
     connection: AbstractSqlConnection,
     tablesBySchemas: Map<string | undefined, Table[]>,
     nativeEnums?: Dictionary<{ name: string; schema?: string; items: string[] }>,
+    ctx?: Transaction,
   ): Promise<Dictionary<Column[]>> {
     const sql = `select table_schema as schema_name, table_name, column_name,
       column_default,
@@ -385,7 +401,7 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
       where (${[...tablesBySchemas.entries()].map(([schema, tables]) => `(table_schema = ${this.platform.quoteValue(schema)} and table_name in (${tables.map(t => this.platform.quoteValue(t.table_name)).join(',')}))`).join(' or ')})
       order by ordinal_position`;
 
-    const allColumns = await connection.execute<any[]>(sql);
+    const allColumns = await connection.execute<any[]>(sql, [], 'all', ctx);
     const str = (val: string | number | undefined) => (val != null ? '' + val : val);
     const ret = {} as Dictionary;
 
@@ -489,12 +505,12 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
   async getAllChecks(
     connection: AbstractSqlConnection,
     tablesBySchemas: Map<string | undefined, Table[]>,
+    ctx?: Transaction,
   ): Promise<Dictionary<CheckDef[]>> {
     const sql = this.getChecksSQL(tablesBySchemas);
-    const allChecks =
-      await connection.execute<
-        { name: string; column_name: string; schema_name: string; table_name: string; expression: string }[]
-      >(sql);
+    const allChecks = await connection.execute<
+      { name: string; column_name: string; schema_name: string; table_name: string; expression: string }[]
+    >(sql, [], 'all', ctx);
     const ret = {} as Dictionary;
     const seen = new Set<string>();
 
@@ -524,6 +540,7 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
   async getAllForeignKeys(
     connection: AbstractSqlConnection,
     tablesBySchemas: Map<string | undefined, Table[]>,
+    ctx?: Transaction,
   ): Promise<Dictionary<Dictionary<ForeignKey>>> {
     const sql = `select nsp1.nspname schema_name, cls1.relname table_name, nsp2.nspname referenced_schema_name,
       cls2.relname referenced_table_name, a.attname column_name, af.attname referenced_column_name, conname constraint_name,
@@ -540,7 +557,7 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
       and confrelid > 0
       order by nsp1.nspname, cls1.relname, constraint_name, ord`;
 
-    const allFks = await connection.execute<any[]>(sql);
+    const allFks = await connection.execute<any[]>(sql, [], 'all', ctx);
     const ret = {} as Dictionary;
 
     function mapReferentialIntegrity(value: string, def: string) {
@@ -590,6 +607,7 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
   async getNativeEnumDefinitions(
     connection: AbstractSqlConnection,
     schemas: string[],
+    ctx?: Transaction,
   ): Promise<Dictionary<{ name: string; schema?: string; items: string[] }>> {
     const uniqueSchemas = Utils.unique(schemas);
     const res = await connection.execute(
@@ -600,6 +618,8 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
         where n.nspname in (${Array(uniqueSchemas.length).fill('?').join(', ')})
         group by t.typname, n.nspname`,
       uniqueSchemas,
+      'all',
+      ctx,
     );
 
     return res.reduce((o, row) => {

--- a/packages/sql/src/dialects/sqlite/SqliteSchemaHelper.ts
+++ b/packages/sql/src/dialects/sqlite/SqliteSchemaHelper.ts
@@ -1,4 +1,4 @@
-import { type Connection, type Dictionary, Utils } from '@mikro-orm/core';
+import { type Connection, type Dictionary, type Transaction, Utils } from '@mikro-orm/core';
 import type { AbstractSqlConnection } from '../../AbstractSqlConnection.js';
 import { SchemaHelper } from '../../schema/SchemaHelper.js';
 import type { CheckDef, Column, IndexDef, Table, TableDifference } from '../../typings.js';
@@ -48,13 +48,17 @@ export class SqliteSchemaHelper extends SchemaHelper {
     );
   }
 
-  override async getAllTables(connection: AbstractSqlConnection, schemas?: string[]): Promise<Table[]> {
-    const databases = await this.getDatabaseList(connection);
+  override async getAllTables(
+    connection: AbstractSqlConnection,
+    schemas?: string[],
+    ctx?: Transaction,
+  ): Promise<Table[]> {
+    const databases = await this.getDatabaseList(connection, ctx);
     const hasAttachedDbs = databases.length > 1; // More than just 'main'
 
     // If no attached databases, use original behavior
     if (!hasAttachedDbs && !schemas?.length) {
-      return connection.execute<Table[]>(this.getListTablesSQL());
+      return connection.execute<Table[]>(this.getListTablesSQL(), [], 'all', ctx);
     }
 
     // With attached databases, query each one
@@ -66,6 +70,9 @@ export class SqliteSchemaHelper extends SchemaHelper {
       const tables = await connection.execute<{ name: string }[]>(
         `select name from ${prefix}sqlite_master where type = 'table' ` +
           `and name != 'sqlite_sequence' and name != 'geometry_columns' and name != 'spatial_ref_sys'`,
+        [],
+        'all',
+        ctx,
       );
       for (const t of tables) {
         allTables.push({ table_name: t.name, schema_name: dbName });
@@ -74,8 +81,8 @@ export class SqliteSchemaHelper extends SchemaHelper {
     return allTables;
   }
 
-  override async getNamespaces(connection: AbstractSqlConnection): Promise<string[]> {
-    return this.getDatabaseList(connection);
+  override async getNamespaces(connection: AbstractSqlConnection, ctx?: Transaction): Promise<string[]> {
+    return this.getDatabaseList(connection, ctx);
   }
 
   private getIgnoredViewsCondition(): string {
@@ -90,13 +97,19 @@ export class SqliteSchemaHelper extends SchemaHelper {
     schema: DatabaseSchema,
     connection: AbstractSqlConnection,
     schemaName?: string,
+    ctx?: Transaction,
   ): Promise<void> {
-    const databases = await this.getDatabaseList(connection);
+    const databases = await this.getDatabaseList(connection, ctx);
     const hasAttachedDbs = databases.length > 1; // More than just 'main'
 
     // If no attached databases and no specific schema, use original behavior
     if (!hasAttachedDbs && !schemaName) {
-      const views = await connection.execute<{ view_name: string; view_definition: string }[]>(this.getListViewsSQL());
+      const views = await connection.execute<{ view_name: string; view_definition: string }[]>(
+        this.getListViewsSQL(),
+        [],
+        'all',
+        ctx,
+      );
       for (const view of views) {
         schema.addView(view.view_name, schemaName, this.extractViewDefinition(view.view_definition));
       }
@@ -110,6 +123,9 @@ export class SqliteSchemaHelper extends SchemaHelper {
       const prefix = this.getSchemaPrefix(dbName);
       const views = await connection.execute<{ view_name: string; view_definition: string }[]>(
         `select name as view_name, sql as view_definition from ${prefix}sqlite_master where type = 'view' and ${this.getIgnoredViewsCondition()} order by name`,
+        [],
+        'all',
+        ctx,
       );
       for (const view of views) {
         schema.addView(view.view_name, dbName, this.extractViewDefinition(view.view_definition));
@@ -131,15 +147,16 @@ export class SqliteSchemaHelper extends SchemaHelper {
     connection: AbstractSqlConnection,
     tables: Table[],
     schemas?: string[],
+    ctx?: Transaction,
   ): Promise<void> {
     for (const t of tables) {
       const table = schema.addTable(t.table_name, t.schema_name, t.table_comment);
-      const cols = await this.getColumns(connection, table.name, table.schema);
-      const indexes = await this.getIndexes(connection, table.name, table.schema);
-      const checks = await this.getChecks(connection, table.name, table.schema);
-      const pks = await this.getPrimaryKeys(connection, indexes, table.name, table.schema);
-      const fks = await this.getForeignKeys(connection, table.name, table.schema);
-      const enums = await this.getEnumDefinitions(connection, table.name, table.schema);
+      const cols = await this.getColumns(connection, table.name, table.schema, ctx);
+      const indexes = await this.getIndexes(connection, table.name, table.schema, ctx);
+      const checks = await this.getChecks(connection, table.name, table.schema, ctx);
+      const pks = await this.getPrimaryKeys(connection, indexes, table.name, table.schema, ctx);
+      const fks = await this.getForeignKeys(connection, table.name, table.schema, ctx);
+      const enums = await this.getEnumDefinitions(connection, table.name, table.schema, ctx);
       table.init(cols, indexes, checks, pks, fks, enums);
     }
   }
@@ -342,8 +359,8 @@ export class SqliteSchemaHelper extends SchemaHelper {
   /**
    * Returns all database names excluding 'temp'.
    */
-  private async getDatabaseList(connection: AbstractSqlConnection): Promise<string[]> {
-    const databases = await connection.execute<{ name: string }[]>('pragma database_list');
+  private async getDatabaseList(connection: AbstractSqlConnection, ctx?: Transaction): Promise<string[]> {
+    const databases = await connection.execute<{ name: string }[]>('pragma database_list', [], 'all', ctx);
     return databases.filter(d => d.name !== 'temp').map(d => d.name);
   }
 
@@ -356,11 +373,16 @@ export class SqliteSchemaHelper extends SchemaHelper {
     return match ? match[1] : viewDefinition;
   }
 
-  private async getColumns(connection: AbstractSqlConnection, tableName: string, schemaName?: string): Promise<any[]> {
+  private async getColumns(
+    connection: AbstractSqlConnection,
+    tableName: string,
+    schemaName?: string,
+    ctx?: Transaction,
+  ): Promise<any[]> {
     const prefix = this.getSchemaPrefix(schemaName);
-    const columns = await connection.execute<any[]>(`pragma ${prefix}table_xinfo('${tableName}')`);
+    const columns = await connection.execute<any[]>(`pragma ${prefix}table_xinfo('${tableName}')`, [], 'all', ctx);
     const sql = `select sql from ${prefix}sqlite_master where type = ? and name = ?`;
-    const tableDefinition = await connection.execute<{ sql: string }>(sql, ['table', tableName], 'get');
+    const tableDefinition = await connection.execute<{ sql: string }>(sql, ['table', tableName], 'get', ctx);
     const composite = columns.reduce((count, col) => count + (col.pk ? 1 : 0), 0) > 1;
     // there can be only one, so naive check like this should be enough
     const hasAutoincrement = tableDefinition.sql.toLowerCase().includes('autoincrement');
@@ -429,10 +451,11 @@ export class SqliteSchemaHelper extends SchemaHelper {
     connection: AbstractSqlConnection,
     tableName: string,
     schemaName?: string,
+    ctx?: Transaction,
   ): Promise<Dictionary<string[]>> {
     const prefix = this.getSchemaPrefix(schemaName);
     const sql = `select sql from ${prefix}sqlite_master where type = ? and name = ?`;
-    const tableDefinition = await connection.execute<{ sql: string }>(sql, ['table', tableName], 'get');
+    const tableDefinition = await connection.execute<{ sql: string }>(sql, ['table', tableName], 'get', ctx);
 
     const checkConstraints = [...(tableDefinition.sql.match(/[`["'][^`\]"']+[`\]"'] text check \(.*?\)/gi) ?? [])];
     return checkConstraints.reduce(
@@ -459,10 +482,11 @@ export class SqliteSchemaHelper extends SchemaHelper {
     indexes: IndexDef[],
     tableName: string,
     schemaName?: string,
+    ctx?: Transaction,
   ): Promise<string[]> {
     const prefix = this.getSchemaPrefix(schemaName);
     const sql = `pragma ${prefix}table_info(\`${tableName}\`)`;
-    const cols = await connection.execute<{ pk: number; name: string }[]>(sql);
+    const cols = await connection.execute<{ pk: number; name: string }[]>(sql, [], 'all', ctx);
 
     return cols.filter(col => !!col.pk).map(col => col.name);
   }
@@ -471,11 +495,12 @@ export class SqliteSchemaHelper extends SchemaHelper {
     connection: AbstractSqlConnection,
     tableName: string,
     schemaName?: string,
+    ctx?: Transaction,
   ): Promise<IndexDef[]> {
     const prefix = this.getSchemaPrefix(schemaName);
     const sql = `pragma ${prefix}table_info(\`${tableName}\`)`;
-    const cols = await connection.execute<{ pk: number; name: string }[]>(sql);
-    const indexes = await connection.execute<any[]>(`pragma ${prefix}index_list(\`${tableName}\`)`);
+    const cols = await connection.execute<{ pk: number; name: string }[]>(sql, [], 'all', ctx);
+    const indexes = await connection.execute<any[]>(`pragma ${prefix}index_list(\`${tableName}\`)`, [], 'all', ctx);
     const ret: IndexDef[] = [];
 
     for (const col of cols.filter(c => c.pk)) {
@@ -489,7 +514,12 @@ export class SqliteSchemaHelper extends SchemaHelper {
     }
 
     for (const index of indexes.filter(index => !this.isImplicitIndex(index.name))) {
-      const res = await connection.execute<{ name: string }[]>(`pragma ${prefix}index_info(\`${index.name}\`)`);
+      const res = await connection.execute<{ name: string }[]>(
+        `pragma ${prefix}index_info(\`${index.name}\`)`,
+        [],
+        'all',
+        ctx,
+      );
       ret.push(
         ...res.map(row => ({
           columnNames: [row.name],
@@ -508,8 +538,9 @@ export class SqliteSchemaHelper extends SchemaHelper {
     connection: AbstractSqlConnection,
     tableName: string,
     schemaName?: string,
+    ctx?: Transaction,
   ): Promise<CheckDef[]> {
-    const { columns, constraints } = await this.getColumnDefinitions(connection, tableName, schemaName);
+    const { columns, constraints } = await this.getColumnDefinitions(connection, tableName, schemaName, ctx);
     const checks: CheckDef[] = [];
 
     for (const key of Object.keys(columns)) {
@@ -545,11 +576,12 @@ export class SqliteSchemaHelper extends SchemaHelper {
     connection: AbstractSqlConnection,
     tableName: string,
     schemaName?: string,
+    ctx?: Transaction,
   ): Promise<{ columns: Dictionary<{ name: string; definition: string }>; constraints: string[] }> {
     const prefix = this.getSchemaPrefix(schemaName);
-    const columns = await connection.execute<any[]>(`pragma ${prefix}table_xinfo('${tableName}')`);
+    const columns = await connection.execute<any[]>(`pragma ${prefix}table_xinfo('${tableName}')`, [], 'all', ctx);
     const sql = `select sql from ${prefix}sqlite_master where type = ? and name = ?`;
-    const tableDefinition = await connection.execute<{ sql: string }>(sql, ['table', tableName], 'get');
+    const tableDefinition = await connection.execute<{ sql: string }>(sql, ['table', tableName], 'get', ctx);
 
     return this.parseTableDefinition(tableDefinition.sql, columns);
   }
@@ -558,10 +590,11 @@ export class SqliteSchemaHelper extends SchemaHelper {
     connection: AbstractSqlConnection,
     tableName: string,
     schemaName?: string,
+    ctx?: Transaction,
   ): Promise<Dictionary> {
-    const { constraints } = await this.getColumnDefinitions(connection, tableName, schemaName);
+    const { constraints } = await this.getColumnDefinitions(connection, tableName, schemaName, ctx);
     const prefix = this.getSchemaPrefix(schemaName);
-    const fks = await connection.execute<any[]>(`pragma ${prefix}foreign_key_list(\`${tableName}\`)`);
+    const fks = await connection.execute<any[]>(`pragma ${prefix}foreign_key_list(\`${tableName}\`)`, [], 'all', ctx);
     const qualifiedTableName = schemaName ? `${schemaName}.${tableName}` : tableName;
 
     return fks.reduce((ret, fk: any) => {

--- a/packages/sql/src/schema/DatabaseSchema.ts
+++ b/packages/sql/src/schema/DatabaseSchema.ts
@@ -4,6 +4,7 @@ import {
   type Dictionary,
   type EntityMetadata,
   type EntityProperty,
+  type Transaction,
   isRaw,
 } from '@mikro-orm/core';
 import { DatabaseTable } from './DatabaseTable.js';
@@ -138,9 +139,10 @@ export class DatabaseSchema {
     takeTables?: (string | RegExp)[],
     skipTables?: (string | RegExp)[],
     skipViews?: (string | RegExp)[],
+    ctx?: Transaction,
   ): Promise<DatabaseSchema> {
     const schema = new DatabaseSchema(platform, schemaName ?? config.get('schema') ?? platform.getDefaultSchemaName());
-    const allTables = await platform.getSchemaHelper()!.getAllTables(connection, schemas);
+    const allTables = await platform.getSchemaHelper()!.getAllTables(connection, schemas, ctx);
     const parts = config.get('migrations').tableName!.split('.');
     const migrationsTableName = parts[1] ?? parts[0];
     const migrationsSchemaName = parts.length > 1 ? parts[0] : config.get('schema', platform.getDefaultSchemaName());
@@ -151,14 +153,14 @@ export class DatabaseSchema {
     );
     await platform
       .getSchemaHelper()!
-      .loadInformationSchema(schema, connection, tables, schemas && schemas.length > 0 ? schemas : undefined);
+      .loadInformationSchema(schema, connection, tables, schemas && schemas.length > 0 ? schemas : undefined, ctx);
 
     // Load views from database
-    await platform.getSchemaHelper()!.loadViews(schema, connection);
+    await platform.getSchemaHelper()!.loadViews(schema, connection, schemaName, ctx);
 
     // Load materialized views (PostgreSQL only)
     if (platform.supportsMaterializedViews()) {
-      await platform.getSchemaHelper()!.loadMaterializedViews(schema, connection, schemaName);
+      await platform.getSchemaHelper()!.loadMaterializedViews(schema, connection, schemaName, ctx);
     }
 
     // Filter out skipped views

--- a/packages/sql/src/schema/SchemaHelper.ts
+++ b/packages/sql/src/schema/SchemaHelper.ts
@@ -1,4 +1,11 @@
-import { type Connection, type Dictionary, type Options, RawQueryFragment, Utils } from '@mikro-orm/core';
+import {
+  type Connection,
+  type Dictionary,
+  type Options,
+  type Transaction,
+  RawQueryFragment,
+  Utils,
+} from '@mikro-orm/core';
 import type { AbstractSqlConnection } from '../AbstractSqlConnection.js';
 import type { AbstractSqlPlatform } from '../AbstractSqlPlatform.js';
 import type { CheckDef, Column, ForeignKey, IndexDef, Table, TableDifference } from '../typings.js';
@@ -101,6 +108,7 @@ export abstract class SchemaHelper {
     connection: AbstractSqlConnection,
     tables: Table[],
     schemas?: string[],
+    ctx?: Transaction,
   ): Promise<void>;
 
   /** Returns the SQL query to list all tables in the database. */
@@ -109,15 +117,20 @@ export abstract class SchemaHelper {
   }
 
   /** Retrieves all tables from the database. */
-  async getAllTables(connection: AbstractSqlConnection, schemas?: string[]): Promise<Table[]> {
-    return connection.execute<Table[]>(this.getListTablesSQL());
+  async getAllTables(connection: AbstractSqlConnection, schemas?: string[], ctx?: Transaction): Promise<Table[]> {
+    return connection.execute<Table[]>(this.getListTablesSQL(), [], 'all', ctx);
   }
 
   getListViewsSQL(): string {
     throw new Error('Not supported by given driver');
   }
 
-  async loadViews(schema: DatabaseSchema, connection: AbstractSqlConnection, schemaName?: string): Promise<void> {
+  async loadViews(
+    schema: DatabaseSchema,
+    connection: AbstractSqlConnection,
+    schemaName?: string,
+    ctx?: Transaction,
+  ): Promise<void> {
     throw new Error('Not supported by given driver');
   }
 
@@ -494,7 +507,7 @@ export abstract class SchemaHelper {
     return '';
   }
 
-  async getNamespaces(connection: AbstractSqlConnection): Promise<string[]> {
+  async getNamespaces(connection: AbstractSqlConnection, ctx?: Transaction): Promise<string[]> {
     return [];
   }
 
@@ -891,6 +904,7 @@ export abstract class SchemaHelper {
     schema: DatabaseSchema,
     connection: AbstractSqlConnection,
     schemaName?: string,
+    ctx?: Transaction,
   ): Promise<void> {
     throw new Error('Not supported by given driver');
   }

--- a/tests/features/migrations/Migrator.postgres.test.ts
+++ b/tests/features/migrations/Migrator.postgres.test.ts
@@ -228,6 +228,42 @@ describe('Migrator (postgres)', () => {
     }
   });
 
+  test('migrator.up with external transaction and snapshot: true does not deadlock (GH #7424)', async () => {
+    const migrations = orm.config.get('migrations');
+    migrations.snapshot = true;
+    const path = process.cwd() + '/temp/migrations-456';
+    const snapshotPath = path + '/.snapshot-mikro_orm_test_migrations.json';
+    await rm(snapshotPath, { force: true });
+
+    const dateMock = vi.spyOn(Date.prototype, 'toISOString');
+    dateMock.mockReturnValue('2019-10-13T21:48:13.382Z');
+    const migration1 = await orm.migrator.create(path, true);
+
+    // mock executeMigrations so no real DDL runs, but runMigrations still
+    // triggers DatabaseSchema.create() for the snapshot update
+    const executeMock = vi.spyOn(Migrator.prototype as any, 'executeMigrations');
+    executeMock.mockResolvedValueOnce([{ name: migration1.fileName }]);
+
+    try {
+      // run migrator.up inside an external transaction — this previously
+      // deadlocked because DatabaseSchema.create() tried to acquire a
+      // separate pool connection while the transaction held locks
+      await orm.em.transactional(async em => {
+        const ret = await orm.migrator.up({ transaction: em.getTransactionContext() });
+        expect(ret).toHaveLength(1);
+      });
+
+      // snapshot should have been written successfully
+      const { existsSync } = await import('node:fs');
+      expect(existsSync(snapshotPath)).toBe(true);
+    } finally {
+      await rm(path + '/' + migration1.fileName, { force: true });
+      await rm(snapshotPath, { force: true });
+      executeMock.mockRestore();
+      migrations.snapshot = false;
+    }
+  });
+
   test('generate initial migration', async () => {
     await orm.schema.dropTableIfExists(orm.config.get('migrations').tableName!, 'custom');
     const getExecutedMigrationsMock = vi.spyOn(Migrator.prototype, 'getExecuted');


### PR DESCRIPTION
## Summary

- `migrator.up({ transaction })` with `snapshot: true` deadlocked on PostgreSQL because `DatabaseSchema.create()` tried to acquire a separate pool connection for schema introspection while the external transaction held DDL locks
- Thread `ctx?: Transaction` through `DatabaseSchema.create()` and all schema helper methods (`getAllTables`, `loadInformationSchema`, `loadViews`, `loadMaterializedViews`, `getNamespaces`, and their sub-methods) across all drivers so introspection queries run on the same transaction connection

Closes #7424

🤖 Generated with [Claude Code](https://claude.com/claude-code)