### PR TITLE
feat(core): add `fields` whitelist option to `serialize()`

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -2,6 +2,8 @@ compressionLevel: mixed
 
 enableGlobalCache: false
 
+enableScripts: false
+
 npmMinimalAgeGate: 1d
 
 nodeLinker: node-modules

--- a/docs/docs/serializing.md
+++ b/docs/docs/serializing.md
@@ -192,12 +192,18 @@ const dto2 = wrap(user1).serialize();
 By default, every relation is considered as not populated - this will result in the foreign key values to be present. Loaded collections will be represented as arrays of the foreign keys. To control the shape of the serialized response you can use the second `options` parameter:
 
 ```ts
-interface SerializeOptions<T extends object, P extends string = never, E extends string = never> {
+interface SerializeOptions<T extends object, P extends string = never, E extends string = never, F extends string = never> {
   /** Specify which relation should be serialized as populated and which as a FK. */
   populate?: AutoPath<T, P>[] | boolean;
 
   /** Specify which properties should be omitted. */
   exclude?: AutoPath<T, E>[];
+
+  /**
+   * Whitelist of properties to serialize (supports dot-paths). When set, only the listed
+   * properties end up in the output, including primary keys. `exclude` takes precedence on conflict.
+   */
+  fields?: AutoPath<T, F>[];
 
   /** Enforce unpopulated references to be returned as objects, e.g. `{ author: { id: 1 } }` instead of `{ author: 1 }`. */
   forceObject?: boolean;
@@ -231,6 +237,41 @@ const dto = wrap(author).serialize({
   skipNull: true, // properties with `null` value won't be part of the result
 });
 ```
+
+### Whitelisting properties via `fields`
+
+While `exclude` is a denylist (everything is in the output by default, listed paths are stripped), `fields` is a whitelist — only the listed properties end up in the output. This is useful for shaping API responses without writing manual `pick()` helpers, and it protects against accidentally exposing newly added entity fields.
+
+```ts
+import { serialize, wrap } from '@mikro-orm/core';
+
+// only `name` is in the output — no PK, no other fields
+const dto1 = serialize(author, { fields: ['name'] });
+// { name: 'Jon Snow' }
+
+// dot-paths drill into relations and embeddables
+const dto2 = serialize(author, {
+  populate: ['books'],
+  fields: ['name', 'books.title'],
+});
+// { name: 'Jon Snow', books: [{ title: '...' }, ...] }
+
+// a bare relation name keeps the entire sub-tree
+const dto3 = serialize(author, {
+  populate: ['books.author'],
+  fields: ['books'], // every field of every book (and its populated author) is included
+});
+
+// the same option is available on `wrap(e).serialize()`
+const dto4 = wrap(author).serialize({ fields: ['id', 'name'] });
+```
+
+A few notes:
+
+- **Primary keys are subject to `fields`.** Unlike the implicit serialization path (`toObject()` after partial loading), the explicit `serialize()` path treats `fields` as a strict whitelist — if you want the PK in the output, list it explicitly.
+- **Precedence with `exclude`**: `exclude` wins on conflict. `serialize(user, { fields: ['name', 'email'], exclude: ['email'] })` returns `{ name }`.
+- **Interaction with `populate`**: orthogonal. `populate` controls whether a relation is expanded into a nested object or shown as an FK; `fields` controls whether the property appears at all and which sub-keys survive.
+- **The return type narrows** to match the listed fields, so the resulting DTO is type-safe end-to-end.
 
 If you try to populate a relation that is not initialized, it will have same effect as the `forceObject` option - the value will be represented as object with just the primary key available.
 

--- a/docs/docs/serializing.md
+++ b/docs/docs/serializing.md
@@ -270,6 +270,7 @@ A few notes:
 
 - **Primary keys are subject to `fields`.** Unlike the implicit serialization path (`toObject()` after partial loading), the explicit `serialize()` path treats `fields` as a strict whitelist — if you want the PK in the output, list it explicitly.
 - **Precedence with `exclude`**: `exclude` wins on conflict. `serialize(user, { fields: ['name', 'email'], exclude: ['email'] })` returns `{ name }`.
+- **Hidden properties are still hidden.** Listing a `hidden: true` property in `fields` does not override that — pass `includeHidden: true` if you really need it.
 - **Interaction with `populate`**: orthogonal. `populate` controls whether a relation is expanded into a nested object or shown as an FK; `fields` controls whether the property appears at all and which sub-keys survive.
 - **The return type narrows** to match the listed fields, so the resulting DTO is type-safe end-to-end.
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -28,7 +28,7 @@
     "prism-react-renderer": "^2.4.1",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "typescript": "6.0.2"
+    "typescript": "6.0.3"
   },
   "browserslist": {
     "production": [
@@ -49,5 +49,5 @@
     "@types/react-dom": "^19.1.5",
     "prettier": "^3.5.3"
   },
-  "packageManager": "yarn@4.13.0"
+  "packageManager": "yarn@4.14.1"
 }

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 8
+  version: 9
   cacheKey: 10
 
 "@algolia/abtesting@npm:1.4.0":
@@ -7032,7 +7032,7 @@ __metadata:
     prism-react-renderer: "npm:^2.4.1"
     react: "npm:^19.2.4"
     react-dom: "npm:^19.2.4"
-    typescript: "npm:6.0.2"
+    typescript: "npm:6.0.3"
   languageName: unknown
   linkType: soft
 
@@ -14466,23 +14466,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:6.0.2":
-  version: 6.0.2
-  resolution: "typescript@npm:6.0.2"
+"typescript@npm:6.0.3":
+  version: 6.0.3
+  resolution: "typescript@npm:6.0.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10/b9fc2fcee7ee8e5ca6f5138181964550531e18e2d20ecb71b802d4d495881e3444e0ef94cbb6e84eb2ba41e913f6feae3ca33cc722b32e6e6dfadb32d23b80e6
+  checksum: 10/0ef2357a4cffd916b52b683a021cdab0f81eea4e9aa35f2d254581c9a5106da02224e3392e1b0ed42b7a48f80c966e5f52b8e1a27941fa0523c1705a9c2e0330
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A6.0.2#optional!builtin<compat/typescript>":
-  version: 6.0.2
-  resolution: "typescript@patch:typescript@npm%3A6.0.2#optional!builtin<compat/typescript>::version=6.0.2&hash=5786d5"
+"typescript@patch:typescript@npm%3A6.0.3#optional!builtin<compat/typescript>":
+  version: 6.0.3
+  resolution: "typescript@patch:typescript@npm%3A6.0.3#optional!builtin<compat/typescript>::version=6.0.3&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10/e5501dfcf8c5b6b9a61f6fa53decc40187cebe3a2b7b2bd51c615007ad4cf6d58298461fef63294f6be9d5f2f33019b2a2e2bf02d9cb7d7f6ec94372bf24ffa2
+  checksum: 10/22b67a18dafedf9b1468b64ca20d9aa02ea61d449b65413d8aa6552aeb63f52ef369e86beb25b6b4c91a803d9726ee5c196f391a9b64201263263410a4223ee6
   languageName: node
   linkType: hard
 

--- a/package.json
+++ b/package.json
@@ -112,6 +112,23 @@
   "resolutions": {
     "@ark/util": "0.56.0"
   },
+  "dependenciesMeta": {
+    "@swc/core": {
+      "built": true
+    },
+    "better-sqlite3": {
+      "built": true
+    },
+    "esbuild": {
+      "built": true
+    },
+    "nx": {
+      "built": true
+    },
+    "oracledb": {
+      "built": true
+    }
+  },
   "devDependencies": {
     "@ark/attest": "0.56.0",
     "@commitlint/cli": "20.5.0",
@@ -148,10 +165,10 @@
     "rimraf": "6.1.3",
     "tsimp": "2.0.12",
     "tsx": "4.21.0",
-    "typescript": "6.0.2",
+    "typescript": "6.0.3",
     "unplugin-swc": "1.5.9",
     "uuid": "11.1.0",
     "vitest": "4.1.4"
   },
-  "packageManager": "yarn@4.13.0"
+  "packageManager": "yarn@4.14.1"
 }

--- a/packages/core/src/entity/BaseEntity.ts
+++ b/packages/core/src/entity/BaseEntity.ts
@@ -3,6 +3,7 @@ import type {
   AutoPath,
   EntityData,
   EntityDTO,
+  ExtractFieldsHint,
   Loaded,
   LoadedReference,
   AddEager,
@@ -130,8 +131,15 @@ export abstract class BaseEntity {
     Fields extends string = never,
   >(
     options?: SerializeOptions<Naked, Hint, Exclude, Fields>,
-  ): SerializeDTO<Naked, Hint, Exclude, never, ResolveSerializeFields<Fields>, SerializeFieldsKeepPK<Fields>> {
-    return EntitySerializer.serialize(this as unknown as Naked, options);
+  ): SerializeDTO<
+    Naked,
+    Hint,
+    Exclude,
+    never,
+    ResolveSerializeFields<Fields, ExtractFieldsHint<Entity>>,
+    SerializeFieldsKeepPK<Fields>
+  > {
+    return EntitySerializer.serialize(this as unknown as Naked, options) as any;
   }
 
   /** Assigns the given data to this entity, updating its properties and relations. */

--- a/packages/core/src/entity/BaseEntity.ts
+++ b/packages/core/src/entity/BaseEntity.ts
@@ -10,7 +10,9 @@ import type {
   FromEntityType,
   IsSubset,
   MergeSelected,
+  ResolveSerializeFields,
   SerializeDTO,
+  SerializeFieldsKeepPK,
 } from '../typings.js';
 import { EntityAssigner, type AssignOptions } from './EntityAssigner.js';
 import type { EntityLoaderOptions } from './EntityLoader.js';
@@ -125,7 +127,10 @@ export abstract class BaseEntity {
     Naked extends FromEntityType<Entity> = FromEntityType<Entity>,
     Hint extends string = never,
     Exclude extends string = never,
-  >(options?: SerializeOptions<Naked, Hint, Exclude>): SerializeDTO<Naked, Hint, Exclude> {
+    Fields extends string = never,
+  >(
+    options?: SerializeOptions<Naked, Hint, Exclude, Fields>,
+  ): SerializeDTO<Naked, Hint, Exclude, never, ResolveSerializeFields<Fields>, SerializeFieldsKeepPK<Fields>> {
     return EntitySerializer.serialize(this as unknown as Naked, options);
   }
 

--- a/packages/core/src/entity/WrappedEntity.ts
+++ b/packages/core/src/entity/WrappedEntity.ts
@@ -18,7 +18,9 @@ import type {
   LoadedReference,
   EntityDTO,
   Loaded,
+  ResolveSerializeFields,
   SerializeDTO,
+  SerializeFieldsKeepPK,
   FromEntityType,
   IsSubset,
   MergeSelected,
@@ -139,9 +141,9 @@ export class WrappedEntity<Entity extends object> {
   }
 
   /** Serializes the entity with control over which relations and fields to include or exclude. */
-  serialize<Hint extends string = never, Exclude extends string = never>(
-    options?: SerializeOptions<Entity, Hint, Exclude>,
-  ): SerializeDTO<Entity, Hint, Exclude> {
+  serialize<Hint extends string = never, Exclude extends string = never, Fields extends string = never>(
+    options?: SerializeOptions<Entity, Hint, Exclude, Fields>,
+  ): SerializeDTO<Entity, Hint, Exclude, never, ResolveSerializeFields<Fields>, SerializeFieldsKeepPK<Fields>> {
     return EntitySerializer.serialize(this.entity, options);
   }
 

--- a/packages/core/src/entity/WrappedEntity.ts
+++ b/packages/core/src/entity/WrappedEntity.ts
@@ -18,6 +18,7 @@ import type {
   LoadedReference,
   EntityDTO,
   Loaded,
+  ExtractFieldsHint,
   ResolveSerializeFields,
   SerializeDTO,
   SerializeFieldsKeepPK,
@@ -142,9 +143,16 @@ export class WrappedEntity<Entity extends object> {
 
   /** Serializes the entity with control over which relations and fields to include or exclude. */
   serialize<Hint extends string = never, Exclude extends string = never, Fields extends string = never>(
-    options?: SerializeOptions<Entity, Hint, Exclude, Fields>,
-  ): SerializeDTO<Entity, Hint, Exclude, never, ResolveSerializeFields<Fields>, SerializeFieldsKeepPK<Fields>> {
-    return EntitySerializer.serialize(this.entity, options);
+    options?: SerializeOptions<FromEntityType<Entity>, Hint, Exclude, Fields>,
+  ): SerializeDTO<
+    FromEntityType<Entity>,
+    Hint,
+    Exclude,
+    never,
+    ResolveSerializeFields<Fields, ExtractFieldsHint<Entity>>,
+    SerializeFieldsKeepPK<Fields>
+  > {
+    return EntitySerializer.serialize(this.entity, options as any) as any;
   }
 
   /** Converts the entity to a plain object, including all properties regardless of serialization rules. */

--- a/packages/core/src/serialization/EntitySerializer.ts
+++ b/packages/core/src/serialization/EntitySerializer.ts
@@ -7,7 +7,9 @@ import type {
   EntityDTOProp,
   ExtractFieldsHint,
   FromEntityType,
+  ResolveSerializeFields,
   SerializeDTO,
+  SerializeFieldsKeepPK,
   EntityKey,
   EntityMetadata,
   EntityProperty,
@@ -24,10 +26,15 @@ import { Reference } from '../entity/Reference.js';
 import { SerializationContext } from './SerializationContext.js';
 import { isRaw } from '../utils/RawQueryFragment.js';
 
+/** Returns true when any entry in `items` is `propName`, the wildcard `*`, or a dot-path under `propName`. */
+function matchesPath(items: readonly string[], propName: string): boolean {
+  return items.some(item => item === propName || item === '*' || item.startsWith(propName + '.'));
+}
+
 function isVisible<T extends object>(
   meta: EntityMetadata<T>,
   propName: EntityKey<T>,
-  options: SerializeOptions<T, any, any>,
+  options: SerializeOptions<T, any, any, any>,
 ): boolean {
   const prop = meta.properties[propName];
 
@@ -35,10 +42,11 @@ function isVisible<T extends object>(
     return prop.groups.some(g => options.groups!.includes(g));
   }
 
-  if (
-    Array.isArray(options.populate) &&
-    options.populate?.find(item => item === propName || item.startsWith(propName + '.') || item === '*')
-  ) {
+  if (Array.isArray(options.fields) && options.fields.length > 0 && !matchesPath(options.fields, propName)) {
+    return false;
+  }
+
+  if (Array.isArray(options.populate) && matchesPath(options.populate, propName)) {
     return true;
   }
 
@@ -52,10 +60,11 @@ function isVisible<T extends object>(
   return visible && !prefixed;
 }
 
-function isPopulated(propName: string, options: SerializeOptions<any, any, any>): boolean {
+function isPopulated(propName: string, options: SerializeOptions<any, any, any, any>): boolean {
   if (
     typeof options.populate !== 'boolean' &&
-    (options.populate as string[])?.find(item => item === propName || item.startsWith(propName + '.') || item === '*')
+    Array.isArray(options.populate) &&
+    matchesPath(options.populate, propName)
   ) {
     return true;
   }
@@ -67,13 +76,13 @@ function isPopulated(propName: string, options: SerializeOptions<any, any, any>)
   return false;
 }
 
-/** Converts entity instances to plain DTOs via `serialize()`, with fine-grained control over populate, exclude, and serialization groups. */
+/** Converts entity instances to plain DTOs via `serialize()`, with fine-grained control over populate, exclude, fields, and serialization groups. */
 export class EntitySerializer {
-  /** Serializes an entity to a plain DTO, with fine-grained control over population, exclusion, groups, and custom types. */
-  static serialize<T extends object, P extends string = never, E extends string = never>(
+  /** Serializes an entity to a plain DTO, with fine-grained control over population, exclusion, fields, groups, and custom types. */
+  static serialize<T extends object, P extends string = never, E extends string = never, F extends string = never>(
     entity: T,
-    options: SerializeOptions<T, P, E> = {},
-  ): SerializeDTO<T, P, E> {
+    options: SerializeOptions<T, P, E, F> = {},
+  ): SerializeDTO<T, P, E, never, ResolveSerializeFields<F>, SerializeFieldsKeepPK<F>> {
     const wrapped = helper(entity);
     const meta = wrapped.__meta;
     let contextCreated = false;
@@ -158,7 +167,7 @@ export class EntitySerializer {
     }
 
     if (!wrapped.isInitialized()) {
-      return ret as SerializeDTO<T, P, E>;
+      return ret as SerializeDTO<T, P, E, never, ResolveSerializeFields<F>, SerializeFieldsKeepPK<F>>;
     }
 
     for (const prop of meta.getterProps) {
@@ -179,7 +188,7 @@ export class EntitySerializer {
       }
     }
 
-    return ret as SerializeDTO<T, P, E>;
+    return ret as SerializeDTO<T, P, E, never, ResolveSerializeFields<F>, SerializeFieldsKeepPK<F>>;
   }
 
   private static propertyName<T>(meta: EntityMetadata<T>, prop: EntityKey<T>): EntityKey<T> {
@@ -198,7 +207,7 @@ export class EntitySerializer {
   private static processProperty<T extends object>(
     prop: EntityKey<T>,
     entity: T,
-    options: SerializeOptions<T, any, any>,
+    options: SerializeOptions<T, any, any, any>,
   ): EntityValue<T> | undefined {
     const parts = prop.split('.');
     prop = parts[0] as EntityKey<T>;
@@ -270,7 +279,7 @@ export class EntitySerializer {
   }
 
   private static extractChildOptions<T extends object, U extends object>(
-    options: SerializeOptions<T, any, any>,
+    options: SerializeOptions<T, any, any, any>,
     prop: EntityKey<T>,
   ): SerializeOptions<U> {
     return {
@@ -279,14 +288,37 @@ export class EntitySerializer {
         ? Utils.extractChildElements(options.populate, prop, '*')
         : options.populate,
       exclude: Array.isArray(options.exclude) ? Utils.extractChildElements(options.exclude, prop) : options.exclude,
+      fields: Array.isArray(options.fields) ? this.extractChildFields(options.fields, prop) : options.fields,
     } as SerializeOptions<U>;
+  }
+
+  /**
+   * Extracts the nested `fields` whitelist for a child property. A bare parent name (`fields: ['books']`) or a
+   * wildcard removes the whitelist on the sub-tree (everything is included), so consumers don't have to repeat
+   * every field of the child. Otherwise dot-paths are stripped of the parent prefix and passed down.
+   */
+  private static extractChildFields(fields: readonly string[], prop: string): readonly string[] | undefined {
+    const out: string[] = [];
+    const dotPrefix = prop + '.';
+
+    for (const field of fields) {
+      if (field === prop || field === '*') {
+        return undefined;
+      }
+
+      if (field.startsWith(dotPrefix)) {
+        out.push(field.substring(dotPrefix.length));
+      }
+    }
+
+    return out;
   }
 
   private static processEntity<T extends object>(
     prop: EntityProperty<T>,
     entity: T,
     platform: Platform,
-    options: SerializeOptions<T, any, any>,
+    options: SerializeOptions<T, any, any, any>,
   ): EntityValue<T> | undefined {
     const child = Reference.unwrapReference(entity[prop.name] as T);
     const wrapped = helper(child);
@@ -322,7 +354,7 @@ export class EntitySerializer {
   private static processCollection<T extends object>(
     prop: EntityProperty<T>,
     entity: T,
-    options: SerializeOptions<T, any, any>,
+    options: SerializeOptions<T, any, any, any>,
   ): EntityValue<T> | undefined {
     const col = entity[prop.name] as Collection<T>;
 
@@ -349,12 +381,19 @@ export class EntitySerializer {
   }
 }
 
-export interface SerializeOptions<T, P extends string = never, E extends string = never> {
+export interface SerializeOptions<T, P extends string = never, E extends string = never, F extends string = never> {
   /** Specify which relation should be serialized as populated and which as a FK. */
   populate?: readonly AutoPath<T, P, `${PopulatePath.ALL}`>[];
 
   /** Specify which properties should be omitted. */
   exclude?: readonly AutoPath<T, E>[];
+
+  /**
+   * Whitelist of properties to serialize, supports dot-paths (e.g. `['name', 'books.title']`). When set, only the
+   * listed properties end up in the output, including primary keys. A bare property name keeps its entire sub-tree;
+   * a dot-path additionally narrows the nested object to the listed sub-keys. `exclude` takes precedence on conflict.
+   */
+  fields?: readonly AutoPath<T, F, `${PopulatePath.ALL}`>[];
 
   /** Enforce unpopulated references to be returned as objects, e.g. `{ author: { id: 1 } }` instead of `{ author: 1 }`. */
   forceObject?: boolean;
@@ -392,13 +431,28 @@ export function serialize<
   Naked extends FromEntityType<Entity> = FromEntityType<Entity>,
   Populate extends string = never,
   Exclude extends string = never,
+  Fields extends string = never,
   Config extends TypeConfig = never,
 >(
   entity: Entity,
-  options?: Config & SerializeOptions<UnboxArray<Entity>, Populate, Exclude>,
+  options?: Config & SerializeOptions<UnboxArray<Entity>, Populate, Exclude, Fields>,
 ): Naked extends object[]
-  ? SerializeDTO<ArrayElement<Naked>, Populate, Exclude, CleanTypeConfig<Config>>[]
-  : SerializeDTO<Naked, Populate, Exclude, CleanTypeConfig<Config>, ExtractFieldsHint<Entity>>;
+  ? SerializeDTO<
+      ArrayElement<Naked>,
+      Populate,
+      Exclude,
+      CleanTypeConfig<Config>,
+      ResolveSerializeFields<Fields, ExtractFieldsHint<Entity>>,
+      SerializeFieldsKeepPK<Fields>
+    >[]
+  : SerializeDTO<
+      Naked,
+      Populate,
+      Exclude,
+      CleanTypeConfig<Config>,
+      ResolveSerializeFields<Fields, ExtractFieldsHint<Entity>>,
+      SerializeFieldsKeepPK<Fields>
+    >;
 
 /**
  * Converts entity instance to POJO, converting the `Collection`s to arrays and unwrapping the `Reference` wrapper, while respecting the serialization options.
@@ -417,13 +471,28 @@ export function serialize<
   Naked extends FromEntityType<Entity> = FromEntityType<Entity>,
   Populate extends string = never,
   Exclude extends string = never,
+  Fields extends string = never,
   Config extends TypeConfig = never,
 >(
   entities: Entity | Entity[],
-  options?: SerializeOptions<Entity, Populate, Exclude>,
+  options?: SerializeOptions<Entity, Populate, Exclude, Fields>,
 ):
-  | SerializeDTO<Naked, Populate, Exclude, CleanTypeConfig<Config>, ExtractFieldsHint<Entity>>
-  | SerializeDTO<Naked, Populate, Exclude, CleanTypeConfig<Config>, ExtractFieldsHint<Entity>>[] {
+  | SerializeDTO<
+      Naked,
+      Populate,
+      Exclude,
+      CleanTypeConfig<Config>,
+      ResolveSerializeFields<Fields, ExtractFieldsHint<Entity>>,
+      SerializeFieldsKeepPK<Fields>
+    >
+  | SerializeDTO<
+      Naked,
+      Populate,
+      Exclude,
+      CleanTypeConfig<Config>,
+      ResolveSerializeFields<Fields, ExtractFieldsHint<Entity>>,
+      SerializeFieldsKeepPK<Fields>
+    >[] {
   if (Array.isArray(entities)) {
     return entities.map(e => EntitySerializer.serialize(e, options)) as any;
   }

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -494,7 +494,14 @@ export interface IWrappedEntity<Entity extends object> {
     Fields extends string = never,
   >(
     options?: SerializeOptions<Naked, Hint, Exclude, Fields>,
-  ): SerializeDTO<Naked, Hint, Exclude, never, ResolveSerializeFields<Fields>, SerializeFieldsKeepPK<Fields>>;
+  ): SerializeDTO<
+    Naked,
+    Hint,
+    Exclude,
+    never,
+    ResolveSerializeFields<Fields, ExtractFieldsHint<Entity>>,
+    SerializeFieldsKeepPK<Fields>
+  >;
   setSerializationContext<Hint extends string = never, Fields extends string = never, Exclude extends string = never>(
     options: LoadHint<Entity, Hint, Fields, Exclude>,
   ): void;

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -491,9 +491,10 @@ export interface IWrappedEntity<Entity extends object> {
     Naked extends FromEntityType<Entity> = FromEntityType<Entity>,
     Hint extends string = never,
     Exclude extends string = never,
+    Fields extends string = never,
   >(
-    options?: SerializeOptions<Naked, Hint, Exclude>,
-  ): SerializeDTO<Naked, Hint, Exclude>;
+    options?: SerializeOptions<Naked, Hint, Exclude, Fields>,
+  ): SerializeDTO<Naked, Hint, Exclude, never, ResolveSerializeFields<Fields>, SerializeFieldsKeepPK<Fields>>;
   setSerializationContext<Hint extends string = never, Fields extends string = never, Exclude extends string = never>(
     options: LoadHint<Entity, Hint, Fields, Exclude>,
   ): void;
@@ -848,7 +849,9 @@ type SerializeSubFields<K extends string, F extends string> = K extends F
     : F extends `${K & string}.${infer Rest}`
       ? Rest
       : never;
-type SerializeFieldsFilter<T, K extends keyof T, F extends string> = K extends Prefix<T, F> | PrimaryProperty<T>
+type SerializeFieldsFilter<T, K extends keyof T, F extends string, KeepPK extends boolean = true> = K extends
+  | Prefix<T, F>
+  | (KeepPK extends true ? PrimaryProperty<T> : never)
   ? K
   : never;
 type SerializePropValue<T, K extends keyof T, H extends string, C extends TypeConfig = never> =
@@ -857,24 +860,58 @@ type SerializePropValue<T, K extends keyof T, H extends string, C extends TypeCo
       ? SerializeDTO<U & object, SerializeSubHints<K & string, H>, never, C>[]
       : SerializeDTO<ExpandProperty<T[K]>, SerializeSubHints<K & string, H>, never, C> | Extract<T[K], null | undefined>
     : EntityDTOProp<T, T[K], C>;
-type SerializePropValueWithFields<T, K extends keyof T, H extends string, C extends TypeConfig, F extends string> =
+type SerializePropValueWithFields<
+  T,
+  K extends keyof T,
+  H extends string,
+  C extends TypeConfig,
+  F extends string,
+  KeepPK extends boolean = true,
+> =
   K & string extends SerializeTopHints<H>
     ? NonNullable<T[K]> extends CollectionShape<infer U>
-      ? SerializeDTO<U & object, SerializeSubHints<K & string, H>, never, C, SerializeSubFields<K & string, F>>[]
+      ? SerializeDTO<
+          U & object,
+          SerializeSubHints<K & string, H>,
+          never,
+          C,
+          SerializeSubFields<K & string, F>,
+          KeepPK
+        >[]
       :
           | SerializeDTO<
               ExpandProperty<T[K]>,
               SerializeSubHints<K & string, H>,
               never,
               C,
-              SerializeSubFields<K & string, F>
+              SerializeSubFields<K & string, F>,
+              KeepPK
             >
           | Extract<T[K], null | undefined>
     : EntityDTOProp<T, T[K], C>;
 
 /**
+ * Resolves a user-provided `Fields` generic to the value passed to `SerializeDTO`'s `F` parameter:
+ * `never` (no `fields` option) falls back to `Default` (typically `'*'` or the entity's `ExtractFieldsHint`).
+ */
+export type ResolveSerializeFields<Fields extends string, Default extends string = '*'> = [Fields] extends [never]
+  ? Default
+  : Fields;
+
+/**
+ * Whether the explicit `serialize()` path should keep primary keys in the output. When the user does not provide
+ * a `fields` option (`Fields = never`), behave like `toObject()` and keep PKs; when they do, treat it as a strict
+ * whitelist so PKs are dropped unless listed.
+ */
+export type SerializeFieldsKeepPK<Fields extends string> = [Fields] extends [never] ? true : false;
+
+/**
  * Return type of `serialize()`. Combines Loaded + EntityDTO in a single pass for better performance.
  * Respects populate hints (`H`), exclude hints (`E`), and fields hints (`F`).
+ *
+ * `KeepPK` controls whether primary keys are auto-included when narrowing by `F`. The `toObject()` path keeps the
+ * default `true` (PKs always present); the explicit `serialize()` path passes `false` so the user-provided `fields`
+ * option is a strict whitelist that can drop PKs from the output.
  */
 export type SerializeDTO<
   T,
@@ -882,6 +919,7 @@ export type SerializeDTO<
   E extends string = never,
   C extends TypeConfig = never,
   F extends string = '*',
+  KeepPK extends boolean = true,
 > = string extends H
   ? EntityDTOFlat<T, C>
   : [F] extends ['*']
@@ -894,8 +932,8 @@ export type SerializeDTO<
         [K in keyof T as ExcludeHidden<T, K> &
           CleanKeys<T, K> &
           (IsNever<E> extends true ? K : Exclude<K, E>) &
-          SerializeFieldsFilter<T, K, F>]:
-          | SerializePropValueWithFields<T, K, H, C, F>
+          SerializeFieldsFilter<T, K, F, KeepPK>]:
+          | SerializePropValueWithFields<T, K, H, C, F, KeepPK>
           | Extract<T[K], null | undefined>;
       };
 

--- a/packages/core/src/utils/Utils.ts
+++ b/packages/core/src/utils/Utils.ts
@@ -724,7 +724,7 @@ export class Utils {
     return classOrName.name as string;
   }
 
-  static extractChildElements(items: string[], prefix: string, allSymbol?: string): string[] {
+  static extractChildElements(items: readonly string[], prefix: string, allSymbol?: string): string[] {
     return items
       .filter(field => field === allSymbol || field.startsWith(`${prefix}.`))
       .map(field => (field === allSymbol ? allSymbol : field.substring(prefix.length + 1)));

--- a/packages/mysql/package.json
+++ b/packages/mysql/package.json
@@ -49,7 +49,7 @@
   "dependencies": {
     "@mikro-orm/sql": "7.0.11",
     "kysely": "0.28.16",
-    "mysql2": "3.22.0",
+    "mysql2": "3.22.1",
     "sqlstring": "2.3.3"
   },
   "devDependencies": {

--- a/tests/features/serialization/explicit-serialization.test.ts
+++ b/tests/features/serialization/explicit-serialization.test.ts
@@ -463,3 +463,22 @@ test('explicit serialization with fields option', async () => {
   const o9 = serialize(jon, { populate: ['favouriteBook'], fields: ['favouriteBook.title'] });
   expect(o9).toEqual({ favouriteBook: { title: 'Bible' } });
 });
+
+test('wrap().serialize() inherits the partial-load fields hint at the type level', async () => {
+  const { author } = await createEntities();
+
+  // partial load — the entity type carries the `fields` hint via `Loaded<...>`
+  const partial = await orm.em.findOneOrFail(Author2, author, { fields: ['name'] });
+
+  // standalone serialize() narrows the return type from the entity hint…
+  const a = serialize(partial);
+  expect(a.name).toBe('Jon Snow');
+  // @ts-expect-error `email` was not partial-loaded
+  expect(a.email).toBeUndefined();
+
+  // …and wrap(e).serialize() does the same now
+  const b = wrap(partial).serialize();
+  expect(b.name).toBe('Jon Snow');
+  // @ts-expect-error `email` was not partial-loaded
+  expect(b.email).toBeUndefined();
+});

--- a/tests/features/serialization/explicit-serialization.test.ts
+++ b/tests/features/serialization/explicit-serialization.test.ts
@@ -399,3 +399,67 @@ test('explicit serialization with convertCustomTypes option', async () => {
     expect(typeof bookId).toBe('string'); // UUID convertToDatabaseValue also returns string
   });
 });
+
+test('explicit serialization with fields option', async () => {
+  const { author } = await createEntities();
+  const jon = await orm.em.findOneOrFail(Author2, author, { populate: ['*'] });
+
+  const o1 = serialize(jon, { fields: ['name'] });
+  expect(o1).toEqual({ name: 'Jon Snow' });
+  // @ts-expect-error `id` is not part of the narrowed type
+  expect(o1.id).toBeUndefined();
+  // @ts-expect-error `email` is not part of the narrowed type
+  expect(o1.email).toBeUndefined();
+
+  const o2 = serialize(jon, { fields: ['id', 'name', 'email'] });
+  expect(o2).toEqual({ id: jon.id, name: 'Jon Snow', email: 'snow@wall.st' });
+
+  const o3 = serialize(jon, { populate: ['books'], fields: ['books.title'] });
+  expect(o3).toEqual({
+    books: [
+      { title: 'My Life on The Wall, part 1' },
+      { title: 'My Life on The Wall, part 2' },
+      { title: 'My Life on The Wall, part 3' },
+    ],
+  });
+  // @ts-expect-error nothing else made it through
+  expect(o3.id).toBeUndefined();
+
+  // a bare relation name in `fields` opts the whole sub-tree in, instead of recursing with an empty whitelist
+  const o4 = serialize(jon, { populate: ['books.author'], fields: ['books'] });
+  expect(Object.keys(o4)).toEqual(['books']);
+  expect(o4.books).toHaveLength(3);
+  expect(o4.books[0]).toMatchObject({
+    title: 'My Life on The Wall, part 1',
+    author: { id: jon.id, name: 'Jon Snow', email: 'snow@wall.st' },
+  });
+  // @ts-expect-error top-level fields are still filtered out
+  expect(o4.name).toBeUndefined();
+
+  const o5 = serialize(jon, { populate: ['books'], fields: ['name', 'books.title'] });
+  expect(o5).toEqual({
+    name: 'Jon Snow',
+    books: [
+      { title: 'My Life on The Wall, part 1' },
+      { title: 'My Life on The Wall, part 2' },
+      { title: 'My Life on The Wall, part 3' },
+    ],
+  });
+
+  // `exclude` wins over `fields` on conflict — strip after whitelist
+  const o6 = serialize(jon, { fields: ['name', 'email'], exclude: ['email'] });
+  expect(o6).toEqual({ name: 'Jon Snow' });
+  // @ts-expect-error `email` was excluded even though listed in fields
+  expect(o6.email).toBeUndefined();
+
+  const o7 = wrap(jon).serialize({ fields: ['name'] });
+  expect(o7).toEqual({ name: 'Jon Snow' });
+  // @ts-expect-error PK dropped under strict whitelist
+  expect(o7.id).toBeUndefined();
+
+  const arr = serialize([jon, jon], { fields: ['name'] });
+  expect(arr).toEqual([{ name: 'Jon Snow' }, { name: 'Jon Snow' }]);
+
+  const o9 = serialize(jon, { populate: ['favouriteBook'], fields: ['favouriteBook.title'] });
+  expect(o9).toEqual({ favouriteBook: { title: 'Bible' } });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 8
+  version: 9
   cacheKey: 10
 
 "@ark/attest@npm:0.56.0":
@@ -1348,7 +1348,7 @@ __metadata:
     "@mikro-orm/core": "npm:^7.0.11"
     "@mikro-orm/sql": "npm:7.0.11"
     kysely: "npm:0.28.16"
-    mysql2: "npm:3.22.0"
+    mysql2: "npm:3.22.1"
     sqlstring: "npm:2.3.3"
   peerDependencies:
     "@mikro-orm/core": 7.0.11
@@ -1435,10 +1435,21 @@ __metadata:
     rimraf: "npm:6.1.3"
     tsimp: "npm:2.0.12"
     tsx: "npm:4.21.0"
-    typescript: "npm:6.0.2"
+    typescript: "npm:6.0.3"
     unplugin-swc: "npm:1.5.9"
     uuid: "npm:11.1.0"
     vitest: "npm:4.1.4"
+  dependenciesMeta:
+    "@swc/core":
+      built: true
+    better-sqlite3:
+      built: true
+    esbuild:
+      built: true
+    nx:
+      built: true
+    oracledb:
+      built: true
   languageName: unknown
   linkType: soft
 
@@ -7230,9 +7241,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mysql2@npm:3.22.0":
-  version: 3.22.0
-  resolution: "mysql2@npm:3.22.0"
+"mysql2@npm:3.22.1":
+  version: 3.22.1
+  resolution: "mysql2@npm:3.22.1"
   dependencies:
     aws-ssl-profiles: "npm:^1.1.2"
     denque: "npm:^2.1.0"
@@ -7244,7 +7255,7 @@ __metadata:
     sql-escaper: "npm:^1.3.3"
   peerDependencies:
     "@types/node": ">= 8"
-  checksum: 10/fbfa0665624f479eeef9d0a9027157f035f07f2f5e782a32ec8b74af95342d3deb8f22f39817e25476fb86d7f93b194a6a319b82ac3af273e011b7a6208ca14e
+  checksum: 10/f8abf958b6d338e092408afb0f12a368a32e3f363de6585181cd90c593ea601fdff1f84784dbbc7bbaa6a36719a55d720534387625ffd75327b115e6c8646dff
   languageName: node
   linkType: hard
 
@@ -9873,13 +9884,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:6.0.2":
-  version: 6.0.2
-  resolution: "typescript@npm:6.0.2"
+"typescript@npm:6.0.3":
+  version: 6.0.3
+  resolution: "typescript@npm:6.0.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10/b9fc2fcee7ee8e5ca6f5138181964550531e18e2d20ecb71b802d4d495881e3444e0ef94cbb6e84eb2ba41e913f6feae3ca33cc722b32e6e6dfadb32d23b80e6
+  checksum: 10/0ef2357a4cffd916b52b683a021cdab0f81eea4e9aa35f2d254581c9a5106da02224e3392e1b0ed42b7a48f80c966e5f52b8e1a27941fa0523c1705a9c2e0330
   languageName: node
   linkType: hard
 
@@ -9893,13 +9904,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A6.0.2#optional!builtin<compat/typescript>":
-  version: 6.0.2
-  resolution: "typescript@patch:typescript@npm%3A6.0.2#optional!builtin<compat/typescript>::version=6.0.2&hash=5786d5"
+"typescript@patch:typescript@npm%3A6.0.3#optional!builtin<compat/typescript>":
+  version: 6.0.3
+  resolution: "typescript@patch:typescript@npm%3A6.0.3#optional!builtin<compat/typescript>::version=6.0.3&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10/e5501dfcf8c5b6b9a61f6fa53decc40187cebe3a2b7b2bd51c615007ad4cf6d58298461fef63294f6be9d5f2f33019b2a2e2bf02d9cb7d7f6ec94372bf24ffa2
+  checksum: 10/22b67a18dafedf9b1468b64ca20d9aa02ea61d449b65413d8aa6552aeb63f52ef369e86beb25b6b4c91a803d9726ee5c196f391a9b64201263263410a4223ee6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

`serialize()` and `wrap(e).serialize()` only support `exclude` (a denylist) today. This adds a first-class `fields` whitelist so callers can guarantee an allowlist-based response shape — protecting API responses from accidentally exposing newly added entity properties.

Reuses the existing `fields` name (already used by `LoadHint` for partial loading + `toObject()`) so the public API stays consistent. Supports dot-paths and embeddables/relations, mirroring `exclude` semantics:

```ts
serialize(user, { fields: ['name'] });
// { name: 'Jon Snow' }  — no PK, no other fields

serialize(jon, { populate: ['books'], fields: ['name', 'books.title'] });
// { name: 'Jon Snow', books: [{ title: '...' }] }

serialize(jon, { populate: ['books.author'], fields: ['books'] });
// bare relation name keeps the entire sub-tree

wrap(jon).serialize({ fields: ['id', 'name'] });
```

- **Strict whitelist semantics** — unlike the partial-loading `toObject()` path, the explicit `serialize()` path drops PKs unless they're listed.
- **`exclude` wins on conflict** — `{ fields: ['name', 'email'], exclude: ['email'] }` returns `{ name }`.
- **Type-safe end to end** — return type narrows via a new `KeepPK` flag on `SerializeDTO` plus two helper aliases (`ResolveSerializeFields`, `SerializeFieldsKeepPK`).

Closes #7507