### PR TITLE
fix(core): skip FK nullification on orphan removal when FK is part of PK

### DIFF
--- a/packages/core/src/entity/EntityHelper.ts
+++ b/packages/core/src/entity/EntityHelper.ts
@@ -298,7 +298,8 @@ export class EntityHelper {
           // but we still need to clean up old's inverse side.
           helper(old).__pk ??= helper(old).getPrimaryKey()!;
 
-          if (old[prop2.name as EntityKey<T>] != null) {
+          // Don't nullify the FK if it's part of the PK — the entity will be deleted via orphan removal
+          if (old[prop2.name as EntityKey<T>] != null && !(prop.orphanRemoval && prop2.primary)) {
             delete helper(old).__data[prop2.name];
             old[prop2.name] = null!;
           }
@@ -351,7 +352,8 @@ export class EntityHelper {
       entity[prop2.name] = Reference.wrapReference(owner, prop) as EntityValue<T>;
     }
 
-    if (old?.[prop2.name] != null) {
+    // Don't nullify the FK if it's part of the PK — the entity will be deleted via orphan removal
+    if (old?.[prop2.name] != null && !(prop.orphanRemoval && prop2.primary)) {
       delete helper(old).__data[prop2.name];
       old[prop2.name] = null!;
     }

--- a/tests/issues/GH7436.test.ts
+++ b/tests/issues/GH7436.test.ts
@@ -1,4 +1,5 @@
 import { MikroORM, PrimaryKeyProp, Ref, ref } from '@mikro-orm/sqlite';
+import { mockLogger } from '../helpers';
 import {
   Entity,
   ManyToOne,
@@ -97,6 +98,49 @@ describe('GH7436', () => {
     expect(reloaded.sync!.externalId).toBe('ext-2');
 
     const allSyncs = await em.find(AuthorSync, {});
+    expect(allSyncs).toHaveLength(1);
+  });
+
+  test('replacing OneToOne with orphanRemoval should not nullify FK that is part of PK on old entity', async () => {
+    const em = orm.em.fork();
+
+    const org = em.create(Organization, { id: 3, name: 'Org3' });
+    const author = em.create(Author, { id: 3, organization: org, name: 'Charlie' });
+    em.create(AuthorSync, { author: ref(author), organization: org, externalId: 'ext-5' });
+    await em.flush();
+    em.clear();
+
+    const loaded = await em.findOneOrFail(Author, { id: 3 }, { populate: ['sync'] });
+    const oldSync = loaded.sync!;
+    expect(oldSync.externalId).toBe('ext-5');
+
+    // Create a new sync entity WITHOUT pre-setting the `author` FK.
+    // This means propagateOneToOne will be invoked (not the shortcut path)
+    // and will attempt to nullify old.author — which is part of the PK.
+    // On PostgreSQL this causes: NotNullConstraintViolationException: SET "author_id" = NULL
+    const newSync = em.create(AuthorSync, {
+      organization: em.getReference(Organization, 3),
+      externalId: 'ext-6',
+    } as any);
+    em.assign(loaded, { sync: newSync });
+
+    // The old entity's FK should NOT be nullified — it's part of the PK
+    // and the entity will be removed via orphan removal anyway.
+    expect(oldSync.author).not.toBeNull();
+
+    await em.flush();
+
+    // Second flush should produce no queries (no stale state from the skipped nullification)
+    const mock = mockLogger(orm);
+    await em.flush();
+    expect(mock.mock.calls).toHaveLength(0);
+
+    em.clear();
+
+    const reloaded = await em.findOneOrFail(Author, { id: 3 }, { populate: ['sync'] });
+    expect(reloaded.sync!.externalId).toBe('ext-6');
+
+    const allSyncs = await em.find(AuthorSync, { organization: 3 });
     expect(allSyncs).toHaveLength(1);
   });
 


### PR DESCRIPTION
Port of #7461 (6.x) to master.

When replacing a OneToOne relation with `orphanRemoval: true`, the old entity's FK was nullified before the orphan DELETE ran. If that FK is part of the composite PK (NOT NULL), this caused a `NotNullConstraintViolationException` on PostgreSQL. Added a guard in two code paths in `EntityHelper` that nullify the old entity's FK — mirroring the existing guard that already handles the `value == null` case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)