### PR TITLE
fix(core): skip shared join columns with null value in mapDataToFieldNames

### DIFF
--- a/packages/core/src/drivers/DatabaseDriver.ts
+++ b/packages/core/src/drivers/DatabaseDriver.ts
@@ -524,7 +524,7 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
       if (prop.joinColumns && Array.isArray(data[k])) {
         const copy = Utils.flatten(data[k]);
         delete data[k];
-        prop.joinColumns.forEach((joinColumn, idx) => (data[joinColumn] = copy[idx]));
+        (prop.ownColumns ?? prop.joinColumns).forEach(col => (data[col] = copy[prop.joinColumns.indexOf(col)]));
 
         return;
       }

--- a/tests/issues/GHx-composite-fk-shared-column.test.ts
+++ b/tests/issues/GHx-composite-fk-shared-column.test.ts
@@ -1,4 +1,4 @@
-import { BaseEntity, MikroORM, PrimaryKeyProp, type Ref } from '@mikro-orm/postgresql';
+import { BaseEntity, MikroORM, PrimaryKeyProp, ref, type Ref } from '@mikro-orm/postgresql';
 import { Entity, ManyToOne, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
 import { randomUUID } from 'node:crypto';
 
@@ -104,6 +104,34 @@ describe('GHx - composite FK with shared join column [object Object] bug', () =>
 
     const verifyEm = orm.em.fork();
     const loaded = await verifyEm.findOneOrFail(Referrer, { label: 'test' }, { populate: ['childA', 'childB'] });
+    expect(loaded.childA!.id).toBe(childA.id);
+    expect(loaded.childB!.id).toBe(childB.id);
+  });
+
+  test('update existing entity to reference new entity in same flush does not nullify shared column', async () => {
+    const em = orm.em.fork();
+    const orgId = randomUUID();
+
+    em.create(Organization, { id: orgId, name: 'Test Org Update' });
+    const childA = em.create(ChildA, { organization: orgId, label: 'A-existing' });
+    await em.flush();
+
+    // Create Referrer WITHOUT childB — flush so it has a real PK
+    const referrer = em.create(Referrer, {
+      organization: orgId,
+      label: 'test-update',
+      childA,
+    });
+    await em.flush();
+
+    // Create new ChildB (PK not yet assigned — defaultRaw) and assign to existing Referrer
+    const childB = em.create(ChildB, { organization: orgId, label: 'B-new' });
+    referrer.childB = ref(childB);
+
+    await em.flush();
+
+    const verifyEm = orm.em.fork();
+    const loaded = await verifyEm.findOneOrFail(Referrer, { label: 'test-update' }, { populate: ['childA', 'childB'] });
     expect(loaded.childA!.id).toBe(childA.id);
     expect(loaded.childB!.id).toBe(childB.id);
   });


### PR DESCRIPTION
## Summary

- When updating an entity with multiple composite FK relations sharing a join column (e.g. `organization_id`), assigning a newly created entity in the same flush would produce `UPDATE SET organization_id = NULL` — the `mapDataToFieldNames` method mapped all `joinColumns` unconditionally, including deduplicated shared columns where the value is `null`
- Now skips null values for non-owned (shared/deduplicated) columns, consistent with how the adjacent null-FK path already uses `prop.ownColumns`

🤖 Generated with [Claude Code](https://claude.com/claude-code)