### PR TITLE
fix(core): resolve EntityIdentifier in composite FK with shared join columns

### DIFF
--- a/packages/core/src/unit-of-work/ChangeSetPersister.ts
+++ b/packages/core/src/unit-of-work/ChangeSetPersister.ts
@@ -1,5 +1,5 @@
 import type { MetadataStorage } from '../metadata';
-import type { AnyEntity, Dictionary, EntityData, EntityDictionary, EntityMetadata, EntityProperty, EntityKey, FilterQuery, IHydrator, IPrimaryKey } from '../typings';
+import type { AnyEntity, Dictionary, EntityData, EntityDictionary, EntityMetadata, EntityProperty, EntityKey, FilterQuery, IHydrator, IPrimaryKey, IPrimaryKeyValue } from '../typings';
 import { EntityIdentifier, helper, type EntityFactory, type EntityValidator, type Collection } from '../entity';
 import { ChangeSetType, type ChangeSet } from './ChangeSet';
 import type { QueryResult } from '../connections';
@@ -128,6 +128,7 @@ export class ChangeSetPersister {
     }
 
     this.mapReturnedValues(changeSet.entity, changeSet.payload, res.row, meta);
+    this.syncCompositeIdentifiers(changeSet);
     this.markAsPopulated(changeSet, meta);
     wrapped.__initialized = true;
     wrapped.__managed = true;
@@ -185,6 +186,7 @@ export class ChangeSetPersister {
       if (res.rows) {
         this.mapReturnedValues(changeSet.entity, changeSet.payload, res.rows[i], meta);
       }
+      this.syncCompositeIdentifiers(changeSet);
       this.markAsPopulated(changeSet, meta);
       wrapped.__initialized = true;
       wrapped.__managed = true;
@@ -274,6 +276,29 @@ export class ChangeSetPersister {
 
     if (wrapped.__identifier && !Array.isArray(wrapped.__identifier)) {
       wrapped.__identifier.setValue(value);
+    }
+  }
+
+  /**
+   * After INSERT + hydration, sync all EntityIdentifier placeholders in composite PK arrays
+   * with the real values now present on the entity. This is needed because `mapPrimaryKey`
+   * only handles the first PK column, but any scalar PK in a composite key may be auto-generated.
+   */
+  private syncCompositeIdentifiers<T extends object>(changeSet: ChangeSet<T>): void {
+    const wrapped = helper(changeSet.entity);
+
+    if (!Array.isArray(wrapped.__identifier)) {
+      return;
+    }
+
+    const pks = changeSet.meta.getPrimaryProps();
+
+    for (let i = 0; i < pks.length; i++) {
+      const ident = wrapped.__identifier[i];
+
+      if (ident instanceof EntityIdentifier && pks[i].kind === ReferenceKind.SCALAR) {
+        ident.setValue(changeSet.entity[pks[i].name] as IPrimaryKeyValue);
+      }
     }
   }
 
@@ -443,8 +468,8 @@ export class ChangeSetPersister {
       return;
     }
 
-    if (Array.isArray(value) && value.every(item => item instanceof EntityIdentifier)) {
-      changeSet.payload[prop.name] = value.map(item => item.getValue());
+    if (Array.isArray(value) && value.some(item => item instanceof EntityIdentifier)) {
+      changeSet.payload[prop.name] = value.map(item => item instanceof EntityIdentifier ? item.getValue() : item);
       return;
     }
 

--- a/tests/issues/GHx-composite-fk-shared-column.test.ts
+++ b/tests/issues/GHx-composite-fk-shared-column.test.ts
@@ -1,0 +1,147 @@
+import {
+  BaseEntity,
+  Entity,
+  ManyToOne,
+  MikroORM,
+  PrimaryKey,
+  PrimaryKeyProp,
+  Property,
+  type Ref,
+} from '@mikro-orm/postgresql';
+import { randomUUID } from 'node:crypto';
+
+@Entity({ tableName: 'cfk_organization' })
+class Organization extends BaseEntity {
+
+  @PrimaryKey({ type: 'uuid' })
+  id!: string;
+
+  @Property()
+  name!: string;
+
+}
+
+@Entity({ tableName: 'cfk_child_a' })
+class ChildA extends BaseEntity {
+
+  [PrimaryKeyProp]?: ['id', 'organization'];
+
+  @PrimaryKey({ type: 'uuid', defaultRaw: 'gen_random_uuid()' })
+  id!: string;
+
+  @ManyToOne({ entity: () => Organization, ref: true, primary: true })
+  organization!: Ref<Organization>;
+
+  @Property()
+  label!: string;
+
+}
+
+@Entity({ tableName: 'cfk_child_b' })
+class ChildB extends BaseEntity {
+
+  [PrimaryKeyProp]?: ['id', 'organization'];
+
+  @PrimaryKey({ type: 'uuid', defaultRaw: 'gen_random_uuid()' })
+  id!: string;
+
+  @ManyToOne({ entity: () => Organization, ref: true, primary: true })
+  organization!: Ref<Organization>;
+
+  @Property()
+  label!: string;
+
+}
+
+@Entity({ tableName: 'cfk_referrer' })
+class Referrer extends BaseEntity {
+
+  [PrimaryKeyProp]?: ['id', 'organization'];
+
+  @PrimaryKey({ type: 'uuid', defaultRaw: 'gen_random_uuid()' })
+  id!: string;
+
+  @ManyToOne({ entity: () => Organization, ref: true, primary: true })
+  organization!: Ref<Organization>;
+
+  @Property({ length: 100 })
+  label!: string;
+
+  @ManyToOne({
+    entity: () => ChildA,
+    ref: true,
+    nullable: true,
+    joinColumns: ['child_a_id', 'organization_id'],
+  })
+  childA?: Ref<ChildA> | null;
+
+  @ManyToOne({
+    entity: () => ChildB,
+    ref: true,
+    nullable: true,
+    joinColumns: ['child_b_id', 'organization_id'],
+  })
+  childB?: Ref<ChildB> | null;
+
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    dbName: 'mikro_orm_composite_fk_shared_column',
+    entities: [Organization, ChildA, ChildB, Referrer],
+  });
+  await orm.schema.refreshDatabase();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+describe('GHx - composite FK with shared join column [object Object] bug', () => {
+
+  test('em.create children + referrer in single flush', async () => {
+    const em = orm.em.fork();
+    const orgId = randomUUID();
+
+    em.create(Organization, { id: orgId, name: 'Test Org' });
+    const childA = em.create(ChildA, { organization: orgId, label: 'A' });
+    const childB = em.create(ChildB, { organization: orgId, label: 'B' });
+
+    em.create(Referrer, {
+      organization: orgId,
+      label: 'test',
+      childA,
+      childB,
+    });
+
+    await em.flush();
+
+    const verifyEm = orm.em.fork();
+    const loaded = await verifyEm.findOneOrFail(Referrer, { label: 'test' }, { populate: ['childA', 'childB'] });
+    expect(loaded.childA!.id).toBe(childA.id);
+    expect(loaded.childB!.id).toBe(childB.id);
+  });
+
+  test('single composite FK still works when child has auto-generated ID', async () => {
+    const em = orm.em.fork();
+    const orgId = randomUUID();
+
+    em.create(Organization, { id: orgId, name: 'Test Org 2' });
+    const childA = em.create(ChildA, { organization: orgId, label: 'A2' });
+
+    em.create(Referrer, {
+      organization: orgId,
+      label: 'test-single-fk',
+      childA,
+    });
+
+    await em.flush();
+
+    const verifyEm = orm.em.fork();
+    const loaded = await verifyEm.findOneOrFail(Referrer, { label: 'test-single-fk' });
+    expect(loaded).toBeDefined();
+  });
+
+});


### PR DESCRIPTION
## Summary

Backport of #7477 to 6.x.

- When an entity has composite FK relations sharing a join column (e.g. `organization_id`) and referenced entities use auto-generated PKs (`defaultRaw`), INSERT/UPDATE produced `[object Object]` or `undefined` column values
- `processProperty` used `.every(instanceof EntityIdentifier)` on composite FK arrays, but shared columns have `undefined` entries — changed to `.some()` with conditional unwrapping
- `mapPrimaryKey` skipped composite PK identifier arrays, so auto-generated PK values never propagated to dependent FK payloads — added composite array handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)