### PR TITLE
fix(sql): use composite unique constraint for OneToOne on STI entities

### DIFF
--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -1651,6 +1651,21 @@ export class MetadataDiscovery {
         newProp.items = Utils.unique([...rootProp.items, ...prop.items]);
       }
 
+      // When multiple STI children share the same unique relation (OneToOne/ManyToOne),
+      // replace the simple unique with a composite one including the discriminator column
+      // so different subtypes can independently reference the same target row.
+      if (
+        rootProp?.unique &&
+        newProp.unique &&
+        [ReferenceKind.ONE_TO_ONE, ReferenceKind.MANY_TO_ONE].includes(newProp.kind)
+      ) {
+        newProp.unique = false;
+        rootProp.unique = false;
+        meta.root.uniques.push({
+          properties: [prop.name, meta.root.discriminatorColumn!] as EntityKey[],
+        });
+      }
+
       newProp.nullable = true;
       newProp.inherited = !rootProp;
       meta.root.addProperty(newProp);

--- a/tests/issues/GH7479.test.ts
+++ b/tests/issues/GH7479.test.ts
@@ -1,0 +1,78 @@
+import type { Ref } from '@mikro-orm/sqlite';
+import { MikroORM, OptionalProps } from '@mikro-orm/sqlite';
+import { Entity, Enum, OneToOne, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+
+@Entity()
+class Owner {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+}
+
+@Entity({ abstract: true, discriminatorColumn: 'type', discriminatorMap: { dog: 'Dog', cat: 'Cat' } })
+abstract class Animal {
+  [OptionalProps]?: 'type';
+
+  @PrimaryKey()
+  id!: number;
+
+  @Enum()
+  type!: string;
+}
+
+@Entity({ discriminatorValue: 'dog' })
+class Dog extends Animal {
+  @OneToOne(() => Owner, { owner: true, ref: true })
+  owner!: Ref<Owner>;
+}
+
+@Entity({ discriminatorValue: 'cat' })
+class Cat extends Animal {
+  @OneToOne(() => Owner, { owner: true, ref: true })
+  owner!: Ref<Owner>;
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    dbName: ':memory:',
+    entities: [Owner, Animal, Dog, Cat],
+    metadataProvider: ReflectMetadataProvider,
+  });
+  await orm.schema.refresh();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+test('GH #7479 - @OneToOne in multiple STI variants should not produce a unique constraint on FK alone', async () => {
+  // The generated schema should have a composite unique on (type, owner_id),
+  // not a simple unique on (owner_id) alone
+  const sql = await orm.schema.getCreateSchemaSQL();
+
+  // Should NOT have a simple unique index on just owner_id
+  expect(sql).not.toMatch(/unique.*\(`owner_id`\)/i);
+
+  // Should have a composite unique including the discriminator column
+  expect(sql).toMatch(/unique.*\(`owner_id`, `type`\)/i);
+
+  // Functional test: both a Dog and Cat can reference the same Owner
+  const em = orm.em.fork();
+  const owner1 = em.create(Owner, { name: 'Alice' });
+  const owner2 = em.create(Owner, { name: 'Bob' });
+  em.create(Dog, { owner: owner1 });
+  em.create(Cat, { owner: owner1 }); // same owner for different animal types
+  em.create(Dog, { owner: owner2 });
+
+  // This should not throw a unique constraint violation
+  await em.flush();
+
+  const dogs = await em.find(Dog, {});
+  const cats = await em.find(Cat, {});
+  expect(dogs).toHaveLength(2);
+  expect(cats).toHaveLength(1);
+});


### PR DESCRIPTION
## Summary
- When multiple STI subclasses each define `@OneToOne` (or `@ManyToOne({ unique: true })`) owner relations, the schema generator now produces a composite unique constraint on `(fk_column, discriminator_column)` instead of a simple unique on the FK column alone
- This allows different discriminator types to independently reference the same target row, fixing the incorrect `UNIQUE` constraint that prevented e.g. both a `Dog` and `Cat` from referencing the same `Owner`
- FK column is placed first in the composite to serve as the MySQL FK backing index

Closes #7479

🤖 Generated with [Claude Code](https://claude.ai/code)