### PR TITLE
fix(core): skip inverse collections when deduplicating ownColumns

### DIFF
--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -525,7 +525,7 @@ export class MetadataDiscovery {
 
       if (prop.joinColumns.length > 1) {
         prop.ownColumns = prop.joinColumns.filter(col => {
-          return !meta.props.find(p => p.name !== prop.name && (!p.fieldNames || p.fieldNames.includes(col)));
+          return !meta.props.find(p => p.name !== prop.name && p.fieldNames?.includes(col));
         });
       }
 

--- a/tests/issues/GHx-composite-fk-shared-column.test.ts
+++ b/tests/issues/GHx-composite-fk-shared-column.test.ts
@@ -1,5 +1,12 @@
-import { BaseEntity, MikroORM, PrimaryKeyProp, ref, type Ref } from '@mikro-orm/postgresql';
-import { Entity, ManyToOne, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+import { BaseEntity, Collection, MikroORM, PrimaryKeyProp, ref, type Ref } from '@mikro-orm/postgresql';
+import {
+  Entity,
+  ManyToOne,
+  OneToMany,
+  PrimaryKey,
+  Property,
+  ReflectMetadataProvider,
+} from '@mikro-orm/decorators/legacy';
 import { randomUUID } from 'node:crypto';
 
 @Entity({ tableName: 'cfk_organization' })
@@ -67,6 +74,29 @@ class Referrer extends BaseEntity {
     joinColumns: ['child_b_id', 'organization_id'],
   })
   childB?: Ref<ChildB> | null;
+
+  // The @OneToMany collection has no fieldNames — it must not break
+  // ownColumns deduplication for sibling composite FK relations.
+  @OneToMany({ entity: () => ReferrerNote, mappedBy: 'referrer' })
+  notes = new Collection<ReferrerNote>(this);
+}
+
+@Entity({ tableName: 'cfk_referrer_note' })
+class ReferrerNote extends BaseEntity {
+  [PrimaryKeyProp]?: ['id', 'organization'];
+
+  @PrimaryKey({ type: 'uuid', defaultRaw: 'gen_random_uuid()' })
+  id!: string;
+
+  @ManyToOne({ entity: () => Organization, ref: true, primary: true })
+  organization!: Ref<Organization>;
+
+  @ManyToOne({
+    entity: () => Referrer,
+    ref: true,
+    joinColumns: ['referrer_id', 'organization_id'],
+  })
+  referrer!: Ref<Referrer>;
 }
 
 let orm: MikroORM;
@@ -75,7 +105,7 @@ beforeAll(async () => {
   orm = await MikroORM.init({
     metadataProvider: ReflectMetadataProvider,
     dbName: 'mikro_orm_composite_fk_shared_column',
-    entities: [Organization, ChildA, ChildB, Referrer],
+    entities: [Organization, ChildA, ChildB, Referrer, ReferrerNote],
   });
   await orm.schema.refresh();
 });
@@ -85,6 +115,18 @@ afterAll(async () => {
 });
 
 describe('GHx - composite FK with shared join column [object Object] bug', () => {
+  test('inverse @OneToMany must not break ownColumns deduplication on owning side', () => {
+    const meta = orm.getMetadata().get(Referrer);
+    const childA = meta.relations.find(p => p.name === 'childA')!;
+    const childB = meta.relations.find(p => p.name === 'childB')!;
+
+    // organization_id is shared with the primary `organization` relation,
+    // so it must be deduplicated out of ownColumns even though Referrer also
+    // has an inverse @OneToMany collection (which has no fieldNames).
+    expect(childA.ownColumns).toEqual(['child_a_id']);
+    expect(childB.ownColumns).toEqual(['child_b_id']);
+  });
+
   test('em.create children + referrer in single flush', async () => {
     const em = orm.em.fork();
     const orgId = randomUUID();


### PR DESCRIPTION
`MetadataDiscovery.initOwnColumns` was excluding a join column from `ownColumns` whenever any *other* property either had no `fieldNames` **or** contained the column. The first half of that check is wrong: inverse collections (`@OneToMany`, inverse `@OneToOne`) have no `fieldNames` but they own no column on this entity, so they must not influence deduplication.

When such a collection coexists with composite FK relations sharing a join column (e.g. `organization_id`), the filter dropped every column, fell back to `joinColumns`, and broke the dedup that #7490 relies on — producing `UPDATE … SET shared_column = NULL` and a NOT NULL violation. Removing a single `@OneToMany` from the entity made the bug disappear.

The fix is a one-line adjustment to the filter: only consider sibling properties whose `fieldNames` actually contain the column.

The same fix is needed on `6.x` (it carries the identical broken filter).