### PR TITLE
fix(core): resolve circular type inference in `defineEntity` with composite `primaryKeys`

### DIFF
--- a/packages/core/src/entity/defineEntity.ts
+++ b/packages/core/src/entity/defineEntity.ts
@@ -1227,7 +1227,7 @@ export interface EntityMetadataWithProperties<
   // Also accepts entity constructors for compatibility with class-based entities
   extends?: { '~entity': TBase } | EntityCtor<TBase>;
   properties: TProperties | ((properties: PropertyBuilders) => TProperties);
-  primaryKeys?: TPK & InferPrimaryKey<TProperties>[];
+  primaryKeys?: TPK & InferPrimaryKeyConstraint<TProperties>[];
   hooks?: DefineEntityHooks;
   // Capture the repository type for InferEntity to include EntityRepositoryType
   repository?: () => TRepository;
@@ -1526,6 +1526,15 @@ type CombinePrimaryKeys<ChildPK, BasePK> = [ChildPK] extends [never]
 /** Extracts the primary key property names from a properties map by finding builders with `primary: true`. */
 export type InferPrimaryKey<Properties extends Record<string, any>> = {
   [K in keyof Properties]: MaybeReturnType<Properties[K]> extends { '~options': { primary: true } } ? K : never;
+}[keyof Properties];
+
+/** Like InferPrimaryKey, but skips evaluating function return types to prevent circular inference (GH #7445). */
+export type InferPrimaryKeyConstraint<Properties extends Record<string, any>> = {
+  [K in keyof Properties]: Properties[K] extends (...args: any) => any
+    ? K
+    : Properties[K] extends { '~options': { primary: true } }
+      ? K
+      : never;
 }[keyof Properties];
 
 type InferBuilderValue<Builder> = Builder extends { '~type'?: { value: infer Value }; '~options'?: infer Options }

--- a/tests/issues/GH7445.test.ts
+++ b/tests/issues/GH7445.test.ts
@@ -1,0 +1,84 @@
+import { Collection, defineEntity, MikroORM, p, PrimaryKeyProp, Ref } from '@mikro-orm/sqlite';
+
+// GH #7445: defineEntity with composite primary keys and circular oneToMany/manyToOne
+// relations triggers TypeScript circular reference errors
+
+const OrganizationSchema = defineEntity({
+  name: 'GH7445_Organization',
+  properties: {
+    id: p.integer().primary().autoincrement(),
+    name: p.string(),
+  },
+});
+class Organization extends OrganizationSchema.class {}
+OrganizationSchema.setClass(Organization);
+
+const MeasurementTaskSchema = defineEntity({
+  name: 'GH7445_MeasurementTask',
+  properties: {
+    organization: () => p.manyToOne(Organization).ref().primary(),
+    id: p.integer().primary(),
+    name: p.string(),
+    sample: () => p.manyToOne(SampleSchema).ref(),
+  },
+  primaryKeys: ['organization', 'id'],
+});
+class MeasurementTask extends MeasurementTaskSchema.class {}
+MeasurementTaskSchema.setClass(MeasurementTask);
+
+const SampleSchema = defineEntity({
+  name: 'GH7445_Sample',
+  properties: {
+    organization: () => p.manyToOne(Organization).ref().primary(),
+    id: p.integer().primary(),
+    name: p.string(),
+    tasks: () => p.oneToMany(MeasurementTask).mappedBy('sample'),
+  },
+  primaryKeys: ['organization', 'id'],
+});
+class Sample extends SampleSchema.class {}
+SampleSchema.setClass(Sample);
+
+type TaskEntity = InstanceType<typeof MeasurementTask>;
+type SampleEntity = InstanceType<typeof Sample>;
+
+const taskPKCheck: TaskEntity[typeof PrimaryKeyProp] = ['organization', 'id'];
+const samplePKCheck: SampleEntity[typeof PrimaryKeyProp] = ['organization', 'id'];
+
+const task = {} as TaskEntity;
+const taskSample: Ref<SampleEntity> = task.sample;
+
+const sample = {} as SampleEntity;
+const sampleTasks: Collection<TaskEntity> = sample.tasks;
+
+describe('GH #7445', () => {
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      entities: [OrganizationSchema, MeasurementTaskSchema, SampleSchema],
+      dbName: ':memory:',
+    });
+    await orm.schema.create();
+  });
+
+  afterAll(() => orm.close(true));
+
+  it('should support composite PKs with circular relations via defineEntity', async () => {
+    const org = orm.em.create(Organization, { name: 'Org1' });
+    const sample = orm.em.create(Sample, { id: 1, organization: org, name: 'Sample1' });
+    const task = orm.em.create(MeasurementTask, { id: 1, organization: org, name: 'Task1', sample });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const found = await orm.em.findOneOrFail(
+      MeasurementTask,
+      { name: 'Task1' },
+      {
+        populate: ['sample'],
+      },
+    );
+    expect(found.name).toBe('Task1');
+    expect(found.sample.unwrap().name).toBe('Sample1');
+  });
+});


### PR DESCRIPTION
## Summary

- The `primaryKeys` constraint in `EntityMetadataWithProperties` used `InferPrimaryKey` which calls `MaybeReturnType` on all properties, forcing TypeScript to eagerly resolve return types of forward-reference closures — triggering circular type inference with mutually-referencing entities
- Added `InferPrimaryKeyConstraint` which accepts function properties (forward references) without evaluating their return types, while still validating non-function properties against `primary: true`

Closes #7445

🤖 Generated with [Claude Code](https://claude.com/claude-code)