### PR TITLE
fix(core): skip required validation for embeddables with only formula properties

### DIFF
--- a/packages/core/src/entity/defineEntity.ts
+++ b/packages/core/src/entity/defineEntity.ts
@@ -1558,6 +1558,12 @@ type MaybeScalarRef<Value, Options> = Options extends { kind: '1:1' | 'm:1' | '1
     ? ScalarReference<Value>
     : Value;
 
+type IsAllPropsOpt<T> = [Exclude<keyof T, symbol>] extends [never]
+  ? false
+  : { [K in Exclude<keyof T, symbol>]-?: T[K] extends Opt ? never : K }[Exclude<keyof T, symbol>] extends never
+    ? true
+    : false;
+
 type MaybeOpt<Value, Options> = Options extends { mapToPk: true }
   ? Value extends Opt<infer OriginalValue>
     ? OriginalValue
@@ -1571,7 +1577,11 @@ type MaybeOpt<Value, Options> = Options extends { mapToPk: true }
         | { version: true }
         | { formula: string | ((...args: any[]) => any) }
     ? Opt<NonNullable<Value>> | Extract<Value, null | undefined>
-    : Value;
+    : Options extends { kind: 'embedded' }
+      ? IsAllPropsOpt<Value> extends true
+        ? Opt<NonNullable<Value>> | Extract<Value, null | undefined>
+        : Value
+      : Value;
 
 type MaybeHidden<Value, Options> = Options extends { hidden: true }
   ? Hidden<NonNullable<Value>> | Extract<Value, null | undefined>

--- a/packages/core/src/unit-of-work/ChangeSetPersister.ts
+++ b/packages/core/src/unit-of-work/ChangeSetPersister.ts
@@ -162,6 +162,10 @@ export class ChangeSetPersister {
         !prop.generated &&
         !prop.embedded &&
         ![ReferenceKind.ONE_TO_MANY, ReferenceKind.MANY_TO_MANY].includes(prop.kind) &&
+        !(
+          prop.kind === ReferenceKind.EMBEDDED &&
+          prop.targetMeta?.props.every(p => p.formula || p.persist === false || p.primary)
+        ) &&
         prop.name !== wrapped.__meta.root.discriminatorColumn &&
         prop.type !== 'ObjectId' &&
         prop.persist !== false &&

--- a/tests/issues/GHx34.test.ts
+++ b/tests/issues/GHx34.test.ts
@@ -1,0 +1,98 @@
+import { defineEntity, MikroORM, p } from '@mikro-orm/sqlite';
+
+const ClientProductMarginSchema = defineEntity({
+  embeddable: true,
+  name: 'ClientProductMargin',
+  properties: {
+    singles: p
+      .decimal('number')
+      .formula(
+        cols => `
+                    CASE
+                        WHEN ${cols}.price_net = 0 THEN 0
+                        ELSE (
+                            (
+                                ${cols}.price_net - ${cols}.cost_price_singles
+                            ) * 1.0 / ${cols}.price_net
+                        ) * 100
+                    END
+                `,
+      )
+      .precision(10)
+      .scale(3),
+    packs: p
+      .decimal('number')
+      .formula(
+        cols => `
+                    CASE
+                        WHEN ${cols}.price_net = 0 THEN 0
+                        ELSE (
+                            (
+                                ${cols}.price_net - ${cols}.cost_price_packs
+                            ) * 1.0 / ${cols}.price_net
+                        ) * 100
+                    END
+                `,
+      )
+      .precision(10)
+      .scale(3),
+  },
+});
+
+export class ClientProductMargin extends ClientProductMarginSchema.class {}
+ClientProductMarginSchema.setClass(ClientProductMargin);
+
+const ClientProductSchema = defineEntity({
+  name: 'ClientProduct',
+  tableName: 'ClientProducts',
+  properties: {
+    id: p.integer().primary(),
+    name: p.string().length(80).unique(),
+    price_net: p.decimal('number').precision(10).scale(2),
+    cost_price_singles: p.decimal('number').precision(10).scale(2),
+    cost_price_packs: p.decimal('number').precision(10).scale(2),
+    margin: () => p.embedded(ClientProductMargin),
+  },
+});
+
+export class ClientProduct extends ClientProductSchema.class {}
+ClientProductSchema.setClass(ClientProduct);
+
+describe('GHx34', () => {
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      dbName: ':memory:',
+      entities: [ClientProduct],
+      serialization: { forceObject: true },
+    });
+    await orm.schema.refresh();
+  });
+
+  afterAll(() => orm.close(true));
+
+  it('should not need formula on create', async () => {
+    const cpNew = orm.em.create(ClientProduct, {
+      name: 'Test Product',
+      price_net: 10,
+      cost_price_packs: 7,
+      cost_price_singles: 14,
+    });
+
+    await orm.em.flush();
+    orm.em.clear();
+
+    expect(cpNew.id).toBeDefined();
+
+    const loaded = await orm.em.findOneOrFail(ClientProduct, cpNew.id);
+    expect(loaded).toMatchObject({
+      name: 'Test Product',
+      price_net: 10,
+      cost_price_packs: 7,
+      cost_price_singles: 14,
+    });
+    expect(loaded.margin.singles).toBeCloseTo(-40);
+    expect(loaded.margin.packs).toBeCloseTo(30);
+  });
+});


### PR DESCRIPTION
## Summary

- Embeddables with only formula (computed) properties no longer require the embedded object in `em.create()`
- Runtime: `validateRequired` skips embedded properties when all target meta props are formula, non-persisted, or primary
- Type-level: new `IsAllPropsOpt<T>` helper in `MaybeOpt` makes the embedded `Opt` when all sub-properties are `Opt`-branded

🤖 Generated with [Claude Code](https://claude.ai/claude-code)