### PR TITLE
feat(core): add `logging` option to `em.upsert()`, `nativeUpdate()` etc

### DIFF
--- a/packages/core/src/drivers/IDatabaseDriver.ts
+++ b/packages/core/src/drivers/IDatabaseDriver.ts
@@ -415,6 +415,7 @@ export interface NativeInsertUpdateOptions<T> {
   /** `nativeUpdate()` only option */
   upsert?: boolean;
   loggerContext?: LogContext;
+  logging?: LoggingOptions;
   /** sql only */
   unionWhere?: ObjectQuery<T>[];
   /** sql only */
@@ -485,6 +486,8 @@ export interface UpdateOptions<T> {
   filters?: FilterOptions;
   schema?: string;
   ctx?: Transaction;
+  loggerContext?: LogContext;
+  logging?: LoggingOptions;
   /** sql only */
   unionWhere?: ObjectQuery<T>[];
   /** sql only */
@@ -526,6 +529,7 @@ export interface DriverMethodOptions {
   ctx?: Transaction;
   schema?: string;
   loggerContext?: LogContext;
+  logging?: LoggingOptions;
 }
 
 /** MongoDB-style collation options for locale-aware string comparison. */

--- a/tests/features/logging/logging.test.ts
+++ b/tests/features/logging/logging.test.ts
@@ -125,6 +125,20 @@ describe('logging', () => {
     expect(mockedLogger).toHaveBeenCalledTimes(1);
   });
 
+  it(`accepts the 'logging' option on write methods (#7557)`, async () => {
+    setDebug([]);
+    const em = orm.em.fork();
+
+    await em.insert(Example, { id: 10, title: 'a' }, { logging: { enabled: true } });
+    await em.insertMany(Example, [{ id: 11, title: 'b' }], { logging: { enabled: true } });
+    await em.upsert(Example, { id: 10, title: 'a2' }, { logging: { enabled: true } });
+    await em.upsertMany(Example, [{ id: 11, title: 'b2' }], { logging: { enabled: true } });
+    await em.nativeUpdate(Example, { id: 10 }, { title: 'a3' }, { logging: { enabled: true } });
+    await em.nativeDelete(Example, { id: 11 }, { logging: { enabled: true } });
+
+    expect(mockedLogger).toHaveBeenCalledTimes(6);
+  });
+
   describe('slow query logging', () => {
     let slowOrm: MikroORM;
     let slowLoggerMock: Mock;


### PR DESCRIPTION
Only `em.find()`/`findOne()`/`count()` exposed `logging` on their option type. The other write methods (`insert`, `insertMany`, `upsert`, `upsertMany`, `nativeUpdate`, `nativeDelete`) already supported it at runtime via `prepareOptions`, but the option wasn't declared on their option interfaces, so users hit a TS error.

Adds `logging?: LoggingOptions` to `NativeInsertUpdateOptions`, `UpdateOptions` and `DriverMethodOptions`, plus `loggerContext?: LogContext` to `UpdateOptions` (the only one still missing it).

Closes #7557