### PR TITLE
docs: fix entityRepository config and clarify type inference

### DIFF
--- a/docs/docs/repositories.md
+++ b/docs/docs/repositories.md
@@ -200,7 +200,7 @@ const repo = em.getRepository(Author); // repo has type AuthorRepository
 </TabItem>
 </Tabs>
 
-> You can also register a custom base repository (for all entities where you do not specify `repository`) globally, via `MikroORM.init({ entityRepository: () => CustomBaseRepository })`.
+> You can also register a custom base repository (for all entities where you do not specify `repository`) globally, via `MikroORM.init({ entityRepository: CustomBaseRepository })`.
 
 ## Generic Custom Repository
 
@@ -237,9 +237,11 @@ Register it globally so all entities use it by default:
 
 ```ts
 MikroORM.init({
-  entityRepository: () => BaseRepository,
+  entityRepository: BaseRepository,
 });
 ```
+
+> **Note:** The global `entityRepository` config option only affects **runtime behavior** — it controls which class gets instantiated, but TypeScript cannot infer the repository type from it. To get proper type inference from `em.getRepository()`, you need to specify the `repository` option on the entity definition, or use the `EntityRepositoryType` symbol on a base entity (see [below](#using-entityrepositorytype-with-a-base-entity)).
 
 ### Entity-specific repositories extending the generic base
 
@@ -363,6 +365,7 @@ values={[
 const BaseEntitySchema = defineEntity({
   name: 'BaseEntity',
   abstract: true,
+  repository: () => BaseRepository,
   properties: {
     id: p.integer().primary(),
   },
@@ -380,13 +383,14 @@ BaseEntitySchema.setClass(BaseEntity);
 export const BaseEntity = defineEntity({
   name: 'BaseEntity',
   abstract: true,
+  repository: () => BaseRepository,
   properties: {
     id: p.integer().primary(),
   },
 });
 ```
 
-With `defineEntity`, when you set `repository` globally via the ORM config, the repository type is resolved automatically for all entities — no `EntityRepositoryType` symbol needed.
+With `defineEntity`, the `repository` option provides both the runtime binding and the type inference — no `EntityRepositoryType` symbol needed. All entities extending this base will inherit the repository type.
 
 </TabItem>
 <TabItem value="reflect-metadata">
@@ -475,7 +479,7 @@ And specify it in the ORM config:
 
 ```ts
 MikroORM.init({
-  entityRepository: () => ExtendedEntityRepository,
+  entityRepository: ExtendedEntityRepository,
 });
 ```
 

--- a/docs/versioned_docs/version-7.0/repositories.md
+++ b/docs/versioned_docs/version-7.0/repositories.md
@@ -200,7 +200,7 @@ const repo = em.getRepository(Author); // repo has type AuthorRepository
 </TabItem>
 </Tabs>
 
-> You can also register a custom base repository (for all entities where you do not specify `repository`) globally, via `MikroORM.init({ entityRepository: () => CustomBaseRepository })`.
+> You can also register a custom base repository (for all entities where you do not specify `repository`) globally, via `MikroORM.init({ entityRepository: CustomBaseRepository })`.
 
 ## Generic Custom Repository
 
@@ -237,9 +237,11 @@ Register it globally so all entities use it by default:
 
 ```ts
 MikroORM.init({
-  entityRepository: () => BaseRepository,
+  entityRepository: BaseRepository,
 });
 ```
+
+> **Note:** The global `entityRepository` config option only affects **runtime behavior** — it controls which class gets instantiated, but TypeScript cannot infer the repository type from it. To get proper type inference from `em.getRepository()`, you need to specify the `repository` option on the entity definition, or use the `EntityRepositoryType` symbol on a base entity (see [below](#using-entityrepositorytype-with-a-base-entity)).
 
 ### Entity-specific repositories extending the generic base
 
@@ -363,6 +365,7 @@ values={[
 const BaseEntitySchema = defineEntity({
   name: 'BaseEntity',
   abstract: true,
+  repository: () => BaseRepository,
   properties: {
     id: p.integer().primary(),
   },
@@ -380,13 +383,14 @@ BaseEntitySchema.setClass(BaseEntity);
 export const BaseEntity = defineEntity({
   name: 'BaseEntity',
   abstract: true,
+  repository: () => BaseRepository,
   properties: {
     id: p.integer().primary(),
   },
 });
 ```
 
-With `defineEntity`, when you set `repository` globally via the ORM config, the repository type is resolved automatically for all entities — no `EntityRepositoryType` symbol needed.
+With `defineEntity`, the `repository` option provides both the runtime binding and the type inference — no `EntityRepositoryType` symbol needed. All entities extending this base will inherit the repository type.
 
 </TabItem>
 <TabItem value="reflect-metadata">
@@ -475,7 +479,7 @@ And specify it in the ORM config:
 
 ```ts
 MikroORM.init({
-  entityRepository: () => ExtendedEntityRepository,
+  entityRepository: ExtendedEntityRepository,
 });
 ```
 


### PR DESCRIPTION
## Summary
- Fix `entityRepository` config examples — it takes a class reference, not a callback (`() => BaseRepository` causes "RepositoryClass is not a constructor" at runtime)
- Add a note clarifying the global `entityRepository` config only affects runtime; for type inference from `em.getRepository()`, `repository` must be specified on the entity definition or via `EntityRepositoryType` on a base entity
- Add `repository: () => BaseRepository` to the `defineEntity` base entity examples so types actually flow through
- Fix misleading text that claimed global config provides automatic type resolution

Closes https://github.com/mikro-orm/mikro-orm/discussions/7392
Ref https://github.com/mikro-orm/mikro-orm/discussions/5223

🤖 Generated with [Claude Code](https://claude.ai/claude-code)