### PR TITLE
fix(core): skip inverse collections when deduplicating ownColumns

### DIFF
--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -532,7 +532,7 @@ export class MetadataDiscovery {
 
       if (prop.joinColumns.length > 1) {
         prop.ownColumns = prop.joinColumns.filter(col => {
-          return !meta.props.find(p => p.name !== prop.name && (!p.fieldNames || p.fieldNames.includes(col)));
+          return !meta.props.find(p => p.name !== prop.name && p.fieldNames?.includes(col));
         });
       }
 

--- a/tests/issues/GHx-composite-fk-shared-column.test.ts
+++ b/tests/issues/GHx-composite-fk-shared-column.test.ts
@@ -1,8 +1,10 @@
 import {
   BaseEntity,
+  Collection,
   Entity,
   ManyToOne,
   MikroORM,
+  OneToMany,
   PrimaryKey,
   PrimaryKeyProp,
   Property,
@@ -84,6 +86,31 @@ class Referrer extends BaseEntity {
   })
   childB?: Ref<ChildB> | null;
 
+  // The @OneToMany collection has no fieldNames — it must not break
+  // ownColumns deduplication for sibling composite FK relations.
+  @OneToMany({ entity: () => ReferrerNote, mappedBy: 'referrer' })
+  notes = new Collection<ReferrerNote>(this);
+
+}
+
+@Entity({ tableName: 'cfk_referrer_note' })
+class ReferrerNote extends BaseEntity {
+
+  [PrimaryKeyProp]?: ['id', 'organization'];
+
+  @PrimaryKey({ type: 'uuid', defaultRaw: 'gen_random_uuid()' })
+  id!: string;
+
+  @ManyToOne({ entity: () => Organization, ref: true, primary: true })
+  organization!: Ref<Organization>;
+
+  @ManyToOne({
+    entity: () => Referrer,
+    ref: true,
+    joinColumns: ['referrer_id', 'organization_id'],
+  })
+  referrer!: Ref<Referrer>;
+
 }
 
 let orm: MikroORM;
@@ -91,7 +118,7 @@ let orm: MikroORM;
 beforeAll(async () => {
   orm = await MikroORM.init({
     dbName: 'mikro_orm_composite_fk_shared_column',
-    entities: [Organization, ChildA, ChildB, Referrer],
+    entities: [Organization, ChildA, ChildB, Referrer, ReferrerNote],
   });
   await orm.schema.refreshDatabase();
 });
@@ -101,6 +128,18 @@ afterAll(async () => {
 });
 
 describe('GHx - composite FK with shared join column [object Object] bug', () => {
+
+  test('inverse @OneToMany must not break ownColumns deduplication on owning side', () => {
+    const meta = orm.getMetadata().get(Referrer);
+    const childA = meta.relations.find(p => p.name === 'childA')!;
+    const childB = meta.relations.find(p => p.name === 'childB')!;
+
+    // organization_id is shared with the primary `organization` relation,
+    // so it must be deduplicated out of ownColumns even though Referrer also
+    // has an inverse @OneToMany collection (which has no fieldNames).
+    expect(childA.ownColumns).toEqual(['child_a_id']);
+    expect(childB.ownColumns).toEqual(['child_b_id']);
+  });
 
   test('em.create children + referrer in single flush', async () => {
     const em = orm.em.fork();


### PR DESCRIPTION
Backport of #7504 to `6.x`.

`MetadataDiscovery.initOwnColumns` was excluding a join column from `ownColumns` whenever any *other* property either had no `fieldNames` **or** contained the column. The first half of that check is wrong: inverse collections (`@OneToMany`, inverse `@OneToOne`) have no `fieldNames` but they own no column on this entity, so they must not influence deduplication.

When such a collection coexists with composite FK relations sharing a join column (e.g. `organization_id`), the filter dropped every column, fell back to `joinColumns`, and broke the dedup that #7492 relies on — producing `UPDATE … SET shared_column = NULL` and a NOT NULL violation. Removing a single `@OneToMany` from the entity made the bug disappear.

The fix is a one-line adjustment to the filter: only consider sibling properties whose `fieldNames` actually contain the column.