### PR TITLE
fix(core): escape special characters in base Platform array marshalling

### DIFF
--- a/packages/core/src/platforms/Platform.ts
+++ b/packages/core/src/platforms/Platform.ts
@@ -444,7 +444,7 @@ export abstract class Platform {
 
   /** Serializes a string array into its database storage format. */
   marshallArray(values: string[]): string {
-    return values.join(',');
+    return values.map(v => (/[,",\\]/.test(v) ? JSON.stringify(v) : v)).join(',');
   }
 
   /** Deserializes a database-stored array string back into a string array. */
@@ -453,7 +453,40 @@ export abstract class Platform {
       return [];
     }
 
-    return value.split(',');
+    if (!value.includes('"')) {
+      return value.split(',');
+    }
+
+    const result: string[] = [];
+    let i = 0;
+
+    while (i < value.length) {
+      if (value[i] === '"') {
+        let j = i + 1;
+        while (j < value.length) {
+          if (value[j] === '\\') {
+            j += 2;
+          } else if (value[j] === '"') {
+            j++;
+            break;
+          } else {
+            j++;
+          }
+        }
+        result.push(JSON.parse(value.substring(i, j)));
+        i = j + 1;
+      } else {
+        const comma = value.indexOf(',', i);
+        if (comma === -1) {
+          result.push(value.substring(i));
+          break;
+        }
+        result.push(value.substring(i, comma));
+        i = comma + 1;
+      }
+    }
+
+    return result;
   }
 
   getBlobDeclarationSQL(): string {

--- a/tests/issues/GH7488.test.ts
+++ b/tests/issues/GH7488.test.ts
@@ -1,0 +1,95 @@
+import { MikroORM, ArrayType } from '@mikro-orm/sqlite';
+import { Entity, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+
+@Entity()
+class Test {
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ type: ArrayType, nullable: true })
+  names?: string[] | null;
+}
+
+describe('GH issue 7488', () => {
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      entities: [Test],
+      dbName: ':memory:',
+    });
+
+    await orm.schema.refresh();
+  });
+
+  beforeEach(async () => {
+    await orm.em.createQueryBuilder(Test).truncate().execute();
+    orm.em.clear();
+  });
+
+  afterAll(() => orm.close(true));
+
+  test('array values containing commas should be preserved', async () => {
+    orm.em.create(Test, { names: ['hello,world', 'hello'] });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const [loaded] = await orm.em.find(Test, {});
+    expect(loaded.names).toEqual(['hello,world', 'hello']);
+  });
+
+  test('array values without commas still work', async () => {
+    orm.em.create(Test, { names: ['hello', 'world'] });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const [loaded] = await orm.em.find(Test, {});
+    expect(loaded.names).toEqual(['hello', 'world']);
+  });
+
+  test('array values containing double quotes should be preserved', async () => {
+    orm.em.create(Test, { names: ['say "hi"', 'normal'] });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const [loaded] = await orm.em.find(Test, {});
+    expect(loaded.names).toEqual(['say "hi"', 'normal']);
+  });
+
+  test('array values containing backslashes should be preserved', async () => {
+    orm.em.create(Test, { names: ['path\\to', 'file'] });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const [loaded] = await orm.em.find(Test, {});
+    expect(loaded.names).toEqual(['path\\to', 'file']);
+  });
+
+  test('empty array should work', async () => {
+    orm.em.create(Test, { names: [] });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const [loaded] = await orm.em.find(Test, {});
+    expect(loaded.names).toEqual([]);
+  });
+
+  test('unquoted values before quoted ones should be preserved', async () => {
+    orm.em.create(Test, { names: ['hello', 'world,foo'] });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const [loaded] = await orm.em.find(Test, {});
+    expect(loaded.names).toEqual(['hello', 'world,foo']);
+  });
+
+  test('null array should work', async () => {
+    orm.em.create(Test, { names: null });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const [loaded] = await orm.em.find(Test, {});
+    expect(loaded.names).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- The base `Platform.marshallArray`/`unmarshallArray` used simple comma join/split, which corrupted array values containing commas (e.g. `['hello,world']` became `['hello', 'world']` on read)
- Values containing `,`, `"`, or `\` are now JSON-quoted during marshalling, with a backward-compatible parser that falls back to simple `split(',')` for unquoted legacy data
- Affects SQLite, MySQL, MariaDB, and MSSQL drivers (PostgreSQL already had its own quoting)

Closes #7488

🤖 Generated with [Claude Code](https://claude.com/claude-code)