### PR TITLE
fix(migrations): skip database connection in `create()` and `getPending()` when snapshot exists

### DIFF
--- a/packages/core/src/utils/AbstractMigrator.ts
+++ b/packages/core/src/utils/AbstractMigrator.ts
@@ -133,16 +133,26 @@ export abstract class AbstractMigrator<D extends IDatabaseDriver> implements IMi
     }
 
     this.initialized = true;
+    await this.initPaths();
+  }
 
-    if (!this.options.migrationsList) {
-      const { fs } = await import('@mikro-orm/core/fs-utils');
-      this.detectSourceFolder(fs);
+  protected async initPaths(): Promise<void> {
+    if (this.absolutePath || this.options.migrationsList) {
+      return;
+    }
 
-      /* v8 ignore next */
-      const key =
-        this.config.get('preferTs', Utils.detectTypeScriptSupport()) && this.options.pathTs ? 'pathTs' : 'path';
-      this.absolutePath = fs.absolutePath(this.options[key]!, this.config.get('baseDir'));
+    const { fs } = await import('@mikro-orm/core/fs-utils');
+    this.detectSourceFolder(fs);
+
+    /* v8 ignore next */
+    const key = this.config.get('preferTs', Utils.detectTypeScriptSupport()) && this.options.pathTs ? 'pathTs' : 'path';
+    this.absolutePath = fs.absolutePath(this.options[key]!, this.config.get('baseDir'));
+
+    try {
       fs.ensureDir(this.absolutePath);
+    } catch {
+      // read-only filesystem — read-only operations (e.g. `getPending` with a
+      // snapshot) may still succeed; write operations will fail on their own
     }
   }
 
@@ -235,7 +245,7 @@ export abstract class AbstractMigrator<D extends IDatabaseDriver> implements IMi
     }
   }
 
-  private async discoverMigrations(): Promise<RunnableMigration[]> {
+  protected async discoverMigrations(): Promise<RunnableMigration[]> {
     if (this.options.migrationsList) {
       return this.options.migrationsList.map(migration => {
         if (typeof migration === 'function') {

--- a/packages/migrations/src/Migrator.ts
+++ b/packages/migrations/src/Migrator.ts
@@ -90,7 +90,8 @@ export class Migrator extends AbstractMigrator<AbstractSqlDriver> {
    * @inheritDoc
    */
   async create(path?: string, blank = false, initial = false, name?: string): Promise<MigrationResult> {
-    await this.init();
+    const offline = !initial && (await this.hasSnapshot());
+    await (offline ? this.initPaths() : this.init());
 
     if (initial) {
       return this.createInitial(path, name, blank);
@@ -110,6 +111,36 @@ export class Migrator extends AbstractMigrator<AbstractSqlDriver> {
       code: migration[0],
       diff,
     };
+  }
+
+  override async getPending(): Promise<MigrationInfo[]> {
+    if (!(await this.hasSnapshot())) {
+      return super.getPending();
+    }
+
+    await this.initPaths();
+    const all = await this.discoverMigrations();
+
+    // probe the DB via `ensureTable` — if it fails, the DB is unreachable and
+    // we treat every discovered migration as pending; otherwise let errors
+    // from `storage.executed()` propagate so real bugs are not swallowed
+    try {
+      await (this.storage as MigrationStorage).ensureTable();
+    } catch {
+      return all.map(m => ({ name: m.name, path: m.path }));
+    }
+
+    const executed = new Set(await this.storage.executed());
+    return all.filter(m => !executed.has(m.name)).map(m => ({ name: m.name, path: m.path }));
+  }
+
+  private async hasSnapshot(): Promise<boolean> {
+    if (!this.options.snapshot) {
+      return false;
+    }
+
+    const { fs } = await import('@mikro-orm/core/fs-utils');
+    return fs.pathExists(await this.getSnapshotPath());
   }
 
   async checkSchema(): Promise<boolean> {

--- a/tests/features/migrations/Migrator.sqlite.test.ts
+++ b/tests/features/migrations/Migrator.sqlite.test.ts
@@ -281,6 +281,110 @@ describe('Migrator (sqlite)', () => {
     }
   });
 
+  test('create works without database connection when snapshot exists', async () => {
+    const migrations = orm.config.get('migrations');
+    migrations.snapshot = true;
+
+    const dateMock = vi.spyOn(Date.prototype, 'toISOString');
+    dateMock.mockReturnValue('2019-10-13T21:48:13.382Z');
+    const path = process.cwd() + '/temp/migrations-3';
+    const migrator = new Migrator(orm.em);
+
+    // create a blank migration — snapshot is written from metadata (getTargetSchema)
+    const migration1 = await migrator.create(path, true);
+    expect(migration1.diff).toEqual({ up: ['select 1'], down: ['select 1'] });
+
+    // create a fresh migrator that has NOT been initialized (no DB connection)
+    const migrator2 = new Migrator(orm.em);
+
+    // mock ensureDatabase and ensureTable to throw — proving we don't need DB
+    const ensureDbMock = vi.spyOn(orm.schema, 'ensureDatabase');
+    ensureDbMock.mockRejectedValue(new Error('should not connect to database'));
+    const ensureTableMock = vi.spyOn(MigrationStorage.prototype, 'ensureTable');
+    ensureTableMock.mockRejectedValue(new Error('should not connect to database'));
+
+    try {
+      // create should succeed without database, using the snapshot for diff
+      const result = await migrator2.create(path);
+      expect(result.fileName).toBe('');
+      expect(result.diff).toEqual({ up: [], down: [] });
+    } finally {
+      const snapshotPath = path + '/.snapshot-memory.json';
+      await rm(path + '/' + migration1.fileName);
+      await rm(snapshotPath, { force: true });
+      ensureDbMock.mockRestore();
+      ensureTableMock.mockRestore();
+      migrations.snapshot = false;
+    }
+  });
+
+  test('getPending works without database connection when snapshot exists', async () => {
+    const migrations = orm.config.get('migrations');
+    migrations.snapshot = true;
+
+    const dateMock = vi.spyOn(Date.prototype, 'toISOString');
+    dateMock.mockReturnValue('2019-10-13T21:48:13.382Z');
+    const path = process.cwd() + '/temp/migrations-3';
+    const migrator = new Migrator(orm.em);
+
+    // create a blank migration so there's a file to discover and a snapshot
+    const migration1 = await migrator.create(path, true);
+
+    // create a fresh migrator that has NOT been initialized (no DB connection)
+    const migrator2 = new Migrator(orm.em);
+
+    // mock ensureDatabase/ensureTable to throw — proving we don't need DB
+    const ensureDbMock = vi.spyOn(orm.schema, 'ensureDatabase');
+    ensureDbMock.mockRejectedValue(new Error('should not connect to database'));
+    const ensureTableMock = vi.spyOn(MigrationStorage.prototype, 'ensureTable');
+    ensureTableMock.mockRejectedValue(new Error('should not connect to database'));
+
+    try {
+      const pending = await migrator2.getPending();
+      expect(pending).toHaveLength(1);
+      expect(pending[0].name).toBe(migration1.fileName.replace(/\.[jt]s$/, ''));
+    } finally {
+      const snapshotPath = path + '/.snapshot-memory.json';
+      await rm(path + '/' + migration1.fileName);
+      await rm(snapshotPath, { force: true });
+      ensureDbMock.mockRestore();
+      ensureTableMock.mockRestore();
+      migrations.snapshot = false;
+    }
+  });
+
+  test('getPending propagates storage errors when database is reachable', async () => {
+    const migrations = orm.config.get('migrations');
+    migrations.snapshot = true;
+
+    const dateMock = vi.spyOn(Date.prototype, 'toISOString');
+    dateMock.mockReturnValue('2019-10-13T21:48:13.382Z');
+    const path = process.cwd() + '/temp/migrations-3';
+    const migrator = new Migrator(orm.em);
+    const migration1 = await migrator.create(path, true);
+
+    const migrator2 = new Migrator(orm.em);
+
+    // DB is reachable (ensureTable succeeds), but `executed()` fails — real
+    // bugs in `storage.executed()` must propagate instead of silently being
+    // converted to "all pending"
+    const ensureTableMock = vi.spyOn(MigrationStorage.prototype, 'ensureTable');
+    ensureTableMock.mockResolvedValue(undefined);
+    const executedMock = vi.spyOn(MigrationStorage.prototype, 'executed');
+    executedMock.mockRejectedValue(new Error('boom'));
+
+    try {
+      await expect(migrator2.getPending()).rejects.toThrow('boom');
+    } finally {
+      const snapshotPath = path + '/.snapshot-memory.json';
+      await rm(path + '/' + migration1.fileName);
+      await rm(snapshotPath, { force: true });
+      ensureTableMock.mockRestore();
+      executedMock.mockRestore();
+      migrations.snapshot = false;
+    }
+  });
+
   test('generate initial migration', async () => {
     await orm.schema.dropTableIfExists(orm.config.get('migrations').tableName!);
     const getExecutedMigrationsMock = vi.spyOn(Migrator.prototype, 'getExecuted');


### PR DESCRIPTION
Extends the offline-friendly behavior previously added for `checkSchema()` (#7493) to `create()` and `getPending()`. When a migration snapshot file exists:

- `create()` (non-initial) resolves paths only and uses the snapshot for the diff — no `ensureDatabase()`/`ensureTable()` calls.
- `getPending()` skips DB init and falls back to treating all discovered migrations as pending if `storage.executed()` fails (no DB).

This makes `migrator:create` and `migrator:pending` usable in CI without a running database, as long as snapshots are enabled. Behavior is unchanged when no snapshot is present.

Asked for in https://github.com/mikro-orm/mikro-orm/discussions/7481#discussioncomment-16538274