### PR TITLE
fix(core): hydrate version property when merging data via SELECT_IN populate

### DIFF
--- a/packages/core/src/entity/EntityFactory.ts
+++ b/packages/core/src/entity/EntityFactory.ts
@@ -229,15 +229,6 @@ export class EntityFactory {
     const originalEntityData = helper(entity).__originalEntityData ?? ({} as EntityData<T>);
     const diff = this.#comparator.diffEntities(meta.class, originalEntityData, existsData);
 
-    // version properties are not part of entity snapshots
-    if (
-      meta.versionProperty &&
-      data[meta.versionProperty] &&
-      data[meta.versionProperty] !== originalEntityData[meta.versionProperty]
-    ) {
-      diff[meta.versionProperty] = data[meta.versionProperty];
-    }
-
     const diff2 = this.#comparator.diffEntities(meta.class, existsData, data, { includeInverseSides: true });
 
     // do not override values changed by user; for uninitialized entities,
@@ -263,12 +254,13 @@ export class EntityFactory {
       })
       .forEach(key => delete diff2[key]);
 
-    // but always add collection properties, formulas, and generated columns if they are part of the `data`,
-    // as these are excluded from `comparableProps` and won't appear in the diff
+    // but always add collection properties, formulas, generated columns, and version properties if they
+    // are part of the `data`, as these are excluded from `comparableProps` and won't appear in the diff
     Utils.keys(data)
       .filter(
         key =>
           meta.properties[key]?.formula ||
+          meta.properties[key]?.version ||
           (meta.properties[key]?.generated && !meta.properties[key]?.primary) ||
           [ReferenceKind.ONE_TO_MANY, ReferenceKind.MANY_TO_MANY].includes(meta.properties[key]?.kind),
       )

--- a/tests/issues/GH7543.test.ts
+++ b/tests/issues/GH7543.test.ts
@@ -1,0 +1,80 @@
+import { LoadStrategy, MikroORM, OptionalProps } from '@mikro-orm/sqlite';
+import { Entity, ManyToOne, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+
+// Version property not hydrated on populated entities when using SELECT_IN
+// strategy. When a parent entity has a FK reference to a child, the child is
+// first created as an uninitialized reference during parent hydration, then
+// mergeData is called when the child is fully loaded via populate. The version
+// property is excluded from comparableProps and never makes it into the merge diff.
+
+@Entity({ tableName: 'ghx40_child' })
+class Child {
+  [OptionalProps]?: 'version';
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @Property({ version: true })
+  version!: number;
+}
+
+@Entity({ tableName: 'ghx40_parent' })
+class Parent {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @ManyToOne(() => Child)
+  child!: Child;
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    metadataProvider: ReflectMetadataProvider,
+    entities: [Parent, Child],
+    dbName: ':memory:',
+  });
+  await orm.schema.create();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+test('version property is hydrated on ManyToOne populated entity (SELECT_IN)', async () => {
+  const em = orm.em.fork();
+
+  const child = em.create(Child, { name: 'c1' });
+  const parent = em.create(Parent, { name: 'p1', child });
+  await em.flush();
+  em.clear();
+
+  const loaded = await em.findOneOrFail(Parent, parent.id, {
+    populate: ['child'],
+    strategy: LoadStrategy.SELECT_IN,
+  });
+
+  expect(loaded.child.version).toBe(1);
+});
+
+test('version property is hydrated when using populate: [*]', async () => {
+  const em = orm.em.fork();
+
+  const child = em.create(Child, { name: 'c2' });
+  const parent = em.create(Parent, { name: 'p2', child });
+  await em.flush();
+  em.clear();
+
+  const loaded = await em.findOneOrFail(Parent, parent.id, {
+    populate: ['*'],
+  });
+
+  expect(loaded.child.version).toBe(1);
+});


### PR DESCRIPTION
## Summary

- Version properties are excluded from `comparableProps` by design, so they never appeared in the diff produced by `mergeData`. When loading a ManyToOne/OneToOne relation via SELECT_IN strategy, the related entity is first created as an uninitialized reference (from the FK), then `mergeData` is called with the full data — but the version field was silently dropped.
- Added `version` to the "always add non-comparable properties" block in `mergeData`, alongside formulas, generated columns, and collections. Removed the old dead-code block that incorrectly added version to the user-changes diff.

Closes #7543

🤖 Generated with [Claude Code](https://claude.com/claude-code)