### PR TITLE
fix(knex): use pivot entity schema for wildcard check in M:N joins

### DIFF
--- a/packages/knex/src/query/QueryBuilderHelper.ts
+++ b/packages/knex/src/query/QueryBuilderHelper.ts
@@ -221,7 +221,7 @@ export class QueryBuilderHelper {
         primaryKeys: prop.referencedColumnNames,
         cond: {},
         table: pivotMeta.tableName,
-        schema: prop.targetMeta?.schema === '*' ? '*' : this.driver.getSchemaName(pivotMeta, { schema }),
+        schema: pivotMeta.schema === '*' ? '*' : this.driver.getSchemaName(pivotMeta, { schema }),
         path: path.endsWith('[pivot]') ? path : `${path}[pivot]`,
       } as JoinOptions,
     };

--- a/tests/issues/GHx37.test.ts
+++ b/tests/issues/GHx37.test.ts
@@ -1,0 +1,62 @@
+import { Collection, Entity, ManyToMany, MikroORM, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/postgresql';
+
+@Entity({ schema: '*' })
+class Role {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ length: 128 })
+  name!: string;
+
+  @ManyToMany(() => Permission, p => p.roles, { owner: true })
+  permissions = new Collection<Permission>(this);
+
+}
+
+@Entity({ schema: 'permissions' })
+class Permission {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ length: 128 })
+  name!: string;
+
+  @ManyToMany(() => Role, r => r.permissions)
+  roles = new Collection<Role>(this);
+
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    metadataProvider: ReflectMetadataProvider,
+    entities: [Role, Permission],
+    dbName: 'mikro_orm_test_ghx37',
+  });
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+test('GHx37 - pivot table should use runtime schema when owner has wildcard and target has fixed schema', async () => {
+  const em = orm.em.fork();
+
+  // query builder with explicit schema should propagate it to the pivot table
+  const sql = em
+    .createQueryBuilder(Role, 'r')
+    .select('r.*')
+    .leftJoinAndSelect('r.permissions', 'p')
+    .where({ id: 1 })
+    .withSchema('tenant_1')
+    .getFormattedQuery();
+
+  // the pivot table must use the runtime schema (tenant_1), not default/public
+  expect(sql).toContain('"tenant_1"."role"');
+  expect(sql).toContain('"tenant_1"."role_permissions"');
+  // the target entity has a fixed schema, so it should keep its own
+  expect(sql).toContain('"permissions"."permission"');
+});


### PR DESCRIPTION
## Summary
Backport of #7466 to 6.x.

- When the M:N owner has `schema: '*'` and the target has a fixed schema, the pivot table join used `prop.targetMeta.schema` for the wildcard check instead of `pivotMeta.schema`
- This caused `withSchema()` to be ignored for the pivot table
- One-line fix: check `pivotMeta.schema === '*'` instead of `prop.targetMeta?.schema === '*'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)