### PR TITLE
fix(core): resolve circular type inference in defineEntity with repository + filters

### DIFF
--- a/packages/core/src/entity/defineEntity.ts
+++ b/packages/core/src/entity/defineEntity.ts
@@ -37,6 +37,7 @@ import type {
   IWrappedEntity,
   DefineConfig,
   Config,
+  MaybePromise,
 } from '../typings.js';
 import type { Raw } from '../utils/RawQueryFragment.js';
 import type { ScalarReference } from './Reference.js';
@@ -54,7 +55,7 @@ import type { IType, Type } from '../types/Type.js';
 import { types } from '../types/index.js';
 import { EntitySchema } from '../metadata/EntitySchema.js';
 import type { Collection } from './Collection.js';
-import type { FilterOptions } from '../drivers/IDatabaseDriver.js';
+import type { FilterOptions, FindOptions, FindOneOptions } from '../drivers/IDatabaseDriver.js';
 
 /** Union of all option keys supported across all property definition types (scalar, enum, embedded, relations). */
 export type UniversalPropertyKeys =
@@ -1217,6 +1218,7 @@ export interface EntityMetadataWithProperties<
   | 'indexes'
   | 'uniques'
   | 'repository'
+  | 'filters'
   | 'orderBy'
 > {
   name: TName;
@@ -1229,6 +1231,23 @@ export interface EntityMetadataWithProperties<
   hooks?: DefineEntityHooks;
   // Capture the repository type for InferEntity to include EntityRepositoryType
   repository?: () => TRepository;
+  // mirrors FilterDefResolved with Dictionary instead of FilterQuery for cond to avoid circular type inference (GH #7440)
+  filters?: Dictionary<{
+    name: string;
+    cond:
+      | Dictionary
+      | ((
+          args: Dictionary,
+          type: 'read' | 'update' | 'delete',
+          em: any,
+          options?: FindOptions<any, any, any, any> | FindOneOptions<any, any, any, any>,
+          entityName?: string,
+        ) => MaybePromise<FilterQuery<any>>);
+    default?: boolean;
+    entity?: EntityName<any> | EntityName<any>[];
+    args?: boolean;
+    strict?: boolean;
+  }>;
   forceObject?: TForceObject;
 
   // Table-per-type inheritance (each entity has its own table)

--- a/tests/defineEntity.test.ts
+++ b/tests/defineEntity.test.ts
@@ -153,6 +153,41 @@ describe('defineEntity', () => {
     assert<IsExact<QuxRepoType & {}, QuxRepository>>(true);
   });
 
+  // GH #7440
+  it('should work with custom repository and filters', () => {
+    class UserRepository extends EntityRepository<User> {}
+
+    const UserSchema = defineEntity({
+      name: 'FilterRepoUser',
+      tableName: 'users',
+      repository: () => UserRepository,
+      properties: {
+        id: p.integer().primary().autoincrement(),
+        name: p.string(),
+        email: p.string().unique(),
+        deletedAt: p.datetime().nullable(),
+      },
+      filters: {
+        softDelete: {
+          name: 'softDelete',
+          cond: { deletedAt: null },
+          default: true,
+        },
+      },
+    });
+
+    class User extends UserSchema.class {}
+    UserSchema.setClass(User);
+
+    expect(UserSchema.init().meta.filters.softDelete).toBeDefined();
+    expect(UserSchema.init().meta.filters.softDelete.default).toBe(true);
+
+    type IUser = InferEntity<typeof UserSchema>;
+    assert<IsExact<IUser['name'], string>>(true);
+    type UserRepoType = IUser[typeof EntityRepositoryType];
+    assert<IsExact<UserRepoType & {}, UserRepository>>(true);
+  });
+
   it('should define entity with primary keys', () => {
     const Foo = defineEntity({
       name: 'Foo',


### PR DESCRIPTION
## Summary

- Fixes circular type errors (TS7022, TS2310, TS2506) when using `defineEntity` with both `repository` and `filters` options
- Omits `filters` from the `EntityMetadata` base type in `EntityMetadataWithProperties` and re-declares it with an inline structural type, avoiding `FilterDef`'s `EntityFromInput` conditional type that forces eager evaluation and breaks TypeScript's deferred circular reference resolution

Closes #7440

🤖 Generated with [Claude Code](https://claude.ai/claude-code)