### PR TITLE
fix(postgres): normalize `!=` to `<>` in check constraint diffing

### DIFF
--- a/packages/sql/src/schema/SchemaComparator.ts
+++ b/packages/sql/src/schema/SchemaComparator.ts
@@ -849,6 +849,7 @@ export class SchemaComparator {
       return (
         str
           ?.replace(/_\w+'(.*?)'/g, '$1')
+          .replace(/!=/g, '<>')
           .replace(/in\s*\((.*?)\)/gi, '= any (array[$1])')
           // MySQL normalizes count(*) to count(0)
           .replace(/\bcount\s*\(\s*0\s*\)/gi, 'count(*)')

--- a/tests/features/schema-generator/check-constraint.postgres.test.ts
+++ b/tests/features/schema-generator/check-constraint.postgres.test.ts
@@ -229,6 +229,35 @@ describe('check constraint [postgres]', () => {
     await orm.close();
   });
 
+  test('check constraint with != operator does not cause drift [postgres]', async () => {
+    const orm = await initORMPostgreSql();
+    const meta = orm.getMetadata();
+    await orm.schema.update();
+
+    // PostgreSQL canonicalizes `!=` to `<>` in stored constraint definitions, so without
+    // normalization in diffExpression this would drop+recreate the constraint on every run.
+    const newTableMeta = new EntitySchema({
+      properties: {
+        id: { primary: true, name: 'id', type: 'number', fieldName: 'id', columnType: 'int' },
+        kind: { type: 'string', name: 'kind', fieldName: 'kind', columnType: 'varchar(20)' },
+      },
+      name: 'NeqCheckTable',
+      tableName: 'neq_check_table',
+      checks: [{ name: 'chk_kind', expression: `kind != 'foo'` }],
+    }).init().meta;
+    meta.set(newTableMeta.class, newTableMeta);
+
+    let diff = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(diff).not.toBe('');
+    await orm.schema.execute(diff);
+
+    diff = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(diff).toBe('');
+
+    await orm.schema.dropDatabase();
+    await orm.close();
+  });
+
   test('check constraint with multiline expression does not cause drift [postgres]', async () => {
     const orm = await initORMPostgreSql();
     const meta = orm.getMetadata();


### PR DESCRIPTION
## Summary

PostgreSQL canonicalizes `!=` to `<>` when storing check constraint definitions, so `pg_get_constraintdef()` always returns `<>` regardless of how the constraint was authored. `SchemaComparator.diffExpression()` normalizes many dialect quirks (quotes, casts, `IN` vs `= ANY`, whitespace, …) but not this operator alias, so constraints written with `!=` produced phantom drop+recreate diffs on every `migration:create`.

Added `!=` → `<>` normalization alongside the existing rules in `simplify()`, plus a regression test.

Closes #7540