### PR TITLE
ci: fixed Oracle's and MySQL9's health checks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       - mysql9:/var/lib/mysql
     healthcheck:
       test: /usr/bin/mysql --protocol=TCP -e 'select 1'
+      start_period: 30s
 
   mariadb:
     image: mariadb:12
@@ -96,10 +97,13 @@ services:
       - ORACLE_PWD=oracle123
       - ORACLE_MEM_TARGET=2G
     healthcheck:
-      test: ["CMD-SHELL", "echo 'select 1 from dual;' | sqlplus -S mikro_orm_test/oracle123@//localhost:1521/freepdb1 || exit 1"]
+      test: bash -c "echo 'select 1 from dual;' | sqlplus -L -S pdbadmin/oracle123@//localhost:1521/FREEPDB1"
+      start_period: 300s
+      start_interval: 5s
     volumes:
       - oracledb:/opt/oracle/data
       - ./docker/oracle-init.sql:/opt/oracle/scripts/startup/oracle-init.sql
+      - ./docker/oracle-startup.sh:/opt/oracle/scripts/startup/oracle-startup.sh
 
 volumes:
   mysql9:

--- a/docker/oracle-init.sql
+++ b/docker/oracle-init.sql
@@ -3,7 +3,7 @@ alter system set commit_wait = 'NOWAIT' scope=memory;
 alter system set commit_logging = 'BATCH' scope=memory;
 
 -- Skip recycle bin for faster DROP TABLE
-alter system set recyclebin = OFF scope=memory;
+alter system set recyclebin = OFF scope=spfile;
 
 -- Disable account locking on failed logins (tests connect as non-existent users triggering ORA-01017)
 alter profile default limit failed_login_attempts unlimited;
@@ -13,7 +13,7 @@ alter profile default limit failed_login_attempts unlimited;
 -- Performance tuning inside the PDB
 alter system set commit_wait = 'NOWAIT' scope=memory;
 alter system set commit_logging = 'BATCH' scope=memory;
-alter system set recyclebin = OFF scope=memory;
+alter system set recyclebin = OFF scope=spfile;
 
 -- Pre-create tablespace and test users to avoid CREATE USER overhead during tests
 create tablespace "mikro_orm" datafile 'mikro_orm.dbf' size 100M autoextend on;

--- a/docker/oracle-startup.sh
+++ b/docker/oracle-startup.sh
@@ -1,0 +1,20 @@
+sed -i "/# MikroORM start/,/# MikroORM end/d" /opt/oracle/product/26ai/dbhomeFree/network/admin/listener.ora
+cat << EOF >> /opt/oracle/product/26ai/dbhomeFree/network/admin/listener.ora
+# MikroORM start
+SID_LIST_LISTENER =
+  (SID_LIST =
+    (SID_DESC =
+      (GLOBAL_DBNAME = FREE)
+      (ORACLE_HOME = /opt/oracle/product/26ai/dbhomeFree)
+      (SID_NAME = FREE)
+    )
+    (SID_DESC =
+      (GLOBAL_DBNAME = FREEPDB1)
+      (ORACLE_HOME = /opt/oracle/product/26ai/dbhomeFree)
+      (SID_NAME = FREE)
+    )
+  )
+# MikroORM end
+
+EOF
+lsnrctl reload


### PR DESCRIPTION
Oracle's test command was outright wrong, as it would always end up with 0 as the exit code. The listener is also not actually enabling TCP connections (though that's only a problem on Windows, as TCP is required there). Fixed the recyclebin setting.

MySQL 9 is heavier than its predecessor. It needs some more generous start_period to finish setup, rather than being labeled "unhealthy" early.