### PR TITLE
fix(core): use symbol brand in CollectionShape to prevent false structural matches

### DIFF
--- a/packages/core/src/entity/Collection.ts
+++ b/packages/core/src/entity/Collection.ts
@@ -1,18 +1,19 @@
-import type {
-  AnyEntity,
-  Dictionary,
-  EntityData,
-  EntityDTO,
-  EntityKey,
-  EntityProperty,
-  EntityValue,
-  FilterKey,
-  FilterQuery,
-  IPrimaryKey,
-  Loaded,
-  LoadedCollection,
-  Populate,
-  Primary,
+import {
+  type AnyEntity,
+  type Dictionary,
+  type EntityData,
+  type EntityDTO,
+  type EntityKey,
+  type EntityProperty,
+  type EntityValue,
+  type FilterKey,
+  type FilterQuery,
+  type IPrimaryKey,
+  type Loaded,
+  type LoadedCollection,
+  type Populate,
+  type Primary,
+  CollectionBrand,
 } from '../typings.js';
 import { Utils } from '../utils/Utils.js';
 import { MetadataError, ValidationError } from '../errors.js';
@@ -40,6 +41,7 @@ const collectionSymbol = Symbol('Collection');
 /** Represents a to-many relation (1:m or m:n) as an iterable, managed collection of entities. */
 export class Collection<T extends object, O extends object = object> {
   [k: number]: T;
+  declare readonly [CollectionBrand]: true;
 
   readonly #items = new Set<T>();
   #initialized = true;

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -113,7 +113,7 @@ export type MaybePromise<T> = T | Promise<T>;
  * - Matching only: `T extends CollectionShape`
  * - With inference: `T extends CollectionShape<infer U>`
  */
-type CollectionShape<T = any> = { [k: number]: T; readonly owner: object };
+type CollectionShape<T = any> = { [k: number]: T; readonly [CollectionBrand]: true };
 
 /**
  * Structural type for matching LoadedCollection (extends CollectionShape with `$` property).
@@ -186,6 +186,9 @@ export const EntityRepositoryType = Symbol('EntityRepositoryType');
 
 /** Symbol used to declare the primary key property name(s) on an entity (e.g., `[PrimaryKeyProp]?: 'id'`). */
 export const PrimaryKeyProp = Symbol('PrimaryKeyProp');
+
+/** Symbol used as a brand on `CollectionShape` to prevent false structural matches with entities that have properties like `owner`. */
+export const CollectionBrand = Symbol('CollectionBrand');
 
 /** Symbol used to declare which properties are optional in `em.create()` (e.g., `[OptionalProps]?: 'createdAt'`). */
 export const OptionalProps = Symbol('OptionalProps');

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -9,6 +9,8 @@ import {
   serialize,
   EntityOptions,
   EntityRepositoryType,
+  defineEntity,
+  p,
 } from '@mikro-orm/core';
 import type {
   BaseEntity,
@@ -1283,6 +1285,28 @@ describe('check typings', () => {
         // @ts-expect-error - populateHints not allowed with empty populate
         { populate: [], populateHints: { books: { joinType: 'left join' } } },
       );
+    }
+  });
+
+  test('GH #7470 - entity with relation named "owner" should not break populate types', async () => {
+    const UserSchema = defineEntity({
+      name: 'User7470',
+      properties: {
+        id: p.integer().primary(),
+      },
+    });
+
+    const ReproductionSchema = defineEntity({
+      name: 'Reproduction7470',
+      properties: {
+        id: p.integer().primary(),
+        owner: p.oneToOne(UserSchema),
+      },
+    });
+
+    const em = {} as EntityManager;
+    if (false as boolean) {
+      await em.findOne(ReproductionSchema, {}, { populate: ['owner'] });
     }
   });
 });


### PR DESCRIPTION
`CollectionShape` used `readonly owner: object` as a structural discriminant, which caused entities with a relation property named `owner` to falsely match the shape, breaking populate type inference in `AutoPath`.

Replaced with a unique `CollectionBrand` symbol property that only the `Collection` class declares, making false structural matches impossible.

Closes #7470

🤖 Generated with [Claude Code](https://claude.ai/claude-code)