### PR TITLE
chore: enable minimum release age and fix maintenance branch dist-tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,8 +96,18 @@ jobs:
           git diff-index --quiet HEAD || git commit -m 'chore(release): update internal dependencies [skip ci]'
           git push
 
+      - name: Determine dist-tag
+        id: dist-tag
+        run: |
+          if [[ "${{ inputs.ref }}" == "master" ]]; then
+            echo "tag=" >> "$GITHUB_OUTPUT"
+          else
+            MAJOR=$(echo "${{ inputs.ref }}" | grep -oP '^\d+')
+            echo "tag=--dist-tag latest-v${MAJOR}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Publish to npm
-        run: yarn publish:prod --yes
+        run: yarn publish:prod ${{ steps.dist-tag.outputs.tag }} --yes
 
       - name: Publish to JSR
         run: yarn publish:jsr

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -2,4 +2,6 @@ compressionLevel: mixed
 
 enableGlobalCache: false
 
+npmMinimalAgeGate: 1d
+
 nodeLinker: node-modules

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
       ":semanticCommitTypeAll(chore)"
     ],
     "semanticCommits": "enabled",
+    "minimumReleaseAge": "1 day",
     "separateMajorMinor": false,
     "dependencyDashboard": false,
     "packageRules": [


### PR DESCRIPTION
## Summary
- Use `latest-vN` dist-tag when publishing from maintenance branches (e.g. `6.x`), so only `master` publishes as `latest`
- Enable 1-day minimum release age in Renovate (`minimumReleaseAge`) and Yarn (`minimumStabilityDays`) to avoid pulling freshly published packages