### PR TITLE
fix(core): brand raw query fragments via prototype property

### DIFF
--- a/packages/core/src/utils/RawQueryFragment.ts
+++ b/packages/core/src/utils/RawQueryFragment.ts
@@ -14,10 +14,6 @@ const RAW_FRAGMENT_BRAND = '__mikroOrmRawFragment';
 // across CJS/ESM module copies via globalThis (#7515): when one copy creates a
 // fragment via `raw('…')` and stores its symbol in a where-clause object key,
 // the other copy still needs to recover the original fragment to assemble SQL.
-// Polluting this map requires in-process code execution, which is strictly
-// stronger than the JSON-spoofing vector that the prototype brand defends
-// against — and an attacker who has code execution can call `raw()` directly,
-// so the shared registry does not widen the attack surface in practice.
 const REGISTRY_KEY = Symbol.for('@mikro-orm/core/RawQueryFragment.references');
 const rawQueryReferences: WeakMap<RawQueryFragmentSymbol, RawQueryFragment> = ((globalThis as any)[REGISTRY_KEY] ??=
   new WeakMap());
@@ -35,9 +31,8 @@ export function isRaw(value: unknown): value is RawQueryFragment {
     return false;
   }
 
-  // Walk the prototype chain so subclasses inherit the brand. Starting from
-  // the *prototype* (not the value itself) keeps JSON payloads out — their
-  // proto is `Object.prototype`, which has no own brand.
+  // Start from the prototype (not the value) so JSON payloads cannot forge
+  // the brand via an own property; walk the chain so subclasses inherit it.
   for (let proto = Object.getPrototypeOf(value); proto != null; proto = Object.getPrototypeOf(proto)) {
     if (Object.hasOwn(proto, RAW_FRAGMENT_BRAND)) {
       return true;

--- a/packages/core/src/utils/RawQueryFragment.ts
+++ b/packages/core/src/utils/RawQueryFragment.ts
@@ -31,10 +31,22 @@ export function isRaw(value: unknown): value is RawQueryFragment {
     return false;
   }
 
-  // Start from the prototype (not the value) so JSON payloads cannot forge
-  // the brand via an own property; walk the chain so subclasses inherit it.
-  for (let proto = Object.getPrototypeOf(value); proto != null; proto = Object.getPrototypeOf(proto)) {
-    if (Object.hasOwn(proto, RAW_FRAGMENT_BRAND)) {
+  // Fast path: intra-module instances, the vast majority when core is loaded once.
+  // eslint-disable-next-line no-use-before-define
+  if (value instanceof RawQueryFragment) {
+    return true;
+  }
+
+  // Fast negative: plain objects cannot be fragments. Also rejects JSON-spoofing
+  // attempts (proto === Object.prototype) without even checking the brand.
+  const proto = Object.getPrototypeOf(value);
+  if (proto === null || proto === Object.prototype) {
+    return false;
+  }
+
+  // Slow path: cross-module fragments or subclasses from a sibling CJS/ESM copy.
+  for (let p: object | null = proto; p != null; p = Object.getPrototypeOf(p)) {
+    if (Object.hasOwn(p, RAW_FRAGMENT_BRAND)) {
       return true;
     }
   }

--- a/packages/core/src/utils/RawQueryFragment.ts
+++ b/packages/core/src/utils/RawQueryFragment.ts
@@ -31,21 +31,17 @@ export function isRaw(value: unknown): value is RawQueryFragment {
     return false;
   }
 
-  // Fast path: intra-module instances, the vast majority when core is loaded once.
+  // Fast path: intra-module instances and their subclasses.
   // eslint-disable-next-line no-use-before-define
   if (value instanceof RawQueryFragment) {
     return true;
   }
 
-  // Fast negative: plain objects cannot be fragments. Also rejects JSON-spoofing
-  // attempts (proto === Object.prototype) without even checking the brand.
-  const proto = Object.getPrototypeOf(value);
-  if (proto === null || proto === Object.prototype) {
-    return false;
-  }
-
-  // Slow path: cross-module fragments or subclasses from a sibling CJS/ESM copy.
-  for (let p: object | null = proto; p != null; p = Object.getPrototypeOf(p)) {
+  // Walk the prototype chain starting from the *prototype* (not the value) so
+  // own-property spoofing from JSON payloads cannot forge the brand. Stop at
+  // `Object.prototype`, which is never branded — that bails plain objects,
+  // JSON payloads, and built-ins like `Date`/`Array`/`Map` at depth 1.
+  for (let p = Object.getPrototypeOf(value); p != null && p !== Object.prototype; p = Object.getPrototypeOf(p)) {
     if (Object.hasOwn(p, RAW_FRAGMENT_BRAND)) {
       return true;
     }
@@ -145,7 +141,15 @@ export class RawQueryFragment<Alias extends string = string> {
   }
 }
 
-Object.defineProperty(RawQueryFragment.prototype, RAW_FRAGMENT_BRAND, { value: true });
+// Non-enumerable so the brand is skipped by JSON/Object.keys/for-in, but writable
+// and configurable so subclass instances can shadow or redefine it without
+// tripping strict-mode assignment. `isRaw` only checks *presence* of the brand,
+// never its value, so mutability does not weaken the spoofing defense.
+Object.defineProperty(RawQueryFragment.prototype, RAW_FRAGMENT_BRAND, {
+  value: true,
+  writable: true,
+  configurable: true,
+});
 
 export { RawQueryFragment as Raw };
 

--- a/packages/core/src/utils/RawQueryFragment.ts
+++ b/packages/core/src/utils/RawQueryFragment.ts
@@ -4,16 +4,15 @@ import type { AnyString, Dictionary, EntityKey } from '../typings.js';
 // Brand lives on the prototype so JSON payloads — whose proto is
 // `Object.prototype` — cannot forge it. String key, not a `Symbol.for(...)`,
 // so each CJS/ESM copy of this module independently installs it on its own
-// prototype (#7515) without publishing a global key for the marker that
-// controls raw SQL assembly. The string is namespaced so it does not collide
-// with property names users might independently install on their own
-// prototypes.
+// prototype without publishing a global key for the marker that controls raw
+// SQL assembly. The string is namespaced so it does not collide with property
+// names users might independently install on their own prototypes.
 const RAW_FRAGMENT_BRAND = '__mikroOrmRawFragment';
 
 // Back-references from a fragment's symbol key to the fragment itself, shared
-// across CJS/ESM module copies via globalThis (#7515): when one copy creates a
-// fragment via `raw('…')` and stores its symbol in a where-clause object key,
-// the other copy still needs to recover the original fragment to assemble SQL.
+// across CJS/ESM module copies via globalThis: when one copy creates a fragment
+// via `raw('…')` and stores its symbol in a where-clause object key, the other
+// copy still needs to recover the original fragment to assemble SQL.
 const REGISTRY_KEY = Symbol.for('@mikro-orm/core/RawQueryFragment.references');
 const rawQueryReferences: WeakMap<RawQueryFragmentSymbol, RawQueryFragment> = ((globalThis as any)[REGISTRY_KEY] ??=
   new WeakMap());
@@ -141,14 +140,17 @@ export class RawQueryFragment<Alias extends string = string> {
   }
 }
 
-// Non-enumerable so the brand is skipped by JSON/Object.keys/for-in, but writable
-// and configurable so subclass instances can shadow or redefine it without
-// tripping strict-mode assignment. `isRaw` only checks *presence* of the brand,
-// never its value, so mutability does not weaken the spoofing defense.
+// Non-enumerable so the brand is skipped by JSON/Object.keys/for-in, and locked
+// down (non-writable, non-configurable) so in-process code cannot delete or
+// overwrite it and thereby silently disable `isRaw` recognition for every
+// fragment in the process. Subclasses don't need mutability here — they inherit
+// the brand via the prototype chain, and sibling-copy classes install their own
+// brand on their own prototype (a different object), so lockdown only blocks
+// tampering with the canonical marker.
 Object.defineProperty(RawQueryFragment.prototype, RAW_FRAGMENT_BRAND, {
   value: true,
-  writable: true,
-  configurable: true,
+  writable: false,
+  configurable: false,
 });
 
 export { RawQueryFragment as Raw };

--- a/packages/core/src/utils/RawQueryFragment.ts
+++ b/packages/core/src/utils/RawQueryFragment.ts
@@ -1,7 +1,26 @@
 import { Utils } from './Utils.js';
 import type { AnyString, Dictionary, EntityKey } from '../typings.js';
 
-const rawSymbol = Symbol('RawQueryFragment');
+// Brand lives on the prototype so JSON payloads — whose proto is
+// `Object.prototype` — cannot forge it. String key, not a `Symbol.for(...)`,
+// so each CJS/ESM copy of this module independently installs it on its own
+// prototype (#7515) without publishing a global key for the marker that
+// controls raw SQL assembly. The string is namespaced so it does not collide
+// with property names users might independently install on their own
+// prototypes.
+const RAW_FRAGMENT_BRAND = '__mikroOrmRawFragment';
+
+// Back-references from a fragment's symbol key to the fragment itself, shared
+// across CJS/ESM module copies via globalThis (#7515): when one copy creates a
+// fragment via `raw('…')` and stores its symbol in a where-clause object key,
+// the other copy still needs to recover the original fragment to assemble SQL.
+// Polluting this map requires in-process code execution, which is strictly
+// stronger than the JSON-spoofing vector that the prototype brand defends
+// against — and an attacker who has code execution can call `raw()` directly,
+// so the shared registry does not widen the attack surface in practice.
+const REGISTRY_KEY = Symbol.for('@mikro-orm/core/RawQueryFragment.references');
+const rawQueryReferences: WeakMap<RawQueryFragmentSymbol, RawQueryFragment> = ((globalThis as any)[REGISTRY_KEY] ??=
+  new WeakMap());
 
 declare const rawFragmentSymbolBrand: unique symbol;
 
@@ -10,9 +29,26 @@ export type RawQueryFragmentSymbol = symbol & {
   readonly [rawFragmentSymbolBrand]: true;
 };
 
+/** Checks whether the given value is a `RawQueryFragment` instance. */
+export function isRaw(value: unknown): value is RawQueryFragment {
+  if (value == null || typeof value !== 'object') {
+    return false;
+  }
+
+  // Walk the prototype chain so subclasses inherit the brand. Starting from
+  // the *prototype* (not the value itself) keeps JSON payloads out — their
+  // proto is `Object.prototype`, which has no own brand.
+  for (let proto = Object.getPrototypeOf(value); proto != null; proto = Object.getPrototypeOf(proto)) {
+    if (Object.hasOwn(proto, RAW_FRAGMENT_BRAND)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 /** Represents a raw SQL fragment with optional parameters, usable as both a value and an object key via Symbol coercion. */
 export class RawQueryFragment<Alias extends string = string> {
-  static #rawQueryReferences = new WeakMap<RawQueryFragmentSymbol, RawQueryFragment>();
   #key?: RawQueryFragmentSymbol;
   /** @internal Type-level only - used to track the alias for type inference */
   declare private readonly __alias?: Alias;
@@ -20,15 +56,13 @@ export class RawQueryFragment<Alias extends string = string> {
   constructor(
     readonly sql: string,
     readonly params: unknown[] = [],
-  ) {
-    Object.defineProperty(this, rawSymbol, { value: true, enumerable: false });
-  }
+  ) {}
 
   /** Returns a unique symbol key for this fragment, creating and caching it on first access. */
   get key(): RawQueryFragmentSymbol {
     if (!this.#key) {
       this.#key = Symbol(this.toJSON()) as RawQueryFragmentSymbol;
-      RawQueryFragment.#rawQueryReferences.set(this.#key, this);
+      rawQueryReferences.set(this.#key, this);
     }
 
     return this.#key;
@@ -64,7 +98,7 @@ export class RawQueryFragment<Alias extends string = string> {
 
   /** Checks whether the given value is a symbol that maps to a known raw query fragment. */
   static isKnownFragmentSymbol(key: unknown): key is RawQueryFragmentSymbol {
-    return typeof key === 'symbol' && this.#rawQueryReferences.has(key as RawQueryFragmentSymbol);
+    return typeof key === 'symbol' && rawQueryReferences.has(key as RawQueryFragmentSymbol);
   }
 
   /** Checks whether an object has any symbol keys that are known raw query fragments. */
@@ -77,16 +111,12 @@ export class RawQueryFragment<Alias extends string = string> {
 
   /** Checks whether the given value is a RawQueryFragment instance or a known fragment symbol. */
   static isKnownFragment(key: unknown): key is RawQueryFragment | symbol {
-    if (key instanceof RawQueryFragment) {
-      return true;
-    }
-
-    return this.isKnownFragmentSymbol(key);
+    return isRaw(key) || this.isKnownFragmentSymbol(key);
   }
 
   /** Retrieves the RawQueryFragment associated with the given key (instance or symbol). */
   static getKnownFragment(key: unknown): RawQueryFragment | undefined {
-    if (key instanceof RawQueryFragment) {
+    if (isRaw(key)) {
       return key;
     }
 
@@ -94,7 +124,7 @@ export class RawQueryFragment<Alias extends string = string> {
       return;
     }
 
-    return this.#rawQueryReferences.get(key as RawQueryFragmentSymbol);
+    return rawQueryReferences.get(key as RawQueryFragmentSymbol);
   }
 
   /** @ignore */
@@ -108,12 +138,9 @@ export class RawQueryFragment<Alias extends string = string> {
   }
 }
 
-export { RawQueryFragment as Raw };
+Object.defineProperty(RawQueryFragment.prototype, RAW_FRAGMENT_BRAND, { value: true });
 
-/** Checks whether the given value is a `RawQueryFragment` instance. */
-export function isRaw(value: unknown): value is RawQueryFragment {
-  return typeof value === 'object' && value !== null && Object.hasOwn(value, rawSymbol);
-}
+export { RawQueryFragment as Raw };
 
 /** @internal */
 export const ALIAS_REPLACEMENT = '[::alias::]';
@@ -180,7 +207,7 @@ export function raw<R = RawQueryFragment & symbol, T extends object = any>(
   sql: EntityKey<T> | EntityKey<T>[] | AnyString | ((alias: string) => string) | RawQueryFragment,
   params?: readonly unknown[] | Dictionary<unknown>,
 ): R {
-  if (sql instanceof RawQueryFragment) {
+  if (isRaw(sql)) {
     return sql as R;
   }
 

--- a/packages/core/src/utils/Utils.ts
+++ b/packages/core/src/utils/Utils.ts
@@ -40,13 +40,23 @@ export function compareObjects(a: any, b: any): boolean {
     return true;
   }
 
-  if (!a || !b || typeof a !== 'object' || typeof b !== 'object' || !compareConstructors(a, b)) {
+  if (!a || !b || typeof a !== 'object' || typeof b !== 'object') {
     return false;
   }
 
+  // Raw fragments are compared by `sql` + `params` *before* the constructor
+  // check, so that two fragments carrying the same SQL but constructed by
+  // different CJS/ESM copies of this module (different classes, different
+  // prototypes) still compare as equal. Without this, the dual-package hazard
+  // would produce spurious change-set diffs when a raw fragment is used as a
+  // property value.
   if (isRaw(a) && isRaw(b)) {
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
     return a.sql === b.sql && compareArrays(a.params, b.params);
+  }
+
+  if (!compareConstructors(a, b)) {
+    return false;
   }
 
   if (a instanceof Date && b instanceof Date) {

--- a/packages/mariadb/src/MariaDbQueryBuilder.ts
+++ b/packages/mariadb/src/MariaDbQueryBuilder.ts
@@ -1,4 +1,12 @@
-import { type AnyEntity, type EntityKey, type EntityMetadata, raw, RawQueryFragment, Utils } from '@mikro-orm/core';
+import {
+  type AnyEntity,
+  type EntityKey,
+  type EntityMetadata,
+  isRaw,
+  raw,
+  RawQueryFragment,
+  Utils,
+} from '@mikro-orm/core';
 import { QueryBuilder } from '@mikro-orm/mysql';
 
 /**
@@ -66,7 +74,7 @@ export class MariaDbQueryBuilder<
             return field.__as === prop;
           }
 
-          if (field instanceof RawQueryFragment) {
+          if (isRaw(field)) {
             // not perfect, but should work most of the time, ideally we should check only the alias (`... as alias`)
             return field.sql.includes(prop);
           }
@@ -74,7 +82,7 @@ export class MariaDbQueryBuilder<
           return false;
         });
 
-        if (field instanceof RawQueryFragment) {
+        if (isRaw(field)) {
           innerQuery.select(this.platform.formatQuery(field.sql, field.params));
         } else if (field) {
           innerQuery.select(field as string);

--- a/packages/oracledb/src/OracleConnection.ts
+++ b/packages/oracledb/src/OracleConnection.ts
@@ -4,11 +4,12 @@ import {
   type ConnectionConfig,
   type Dictionary,
   type EntityData,
+  isRaw,
   type LoggingOptions,
   NativeQueryBuilder,
   OracleDialect,
   type QueryResult,
-  RawQueryFragment,
+  type RawQueryFragment,
   type Transaction,
   Utils,
 } from '@mikro-orm/sql';
@@ -108,7 +109,7 @@ export class OracleConnection extends AbstractSqlConnection {
       query = query.toRaw();
     }
 
-    if (query instanceof RawQueryFragment) {
+    if (isRaw(query)) {
       params = query.params;
       query = query.sql;
     }

--- a/packages/sql/src/AbstractSqlConnection.ts
+++ b/packages/sql/src/AbstractSqlConnection.ts
@@ -5,12 +5,13 @@ import {
   type Dictionary,
   type EntityData,
   EventType,
+  isRaw,
   type IsolationLevel,
   type LogContext,
   type LoggingOptions,
   type MaybePromise,
   type QueryResult,
-  RawQueryFragment,
+  type RawQueryFragment,
   type Transaction,
   type TransactionEventBroadcaster,
   Utils,
@@ -249,7 +250,7 @@ export abstract class AbstractSqlConnection extends Connection {
       query = query.toRaw();
     }
 
-    if (query instanceof RawQueryFragment) {
+    if (isRaw(query)) {
       params = query.params;
       query = query.sql;
     }

--- a/packages/sql/src/AbstractSqlDriver.ts
+++ b/packages/sql/src/AbstractSqlDriver.ts
@@ -324,7 +324,7 @@ export abstract class AbstractSqlDriver<
       );
     }
 
-    if (res instanceof RawQueryFragment) {
+    if (isRaw(res)) {
       const expr = this.platform.formatQuery(res.sql, res.params);
       return this.wrapVirtualExpressionInSubquery(meta, expr, where, options as FindOptions<T, any>, type);
     }
@@ -382,7 +382,7 @@ export abstract class AbstractSqlDriver<
       return;
     }
 
-    if (res instanceof RawQueryFragment) {
+    if (isRaw(res)) {
       const expr = this.platform.formatQuery(res.sql, res.params);
       yield* this.wrapVirtualExpressionInSubqueryStream(
         meta,

--- a/packages/sql/src/dialects/mssql/MsSqlNativeQueryBuilder.ts
+++ b/packages/sql/src/dialects/mssql/MsSqlNativeQueryBuilder.ts
@@ -1,4 +1,4 @@
-import { LockMode, QueryFlag, RawQueryFragment, Utils } from '@mikro-orm/core';
+import { isRaw, LockMode, QueryFlag, Utils } from '@mikro-orm/core';
 import { NativeQueryBuilder } from '../../query/NativeQueryBuilder.js';
 import { QueryType } from '../../query/enums.js';
 
@@ -121,7 +121,7 @@ export class MsSqlNativeQueryBuilder extends NativeQueryBuilder {
     this.parts.push(`merge into ${this.getTableName()}`);
     this.parts.push(`using (values ${parts.join(', ')}) as tsource(${keys.map(key => this.quote(key)).join(', ')})`);
 
-    if (clause.fields instanceof RawQueryFragment) {
+    if (isRaw(clause.fields)) {
       this.parts.push(clause.fields.sql);
       this.params.push(...clause.fields.params);
     } else if (clause.fields.length > 0) {

--- a/packages/sql/src/dialects/mysql/MySqlNativeQueryBuilder.ts
+++ b/packages/sql/src/dialects/mysql/MySqlNativeQueryBuilder.ts
@@ -1,4 +1,4 @@
-import { type Dictionary, LockMode, RawQueryFragment, Utils } from '@mikro-orm/core';
+import { type Dictionary, isRaw, LockMode, Utils } from '@mikro-orm/core';
 import { NativeQueryBuilder } from '../../query/NativeQueryBuilder.js';
 
 /** @internal */
@@ -80,7 +80,7 @@ export class MySqlNativeQueryBuilder extends NativeQueryBuilder {
 
     this.parts.push('on conflict');
 
-    if (clause.fields instanceof RawQueryFragment) {
+    if (isRaw(clause.fields)) {
       this.parts.push(clause.fields.sql);
       this.params.push(...clause.fields.params);
     } else if (clause.fields.length > 0) {

--- a/packages/sql/src/dialects/oracledb/OracleNativeQueryBuilder.ts
+++ b/packages/sql/src/dialects/oracledb/OracleNativeQueryBuilder.ts
@@ -1,4 +1,4 @@
-import { type Dictionary, raw, RawQueryFragment, Utils } from '@mikro-orm/core';
+import { type Dictionary, isRaw, raw, Utils } from '@mikro-orm/core';
 import { QueryType } from '../../query/enums.js';
 import { NativeQueryBuilder } from '../../query/NativeQueryBuilder.js';
 
@@ -196,7 +196,7 @@ export class OracleNativeQueryBuilder extends NativeQueryBuilder {
     this.parts.push(`using (${parts.join(' union all ')}) tsource`);
 
     /* v8 ignore next 4: RawQueryFragment conflict fields branch */
-    if (clause.fields instanceof RawQueryFragment) {
+    if (isRaw(clause.fields)) {
       this.parts.push(clause.fields.sql);
       this.params.push(...clause.fields.params);
     } else if (clause.fields.length > 0) {

--- a/packages/sql/src/query/NativeQueryBuilder.ts
+++ b/packages/sql/src/query/NativeQueryBuilder.ts
@@ -1,9 +1,10 @@
 import {
   type Dictionary,
+  isRaw,
   LockMode,
   type QueryFlag,
   raw,
-  RawQueryFragment,
+  type RawQueryFragment,
   type Subquery,
   Utils,
 } from '@mikro-orm/core';
@@ -272,7 +273,7 @@ export class NativeQueryBuilder implements Subquery {
 
     this.parts.push('on conflict');
 
-    if (clause.fields instanceof RawQueryFragment) {
+    if (isRaw(clause.fields)) {
       this.parts.push(clause.fields.sql);
       this.params.push(...clause.fields.params);
     } else if (clause.fields.length > 0) {
@@ -664,7 +665,7 @@ export class NativeQueryBuilder implements Subquery {
 
     const indexHint = this.options.indexHint ? ' ' + this.options.indexHint : '';
 
-    if (this.options.tableName instanceof RawQueryFragment) {
+    if (isRaw(this.options.tableName)) {
       this.params.push(...this.options.tableName.params);
       return this.options.tableName.sql + indexHint;
     }
@@ -673,7 +674,7 @@ export class NativeQueryBuilder implements Subquery {
   }
 
   protected quote(id: string | RawQueryFragment | NativeQueryBuilder): string {
-    if (id instanceof RawQueryFragment) {
+    if (isRaw(id)) {
       return this.platform.formatQuery(id.sql, id.params);
     }
 

--- a/packages/sql/src/query/QueryBuilderHelper.ts
+++ b/packages/sql/src/query/QueryBuilderHelper.ts
@@ -825,23 +825,28 @@ export class QueryBuilderHelper {
       const processed = this.#platform.mapRegExpCondition(mappedKey, value);
       parts.push(processed.sql);
       params.push(...processed.params);
-    } else if (isRaw(value[op]) || typeof value[op]?.toRaw === 'function') {
-      const query = isRaw(value[op]) ? value[op] : value[op].toRaw();
-      const mappedKey = this.mapper(key, type, query, null);
-
-      let sql = query.sql.replaceAll(ALIAS_REPLACEMENT, this.#alias);
-
-      if (['$in', '$nin'].includes(op)) {
-        sql = `(${sql})`;
-      }
-
-      parts.push(`${this.#platform.quoteIdentifier(mappedKey)} ${replacement} ${sql}`);
-      params.push(...query.params);
     } else {
-      const mappedKey = this.mapper(key, type, value[op], null);
-      const val = this.getValueReplacement(fields, value[op], params, op, prop);
+      const opValue = value[op];
+      const opValueIsRaw = isRaw(opValue);
 
-      parts.push(`${this.#platform.quoteIdentifier(mappedKey)} ${replacement} ${val}`);
+      if (opValueIsRaw || typeof opValue?.toRaw === 'function') {
+        const query: RawQueryFragment = opValueIsRaw ? opValue : opValue.toRaw();
+        const mappedKey = this.mapper(key, type, query, null);
+
+        let sql = query.sql.replaceAll(ALIAS_REPLACEMENT, this.#alias);
+
+        if (['$in', '$nin'].includes(op)) {
+          sql = `(${sql})`;
+        }
+
+        parts.push(`${this.#platform.quoteIdentifier(mappedKey)} ${replacement} ${sql}`);
+        params.push(...query.params);
+      } else {
+        const mappedKey = this.mapper(key, type, opValue, null);
+        const val = this.getValueReplacement(fields, opValue, params, op, prop);
+
+        parts.push(`${this.#platform.quoteIdentifier(mappedKey)} ${replacement} ${val}`);
+      }
     }
 
     return { sql: parts.join(' and '), params };

--- a/packages/sql/src/query/QueryBuilderHelper.ts
+++ b/packages/sql/src/query/QueryBuilderHelper.ts
@@ -825,8 +825,8 @@ export class QueryBuilderHelper {
       const processed = this.#platform.mapRegExpCondition(mappedKey, value);
       parts.push(processed.sql);
       params.push(...processed.params);
-    } else if (value[op] instanceof Raw || typeof value[op]?.toRaw === 'function') {
-      const query = value[op] instanceof Raw ? value[op] : value[op].toRaw();
+    } else if (isRaw(value[op]) || typeof value[op]?.toRaw === 'function') {
+      const query = isRaw(value[op]) ? value[op] : value[op].toRaw();
       const mappedKey = this.mapper(key, type, query, null);
 
       let sql = query.sql.replaceAll(ALIAS_REPLACEMENT, this.#alias);
@@ -1087,7 +1087,7 @@ export class QueryBuilderHelper {
       const alias = always ? (quote ? tptAlias : this.#platform.quoteIdentifier(tptAlias)) + '.' : '';
       const fieldName = this.fieldName(field, tptAlias, always, idx);
 
-      if (fieldName instanceof Raw) {
+      if (isRaw(fieldName)) {
         return fieldName.sql;
       }
 
@@ -1102,7 +1102,7 @@ export class QueryBuilderHelper {
       const resolvedAlias = isTableAlias ? this.getTPTAliasForProperty(f, a) : a;
       const fieldName = this.fieldName(f, resolvedAlias, always, idx);
 
-      if (fieldName instanceof Raw) {
+      if (isRaw(fieldName)) {
         return fieldName.sql;
       }
 

--- a/packages/sql/src/schema/DatabaseTable.ts
+++ b/packages/sql/src/schema/DatabaseTable.ts
@@ -8,8 +8,8 @@ import {
   EntitySchema,
   type IndexCallback,
   type IndexOptions,
+  isRaw,
   type NamingStrategy,
-  RawQueryFragment,
   ReferenceKind,
   t,
   Type,
@@ -138,10 +138,9 @@ export class DatabaseTable {
       this.#columns[field] = {
         name: prop.fieldNames[idx],
         type: prop.columnTypes[idx],
-        generated:
-          prop.generated instanceof RawQueryFragment
-            ? this.#platform.formatQuery(prop.generated.sql, prop.generated.params)
-            : (prop.generated as string),
+        generated: isRaw(prop.generated)
+          ? this.#platform.formatQuery(prop.generated.sql, prop.generated.params)
+          : (prop.generated as string),
         mappedType,
         unsigned: prop.unsigned && this.#platform.isNumericColumn(mappedType),
         autoincrement:
@@ -1067,7 +1066,7 @@ export class DatabaseTable {
       };
       const columns = meta.createSchemaColumnMappingObject();
       const exp = expression(columns, table, indexName);
-      return exp instanceof RawQueryFragment ? this.#platform.formatQuery(exp.sql, exp.params) : exp;
+      return isRaw(exp) ? this.#platform.formatQuery(exp.sql, exp.params) : exp;
     }
 
     return expression;

--- a/packages/sql/src/schema/SchemaHelper.ts
+++ b/packages/sql/src/schema/SchemaHelper.ts
@@ -1,9 +1,10 @@
 import {
   type Connection,
   type Dictionary,
+  isRaw,
   type Options,
   type Transaction,
-  RawQueryFragment,
+  type RawQueryFragment,
   Utils,
 } from '@mikro-orm/core';
 import type { AbstractSqlConnection } from '../AbstractSqlConnection.js';
@@ -581,7 +582,7 @@ export abstract class SchemaHelper {
       return defaultValue;
     }
 
-    if (defaultValue instanceof RawQueryFragment) {
+    if (isRaw(defaultValue)) {
       return this.platform.formatQuery(defaultValue.sql, defaultValue.params);
     }
 

--- a/tests/features/raw-queries/GHx6.test.ts
+++ b/tests/features/raw-queries/GHx6.test.ts
@@ -240,9 +240,19 @@ test('plain objects with __raw should not be treated as RawQueryFragment in nati
 });
 
 test('plain objects carrying the prototype brand key directly should not be treated as RawQueryFragment', async () => {
-  const input = { __mikroOrmRawFragment: true, sql: 'malicious_input', params: [] };
+  orm.em.create(Tag, { name: 'brand-spoof', job: orm.em.create(Job, {}) });
+  await orm.em.flush();
+  orm.em.clear();
 
-  await expect(orm.em.find(Tag, { name: input as any })).rejects.toThrow();
+  const input = { __mikroOrmRawFragment: true, sql: 'malicious_input', params: [] };
+  const mock = mockLogger(orm);
+
+  await orm.em.nativeUpdate(Tag, { name: 'brand-spoof' }, { name: input as any });
+
+  const queries = mock.mock.calls.map((c: any) => c[0]);
+  const updateQuery = queries.find((q: string) => q.includes('update'));
+  expect(updateQuery).toBeDefined();
+  expect(updateQuery).toContain(JSON.stringify(input).replace(/'/g, "''"));
 });
 
 test('isRaw walks the prototype chain so subclasses are still recognised', () => {
@@ -254,10 +264,8 @@ test('isRaw walks the prototype chain so subclasses are still recognised', () =>
 });
 
 test('sibling module copies share the fragment registry and recognise each others fragments', () => {
-  // Simulates a second CJS/ESM copy of `RawQueryFragment.js` — its own class,
-  // its own prototype, brand independently installed during init, registering
-  // its symbol keys into the same globalThis-shared registry the real module
-  // uses (which is the only way `getKnownFragment` works across copies).
+  // Simulates a second CJS/ESM copy of the module — its own class and prototype,
+  // sharing the globalThis-published fragment registry with the real module.
   const sharedRegistry = (globalThis as any)[Symbol.for('@mikro-orm/core/RawQueryFragment.references')];
   expect(sharedRegistry).toBeInstanceOf(WeakMap);
 

--- a/tests/features/raw-queries/GHx6.test.ts
+++ b/tests/features/raw-queries/GHx6.test.ts
@@ -300,3 +300,44 @@ test('sibling module copies share the fragment registry and recognise each other
   expect(RawQueryFragment.getKnownFragment(symbol)).toBe(sibling);
   expect(RawQueryFragment.hasObjectFragments({ [symbol]: 'value' })).toBe(true);
 });
+
+test('sibling module fragment drives SQL assembly through em.nativeUpdate end-to-end', async () => {
+  // Same sibling-copy simulation as above, but this time passed as a value
+  // into a real EntityManager operation so the whole query assembly path is
+  // exercised, not just the helper-level checks.
+  const sharedRegistry = (globalThis as any)[Symbol.for('@mikro-orm/core/RawQueryFragment.references')];
+
+  class SiblingRawQueryFragment {
+    #key?: symbol;
+
+    constructor(
+      public sql: string,
+      public params: unknown[] = [],
+    ) {}
+
+    get key(): symbol {
+      if (!this.#key) {
+        this.#key = Symbol(`raw('${this.sql}')`);
+        sharedRegistry.set(this.#key, this);
+      }
+      return this.#key;
+    }
+  }
+  Object.defineProperty(SiblingRawQueryFragment.prototype, '__mikroOrmRawFragment', { value: true });
+
+  orm.em.create(Tag, { name: 'sibling-roundtrip', job: orm.em.create(Job, {}) });
+  await orm.em.flush();
+  orm.em.clear();
+
+  const mock = mockLogger(orm);
+  const siblingFragment = new SiblingRawQueryFragment(`'rewritten-by-sibling'`) as any;
+
+  await orm.em.nativeUpdate(Tag, { name: 'sibling-roundtrip' }, { name: siblingFragment });
+
+  const queries = mock.mock.calls.map((c: any) => c[0]);
+  const updateQuery = queries.find((q: string) => q.includes('update'));
+  expect(updateQuery).toBeDefined();
+  // The sibling's raw SQL must be inlined verbatim (no JSON stringification,
+  // no '?' parameter placeholder), proving `isRaw` recognised it across copies.
+  expect(updateQuery).toContain(`'rewritten-by-sibling'`);
+});

--- a/tests/features/raw-queries/GHx6.test.ts
+++ b/tests/features/raw-queries/GHx6.test.ts
@@ -1,4 +1,5 @@
 import { Collection, MikroORM, QueryOrder, raw } from '@mikro-orm/sqlite';
+import { isRaw, RawQueryFragment } from '@mikro-orm/core';
 import {
   Entity,
   ManyToMany,
@@ -236,4 +237,58 @@ test('plain objects with __raw should not be treated as RawQueryFragment in nati
   const updateQuery = queries.find((q: string) => q.includes('update'));
   expect(updateQuery).toBeDefined();
   expect(updateQuery).toContain(JSON.stringify(input).replace(/'/g, "''"));
+});
+
+test('plain objects carrying the prototype brand key directly should not be treated as RawQueryFragment', async () => {
+  const input = { __mikroOrmRawFragment: true, sql: 'malicious_input', params: [] };
+
+  await expect(orm.em.find(Tag, { name: input as any })).rejects.toThrow();
+});
+
+test('isRaw walks the prototype chain so subclasses are still recognised', () => {
+  class CustomRaw extends RawQueryFragment {}
+
+  const fragment = new CustomRaw('select 1');
+  expect(isRaw(fragment)).toBe(true);
+  expect(RawQueryFragment.isKnownFragment(fragment)).toBe(true);
+});
+
+test('sibling module copies share the fragment registry and recognise each others fragments', () => {
+  // Simulates a second CJS/ESM copy of `RawQueryFragment.js` — its own class,
+  // its own prototype, brand independently installed during init, registering
+  // its symbol keys into the same globalThis-shared registry the real module
+  // uses (which is the only way `getKnownFragment` works across copies).
+  const sharedRegistry = (globalThis as any)[Symbol.for('@mikro-orm/core/RawQueryFragment.references')];
+  expect(sharedRegistry).toBeInstanceOf(WeakMap);
+
+  class SiblingRawQueryFragment {
+    #key?: symbol;
+
+    constructor(
+      public sql: string,
+      public params: unknown[] = [],
+    ) {}
+
+    get key(): symbol {
+      if (!this.#key) {
+        this.#key = Symbol(`raw('${this.sql}')`);
+        sharedRegistry.set(this.#key, this);
+      }
+      return this.#key;
+    }
+  }
+  Object.defineProperty(SiblingRawQueryFragment.prototype, '__mikroOrmRawFragment', { value: true });
+
+  const sibling = new SiblingRawQueryFragment('select 1');
+
+  // value-as-fragment path
+  expect(isRaw(sibling)).toBe(true);
+  expect(RawQueryFragment.isKnownFragment(sibling)).toBe(true);
+
+  // key-as-fragment path: produce the symbol from the sibling, then look it
+  // back up through the real module's static helpers.
+  const symbol = sibling.key;
+  expect(RawQueryFragment.isKnownFragmentSymbol(symbol)).toBe(true);
+  expect(RawQueryFragment.getKnownFragment(symbol)).toBe(sibling);
+  expect(RawQueryFragment.hasObjectFragments({ [symbol]: 'value' })).toBe(true);
 });

--- a/tests/features/raw-queries/GHx6.test.ts
+++ b/tests/features/raw-queries/GHx6.test.ts
@@ -1,5 +1,5 @@
 import { Collection, MikroORM, QueryOrder, raw } from '@mikro-orm/sqlite';
-import { isRaw, RawQueryFragment } from '@mikro-orm/core';
+import { compareObjects, isRaw, RawQueryFragment } from '@mikro-orm/core';
 import {
   Entity,
   ManyToMany,
@@ -299,6 +299,28 @@ test('sibling module copies share the fragment registry and recognise each other
   expect(RawQueryFragment.isKnownFragmentSymbol(symbol)).toBe(true);
   expect(RawQueryFragment.getKnownFragment(symbol)).toBe(sibling);
   expect(RawQueryFragment.hasObjectFragments({ [symbol]: 'value' })).toBe(true);
+});
+
+test('compareObjects matches cross-copy fragments carrying the same sql/params', () => {
+  // compareObjects previously gated raw-fragment value comparison behind
+  // compareConstructors, so a real RawQueryFragment and a sibling-copy
+  // instance with identical sql/params compared as unequal and produced
+  // spurious change-set diffs in dual-package setups.
+  class SiblingRawQueryFragment {
+    constructor(
+      public sql: string,
+      public params: unknown[] = [],
+    ) {}
+  }
+  Object.defineProperty(SiblingRawQueryFragment.prototype, '__mikroOrmRawFragment', { value: true });
+
+  const real = new RawQueryFragment('select ?', [1]);
+  const sibling = new SiblingRawQueryFragment('select ?', [1]);
+
+  expect(compareObjects(real, sibling)).toBe(true);
+  expect(compareObjects(sibling, real)).toBe(true);
+  expect(compareObjects(real, new SiblingRawQueryFragment('select ?', [2]))).toBe(false);
+  expect(compareObjects(real, new SiblingRawQueryFragment('select 1', [1]))).toBe(false);
 });
 
 test('sibling module fragment drives SQL assembly through em.nativeUpdate end-to-end', async () => {


### PR DESCRIPTION
## Summary

Follow-up to #7518 covering the same CJS/ESM dual-package hazard for `RawQueryFragment`. When `tsx` registers both an ESM and a CJS hook for the CLI, `@mikro-orm/core` ends up loaded twice and `RawQueryFragment` ends up with two distinct classes, prototypes, brand symbols, and registry WeakMaps. A fragment built by `raw('…')` in one copy was invisible to `isRaw` and to `getKnownFragment` running in the other, so:

- `{ name: raw('now()') }` (value-as-fragment) flowed through SQL assembly as a plain object.
- `{ [raw('lower(name)')]: 'x' }` (key-as-fragment) was lost entirely — the symbol-key path goes through `isKnownFragmentSymbol` / `getKnownFragment` and never touches `isRaw`.

`Symbol.for(...)` for the brand was the wrong tool: raw fragments are *the* primitive that turns a string into raw SQL, and publishing a global key would let any in-process code trivially manufacture forged fragments — that is exactly the vector the JSON-spoofing protection added in f7e59a5ce was guarding against.

Three coordinated changes:

1. **Brand the prototype, not the instance.** Install a non-enumerable string-keyed `__mikroOrmRawFragment` on `RawQueryFragment.prototype` and have `isRaw` walk the value's *prototype chain* via `Object.hasOwn`. JSON payloads have `Object.prototype` as their proto and so cannot forge it; subclasses inherit the brand.

2. **Share the symbol-key registry across module copies.** Move `#rawQueryReferences` to a module-local WeakMap stashed on `globalThis` under a `Symbol.for(...)` key, matching the pattern already used for `EntitySchema.REGISTRY`. The shared registry does not widen the attack surface in practice — polluting it requires in-process code execution, which already lets the attacker call `raw()` directly.

3. **Replace remaining `instanceof RawQueryFragment` checks** in `isKnownFragment` / `getKnownFragment` / `raw()` with `isRaw()`, so cross-copy fragments are recognised everywhere.

Three regression tests added to `tests/features/raw-queries/GHx6.test.ts`:
- A JSON payload that targets the new brand key is still rejected.
- Subclasses of `RawQueryFragment` inherit the brand.
- A simulated sibling-copy class is recognised end-to-end through both the value path (`isRaw` / `isKnownFragment`) and the symbol-key path (`isKnownFragmentSymbol` / `getKnownFragment` / `hasObjectFragments`).