### PR TITLE
fix(core): support TPT inheritance targets in polymorphic relations

### DIFF
--- a/packages/core/src/entity/EntityLoader.ts
+++ b/packages/core/src/entity/EntityLoader.ts
@@ -850,7 +850,12 @@ export class EntityLoader {
     if (prop.polymorphic && prop.polymorphTargets) {
       await Promise.all(
         prop.polymorphTargets.map(async targetMeta => {
-          const targetChildren = unique.filter(child => helper(child).__meta.className === targetMeta.className);
+          const targetChildren = unique.filter(child => {
+            const childMeta = helper(child).__meta;
+            // Use root.className for TPT entities: a Dog (root: Animal) should match
+            // targetMeta Animal. For non-TPT entities, root === self.
+            return childMeta.root.className === targetMeta.root.className;
+          });
           if (targetChildren.length > 0) {
             await populateChildren(targetMeta, targetChildren);
           }

--- a/packages/core/src/utils/EntityComparator.ts
+++ b/packages/core/src/utils/EntityComparator.ts
@@ -817,14 +817,13 @@ export class EntityComparator {
         ret += `      ret${dataKey} = null;\n`;
         ret += `    } else if (typeof entity${entityKey} !== 'undefined') {\n`;
         ret += `      const val${level} = entity${entityKey}${unwrap};\n`;
-        ret += `      let discriminator = ${discriminatorMapKey}.get(val${level}?.constructor);\n`;
-        ret += `      if (discriminator === undefined && val${level}?.constructor) {\n`;
-        ret += `        let __proto = Object.getPrototypeOf(val${level}.constructor);\n`;
-        ret += `        while (__proto && __proto !== Object) {\n`;
-        ret += `          discriminator = ${discriminatorMapKey}.get(__proto);\n`;
-        ret += `          if (discriminator !== undefined) break;\n`;
-        ret += `          __proto = Object.getPrototypeOf(__proto);\n`;
-        ret += `        }\n`;
+        // walk up the prototype chain so TPT subclasses resolve to their root's discriminator
+        ret += `      let __cls${level} = val${level}?.constructor;\n`;
+        ret += `      let discriminator;\n`;
+        ret += `      while (__cls${level} != null) {\n`;
+        ret += `        discriminator = ${discriminatorMapKey}.get(__cls${level});\n`;
+        ret += `        if (discriminator !== undefined) break;\n`;
+        ret += `        __cls${level} = Object.getPrototypeOf(__cls${level});\n`;
         ret += `      }\n`;
         ret += `      const pk = val${level}?.__helper?.__identifier && !val${level}?.__helper?.hasPrimaryKey()\n`;
         ret += `        ? val${level}.__helper.__identifier\n`;

--- a/packages/core/src/utils/EntityComparator.ts
+++ b/packages/core/src/utils/EntityComparator.ts
@@ -817,7 +817,15 @@ export class EntityComparator {
         ret += `      ret${dataKey} = null;\n`;
         ret += `    } else if (typeof entity${entityKey} !== 'undefined') {\n`;
         ret += `      const val${level} = entity${entityKey}${unwrap};\n`;
-        ret += `      const discriminator = ${discriminatorMapKey}.get(val${level}?.constructor);\n`;
+        ret += `      let discriminator = ${discriminatorMapKey}.get(val${level}?.constructor);\n`;
+        ret += `      if (discriminator === undefined && val${level}?.constructor) {\n`;
+        ret += `        let __proto = Object.getPrototypeOf(val${level}.constructor);\n`;
+        ret += `        while (__proto && __proto !== Object) {\n`;
+        ret += `          discriminator = ${discriminatorMapKey}.get(__proto);\n`;
+        ret += `          if (discriminator !== undefined) break;\n`;
+        ret += `          __proto = Object.getPrototypeOf(__proto);\n`;
+        ret += `        }\n`;
+        ret += `      }\n`;
         ret += `      const pk = val${level}?.__helper?.__identifier && !val${level}?.__helper?.hasPrimaryKey()\n`;
         ret += `        ? val${level}.__helper.__identifier\n`;
         ret += `        : toArray(val${level}?.__helper?.getPrimaryKey(true));\n`;

--- a/packages/core/src/utils/QueryHelper.ts
+++ b/packages/core/src/utils/QueryHelper.ts
@@ -25,26 +25,20 @@ export class QueryHelper {
 
   /**
    * Finds the discriminator value (key) for a given entity class in a discriminator map.
+   * Walks up the prototype chain so TPT subclasses resolve to their root's key.
    */
   static findDiscriminatorValue<T>(discriminatorMap: Dictionary<T>, targetClass: T): string | undefined {
-    const result = Object.entries(discriminatorMap).find(([, cls]) => cls === targetClass)?.[0];
+    const entries = Object.entries(discriminatorMap);
+    let current = targetClass;
 
-    if (result) {
-      return result;
-    }
+    while (current != null) {
+      const hit = entries.find(([, cls]) => cls === current)?.[0];
 
-    // Walk up the prototype chain (TPT hierarchy): if targetClass is a TPT
-    // child whose parent is in the discriminator map, return the parent's key.
-    let parent = Object.getPrototypeOf(targetClass);
-
-    while (parent && parent !== Object) {
-      const parentResult = Object.entries(discriminatorMap).find(([, cls]) => cls === parent)?.[0];
-
-      if (parentResult) {
-        return parentResult;
+      if (hit) {
+        return hit;
       }
 
-      parent = Object.getPrototypeOf(parent);
+      current = Object.getPrototypeOf(current);
     }
 
     return undefined;

--- a/packages/core/src/utils/QueryHelper.ts
+++ b/packages/core/src/utils/QueryHelper.ts
@@ -27,7 +27,27 @@ export class QueryHelper {
    * Finds the discriminator value (key) for a given entity class in a discriminator map.
    */
   static findDiscriminatorValue<T>(discriminatorMap: Dictionary<T>, targetClass: T): string | undefined {
-    return Object.entries(discriminatorMap).find(([, cls]) => cls === targetClass)?.[0];
+    const result = Object.entries(discriminatorMap).find(([, cls]) => cls === targetClass)?.[0];
+
+    if (result) {
+      return result;
+    }
+
+    // Walk up the prototype chain (TPT hierarchy): if targetClass is a TPT
+    // child whose parent is in the discriminator map, return the parent's key.
+    let parent = Object.getPrototypeOf(targetClass);
+
+    while (parent && parent !== Object) {
+      const parentResult = Object.entries(discriminatorMap).find(([, cls]) => cls === parent)?.[0];
+
+      if (parentResult) {
+        return parentResult;
+      }
+
+      parent = Object.getPrototypeOf(parent);
+    }
+
+    return undefined;
   }
 
   static processParams(params: unknown): any {

--- a/packages/sql/src/AbstractSqlDriver.ts
+++ b/packages/sql/src/AbstractSqlDriver.ts
@@ -606,27 +606,12 @@ export abstract class AbstractSqlDriver<
               this.mapJoinedProp(relationPojo, p, relationAlias, root, tz, meta2);
             }
 
-            // Handle TPT child fields — determines concrete type from
-            // discriminator and maps child-specific properties.
-            this.mapTPTChildFields(relationPojo, meta2, relationAlias, qb, root);
+            // For TPT base targets, map child-specific fields and resolve the
+            // concrete class so the factory creates the correct subtype.
+            const concreteMeta = this.mapTPTChildFields(relationPojo, meta2, relationAlias, qb, root);
 
-            // Determine the concrete class: if TPT resolved a more specific
-            // type via the discriminator, use that; otherwise use the
-            // polymorphic target's class.
-            let concreteClass = meta2.class;
-
-            if (meta2.root?.tptDiscriminatorColumn && relationPojo[meta2.root.tptDiscriminatorColumn as EntityKey<T>]) {
-              const discValue = relationPojo[meta2.root.tptDiscriminatorColumn as EntityKey<T>] as string;
-              const resolved = meta2.root.discriminatorMap?.[discValue];
-
-              if (resolved) {
-                concreteClass = resolved;
-              }
-            }
-
-            // Inject the entity class constructor so that the factory creates the correct type
             Object.defineProperty(relationPojo, 'constructor', {
-              value: concreteClass,
+              value: concreteMeta?.class ?? meta2.class,
               enumerable: false,
               configurable: true,
             });
@@ -2382,13 +2367,11 @@ export abstract class AbstractSqlDriver<
     relationAlias: string,
     qb: AnyQueryBuilder<T>,
     root: EntityData<T>,
-  ): void {
-    // Check if this is a TPT base with polymorphic children
+  ): EntityMetadata | undefined {
     if (meta.inheritanceType !== 'tpt' || !meta.root.tptDiscriminatorColumn) {
       return;
     }
 
-    // Read the discriminator value
     const discriminatorAlias = `${relationAlias}__${meta.root.tptDiscriminatorColumn}` as EntityKey<T>;
     const discriminatorValue = root[discriminatorAlias] as string;
 
@@ -2396,10 +2379,8 @@ export abstract class AbstractSqlDriver<
       return;
     }
 
-    // Set the discriminator in the pojo for EntityFactory
     relationPojo[meta.root.tptDiscriminatorColumn as EntityKey<T>] = discriminatorValue as EntityDataValue<T>;
 
-    // Find the concrete metadata from discriminator map
     const concreteClass = meta.root.discriminatorMap?.[discriminatorValue];
     /* v8 ignore next 3 - defensive check for invalid discriminator values */
     if (!concreteClass) {
@@ -2407,11 +2388,10 @@ export abstract class AbstractSqlDriver<
     }
 
     const concreteMeta = this.metadata.get(concreteClass);
+    delete root[discriminatorAlias];
 
     if (concreteMeta === meta) {
-      // Already the concrete type, no child fields to map
-      delete root[discriminatorAlias];
-      return;
+      return concreteMeta;
     }
 
     // Traverse up from concrete type and map fields from each level's table
@@ -2433,8 +2413,7 @@ export abstract class AbstractSqlDriver<
       currentMeta = currentMeta.tptParent;
     }
 
-    // Clean up the discriminator alias
-    delete root[discriminatorAlias];
+    return concreteMeta;
   }
 
   /**

--- a/packages/sql/src/AbstractSqlDriver.ts
+++ b/packages/sql/src/AbstractSqlDriver.ts
@@ -606,9 +606,27 @@ export abstract class AbstractSqlDriver<
               this.mapJoinedProp(relationPojo, p, relationAlias, root, tz, meta2);
             }
 
+            // Handle TPT child fields — determines concrete type from
+            // discriminator and maps child-specific properties.
+            this.mapTPTChildFields(relationPojo, meta2, relationAlias, qb, root);
+
+            // Determine the concrete class: if TPT resolved a more specific
+            // type via the discriminator, use that; otherwise use the
+            // polymorphic target's class.
+            let concreteClass = meta2.class;
+
+            if (meta2.root?.tptDiscriminatorColumn && relationPojo[meta2.root.tptDiscriminatorColumn as EntityKey<T>]) {
+              const discValue = relationPojo[meta2.root.tptDiscriminatorColumn as EntityKey<T>] as string;
+              const resolved = meta2.root.discriminatorMap?.[discValue];
+
+              if (resolved) {
+                concreteClass = resolved;
+              }
+            }
+
             // Inject the entity class constructor so that the factory creates the correct type
             Object.defineProperty(relationPojo, 'constructor', {
-              value: meta2.class,
+              value: concreteClass,
               enumerable: false,
               configurable: true,
             });
@@ -2126,6 +2144,13 @@ export abstract class AbstractSqlDriver<
             targetPath,
             schema,
           );
+
+          // For polymorphic targets that are TPT base classes, also LEFT JOIN
+          // all descendant tables so child-specific fields can be selected.
+          if (targetMeta.inheritanceType === 'tpt' && targetMeta.tptChildren?.length && !ref) {
+            const tptMeta = this.metadata.get(targetMeta.class);
+            this.addTPTPolymorphicJoinsForRelation(qb, tptMeta, tableAlias, fields);
+          }
 
           if (ref) {
             // For filter :ref hints, schedule filter check for each target (no field selection)

--- a/tests/features/polymorphic-relations/polymorphic-tpt.sqlite.test.ts
+++ b/tests/features/polymorphic-relations/polymorphic-tpt.sqlite.test.ts
@@ -184,19 +184,16 @@ describe('polymorphic ManyToOne with TPT targets', () => {
   // -------------------------------------------------------------------------
 
   test('SELECT JOINED: polymorphic populate resolves TPT child entities', async () => {
-    const conn = orm.em.getConnection();
-    await conn.execute(`insert into \`animal\` (\`name\`) values ('Buddy')`);
-    const [{ id: animalId }] = await conn.execute(`select last_insert_rowid() as id`);
-    await conn.execute(`insert into \`dog\` (\`id\`, \`breed\`) values (${animalId}, 'Labrador')`);
-    await conn.execute(
-      `insert into \`activity\` (\`description\`, \`subject_type\`, \`subject_id\`) values ('Walk the dog', 'animal', ${animalId})`,
-    );
+    const dog = orm.em.create(Dog, { name: 'Buddy', breed: 'Labrador' });
+    const person = orm.em.create(Person, { personName: 'Bob' });
+    await orm.em.flush();
 
-    await conn.execute(`insert into \`person\` (\`person_name\`) values ('Bob')`);
-    const [{ id: personId }] = await conn.execute(`select last_insert_rowid() as id`);
-    await conn.execute(
-      `insert into \`activity\` (\`description\`, \`subject_type\`, \`subject_id\`) values ('Person walked', 'person', ${personId})`,
-    );
+    // @ts-expect-error TS limitation: polymorphic union doesn't accept a single-target ref
+    orm.em.create(Activity, { description: 'Walk the dog', subject: ref(dog) });
+    // @ts-expect-error
+    orm.em.create(Activity, { description: 'Person walked', subject: ref(person) });
+    await orm.em.flush();
+    orm.em.clear();
 
     const activities = await orm.em.find(Activity, {}, { populate: ['subject'], strategy: LoadStrategy.JOINED });
 
@@ -215,13 +212,13 @@ describe('polymorphic ManyToOne with TPT targets', () => {
   });
 
   test('SELECT JOINED: Cat (second TPT child)', async () => {
-    const conn = orm.em.getConnection();
-    await conn.execute(`insert into \`animal\` (\`name\`) values ('Whiskers')`);
-    const [{ id: animalId }] = await conn.execute(`select last_insert_rowid() as id`);
-    await conn.execute(`insert into \`cat\` (\`id\`, \`indoor\`) values (${animalId}, 1)`);
-    await conn.execute(
-      `insert into \`activity\` (\`description\`, \`subject_type\`, \`subject_id\`) values ('Cat adopted', 'animal', ${animalId})`,
-    );
+    const cat = orm.em.create(Cat, { name: 'Whiskers', indoor: true });
+    await orm.em.flush();
+
+    // @ts-expect-error
+    orm.em.create(Activity, { description: 'Cat adopted', subject: ref(cat) });
+    await orm.em.flush();
+    orm.em.clear();
 
     const activities = await orm.em.find(Activity, {}, { populate: ['subject'], strategy: LoadStrategy.JOINED });
 
@@ -232,16 +229,17 @@ describe('polymorphic ManyToOne with TPT targets', () => {
   });
 
   test('SELECT JOINED: nested TPT grandchild hydrates all intermediate properties', async () => {
-    const conn = orm.em.getConnection();
-    await conn.execute(`insert into \`animal\` (\`name\`) values ('Kaiser')`);
-    const [{ id: animalId }] = await conn.execute(`select last_insert_rowid() as id`);
-    await conn.execute(`insert into \`dog\` (\`id\`, \`breed\`) values (${animalId}, 'German Shepherd')`);
-    await conn.execute(
-      `insert into \`german_shepherd\` (\`id\`, \`lineage\`) values (${animalId}, 'Schutzhund Champion')`,
-    );
-    await conn.execute(
-      `insert into \`activity\` (\`description\`, \`subject_type\`, \`subject_id\`) values ('GSD activity', 'animal', ${animalId})`,
-    );
+    const gs = orm.em.create(GermanShepherd, {
+      name: 'Kaiser',
+      breed: 'German Shepherd',
+      lineage: 'Schutzhund Champion',
+    });
+    await orm.em.flush();
+
+    // @ts-expect-error
+    orm.em.create(Activity, { description: 'GSD activity', subject: ref(gs) });
+    await orm.em.flush();
+    orm.em.clear();
 
     const activities = await orm.em.find(
       Activity,
@@ -262,19 +260,16 @@ describe('polymorphic ManyToOne with TPT targets', () => {
   // -------------------------------------------------------------------------
 
   test('SELECT_IN: polymorphic populate resolves TPT child entities', async () => {
-    const conn = orm.em.getConnection();
-    await conn.execute(`insert into \`animal\` (\`name\`) values ('Buddy')`);
-    const [{ id: animalId }] = await conn.execute(`select last_insert_rowid() as id`);
-    await conn.execute(`insert into \`dog\` (\`id\`, \`breed\`) values (${animalId}, 'Labrador')`);
-    await conn.execute(
-      `insert into \`activity\` (\`description\`, \`subject_type\`, \`subject_id\`) values ('Walk the dog', 'animal', ${animalId})`,
-    );
+    const dog = orm.em.create(Dog, { name: 'Buddy', breed: 'Labrador' });
+    const person = orm.em.create(Person, { personName: 'Bob' });
+    await orm.em.flush();
 
-    await conn.execute(`insert into \`person\` (\`person_name\`) values ('Bob')`);
-    const [{ id: personId }] = await conn.execute(`select last_insert_rowid() as id`);
-    await conn.execute(
-      `insert into \`activity\` (\`description\`, \`subject_type\`, \`subject_id\`) values ('Person walked', 'person', ${personId})`,
-    );
+    // @ts-expect-error
+    orm.em.create(Activity, { description: 'Walk the dog', subject: ref(dog) });
+    // @ts-expect-error
+    orm.em.create(Activity, { description: 'Person walked', subject: ref(person) });
+    await orm.em.flush();
+    orm.em.clear();
 
     const activities = await orm.em.find(Activity, {}, { populate: ['subject'], strategy: LoadStrategy.SELECT_IN });
 
@@ -293,16 +288,17 @@ describe('polymorphic ManyToOne with TPT targets', () => {
   });
 
   test('SELECT_IN: nested TPT grandchild hydrates correctly', async () => {
-    const conn = orm.em.getConnection();
-    await conn.execute(`insert into \`animal\` (\`name\`) values ('Kaiser')`);
-    const [{ id: animalId }] = await conn.execute(`select last_insert_rowid() as id`);
-    await conn.execute(`insert into \`dog\` (\`id\`, \`breed\`) values (${animalId}, 'German Shepherd')`);
-    await conn.execute(
-      `insert into \`german_shepherd\` (\`id\`, \`lineage\`) values (${animalId}, 'Schutzhund Champion')`,
-    );
-    await conn.execute(
-      `insert into \`activity\` (\`description\`, \`subject_type\`, \`subject_id\`) values ('GSD activity', 'animal', ${animalId})`,
-    );
+    const gs = orm.em.create(GermanShepherd, {
+      name: 'Kaiser',
+      breed: 'German Shepherd',
+      lineage: 'Schutzhund Champion',
+    });
+    await orm.em.flush();
+
+    // @ts-expect-error
+    orm.em.create(Activity, { description: 'GSD activity', subject: ref(gs) });
+    await orm.em.flush();
+    orm.em.clear();
 
     const activities = await orm.em.find(
       Activity,
@@ -599,44 +595,23 @@ describe('polymorphic ManyToOne with TPT targets', () => {
   // -------------------------------------------------------------------------
 
   test('mixed query: Dog, Cat, GermanShepherd, and Person all in one populate', async () => {
-    const conn = orm.em.getConnection();
+    const dog = orm.em.create(Dog, { name: 'Buddy', breed: 'Labrador' });
+    const cat = orm.em.create(Cat, { name: 'Whiskers', indoor: true });
+    const gsd = orm.em.create(GermanShepherd, { name: 'Kaiser', breed: 'German Shepherd', lineage: 'Champion' });
+    const person = orm.em.create(Person, { personName: 'Alice' });
+    await orm.em.flush();
 
-    // Dog
-    await conn.execute(`insert into \`animal\` (\`name\`) values ('Buddy')`);
-    let [{ id }] = await conn.execute(`select last_insert_rowid() as id`);
-    await conn.execute(`insert into \`dog\` (\`id\`, \`breed\`) values (${id}, 'Labrador')`);
-    await conn.execute(
-      `insert into \`activity\` (\`description\`, \`subject_type\`, \`subject_id\`) values ('dog activity', 'animal', ${id})`,
-    );
-
-    // Cat
-    await conn.execute(`insert into \`animal\` (\`name\`) values ('Whiskers')`);
-    [{ id }] = await conn.execute(`select last_insert_rowid() as id`);
-    await conn.execute(`insert into \`cat\` (\`id\`, \`indoor\`) values (${id}, 1)`);
-    await conn.execute(
-      `insert into \`activity\` (\`description\`, \`subject_type\`, \`subject_id\`) values ('cat activity', 'animal', ${id})`,
-    );
-
-    // GermanShepherd
-    await conn.execute(`insert into \`animal\` (\`name\`) values ('Kaiser')`);
-    [{ id }] = await conn.execute(`select last_insert_rowid() as id`);
-    await conn.execute(`insert into \`dog\` (\`id\`, \`breed\`) values (${id}, 'German Shepherd')`);
-    await conn.execute(`insert into \`german_shepherd\` (\`id\`, \`lineage\`) values (${id}, 'Champion')`);
-    await conn.execute(
-      `insert into \`activity\` (\`description\`, \`subject_type\`, \`subject_id\`) values ('gsd activity', 'animal', ${id})`,
-    );
-
-    // Person
-    await conn.execute(`insert into \`person\` (\`person_name\`) values ('Alice')`);
-    [{ id }] = await conn.execute(`select last_insert_rowid() as id`);
-    await conn.execute(
-      `insert into \`activity\` (\`description\`, \`subject_type\`, \`subject_id\`) values ('person activity', 'person', ${id})`,
-    );
-
-    // Null subject
-    await conn.execute(
-      `insert into \`activity\` (\`description\`, \`subject_type\`, \`subject_id\`) values ('null activity', null, null)`,
-    );
+    // @ts-expect-error TS limitation: polymorphic union doesn't accept a single-target ref
+    orm.em.create(Activity, { description: 'dog activity', subject: ref(dog) });
+    // @ts-expect-error
+    orm.em.create(Activity, { description: 'cat activity', subject: ref(cat) });
+    // @ts-expect-error
+    orm.em.create(Activity, { description: 'gsd activity', subject: ref(gsd) });
+    // @ts-expect-error
+    orm.em.create(Activity, { description: 'person activity', subject: ref(person) });
+    orm.em.create(Activity, { description: 'null activity', subject: null });
+    await orm.em.flush();
+    orm.em.clear();
 
     const activities = await orm.em.find(Activity, {}, { populate: ['subject'], orderBy: { description: 'asc' } });
 

--- a/tests/features/polymorphic-relations/polymorphic-tpt.sqlite.test.ts
+++ b/tests/features/polymorphic-relations/polymorphic-tpt.sqlite.test.ts
@@ -1,7 +1,9 @@
-import { MikroORM, ref } from '@mikro-orm/sqlite';
+import { Collection, LoadStrategy, MikroORM, ref, wrap } from '@mikro-orm/sqlite';
 import {
   Entity,
+  ManyToMany,
   ManyToOne,
+  OneToMany,
   PrimaryKey,
   Property,
   ReflectMetadataProvider,
@@ -10,6 +12,7 @@ import { mockLogger } from '../../bootstrap.js';
 
 // ---------------------------------------------------------------------------
 // TPT hierarchy: Animal (abstract) -> Dog, Cat (concrete)
+//                                     Dog -> GermanShepherd (nested)
 // ---------------------------------------------------------------------------
 
 @Entity({ inheritance: 'tpt' })
@@ -19,6 +22,9 @@ abstract class Animal {
 
   @Property()
   name!: string;
+
+  @OneToMany(() => Activity, a => a.subject)
+  activities = new Collection<Activity>(this);
 }
 
 @Entity()
@@ -51,6 +57,9 @@ class Person {
 
   @Property()
   personName!: string;
+
+  @OneToMany(() => Activity, a => a.subject)
+  activities = new Collection<Activity>(this);
 }
 
 @Entity()
@@ -80,7 +89,36 @@ class Activity {
   subject?: Animal | Person | Shelter | null;
 }
 
-describe('polymorphic relations with TPT targets', () => {
+// ---------------------------------------------------------------------------
+// M:N polymorphic pivot table entities — Tag can be applied to
+// Animal (TPT hierarchy) or Person (plain entity) via a shared pivot table.
+// ---------------------------------------------------------------------------
+
+@Entity()
+class Tag {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  label!: string;
+
+  @ManyToMany(() => Animal, animal => animal.tags)
+  animals = new Collection<Animal>(this);
+
+  @ManyToMany(() => Person, person => person.tags)
+  people = new Collection<Person>(this);
+}
+
+// Extend the entities with M:N owner sides (must be declared after Tag to
+// avoid circular reference issues with decorators).
+// We use a separate describe block below that re-initializes the ORM with
+// augmented entities.
+
+// ---------------------------------------------------------------------------
+// Tests — ManyToOne polymorphic with TPT targets
+// ---------------------------------------------------------------------------
+
+describe('polymorphic ManyToOne with TPT targets', () => {
   let orm: MikroORM;
 
   beforeAll(async () => {
@@ -101,9 +139,7 @@ describe('polymorphic relations with TPT targets', () => {
   });
 
   // -------------------------------------------------------------------------
-  // Bug 1: INSERT — When assigning a TPT child (Dog) as a polymorphic ref
-  // that lists the abstract parent (Animal), MikroORM should resolve the
-  // discriminator to the TPT root's table name ('animal'), not null.
+  // INSERT — discriminator resolution
   // -------------------------------------------------------------------------
 
   test('INSERT: discriminator is set correctly for TPT child entities', async () => {
@@ -148,101 +184,32 @@ describe('polymorphic relations with TPT targets', () => {
     expect(activity.subject).toBeDefined();
   });
 
-  // -------------------------------------------------------------------------
-  // Bug 2: SELECT — When populating a polymorphic relation that targets a
-  // TPT base class, MikroORM should JOIN the child tables too, so the entity
-  // is hydrated as the concrete subclass with all its properties.
-  // -------------------------------------------------------------------------
+  test('INSERT: nested TPT grandchild resolves discriminator correctly', async () => {
+    const mock = mockLogger(orm);
 
-  test('SELECT: polymorphic populate resolves TPT child entities (joined strategy)', async () => {
-    // Seed data via raw SQL to bypass the INSERT bug for this test
-    const conn = orm.em.getConnection();
-    await conn.execute(`insert into \`animal\` (\`name\`) values ('Buddy')`);
-    const [{ id: animalId }] = await conn.execute(`select last_insert_rowid() as id`);
-    await conn.execute(`insert into \`dog\` (\`id\`, \`breed\`) values (${animalId}, 'Labrador')`);
-    await conn.execute(
-      `insert into \`activity\` (\`description\`, \`subject_type\`, \`subject_id\`) values ('Walk the dog', 'animal', ${animalId})`,
-    );
-
-    // Also insert a Person-linked activity to verify non-TPT types still work
-    await conn.execute(`insert into \`person\` (\`person_name\`) values ('Bob')`);
-    const [{ id: personId }] = await conn.execute(`select last_insert_rowid() as id`);
-    await conn.execute(
-      `insert into \`activity\` (\`description\`, \`subject_type\`, \`subject_id\`) values ('Person walked', 'person', ${personId})`,
-    );
-
-    const activities = await orm.em.find(
-      Activity,
-      {},
-      { populate: ['subject'] },
-    );
-
-    expect(activities.length).toBe(2);
-
-    // The Dog-linked activity should be hydrated as a Dog, not a bare Animal
-    const dogActivity = activities.find(a => a.description === 'Walk the dog')!;
-    expect(dogActivity).toBeDefined();
-    expect(dogActivity.subject).toBeDefined();
-    expect(dogActivity.subject).toBeInstanceOf(Dog);
-    expect((dogActivity.subject as Dog).breed).toBe('Labrador');
-    expect((dogActivity.subject as Dog).name).toBe('Buddy');
-
-    // The Person-linked activity should still work
-    const personActivity = activities.find(a => a.description === 'Person walked')!;
-    expect(personActivity).toBeDefined();
-    expect(personActivity.subject).toBeDefined();
-    expect(personActivity.subject).toBeInstanceOf(Person);
-    expect((personActivity.subject as Person).personName).toBe('Bob');
-  });
-
-  test('SELECT: polymorphic populate with Cat (second TPT child)', async () => {
-    const conn = orm.em.getConnection();
-    await conn.execute(`insert into \`animal\` (\`name\`) values ('Whiskers')`);
-    const [{ id: animalId }] = await conn.execute(`select last_insert_rowid() as id`);
-    await conn.execute(`insert into \`cat\` (\`id\`, \`indoor\`) values (${animalId}, 1)`);
-    await conn.execute(
-      `insert into \`activity\` (\`description\`, \`subject_type\`, \`subject_id\`) values ('Cat adopted', 'animal', ${animalId})`,
-    );
-
-    const activities = await orm.em.find(
-      Activity,
-      {},
-      { populate: ['subject'] },
-    );
-
-    const catActivity = activities.find(a => a.description === 'Cat adopted')!;
-    expect(catActivity).toBeDefined();
-    expect(catActivity.subject).toBeDefined();
-    expect(catActivity.subject).toBeInstanceOf(Cat);
-    expect((catActivity.subject as Cat).indoor).toBe(true);
-    expect((catActivity.subject as Cat).name).toBe('Whiskers');
-  });
-
-  test('INSERT + SELECT round-trip: TPT child through polymorphic relation', async () => {
-    // Create a Dog and assign it to an Activity
-    const dog = orm.em.create(Dog, { name: 'Max', breed: 'Poodle' });
+    const gs = orm.em.create(GermanShepherd, {
+      name: 'Kaiser',
+      breed: 'German Shepherd',
+      lineage: 'Schutzhund Champion',
+    });
     await orm.em.flush();
 
-    // @ts-expect-error Same TS limitation as above
+    // @ts-expect-error GermanShepherd extends Dog extends Animal
     orm.em.create(Activity, {
-      description: 'Walk Max',
-      subject: ref(dog),
+      description: 'Trained a GSD',
+      subject: ref(gs),
     });
     await orm.em.flush();
     orm.em.clear();
 
-    // Read back with populate
-    const activities = await orm.em.find(
-      Activity,
-      { description: 'Walk Max' },
-      { populate: ['subject'] },
+    const insertActivityQuery = mock.mock.calls.find(
+      c => typeof c[0] === 'string' && c[0].includes('insert into `activity`') && c[0].includes('Trained a GSD'),
     );
+    expect(insertActivityQuery).toBeDefined();
+    expect(insertActivityQuery![0]).toContain("'animal'");
 
-    expect(activities.length).toBe(1);
-    expect(activities[0].subject).toBeDefined();
-    expect(activities[0].subject).toBeInstanceOf(Dog);
-    expect((activities[0].subject as Dog).breed).toBe('Poodle');
-    expect((activities[0].subject as Dog).name).toBe('Max');
+    const activity = await orm.em.findOneOrFail(Activity, { description: 'Trained a GSD' });
+    expect(activity.subject).toBeDefined();
   });
 
   test('INSERT: null subject is handled correctly', async () => {
@@ -258,44 +225,67 @@ describe('polymorphic relations with TPT targets', () => {
   });
 
   // -------------------------------------------------------------------------
-  // Nested TPT: GermanShepherd extends Dog extends Animal
-  // The polymorphic union lists Animal, so GermanShepherd (two levels deep)
-  // must resolve its discriminator and hydrate with all intermediate props.
+  // SELECT — JOINED strategy (default)
   // -------------------------------------------------------------------------
 
-  test('INSERT: nested TPT grandchild resolves discriminator correctly', async () => {
-    const mock = mockLogger(orm);
-
-    const gs = orm.em.create(GermanShepherd, {
-      name: 'Kaiser',
-      breed: 'German Shepherd',
-      lineage: 'Schutzhund Champion',
-    });
-    await orm.em.flush();
-
-    // @ts-expect-error GermanShepherd extends Dog extends Animal, Animal is in the union
-    orm.em.create(Activity, {
-      description: 'Trained a GSD',
-      subject: ref(gs),
-    });
-    await orm.em.flush();
-    orm.em.clear();
-
-    // Verify the SQL wrote 'animal' as the discriminator (the TPT root)
-    const insertActivityQuery = mock.mock.calls.find(
-      c => typeof c[0] === 'string' && c[0].includes('insert into `activity`') && c[0].includes('Trained a GSD'),
+  test('SELECT JOINED: polymorphic populate resolves TPT child entities', async () => {
+    const conn = orm.em.getConnection();
+    await conn.execute(`insert into \`animal\` (\`name\`) values ('Buddy')`);
+    const [{ id: animalId }] = await conn.execute(`select last_insert_rowid() as id`);
+    await conn.execute(`insert into \`dog\` (\`id\`, \`breed\`) values (${animalId}, 'Labrador')`);
+    await conn.execute(
+      `insert into \`activity\` (\`description\`, \`subject_type\`, \`subject_id\`) values ('Walk the dog', 'animal', ${animalId})`,
     );
-    expect(insertActivityQuery).toBeDefined();
-    expect(insertActivityQuery![0]).toContain("'animal'");
 
-    const activity = await orm.em.findOneOrFail(Activity, { description: 'Trained a GSD' });
-    expect(activity.subject).toBeDefined();
+    await conn.execute(`insert into \`person\` (\`person_name\`) values ('Bob')`);
+    const [{ id: personId }] = await conn.execute(`select last_insert_rowid() as id`);
+    await conn.execute(
+      `insert into \`activity\` (\`description\`, \`subject_type\`, \`subject_id\`) values ('Person walked', 'person', ${personId})`,
+    );
+
+    const activities = await orm.em.find(
+      Activity,
+      {},
+      { populate: ['subject'], strategy: LoadStrategy.JOINED },
+    );
+
+    expect(activities.length).toBe(2);
+
+    const dogActivity = activities.find(a => a.description === 'Walk the dog')!;
+    expect(dogActivity.subject).toBeDefined();
+    expect(dogActivity.subject).toBeInstanceOf(Dog);
+    expect((dogActivity.subject as Dog).breed).toBe('Labrador');
+    expect((dogActivity.subject as Dog).name).toBe('Buddy');
+
+    const personActivity = activities.find(a => a.description === 'Person walked')!;
+    expect(personActivity.subject).toBeDefined();
+    expect(personActivity.subject).toBeInstanceOf(Person);
+    expect((personActivity.subject as Person).personName).toBe('Bob');
   });
 
-  test('SELECT: nested TPT grandchild is hydrated with all intermediate properties', async () => {
+  test('SELECT JOINED: Cat (second TPT child)', async () => {
     const conn = orm.em.getConnection();
+    await conn.execute(`insert into \`animal\` (\`name\`) values ('Whiskers')`);
+    const [{ id: animalId }] = await conn.execute(`select last_insert_rowid() as id`);
+    await conn.execute(`insert into \`cat\` (\`id\`, \`indoor\`) values (${animalId}, 1)`);
+    await conn.execute(
+      `insert into \`activity\` (\`description\`, \`subject_type\`, \`subject_id\`) values ('Cat adopted', 'animal', ${animalId})`,
+    );
 
-    // Insert Animal -> Dog -> GermanShepherd via raw SQL
+    const activities = await orm.em.find(
+      Activity,
+      {},
+      { populate: ['subject'], strategy: LoadStrategy.JOINED },
+    );
+
+    const catActivity = activities.find(a => a.description === 'Cat adopted')!;
+    expect(catActivity.subject).toBeInstanceOf(Cat);
+    expect((catActivity.subject as Cat).indoor).toBe(true);
+    expect((catActivity.subject as Cat).name).toBe('Whiskers');
+  });
+
+  test('SELECT JOINED: nested TPT grandchild hydrates all intermediate properties', async () => {
+    const conn = orm.em.getConnection();
     await conn.execute(`insert into \`animal\` (\`name\`) values ('Kaiser')`);
     const [{ id: animalId }] = await conn.execute(`select last_insert_rowid() as id`);
     await conn.execute(`insert into \`dog\` (\`id\`, \`breed\`) values (${animalId}, 'German Shepherd')`);
@@ -307,22 +297,109 @@ describe('polymorphic relations with TPT targets', () => {
     const activities = await orm.em.find(
       Activity,
       { description: 'GSD activity' },
-      { populate: ['subject'] },
+      { populate: ['subject'], strategy: LoadStrategy.JOINED },
     );
 
     expect(activities.length).toBe(1);
     const subject = activities[0].subject;
-    expect(subject).toBeDefined();
     expect(subject).toBeInstanceOf(GermanShepherd);
-    // Properties from Animal (root)
     expect((subject as GermanShepherd).name).toBe('Kaiser');
-    // Properties from Dog (intermediate)
     expect((subject as GermanShepherd).breed).toBe('German Shepherd');
-    // Properties from GermanShepherd (leaf)
     expect((subject as GermanShepherd).lineage).toBe('Schutzhund Champion');
   });
 
-  test('INSERT + SELECT round-trip: nested TPT grandchild through polymorphic relation', async () => {
+  // -------------------------------------------------------------------------
+  // SELECT — SELECT_IN strategy
+  // -------------------------------------------------------------------------
+
+  test('SELECT_IN: polymorphic populate resolves TPT child entities', async () => {
+    const conn = orm.em.getConnection();
+    await conn.execute(`insert into \`animal\` (\`name\`) values ('Buddy')`);
+    const [{ id: animalId }] = await conn.execute(`select last_insert_rowid() as id`);
+    await conn.execute(`insert into \`dog\` (\`id\`, \`breed\`) values (${animalId}, 'Labrador')`);
+    await conn.execute(
+      `insert into \`activity\` (\`description\`, \`subject_type\`, \`subject_id\`) values ('Walk the dog', 'animal', ${animalId})`,
+    );
+
+    await conn.execute(`insert into \`person\` (\`person_name\`) values ('Bob')`);
+    const [{ id: personId }] = await conn.execute(`select last_insert_rowid() as id`);
+    await conn.execute(
+      `insert into \`activity\` (\`description\`, \`subject_type\`, \`subject_id\`) values ('Person walked', 'person', ${personId})`,
+    );
+
+    const activities = await orm.em.find(
+      Activity,
+      {},
+      { populate: ['subject'], strategy: LoadStrategy.SELECT_IN },
+    );
+
+    expect(activities.length).toBe(2);
+
+    const dogActivity = activities.find(a => a.description === 'Walk the dog')!;
+    expect(dogActivity.subject).toBeDefined();
+    expect(dogActivity.subject).toBeInstanceOf(Dog);
+    expect((dogActivity.subject as Dog).breed).toBe('Labrador');
+    expect((dogActivity.subject as Dog).name).toBe('Buddy');
+
+    const personActivity = activities.find(a => a.description === 'Person walked')!;
+    expect(personActivity.subject).toBeDefined();
+    expect(personActivity.subject).toBeInstanceOf(Person);
+    expect((personActivity.subject as Person).personName).toBe('Bob');
+  });
+
+  test('SELECT_IN: nested TPT grandchild hydrates correctly', async () => {
+    const conn = orm.em.getConnection();
+    await conn.execute(`insert into \`animal\` (\`name\`) values ('Kaiser')`);
+    const [{ id: animalId }] = await conn.execute(`select last_insert_rowid() as id`);
+    await conn.execute(`insert into \`dog\` (\`id\`, \`breed\`) values (${animalId}, 'German Shepherd')`);
+    await conn.execute(`insert into \`german_shepherd\` (\`id\`, \`lineage\`) values (${animalId}, 'Schutzhund Champion')`);
+    await conn.execute(
+      `insert into \`activity\` (\`description\`, \`subject_type\`, \`subject_id\`) values ('GSD activity', 'animal', ${animalId})`,
+    );
+
+    const activities = await orm.em.find(
+      Activity,
+      { description: 'GSD activity' },
+      { populate: ['subject'], strategy: LoadStrategy.SELECT_IN },
+    );
+
+    expect(activities.length).toBe(1);
+    const subject = activities[0].subject;
+    expect(subject).toBeInstanceOf(GermanShepherd);
+    expect((subject as GermanShepherd).name).toBe('Kaiser');
+    expect((subject as GermanShepherd).breed).toBe('German Shepherd');
+    expect((subject as GermanShepherd).lineage).toBe('Schutzhund Champion');
+  });
+
+  // -------------------------------------------------------------------------
+  // INSERT + SELECT round-trip
+  // -------------------------------------------------------------------------
+
+  test('round-trip: TPT child through polymorphic relation', async () => {
+    const dog = orm.em.create(Dog, { name: 'Max', breed: 'Poodle' });
+    await orm.em.flush();
+
+    // @ts-expect-error Same TS limitation as above
+    orm.em.create(Activity, {
+      description: 'Walk Max',
+      subject: ref(dog),
+    });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const activities = await orm.em.find(
+      Activity,
+      { description: 'Walk Max' },
+      { populate: ['subject'] },
+    );
+
+    expect(activities.length).toBe(1);
+    expect(activities[0].subject).toBeInstanceOf(Dog);
+    expect((activities[0].subject as Dog).breed).toBe('Poodle');
+    expect((activities[0].subject as Dog).name).toBe('Max');
+  });
+
+  test('round-trip: nested TPT grandchild through polymorphic relation', async () => {
     const gs = orm.em.create(GermanShepherd, {
       name: 'Bruno',
       breed: 'German Shepherd',
@@ -346,10 +423,318 @@ describe('polymorphic relations with TPT targets', () => {
 
     expect(activities.length).toBe(1);
     const subject = activities[0].subject;
-    expect(subject).toBeDefined();
     expect(subject).toBeInstanceOf(GermanShepherd);
     expect((subject as GermanShepherd).name).toBe('Bruno');
     expect((subject as GermanShepherd).breed).toBe('German Shepherd');
     expect((subject as GermanShepherd).lineage).toBe('Working Line');
+  });
+
+  // -------------------------------------------------------------------------
+  // UPDATE — changing polymorphic ref between TPT children and across types
+  // -------------------------------------------------------------------------
+
+  test('UPDATE: change polymorphic ref from Dog to Cat (same TPT hierarchy)', async () => {
+    const dog = orm.em.create(Dog, { name: 'Rex', breed: 'German Shepherd' });
+    const cat = orm.em.create(Cat, { name: 'Whiskers', indoor: true });
+    await orm.em.flush();
+
+    // @ts-expect-error
+    const activity = orm.em.create(Activity, { description: 'Pet care', subject: ref(dog) });
+    await orm.em.flush();
+    orm.em.clear();
+
+    // Load and update
+    const loaded = await orm.em.findOneOrFail(Activity, { description: 'Pet care' });
+    const catRef = orm.em.getReference(Cat, cat.id);
+    // @ts-expect-error
+    loaded.subject = catRef;
+    await orm.em.flush();
+    orm.em.clear();
+
+    // Verify the update
+    const updated = await orm.em.findOneOrFail(
+      Activity,
+      { description: 'Pet care' },
+      { populate: ['subject'] },
+    );
+    expect(updated.subject).toBeDefined();
+    expect(updated.subject).toBeInstanceOf(Cat);
+    expect((updated.subject as Cat).name).toBe('Whiskers');
+    expect((updated.subject as Cat).indoor).toBe(true);
+  });
+
+  test('UPDATE: change polymorphic ref from Dog to Person (cross-type)', async () => {
+    const dog = orm.em.create(Dog, { name: 'Rex', breed: 'German Shepherd' });
+    const person = orm.em.create(Person, { personName: 'Alice' });
+    await orm.em.flush();
+
+    // @ts-expect-error
+    const activity = orm.em.create(Activity, { description: 'Reassign', subject: ref(dog) });
+    await orm.em.flush();
+    orm.em.clear();
+
+    // Load and change from Dog to Person
+    const loaded = await orm.em.findOneOrFail(Activity, { description: 'Reassign' });
+    const personRef = orm.em.getReference(Person, person.id);
+    loaded.subject = personRef;
+    await orm.em.flush();
+    orm.em.clear();
+
+    // Verify the update — discriminator should change from 'animal' to 'person'
+    const updated = await orm.em.findOneOrFail(
+      Activity,
+      { description: 'Reassign' },
+      { populate: ['subject'] },
+    );
+    expect(updated.subject).toBeDefined();
+    expect(updated.subject).toBeInstanceOf(Person);
+    expect((updated.subject as Person).personName).toBe('Alice');
+  });
+
+  test('UPDATE: change polymorphic ref from Person to Dog (cross-type into TPT)', async () => {
+    const person = orm.em.create(Person, { personName: 'Bob' });
+    const dog = orm.em.create(Dog, { name: 'Fido', breed: 'Beagle' });
+    await orm.em.flush();
+
+    const activity = orm.em.create(Activity, { description: 'Switch to dog', subject: ref(person) });
+    await orm.em.flush();
+    orm.em.clear();
+
+    // Load and change from Person to Dog
+    const loaded = await orm.em.findOneOrFail(Activity, { description: 'Switch to dog' });
+    const dogRef = orm.em.getReference(Dog, dog.id);
+    // @ts-expect-error
+    loaded.subject = dogRef;
+    await orm.em.flush();
+    orm.em.clear();
+
+    const updated = await orm.em.findOneOrFail(
+      Activity,
+      { description: 'Switch to dog' },
+      { populate: ['subject'] },
+    );
+    expect(updated.subject).toBeDefined();
+    expect(updated.subject).toBeInstanceOf(Dog);
+    expect((updated.subject as Dog).name).toBe('Fido');
+    expect((updated.subject as Dog).breed).toBe('Beagle');
+  });
+
+  // -------------------------------------------------------------------------
+  // Inverse side — OneToMany loading
+  // -------------------------------------------------------------------------
+
+  test('inverse side: load activities from a Dog entity', async () => {
+    const dog = orm.em.create(Dog, { name: 'Rex', breed: 'German Shepherd' });
+    await orm.em.flush();
+
+    // @ts-expect-error
+    orm.em.create(Activity, { description: 'Walk', subject: ref(dog) });
+    // @ts-expect-error
+    orm.em.create(Activity, { description: 'Feed', subject: ref(dog) });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const loadedDog = await orm.em.findOneOrFail(Dog, { name: 'Rex' }, { populate: ['activities'] });
+    expect(loadedDog.activities).toHaveLength(2);
+    expect(loadedDog.activities.getItems().map(a => a.description).sort()).toEqual(['Feed', 'Walk']);
+  });
+
+  test('inverse side: load activities from a Person entity', async () => {
+    const person = orm.em.create(Person, { personName: 'Alice' });
+    await orm.em.flush();
+
+    orm.em.create(Activity, { description: 'Volunteer', subject: ref(person) });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const loadedPerson = await orm.em.findOneOrFail(Person, { personName: 'Alice' }, { populate: ['activities'] });
+    expect(loadedPerson.activities).toHaveLength(1);
+    expect(loadedPerson.activities[0].description).toBe('Volunteer');
+  });
+
+  // -------------------------------------------------------------------------
+  // Lazy loading via em.populate()
+  // -------------------------------------------------------------------------
+
+  test('em.populate: lazy-load polymorphic ref to TPT entity', async () => {
+    const dog = orm.em.create(Dog, { name: 'Rex', breed: 'Husky' });
+    await orm.em.flush();
+
+    // @ts-expect-error
+    orm.em.create(Activity, { description: 'Lazy walk', subject: ref(dog) });
+    await orm.em.flush();
+    orm.em.clear();
+
+    // Load without populate first
+    const activity = await orm.em.findOneOrFail(Activity, { description: 'Lazy walk' });
+    // Subject should be a reference (not initialized)
+    expect(activity.subject).toBeDefined();
+    expect(wrap(activity.subject!).isInitialized()).toBe(false);
+
+    // Now populate lazily
+    await orm.em.populate(activity, ['subject']);
+    expect(wrap(activity.subject!).isInitialized()).toBe(true);
+    expect(activity.subject).toBeInstanceOf(Dog);
+    expect((activity.subject as Dog).breed).toBe('Husky');
+    expect((activity.subject as Dog).name).toBe('Rex');
+  });
+
+  test('em.populate: lazy-load polymorphic ref to nested TPT grandchild', async () => {
+    const gs = orm.em.create(GermanShepherd, {
+      name: 'Kaiser',
+      breed: 'German Shepherd',
+      lineage: 'Working Line',
+    });
+    await orm.em.flush();
+
+    // @ts-expect-error
+    orm.em.create(Activity, { description: 'Lazy GSD', subject: ref(gs) });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const activity = await orm.em.findOneOrFail(Activity, { description: 'Lazy GSD' });
+    expect(wrap(activity.subject!).isInitialized()).toBe(false);
+
+    await orm.em.populate(activity, ['subject']);
+    expect(wrap(activity.subject!).isInitialized()).toBe(true);
+    expect(activity.subject).toBeInstanceOf(GermanShepherd);
+    expect((activity.subject as GermanShepherd).name).toBe('Kaiser');
+    expect((activity.subject as GermanShepherd).breed).toBe('German Shepherd');
+    expect((activity.subject as GermanShepherd).lineage).toBe('Working Line');
+  });
+
+  // -------------------------------------------------------------------------
+  // Serialization — wrap().toJSON()
+  // -------------------------------------------------------------------------
+
+  test('serialization: toJSON with populated TPT child subject', async () => {
+    const dog = orm.em.create(Dog, { name: 'Rex', breed: 'Poodle' });
+    await orm.em.flush();
+
+    // @ts-expect-error
+    orm.em.create(Activity, { description: 'Serialize test', subject: ref(dog) });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const activity = await orm.em.findOneOrFail(
+      Activity,
+      { description: 'Serialize test' },
+      { populate: ['subject'] },
+    );
+
+    const json = wrap(activity).toJSON();
+    expect(json.description).toBe('Serialize test');
+    expect(json.subject).toBeDefined();
+    expect(json.subject).toHaveProperty('name', 'Rex');
+    expect(json.subject).toHaveProperty('breed', 'Poodle');
+    expect(json.subject).toHaveProperty('id');
+  });
+
+  test('serialization: toJSON with populated nested TPT grandchild', async () => {
+    const gs = orm.em.create(GermanShepherd, {
+      name: 'Kaiser',
+      breed: 'German Shepherd',
+      lineage: 'Champion',
+    });
+    await orm.em.flush();
+
+    // @ts-expect-error
+    orm.em.create(Activity, { description: 'Serialize GSD', subject: ref(gs) });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const activity = await orm.em.findOneOrFail(
+      Activity,
+      { description: 'Serialize GSD' },
+      { populate: ['subject'] },
+    );
+
+    const json = wrap(activity).toJSON();
+    expect(json.subject).toHaveProperty('name', 'Kaiser');
+    expect(json.subject).toHaveProperty('breed', 'German Shepherd');
+    expect(json.subject).toHaveProperty('lineage', 'Champion');
+  });
+
+  test('serialization: toJSON with non-populated ref is just the PK', async () => {
+    const dog = orm.em.create(Dog, { name: 'Rex', breed: 'Poodle' });
+    await orm.em.flush();
+
+    // @ts-expect-error
+    orm.em.create(Activity, { description: 'No populate', subject: ref(dog) });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const activity = await orm.em.findOneOrFail(Activity, { description: 'No populate' });
+    const json = wrap(activity).toJSON();
+    // When not populated, subject should serialize as the PK value
+    expect(json.subject).toBe(dog.id);
+  });
+
+  // -------------------------------------------------------------------------
+  // Mixed: multiple TPT children + non-TPT entities in one query
+  // -------------------------------------------------------------------------
+
+  test('mixed query: Dog, Cat, GermanShepherd, and Person all in one populate', async () => {
+    const conn = orm.em.getConnection();
+
+    // Dog
+    await conn.execute(`insert into \`animal\` (\`name\`) values ('Buddy')`);
+    let [{ id }] = await conn.execute(`select last_insert_rowid() as id`);
+    await conn.execute(`insert into \`dog\` (\`id\`, \`breed\`) values (${id}, 'Labrador')`);
+    await conn.execute(
+      `insert into \`activity\` (\`description\`, \`subject_type\`, \`subject_id\`) values ('dog activity', 'animal', ${id})`,
+    );
+
+    // Cat
+    await conn.execute(`insert into \`animal\` (\`name\`) values ('Whiskers')`);
+    [{ id }] = await conn.execute(`select last_insert_rowid() as id`);
+    await conn.execute(`insert into \`cat\` (\`id\`, \`indoor\`) values (${id}, 1)`);
+    await conn.execute(
+      `insert into \`activity\` (\`description\`, \`subject_type\`, \`subject_id\`) values ('cat activity', 'animal', ${id})`,
+    );
+
+    // GermanShepherd
+    await conn.execute(`insert into \`animal\` (\`name\`) values ('Kaiser')`);
+    [{ id }] = await conn.execute(`select last_insert_rowid() as id`);
+    await conn.execute(`insert into \`dog\` (\`id\`, \`breed\`) values (${id}, 'German Shepherd')`);
+    await conn.execute(`insert into \`german_shepherd\` (\`id\`, \`lineage\`) values (${id}, 'Champion')`);
+    await conn.execute(
+      `insert into \`activity\` (\`description\`, \`subject_type\`, \`subject_id\`) values ('gsd activity', 'animal', ${id})`,
+    );
+
+    // Person
+    await conn.execute(`insert into \`person\` (\`person_name\`) values ('Alice')`);
+    [{ id }] = await conn.execute(`select last_insert_rowid() as id`);
+    await conn.execute(
+      `insert into \`activity\` (\`description\`, \`subject_type\`, \`subject_id\`) values ('person activity', 'person', ${id})`,
+    );
+
+    // Null subject
+    await conn.execute(
+      `insert into \`activity\` (\`description\`, \`subject_type\`, \`subject_id\`) values ('null activity', null, null)`,
+    );
+
+    const activities = await orm.em.find(Activity, {}, { populate: ['subject'], orderBy: { description: 'asc' } });
+
+    expect(activities).toHaveLength(5);
+
+    // cat activity
+    expect(activities[0].subject).toBeInstanceOf(Cat);
+    expect((activities[0].subject as Cat).indoor).toBe(true);
+
+    // dog activity
+    expect(activities[1].subject).toBeInstanceOf(Dog);
+    expect((activities[1].subject as Dog).breed).toBe('Labrador');
+
+    // gsd activity
+    expect(activities[2].subject).toBeInstanceOf(GermanShepherd);
+    expect((activities[2].subject as GermanShepherd).lineage).toBe('Champion');
+
+    // null activity
+    expect(activities[3].subject).toBeNull();
+
+    // person activity
+    expect(activities[4].subject).toBeInstanceOf(Person);
+    expect((activities[4].subject as Person).personName).toBe('Alice');
   });
 });

--- a/tests/features/polymorphic-relations/polymorphic-tpt.sqlite.test.ts
+++ b/tests/features/polymorphic-relations/polymorphic-tpt.sqlite.test.ts
@@ -1,0 +1,355 @@
+import { MikroORM, ref } from '@mikro-orm/sqlite';
+import {
+  Entity,
+  ManyToOne,
+  PrimaryKey,
+  Property,
+  ReflectMetadataProvider,
+} from '@mikro-orm/decorators/legacy';
+import { mockLogger } from '../../bootstrap.js';
+
+// ---------------------------------------------------------------------------
+// TPT hierarchy: Animal (abstract) -> Dog, Cat (concrete)
+// ---------------------------------------------------------------------------
+
+@Entity({ inheritance: 'tpt' })
+abstract class Animal {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+}
+
+@Entity()
+class Dog extends Animal {
+  @Property()
+  breed!: string;
+}
+
+@Entity()
+class Cat extends Animal {
+  @Property()
+  indoor!: boolean;
+}
+
+// Multi-level TPT: GermanShepherd extends Dog extends Animal
+@Entity()
+class GermanShepherd extends Dog {
+  @Property()
+  lineage!: string;
+}
+
+// ---------------------------------------------------------------------------
+// Simple entities used in the polymorphic union
+// ---------------------------------------------------------------------------
+
+@Entity()
+class Person {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  personName!: string;
+}
+
+@Entity()
+class Shelter {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  location!: string;
+}
+
+// ---------------------------------------------------------------------------
+// Entity with a polymorphic manyToOne that includes the abstract TPT root
+// ---------------------------------------------------------------------------
+
+@Entity()
+class Activity {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  description!: string;
+
+  // Polymorphic relation — subject can be an Animal, Person, or Shelter.
+  // Animal is a TPT entity with concrete subclasses Dog and Cat.
+  @ManyToOne(() => [Animal, Person, Shelter], { nullable: true })
+  subject?: Animal | Person | Shelter | null;
+}
+
+describe('polymorphic relations with TPT targets', () => {
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      entities: [Animal, Dog, Cat, GermanShepherd, Person, Shelter, Activity],
+      dbName: ':memory:',
+      metadataProvider: ReflectMetadataProvider,
+    });
+    await orm.schema.create();
+  });
+
+  afterAll(async () => {
+    await orm.close(true);
+  });
+
+  beforeEach(async () => {
+    await orm.schema.clear();
+  });
+
+  // -------------------------------------------------------------------------
+  // Bug 1: INSERT — When assigning a TPT child (Dog) as a polymorphic ref
+  // that lists the abstract parent (Animal), MikroORM should resolve the
+  // discriminator to the TPT root's table name ('animal'), not null.
+  // -------------------------------------------------------------------------
+
+  test('INSERT: discriminator is set correctly for TPT child entities', async () => {
+    const mock = mockLogger(orm);
+
+    const dog = orm.em.create(Dog, { name: 'Rex', breed: 'German Shepherd' });
+    await orm.em.flush();
+
+    // @ts-expect-error Dog extends Animal which is in the union, but
+    // MikroORM's types don't account for TPT subclasses in polymorphic unions.
+    orm.em.create(Activity, {
+      description: 'Adopted a dog',
+      subject: ref(dog),
+    });
+    await orm.em.flush();
+    orm.em.clear();
+
+    // Verify the SQL wrote 'animal' as the discriminator, not null
+    const insertActivityQuery = mock.mock.calls.find(
+      c => typeof c[0] === 'string' && c[0].includes('insert into `activity`'),
+    );
+    expect(insertActivityQuery).toBeDefined();
+    expect(insertActivityQuery![0]).toContain("'animal'");
+
+    // Verify we can read back the activity with its subject
+    const activity = await orm.em.findOneOrFail(Activity, { description: 'Adopted a dog' });
+    expect(activity.subject).toBeDefined();
+  });
+
+  test('INSERT: discriminator works for non-TPT entities in the same union', async () => {
+    const person = orm.em.create(Person, { personName: 'Alice' });
+    await orm.em.flush();
+
+    orm.em.create(Activity, {
+      description: 'Person volunteered',
+      subject: ref(person),
+    });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const activity = await orm.em.findOneOrFail(Activity, { description: 'Person volunteered' });
+    expect(activity.subject).toBeDefined();
+  });
+
+  // -------------------------------------------------------------------------
+  // Bug 2: SELECT — When populating a polymorphic relation that targets a
+  // TPT base class, MikroORM should JOIN the child tables too, so the entity
+  // is hydrated as the concrete subclass with all its properties.
+  // -------------------------------------------------------------------------
+
+  test('SELECT: polymorphic populate resolves TPT child entities (joined strategy)', async () => {
+    // Seed data via raw SQL to bypass the INSERT bug for this test
+    const conn = orm.em.getConnection();
+    await conn.execute(`insert into \`animal\` (\`name\`) values ('Buddy')`);
+    const [{ id: animalId }] = await conn.execute(`select last_insert_rowid() as id`);
+    await conn.execute(`insert into \`dog\` (\`id\`, \`breed\`) values (${animalId}, 'Labrador')`);
+    await conn.execute(
+      `insert into \`activity\` (\`description\`, \`subject_type\`, \`subject_id\`) values ('Walk the dog', 'animal', ${animalId})`,
+    );
+
+    // Also insert a Person-linked activity to verify non-TPT types still work
+    await conn.execute(`insert into \`person\` (\`person_name\`) values ('Bob')`);
+    const [{ id: personId }] = await conn.execute(`select last_insert_rowid() as id`);
+    await conn.execute(
+      `insert into \`activity\` (\`description\`, \`subject_type\`, \`subject_id\`) values ('Person walked', 'person', ${personId})`,
+    );
+
+    const activities = await orm.em.find(
+      Activity,
+      {},
+      { populate: ['subject'] },
+    );
+
+    expect(activities.length).toBe(2);
+
+    // The Dog-linked activity should be hydrated as a Dog, not a bare Animal
+    const dogActivity = activities.find(a => a.description === 'Walk the dog')!;
+    expect(dogActivity).toBeDefined();
+    expect(dogActivity.subject).toBeDefined();
+    expect(dogActivity.subject).toBeInstanceOf(Dog);
+    expect((dogActivity.subject as Dog).breed).toBe('Labrador');
+    expect((dogActivity.subject as Dog).name).toBe('Buddy');
+
+    // The Person-linked activity should still work
+    const personActivity = activities.find(a => a.description === 'Person walked')!;
+    expect(personActivity).toBeDefined();
+    expect(personActivity.subject).toBeDefined();
+    expect(personActivity.subject).toBeInstanceOf(Person);
+    expect((personActivity.subject as Person).personName).toBe('Bob');
+  });
+
+  test('SELECT: polymorphic populate with Cat (second TPT child)', async () => {
+    const conn = orm.em.getConnection();
+    await conn.execute(`insert into \`animal\` (\`name\`) values ('Whiskers')`);
+    const [{ id: animalId }] = await conn.execute(`select last_insert_rowid() as id`);
+    await conn.execute(`insert into \`cat\` (\`id\`, \`indoor\`) values (${animalId}, 1)`);
+    await conn.execute(
+      `insert into \`activity\` (\`description\`, \`subject_type\`, \`subject_id\`) values ('Cat adopted', 'animal', ${animalId})`,
+    );
+
+    const activities = await orm.em.find(
+      Activity,
+      {},
+      { populate: ['subject'] },
+    );
+
+    const catActivity = activities.find(a => a.description === 'Cat adopted')!;
+    expect(catActivity).toBeDefined();
+    expect(catActivity.subject).toBeDefined();
+    expect(catActivity.subject).toBeInstanceOf(Cat);
+    expect((catActivity.subject as Cat).indoor).toBe(true);
+    expect((catActivity.subject as Cat).name).toBe('Whiskers');
+  });
+
+  test('INSERT + SELECT round-trip: TPT child through polymorphic relation', async () => {
+    // Create a Dog and assign it to an Activity
+    const dog = orm.em.create(Dog, { name: 'Max', breed: 'Poodle' });
+    await orm.em.flush();
+
+    // @ts-expect-error Same TS limitation as above
+    orm.em.create(Activity, {
+      description: 'Walk Max',
+      subject: ref(dog),
+    });
+    await orm.em.flush();
+    orm.em.clear();
+
+    // Read back with populate
+    const activities = await orm.em.find(
+      Activity,
+      { description: 'Walk Max' },
+      { populate: ['subject'] },
+    );
+
+    expect(activities.length).toBe(1);
+    expect(activities[0].subject).toBeDefined();
+    expect(activities[0].subject).toBeInstanceOf(Dog);
+    expect((activities[0].subject as Dog).breed).toBe('Poodle');
+    expect((activities[0].subject as Dog).name).toBe('Max');
+  });
+
+  test('INSERT: null subject is handled correctly', async () => {
+    orm.em.create(Activity, {
+      description: 'No subject',
+      subject: null,
+    });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const activity = await orm.em.findOneOrFail(Activity, { description: 'No subject' });
+    expect(activity.subject).toBeNull();
+  });
+
+  // -------------------------------------------------------------------------
+  // Nested TPT: GermanShepherd extends Dog extends Animal
+  // The polymorphic union lists Animal, so GermanShepherd (two levels deep)
+  // must resolve its discriminator and hydrate with all intermediate props.
+  // -------------------------------------------------------------------------
+
+  test('INSERT: nested TPT grandchild resolves discriminator correctly', async () => {
+    const mock = mockLogger(orm);
+
+    const gs = orm.em.create(GermanShepherd, {
+      name: 'Kaiser',
+      breed: 'German Shepherd',
+      lineage: 'Schutzhund Champion',
+    });
+    await orm.em.flush();
+
+    // @ts-expect-error GermanShepherd extends Dog extends Animal, Animal is in the union
+    orm.em.create(Activity, {
+      description: 'Trained a GSD',
+      subject: ref(gs),
+    });
+    await orm.em.flush();
+    orm.em.clear();
+
+    // Verify the SQL wrote 'animal' as the discriminator (the TPT root)
+    const insertActivityQuery = mock.mock.calls.find(
+      c => typeof c[0] === 'string' && c[0].includes('insert into `activity`') && c[0].includes('Trained a GSD'),
+    );
+    expect(insertActivityQuery).toBeDefined();
+    expect(insertActivityQuery![0]).toContain("'animal'");
+
+    const activity = await orm.em.findOneOrFail(Activity, { description: 'Trained a GSD' });
+    expect(activity.subject).toBeDefined();
+  });
+
+  test('SELECT: nested TPT grandchild is hydrated with all intermediate properties', async () => {
+    const conn = orm.em.getConnection();
+
+    // Insert Animal -> Dog -> GermanShepherd via raw SQL
+    await conn.execute(`insert into \`animal\` (\`name\`) values ('Kaiser')`);
+    const [{ id: animalId }] = await conn.execute(`select last_insert_rowid() as id`);
+    await conn.execute(`insert into \`dog\` (\`id\`, \`breed\`) values (${animalId}, 'German Shepherd')`);
+    await conn.execute(`insert into \`german_shepherd\` (\`id\`, \`lineage\`) values (${animalId}, 'Schutzhund Champion')`);
+    await conn.execute(
+      `insert into \`activity\` (\`description\`, \`subject_type\`, \`subject_id\`) values ('GSD activity', 'animal', ${animalId})`,
+    );
+
+    const activities = await orm.em.find(
+      Activity,
+      { description: 'GSD activity' },
+      { populate: ['subject'] },
+    );
+
+    expect(activities.length).toBe(1);
+    const subject = activities[0].subject;
+    expect(subject).toBeDefined();
+    expect(subject).toBeInstanceOf(GermanShepherd);
+    // Properties from Animal (root)
+    expect((subject as GermanShepherd).name).toBe('Kaiser');
+    // Properties from Dog (intermediate)
+    expect((subject as GermanShepherd).breed).toBe('German Shepherd');
+    // Properties from GermanShepherd (leaf)
+    expect((subject as GermanShepherd).lineage).toBe('Schutzhund Champion');
+  });
+
+  test('INSERT + SELECT round-trip: nested TPT grandchild through polymorphic relation', async () => {
+    const gs = orm.em.create(GermanShepherd, {
+      name: 'Bruno',
+      breed: 'German Shepherd',
+      lineage: 'Working Line',
+    });
+    await orm.em.flush();
+
+    // @ts-expect-error Same TS limitation
+    orm.em.create(Activity, {
+      description: 'Walk Bruno',
+      subject: ref(gs),
+    });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const activities = await orm.em.find(
+      Activity,
+      { description: 'Walk Bruno' },
+      { populate: ['subject'] },
+    );
+
+    expect(activities.length).toBe(1);
+    const subject = activities[0].subject;
+    expect(subject).toBeDefined();
+    expect(subject).toBeInstanceOf(GermanShepherd);
+    expect((subject as GermanShepherd).name).toBe('Bruno');
+    expect((subject as GermanShepherd).breed).toBe('German Shepherd');
+    expect((subject as GermanShepherd).lineage).toBe('Working Line');
+  });
+});

--- a/tests/features/polymorphic-relations/polymorphic-tpt.sqlite.test.ts
+++ b/tests/features/polymorphic-relations/polymorphic-tpt.sqlite.test.ts
@@ -1,7 +1,6 @@
 import { Collection, LoadStrategy, MikroORM, ref, wrap } from '@mikro-orm/sqlite';
 import {
   Entity,
-  ManyToMany,
   ManyToOne,
   OneToMany,
   PrimaryKey,
@@ -10,11 +9,7 @@ import {
 } from '@mikro-orm/decorators/legacy';
 import { mockLogger } from '../../bootstrap.js';
 
-// ---------------------------------------------------------------------------
-// TPT hierarchy: Animal (abstract) -> Dog, Cat (concrete)
-//                                     Dog -> GermanShepherd (nested)
-// ---------------------------------------------------------------------------
-
+// TPT hierarchy: Animal (abstract) -> Dog, Cat; Dog -> GermanShepherd (nested)
 @Entity({ inheritance: 'tpt' })
 abstract class Animal {
   @PrimaryKey()
@@ -39,16 +34,11 @@ class Cat extends Animal {
   indoor!: boolean;
 }
 
-// Multi-level TPT: GermanShepherd extends Dog extends Animal
 @Entity()
 class GermanShepherd extends Dog {
   @Property()
   lineage!: string;
 }
-
-// ---------------------------------------------------------------------------
-// Simple entities used in the polymorphic union
-// ---------------------------------------------------------------------------
 
 @Entity()
 class Person {
@@ -71,10 +61,6 @@ class Shelter {
   location!: string;
 }
 
-// ---------------------------------------------------------------------------
-// Entity with a polymorphic manyToOne that includes the abstract TPT root
-// ---------------------------------------------------------------------------
-
 @Entity()
 class Activity {
   @PrimaryKey()
@@ -83,40 +69,9 @@ class Activity {
   @Property()
   description!: string;
 
-  // Polymorphic relation — subject can be an Animal, Person, or Shelter.
-  // Animal is a TPT entity with concrete subclasses Dog and Cat.
   @ManyToOne(() => [Animal, Person, Shelter], { nullable: true })
   subject?: Animal | Person | Shelter | null;
 }
-
-// ---------------------------------------------------------------------------
-// M:N polymorphic pivot table entities — Tag can be applied to
-// Animal (TPT hierarchy) or Person (plain entity) via a shared pivot table.
-// ---------------------------------------------------------------------------
-
-@Entity()
-class Tag {
-  @PrimaryKey()
-  id!: number;
-
-  @Property()
-  label!: string;
-
-  @ManyToMany(() => Animal, animal => animal.tags)
-  animals = new Collection<Animal>(this);
-
-  @ManyToMany(() => Person, person => person.tags)
-  people = new Collection<Person>(this);
-}
-
-// Extend the entities with M:N owner sides (must be declared after Tag to
-// avoid circular reference issues with decorators).
-// We use a separate describe block below that re-initializes the ORM with
-// augmented entities.
-
-// ---------------------------------------------------------------------------
-// Tests — ManyToOne polymorphic with TPT targets
-// ---------------------------------------------------------------------------
 
 describe('polymorphic ManyToOne with TPT targets', () => {
   let orm: MikroORM;
@@ -148,10 +103,9 @@ describe('polymorphic ManyToOne with TPT targets', () => {
     const dog = orm.em.create(Dog, { name: 'Rex', breed: 'German Shepherd' });
     await orm.em.flush();
 
-    // @ts-expect-error Dog extends Animal which is in the union, but
-    // MikroORM's types don't account for TPT subclasses in polymorphic unions.
     orm.em.create(Activity, {
       description: 'Adopted a dog',
+      // @ts-expect-error TS limitation: polymorphic union doesn't accept a single-target ref
       subject: ref(dog),
     });
     await orm.em.flush();
@@ -175,6 +129,7 @@ describe('polymorphic ManyToOne with TPT targets', () => {
 
     orm.em.create(Activity, {
       description: 'Person volunteered',
+      // @ts-expect-error
       subject: ref(person),
     });
     await orm.em.flush();
@@ -194,9 +149,9 @@ describe('polymorphic ManyToOne with TPT targets', () => {
     });
     await orm.em.flush();
 
-    // @ts-expect-error GermanShepherd extends Dog extends Animal
     orm.em.create(Activity, {
       description: 'Trained a GSD',
+      // @ts-expect-error
       subject: ref(gs),
     });
     await orm.em.flush();
@@ -243,11 +198,7 @@ describe('polymorphic ManyToOne with TPT targets', () => {
       `insert into \`activity\` (\`description\`, \`subject_type\`, \`subject_id\`) values ('Person walked', 'person', ${personId})`,
     );
 
-    const activities = await orm.em.find(
-      Activity,
-      {},
-      { populate: ['subject'], strategy: LoadStrategy.JOINED },
-    );
+    const activities = await orm.em.find(Activity, {}, { populate: ['subject'], strategy: LoadStrategy.JOINED });
 
     expect(activities.length).toBe(2);
 
@@ -272,11 +223,7 @@ describe('polymorphic ManyToOne with TPT targets', () => {
       `insert into \`activity\` (\`description\`, \`subject_type\`, \`subject_id\`) values ('Cat adopted', 'animal', ${animalId})`,
     );
 
-    const activities = await orm.em.find(
-      Activity,
-      {},
-      { populate: ['subject'], strategy: LoadStrategy.JOINED },
-    );
+    const activities = await orm.em.find(Activity, {}, { populate: ['subject'], strategy: LoadStrategy.JOINED });
 
     const catActivity = activities.find(a => a.description === 'Cat adopted')!;
     expect(catActivity.subject).toBeInstanceOf(Cat);
@@ -289,7 +236,9 @@ describe('polymorphic ManyToOne with TPT targets', () => {
     await conn.execute(`insert into \`animal\` (\`name\`) values ('Kaiser')`);
     const [{ id: animalId }] = await conn.execute(`select last_insert_rowid() as id`);
     await conn.execute(`insert into \`dog\` (\`id\`, \`breed\`) values (${animalId}, 'German Shepherd')`);
-    await conn.execute(`insert into \`german_shepherd\` (\`id\`, \`lineage\`) values (${animalId}, 'Schutzhund Champion')`);
+    await conn.execute(
+      `insert into \`german_shepherd\` (\`id\`, \`lineage\`) values (${animalId}, 'Schutzhund Champion')`,
+    );
     await conn.execute(
       `insert into \`activity\` (\`description\`, \`subject_type\`, \`subject_id\`) values ('GSD activity', 'animal', ${animalId})`,
     );
@@ -327,11 +276,7 @@ describe('polymorphic ManyToOne with TPT targets', () => {
       `insert into \`activity\` (\`description\`, \`subject_type\`, \`subject_id\`) values ('Person walked', 'person', ${personId})`,
     );
 
-    const activities = await orm.em.find(
-      Activity,
-      {},
-      { populate: ['subject'], strategy: LoadStrategy.SELECT_IN },
-    );
+    const activities = await orm.em.find(Activity, {}, { populate: ['subject'], strategy: LoadStrategy.SELECT_IN });
 
     expect(activities.length).toBe(2);
 
@@ -352,7 +297,9 @@ describe('polymorphic ManyToOne with TPT targets', () => {
     await conn.execute(`insert into \`animal\` (\`name\`) values ('Kaiser')`);
     const [{ id: animalId }] = await conn.execute(`select last_insert_rowid() as id`);
     await conn.execute(`insert into \`dog\` (\`id\`, \`breed\`) values (${animalId}, 'German Shepherd')`);
-    await conn.execute(`insert into \`german_shepherd\` (\`id\`, \`lineage\`) values (${animalId}, 'Schutzhund Champion')`);
+    await conn.execute(
+      `insert into \`german_shepherd\` (\`id\`, \`lineage\`) values (${animalId}, 'Schutzhund Champion')`,
+    );
     await conn.execute(
       `insert into \`activity\` (\`description\`, \`subject_type\`, \`subject_id\`) values ('GSD activity', 'animal', ${animalId})`,
     );
@@ -379,19 +326,15 @@ describe('polymorphic ManyToOne with TPT targets', () => {
     const dog = orm.em.create(Dog, { name: 'Max', breed: 'Poodle' });
     await orm.em.flush();
 
-    // @ts-expect-error Same TS limitation as above
     orm.em.create(Activity, {
       description: 'Walk Max',
+      // @ts-expect-error TS limitation: polymorphic union doesn't accept a single-target ref
       subject: ref(dog),
     });
     await orm.em.flush();
     orm.em.clear();
 
-    const activities = await orm.em.find(
-      Activity,
-      { description: 'Walk Max' },
-      { populate: ['subject'] },
-    );
+    const activities = await orm.em.find(Activity, { description: 'Walk Max' }, { populate: ['subject'] });
 
     expect(activities.length).toBe(1);
     expect(activities[0].subject).toBeInstanceOf(Dog);
@@ -407,19 +350,15 @@ describe('polymorphic ManyToOne with TPT targets', () => {
     });
     await orm.em.flush();
 
-    // @ts-expect-error Same TS limitation
     orm.em.create(Activity, {
       description: 'Walk Bruno',
+      // @ts-expect-error
       subject: ref(gs),
     });
     await orm.em.flush();
     orm.em.clear();
 
-    const activities = await orm.em.find(
-      Activity,
-      { description: 'Walk Bruno' },
-      { populate: ['subject'] },
-    );
+    const activities = await orm.em.find(Activity, { description: 'Walk Bruno' }, { populate: ['subject'] });
 
     expect(activities.length).toBe(1);
     const subject = activities[0].subject;
@@ -446,17 +385,12 @@ describe('polymorphic ManyToOne with TPT targets', () => {
     // Load and update
     const loaded = await orm.em.findOneOrFail(Activity, { description: 'Pet care' });
     const catRef = orm.em.getReference(Cat, cat.id);
-    // @ts-expect-error
     loaded.subject = catRef;
     await orm.em.flush();
     orm.em.clear();
 
     // Verify the update
-    const updated = await orm.em.findOneOrFail(
-      Activity,
-      { description: 'Pet care' },
-      { populate: ['subject'] },
-    );
+    const updated = await orm.em.findOneOrFail(Activity, { description: 'Pet care' }, { populate: ['subject'] });
     expect(updated.subject).toBeDefined();
     expect(updated.subject).toBeInstanceOf(Cat);
     expect((updated.subject as Cat).name).toBe('Whiskers');
@@ -481,11 +415,7 @@ describe('polymorphic ManyToOne with TPT targets', () => {
     orm.em.clear();
 
     // Verify the update — discriminator should change from 'animal' to 'person'
-    const updated = await orm.em.findOneOrFail(
-      Activity,
-      { description: 'Reassign' },
-      { populate: ['subject'] },
-    );
+    const updated = await orm.em.findOneOrFail(Activity, { description: 'Reassign' }, { populate: ['subject'] });
     expect(updated.subject).toBeDefined();
     expect(updated.subject).toBeInstanceOf(Person);
     expect((updated.subject as Person).personName).toBe('Alice');
@@ -496,6 +426,7 @@ describe('polymorphic ManyToOne with TPT targets', () => {
     const dog = orm.em.create(Dog, { name: 'Fido', breed: 'Beagle' });
     await orm.em.flush();
 
+    // @ts-expect-error TS limitation: polymorphic union doesn't accept a single-target ref
     const activity = orm.em.create(Activity, { description: 'Switch to dog', subject: ref(person) });
     await orm.em.flush();
     orm.em.clear();
@@ -503,16 +434,11 @@ describe('polymorphic ManyToOne with TPT targets', () => {
     // Load and change from Person to Dog
     const loaded = await orm.em.findOneOrFail(Activity, { description: 'Switch to dog' });
     const dogRef = orm.em.getReference(Dog, dog.id);
-    // @ts-expect-error
     loaded.subject = dogRef;
     await orm.em.flush();
     orm.em.clear();
 
-    const updated = await orm.em.findOneOrFail(
-      Activity,
-      { description: 'Switch to dog' },
-      { populate: ['subject'] },
-    );
+    const updated = await orm.em.findOneOrFail(Activity, { description: 'Switch to dog' }, { populate: ['subject'] });
     expect(updated.subject).toBeDefined();
     expect(updated.subject).toBeInstanceOf(Dog);
     expect((updated.subject as Dog).name).toBe('Fido');
@@ -536,13 +462,19 @@ describe('polymorphic ManyToOne with TPT targets', () => {
 
     const loadedDog = await orm.em.findOneOrFail(Dog, { name: 'Rex' }, { populate: ['activities'] });
     expect(loadedDog.activities).toHaveLength(2);
-    expect(loadedDog.activities.getItems().map(a => a.description).sort()).toEqual(['Feed', 'Walk']);
+    expect(
+      loadedDog.activities
+        .getItems()
+        .map(a => a.description)
+        .sort(),
+    ).toEqual(['Feed', 'Walk']);
   });
 
   test('inverse side: load activities from a Person entity', async () => {
     const person = orm.em.create(Person, { personName: 'Alice' });
     await orm.em.flush();
 
+    // @ts-expect-error TS limitation: polymorphic union doesn't accept a single-target ref
     orm.em.create(Activity, { description: 'Volunteer', subject: ref(person) });
     await orm.em.flush();
     orm.em.clear();
@@ -616,11 +548,7 @@ describe('polymorphic ManyToOne with TPT targets', () => {
     await orm.em.flush();
     orm.em.clear();
 
-    const activity = await orm.em.findOneOrFail(
-      Activity,
-      { description: 'Serialize test' },
-      { populate: ['subject'] },
-    );
+    const activity = await orm.em.findOneOrFail(Activity, { description: 'Serialize test' }, { populate: ['subject'] });
 
     const json = wrap(activity).toJSON();
     expect(json.description).toBe('Serialize test');
@@ -643,11 +571,7 @@ describe('polymorphic ManyToOne with TPT targets', () => {
     await orm.em.flush();
     orm.em.clear();
 
-    const activity = await orm.em.findOneOrFail(
-      Activity,
-      { description: 'Serialize GSD' },
-      { populate: ['subject'] },
-    );
+    const activity = await orm.em.findOneOrFail(Activity, { description: 'Serialize GSD' }, { populate: ['subject'] });
 
     const json = wrap(activity).toJSON();
     expect(json.subject).toHaveProperty('name', 'Kaiser');
@@ -736,5 +660,39 @@ describe('polymorphic ManyToOne with TPT targets', () => {
     // person activity
     expect(activities[4].subject).toBeInstanceOf(Person);
     expect((activities[4].subject as Person).personName).toBe('Alice');
+  });
+
+  // Deep populate recursion — exercises the polymorphic target bucketing that
+  // previously compared className exactly, dropping TPT/STI subclasses. With
+  // subjects of different TPT children and a non-TPT target, the inner populate
+  // for `activities` must correctly bucket each subject under its polymorph target.
+  test('deep populate: polymorphic subject -> inverse activities across TPT/non-TPT targets', async () => {
+    const dog = orm.em.create(Dog, { name: 'Rex', breed: 'Labrador' });
+    const cat = orm.em.create(Cat, { name: 'Whiskers', indoor: true });
+    const person = orm.em.create(Person, { personName: 'Alice' });
+    await orm.em.flush();
+
+    // @ts-expect-error TS limitation: Dog/Cat extend Animal which is in the union
+    orm.em.create(Activity, { description: 'Walk Rex', subject: ref(dog) });
+    // @ts-expect-error
+    orm.em.create(Activity, { description: 'Pet Whiskers', subject: ref(cat) });
+    // @ts-expect-error
+    orm.em.create(Activity, { description: 'Call Alice', subject: ref(person) });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const activities = await orm.em.find(
+      Activity,
+      {},
+      { populate: ['subject.activities'], orderBy: { description: 'asc' } },
+    );
+
+    expect(activities).toHaveLength(3);
+    expect(activities[0].subject).toBeInstanceOf(Person);
+    expect(wrap((activities[0].subject as Person).activities).isInitialized()).toBe(true);
+    expect(activities[1].subject).toBeInstanceOf(Cat);
+    expect(wrap((activities[1].subject as Cat).activities).isInitialized()).toBe(true);
+    expect(activities[2].subject).toBeInstanceOf(Dog);
+    expect(wrap((activities[2].subject as Dog).activities).isInitialized()).toBe(true);
   });
 });


### PR DESCRIPTION
When a polymorphic ManyToOne relation (e.g. `@ManyToOne(() => [Animal, Person])`) includes a TPT base class as a target, three bugs prevented it from working:

1. INSERT: The discriminator value (subject_type) was written as NULL because the concrete TPT child class (e.g. Dog) wasn't found in the polymorphic discriminator map, which only contains the root class (Animal). Fixed by walking the prototype chain in `QueryHelper.findDiscriminatorValue()` and the JIT-compiled snapshot code in `EntityComparator`.
2. SELECT: Populating the polymorphic relation didn't JOIN the TPT child tables, so child-specific properties (e.g. breed) were missing and the entity was hydrated as the abstract base class instead of the concrete subclass. Fixed by calling `addTPTPolymorphicJoinsForRelation()` in the polymorphic branch of `getFieldsForJoinedLoad()`, and adding `mapTPTChildFields()` with concrete class resolution in `mapJoinedProps()`.
3. M:N pivot loading: `EntityLoader.findChildrenFromPivotTable` compared `className` exactly, so TPT children (e.g. Dog) didn't match their root target (Animal) and were silently dropped from collection results. Fixed by comparing `root.className` instead.

All fixes use fallback logic that only activates for TPT hierarchies, so existing behavior for plain entities and STI is unaffected. Includes 22 test cases covering INSERT, SELECT (JOINED + SELECT_IN), UPDATE, inverse side, lazy loading, serialization, nested TPT, and mixed-type queries.

Also fixes a pre-existing STI bug in M:N polymorphic pivot table loading. STI children were silently dropped from the population step due to the exact className match. Our root.className comparison fixes both TPT and STI cases.

Closes #7563