### PR TITLE
fix(migrations): skip database connection in checkSchema() when snapshot exists

### DIFF
--- a/packages/migrations/src/Migrator.ts
+++ b/packages/migrations/src/Migrator.ts
@@ -113,9 +113,20 @@ export class Migrator extends AbstractMigrator<AbstractSqlDriver> {
   }
 
   async checkSchema(): Promise<boolean> {
-    await this.init();
-    const diff = await this.getSchemaDiff(false, false);
-    return diff.up.length > 0;
+    const snapshot = await this.getSchemaFromSnapshot();
+
+    if (!snapshot) {
+      await this.init();
+    }
+
+    const diff = await this.#schemaGenerator.getUpdateSchemaMigrationSQL({
+      wrap: false,
+      safe: this.options.safe,
+      dropTables: this.options.dropTables,
+      fromSchema: snapshot,
+    });
+
+    return diff.up.trim().length > 0;
   }
 
   /**

--- a/tests/features/migrations/Migrator.sqlite.test.ts
+++ b/tests/features/migrations/Migrator.sqlite.test.ts
@@ -245,6 +245,42 @@ describe('Migrator (sqlite)', () => {
     }
   });
 
+  test('checkSchema works without database connection when snapshot exists', async () => {
+    const migrations = orm.config.get('migrations');
+    migrations.snapshot = true;
+
+    const dateMock = vi.spyOn(Date.prototype, 'toISOString');
+    dateMock.mockReturnValue('2019-10-13T21:48:13.382Z');
+    const path = process.cwd() + '/temp/migrations-3';
+    const migrator = new Migrator(orm.em);
+
+    // create a blank migration — snapshot is written from metadata (getTargetSchema)
+    const migration1 = await migrator.create(path, true);
+    expect(migration1.diff).toEqual({ up: ['select 1'], down: ['select 1'] });
+
+    // create a fresh migrator that has NOT been initialized (no DB connection)
+    const migrator2 = new Migrator(orm.em);
+
+    // mock ensureDatabase and ensureTable to throw — proving we don't need DB
+    const ensureDbMock = vi.spyOn(orm.schema, 'ensureDatabase');
+    ensureDbMock.mockRejectedValue(new Error('should not connect to database'));
+    const ensureTableMock = vi.spyOn(MigrationStorage.prototype, 'ensureTable');
+    ensureTableMock.mockRejectedValue(new Error('should not connect to database'));
+
+    try {
+      // checkSchema should succeed without database, using the snapshot
+      const outOfSync = await migrator2.checkSchema();
+      expect(outOfSync).toBe(false);
+    } finally {
+      const snapshotPath = path + '/.snapshot-memory.json';
+      await rm(path + '/' + migration1.fileName);
+      await rm(snapshotPath, { force: true });
+      ensureDbMock.mockRestore();
+      ensureTableMock.mockRestore();
+      migrations.snapshot = false;
+    }
+  });
+
   test('generate initial migration', async () => {
     await orm.schema.dropTableIfExists(orm.config.get('migrations').tableName!);
     const getExecutedMigrationsMock = vi.spyOn(Migrator.prototype, 'getExecuted');


### PR DESCRIPTION
## Summary

- When a migration snapshot file exists, `checkSchema()` now skips `init()` entirely (no `ensureDatabase()` or `ensureTable()` calls), comparing the snapshot against target schema from metadata instead
- This allows `migrator:check` CLI command (and `checkSchema()` API) to work in CI environments without a running database, as long as snapshots are enabled
- When no snapshot exists, behavior is unchanged — full initialization with DB connection is performed

Fixes https://github.com/mikro-orm/mikro-orm/discussions/7481

🤖 Generated with [Claude Code](https://claude.com/claude-code)