### PR TITLE
feat(core): add `initNullableProperties` config option

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -366,6 +366,18 @@ MikroORM.init({
 });
 ```
 
+## Initializing nullable properties to `null`
+
+By default, nullable properties that are not provided in `em.create()` data remain `undefined` on the entity object. This can lead to a mismatch between the runtime value (`undefined`) and what the database returns after loading (`null`).
+
+With `initNullableProperties` enabled, nullable properties are initialized to `null` (or `undefined` when `forceUndefined` is set) during `em.create()`. Properties with explicit `default`, `defaultRaw`, or `onCreate` are not affected.
+
+```ts
+MikroORM.init({
+  initNullableProperties: true,
+});
+```
+
 ## Ignoring `undefined` values in Find Queries
 
 The ORM will treat explicitly defined `undefined` values in your `em.find()` queries as `null`s. If you want to ignore them instead, use `ignoreUndefinedInQuery` option:

--- a/packages/core/src/entity/EntityFactory.ts
+++ b/packages/core/src/entity/EntityFactory.ts
@@ -473,6 +473,15 @@ export class EntityFactory {
         entity[prop.name] ??= prop.onCreate(entity, this.#em);
       } else if (!onCreateOnly && prop.default != null && !isRaw(prop.default) && entity[prop.name] === undefined) {
         entity[prop.name] = prop.default as EntityValue<T>;
+      } else if (
+        !onCreateOnly &&
+        this.#config.get('initNullableProperties') &&
+        prop.nullable &&
+        prop.default == null &&
+        !prop.defaultRaw &&
+        entity[prop.name] === undefined
+      ) {
+        entity[prop.name] = (this.#config.get('forceUndefined') ? undefined : null) as EntityValue<T>;
       }
 
       if (prop.kind === ReferenceKind.EMBEDDED && entity[prop.name]) {
@@ -480,7 +489,21 @@ export class EntityFactory {
 
         for (const item of items) {
           // Embedded sub-properties need all defaults since the DB can't apply them within JSON columns.
-          this.assignDefaultValues(item, prop.targetMeta! as EntityMetadata<T>);
+          // For polymorphic embeddables, resolve the actual subtype to avoid setting
+          // properties from other subtypes (e.g. Cat's canMeow on a Dog instance).
+          let targetMeta = prop.targetMeta! as EntityMetadata<T>;
+
+          if (targetMeta.polymorphs && targetMeta.discriminatorColumn) {
+            const discValue = (item as Dictionary)[targetMeta.discriminatorColumn];
+            // eslint-disable-next-line eqeqeq
+            const resolved = targetMeta.polymorphs.find(m => m.discriminatorValue == discValue);
+
+            if (resolved) {
+              targetMeta = resolved as EntityMetadata<T>;
+            }
+          }
+
+          this.assignDefaultValues(item, targetMeta);
         }
       }
     }

--- a/packages/core/src/utils/Configuration.ts
+++ b/packages/core/src/utils/Configuration.ts
@@ -99,6 +99,7 @@ const DEFAULTS = {
   upsertManaged: true,
   forceEntityConstructor: false,
   forceUndefined: false,
+  initNullableProperties: false,
   forceUtcTimezone: true,
   processOnCreateHooksEarly: true,
   ensureDatabase: true,
@@ -947,6 +948,13 @@ export interface Options<
    * @default false
    */
   forceUndefined: boolean;
+  /**
+   * Initialize nullable properties to `null` (or `undefined` when `forceUndefined` is set)
+   * during `em.create()` when they are not provided in the data. Without this option,
+   * nullable properties remain `undefined` until the entity is loaded from the database.
+   * @default false
+   */
+  initNullableProperties: boolean;
   /**
    * Property `onCreate` hooks are normally executed during `flush` operation.
    * With this option, they will be processed early inside `em.create()` method.

--- a/tests/issues/GHx40-init-nullable-properties.test.ts
+++ b/tests/issues/GHx40-init-nullable-properties.test.ts
@@ -1,0 +1,110 @@
+import { defineEntity, MikroORM, p } from '@mikro-orm/sqlite';
+
+// When `initNullableProperties` is enabled, nullable properties (both
+// nullable() and strictNullable()) should be initialized to `null` (or
+// `undefined` when forceUndefined is set) when omitted from em.create()
+// data, so the runtime value matches the type and the database
+// representation from the start.
+
+const UserSchema = defineEntity({
+  name: 'GHx40User',
+  properties: {
+    id: p.integer().primary().autoincrement(),
+    name: p.string(),
+    // nullable() — T | null | undefined
+    locale: p.string().nullable(),
+    code: p.integer().nullable(),
+    // strictNullable() — T | null
+    bio: p.string().strictNullable(),
+    created: p.datetime().strictNullable(),
+  },
+});
+
+let orm: MikroORM;
+
+afterEach(() => orm.close(true));
+
+describe('GHx40 - initNullableProperties option', () => {
+  test('nullable and strictNullable properties are null after em.create()', async () => {
+    orm = await MikroORM.init({
+      entities: [UserSchema],
+      dbName: ':memory:',
+      initNullableProperties: true,
+    });
+    await orm.schema.create();
+
+    const user = orm.em.create(UserSchema, { name: 'Foo' });
+
+    // All nullable properties should be null immediately, not undefined
+    expect(user.locale).toBeNull();
+    expect(user.code).toBeNull();
+    expect(user.bio).toBeNull();
+    expect(user.created).toBeNull();
+
+    await orm.em.flush();
+    orm.em.clear();
+
+    // After round-trip, values should still be null
+    const loaded = await orm.em.findOneOrFail(UserSchema, user.id);
+    expect(loaded.locale).toBeNull();
+    expect(loaded.code).toBeNull();
+    expect(loaded.bio).toBeNull();
+    expect(loaded.created).toBeNull();
+  });
+
+  test('nullable properties respect forceUndefined config', async () => {
+    orm = await MikroORM.init({
+      entities: [UserSchema],
+      dbName: ':memory:',
+      initNullableProperties: true,
+      forceUndefined: true,
+    });
+    await orm.schema.create();
+
+    const user = orm.em.create(UserSchema, { name: 'Bar' });
+
+    // With forceUndefined, nullable properties should be undefined
+    expect(user.locale).toBeUndefined();
+    expect(user.code).toBeUndefined();
+    expect(user.bio).toBeUndefined();
+    expect(user.created).toBeUndefined();
+  });
+
+  test('explicitly provided values are not overwritten', async () => {
+    orm = await MikroORM.init({
+      entities: [UserSchema],
+      dbName: ':memory:',
+      initNullableProperties: true,
+    });
+    await orm.schema.create();
+
+    const now = new Date();
+    const user = orm.em.create(UserSchema, {
+      name: 'Baz',
+      locale: 'en',
+      code: 42,
+      bio: 'Hello',
+      created: now,
+    });
+
+    expect(user.locale).toBe('en');
+    expect(user.code).toBe(42);
+    expect(user.bio).toBe('Hello');
+    expect(user.created).toBe(now);
+  });
+
+  test('disabled by default — nullable properties remain undefined', async () => {
+    orm = await MikroORM.init({
+      entities: [UserSchema],
+      dbName: ':memory:',
+    });
+    await orm.schema.create();
+
+    const user = orm.em.create(UserSchema, { name: 'Qux' });
+
+    expect(user.locale).toBeUndefined();
+    expect(user.code).toBeUndefined();
+    expect(user.bio).toBeUndefined();
+    expect(user.created).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- Add opt-in `initNullableProperties` config option (default `false`) that initializes nullable properties to `null` when omitted from `em.create()` data, so the runtime value matches the type contract and the database representation from the start.
- Respects `forceUndefined` config — uses `undefined` instead of `null` when set.
- Properties with `default`, `defaultRaw`, or `onCreate` are not affected.
- For polymorphic embeddables, resolves the actual subtype metadata before recursing to avoid setting cross-subtype properties.

Closes #7551

🤖 Generated with [Claude Code](https://claude.com/claude-code)