### PR TITLE
fix(core): use globally registered symbols for Reference/Collection markers

### DIFF
--- a/packages/core/src/entity/Collection.ts
+++ b/packages/core/src/entity/Collection.ts
@@ -36,7 +36,9 @@ export interface MatchingOptions<T extends object, P extends string = never> ext
   ctx?: Transaction;
 }
 
-const collectionSymbol = Symbol('Collection');
+// Globally registered so the marker survives the CJS/ESM dual-package hazard
+// (see entitySymbol rationale in EntityHelper.ts and #7515/#7534).
+const collectionSymbol = Symbol.for('@mikro-orm/core/Collection');
 
 /** Represents a to-many relation (1:m or m:n) as an iterable, managed collection of entities. */
 export class Collection<T extends object, O extends object = object> {

--- a/packages/core/src/entity/Reference.ts
+++ b/packages/core/src/entity/Reference.ts
@@ -19,8 +19,10 @@ import type { FindOneOptions, FindOneOrFailOptions } from '../drivers/IDatabaseD
 import { NotFoundError } from '../errors.js';
 import { inspect } from '../logging/inspect.js';
 
-const referenceSymbol = Symbol('Reference');
-const scalarReferenceSymbol = Symbol('ScalarReference');
+// Globally registered so the markers survive the CJS/ESM dual-package hazard
+// (see entitySymbol rationale in EntityHelper.ts and #7515/#7534).
+const referenceSymbol = Symbol.for('@mikro-orm/core/Reference');
+const scalarReferenceSymbol = Symbol.for('@mikro-orm/core/ScalarReference');
 
 /** Wrapper around an entity that provides lazy loading capabilities and identity-preserving reference semantics. */
 export class Reference<T extends object> {

--- a/tests/issues/GH7534.test.ts
+++ b/tests/issues/GH7534.test.ts
@@ -1,0 +1,47 @@
+import { Collection, defineEntity, MikroORM, p, ref, Reference, ScalarReference } from '@mikro-orm/sqlite';
+
+// GH #7534: `referenceSymbol`, `scalarReferenceSymbol`, and `collectionSymbol`
+// must use globally-registered Symbol.for() to survive the CJS/ESM dual-package
+// hazard, just like `entitySymbol` was fixed in #7515.
+
+const User = defineEntity({
+  name: 'User7534',
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+  },
+});
+
+test('Reference/Collection/ScalarReference markers survive dual module copies (#7534)', async () => {
+  const orm = await MikroORM.init({
+    dbName: ':memory:',
+    entities: [User],
+  });
+  await orm.schema.create();
+
+  const user = orm.em.create(User, { name: 'Foo' });
+  await orm.em.flush();
+
+  // A second module copy would resolve these markers via Symbol.for(...)
+  // and see the same values installed by the first copy.
+  const refSym = Symbol.for('@mikro-orm/core/Reference');
+  const colSym = Symbol.for('@mikro-orm/core/Collection');
+  const scalarRefSym = Symbol.for('@mikro-orm/core/ScalarReference');
+
+  // Reference marker
+  const wrapped = ref(user);
+  expect((wrapped as any)[refSym]).toBe(true);
+  expect(Reference.isReference(wrapped)).toBe(true);
+
+  // Collection marker
+  const col = new Collection(user);
+  expect((col as any)[colSym]).toBe(true);
+  expect(Collection.isCollection(col)).toBe(true);
+
+  // ScalarReference marker
+  const sr = new ScalarReference('test');
+  expect((sr as any)[scalarRefSym]).toBe(true);
+  expect(ScalarReference.isScalarReference(sr)).toBe(true);
+
+  await orm.close(true);
+});


### PR DESCRIPTION
Same CJS/ESM dual-package hazard as #7515 — when `tsx` loads both an ESM and a CJS copy of `@mikro-orm/core`, module-local `Symbol()` values diverge between copies, causing `Reference.isReference()`, `ScalarReference.isScalarReference()`, and `Collection.isCollection()` checks to fail when entities are created by one copy and checked by the other. This manifests as seeder failures when running from CLI with `ref()` relations.

Switches `referenceSymbol`, `scalarReferenceSymbol`, and `collectionSymbol` from `Symbol()` to `Symbol.for()` so both copies resolve to the same marker — the same fix applied to `entitySymbol` in #7515.

Closes #7534