### PR TITLE
fix(core): exclude namespace functions from enum type inference in defineEntity

### DIFF
--- a/packages/core/src/entity/defineEntity.ts
+++ b/packages/core/src/entity/defineEntity.ts
@@ -1606,6 +1606,10 @@ type MaybeHidden<Value, Options> = Options extends { hidden: true }
   ? Hidden<NonNullable<Value>> | Extract<Value, null | undefined>
   : Value;
 
-type ValueOf<T extends Dictionary> = T[keyof T];
+type ValueOf<T extends Dictionary> = T[keyof T] extends infer V
+  ? V extends (...args: any[]) => any
+    ? never
+    : V
+  : never;
 
 type IsUnion<T, U = T> = T extends U ? ([U] extends [T] ? false : true) : false;

--- a/tests/defineEntity.test.ts
+++ b/tests/defineEntity.test.ts
@@ -31,6 +31,21 @@ import type { PropertyChain, UniversalPropertyOptionsBuilder } from '../packages
 import { IsExact, assert } from 'conditional-type-checks';
 import { ObjectId } from 'bson';
 
+// GH #7446 - enum merged with namespace (must be at module level)
+enum Status7446 {
+  Pending = 0,
+  Success = 1,
+  Error = 2,
+  Running = 3,
+}
+
+// eslint-disable-next-line @typescript-eslint/no-namespace
+namespace Status7446 {
+  export function isComplete(status: Status7446): boolean {
+    return status === Status7446.Success || status === Status7446.Error;
+  }
+}
+
 // Compile-time assertion: PropertyChain method parameters must match
 // UniversalPropertyOptionsBuilder. Catches signature drift between the lightweight
 // interface and the implementation class. Return types are intentionally different.
@@ -580,6 +595,21 @@ describe('defineEntity', () => {
     });
 
     expect(Foo.meta).toEqual(asSnapshot(FooSchema.meta));
+  });
+
+  // GH #7446
+  it('should define entity with enum merged with namespace', () => {
+    const Foo = defineEntity({
+      name: 'Foo',
+      properties: {
+        id: p.uuid().primary(),
+        status: p.enum(() => Status7446),
+      },
+    });
+
+    type IFoo = InferEntity<typeof Foo>;
+    // The type should only include enum values, not namespace functions
+    assert<IsExact<IFoo['status'], Status7446>>(true);
   });
 
   it('should define entity with embedded', () => {


### PR DESCRIPTION
Closes #7446

When a TypeScript enum is merged with a namespace containing functions (a valid TS pattern), `p.enum(() => Status)` in `defineEntity` would include the namespace function types in the inferred property type. This broke exhaustive switch checks.

The `ValueOf` helper now filters out function members, so only actual enum values are included in the inferred type.