### PR TITLE
fix(core): allow `unknown` values for `Opt<unknown>` properties

### DIFF
--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -676,6 +676,14 @@ type ProbablyOptionalProps<T> =
   | ExplicitlyOptionalProps<T>
   | Exclude<NonNullable<NullableKeys<T, null | undefined>>, RequiredNullableKeys<T>>;
 
+// `Opt<unknown>` collapses to `Opt.Brand` (since `unknown & T = T`), losing the `unknown`.
+// Detect this case and restore `unknown` so that `unknown`-typed values are assignable.
+type RestoreOptUnknown<T> = [Exclude<T, null | undefined>] extends [Opt.Brand]
+  ? [Opt.Brand] extends [Exclude<T, null | undefined>]
+    ? unknown
+    : T
+  : T;
+
 type IsOptional<T, K extends keyof T, I> = T[K] extends CollectionShape
   ? true
   : ExtractType<T[K]> extends I
@@ -686,7 +694,9 @@ type IsOptional<T, K extends keyof T, I> = T[K] extends CollectionShape
 type RequiredKeys<T, K extends keyof T, I> = IsOptional<T, K, I> extends false ? CleanKeys<T, K> : never;
 type OptionalKeys<T, K extends keyof T, I> = IsOptional<T, K, I> extends false ? never : CleanKeys<T, K>;
 /** Data shape for creating or updating entities. All properties are optional. Used in `em.create()` and `em.assign()`. */
-export type EntityData<T, C extends boolean = false> = { [K in EntityKey<T>]?: EntityDataItem<T[K] & {}, C> };
+export type EntityData<T, C extends boolean = false> = {
+  [K in EntityKey<T>]?: RestoreOptUnknown<T[K]> | EntityDataItem<T[K] & {}, C>;
+};
 
 /**
  * Data shape for `em.create()` with required/optional distinction based on entity metadata.
@@ -695,14 +705,14 @@ export type EntityData<T, C extends boolean = false> = { [K in EntityKey<T>]?: E
  */
 export type RequiredEntityData<T, I = never, C extends boolean = false> = {
   [K in keyof T as RequiredKeys<T, K, I>]:
-    | T[K]
+    | RestoreOptUnknown<T[K]>
     | RequiredEntityDataProp<T[K], T, C>
     | Primary<T[K]>
     | PolymorphicPrimary<T[K]>
     | Raw;
 } & {
   [K in keyof T as OptionalKeys<T, K, I>]?:
-    | T[K]
+    | RestoreOptUnknown<T[K]>
     | RequiredEntityDataProp<T[K], T, C>
     | Primary<T[K]>
     | PolymorphicPrimary<T[K]>

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -14,6 +14,7 @@ import {
 } from '@mikro-orm/core';
 import type {
   BaseEntity,
+  Opt,
   Ref,
   Reference,
   Collection,
@@ -495,6 +496,46 @@ describe('check typings', () => {
     let bar: RequiredEntityData<User>['bar'];
     bar = '';
     bar = null;
+  });
+
+  test('RequiredEntityData allows unknown values for Opt<unknown> properties', async () => {
+    interface Row {
+      id: number;
+      data: Opt<unknown>;
+    }
+
+    interface RowNullable {
+      id: number;
+      data: Opt<unknown> | null;
+    }
+
+    const unknownValue = JSON.parse('{}') as unknown;
+
+    // Opt<unknown> properties should be omittable
+    const r1: RequiredEntityData<Row> = {};
+
+    // Opt<unknown> properties should accept unknown values
+    let r2: RequiredEntityData<Row>;
+    r2 = { data: unknownValue };
+    r2 = { data: 'string' };
+    r2 = { data: 123 };
+    r2 = { data: null };
+
+    // Opt<unknown> | null should also work
+    let r3: RequiredEntityData<RowNullable>;
+    r3 = {};
+    r3 = { data: unknownValue };
+    r3 = { data: null };
+
+    // EntityData (used by em.assign / em.create with partial: true) should also accept unknown
+    let r4: EntityData<Row>;
+    r4 = { data: unknownValue };
+    r4 = { data: 'string' };
+    r4 = { data: null };
+
+    let r5: EntityData<RowNullable>;
+    r5 = { data: unknownValue };
+    r5 = { data: null };
   });
 
   test('FilterQuery ok assignments', async () => {

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -536,6 +536,14 @@ describe('check typings', () => {
     let r5: EntityData<RowNullable>;
     r5 = { data: unknownValue };
     r5 = { data: null };
+
+    // RestoreOptUnknown should not widen non-Opt properties
+    interface RowTyped {
+      id: number;
+      name: string;
+    }
+    // @ts-expect-error name requires a string, not a number
+    const r6: RequiredEntityData<RowTyped> = { name: 123 };
   });
 
   test('FilterQuery ok assignments', async () => {


### PR DESCRIPTION
## Summary

- `Opt<unknown>` collapses to `Opt.Brand` due to TypeScript's `unknown & T = T`, losing the original type — making it impossible to assign `unknown`-typed values in `em.create()` or `em.assign()`
- Added `RestoreOptUnknown<T>` helper that detects the degenerate case via bidirectional extends check and restores `unknown` as the accepted value type
- Applied to both `RequiredEntityData` and `EntityData`

Ref: https://github.com/mikro-orm/mikro-orm/discussions/7550