### PR TITLE
fix(core): fix three TPT inheritance bugs

### DIFF
--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -2622,6 +2622,11 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
         .flat() as any;
     }
 
+    // Save flag before normalization replaces it (needed for TPT child relation population, GH #7453)
+    if (Utils.asArray(options.populate).some((p: any) => p === true || (typeof p === 'object' && p.all))) {
+      (options as Dictionary).populateAll = true;
+    }
+
     const populate: PopulateOptions<Entity>[] = this.#entityLoader.normalizePopulate<Entity>(
       entityName,
       options.populate as true,

--- a/packages/core/src/entity/EntityLoader.ts
+++ b/packages/core/src/entity/EntityLoader.ts
@@ -93,11 +93,12 @@ export class EntityLoader {
     populate: PopulateOptions<Entity>[] | boolean,
     options: EntityLoaderOptions<Entity, Fields>,
   ): Promise<void> {
-    if (entities.length === 0 || Utils.isEmpty(populate)) {
+    const meta = this.#metadata.find(entityName)!;
+    const populateAll = !!(options as Dictionary).populateAll;
+
+    if (entities.length === 0 || (Utils.isEmpty(populate) && !populateAll)) {
       return this.setSerializationContext(entities, populate, options);
     }
-
-    const meta = this.#metadata.find(entityName)!;
 
     if ((entities as AnyEntity[]).some(e => !e.__helper)) {
       const entity = entities.find(e => !Utils.isEntity(e));
@@ -139,6 +140,11 @@ export class EntityLoader {
 
     for (const pop of populate) {
       await this.populateField<Entity>(entityName, entities, pop, options as Required<EntityLoaderOptions<Entity>>);
+    }
+
+    // For TPT entities with populate: *, also populate child-specific relations (GH #7453).
+    if (populateAll && meta.inheritanceType === 'tpt' && meta.tptChildren?.length) {
+      await this.populateTPTChildRelations<Entity>(meta, entities, options as Required<EntityLoaderOptions<Entity>>);
     }
 
     for (const entity of entities) {
@@ -1093,6 +1099,48 @@ export class EntityLoader {
     });
 
     return ret;
+  }
+
+  /**
+   * For TPT entities queried via a parent type with `populate: *`, the parent metadata
+   * only knows about its own relations. Child-specific relations are missed. This method
+   * groups entities by their concrete type and populates any relations not in the parent.
+   */
+  private async populateTPTChildRelations<Entity extends object>(
+    parentMeta: EntityMetadata<Entity>,
+    entities: Entity[],
+    options: Required<EntityLoaderOptions<Entity>>,
+  ): Promise<void> {
+    const parentRelNames = new Set<string>(parentMeta.relations.map(r => r.name as string));
+    const byType = new Map<EntityMetadata, Entity[]>();
+
+    for (const entity of entities) {
+      const entityMeta = helper(entity).__meta;
+
+      if (entityMeta !== parentMeta) {
+        let group = byType.get(entityMeta);
+
+        if (!group) {
+          group = [];
+          byType.set(entityMeta, group);
+        }
+
+        group.push(entity);
+      }
+    }
+
+    for (const [childMeta, childEntities] of byType) {
+      const childOnlyRelations = childMeta.relations.filter(r => !parentRelNames.has(r.name as string));
+
+      for (const prop of childOnlyRelations) {
+        const pop = {
+          field: prop.name,
+          strategy: LoadStrategy.SELECT_IN,
+          all: true,
+        } as PopulateOptions<Entity>;
+        await this.populateField(childMeta.className as unknown as EntityName<Entity>, childEntities, pop, options);
+      }
+    }
   }
 
   private getRelationName<Entity>(meta: EntityMetadata<Entity>, prop: EntityProperty<Entity>): EntityKey<Entity> {

--- a/packages/core/src/unit-of-work/UnitOfWork.ts
+++ b/packages/core/src/unit-of-work/UnitOfWork.ts
@@ -434,8 +434,70 @@ export class UnitOfWork {
     const cs = this.#changeSetComputer.computeChangeSet(entity);
 
     if (cs && !this.checkUniqueProps(cs)) {
-      Object.assign(changeSet.payload, cs.payload);
-      helper(entity).__originalEntityData = this.#comparator.prepareEntity(entity);
+      const wrapped = helper(entity);
+
+      // For TPT entities, split the recomputed payload among the leaf and parent changesets,
+      // so parent columns don't leak into the leaf table's INSERT/UPDATE (GH #7455).
+      if (wrapped.__meta.inheritanceType === 'tpt' && wrapped.__meta.tptParent) {
+        // Update leaf changeset with only its own props
+        for (const prop of wrapped.__meta.ownProps!) {
+          if (prop.name in cs.payload) {
+            (changeSet.payload as Dictionary)[prop.name] = (cs.payload as Dictionary)[prop.name];
+          }
+        }
+
+        // Update existing parent changesets
+        if (changeSet.tptChangeSets) {
+          for (const parentCs of changeSet.tptChangeSets) {
+            for (const prop of parentCs.meta.ownProps!) {
+              if (prop.name in cs.payload) {
+                (parentCs.payload as Dictionary)[prop.name] = (cs.payload as Dictionary)[prop.name];
+              }
+            }
+          }
+        } else {
+          // Create parent changesets if they don't exist yet
+          const parentChangeSets: ChangeSet<T>[] = [];
+          let current: EntityMetadata | undefined = wrapped.__meta.tptParent;
+
+          while (current) {
+            const payload: Dictionary = {};
+
+            for (const prop of current.ownProps!) {
+              if (prop.name in cs.payload) {
+                payload[prop.name] = (cs.payload as Dictionary)[prop.name];
+              }
+            }
+
+            if (Object.keys(payload).length > 0 || changeSet.type === ChangeSetType.CREATE) {
+              // For CREATE on non-root tables, include the PK
+              if (changeSet.type === ChangeSetType.CREATE && current.tptParent) {
+                const identifier = wrapped.__identifier;
+                const identifiers = Array.isArray(identifier) ? identifier : [identifier];
+
+                for (let i = 0; i < current.primaryKeys.length; i++) {
+                  const pk = current.primaryKeys[i];
+                  payload[pk] = identifiers[i] ?? (cs.payload as Dictionary)[pk];
+                }
+              }
+
+              parentChangeSets.push(
+                new ChangeSet(entity, changeSet.type, payload as EntityDictionary<T>, current as EntityMetadata<T>),
+              );
+            }
+
+            current = current.tptParent;
+          }
+
+          if (parentChangeSets.length > 0) {
+            changeSet.tptChangeSets = parentChangeSets;
+          }
+        }
+      } else {
+        Object.assign(changeSet.payload, cs.payload);
+      }
+
+      wrapped.__originalEntityData = this.#comparator.prepareEntity(entity);
     }
   }
 
@@ -1304,7 +1366,14 @@ export class UnitOfWork {
     await this.#changeSetPersister.executeInserts(changeSets, { ctx });
 
     for (const changeSet of changeSets) {
-      this.register<T>(changeSet.entity, changeSet.payload, { refresh: true });
+      // For TPT entities, use the full entity snapshot instead of the partial changeset payload,
+      // since each table's changeset only contains its own properties. Without this, the snapshot
+      // would only have the last table's properties, causing spurious UPDATEs on next flush (GH #7454).
+      const data =
+        changeSet.meta.inheritanceType === 'tpt'
+          ? (this.#comparator.prepareEntity(changeSet.entity) as EntityData<T>)
+          : changeSet.payload;
+      this.register<T>(changeSet.entity, data, { refresh: true });
       await this.runHooks(EventType.afterCreate, changeSet);
     }
   }

--- a/tests/features/table-per-type-inheritance/table-per-type-inheritance.test.ts
+++ b/tests/features/table-per-type-inheritance/table-per-type-inheritance.test.ts
@@ -1,4 +1,6 @@
 import { Collection, EntitySchema, MikroORM, quote, Ref, wrap, raw, Type, Opt } from '@mikro-orm/sqlite';
+import type { EventSubscriber, FlushEventArgs } from '@mikro-orm/sqlite';
+import { ChangeSetType } from '@mikro-orm/sqlite';
 import {
   Embeddable,
   Embedded,
@@ -2810,6 +2812,156 @@ describe('TPT QueryBuilder update/delete', () => {
 
     const logs = mock.mock.calls.map(c => c[0]);
     expect(logs.some((l: string) => l.includes('delete from `foo_integration`'))).toBe(true);
+
+    await orm.close();
+  });
+});
+
+// GH #7454
+describe('TPT sequential flush regression', () => {
+  test('sequential flush of unchanged TPT entity does not trigger update', async () => {
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      dbName: ':memory:',
+      entities: [Integration, FooIntegration, BarIntegration, BazIntegration],
+    });
+    await orm.schema.create();
+
+    orm.em.create(FooIntegration, {
+      name: 'Foo Integration',
+      fooData: 'foo-data',
+    });
+    await orm.em.flush();
+
+    const mock = mockLogger(orm);
+    // Second flush without changes — should NOT produce any queries
+    await orm.em.flush();
+
+    const logs = mock.mock.calls.map(c => c[0]);
+    expect(logs.some((l: string) => l.includes('update'))).toBe(false);
+
+    await orm.close();
+  });
+
+  test('sequential flush of unchanged multi-level TPT entity does not trigger update', async () => {
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      dbName: ':memory:',
+      entities: [Integration, FooIntegration, BarIntegration, BazIntegration],
+    });
+    await orm.schema.create();
+
+    orm.em.create(BazIntegration, {
+      name: 'Baz Integration',
+      barData: 'bar-data',
+      bazData: 'baz-data',
+    });
+    await orm.em.flush();
+
+    const mock = mockLogger(orm);
+    await orm.em.flush();
+
+    const logs = mock.mock.calls.map(c => c[0]);
+    expect(logs.some((l: string) => l.includes('update'))).toBe(false);
+
+    await orm.close();
+  });
+});
+
+// GH #7455
+describe('TPT recomputeSingleChangeSet regression', () => {
+  test('recomputeSingleChangeSet works for TPT entities in onFlush', async () => {
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      dbName: ':memory:',
+      entities: [Integration, FooIntegration, BarIntegration, BazIntegration],
+    });
+    await orm.schema.create();
+
+    class Subscriber implements EventSubscriber {
+      async onFlush(args: FlushEventArgs): Promise<void> {
+        const changeSets = args.uow.getChangeSets();
+        const cs = changeSets.find(cs => cs.type === ChangeSetType.CREATE && cs.entity instanceof FooIntegration);
+
+        if (cs) {
+          (cs.entity as FooIntegration).fooData = 'modified-in-hook';
+          args.uow.recomputeSingleChangeSet(cs.entity);
+        }
+      }
+    }
+
+    const em = orm.em.fork();
+    em.getEventManager().registerSubscriber(new Subscriber());
+
+    em.create(FooIntegration, {
+      name: 'Foo Integration',
+      fooData: 'original',
+    });
+
+    // Should not throw "table foo_integration has no column named name"
+    await em.flush();
+
+    em.clear();
+    const loaded = await em.findOneOrFail(FooIntegration, { name: 'Foo Integration' });
+    expect(loaded.fooData).toBe('modified-in-hook');
+    expect(loaded.name).toBe('Foo Integration');
+
+    await orm.close();
+  });
+});
+
+// GH #7453
+describe('TPT child relation population regression', () => {
+  @Entity({ inheritance: 'tpt' })
+  abstract class Person7453 {
+    @PrimaryKey()
+    id!: number;
+
+    @Property()
+    name!: string;
+  }
+
+  @Entity()
+  class Address7453 {
+    @PrimaryKey()
+    id!: number;
+
+    @Property()
+    street!: string;
+  }
+
+  @Entity()
+  class Employee7453 extends Person7453 {
+    @Property()
+    department!: string;
+
+    @ManyToOne(() => Address7453, { ref: true, nullable: true })
+    address?: Ref<Address7453>;
+  }
+
+  test('child-specific relations are populated when querying via parent type with populate: *', async () => {
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      dbName: ':memory:',
+      entities: [Person7453, Employee7453, Address7453],
+    });
+    await orm.schema.create();
+
+    const address = orm.em.create(Address7453, { street: '123 Main St' });
+    orm.em.create(Employee7453, {
+      name: 'John Doe',
+      department: 'Engineering',
+      address,
+    });
+    await orm.em.flush();
+    orm.em.clear();
+
+    // Query via parent type with populate: ['*']
+    const person = await orm.em.findOneOrFail(Person7453, { name: 'John Doe' }, { populate: ['*'] });
+    expect(person).toBeInstanceOf(Employee7453);
+    expect((person as Employee7453).address).toBeDefined();
+    expect((person as Employee7453).address!.unwrap()).toBeInstanceOf(Address7453);
+    expect((person as Employee7453).address!.unwrap().street).toBe('123 Main St');
 
     await orm.close();
   });


### PR DESCRIPTION
## Summary

- **#7454**: Sequential flush of unchanged TPT entity triggered spurious UPDATE — `commitCreateChangeSets()` used partial changeset payload for the entity snapshot; now uses full entity snapshot (matching what `commitUpdateChangeSets` already does).
- **#7455**: `recomputeSingleChangeSet()` leaked parent fields into leaf changeset — now splits the recomputed payload among leaf and parent changesets using `ownProps`.
- **#7453**: Child-specific relations not populated when querying via parent type with `populate: ['*']` — after the main populate loop, detects TPT child entities and populates their child-only relations.

Closes #7453
Closes #7454
Closes #7455