### PR TITLE
fix(sql): allow joining relations on entity-typed CTE in `from()`

### DIFF
--- a/packages/sql/src/query/QueryBuilder.ts
+++ b/packages/sql/src/query/QueryBuilder.ts
@@ -541,6 +541,7 @@ export interface QBState<Entity extends object> {
     name: string;
     query: NativeQueryBuilder | RawQueryFragment;
     recursive?: boolean;
+    meta?: EntityMetadata;
   })[];
   tptJoinsApplied: boolean;
   autoJoinedPaths: string[];
@@ -2809,6 +2810,7 @@ export class QueryBuilder<
       recursive,
       columns: options?.columns,
       materialized: options?.materialized,
+      meta: query instanceof QueryBuilder ? query.mainAlias.meta : undefined,
     });
     return this;
   }
@@ -4061,14 +4063,21 @@ export class QueryBuilder<
 
   private fromRawTable(tableName: string, aliasName?: string): void {
     aliasName ??= this.#state.mainAlias?.aliasName ?? this.getNextAlias(tableName);
-    const meta = new EntityMetadata<Entity>({
-      className: tableName,
-      collection: tableName,
-    });
-    meta.root = meta;
+    // If the raw table name matches a CTE registered via `.with()` from a typed QueryBuilder,
+    // reuse the source entity meta so relation joins (`leftJoinAndSelect` etc.) keep working.
+    const cteMeta = this.#state.ctes.find(c => c.name === tableName)?.meta;
+    let meta: EntityMetadata<Entity>;
+
+    if (cteMeta) {
+      meta = cteMeta as EntityMetadata<Entity>;
+    } else {
+      meta = new EntityMetadata<Entity>({ className: tableName, collection: tableName });
+      meta.root = meta;
+    }
+
     this.#state.mainAlias = {
       aliasName,
-      entityName: tableName as unknown as EntityName<Entity>,
+      entityName: (cteMeta?.className ?? tableName) as unknown as EntityName<Entity>,
       meta,
       rawTableName: tableName,
     };

--- a/tests/features/query-builder/query-builder-cte.test.ts
+++ b/tests/features/query-builder/query-builder-cte.test.ts
@@ -155,6 +155,28 @@ describe.each(Utils.keys(options))('CTE [%s]', type => {
     expect(sql).not.toMatch(/custom_schema.*my_cte/);
   });
 
+  test('CTE from() supports joining relations on the inferred entity type (#7485)', async () => {
+    const sub = orm.em.createQueryBuilder(Book, 'b').select('*');
+    const qb = orm.em
+      .createQueryBuilder(Book)
+      .with('updated_books', sub)
+      .select('*')
+      .from('updated_books', 'ub')
+      .leftJoinAndSelect('ub.author', 'a');
+
+    // strip dialect-specific identifier quote chars (`, ", [, ]) for portable assertions
+    const sql = qb.getFormattedQuery().replace(/[`"[\]]/g, '');
+    expect(sql).toMatch(/with updated_books as \(select .* from book/i);
+    expect(sql).toMatch(/from updated_books/i);
+    expect(sql).toMatch(/left join author as a on ub\.author_id = a\.id/i);
+
+    const rows = await qb.execute<{ id: number; title: string; author: { id: number; name: string } }[]>();
+    expect(rows).toHaveLength(2);
+    const byTitle = Object.fromEntries(rows.map(r => [r.title, r.author]));
+    expect(byTitle['Alice Book']).toMatchObject({ name: 'Alice' });
+    expect(byTitle['Bob Book']).toMatchObject({ name: 'Bob' });
+  });
+
   test('CTE type-safe from() infers entity type', async () => {
     const sub = orm.em.createQueryBuilder(Author, 'a').select(['a.id', 'a.name']).where({ name: 'Alice' });
     const qb = orm.em.createQueryBuilder(Author).with('typed_cte', sub).select('*').from('typed_cte', 'tc');


### PR DESCRIPTION
## Summary

When a CTE is registered via `qb.with('name', sourceQb)` and then queried through `qb.from('name', 'alias')`, the resulting `SelectQueryBuilder` is typed against the source entity — `from<Name extends keyof CTEs>(...) → SelectQueryBuilder<CTEs[Name], …>`. The TypeScript surface promises that `'alias.relation'` joins compile cleanly.

At runtime that promise broke: `from()` saw a string not in metadata storage, fell through to `fromRawTable()`, and built the alias against a synthetic `EntityMetadata` with zero properties. Any subsequent `leftJoinAndSelect('alias.relation', …)` then blew up with `MetadataError: Metadata for entity <cte> not found` from `joinReference`.

Reported in mikro-orm/mikro-orm#7485.

## Fix

- `addCte()` keeps a reference to the source `QueryBuilder.mainAlias.meta` on the CTE record (only when the CTE source is a typed `QueryBuilder` — raw SQL / `NativeQueryBuilder` CTEs stay unchanged).
- `fromRawTable()` looks up the table name in the CTE registry; on a hit, it reuses the real entity meta as `mainAlias.meta` and uses the source entity's `className` as `entityName`, while still pointing `rawTableName` at the CTE name so the SQL `FROM` references the CTE — not the underlying table.

Result: `joinReference` resolves the relation against the real meta, the join SQL is emitted against the CTE alias, and existing raw-SQL CTE behavior is unchanged.

## Repro (now passing)

```ts
const sub = orm.em.createQueryBuilder(Book, 'b').select('*');
const qb = orm.em
  .createQueryBuilder(Book)
  .with('updated_books', sub)
  .select('*')
  .from('updated_books', 'ub')
  .leftJoinAndSelect('ub.author', 'a');

await qb.execute();
```

emits

```sql
with "updated_books" as (select "b".* from "book" as "b")
select "ub".*, "a"."id" as "a__id", "a"."name" as "a__name", "a"."age" as "a__age"
from "updated_books" as "ub"
left join "author" as "a" on "ub"."author_id" = "a"."id"
```

The original use case from the discussion — wrapping `UPDATE … RETURNING *` in a CTE and joining a relation off it — works the same way.