### PR TITLE
fix(core): recursively nullify nested inline embeddable columns when parent is null

### DIFF
--- a/packages/core/src/utils/EntityComparator.ts
+++ b/packages/core/src/utils/EntityComparator.ts
@@ -520,14 +520,7 @@ export class EntityComparator {
       ret += `${padding}if (${nullCond}) ret${dataKey} = null;\n`;
     } else {
       ret += `${padding}if (${nullCond}) {\n`;
-      ret += meta.props.filter(p =>
-        p.embedded?.[0] === prop.name
-        // object for JSON embeddable
-        && (p.object || (p.persist !== false)),
-      ).map(childProp => {
-        const childDataKey = meta.embeddable || prop.object ? dataKey + this.wrap(childProp.embedded![1]) : this.wrap(childProp.name);
-        return `${padding}  ret${childDataKey} = null;`;
-      }).join('\n') + `\n`;
+      ret += this.getInlineEmbeddedNullLines(meta, prop.name, padding, dataKey, !!(meta.embeddable || prop.object)).join('\n') + `\n`;
       ret += `${padding}}\n`;
     }
 
@@ -586,6 +579,21 @@ export class EntityComparator {
     }
 
     return `${ret}${padding}}`;
+  }
+
+  private getInlineEmbeddedNullLines<T>(meta: EntityMetadata<T>, parentName: string, padding: string, dataKey: string, useEmbeddedKey: boolean): string[] {
+    return meta.props.filter(p =>
+      p.embedded?.[0] === parentName
+      && (p.object || (p.persist !== false)),
+    ).flatMap(childProp => {
+      const childDataKey = useEmbeddedKey ? dataKey + this.wrap(childProp.embedded![1]) : this.wrap(childProp.name);
+
+      if (childProp.kind === ReferenceKind.EMBEDDED && !childProp.object) {
+        return this.getInlineEmbeddedNullLines(meta, childProp.name, padding, childDataKey, useEmbeddedKey);
+      }
+
+      return [`${padding}  ret${childDataKey} = null;`];
+    });
   }
 
   private registerCustomType<T>(prop: EntityProperty<T>, context: Map<string, any>) {

--- a/tests/features/embeddables/GH7463.test.ts
+++ b/tests/features/embeddables/GH7463.test.ts
@@ -1,0 +1,99 @@
+import { Embeddable, Embedded, Entity, MikroORM, PrimaryKey, Property } from '@mikro-orm/sqlite';
+
+@Embeddable()
+class InnerEmbeddable {
+
+  @Property()
+  name!: string;
+
+}
+
+@Embeddable()
+class OuterEmbeddable {
+
+  @Embedded(() => InnerEmbeddable, { nullable: true })
+  inner?: InnerEmbeddable;
+
+}
+
+@Entity()
+class User {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @Embedded(() => OuterEmbeddable, { nullable: true })
+  outer?: OuterEmbeddable;
+
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    dbName: ':memory:',
+    entities: [User],
+  });
+  await orm.schema.refreshDatabase();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+test('GH #7463 - snapshot generator', async () => {
+  const comparator = orm.em.getComparator();
+  const snapshotGenerator = comparator.getSnapshotGenerator('User');
+  expect(snapshotGenerator.toString()).toMatchSnapshot();
+});
+
+test('GH #7463', async () => {
+  orm.em.create(User, {
+    name: 'Foo',
+    outer: {
+      inner: { name: 'inner' },
+    },
+  });
+  await orm.em.flush();
+  orm.em.clear();
+
+  const user = await orm.em.findOneOrFail(User, { name: 'Foo' });
+  expect(user.outer!.inner!.name).toBe('inner');
+  orm.em.assign(user, { outer: null });
+  await orm.em.flush();
+  orm.em.clear();
+
+  const userAfter = await orm.em.findOneOrFail(User, { name: 'Foo' });
+  expect(userAfter.outer).toBeNull();
+});
+
+test('GH #7463 - create after null', async () => {
+  orm.em.create(User, {
+    name: 'Bar',
+    outer: {
+      inner: { name: 'nested' },
+    },
+  });
+  await orm.em.flush();
+  orm.em.clear();
+
+  const user = await orm.em.findOneOrFail(User, { name: 'Bar' });
+  expect(user.outer!.inner!.name).toBe('nested');
+  orm.em.assign(user, { outer: null });
+  await orm.em.flush();
+  orm.em.clear();
+
+  const user2 = await orm.em.findOneOrFail(User, { name: 'Bar' });
+  expect(user2.outer).toBeNull();
+
+  // re-assign and verify it persists correctly
+  orm.em.assign(user2, { outer: { inner: { name: 'new' } } });
+  await orm.em.flush();
+  orm.em.clear();
+
+  const user3 = await orm.em.findOneOrFail(User, { name: 'Bar' });
+  expect(user3.outer!.inner!.name).toBe('new');
+});

--- a/tests/features/embeddables/__snapshots__/GH7463.test.ts.snap
+++ b/tests/features/embeddables/__snapshots__/GH7463.test.ts.snap
@@ -1,0 +1,30 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`GH #7463 - snapshot generator 1`] = `
+"function(entity) {
+  const ret = {};
+  if (typeof entity.id !== 'undefined') {
+    ret.id = entity.id;
+  }
+
+  if (typeof entity.name !== 'undefined') {
+    ret.name = entity.name;
+  }
+
+  if (entity.outer === null) {
+    ret.outer_inner_name = null;
+  }
+  if (entity.outer != null) {
+
+    if (entity.outer.inner === null) {
+      ret.outer_inner_name = null;
+    }
+    if (entity.outer.inner != null) {
+      if (typeof entity.outer.inner.name !== 'undefined') ret.outer_inner_name = clone(entity.outer.inner.name);
+    }
+
+  }
+
+  return ret;
+}"
+`;

--- a/tests/features/embeddables/__snapshots__/embeddable-custom-types.postgres.test.ts.snap
+++ b/tests/features/embeddables/__snapshots__/embeddable-custom-types.postgres.test.ts.snap
@@ -26,7 +26,7 @@ exports[`embedded entities with custom types snapshot generator 1`] = `
 
   if (entity.nested === null) {
     ret.nested_someValue = null;
-    ret.nested_deep = null;
+    ret.nested_deep_someValue = null;
   }
   if (entity.nested != null) {
     if (typeof entity.nested.someValue !== 'undefined') ret.nested_someValue = clone(convertToDatabaseValue_nested_someValue(entity.nested.someValue));

--- a/tests/features/embeddables/__snapshots__/entities-in-embeddables.mongo.test.ts.snap
+++ b/tests/features/embeddables/__snapshots__/entities-in-embeddables.mongo.test.ts.snap
@@ -13,7 +13,12 @@ exports[`embedded entities in mongo diffing 1`] = `
 
   if (entity.profile1 === null) {
     ret.profile1_username = null;
-    ret.profile1_identity = null;
+    ret.profile1_identity_email = null;
+    ret.profile1_identity_meta_foo = null;
+    ret.profile1_identity_meta_bar = null;
+    ret.profile1_identity_meta_source = null;
+    ret.profile1_identity_links = null;
+    ret.profile1_identity_source = null;
     ret.profile1_source = null;
   }
   if (entity.profile1 != null) {
@@ -21,7 +26,9 @@ exports[`embedded entities in mongo diffing 1`] = `
 
     if (entity.profile1.identity === null) {
       ret.profile1_identity_email = null;
-      ret.profile1_identity_meta = null;
+      ret.profile1_identity_meta_foo = null;
+      ret.profile1_identity_meta_bar = null;
+      ret.profile1_identity_meta_source = null;
       ret.profile1_identity_links = null;
       ret.profile1_identity_source = null;
     }

--- a/tests/features/embeddables/__snapshots__/entities-in-embeddables.postgres.test.ts.snap
+++ b/tests/features/embeddables/__snapshots__/entities-in-embeddables.postgres.test.ts.snap
@@ -13,7 +13,12 @@ exports[`embedded entities in postgres diffing 1`] = `
 
   if (entity.profile1 === null) {
     ret.profile1_username = null;
-    ret.profile1_identity = null;
+    ret.profile1_identity_email = null;
+    ret.profile1_identity_meta_foo = null;
+    ret.profile1_identity_meta_bar = null;
+    ret.profile1_identity_meta_source = null;
+    ret.profile1_identity_links = null;
+    ret.profile1_identity_source = null;
     ret.profile1_source = null;
   }
   if (entity.profile1 != null) {
@@ -21,7 +26,9 @@ exports[`embedded entities in postgres diffing 1`] = `
 
     if (entity.profile1.identity === null) {
       ret.profile1_identity_email = null;
-      ret.profile1_identity_meta = null;
+      ret.profile1_identity_meta_foo = null;
+      ret.profile1_identity_meta_bar = null;
+      ret.profile1_identity_meta_source = null;
       ret.profile1_identity_links = null;
       ret.profile1_identity_source = null;
     }

--- a/tests/features/embeddables/__snapshots__/nested-embeddables.mongo.test.ts.snap
+++ b/tests/features/embeddables/__snapshots__/nested-embeddables.mongo.test.ts.snap
@@ -13,14 +13,17 @@ exports[`embedded entities in mongo diffing 1`] = `
 
   if (entity.profile1 === null) {
     ret.profile1_username = null;
-    ret.profile1_identity = null;
+    ret.profile1_identity_email = null;
+    ret.profile1_identity_meta_foo = null;
+    ret.profile1_identity_meta_bar = null;
   }
   if (entity.profile1 != null) {
     if (typeof entity.profile1.username !== 'undefined') ret.profile1_username = clone(entity.profile1.username);
 
     if (entity.profile1.identity === null) {
       ret.profile1_identity_email = null;
-      ret.profile1_identity_meta = null;
+      ret.profile1_identity_meta_foo = null;
+      ret.profile1_identity_meta_bar = null;
     }
     if (entity.profile1.identity != null) {
       if (typeof entity.profile1.identity.email !== 'undefined') ret.profile1_identity_email = clone(entity.profile1.identity.email);

--- a/tests/features/embeddables/__snapshots__/nested-embeddables.postgres.test.ts.snap
+++ b/tests/features/embeddables/__snapshots__/nested-embeddables.postgres.test.ts.snap
@@ -13,14 +13,18 @@ exports[`embedded entities in postgres diffing 1`] = `
 
   if (entity.profile1 === null) {
     ret.profile1_username = null;
-    ret.profile1_identity = null;
+    ret.profile1_identity_email = null;
+    ret.profile1_identity_meta_foo = null;
+    ret.profile1_identity_meta_bar = null;
+    ret.profile1_identity_links = null;
   }
   if (entity.profile1 != null) {
     if (typeof entity.profile1.username !== 'undefined') ret.profile1_username = clone(entity.profile1.username);
 
     if (entity.profile1.identity === null) {
       ret.profile1_identity_email = null;
-      ret.profile1_identity_meta = null;
+      ret.profile1_identity_meta_foo = null;
+      ret.profile1_identity_meta_bar = null;
       ret.profile1_identity_links = null;
     }
     if (entity.profile1.identity != null) {

--- a/tests/features/embeddables/__snapshots__/polymorphic-embedded-entities.sqlite.test.ts.snap
+++ b/tests/features/embeddables/__snapshots__/polymorphic-embedded-entities.sqlite.test.ts.snap
@@ -602,7 +602,8 @@ exports[`polymorphic embeddables in sqlite diffing 2`] = `
     ret.pet_type = null;
     ret.pet_name = null;
     ret.pet_canMeow = null;
-    ret.pet_food = null;
+    ret.pet_food_cats = null;
+    ret.pet_food_mice = null;
   }
   if (entity.pet != null) {
     if (typeof entity.pet.canBark !== 'undefined') ret.pet_canBark = clone(entity.pet.canBark);


### PR DESCRIPTION
## Summary

- When a parent inline embeddable was set to `null`, the snapshot generator only emitted null assignments for direct children. If a child was itself a nested inline embeddable, it produced an invalid virtual column name (e.g. `ret.outer_inner = null`) instead of recursively expanding to the actual leaf columns (e.g. `ret.outer_inner_name = null`).
- Extracted the null-line generation into a recursive `getInlineEmbeddedNullLines` method in `EntityComparator` that properly expands nested inline embeddables to their leaf columns, mirroring what the non-null branch already does.
- Regression introduced in d0913f196 (fix for #6966).

Closes #7463

🤖 Generated with [Claude Code](https://claude.com/claude-code)