### PR TITLE
fix(core): skip phantom delete changesets with null PKs in orphan removal

### DIFF
--- a/packages/core/src/unit-of-work/ChangeSetPersister.ts
+++ b/packages/core/src/unit-of-work/ChangeSetPersister.ts
@@ -123,7 +123,12 @@ export class ChangeSetPersister {
 
     for (let i = 0; i < changeSets.length; i += size) {
       const chunk = changeSets.slice(i, i + size);
-      const pks = chunk.map(cs => cs.getPrimaryKey());
+      const pks = chunk.map(cs => cs.getPrimaryKey()).filter(v => v != null);
+
+      if (pks.length === 0) {
+        continue;
+      }
+
       options = this.prepareOptions(meta, options);
       await this.#driver.nativeDelete(meta.root.class, { [pk]: { $in: pks } } as FilterQuery<T>, options);
     }

--- a/packages/core/src/unit-of-work/UnitOfWork.ts
+++ b/packages/core/src/unit-of-work/UnitOfWork.ts
@@ -660,7 +660,7 @@ export class UnitOfWork {
     }
 
     for (const entity of this.#orphanRemoveStack) {
-      if (!helper(entity).__processing) {
+      if (!helper(entity).__processing && helper(entity).hasPrimaryKey()) {
         this.#removeStack.add(entity);
       }
     }

--- a/tests/issues/GH7435.test.ts
+++ b/tests/issues/GH7435.test.ts
@@ -1,0 +1,117 @@
+import { MikroORM, PrimaryKeyProp, Ref, ref } from '@mikro-orm/sqlite';
+import {
+  Entity,
+  ManyToOne,
+  OneToOne,
+  PrimaryKey,
+  Property,
+  ReflectMetadataProvider,
+} from '@mikro-orm/decorators/legacy';
+
+@Entity()
+class Organization {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+}
+
+@Entity()
+class Risk {
+  [PrimaryKeyProp]?: ['id', 'organization'];
+
+  @PrimaryKey()
+  id!: number;
+
+  @ManyToOne({ entity: () => Organization, ref: true, primary: true })
+  organization!: Ref<Organization>;
+
+  @Property()
+  name!: string;
+
+  @OneToOne({ entity: () => RiskAuditSync, mappedBy: 'risk', nullable: true, orphanRemoval: true })
+  syncedAudit!: Ref<RiskAuditSync> | null;
+}
+
+@Entity()
+class RiskAuditSync {
+  [PrimaryKeyProp]?: ['risk', 'organization', 'auditId'];
+
+  @OneToOne({
+    entity: () => Risk,
+    inversedBy: 'syncedAudit',
+    joinColumns: ['risk_id', 'organization_id'],
+    primary: true,
+  })
+  risk!: Ref<Risk> | null;
+
+  @ManyToOne({ entity: () => Organization, ref: true, primary: true })
+  organization!: Ref<Organization>;
+
+  @Property({ primary: true })
+  auditId!: string;
+}
+
+describe('GH7435', () => {
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      entities: [Organization, Risk, RiskAuditSync],
+      dbName: ':memory:',
+    });
+    await orm.schema.create();
+  });
+
+  afterAll(() => orm.close(true));
+  beforeEach(() => orm.schema.clear());
+
+  test('executeDeletes should not crash when orphan-removed entity has composite FK in PK', async () => {
+    const em = orm.em.fork();
+
+    const org = em.create(Organization, { id: 1, name: 'Org' });
+    const risk = em.create(Risk, { id: 1, organization: org, name: 'Risk1' });
+    em.create(RiskAuditSync, { risk: ref(risk), organization: org, auditId: 'audit-1' });
+    await em.flush();
+    em.clear();
+
+    // Load and remove the synced audit via orphanRemoval
+    const loaded = await em.findOneOrFail(Risk, { id: 1 }, { populate: ['syncedAudit'] });
+    expect(loaded.syncedAudit).toBeTruthy();
+
+    em.assign(loaded, { syncedAudit: null });
+    await em.flush();
+    em.clear();
+
+    const reloaded = await em.findOneOrFail(Risk, { id: 1 }, { populate: ['syncedAudit'] });
+    expect(reloaded.syncedAudit).toBeNull();
+    expect(await em.count(RiskAuditSync, {})).toBe(0);
+  });
+
+  test('multiple risks with orphanRemoval should not cause phantom deletes', async () => {
+    const em = orm.em.fork();
+
+    const org = em.create(Organization, { id: 2, name: 'Org2' });
+    const risk1 = em.create(Risk, { id: 2, organization: org, name: 'Risk2' });
+    const risk2 = em.create(Risk, { id: 3, organization: org, name: 'Risk3' });
+    em.create(RiskAuditSync, { risk: ref(risk1), organization: org, auditId: 'audit-2' });
+    em.create(RiskAuditSync, { risk: ref(risk2), organization: org, auditId: 'audit-3' });
+    await em.flush();
+    em.clear();
+
+    // Load both risks and remove their synced audits
+    const loaded1 = await em.findOneOrFail(Risk, { id: 2 }, { populate: ['syncedAudit'] });
+    const loaded2 = await em.findOneOrFail(Risk, { id: 3 }, { populate: ['syncedAudit'] });
+    expect(loaded1.syncedAudit).toBeTruthy();
+    expect(loaded2.syncedAudit).toBeTruthy();
+
+    em.assign(loaded1, { syncedAudit: null });
+    em.assign(loaded2, { syncedAudit: null });
+    await em.flush();
+    em.clear();
+
+    expect(await em.count(RiskAuditSync, {})).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Entities with composite FK-in-PK that end up in the orphan remove stack without a valid primary key caused `DriverException` during `executeDeletes` because null PKs were passed to the `$in` clause
- Filters null PKs in `ChangeSetPersister.executeDeletes` to prevent the crash
- Skips entities without valid PKs when promoting from `orphanRemoveStack` to `removeStack` in `UnitOfWork.computeChangeSets`
- Regression introduced between 6.4.16 and 6.6.10, manifests with complex entity graphs (multiple models per table, cascade/orphan-removal traversal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)