### PR TITLE
fix(core): use full entity snapshot for TPT entities in commitCreateChangeSets

### DIFF
--- a/packages/core/src/unit-of-work/UnitOfWork.ts
+++ b/packages/core/src/unit-of-work/UnitOfWork.ts
@@ -1304,7 +1304,14 @@ export class UnitOfWork {
     await this.#changeSetPersister.executeInserts(changeSets, { ctx });
 
     for (const changeSet of changeSets) {
-      this.register<T>(changeSet.entity, changeSet.payload, { refresh: true });
+      // For TPT entities, use the full entity snapshot instead of the partial changeset payload,
+      // since each table's changeset only contains its own properties. Without this, the snapshot
+      // would only have the last table's properties, causing spurious UPDATEs on next flush (GH #7454).
+      const data =
+        changeSet.meta.inheritanceType === 'tpt'
+          ? (this.#comparator.prepareEntity(changeSet.entity) as EntityData<T>)
+          : changeSet.payload;
+      this.register<T>(changeSet.entity, data, { refresh: true });
       await this.runHooks(EventType.afterCreate, changeSet);
     }
   }

--- a/tests/features/table-per-type-inheritance/table-per-type-inheritance.test.ts
+++ b/tests/features/table-per-type-inheritance/table-per-type-inheritance.test.ts
@@ -2814,3 +2814,54 @@ describe('TPT QueryBuilder update/delete', () => {
     await orm.close();
   });
 });
+
+// GH #7454
+describe('TPT sequential flush regression', () => {
+  test('sequential flush of unchanged TPT entity does not trigger update', async () => {
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      dbName: ':memory:',
+      entities: [Integration, FooIntegration, BarIntegration, BazIntegration],
+    });
+    await orm.schema.create();
+
+    orm.em.create(FooIntegration, {
+      name: 'Foo Integration',
+      fooData: 'foo-data',
+    });
+    await orm.em.flush();
+
+    const mock = mockLogger(orm);
+    // Second flush without changes — should NOT produce any queries
+    await orm.em.flush();
+
+    const logs = mock.mock.calls.map(c => c[0]);
+    expect(logs.some((l: string) => l.includes('update'))).toBe(false);
+
+    await orm.close();
+  });
+
+  test('sequential flush of unchanged multi-level TPT entity does not trigger update', async () => {
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      dbName: ':memory:',
+      entities: [Integration, FooIntegration, BarIntegration, BazIntegration],
+    });
+    await orm.schema.create();
+
+    orm.em.create(BazIntegration, {
+      name: 'Baz Integration',
+      barData: 'bar-data',
+      bazData: 'baz-data',
+    });
+    await orm.em.flush();
+
+    const mock = mockLogger(orm);
+    await orm.em.flush();
+
+    const logs = mock.mock.calls.map(c => c[0]);
+    expect(logs.some((l: string) => l.includes('update'))).toBe(false);
+
+    await orm.close();
+  });
+});


### PR DESCRIPTION
## Summary

After inserting a TPT entity, `commitCreateChangeSets` called `register()` per changeset with only that table's partial payload as the snapshot. Since parent and leaf changesets are processed in separate groups, the leaf's call overwrote `__originalEntityData` with only leaf properties, losing parent properties. On the next flush, `computePayload()` would diff against this partial snapshot and generate a spurious UPDATE.

The fix uses `this.#comparator.prepareEntity()` (the full entity snapshot) for TPT entities, matching what `commitUpdateChangeSets` already does.

Closes #7454

🤖 Generated with [Claude Code](https://claude.com/claude-code)