### PR TITLE
fix(sql): resolve alias placeholder in raw fragments used as operator values

### DIFF
--- a/packages/sql/src/query/QueryBuilderHelper.ts
+++ b/packages/sql/src/query/QueryBuilderHelper.ts
@@ -828,7 +828,7 @@ export class QueryBuilderHelper {
       const query = value[op] instanceof Raw ? value[op] : value[op].toRaw();
       const mappedKey = this.mapper(key, type, query, null);
 
-      let sql = query.sql;
+      let sql = query.sql.replaceAll(ALIAS_REPLACEMENT, this.#alias);
 
       if (['$in', '$nin'].includes(op)) {
         sql = `(${sql})`;

--- a/tests/features/raw-queries/GHx6.test.ts
+++ b/tests/features/raw-queries/GHx6.test.ts
@@ -112,6 +112,48 @@ test('raw fragments with populateOrderBy on relation', async () => {
   );
 });
 
+test('raw fragments with alias callback as value in $nin (GH #7422)', async () => {
+  const mock = mockLogger(orm);
+  await orm.em.findAll(Job, {
+    where: {
+      id: {
+        $nin: raw(alias => `SELECT 1 FROM job j2 WHERE j2.id = ${alias}.id`),
+      },
+    },
+  });
+  expect(mock.mock.calls[0][0]).toMatch(
+    'select `j0`.* from `job` as `j0` where `j0`.`id` not in (SELECT 1 FROM job j2 WHERE j2.id = j0.id)',
+  );
+});
+
+test('raw fragments with alias callback as value in $in', async () => {
+  const mock = mockLogger(orm);
+  await orm.em.findAll(Job, {
+    where: {
+      id: {
+        $in: raw(alias => `SELECT j2.id FROM job j2 WHERE j2.id != ${alias}.id`),
+      },
+    },
+  });
+  expect(mock.mock.calls[0][0]).toMatch(
+    'select `j0`.* from `job` as `j0` where `j0`.`id` in (SELECT j2.id FROM job j2 WHERE j2.id != j0.id)',
+  );
+});
+
+test('raw fragments with alias callback as value in comparison operator', async () => {
+  const mock = mockLogger(orm);
+  await orm.em.findAll(Job, {
+    where: {
+      id: {
+        $gt: raw(alias => `(SELECT count(*) FROM job j2 WHERE j2.id < ${alias}.id)`),
+      },
+    },
+  });
+  expect(mock.mock.calls[0][0]).toMatch(
+    'select `j0`.* from `job` as `j0` where `j0`.`id` > (SELECT count(*) FROM job j2 WHERE j2.id < j0.id)',
+  );
+});
+
 test('raw fragments with multiple items in filter', async () => {
   const mock = mockLogger(orm);
   await orm.em.findAll(Tag, {


### PR DESCRIPTION
## Summary
- When using `raw()` with an alias callback as a **value** in operators like `$in`, `$nin`, or comparison operators (e.g., `$gt`), the `[::alias::]` placeholder was not replaced with the actual table alias, producing invalid SQL.
- The alias replacement was already done for raw fragments used as **keys** but was missing from the operator value code path in `QueryBuilderHelper`.

Closes #7422

🤖 Generated with [Claude Code](https://claude.com/claude-code)