### PR TITLE
fix(migrations): save transaction ref before prefix() deletes it from options

### DIFF
--- a/packages/migrations/src/Migrator.ts
+++ b/packages/migrations/src/Migrator.ts
@@ -429,18 +429,19 @@ export class Migrator implements IMigrator {
   private async runMigrations(method: 'up' | 'down', options?: string | string[] | MigrateOptions) {
     await this.ensureDatabase();
 
+    // Save transaction reference before prefix() deletes it from options
+    const ctx = Utils.isObject<MigrateOptions>(options) ? options.transaction : undefined;
     let result: UmzugMigration[];
 
     if (!this.options.transactional || !this.options.allOrNothing) {
       result = await this.umzug[method](this.prefix(options as string[]));
-    } else if (Utils.isObject<MigrateOptions>(options) && options.transaction) {
-      result = await this.runInTransaction(options.transaction, method, options);
+    } else if (ctx) {
+      result = await this.runInTransaction(ctx, method, options);
     } else {
       result = await this.driver.getConnection().transactional(trx => this.runInTransaction(trx, method, options));
     }
 
     if (result.length > 0 && this.options.snapshot) {
-      const ctx = Utils.isObject<MigrateOptions>(options) ? options.transaction : undefined;
       const schema = await DatabaseSchema.create(
         this.em.getConnection(),
         this.em.getPlatform(),

--- a/tests/features/migrations/Migrator.postgres.test.ts
+++ b/tests/features/migrations/Migrator.postgres.test.ts
@@ -27,6 +27,18 @@ class MigrationTest1 extends Migration {
 
 }
 
+class MigrationTestAlterTable extends Migration {
+
+  async up(): Promise<void> {
+    this.addSql('alter table "custom"."author2" add column "temp_test_col" varchar(255)');
+  }
+
+  async down(): Promise<void> {
+    this.addSql('alter table "custom"."author2" drop column "temp_test_col"');
+  }
+
+}
+
 class MigrationTest2 extends Migration {
 
   async up(): Promise<void> {
@@ -274,6 +286,29 @@ describe('Migrator (postgres)', () => {
       migrations.snapshot = false;
     }
   });
+
+  test('migrator.up with external transaction and snapshot: true does not deadlock with real DDL (GH #7424)', async () => {
+    const migrationsConfig = orm.config.get('migrations');
+    const origSnapshot = migrationsConfig.snapshot;
+    const origMigrationsList = migrationsConfig.migrationsList;
+    migrationsConfig.snapshot = true;
+    migrationsConfig.migrationsList = [{ class: MigrationTestAlterTable, name: 'MigrationTestAlterTable' }];
+    orm.config.resetServiceCache();
+
+    try {
+      await orm.em.transactional(async em => {
+        const ret = await orm.migrator.up({ transaction: em.getTransactionContext() });
+        expect(ret).toHaveLength(1);
+      });
+    } finally {
+      await orm.schema.execute('alter table "custom"."author2" drop column if exists "temp_test_col"');
+      const knex = orm.em.getKnex();
+      await knex('mikro_orm_migrations').withSchema('custom').where('name', 'MigrationTestAlterTable').delete();
+      migrationsConfig.snapshot = origSnapshot;
+      migrationsConfig.migrationsList = origMigrationsList;
+      orm.config.resetServiceCache();
+    }
+  }, 10_000);
 
   test('generate initial migration', async () => {
     await orm.em.getKnex().schema.dropTableIfExists(orm.config.get('migrations').tableName!).withSchema('custom');


### PR DESCRIPTION
## Summary
- The previous fix for #7424 correctly identified that `DatabaseSchema.create()` needs the transaction context, but `prefix()` deletes `options.transaction` before the snapshot code reads it — making `ctx` always `undefined`
- Save the transaction reference at the top of `runMigrations()` before `runInTransaction()` → `prefix()` can delete it
- Add a test that runs real DDL (`ALTER TABLE`) inside an external transaction with `snapshot: true`, reproducing the actual deadlock (AccessExclusiveLock contention)

Reproduction: https://github.com/zachkirsch/mikro-orm-migration-hang-repro

🤖 Generated with [Claude Code](https://claude.com/claude-code)