### PR TITLE
fix(schema): detect native enum value changes on array columns

### DIFF
--- a/packages/sql/src/schema/SchemaComparator.ts
+++ b/packages/sql/src/schema/SchemaComparator.ts
@@ -662,11 +662,11 @@ export class SchemaComparator {
       changedProperties.add('comment');
     }
 
-    if (
-      !(fromColumn.mappedType instanceof ArrayType) &&
-      !(toColumn.mappedType instanceof ArrayType) &&
-      this.diffEnumItems(fromColumn.enumItems, toColumn.enumItems)
-    ) {
+    const isNonNativeEnumArray =
+      !(fromColumn.nativeEnumName || toColumn.nativeEnumName) &&
+      (fromColumn.mappedType instanceof ArrayType || toColumn.mappedType instanceof ArrayType);
+
+    if (!isNonNativeEnumArray && this.diffEnumItems(fromColumn.enumItems, toColumn.enumItems)) {
       log(`'enumItems' changed for column ${fromTable.name}.${fromColumn.name}`, { fromColumn, toColumn });
       changedProperties.add('enumItems');
     }

--- a/tests/features/native-postgres-enums/GH7560.test.ts
+++ b/tests/features/native-postgres-enums/GH7560.test.ts
@@ -1,0 +1,42 @@
+import { MikroORM } from '@mikro-orm/postgresql';
+import { Entity, Enum, PrimaryKey, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+
+enum MyEnum {
+  LOCAL = 'local',
+  GLOBAL = 'global',
+}
+
+@Entity()
+class EnumEntity {
+  @PrimaryKey()
+  id!: number;
+
+  @Enum({ items: () => MyEnum, nativeEnumName: 'my_enum', array: true })
+  types: MyEnum[] = [];
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    metadataProvider: ReflectMetadataProvider,
+    entities: [EnumEntity],
+    dbName: '7560',
+  });
+
+  await orm.schema.ensureDatabase();
+  await orm.schema.execute(`drop type if exists my_enum cascade`);
+  await orm.schema.execute(`drop table if exists enum_entity`);
+});
+
+afterAll(() => orm.close());
+
+test('GH #7560 — adding new native enum value on array column generates migration', async () => {
+  await orm.schema.execute(await orm.schema.getCreateSchemaSQL());
+
+  const meta = orm.getMetadata(EnumEntity);
+  meta.properties.types.items = ['local', 'global', 'archived'];
+
+  const diff = await orm.schema.getUpdateSchemaSQL();
+  expect(diff).toMatch(`alter type "my_enum" add value if not exists 'archived' after 'global';`);
+});


### PR DESCRIPTION
## Summary

When a new value is added to a native PostgreSQL enum that's only used on columns declared with `array: true`, `getUpdateSchemaSQL()` returned an empty string and no `ALTER TYPE ... ADD VALUE` statement was generated.

The cause was in `SchemaComparator.diffColumn`: the `enumItems` diff was skipped for any `ArrayType` column (originally added in 9accdf60 because non-native enum arrays don't enforce items at the schema level). Native enums do enforce their items at the type level, so the skip should only apply when the column is not backed by a `nativeEnumName`.

Closes #7560