### PR TITLE
fix(core): fire orphan removal for OneToOne replacement when inverse already set

### DIFF
--- a/packages/core/src/entity/EntityHelper.ts
+++ b/packages/core/src/entity/EntityHelper.ts
@@ -264,10 +264,20 @@ export class EntityHelper {
           if (entity && (!prop.owner || helper(entity).__initialized)) {
             EntityHelper.propagateOneToOne(entity, owner, prop, prop2, value, old as T);
           }
+        } else if (old && old !== value) {
+          // Inverse already points to owner — propagation is not needed,
+          // but we still need to clean up old's inverse side.
+          helper(old).__pk ??= helper(old).getPrimaryKey()!;
 
-          if (old && prop.orphanRemoval) {
-            helper(old).__em?.getUnitOfWork().scheduleOrphanRemoval(old);
+          if (old[prop2.name as EntityKey<T>] != null) {
+            delete helper(old).__data[prop2.name];
+            old[prop2.name as EntityKey<T>] = null!;
           }
+        }
+
+        if (old && old !== value && prop.orphanRemoval) {
+          helper(old).__pk ??= helper(old).getPrimaryKey()!;
+          helper(old).__em?.getUnitOfWork().scheduleOrphanRemoval(old);
         }
       }
     }

--- a/tests/issues/GH7436.test.ts
+++ b/tests/issues/GH7436.test.ts
@@ -1,0 +1,123 @@
+import { Entity, ManyToOne, MikroORM, OneToOne, PrimaryKey, PrimaryKeyProp, Property, Ref, ref, ReflectMetadataProvider } from '@mikro-orm/sqlite';
+
+@Entity()
+class Organization {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+}
+
+@Entity()
+class Author {
+
+  [PrimaryKeyProp]?: ['id', 'organization'];
+
+  @PrimaryKey()
+  id!: number;
+
+  @ManyToOne({ entity: () => Organization, ref: true, primary: true })
+  organization!: Ref<Organization>;
+
+  @Property()
+  name!: string;
+
+  @OneToOne({ entity: () => AuthorSync, mappedBy: 'author', nullable: true, orphanRemoval: true })
+  sync!: Ref<AuthorSync> | null;
+
+}
+
+@Entity()
+class AuthorSync {
+
+  [PrimaryKeyProp]?: ['author', 'organization', 'externalId'];
+
+  @OneToOne({
+    entity: () => Author,
+    inversedBy: 'sync',
+    joinColumns: ['author_id', 'organization_id'],
+    primary: true,
+  })
+  author!: Ref<Author> | null;
+
+  @ManyToOne({ entity: () => Organization, ref: true, primary: true })
+  organization!: Ref<Organization>;
+
+  @Property({ primary: true })
+  externalId!: string;
+
+}
+
+describe('GH7436', () => {
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      entities: [Organization, Author, AuthorSync],
+      dbName: ':memory:',
+      metadataProvider: ReflectMetadataProvider,
+    });
+    await orm.schema.refreshDatabase();
+  });
+
+  afterAll(() => orm.close(true));
+  beforeEach(() => orm.schema.refreshDatabase());
+
+  test('replacing OneToOne with orphanRemoval should delete old entity (composite PK with overlapping FK)', async () => {
+    const em = orm.em.fork();
+
+    const org = em.create(Organization, { id: 1, name: 'Org' });
+    const author = em.create(Author, { id: 1, organization: org, name: 'Alice' });
+    em.create(AuthorSync, { author: ref(author), organization: org, externalId: 'ext-1' });
+    await em.flush();
+    em.clear();
+
+    const loaded = await em.findOneOrFail(Author, { id: 1 }, { populate: ['sync'] });
+    expect(loaded.sync).toBeTruthy();
+    expect(loaded.sync!.externalId).toBe('ext-1');
+
+    // Replace sync with a new entity — new entity's inverse already points to author
+    const newSync = new AuthorSync();
+    em.assign(newSync, {
+      author: em.getReference(Author, [1, 1]),
+      organization: 1,
+      externalId: 'ext-2',
+    });
+    em.assign(loaded, { sync: newSync });
+
+    await em.flush();
+    em.clear();
+
+    const reloaded = await em.findOneOrFail(Author, { id: 1 }, { populate: ['sync'] });
+    expect(reloaded.sync!.externalId).toBe('ext-2');
+
+    const allSyncs = await em.find(AuthorSync, {});
+    expect(allSyncs).toHaveLength(1);
+  });
+
+  test('setting OneToOne to null with orphanRemoval should delete old entity (composite PK with overlapping FK)', async () => {
+    const em = orm.em.fork();
+
+    const org = em.create(Organization, { id: 2, name: 'Org2' });
+    const author = em.create(Author, { id: 2, organization: org, name: 'Bob' });
+    em.create(AuthorSync, { author: ref(author), organization: org, externalId: 'ext-3' });
+    await em.flush();
+    em.clear();
+
+    const loaded = await em.findOneOrFail(Author, { id: 2 }, { populate: ['sync'] });
+    expect(loaded.sync).toBeTruthy();
+
+    em.assign(loaded, { sync: null });
+    await em.flush();
+    em.clear();
+
+    const reloaded = await em.findOneOrFail(Author, { id: 2 }, { populate: ['sync'] });
+    expect(reloaded.sync).toBeNull();
+
+    const allSyncs = await em.find(AuthorSync, { organization: 2 });
+    expect(allSyncs).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Backport of #7436 to 6.x.

Fixes orphan removal not firing when replacing a OneToOne relation where the new entity's inverse side already points to the owner (composite PK with overlapping FK).