### PR TITLE
fix(sql): fix populate of 1:1 on TPT leaf entity with joined strategy

### DIFF
--- a/packages/sql/src/AbstractSqlDriver.ts
+++ b/packages/sql/src/AbstractSqlDriver.ts
@@ -2174,6 +2174,27 @@ export abstract class AbstractSqlDriver<
         prop.targetMeta!.schema === '*' ? (options?.schema ?? this.config.get('schema')) : prop.targetMeta!.schema;
       qb.join(field as any, tableAlias, {}, joinType, path, schema);
 
+      // For relations to TPT child entities, INNER JOIN parent tables (GH #7469)
+      if (meta2.inheritanceType === 'tpt' && meta2.tptParent) {
+        let childAlias = tableAlias;
+        let childMeta: EntityMetadata = meta2;
+        while (childMeta.tptParent) {
+          const parentMeta = childMeta.tptParent;
+          const parentAlias = qb.getNextAlias(parentMeta.className);
+          qb.createAlias(parentMeta.class, parentAlias);
+          qb.state.tptAlias[`${tableAlias}:${parentMeta.className}`] = parentAlias;
+          qb.addPropertyJoin(
+            childMeta.tptParentProp!,
+            childAlias,
+            parentAlias,
+            JoinType.innerJoin,
+            `${path}.[tpt]${childMeta.className}`,
+          );
+          childAlias = parentAlias;
+          childMeta = parentMeta;
+        }
+      }
+
       // For relations to TPT base classes, add LEFT JOINs for all child tables (polymorphic loading)
       if (meta2.inheritanceType === 'tpt' && meta2.tptChildren?.length && !ref) {
         // Use the registry metadata to ensure allTPTDescendants is available
@@ -2444,8 +2465,9 @@ export abstract class AbstractSqlDriver<
       return [raw(`${this.evaluateFormula(prop.formula, columns, table)} as ${aliased}`)];
     }
 
+    const sourceAlias = qb.helper.getTPTAliasForProperty(prop.name, tableAlias);
     return prop.fieldNames.map(fieldName => {
-      return raw('?? as ??', [`${tableAlias}.${fieldName}`, `${tableAlias}__${fieldName}`]);
+      return raw('?? as ??', [`${sourceAlias}.${fieldName}`, `${tableAlias}__${fieldName}`]);
     });
   }
 

--- a/packages/sql/src/query/QueryBuilderHelper.ts
+++ b/packages/sql/src/query/QueryBuilderHelper.ts
@@ -88,7 +88,8 @@ export class QueryBuilderHelper {
     let parentMeta: EntityMetadata | undefined = meta.tptParent;
 
     while (parentMeta) {
-      const parentAlias = this.#tptAliasMap[parentMeta.className];
+      const parentAlias =
+        this.#tptAliasMap[`${defaultAlias}:${parentMeta.className}`] ?? this.#tptAliasMap[parentMeta.className];
 
       if (parentAlias && parentMeta.ownProps?.some(p => p.name === propName || p.fieldNames?.includes(propName))) {
         return parentAlias;

--- a/tests/features/table-per-type-inheritance/table-per-type-inheritance.test.ts
+++ b/tests/features/table-per-type-inheritance/table-per-type-inheritance.test.ts
@@ -3331,3 +3331,72 @@ describe('TPT recomputeSingleChangeSet regression', () => {
     await orm.close();
   });
 });
+
+describe('GH #7469 - populate 1:1 on TPT leaf entity with reverse declared', () => {
+  test('owning side of 1:1 on TPT leaf populates when reverse is declared', async () => {
+    @Entity({ inheritance: 'tpt' })
+    abstract class Person7469 {
+      @PrimaryKey()
+      id!: number;
+
+      @Property()
+      name!: string;
+    }
+
+    @Entity()
+    class Employee7469 extends Person7469 {
+      @Property()
+      department!: string;
+
+      @OneToOne(() => OfficeSpace7469, { owner: true, nullable: true, ref: true })
+      officeSpace?: Ref<OfficeSpace7469>;
+    }
+
+    @Entity()
+    class OfficeSpace7469 {
+      @PrimaryKey()
+      id!: number;
+
+      @Property()
+      location!: string;
+
+      @OneToOne(() => Employee7469, e => e.officeSpace)
+      employee?: Employee7469;
+    }
+
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      dbName: ':memory:',
+      entities: [OfficeSpace7469, Person7469, Employee7469],
+    });
+
+    await orm.schema.create();
+
+    const officeSpace = orm.em.create(OfficeSpace7469, { location: 'Building A' });
+    const employee = orm.em.create(Employee7469, { name: 'Alice', department: 'Engineering', officeSpace });
+    await orm.em.flush();
+    orm.em.clear();
+
+    // Loading employee with populate of the owning 1:1 should work (joined strategy)
+    const loadedEmployee = await orm.em.findOneOrFail(Employee7469, employee.id, {
+      populate: ['officeSpace'],
+      strategy: 'joined',
+    });
+    expect(loadedEmployee.name).toBe('Alice');
+    expect(loadedEmployee.department).toBe('Engineering');
+    expect(loadedEmployee.officeSpace?.unwrap().location).toBe('Building A');
+
+    orm.em.clear();
+
+    // Loading office space with populate of the reverse 1:1 should also work (joined strategy)
+    const loadedOffice = await orm.em.findOneOrFail(OfficeSpace7469, officeSpace.id, {
+      populate: ['employee'],
+      strategy: 'joined',
+    });
+    expect(loadedOffice.location).toBe('Building A');
+    expect(loadedOffice.employee?.name).toBe('Alice');
+    expect(loadedOffice.employee?.department).toBe('Engineering');
+
+    await orm.close();
+  });
+});


### PR DESCRIPTION
## Summary
- When populating a relation targeting a TPT child entity via joined strategy, the query incorrectly selected parent table columns (e.g. `name`) from the child table (e.g. `employee`), causing `no such column` errors
- Now INNER JOINs parent tables when a TPT child is joined via a relation, and aliases parent fields with the child's prefix so the hydrator maps them correctly

Closes #7469

🤖 Generated with [Claude Code](https://claude.ai/claude-code)