### PR TITLE
feat(migrations): add migration:rollup command

### DIFF
--- a/docs/docs/migrations.md
+++ b/docs/docs/migrations.md
@@ -250,6 +250,7 @@ npx mikro-orm migration:pending  # List all pending migrations
 npx mikro-orm migration:fresh    # Drop the database and migrate up to the latest version
 npx mikro-orm migration:log      # Mark a migration as executed without running it
 npx mikro-orm migration:unlog    # Remove a migration from the executed list without reverting it
+npx mikro-orm migration:rollup   # Combine all executed migrations into a single migration
 ```
 
 > To create blank migration file, you can use `npx mikro-orm migration:create --blank`.
@@ -272,6 +273,8 @@ npx mikro-orm migration:fresh --seed=UsersSeeder  # seed the database with the U
 ```
 
 > You can specify the default database seeder in the orm config with the key `config.seeder.defaultSeeder`
+
+The `migration:rollup` command combines all executed migrations into a single migration file. This is useful for cleaning up a large number of migrations that have accumulated over time. It works by extracting the source code from each migration's `up()` and `down()` methods and concatenating them into a new migration file — no database interaction required (other than updating the migration log), so there is no risk of data loss.
 
 ## Using the Migrator programmatically
 
@@ -296,6 +299,8 @@ import { Migrator } from '@mikro-orm/migrations';
   await orm.migrator.down('name'); // runs only given migration, down
   await orm.migrator.down({ to: 'down-to-name' }); // runs migrations down to given version
   await orm.migrator.down({ to: 0 }); // migrates down to the first version
+  await orm.migrator.rollup(); // combines all executed migrations into one
+  await orm.migrator.rollup(['Migration1', 'Migration2']); // combines specific migrations
 
   await orm.close(true);
 })();

--- a/packages/cli/src/CLIConfigurator.ts
+++ b/packages/cli/src/CLIConfigurator.ts
@@ -88,5 +88,6 @@ export async function configure(): Promise<Argv<{ config: string[] | undefined; 
     .command(MigrationCommandFactory.create('fresh'))
     .command(MigrationCommandFactory.create('log'))
     .command(MigrationCommandFactory.create('unlog'))
+    .command(MigrationCommandFactory.create('rollup'))
     .command(new DebugCommand());
 }

--- a/packages/cli/src/commands/MigrationCommandFactory.ts
+++ b/packages/cli/src/commands/MigrationCommandFactory.ts
@@ -23,6 +23,7 @@ export class MigrationCommandFactory {
     fresh: 'Clear the database and rerun all migrations',
     log: 'Mark a migration as executed without running it',
     unlog: 'Remove a migration from the executed list without reverting it',
+    rollup: 'Combine multiple migrations into a single migration',
   };
 
   static create<const T extends MigratorMethod>(command: T) {
@@ -148,6 +149,9 @@ export class MigrationCommandFactory {
       case 'unlog':
         await this.handleLogUnlogCommand(args, orm.migrator, method);
         break;
+      case 'rollup':
+        await this.handleRollupCommand(orm.migrator);
+        break;
     }
 
     await orm.close(true);
@@ -269,6 +273,11 @@ export class MigrationCommandFactory {
     CLIHelper.dump(colors.green(`Successfully ${action} migration '${args.name}'`));
   }
 
+  private static async handleRollupCommand(migrator: IMigrator): Promise<void> {
+    const ret = await migrator.rollup();
+    CLIHelper.dump(colors.green(`${ret.fileName} successfully created (rollup)`));
+  }
+
   private static getUpDownOptions(flags: CliUpDownOptions): MigrateOptions {
     if (!flags.to && !flags.from && flags.only) {
       return { migrations: flags.only.split(/[, ]+/) };
@@ -330,6 +339,7 @@ type MigrationOptionsMap = {
   fresh: MigratorFreshOptions;
   log: MigratorLogUnlogOptions;
   unlog: MigratorLogUnlogOptions;
+  rollup: BaseArgs;
 };
 type MigratorMethod = keyof MigrationOptionsMap;
 type Opts = BaseArgs & MigratorCreateOptions & CliUpDownOptions & MigratorFreshOptions & MigratorLogUnlogOptions;

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -1747,6 +1747,12 @@ export interface IMigrator {
   down(options?: string | string[] | Omit<MigrateOptions, 'from'>): Promise<MigrationInfo[]>;
 
   /**
+   * Combines multiple executed migrations into a single migration file.
+   * Concatenates source code without touching the database schema.
+   */
+  rollup(migrations?: string[]): Promise<MigrationResult>;
+
+  /**
    * Registers event handler.
    */
   on(event: MigratorEvent, listener: (event: MigrationInfo) => MaybePromise<void>): IMigrator;

--- a/packages/core/src/utils/AbstractMigrator.ts
+++ b/packages/core/src/utils/AbstractMigrator.ts
@@ -7,6 +7,7 @@ import type {
   MaybePromise,
   Migration,
   MigrationInfo,
+  MigrationResult,
   MigrationRow,
   MigratorEvent,
 } from '../typings.js';
@@ -123,6 +124,255 @@ export abstract class AbstractMigrator<D extends IDatabaseDriver> implements IMi
    */
   async down(options?: string | string[] | Omit<MigrateOptions, 'from'>): Promise<MigrationInfo[]> {
     return this.runMigrations('down', options);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  async rollup(migrations?: string[]): Promise<MigrationResult> {
+    await this.init();
+    const { fs } = await import('@mikro-orm/core/fs-utils');
+
+    const all = await this.discoverMigrations();
+    const executedSet = new Set(await this.storage.executed());
+
+    let toRollup: RunnableMigration[];
+
+    if (migrations && migrations.length > 0) {
+      const requested = new Set(migrations.map(m => this.getMigrationFilename(m)));
+      toRollup = all.filter(m => requested.has(m.name));
+
+      const found = new Set(toRollup.map(m => m.name));
+      const notFound = [...requested].filter(name => !found.has(name));
+
+      if (notFound.length > 0) {
+        throw new Error(`Migrations not found: ${notFound.join(', ')}`);
+      }
+
+      const notExecuted = toRollup.filter(m => !executedSet.has(m.name));
+
+      if (notExecuted.length > 0) {
+        throw new Error(
+          `Cannot roll up migrations that have not been executed: ${notExecuted.map(m => m.name).join(', ')}`,
+        );
+      }
+    } else {
+      toRollup = all.filter(m => executedSet.has(m.name));
+    }
+
+    if (toRollup.length < 2) {
+      throw new Error('At least 2 executed migrations are required for rollup');
+    }
+
+    const withoutPath = toRollup.filter(m => !m.path);
+
+    if (withoutPath.length > 0) {
+      throw new Error(
+        `Cannot roll up migrations without file paths (class-based migrations): ${withoutPath.map(m => m.name).join(', ')}`,
+      );
+    }
+
+    const upBodies: string[] = [];
+    const downBodies: string[] = [];
+    const placeholder = `__mikro_orm_rollup_${Date.now()}__`;
+
+    for (const migration of toRollup) {
+      const source = await fs.readFile(migration.path!);
+      const upBody = this.extractMethodBody(source, 'up');
+      const downBody = this.extractMethodBody(source, 'down');
+
+      if (upBody) {
+        upBodies.push(`    // --- merged from ${migration.name} ---\n${upBody}`);
+      }
+
+      if (downBody) {
+        downBodies.unshift(`    // --- merged from ${migration.name} ---\n${downBody}`);
+      }
+    }
+
+    const diff = {
+      up: [placeholder],
+      down: downBodies.length > 0 ? [placeholder] : [],
+    };
+    const [templateCode, fileName] = await this.generator.generate(diff);
+    const placeholderRe = new RegExp(`^.*${placeholder}.*$`, 'm');
+    let code = templateCode.replace(placeholderRe, upBodies.join('\n'));
+
+    if (downBodies.length > 0) {
+      code = code.replace(placeholderRe, downBodies.join('\n'));
+    }
+
+    await fs.writeFile(fs.normalizePath(this.absolutePath, fileName), code, { flush: true });
+
+    const updateStorage = async () => {
+      for (const migration of toRollup) {
+        await this.storage.unlogMigration({ name: migration.name });
+      }
+
+      await this.storage.logMigration({ name: fileName.replace(/\.[jt]s$/, '') });
+    };
+
+    if (this.options.transactional) {
+      await this.driver.getConnection().transactional(async trx => {
+        this.storage.setMasterMigration(trx);
+
+        try {
+          await updateStorage();
+        } finally {
+          this.storage.unsetMasterMigration();
+        }
+      });
+    } else {
+      await updateStorage();
+    }
+
+    await Promise.all(toRollup.map(migration => fs.unlink(migration.path!)));
+
+    return { fileName, code, diff: { up: [], down: [] } };
+  }
+
+  /**
+   * Extracts the body of a method from migration source code using brace counting.
+   * Returns the raw lines between the opening and closing braces, or empty string if not found.
+   * @internal
+   */
+  private extractMethodBody(source: string, methodName: string): string {
+    const lines = source.split('\n');
+    // match method declarations, not occurrences in comments/strings — require preceding whitespace or keyword
+    const methodPattern = new RegExp(`^\\s+(?:override\\s+|async\\s+)*${methodName}\\s*\\(`);
+    let methodLine = -1;
+
+    for (let i = 0; i < lines.length; i++) {
+      if (methodPattern.test(lines[i])) {
+        methodLine = i;
+        break;
+      }
+    }
+
+    if (methodLine === -1) {
+      return '';
+    }
+
+    let braceCount = 0;
+    let bodyStart = -1;
+    let bodyEnd = -1;
+    let bodyStartCol = -1;
+    let bodyEndCol = -1;
+    let inBacktick = false;
+    let inBlockComment = false;
+    // stack tracks brace depth at which each template expression `${...}` was entered
+    const templateExprStack: number[] = [];
+
+    for (let i = methodLine; i < lines.length; i++) {
+      const line = lines[i];
+
+      for (let j = 0; j < line.length; j++) {
+        // handle multi-line block comments
+        if (inBlockComment) {
+          if (line[j] === '*' && j + 1 < line.length && line[j + 1] === '/') {
+            inBlockComment = false;
+            j++;
+          }
+
+          continue;
+        }
+
+        // handle multi-line template literals
+        if (inBacktick) {
+          if (line[j] === '\\') {
+            j++;
+          } else if (line[j] === '`') {
+            inBacktick = false;
+          } else if (line[j] === '$' && j + 1 < line.length && line[j + 1] === '{') {
+            // entering template expression — resume brace counting
+            templateExprStack.push(braceCount);
+            inBacktick = false;
+            j++; // skip the {
+            braceCount++;
+          }
+
+          continue;
+        }
+
+        const ch = line[j];
+
+        // single/double quoted strings (single-line only)
+        if (ch === "'" || ch === '"') {
+          const quote = ch;
+          j++;
+
+          while (j < line.length) {
+            if (line[j] === '\\') {
+              j++;
+            } else if (line[j] === quote) {
+              break;
+            }
+
+            j++;
+          }
+
+          continue;
+        }
+
+        // template literal start
+        if (ch === '`') {
+          inBacktick = true;
+          continue;
+        }
+
+        // single-line comment
+        if (ch === '/' && j + 1 < line.length && line[j + 1] === '/') {
+          break;
+        }
+
+        // block comment start
+        if (ch === '/' && j + 1 < line.length && line[j + 1] === '*') {
+          inBlockComment = true;
+          j++;
+          continue;
+        }
+
+        if (ch === '{') {
+          if (braceCount === 0) {
+            bodyStart = i;
+            bodyStartCol = j + 1;
+          }
+
+          braceCount++;
+        } else if (ch === '}') {
+          braceCount--;
+
+          // closing a template expression — re-enter backtick mode
+          if (templateExprStack.length > 0 && braceCount === templateExprStack[templateExprStack.length - 1]) {
+            templateExprStack.pop();
+            inBacktick = true;
+            continue;
+          }
+
+          if (braceCount === 0) {
+            bodyEnd = i;
+            bodyEndCol = j;
+            break;
+          }
+        }
+      }
+
+      if (bodyEnd !== -1) {
+        break;
+      }
+    }
+
+    if (bodyStart === -1 || bodyEnd === -1) {
+      return '';
+    }
+
+    // single-line method body: extract content between braces on the same line
+    if (bodyStart === bodyEnd) {
+      const content = lines[bodyStart].slice(bodyStartCol, bodyEndCol).trim();
+      return content ? `    ${content}` : '';
+    }
+
+    return lines.slice(bodyStart + 1, bodyEnd).join('\n');
   }
 
   abstract getStorage(): IMigratorStorage;

--- a/packages/core/src/utils/fs-utils.ts
+++ b/packages/core/src/utils/fs-utils.ts
@@ -1,5 +1,5 @@
 import { existsSync, globSync as nodeGlobSync, mkdirSync, readFileSync, realpathSync, statSync } from 'node:fs';
-import { writeFile as nodeWriteFile } from 'node:fs/promises';
+import { readFile as nodeReadFile, unlink as nodeUnlink, writeFile as nodeWriteFile } from 'node:fs/promises';
 import { isAbsolute, join, normalize, relative } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { Utils } from './Utils.js';
@@ -27,7 +27,9 @@ export interface FsUtils {
   normalizePath(...parts: string[]): string;
   relativePath(path: string, relativeTo: string): string;
   absolutePath(path: string, baseDir?: string): string;
+  readFile(path: string): Promise<string>;
   writeFile(path: string, data: string, options?: Record<string, any>): Promise<void>;
+  unlink(path: string): Promise<void>;
   dynamicImport<T = any>(id: string): Promise<T>;
 }
 
@@ -245,8 +247,16 @@ export const fs: FsUtils = {
     return this.normalizePath(path);
   },
 
+  async readFile(path: string): Promise<string> {
+    return nodeReadFile(path, 'utf-8');
+  },
+
   async writeFile(path: string, data: string, options?: Record<string, any>): Promise<void> {
     await nodeWriteFile(path, data, options);
+  },
+
+  async unlink(path: string): Promise<void> {
+    await nodeUnlink(path);
   },
 
   async dynamicImport<T = any>(id: string): Promise<T> {

--- a/tests/features/cli/CLIHelper.test.ts
+++ b/tests/features/cli/CLIHelper.test.ts
@@ -761,6 +761,7 @@ Maybe you want to check, or regenerate your yarn.lock or package-lock.json file?
       'migration:fresh',
       'migration:log',
       'migration:unlog',
+      'migration:rollup',
       'debug',
     ]);
   });

--- a/tests/features/cli/RollupMigrationCommand.test.ts
+++ b/tests/features/cli/RollupMigrationCommand.test.ts
@@ -1,0 +1,42 @@
+process.env.FORCE_COLOR = '0';
+
+import { Migrator } from '@mikro-orm/migrations';
+import { MikroORM } from '@mikro-orm/core';
+import { SqliteDriver } from '@mikro-orm/sqlite';
+import { CLIHelper } from '@mikro-orm/cli';
+import { MigrationCommandFactory } from '../../../packages/cli/src/commands/MigrationCommandFactory.js';
+import { initORMSqlite } from '../../bootstrap.js';
+
+describe('RollupMigrationCommand', () => {
+  let orm: MikroORM<SqliteDriver>;
+
+  beforeAll(async () => {
+    orm = await initORMSqlite();
+    const getORMMock = vi.spyOn(CLIHelper, 'getORM');
+    getORMMock.mockResolvedValue(orm);
+  });
+
+  afterAll(async () => orm.close(true));
+
+  test('builder', async () => {
+    const cmd = MigrationCommandFactory.create('rollup');
+    const args = { option: vi.fn() };
+    cmd.builder(args as any);
+  });
+
+  test('handler', async () => {
+    const closeSpy = vi.spyOn(MikroORM.prototype, 'close');
+    vi.spyOn(CLIHelper, 'showHelp').mockImplementation(() => void 0);
+    const rollupMock = vi.spyOn(Migrator.prototype, 'rollup');
+    rollupMock.mockResolvedValue({ fileName: 'Migration20250401000000.ts', code: '...', diff: { up: [], down: [] } });
+    const dumpMock = vi.spyOn(CLIHelper, 'dump');
+    dumpMock.mockImplementation(() => void 0);
+
+    const cmd = MigrationCommandFactory.create('rollup');
+
+    await expect(cmd.handler({} as any)).resolves.toBeUndefined();
+    expect(rollupMock).toHaveBeenCalledTimes(1);
+    expect(closeSpy).toHaveBeenCalledTimes(1);
+    expect(dumpMock).toHaveBeenLastCalledWith('Migration20250401000000.ts successfully created (rollup)');
+  });
+});

--- a/tests/features/migrations/Migrator.mongo.test.ts
+++ b/tests/features/migrations/Migrator.mongo.test.ts
@@ -371,3 +371,159 @@ describe('Migrator (mongo) - with explicit migrations class only (#6099)', () =>
     await orm.close();
   });
 });
+
+describe('Migrator (mongo) - rollup', () => {
+  let orm: MikroORM<MongoDriver>;
+  const migrationsPath = process.cwd() + '/temp/migrations-mongo-rollup';
+
+  beforeAll(async () => {
+    orm = await initORMMongo(true, {
+      migrations: { path: migrationsPath },
+    });
+  });
+
+  beforeEach(async () => {
+    const { rm: rmdir } = await import('node:fs/promises');
+    await rmdir(migrationsPath, { recursive: true, force: true });
+    const storage = orm.migrator.getStorage();
+    const executed = await storage.executed();
+    for (const name of executed) {
+      await storage.unlogMigration({ name });
+    }
+    orm.config.resetServiceCache();
+  });
+
+  afterAll(async () => {
+    await orm.close();
+  });
+
+  test('rollup combines mongo migrations', async () => {
+    const dateMock = vi.spyOn(Date.prototype, 'toISOString');
+    dateMock.mockReturnValueOnce('2020-01-01T00:00:00.000Z');
+    dateMock.mockReturnValueOnce('2020-02-01T00:00:00.000Z');
+
+    const migrator = orm.migrator;
+    const m1 = await migrator.create(migrationsPath);
+    const m2 = await migrator.create(migrationsPath);
+
+    // overwrite with known content
+    const { writeFile } = await import('node:fs/promises');
+    const m1Content = `import { Migration } from '@mikro-orm/migrations-mongodb';\n\nexport class ${m1.fileName.replace('.ts', '')} extends Migration {\n\n  async up(): Promise<void> {\n    await this.getCollection('test').insertOne({ a: 1 });\n  }\n\n  async down(): Promise<void> {\n    await this.getCollection('test').deleteOne({ a: 1 });\n  }\n\n}\n`;
+    const m2Content = `import { Migration } from '@mikro-orm/migrations-mongodb';\n\nexport class ${m2.fileName.replace('.ts', '')} extends Migration {\n\n  async up(): Promise<void> {\n    await this.getCollection('test').insertOne({ b: 2 });\n  }\n\n  async down(): Promise<void> {\n    await this.getCollection('test').deleteOne({ b: 2 });\n  }\n\n}\n`;
+
+    await writeFile(migrationsPath + '/' + m1.fileName, m1Content);
+    await writeFile(migrationsPath + '/' + m2.fileName, m2Content);
+
+    const executeMock = vi.spyOn(Migrator.prototype as any, 'executeMigrations');
+    executeMock.mockResolvedValue([]);
+
+    // manually log as executed
+    const storage = migrator.getStorage();
+    await storage.logMigration({ name: m1.fileName });
+    await storage.logMigration({ name: m2.fileName });
+
+    dateMock.mockReturnValueOnce('2020-03-01T00:00:00.000Z');
+    const result = await migrator.rollup();
+
+    expect(result.fileName).toMatch(/\.ts$/);
+    expect(result.code).toContain('merged from');
+    expect(result.code).toContain('insertOne({ a: 1 })');
+    expect(result.code).toContain('insertOne({ b: 2 })');
+    expect(result.code).toContain('deleteOne({ a: 1 })');
+    expect(result.code).toContain('deleteOne({ b: 2 })');
+    expect(result.code).toContain('@mikro-orm/migrations-mongodb');
+
+    // verify down is in reverse
+    const downSection = result.code.slice(result.code.indexOf('down()'));
+    const downIdx1 = downSection.indexOf('deleteOne({ b: 2 })');
+    const downIdx2 = downSection.indexOf('deleteOne({ a: 1 })');
+    expect(downIdx1).toBeLessThan(downIdx2);
+
+    const { existsSync } = await import('node:fs');
+    expect(existsSync(migrationsPath + '/' + m1.fileName)).toBe(false);
+    expect(existsSync(migrationsPath + '/' + m2.fileName)).toBe(false);
+    expect(existsSync(migrationsPath + '/' + result.fileName)).toBe(true);
+
+    executeMock.mockRestore();
+    dateMock.mockRestore();
+  });
+
+  test('rollup throws with less than 2 mongo migrations', async () => {
+    const dateMock = vi.spyOn(Date.prototype, 'toISOString');
+    dateMock.mockReturnValue('2020-01-01T00:00:00.000Z');
+
+    const migrator = orm.migrator;
+    const m1 = await migrator.create(migrationsPath);
+
+    const storage = migrator.getStorage();
+    await storage.logMigration({ name: m1.fileName });
+
+    await expect(migrator.rollup()).rejects.toThrow('At least 2 executed migrations are required for rollup');
+
+    dateMock.mockRestore();
+  });
+});
+
+describe('Migrator (mongo) - rollup coverage', () => {
+  test('mongo JS generator rollup', async () => {
+    const orm = await initORMMongo(true, {
+      migrations: {
+        path: process.cwd() + '/temp/migrations-mongo-rollup-js',
+        emit: 'js',
+      },
+    });
+
+    const dateMock = vi.spyOn(Date.prototype, 'toISOString');
+    dateMock.mockReturnValueOnce('2020-01-01T00:00:00.000Z');
+    dateMock.mockReturnValueOnce('2020-02-01T00:00:00.000Z');
+
+    const migrator = orm.migrator;
+    const m1 = await migrator.create();
+    const m2 = await migrator.create();
+
+    const storage = migrator.getStorage();
+    await storage.logMigration({ name: m1.fileName });
+    await storage.logMigration({ name: m2.fileName });
+
+    dateMock.mockReturnValueOnce('2020-03-01T00:00:00.000Z');
+    const result = await migrator.rollup();
+
+    expect(result.fileName).toMatch(/\.js$/);
+    expect(result.code).toContain("require('@mikro-orm/migrations-mongodb')");
+    expect(result.code).toContain('async up()');
+
+    const { rm: rmdir } = await import('node:fs/promises');
+    await rmdir(process.cwd() + '/temp/migrations-mongo-rollup-js', { recursive: true, force: true });
+    dateMock.mockRestore();
+    await orm.close();
+  });
+
+  test('mongo rollup without down methods', async () => {
+    const orm = await initORMMongo(true, {
+      migrations: { path: process.cwd() + '/temp/migrations-mongo-rollup-nodown' },
+    });
+
+    const dateMock = vi.spyOn(Date.prototype, 'toISOString');
+    dateMock.mockReturnValueOnce('2020-01-01T00:00:00.000Z');
+    dateMock.mockReturnValueOnce('2020-02-01T00:00:00.000Z');
+
+    const migrator = orm.migrator;
+    const m1 = await migrator.create();
+    const m2 = await migrator.create();
+
+    // blank migrations have no down() — covers the false branch
+    const storage = migrator.getStorage();
+    await storage.logMigration({ name: m1.fileName });
+    await storage.logMigration({ name: m2.fileName });
+
+    dateMock.mockReturnValueOnce('2020-03-01T00:00:00.000Z');
+    const result = await migrator.rollup();
+
+    expect(result.code).not.toContain('down()');
+
+    const { rm: rmdir } = await import('node:fs/promises');
+    await rmdir(process.cwd() + '/temp/migrations-mongo-rollup-nodown', { recursive: true, force: true });
+    dateMock.mockRestore();
+    await orm.close();
+  });
+});

--- a/tests/features/migrations/Migrator.test.ts
+++ b/tests/features/migrations/Migrator.test.ts
@@ -2,7 +2,7 @@ process.env.FORCE_COLOR = '0';
 import { MetadataStorage, MigrationInfo, MikroORM, raw, SimpleLogger } from '@mikro-orm/core';
 import { Migration, MigrationStorage, Migrator } from '@mikro-orm/migrations';
 import { DatabaseTable, MySqlDriver, DatabaseSchema, SchemaGenerator } from '@mikro-orm/mysql';
-import { rm } from 'node:fs/promises';
+import { rm, writeFile } from 'node:fs/promises';
 import { initORMMySql, mockLogger } from '../../bootstrap.js';
 
 class MigrationTest1 extends Migration {
@@ -631,5 +631,594 @@ describe('Migrator - with explicit migrations class only (#6099)', () => {
         .replace(/ `trx\d+/, 'trx_xx');
     });
     expect(calls).toMatchSnapshot('migrator-migrations-list');
+  });
+});
+
+describe('Migrator - rollup', () => {
+  let orm: MikroORM<MySqlDriver>;
+  const migrationsPath = process.cwd() + '/temp/migrations-rollup';
+
+  beforeAll(async () => {
+    orm = await initORMMySql(
+      'mysql',
+      {
+        dbName: 'mikro_orm_test_migrations',
+        migrations: { path: migrationsPath, snapshot: false },
+        loggerFactory: SimpleLogger.create,
+      },
+      true,
+    );
+  });
+
+  beforeEach(async () => {
+    await rm(migrationsPath, { recursive: true, force: true });
+    await orm.schema.dropTableIfExists(orm.config.get('migrations').tableName!);
+    orm.config.resetServiceCache();
+  });
+
+  afterAll(async () => {
+    await orm.schema.dropDatabase();
+    await orm.close(true);
+  });
+
+  test('rollup combines multiple migrations into one', async () => {
+    const dateMock = vi.spyOn(Date.prototype, 'toISOString');
+    dateMock.mockReturnValueOnce('2020-01-01T00:00:00.000Z');
+    dateMock.mockReturnValueOnce('2020-02-01T00:00:00.000Z');
+    dateMock.mockReturnValueOnce('2020-03-01T00:00:00.000Z');
+
+    const migrator = new Migrator(orm.em);
+
+    const m1 = await migrator.create(migrationsPath, true);
+    const m2 = await migrator.create(migrationsPath, true);
+    const m3 = await migrator.create(migrationsPath, true);
+
+    // overwrite files with known content
+    const makeMigration = (name: string, upSql: string, downSql: string) =>
+      `import { Migration } from '@mikro-orm/migrations';\n\nexport class ${name} extends Migration {\n\n  override up(): void | Promise<void> {\n    this.addSql(\`${upSql}\`);\n  }\n\n  override down(): void | Promise<void> {\n    this.addSql(\`${downSql}\`);\n  }\n\n}\n`;
+
+    await writeFile(
+      migrationsPath + '/' + m1.fileName,
+      makeMigration(m1.fileName.replace('.ts', ''), 'select 1', 'select -1'),
+    );
+    await writeFile(
+      migrationsPath + '/' + m2.fileName,
+      makeMigration(m2.fileName.replace('.ts', ''), 'select 2', 'select -2'),
+    );
+    await writeFile(
+      migrationsPath + '/' + m3.fileName,
+      makeMigration(m3.fileName.replace('.ts', ''), 'select 3', 'select -3'),
+    );
+
+    await migrator.up();
+
+    const executedBefore = await migrator.getStorage().executed();
+    expect(executedBefore).toHaveLength(3);
+
+    dateMock.mockReturnValueOnce('2020-04-01T00:00:00.000Z');
+    const result = await migrator.rollup();
+
+    expect(result.fileName).toMatch(/\.ts$/);
+    expect(result.code).toContain('merged from');
+    expect(result.code).toContain('select 1');
+    expect(result.code).toContain('select 2');
+    expect(result.code).toContain('select 3');
+    expect(result.code).toContain('select -1');
+    expect(result.code).toContain('select -2');
+    expect(result.code).toContain('select -3');
+
+    // verify up bodies are in chronological order
+    const upIdx1 = result.code.indexOf('select 1');
+    const upIdx2 = result.code.indexOf('select 2');
+    const upIdx3 = result.code.indexOf('select 3');
+    expect(upIdx1).toBeLessThan(upIdx2);
+    expect(upIdx2).toBeLessThan(upIdx3);
+
+    // verify down bodies are in reverse order
+    const downSection = result.code.slice(result.code.indexOf('down()'));
+    const downIdx1 = downSection.indexOf('select -3');
+    const downIdx2 = downSection.indexOf('select -2');
+    const downIdx3 = downSection.indexOf('select -1');
+    expect(downIdx1).toBeLessThan(downIdx2);
+    expect(downIdx2).toBeLessThan(downIdx3);
+
+    // verify old files are deleted
+    const { existsSync } = await import('node:fs');
+    expect(existsSync(migrationsPath + '/' + m1.fileName)).toBe(false);
+    expect(existsSync(migrationsPath + '/' + m2.fileName)).toBe(false);
+    expect(existsSync(migrationsPath + '/' + m3.fileName)).toBe(false);
+
+    // verify new file exists
+    expect(existsSync(migrationsPath + '/' + result.fileName)).toBe(true);
+
+    // verify storage: old entries removed, new one added
+    const executedAfter = await migrator.getStorage().executed();
+    expect(executedAfter).toHaveLength(1);
+    expect(executedAfter[0]).toBe(result.fileName.replace('.ts', ''));
+
+    dateMock.mockRestore();
+  });
+
+  test('rollup with specific migrations', async () => {
+    const dateMock = vi.spyOn(Date.prototype, 'toISOString');
+    dateMock.mockReturnValueOnce('2020-01-01T00:00:00.000Z');
+    dateMock.mockReturnValueOnce('2020-02-01T00:00:00.000Z');
+    dateMock.mockReturnValueOnce('2020-03-01T00:00:00.000Z');
+
+    const migrator = new Migrator(orm.em);
+
+    const m1 = await migrator.create(migrationsPath, true);
+    const m2 = await migrator.create(migrationsPath, true);
+    const m3 = await migrator.create(migrationsPath, true);
+
+    await migrator.up();
+
+    dateMock.mockReturnValueOnce('2020-04-01T00:00:00.000Z');
+    const result = await migrator.rollup([m1.fileName, m2.fileName]);
+
+    const executedAfter = await migrator.getStorage().executed();
+    expect(executedAfter).toHaveLength(2); // rollup + m3
+
+    const { existsSync } = await import('node:fs');
+    expect(existsSync(migrationsPath + '/' + m3.fileName)).toBe(true);
+
+    dateMock.mockRestore();
+  });
+
+  test('rollup throws with less than 2 migrations', async () => {
+    const dateMock = vi.spyOn(Date.prototype, 'toISOString');
+    dateMock.mockReturnValue('2020-01-01T00:00:00.000Z');
+
+    const migrator = new Migrator(orm.em);
+    await migrator.create(migrationsPath, true);
+    await migrator.up();
+
+    await expect(migrator.rollup()).rejects.toThrow('At least 2 executed migrations are required for rollup');
+
+    dateMock.mockRestore();
+  });
+
+  test('rollup throws when migrations not executed', async () => {
+    const dateMock = vi.spyOn(Date.prototype, 'toISOString');
+    dateMock.mockReturnValueOnce('2020-01-01T00:00:00.000Z');
+    dateMock.mockReturnValueOnce('2020-02-01T00:00:00.000Z');
+
+    const migrator = new Migrator(orm.em);
+    const m1 = await migrator.create(migrationsPath, true);
+    const m2 = await migrator.create(migrationsPath, true);
+
+    await expect(migrator.rollup([m1.fileName, m2.fileName])).rejects.toThrow(
+      'Cannot roll up migrations that have not been executed',
+    );
+
+    dateMock.mockRestore();
+  });
+
+  test('rollup throws for class-based migrations', async () => {
+    const orm2 = await initORMMySql(
+      'mysql',
+      {
+        dbName: 'mikro_orm_test_migrations',
+        migrations: {
+          migrationsList: [
+            { name: 'test1.ts', class: MigrationTest1 },
+            { name: 'test2.ts', class: MigrationTest1 },
+          ],
+        },
+      },
+      true,
+    );
+
+    const migrator = new Migrator(orm2.em);
+    await migrator.up();
+
+    await expect(migrator.rollup()).rejects.toThrow('Cannot roll up migrations without file paths');
+
+    await orm2.schema.dropDatabase();
+    await orm2.close(true);
+  });
+
+  test('rollup handles migrations without down method', async () => {
+    const dateMock = vi.spyOn(Date.prototype, 'toISOString');
+    dateMock.mockReturnValueOnce('2020-01-01T00:00:00.000Z');
+    dateMock.mockReturnValueOnce('2020-02-01T00:00:00.000Z');
+
+    const migrator = new Migrator(orm.em);
+    const m1 = await migrator.create(migrationsPath, true);
+    const m2 = await migrator.create(migrationsPath, true);
+
+    const makeUpOnly = (name: string, upSql: string) =>
+      `import { Migration } from '@mikro-orm/migrations';\n\nexport class ${name} extends Migration {\n\n  override up(): void | Promise<void> {\n    this.addSql(\`${upSql}\`);\n  }\n\n}\n`;
+
+    await writeFile(migrationsPath + '/' + m1.fileName, makeUpOnly(m1.fileName.replace('.ts', ''), 'select 1'));
+    await writeFile(migrationsPath + '/' + m2.fileName, makeUpOnly(m2.fileName.replace('.ts', ''), 'select 2'));
+
+    await migrator.up();
+
+    dateMock.mockReturnValueOnce('2020-03-01T00:00:00.000Z');
+    const result = await migrator.rollup();
+
+    expect(result.code).toContain('select 1');
+    expect(result.code).toContain('select 2');
+    expect(result.code).not.toContain('down()');
+
+    dateMock.mockRestore();
+  });
+});
+
+describe('Migrator - rollup edge cases', () => {
+  let orm: MikroORM<MySqlDriver>;
+  const migrationsPath = process.cwd() + '/temp/migrations-rollup-edge';
+
+  beforeAll(async () => {
+    orm = await initORMMySql(
+      'mysql',
+      {
+        dbName: 'mikro_orm_test_migrations',
+        migrations: { path: migrationsPath, snapshot: false },
+        loggerFactory: SimpleLogger.create,
+      },
+      true,
+    );
+  });
+
+  beforeEach(async () => {
+    await rm(migrationsPath, { recursive: true, force: true });
+    await orm.schema.dropTableIfExists(orm.config.get('migrations').tableName!);
+    orm.config.resetServiceCache();
+  });
+
+  afterAll(async () => {
+    await orm.schema.dropDatabase();
+    await orm.close(true);
+  });
+
+  test('rollup handles multi-line template literals with braces', async () => {
+    const dateMock = vi.spyOn(Date.prototype, 'toISOString');
+    dateMock.mockReturnValueOnce('2020-01-01T00:00:00.000Z');
+    dateMock.mockReturnValueOnce('2020-02-01T00:00:00.000Z');
+
+    const migrator = new Migrator(orm.em);
+    const m1 = await migrator.create(migrationsPath, true);
+    const m2 = await migrator.create(migrationsPath, true);
+
+    // migration with multi-line template literal containing braces
+    const m1Content = [
+      `import { Migration } from '@mikro-orm/migrations';`,
+      ``,
+      `export class ${m1.fileName.replace('.ts', '')} extends Migration {`,
+      ``,
+      `  override up(): void | Promise<void> {`,
+      '    this.addSql(`create type "foo" as enum {',
+      `      'bar',`,
+      `      'baz'`,
+      '    }`);',
+      `  }`,
+      ``,
+      `  override down(): void | Promise<void> {`,
+      '    this.addSql(`drop type "foo"`);',
+      `  }`,
+      ``,
+      `}`,
+    ].join('\n');
+
+    const m2Content = `import { Migration } from '@mikro-orm/migrations';\n\nexport class ${m2.fileName.replace('.ts', '')} extends Migration {\n\n  override up(): void | Promise<void> {\n    this.addSql(\`select 2\`);\n  }\n\n  override down(): void | Promise<void> {\n    this.addSql(\`select -2\`);\n  }\n\n}\n`;
+
+    await writeFile(migrationsPath + '/' + m1.fileName, m1Content);
+    await writeFile(migrationsPath + '/' + m2.fileName, m2Content);
+
+    // manually log as executed (can't actually run the fake SQL against MySQL)
+    const storage = migrator.getStorage();
+    await storage.logMigration({ name: m1.fileName });
+    await storage.logMigration({ name: m2.fileName });
+
+    dateMock.mockReturnValueOnce('2020-03-01T00:00:00.000Z');
+    const result = await migrator.rollup();
+
+    // the multi-line template literal should be preserved intact
+    expect(result.code).toContain('create type "foo" as enum {');
+    expect(result.code).toContain("'bar'");
+    expect(result.code).toContain('select 2');
+    expect(result.code).toContain('drop type "foo"');
+    expect(result.code).toContain('select -2');
+
+    dateMock.mockRestore();
+  });
+
+  test('rollup handles single-line method bodies', async () => {
+    const dateMock = vi.spyOn(Date.prototype, 'toISOString');
+    dateMock.mockReturnValueOnce('2020-01-01T00:00:00.000Z');
+    dateMock.mockReturnValueOnce('2020-02-01T00:00:00.000Z');
+
+    const migrator = new Migrator(orm.em);
+    const m1 = await migrator.create(migrationsPath, true);
+    const m2 = await migrator.create(migrationsPath, true);
+
+    // migration with single-line method body
+    const m1Content = [
+      `import { Migration } from '@mikro-orm/migrations';`,
+      ``,
+      `export class ${m1.fileName.replace('.ts', '')} extends Migration {`,
+      `  override up(): void | Promise<void> { this.addSql(\`select 1\`); }`,
+      `  override down(): void | Promise<void> { this.addSql(\`select -1\`); }`,
+      `}`,
+    ].join('\n');
+
+    const m2Content = `import { Migration } from '@mikro-orm/migrations';\n\nexport class ${m2.fileName.replace('.ts', '')} extends Migration {\n\n  override up(): void | Promise<void> {\n    this.addSql(\`select 2\`);\n  }\n\n  override down(): void | Promise<void> {\n    this.addSql(\`select -2\`);\n  }\n\n}\n`;
+
+    await writeFile(migrationsPath + '/' + m1.fileName, m1Content);
+    await writeFile(migrationsPath + '/' + m2.fileName, m2Content);
+
+    // manually log as executed (single-line format can't be dynamically imported)
+    const storage = migrator.getStorage();
+    await storage.logMigration({ name: m1.fileName });
+    await storage.logMigration({ name: m2.fileName });
+
+    dateMock.mockReturnValueOnce('2020-03-01T00:00:00.000Z');
+    const result = await migrator.rollup();
+
+    expect(result.code).toContain('select 1');
+    expect(result.code).toContain('select 2');
+    expect(result.code).toContain('select -1');
+    expect(result.code).toContain('select -2');
+
+    dateMock.mockRestore();
+  });
+
+  test('rollup throws when requested migration not found', async () => {
+    const dateMock = vi.spyOn(Date.prototype, 'toISOString');
+    dateMock.mockReturnValue('2020-01-01T00:00:00.000Z');
+
+    const migrator = new Migrator(orm.em);
+    const m1 = await migrator.create(migrationsPath, true);
+    const m2 = await migrator.create(migrationsPath, true);
+    await migrator.up();
+
+    await expect(migrator.rollup([m1.fileName, 'NonExistent'])).rejects.toThrow('Migrations not found: NonExistent');
+
+    dateMock.mockRestore();
+  });
+});
+
+describe('Migrator - rollup coverage', () => {
+  let orm: MikroORM<MySqlDriver>;
+  const migrationsPath = process.cwd() + '/temp/migrations-rollup-cov';
+
+  beforeAll(async () => {
+    orm = await initORMMySql(
+      'mysql',
+      {
+        dbName: 'mikro_orm_test_migrations',
+        migrations: { path: migrationsPath, snapshot: false },
+        loggerFactory: SimpleLogger.create,
+      },
+      true,
+    );
+  });
+
+  beforeEach(async () => {
+    await rm(migrationsPath, { recursive: true, force: true });
+    await orm.schema.dropTableIfExists(orm.config.get('migrations').tableName!);
+    orm.config.resetServiceCache();
+  });
+
+  afterAll(async () => {
+    await orm.schema.dropDatabase();
+    await orm.close(true);
+  });
+
+  test('rollup handles block comments spanning multiple lines', async () => {
+    const dateMock = vi.spyOn(Date.prototype, 'toISOString');
+    dateMock.mockReturnValueOnce('2020-01-01T00:00:00.000Z');
+    dateMock.mockReturnValueOnce('2020-02-01T00:00:00.000Z');
+
+    const migrator = new Migrator(orm.em);
+    const m1 = await migrator.create(migrationsPath, true);
+    const m2 = await migrator.create(migrationsPath, true);
+
+    const m1Content = [
+      `import { Migration } from '@mikro-orm/migrations';`,
+      ``,
+      `export class ${m1.fileName.replace('.ts', '')} extends Migration {`,
+      ``,
+      `  override up(): void | Promise<void> {`,
+      `    /* this is a {`,
+      `       multi-line } comment */`,
+      `    this.addSql(\`select 1\`);`,
+      `  }`,
+      ``,
+      `  override down(): void | Promise<void> {`,
+      `    this.addSql(\`select -1\`);`,
+      `  }`,
+      ``,
+      `}`,
+    ].join('\n');
+
+    const m2Content = `import { Migration } from '@mikro-orm/migrations';\n\nexport class ${m2.fileName.replace('.ts', '')} extends Migration {\n\n  override up(): void | Promise<void> {\n    this.addSql(\`select 2\`);\n  }\n\n  override down(): void | Promise<void> {\n    this.addSql(\`select -2\`);\n  }\n\n}\n`;
+
+    await writeFile(migrationsPath + '/' + m1.fileName, m1Content);
+    await writeFile(migrationsPath + '/' + m2.fileName, m2Content);
+
+    const storage = migrator.getStorage();
+    await storage.logMigration({ name: m1.fileName });
+    await storage.logMigration({ name: m2.fileName });
+
+    dateMock.mockReturnValueOnce('2020-03-01T00:00:00.000Z');
+    const result = await migrator.rollup();
+
+    expect(result.code).toContain('select 1');
+    expect(result.code).toContain('select 2');
+
+    dateMock.mockRestore();
+  });
+
+  test('rollup handles nested template expressions', async () => {
+    const dateMock = vi.spyOn(Date.prototype, 'toISOString');
+    dateMock.mockReturnValueOnce('2020-01-01T00:00:00.000Z');
+    dateMock.mockReturnValueOnce('2020-02-01T00:00:00.000Z');
+
+    const migrator = new Migrator(orm.em);
+    const m1 = await migrator.create(migrationsPath, true);
+    const m2 = await migrator.create(migrationsPath, true);
+
+    const m1Content = [
+      `import { Migration } from '@mikro-orm/migrations';`,
+      ``,
+      `export class ${m1.fileName.replace('.ts', '')} extends Migration {`,
+      ``,
+      `  override up(): void | Promise<void> {`,
+      '    this.addSql(`select ${`inner`}`);',
+      `  }`,
+      ``,
+      `}`,
+    ].join('\n');
+
+    const m2Content = `import { Migration } from '@mikro-orm/migrations';\n\nexport class ${m2.fileName.replace('.ts', '')} extends Migration {\n\n  override up(): void | Promise<void> {\n    this.addSql(\`select 2\`);\n  }\n\n}\n`;
+
+    await writeFile(migrationsPath + '/' + m1.fileName, m1Content);
+    await writeFile(migrationsPath + '/' + m2.fileName, m2Content);
+
+    const storage = migrator.getStorage();
+    await storage.logMigration({ name: m1.fileName });
+    await storage.logMigration({ name: m2.fileName });
+
+    dateMock.mockReturnValueOnce('2020-03-01T00:00:00.000Z');
+    const result = await migrator.rollup();
+
+    expect(result.code).toContain('select ${`inner`}');
+    expect(result.code).toContain('select 2');
+
+    dateMock.mockRestore();
+  });
+
+  test('rollup with non-transactional option', async () => {
+    const dateMock = vi.spyOn(Date.prototype, 'toISOString');
+    dateMock.mockReturnValueOnce('2020-01-01T00:00:00.000Z');
+    dateMock.mockReturnValueOnce('2020-02-01T00:00:00.000Z');
+
+    const migrator = new Migrator(orm.em);
+    // @ts-ignore
+    migrator.options.transactional = false;
+
+    const m1 = await migrator.create(migrationsPath, true);
+    const m2 = await migrator.create(migrationsPath, true);
+
+    await migrator.up();
+
+    dateMock.mockReturnValueOnce('2020-03-01T00:00:00.000Z');
+    const result = await migrator.rollup();
+
+    expect(result.fileName).toMatch(/\.ts$/);
+    const executedAfter = await migrator.getStorage().executed();
+    expect(executedAfter).toHaveLength(1);
+
+    dateMock.mockRestore();
+  });
+
+  test('rollup with js emit', async () => {
+    const dateMock = vi.spyOn(Date.prototype, 'toISOString');
+    dateMock.mockReturnValueOnce('2020-01-01T00:00:00.000Z');
+    dateMock.mockReturnValueOnce('2020-02-01T00:00:00.000Z');
+
+    const migrator = new Migrator(orm.em);
+    // @ts-ignore
+    migrator.options.emit = 'js';
+    migrator['initServices']();
+
+    const m1 = await migrator.create(migrationsPath, true);
+    const m2 = await migrator.create(migrationsPath, true);
+
+    const storage = migrator.getStorage();
+    await storage.logMigration({ name: m1.fileName });
+    await storage.logMigration({ name: m2.fileName });
+
+    dateMock.mockReturnValueOnce('2020-03-01T00:00:00.000Z');
+    const result = await migrator.rollup();
+
+    expect(result.fileName).toMatch(/\.js$/);
+    expect(result.code).toContain("require('@mikro-orm/migrations')");
+    expect(result.code).toContain('async up()');
+
+    dateMock.mockRestore();
+  });
+
+  test('rollup handles migration with single-line // comments containing method names', async () => {
+    const dateMock = vi.spyOn(Date.prototype, 'toISOString');
+    dateMock.mockReturnValueOnce('2020-01-01T00:00:00.000Z');
+    dateMock.mockReturnValueOnce('2020-02-01T00:00:00.000Z');
+
+    const migrator = new Migrator(orm.em);
+    const m1 = await migrator.create(migrationsPath, true);
+    const m2 = await migrator.create(migrationsPath, true);
+
+    // migration with a // comment containing "up(" before the actual up() method
+    const m1Content = [
+      `import { Migration } from '@mikro-orm/migrations';`,
+      ``,
+      `export class ${m1.fileName.replace('.ts', '')} extends Migration {`,
+      ``,
+      `  // set up (tables)`,
+      `  override up(): void | Promise<void> {`,
+      `    this.addSql(\`select 1\`);`,
+      `  }`,
+      ``,
+      `}`,
+    ].join('\n');
+
+    const m2Content = `import { Migration } from '@mikro-orm/migrations';\n\nexport class ${m2.fileName.replace('.ts', '')} extends Migration {\n\n  override up(): void | Promise<void> {\n    this.addSql(\`select 2\`);\n  }\n\n}\n`;
+
+    await writeFile(migrationsPath + '/' + m1.fileName, m1Content);
+    await writeFile(migrationsPath + '/' + m2.fileName, m2Content);
+
+    const storage = migrator.getStorage();
+    await storage.logMigration({ name: m1.fileName });
+    await storage.logMigration({ name: m2.fileName });
+
+    dateMock.mockReturnValueOnce('2020-03-01T00:00:00.000Z');
+    const result = await migrator.rollup();
+
+    expect(result.code).toContain('select 1');
+    expect(result.code).toContain('select 2');
+
+    dateMock.mockRestore();
+  });
+
+  test('rollup with single-quoted strings containing braces', async () => {
+    const dateMock = vi.spyOn(Date.prototype, 'toISOString');
+    dateMock.mockReturnValueOnce('2020-01-01T00:00:00.000Z');
+    dateMock.mockReturnValueOnce('2020-02-01T00:00:00.000Z');
+
+    const migrator = new Migrator(orm.em);
+    const m1 = await migrator.create(migrationsPath, true);
+    const m2 = await migrator.create(migrationsPath, true);
+
+    const m1Content = [
+      `import { Migration } from '@mikro-orm/migrations';`,
+      ``,
+      `export class ${m1.fileName.replace('.ts', '')} extends Migration {`,
+      ``,
+      `  override up(): void | Promise<void> {`,
+      `    this.addSql('select "{"');`,
+      `  }`,
+      ``,
+      `}`,
+    ].join('\n');
+
+    const m2Content = `import { Migration } from '@mikro-orm/migrations';\n\nexport class ${m2.fileName.replace('.ts', '')} extends Migration {\n\n  override up(): void | Promise<void> {\n    this.addSql(\`select 2\`);\n  }\n\n}\n`;
+
+    await writeFile(migrationsPath + '/' + m1.fileName, m1Content);
+    await writeFile(migrationsPath + '/' + m2.fileName, m2Content);
+
+    const storage = migrator.getStorage();
+    await storage.logMigration({ name: m1.fileName });
+    await storage.logMigration({ name: m2.fileName });
+
+    dateMock.mockReturnValueOnce('2020-03-01T00:00:00.000Z');
+    const result = await migrator.rollup();
+
+    expect(result.code).toContain('select "{"');
+    expect(result.code).toContain('select 2');
+
+    dateMock.mockRestore();
   });
 });

--- a/tests/features/migrations/Migrator.test.ts
+++ b/tests/features/migrations/Migrator.test.ts
@@ -1221,4 +1221,160 @@ describe('Migrator - rollup coverage', () => {
 
     dateMock.mockRestore();
   });
+
+  test('rollup handles escape sequences inside template literals and single-quoted strings', async () => {
+    const dateMock = vi.spyOn(Date.prototype, 'toISOString');
+    dateMock.mockReturnValueOnce('2020-01-01T00:00:00.000Z');
+    dateMock.mockReturnValueOnce('2020-02-01T00:00:00.000Z');
+
+    const migrator = new Migrator(orm.em);
+    const m1 = await migrator.create(migrationsPath, true);
+    const m2 = await migrator.create(migrationsPath, true);
+
+    // migration with `\`` inside template literal and `\'` inside single-quoted string
+    const m1Content = [
+      `import { Migration } from '@mikro-orm/migrations';`,
+      ``,
+      `export class ${m1.fileName.replace('.ts', '')} extends Migration {`,
+      ``,
+      `  override up(): void | Promise<void> {`,
+      '    this.addSql(`select \\`foo\\` from bar',
+      '    where x = 1`);',
+      `    this.addSql('it\\'s fine {');`,
+      `  }`,
+      ``,
+      `}`,
+    ].join('\n');
+
+    const m2Content = `import { Migration } from '@mikro-orm/migrations';\n\nexport class ${m2.fileName.replace('.ts', '')} extends Migration {\n\n  override up(): void | Promise<void> {\n    this.addSql(\`select 2\`);\n  }\n\n}\n`;
+
+    await writeFile(migrationsPath + '/' + m1.fileName, m1Content);
+    await writeFile(migrationsPath + '/' + m2.fileName, m2Content);
+
+    const storage = migrator.getStorage();
+    await storage.logMigration({ name: m1.fileName });
+    await storage.logMigration({ name: m2.fileName });
+
+    dateMock.mockReturnValueOnce('2020-03-01T00:00:00.000Z');
+    const result = await migrator.rollup();
+
+    expect(result.code).toContain('from bar');
+    expect(result.code).toContain("it\\'s fine {");
+    expect(result.code).toContain('select 2');
+
+    dateMock.mockRestore();
+  });
+
+  test('rollup handles single-line // comments inside method bodies', async () => {
+    const dateMock = vi.spyOn(Date.prototype, 'toISOString');
+    dateMock.mockReturnValueOnce('2020-01-01T00:00:00.000Z');
+    dateMock.mockReturnValueOnce('2020-02-01T00:00:00.000Z');
+
+    const migrator = new Migrator(orm.em);
+    const m1 = await migrator.create(migrationsPath, true);
+    const m2 = await migrator.create(migrationsPath, true);
+
+    const m1Content = [
+      `import { Migration } from '@mikro-orm/migrations';`,
+      ``,
+      `export class ${m1.fileName.replace('.ts', '')} extends Migration {`,
+      ``,
+      `  override up(): void | Promise<void> {`,
+      `    // inline comment with { brace`,
+      `    this.addSql(\`select 1\`);`,
+      `  }`,
+      ``,
+      `}`,
+    ].join('\n');
+
+    const m2Content = `import { Migration } from '@mikro-orm/migrations';\n\nexport class ${m2.fileName.replace('.ts', '')} extends Migration {\n\n  override up(): void | Promise<void> {\n    this.addSql(\`select 2\`);\n  }\n\n}\n`;
+
+    await writeFile(migrationsPath + '/' + m1.fileName, m1Content);
+    await writeFile(migrationsPath + '/' + m2.fileName, m2Content);
+
+    const storage = migrator.getStorage();
+    await storage.logMigration({ name: m1.fileName });
+    await storage.logMigration({ name: m2.fileName });
+
+    dateMock.mockReturnValueOnce('2020-03-01T00:00:00.000Z');
+    const result = await migrator.rollup();
+
+    expect(result.code).toContain('select 1');
+    expect(result.code).toContain('select 2');
+
+    dateMock.mockRestore();
+  });
+
+  test('rollup skips migrations with malformed method body (no closing brace)', async () => {
+    const dateMock = vi.spyOn(Date.prototype, 'toISOString');
+    dateMock.mockReturnValueOnce('2020-01-01T00:00:00.000Z');
+    dateMock.mockReturnValueOnce('2020-02-01T00:00:00.000Z');
+
+    const migrator = new Migrator(orm.em);
+    const m1 = await migrator.create(migrationsPath, true);
+    const m2 = await migrator.create(migrationsPath, true);
+
+    // m1 has an up() declaration with no body braces — extractMethodBody returns ''
+    const m1Content = [
+      `import { Migration } from '@mikro-orm/migrations';`,
+      ``,
+      `export class ${m1.fileName.replace('.ts', '')} extends Migration {`,
+      ``,
+      `  override up(): void | Promise<void>`,
+      ``,
+      `}`,
+    ].join('\n');
+
+    const m2Content = `import { Migration } from '@mikro-orm/migrations';\n\nexport class ${m2.fileName.replace('.ts', '')} extends Migration {\n\n  override up(): void | Promise<void> {\n    this.addSql(\`select 2\`);\n  }\n\n}\n`;
+
+    await writeFile(migrationsPath + '/' + m1.fileName, m1Content);
+    await writeFile(migrationsPath + '/' + m2.fileName, m2Content);
+
+    const storage = migrator.getStorage();
+    await storage.logMigration({ name: m1.fileName });
+    await storage.logMigration({ name: m2.fileName });
+
+    dateMock.mockReturnValueOnce('2020-03-01T00:00:00.000Z');
+    const result = await migrator.rollup();
+
+    // m1 has no extractable body so only m2's body is merged
+    expect(result.code).toContain('select 2');
+
+    dateMock.mockRestore();
+  });
+
+  test('rollup handles empty single-line method body', async () => {
+    const dateMock = vi.spyOn(Date.prototype, 'toISOString');
+    dateMock.mockReturnValueOnce('2020-01-01T00:00:00.000Z');
+    dateMock.mockReturnValueOnce('2020-02-01T00:00:00.000Z');
+
+    const migrator = new Migrator(orm.em);
+    const m1 = await migrator.create(migrationsPath, true);
+    const m2 = await migrator.create(migrationsPath, true);
+
+    // single-line up() with an empty body
+    const m1Content = [
+      `import { Migration } from '@mikro-orm/migrations';`,
+      ``,
+      `export class ${m1.fileName.replace('.ts', '')} extends Migration {`,
+      `  override up(): void | Promise<void> {}`,
+      `}`,
+    ].join('\n');
+
+    const m2Content = `import { Migration } from '@mikro-orm/migrations';\n\nexport class ${m2.fileName.replace('.ts', '')} extends Migration {\n\n  override up(): void | Promise<void> {\n    this.addSql(\`select 2\`);\n  }\n\n}\n`;
+
+    await writeFile(migrationsPath + '/' + m1.fileName, m1Content);
+    await writeFile(migrationsPath + '/' + m2.fileName, m2Content);
+
+    const storage = migrator.getStorage();
+    await storage.logMigration({ name: m1.fileName });
+    await storage.logMigration({ name: m2.fileName });
+
+    dateMock.mockReturnValueOnce('2020-03-01T00:00:00.000Z');
+    const result = await migrator.rollup();
+
+    expect(result.code).toContain('select 2');
+
+    dateMock.mockRestore();
+  });
 });


### PR DESCRIPTION
## Summary

- Adds `migration:rollup` CLI command and `migrator.rollup()` API that combines multiple executed migrations into a single migration file
- Works by extracting `up()`/`down()` method bodies from source files via brace-counting parser and concatenating them (up in chronological order, down in reverse)
- Pure file operation — no database schema changes, only updates the migration log table, so zero risk of data loss
- Supports both SQL and MongoDB migrations

Closes #3633