### PR TITLE
fix(core): unwrap IType serialized type for scalar-based properties in EntityDTO

### DIFF
--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -760,7 +760,11 @@ type DTOWrapper<T, C extends TypeConfig, Flat extends boolean> = Flat extends tr
 
 /** Resolves the serialized (DTO) type for a single entity property. Unwraps references, collections, and custom serialized types. */
 export type EntityDTOProp<E, T, C extends TypeConfig = never, Flat extends boolean = false> = T extends Scalar
-  ? T
+  ? T extends { __serialized?: infer U }
+    ? IsUnknown<U> extends false
+      ? U
+      : T
+    : T
   : T extends ScalarReference<infer U>
     ? U
     : T extends { __serialized?: infer U }

--- a/tests/bench/types/api-methods.ts
+++ b/tests/bench/types/api-methods.ts
@@ -92,19 +92,19 @@ bench('em.create() return type', () => {
   type R = ReturnType<typeof em.create<Author>>;
   const x = {} as R;
   void x;
-}).types([2444, 'instantiations']);
+}).types([2442, 'instantiations']);
 
 bench('RequiredEntityData - Author', () => {
   type R = RequiredEntityData<Author>;
   const x = {} as R;
   void x;
-}).types([1505, 'instantiations']);
+}).types([1503, 'instantiations']);
 
 bench('RequiredEntityData - Book', () => {
   type R = RequiredEntityData<Book>;
   const x = {} as R;
   void x;
-}).types([1310, 'instantiations']);
+}).types([1309, 'instantiations']);
 
 // New<T> type (used as create return type)
 bench('New<Author>', () => {
@@ -117,7 +117,7 @@ bench('New<Author, "books">', () => {
   type R = New<Author, 'books'>;
   const x = {} as R;
   void x;
-}).types([1004, 'instantiations']);
+}).types([1003, 'instantiations']);
 
 // ============================================
 // em.populate() - return type computation
@@ -137,25 +137,25 @@ bench('EntityDTO<Author>', () => {
   type R = EntityDTO<Author>;
   const x = {} as R;
   void x;
-}).types([1114, 'instantiations']);
+}).types([1112, 'instantiations']);
 
 bench('EntityDTO<Book>', () => {
   type R = EntityDTO<Book>;
   const x = {} as R;
   void x;
-}).types([984, 'instantiations']);
+}).types([983, 'instantiations']);
 
 bench('EntityDTO<Loaded<Author, "books">>', () => {
   type R = EntityDTO<Loaded<Author, 'books'>>;
   const x = {} as R;
   void x;
-}).types([3621, 'instantiations']);
+}).types([3620, 'instantiations']);
 
 bench('EntityDTO<Loaded<Author, "books.publisher">>', () => {
   type R = EntityDTO<Loaded<Author, 'books.publisher'>>;
   const x = {} as R;
   void x;
-}).types([3621, 'instantiations']);
+}).types([3620, 'instantiations']);
 
 // ============================================
 // FilterQuery - used in where clauses
@@ -206,13 +206,13 @@ bench('wrap(author).toObject() return type', () => {
   type R = ToObjectReturn<Author>;
   const x = {} as R;
   void x;
-}).types([1115, 'instantiations']);
+}).types([1113, 'instantiations']);
 
 bench('wrap(loadedAuthor).toObject() return type', () => {
   type R = ToObjectReturn<Loaded<Author, 'books'>>;
   const x = {} as R;
   void x;
-}).types([3623, 'instantiations']);
+}).types([3622, 'instantiations']);
 
 // ============================================
 // Complex scenarios
@@ -224,4 +224,4 @@ bench('find result then EntityDTO', () => {
   type DTOResult = EntityDTO<FindResult>;
   const x = {} as DTOResult;
   void x;
-}).types([3621, 'instantiations']);
+}).types([3620, 'instantiations']);

--- a/tests/bench/types/assign-types.ts
+++ b/tests/bench/types/assign-types.ts
@@ -68,7 +68,7 @@ bench('FromEntityType - plain entity', () => {
 
 bench('FromEntityType - Loaded entity', () => {
   useFromEntityType<Loaded<Author, 'books'>>({} as FromEntityType<Loaded<Author, 'books'>>);
-}).types([1122, 'instantiations']);
+}).types([1121, 'instantiations']);
 
 // ============================================
 // IsSubset benchmarks
@@ -103,7 +103,7 @@ bench('MergeSelected - Loaded entity', () => {
   type R = MergeSelected<Loaded<Author, 'books'>, Author, 'name'>;
   const x = {} as R;
   void x;
-}).types([1646, 'instantiations']);
+}).types([1645, 'instantiations']);
 
 // ============================================
 // Full assign signature simulation
@@ -122,7 +122,7 @@ bench('assign return type - Loaded entity', () => {
   type R = AssignReturnType<Loaded<Author, 'books'>, { name: string }>;
   const x = {} as R;
   void x;
-}).types([1665, 'instantiations']);
+}).types([1664, 'instantiations']);
 
 // ============================================
 // Data parameter type computation
@@ -136,10 +136,10 @@ bench('assign data type - plain entity', () => {
   type R = AssignDataType<Author>;
   const x = {} as R;
   void x;
-}).types([2358, 'instantiations']);
+}).types([2374, 'instantiations']);
 
 bench('assign data type - Loaded entity', () => {
   type R = AssignDataType<Loaded<Author, 'books'>>;
   const x = {} as R;
   void x;
-}).types([3429, 'instantiations']);
+}).types([3445, 'instantiations']);

--- a/tests/bench/types/asterisk-hints.ts
+++ b/tests/bench/types/asterisk-hints.ts
@@ -59,24 +59,24 @@ function useLoaded<T, L extends string = never, F extends string = '*'>(_entity:
 
 bench('Loaded<Author, "*"> - asterisk populate all', () => {
   useLoaded<Author, '*'>({} as Loaded<Author, '*'>);
-}).types([1362, 'instantiations']);
+}).types([1360, 'instantiations']);
 
 bench('Loaded<Book, "*"> - asterisk populate all', () => {
   useLoaded<Book, '*'>({} as Loaded<Book, '*'>);
-}).types([1893, 'instantiations']);
+}).types([1890, 'instantiations']);
 
 bench('Loaded<Publisher, "*"> - asterisk populate all', () => {
   useLoaded<Publisher, '*'>({} as Loaded<Publisher, '*'>);
-}).types([1038, 'instantiations']);
+}).types([1037, 'instantiations']);
 
 // Compare with explicit paths
 bench('Loaded<Author, "books"> - single relation', () => {
   useLoaded<Author, 'books'>({} as Loaded<Author, 'books'>);
-}).types([1135, 'instantiations']);
+}).types([1134, 'instantiations']);
 
 bench('Loaded<Author, "books" | "friends"> - multiple relations', () => {
   useLoaded<Author, 'books' | 'friends'>({} as Loaded<Author, 'books' | 'friends'>);
-}).types([1255, 'instantiations']);
+}).types([1253, 'instantiations']);
 
 // ============================================
 // Loaded with asterisk fields (F parameter)
@@ -84,7 +84,7 @@ bench('Loaded<Author, "books" | "friends"> - multiple relations', () => {
 
 bench('Loaded<Author, "books", "*"> - default fields', () => {
   useLoaded<Author, 'books', '*'>({} as Loaded<Author, 'books', '*'>);
-}).types([995, 'instantiations']);
+}).types([994, 'instantiations']);
 
 bench('Loaded<Author, "books", "name" | "email"> - specific fields', () => {
   useLoaded<Author, 'books', 'name' | 'email'>({} as Loaded<Author, 'books', 'name' | 'email'>);

--- a/tests/bench/types/autopath-loaded-isolated.ts
+++ b/tests/bench/types/autopath-loaded-isolated.ts
@@ -116,7 +116,7 @@ bench('AutoPath SELF-REF - 2 levels', () => {
 
 bench('AutoPath SELF-REF - children (Collection)', () => {
   validatePath<TreeNode, 'children'>('children');
-}).types([607, 'instantiations']);
+}).types([606, 'instantiations']);
 
 bench('Loaded SELF-REF - 1 level (Ref)', () => {
   useLoaded<TreeNode, 'parent'>({} as Loaded<TreeNode, 'parent'>);
@@ -128,7 +128,7 @@ bench('Loaded SELF-REF - 2 levels (Ref)', () => {
 
 bench('Loaded SELF-REF - children (Collection)', () => {
   useLoaded<TreeNode, 'children'>({} as Loaded<TreeNode, 'children'>);
-}).types([895, 'instantiations']);
+}).types([894, 'instantiations']);
 
 // ============================================
 // TWO-WAY circular reference (A <-> B)
@@ -175,11 +175,11 @@ bench('Loaded CIRCULAR - back to start (Ref)', () => {
 
 bench('Loaded CIRCULAR - collection', () => {
   useLoaded<Department, 'employees'>({} as Loaded<Department, 'employees'>);
-}).types([895, 'instantiations']);
+}).types([894, 'instantiations']);
 
 bench('Loaded CIRCULAR - collection nested', () => {
   useLoaded<Department, 'employees.department'>({} as Loaded<Department, 'employees.department'>);
-}).types([895, 'instantiations']);
+}).types([894, 'instantiations']);
 
 // ============================================
 // Entity with many properties (width test)

--- a/tests/bench/types/autopath-loaded.ts
+++ b/tests/bench/types/autopath-loaded.ts
@@ -62,19 +62,19 @@ bench('AutoPath - simple property access', () => {
 
 bench('AutoPath - single relation', () => {
   validatePath<Author, 'books'>('books');
-}).types([773, 'instantiations']);
+}).types([772, 'instantiations']);
 
 bench('AutoPath - nested relation (2 levels)', () => {
   validatePath<Author, 'books.publisher'>('books.publisher');
-}).types([1000, 'instantiations']);
+}).types([999, 'instantiations']);
 
 bench('AutoPath - nested relation (3 levels)', () => {
   validatePath<Author, 'books.publisher.books'>('books.publisher.books');
-}).types([1043, 'instantiations']);
+}).types([1042, 'instantiations']);
 
 bench('AutoPath - nested relation (4 levels)', () => {
   validatePath<Author, 'books.publisher.books.author'>('books.publisher.books.author');
-}).types([1106, 'instantiations']);
+}).types([1105, 'instantiations']);
 
 bench('AutoPath - collection with :ref', () => {
   validatePath<Author, 'books:ref'>('books:ref');
@@ -93,25 +93,25 @@ bench('Loaded - no populate', () => {
 
 bench('Loaded - single relation', () => {
   useLoaded<Author, 'books'>({} as Loaded<Author, 'books'>);
-}).types([961, 'instantiations']);
+}).types([960, 'instantiations']);
 
 bench('Loaded - nested relation (2 levels)', () => {
   useLoaded<Author, 'books.publisher'>({} as Loaded<Author, 'books.publisher'>);
-}).types([961, 'instantiations']);
+}).types([960, 'instantiations']);
 
 bench('Loaded - nested relation (3 levels)', () => {
   useLoaded<Author, 'books.publisher.books'>({} as Loaded<Author, 'books.publisher.books'>);
-}).types([961, 'instantiations']);
+}).types([960, 'instantiations']);
 
 bench('Loaded - multiple relations', () => {
   useLoaded<Author, 'books' | 'friends' | 'favouriteBook'>({} as Loaded<Author, 'books' | 'friends' | 'favouriteBook'>);
-}).types([1242, 'instantiations']);
+}).types([1240, 'instantiations']);
 
 bench('Loaded - complex nested paths', () => {
   useLoaded<Author, 'books.tags' | 'books.publisher' | 'friends.books'>(
     {} as Loaded<Author, 'books.tags' | 'books.publisher' | 'friends.books'>,
   );
-}).types([1119, 'instantiations']);
+}).types([1117, 'instantiations']);
 
 // ============================================
 // Deep hierarchy tests

--- a/tests/bench/types/defineEntity-extends.ts
+++ b/tests/bench/types/defineEntity-extends.ts
@@ -19,7 +19,7 @@ bench('entity extends entity', () => {
       extra: p.string(),
     },
   });
-}).types([1460, 'instantiations']);
+}).types([1459, 'instantiations']);
 
 bench('entity extends entity with discriminator', () => {
   const base = defineEntity({
@@ -40,7 +40,7 @@ bench('entity extends entity with discriminator', () => {
       extra: p.string(),
     },
   });
-}).types([1481, 'instantiations']);
+}).types([1480, 'instantiations']);
 
 bench('embeddable extends embeddable', () => {
   const base = defineEntity({
@@ -60,7 +60,7 @@ bench('embeddable extends embeddable', () => {
       bar: p.string(),
     },
   });
-}).types([914, 'instantiations']);
+}).types([913, 'instantiations']);
 
 bench('embeddable extends embeddable with discriminator', () => {
   const base = defineEntity({
@@ -83,7 +83,7 @@ bench('embeddable extends embeddable with discriminator', () => {
       bar: p.string(),
     },
   });
-}).types([935, 'instantiations']);
+}).types([934, 'instantiations']);
 
 bench('polymorphic embeddables', () => {
   const base = defineEntity({
@@ -198,7 +198,7 @@ bench('polymorphic embeddables', () => {
       data: () => p.embedded([documentDataAwEdCard, documentDataCoCheckMig, documentDataMvDiCard]).object(),
     },
   });
-}).types([3253, 'instantiations']);
+}).types([3252, 'instantiations']);
 
 bench('realistic entity (~20 props, relations, extends)', () => {
   const base = defineEntity({
@@ -270,7 +270,7 @@ bench('realistic entity (~20 props, relations, extends)', () => {
       tags: () => p.manyToMany(Tag),
     },
   });
-}).types([7311, 'instantiations']);
+}).types([7310, 'instantiations']);
 
 bench('realistic entity - InferEntity usage', () => {
   const base = defineEntity({
@@ -350,7 +350,7 @@ bench('realistic entity - InferEntity usage', () => {
 
   // Force evaluation of all entity types
   const _check: [IAuthor, IBook, ITag, IPublisher] = {} as any;
-}).types([7403, 'instantiations']);
+}).types([7402, 'instantiations']);
 
 bench('realistic entity - setClass pattern', () => {
   const BaseSchema = defineEntity({
@@ -436,4 +436,4 @@ bench('realistic entity - setClass pattern', () => {
   PublisherSchema.setClass(Publisher);
   AuthorSchema.setClass(Author);
   BookSchema.setClass(Book);
-}).types([7419, 'instantiations']);
+}).types([7425, 'instantiations']);

--- a/tests/bench/types/defineEntity.ts
+++ b/tests/bench/types/defineEntity.ts
@@ -19,7 +19,7 @@ bench('defineEntity with relations', () => {
       strictNullRef: () => p.oneToOne(Foo).strictNullable(),
     },
   });
-}).types([7118, 'instantiations']);
+}).types([7117, 'instantiations']);
 
 bench('defineEntity with ref and nullable', () => {
   const Foo = defineEntity({
@@ -36,7 +36,7 @@ bench('defineEntity with ref and nullable', () => {
       scalarRefNullable: p.string().ref().nullable(),
     },
   });
-}).types([6608, 'instantiations']);
+}).types([6607, 'instantiations']);
 
 bench('defineEntity only with ref and nullable', () => {
   const Foo = defineEntity({
@@ -46,7 +46,7 @@ bench('defineEntity only with ref and nullable', () => {
       toOneRefNullable: () => p.oneToOne(Foo).ref().nullable(),
     },
   });
-}).types([1837, 'instantiations']);
+}).types([1836, 'instantiations']);
 
 bench('defineEntity only with nullable and ref', () => {
   const Foo = defineEntity({
@@ -56,7 +56,7 @@ bench('defineEntity only with nullable and ref', () => {
       toOneRefNullable: () => p.oneToOne(Foo).nullable().ref(),
     },
   });
-}).types([1837, 'instantiations']);
+}).types([1836, 'instantiations']);
 
 bench('defineEntity with relations using class', () => {
   class Foo {
@@ -88,7 +88,7 @@ bench('defineEntity with relations using class', () => {
       scalarRefNullable: p.string().ref().nullable(),
     },
   });
-}).types([7106, 'instantiations']);
+}).types([7105, 'instantiations']);
 
 bench('defineEntity with ref and nullable using class', () => {
   class Foo {
@@ -120,7 +120,7 @@ bench('defineEntity with ref and nullable using class', () => {
       scalarRefNullable: p.string().ref().nullable(),
     },
   });
-}).types([7106, 'instantiations']);
+}).types([7105, 'instantiations']);
 
 bench('defineEntity only with ref and nullable using class', () => {
   class Foo {
@@ -138,7 +138,7 @@ bench('defineEntity only with ref and nullable using class', () => {
       toOneRefNullable: () => p.oneToOne(Foo).ref().nullable(),
     },
   });
-}).types([2360, 'instantiations']);
+}).types([2359, 'instantiations']);
 
 bench('defineEntity only with nullable and ref using class', () => {
   class Foo {
@@ -156,7 +156,7 @@ bench('defineEntity only with nullable and ref using class', () => {
       toOneRefNullable: () => p.oneToOne(Foo).nullable().ref(),
     },
   });
-}).types([2360, 'instantiations']);
+}).types([2359, 'instantiations']);
 
 bench('EntitySchema', () => {
   interface IFoo {
@@ -241,4 +241,4 @@ bench('defineEntity with setClass pattern (circular relations)', () => {
 
   AuthorSchema.setClass(Author);
   BookSchema.setClass(Book);
-}).types([5567, 'instantiations']);
+}).types([5571, 'instantiations']);

--- a/tests/bench/types/entitydto-isolated.ts
+++ b/tests/bench/types/entitydto-isolated.ts
@@ -51,7 +51,7 @@ bench('EntityDTO<EntityWithRef> - with Ref', () => {
 
 bench('EntityDTO<EntityWithCollection> - with Collection', () => {
   useDTO<EntityWithCollection>({} as EntityDTO<EntityWithCollection>);
-}).types([791, 'instantiations']);
+}).types([790, 'instantiations']);
 
 // ============================================
 // EntityDTO on Loaded entities
@@ -71,7 +71,7 @@ bench('EntityDTO<Loaded<EntityWithRef, "parent">> - loaded with populated Ref', 
 
 bench('EntityDTO<Loaded<EntityWithCollection>> - loaded with Collection', () => {
   useDTO<Loaded<EntityWithCollection>>({} as EntityDTO<Loaded<EntityWithCollection>>);
-}).types([1741, 'instantiations']);
+}).types([1740, 'instantiations']);
 
 bench('EntityDTO<Loaded<EntityWithCollection, "items">> - loaded with populated Collection', () => {
   useDTO<Loaded<EntityWithCollection, 'items'>>({} as EntityDTO<Loaded<EntityWithCollection, 'items'>>);
@@ -86,4 +86,4 @@ function useLoaded<T, L extends string = never>(_entity: Loaded<T, L>): void {}
 
 bench('Loaded<EntityWithCollection, "items"> - without EntityDTO', () => {
   useLoaded<EntityWithCollection, 'items'>({} as Loaded<EntityWithCollection, 'items'>);
-}).types([873, 'instantiations']);
+}).types([872, 'instantiations']);

--- a/tests/bench/types/filter-query.ts
+++ b/tests/bench/types/filter-query.ts
@@ -137,7 +137,7 @@ bench('FilterQuery nested - author.books', () => {
   type R = FilterObject<Author>['books'];
   const x = {} as R;
   void x;
-}).types([1027, 'instantiations']);
+}).types([1026, 'instantiations']);
 
 bench('FilterQuery nested - book.author', () => {
   type R = FilterObject<Book>['author'];

--- a/tests/bench/types/filterquery-deep.ts
+++ b/tests/bench/types/filterquery-deep.ts
@@ -84,15 +84,15 @@ bench('FilterQuery<Author> - complex entity', () => {
 
 bench('FilterQuery<Author> - nested 1 level', () => {
   useFilter<Author>({ books: { title: 'test' } });
-}).types([1063, 'instantiations']);
+}).types([1062, 'instantiations']);
 
 bench('FilterQuery<Author> - nested 2 levels', () => {
   useFilter<Author>({ books: { publisher: { name: 'test' } } });
-}).types([1357, 'instantiations']);
+}).types([1356, 'instantiations']);
 
 bench('FilterQuery<Author> - nested 3 levels', () => {
   useFilter<Author>({ books: { publisher: { books: { title: 'test' } } } });
-}).types([1389, 'instantiations']);
+}).types([1388, 'instantiations']);
 
 // ============================================
 // Component type benchmarks

--- a/tests/bench/types/other-types.ts
+++ b/tests/bench/types/other-types.ts
@@ -74,7 +74,7 @@ bench('FilterQuery<Author> - simple', () => {
 
 bench('FilterQuery<Author> - with relation', () => {
   useFilter<Author>({ books: { title: 'test' } });
-}).types([1085, 'instantiations']);
+}).types([1084, 'instantiations']);
 
 bench('FilterQuery<Author> - with operators', () => {
   useFilter<Author>({ age: { $gt: 18 }, name: { $like: '%test%' } });
@@ -82,7 +82,7 @@ bench('FilterQuery<Author> - with operators', () => {
 
 bench('FilterQuery<Book> - nested relations', () => {
   useFilter<Book>({ author: { books: { publisher: { name: 'test' } } } });
-}).types([1483, 'instantiations']);
+}).types([1482, 'instantiations']);
 
 // ============================================
 // EntityData benchmarks
@@ -112,11 +112,11 @@ function useRequiredData<T>(_data: RequiredEntityData<T>): void {}
 
 bench('RequiredEntityData<Author> - simple', () => {
   useRequiredData<Author>({ name: 'test', email: 'test@test.com' });
-}).types([2149, 'instantiations']);
+}).types([2147, 'instantiations']);
 
 bench('RequiredEntityData<Book> - with required relations', () => {
   useRequiredData<Book>({ title: 'test', price: 10, author: {} as Author });
-}).types([3521, 'instantiations']);
+}).types([3518, 'instantiations']);
 
 // ============================================
 // Primary type benchmarks
@@ -142,8 +142,8 @@ function useDTO<T>(_dto: EntityDTO<T>): void {}
 
 bench('EntityDTO<Author> - simple', () => {
   useDTO<Author>({} as EntityDTO<Author>);
-}).types([1180, 'instantiations']);
+}).types([1178, 'instantiations']);
 
 bench('EntityDTO<Loaded<Author, "books">> - with loaded hint', () => {
   useDTO<Loaded<Author, 'books'>>({} as EntityDTO<Loaded<Author, 'books'>>);
-}).types([3892, 'instantiations']);
+}).types([3891, 'instantiations']);

--- a/tests/bench/types/populate-all.ts
+++ b/tests/bench/types/populate-all.ts
@@ -71,8 +71,8 @@ bench('AutoPath<Publisher, true> - populate all', () => {
 // Compare with string paths
 bench('AutoPath<Author, "books"> - string path', () => {
   validatePath<Author, 'books'>('books');
-}).types([795, 'instantiations']);
+}).types([794, 'instantiations']);
 
 bench('AutoPath<Author, "books.publisher"> - nested string', () => {
   validatePath<Author, 'books.publisher'>('books.publisher');
-}).types([1033, 'instantiations']);
+}).types([1032, 'instantiations']);

--- a/tests/bench/types/querybuilder.ts
+++ b/tests/bench/types/querybuilder.ts
@@ -140,11 +140,11 @@ function useOrderBy<E, R extends string, C>(_order: ContextOrderByMap<E, R, C>):
 
 bench('ContextOrderByMap<Author, "a", never> - no context', () => {
   useOrderBy<Author, 'a', never>({ name: 'asc' });
-}).types([558, 'instantiations']);
+}).types([557, 'instantiations']);
 
 bench('ContextOrderByMap<Author, "a", SimpleContext> - with join', () => {
   useOrderBy<Author, 'a', SimpleContext>({ 'b.title': 'asc' });
-}).types([595, 'instantiations']);
+}).types([594, 'instantiations']);
 
 // ============================================
 // QBFilterQuery benchmarks
@@ -230,19 +230,19 @@ bench('execute() return - wildcard fields', () => {
   const r = {} as EntityDTOFlat<Author>;
   const _: string = r.name;
   void _;
-}).types([446, 'instantiations']);
+}).types([454, 'instantiations']);
 
 bench('execute() return - selected fields', () => {
   const r = {} as DirectDTO<Author, 'id' | 'email'>;
   const _: string = r.email;
   void _;
-}).types([21, 'instantiations']);
+}).types([29, 'instantiations']);
 
 bench('execute("get") return - selected fields (single)', () => {
   const r = {} as DirectDTO<Author, 'id' | 'email'>;
   const _: number = r.id;
   void _;
-}).types([21, 'instantiations']);
+}).types([29, 'instantiations']);
 
 bench('execute() return - with join hint', () => {
   const r = {} as DirectDTO<Author, 'id'> & {
@@ -250,7 +250,7 @@ bench('execute() return - with join hint', () => {
   };
   const _: number = r.id;
   void _;
-}).types([42, 'instantiations']);
+}).types([50, 'instantiations']);
 
 bench('execute() return - with join hint and wildcard', () => {
   const r = {} as Omit<EntityDTOFlat<Author>, 'books'> & {
@@ -258,19 +258,19 @@ bench('execute() return - with join hint and wildcard', () => {
   };
   const _: string = r.name;
   void _;
-}).types([647, 'instantiations']);
+}).types([655, 'instantiations']);
 
 bench('execute() return - 2-level nested wildcard', () => {
   const r = {} as SerializeDTO<Author, 'books' | 'books.publisher'>;
   const _: string = r.name;
   void _;
-}).types([589, 'instantiations']);
+}).types([593, 'instantiations']);
 
 bench('execute() return - 3-level nested wildcard', () => {
   const r = {} as SerializeDTO<Author, 'books' | 'books.publisher' | 'books.publisher.books'>;
   const _: string = r.name;
   void _;
-}).types([595, 'instantiations']);
+}).types([599, 'instantiations']);
 
 bench('execute() return - 3-level nested with fields', () => {
   const r = {} as EntityDTOFlat<
@@ -282,7 +282,7 @@ bench('execute() return - 3-level nested with fields', () => {
   >;
   const _: number = r.id;
   void _;
-}).types([1697, 'instantiations']);
+}).types([1709, 'instantiations']);
 
 // ============================================
 // EntityDTOFlat vs EntityDTO comparison (wide entities)
@@ -346,25 +346,25 @@ bench('EntityDTO<Loaded<WideAuthor, "books">> - 2-pass recursive', () => {
   const r = {} as EntityDTO<Loaded<WideAuthor, 'books'>>;
   const _: string = r.name;
   void _;
-}).types([5080, 'instantiations']);
+}).types([5088, 'instantiations']);
 
 bench('EntityDTOFlat<Loaded<WideAuthor, "books">> - 1-pass recursive', () => {
   const r = {} as EntityDTOFlat<Loaded<WideAuthor, 'books'>>;
   const _: string = r.name;
   void _;
-}).types([4071, 'instantiations']);
+}).types([4079, 'instantiations']);
 
 bench('EntityDTO<Loaded<WideAuthor, "books.publisher">> - 2-pass recursive 2-level', () => {
   const r = {} as EntityDTO<Loaded<WideAuthor, 'books' | 'books.publisher'>>;
   const _: string = r.name;
   void _;
-}).types([5112, 'instantiations']);
+}).types([5120, 'instantiations']);
 
 bench('EntityDTOFlat<Loaded<WideAuthor, "books.publisher">> - 1-pass recursive 2-level', () => {
   const r = {} as EntityDTOFlat<Loaded<WideAuthor, 'books' | 'books.publisher'>>;
   const _: string = r.name;
   void _;
-}).types([4103, 'instantiations']);
+}).types([4111, 'instantiations']);
 
 // ============================================
 // CTE type safety benchmarks

--- a/tests/bench/types/scalar-test.ts
+++ b/tests/bench/types/scalar-test.ts
@@ -32,4 +32,4 @@ bench('AutoPath - scalar Date property should not expand', () => {
 bench('AutoPath - relation should expand', () => {
   // Use 'books.title' - a valid nested path (not 'books.' which is just a prefix)
   validatePath<Author, 'books.title'>('books.title');
-}).types([871, 'instantiations']);
+}).types([870, 'instantiations']);

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -997,6 +997,17 @@ describe('check typings', () => {
     const dOk3 = {} as EntityData<MyEntity, false>;
   });
 
+  test('IType with scalar runtime type unwraps serialized type in EntityDTO', async () => {
+    class MyEntity {
+      dateAsString!: IType<Date, number, string>;
+      dateAsNumber!: IType<Date, number>;
+    }
+
+    const o = {} as EntityDTO<MyEntity>;
+    assert<IsExact<typeof o.dateAsString, string>>(true);
+    assert<IsExact<typeof o.dateAsNumber, number>>(true);
+  });
+
   test('explicit serialization', async () => {
     interface CustomerSubscription {
       id: number;


### PR DESCRIPTION
## Summary

- `EntityDTOProp` resolves `IType<Date, number, string>` to the full branded type instead of `string` because `Date` matches the `T extends Scalar` branch before reaching the `__serialized` unwrap check
- Added `__serialized` unwrapping inside the `Scalar` branch of `EntityDTOProp` so scalar-based `IType` properties correctly resolve their serialized type in `EntityDTO`

Reported in https://github.com/mikro-orm/mikro-orm/discussions/6555#discussioncomment-16520713