### PR TITLE
fix(sql): skip redundant mapResult in QB when row is already mapped

### DIFF
--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -1812,10 +1812,11 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
   map<Entity extends object>(
     entityName: EntityName<Entity>,
     result: EntityDictionary<Entity>,
-    options: { schema?: string } = {},
+    options: { schema?: string; mapped?: boolean } = {},
   ): Entity {
+    const { mapped, ...rest } = options;
     const meta = this.metadata.get(entityName);
-    const data = this.driver.mapResult(result, meta) as Dictionary;
+    const data = (mapped ? result : this.driver.mapResult(result, meta)) as Dictionary;
 
     for (const k of Object.keys(data)) {
       const prop = meta.properties[k as EntityKey<Entity>];
@@ -1834,7 +1835,7 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
       convertCustomTypes: true,
       refresh: true,
       validate: false,
-      ...options,
+      ...rest,
     });
   }
 

--- a/packages/sql/src/query/QueryBuilder.ts
+++ b/packages/sql/src/query/QueryBuilder.ts
@@ -2539,11 +2539,10 @@ export class QueryBuilder<
       return row as Loaded<Entity, Hint, Fields>;
     }
 
-    const entity = this.em!.map<Entity>(this.mainAlias.entityName, row, { schema: this.#state.schema }) as Loaded<
-      Entity,
-      Hint,
-      Fields
-    >;
+    const entity = this.em!.map<Entity>(this.mainAlias.entityName, row, {
+      schema: this.#state.schema,
+      mapped: true,
+    }) as Loaded<Entity, Hint, Fields>;
     this.propagatePopulateHint(entity as Entity, this.#state.populate);
 
     return entity;

--- a/tests/issues/GH7527.test.ts
+++ b/tests/issues/GH7527.test.ts
@@ -1,0 +1,61 @@
+import { EntitySchema } from '@mikro-orm/core';
+import { MikroORM } from '@mikro-orm/sqlite';
+
+const Kind = Object.freeze({ A: 'A', B: 'B', C: 'C' });
+
+interface ITarget {
+  id: number;
+}
+
+interface IThing {
+  id: number;
+  _kind: string | null;
+  kind: ITarget | null;
+}
+
+const Target = new EntitySchema<ITarget>({
+  name: 'GH7527Target',
+  tableName: 'gh7527_target',
+  properties: {
+    id: { type: 'number', primary: true, autoincrement: true },
+  },
+});
+
+// "safe rename" shape: legacy enum column `kind` kept as `_kind`
+// via fieldName, new ManyToOne relation exposed as `kind`.
+const Thing = new EntitySchema<IThing>({
+  name: 'GH7527Thing',
+  tableName: 'gh7527_thing',
+  properties: {
+    id: { type: 'number', primary: true, autoincrement: true },
+    _kind: { enum: true, items: () => Kind, fieldName: 'kind', nullable: true },
+    kind: { kind: 'm:1', entity: () => Target, nullable: true },
+  },
+});
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    entities: [Thing, Target],
+    dbName: ':memory:',
+  });
+  await orm.schema.refresh();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+test('GH #7527: QB does not double-map rows when fieldName collides with another property name', async () => {
+  await orm.em.getConnection().execute(`insert into gh7527_target (id) values (1)`);
+  await orm.em.getConnection().execute(`insert into gh7527_thing (id, kind, kind_id) values (1, 'A', 1)`);
+
+  const em = orm.em.fork();
+  const results = await em.createQueryBuilder(Thing).select('*').getResultList();
+
+  expect(results).toHaveLength(1);
+  const thing = results[0];
+  expect(thing._kind).toBe('A');
+  expect(thing.kind).toBeDefined();
+});


### PR DESCRIPTION
## Summary

- `QueryBuilder.execute()` maps raw DB rows via `driver.mapResult()`, then `em.map()` calls it again on the already-mapped data. When a property's `fieldName` collides with another property's name (e.g. a legacy enum with `fieldName: 'kind'` alongside a ManyToOne also called `kind`), the second mapping corrupts values — the FK value overwrites the enum field.
- Added a `mapped` option to `em.map()` so the QB can signal that `driver.mapResult()` was already called, skipping the redundant second pass.

Closes #7527

🤖 Generated with [Claude Code](https://claude.ai/claude-code)