### PR TITLE
feat(core): union-target polymorphic M:N relations

### DIFF
--- a/docs/docs/relationships.md
+++ b/docs/docs/relationships.md
@@ -1752,25 +1752,52 @@ console.log(loadedTag.videos.length); // 1
 
 The previous section covers the case where several owner types (`Post`, `Video`) share one pivot pointing at a single target (`Tag`) — the discriminator identifies the owner type. The mirror shape is also supported: a single owner holding a **union collection** of multiple target types, where the discriminator identifies the target type on each pivot row.
 
+<Tabs
+  groupId="entity-def"
+  defaultValue="reflect-metadata"
+  values={[
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+    {label: 'defineEntity', value: 'define-entity'},
+]
+  }
+>
+  <TabItem value="reflect-metadata">
+
 ```ts
 @Entity()
 class Image {
-  @PrimaryKey() id!: number;
-  @Property()    url!: string;
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  url!: string;
+
+  @ManyToMany(() => Post, post => post.attachments)
+  posts = new Collection<Post>(this);
 }
 
 @Entity()
 class Video {
-  @PrimaryKey() id!: number;
-  @Property()    src!: string;
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  src!: string;
+
+  @ManyToMany(() => Post, post => post.attachments)
+  posts = new Collection<Post>(this);
 }
 
 @Entity()
 class Post {
-  @PrimaryKey() id!: number;
-  @Property()   title!: string;
+  @PrimaryKey()
+  id!: number;
 
-  @ManyToMany(() => [Image, Video], undefined, {
+  @Property()
+  title!: string;
+
+  @ManyToMany(() => [Image, Video], {
     pivotTable: 'attachables',
     discriminator: 'attachable',
     owner: true,
@@ -1779,13 +1806,96 @@ class Post {
 }
 ```
 
+  </TabItem>
+  <TabItem value="ts-morph">
+
+```ts
+@Entity()
+class Image {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  url!: string;
+
+  @ManyToMany(() => Post, post => post.attachments)
+  posts = new Collection<Post>(this);
+}
+
+@Entity()
+class Video {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  src!: string;
+
+  @ManyToMany(() => Post, post => post.attachments)
+  posts = new Collection<Post>(this);
+}
+
+@Entity()
+class Post {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  title!: string;
+
+  @ManyToMany(() => [Image, Video], {
+    pivotTable: 'attachables',
+    discriminator: 'attachable',
+    owner: true,
+  })
+  attachments = new Collection<Image | Video>(this);
+}
+```
+
+  </TabItem>
+  <TabItem value="define-entity">
+
+```ts
+export const Image = defineEntity({
+  name: 'Image',
+  properties: {
+    id: p.number().primary(),
+    url: p.string(),
+    posts: () => p.manyToMany(Post).mappedBy('attachments'),
+  },
+});
+
+export const Video = defineEntity({
+  name: 'Video',
+  properties: {
+    id: p.number().primary(),
+    src: p.string(),
+    posts: () => p.manyToMany(Post).mappedBy('attachments'),
+  },
+});
+
+export const Post = defineEntity({
+  name: 'Post',
+  properties: {
+    id: p.number().primary(),
+    title: p.string(),
+    attachments: () => p.manyToMany([Image, Video])
+      .pivotTable('attachables')
+      .discriminator('attachable')
+      .owner(),
+  },
+});
+```
+
+  </TabItem>
+</Tabs>
+
 The pivot table stores `(post_id, attachable_type, attachable_id)` — `attachable_type` holds the target discriminator (`'image'` or `'video'`), and `attachable_id` points at the row in the corresponding target table. There is no FK constraint on `attachable_id` since it spans multiple target tables.
 
 ```sql
 CREATE TABLE attachables (
-  post_id         INTEGER,     -- FK to post.id
-  attachable_type VARCHAR(255),-- 'image' or 'video'
-  attachable_id   INTEGER,     -- FK to image.id or video.id
+  post_id         INTEGER,      -- FK to post.id
+  attachable_type VARCHAR(255), -- 'image' or 'video'
+  attachable_id   INTEGER,      -- FK to image.id or video.id
   PRIMARY KEY (post_id, attachable_type, attachable_id)
 );
 ```
@@ -1804,39 +1914,37 @@ for (const a of loaded.attachments) {
 }
 ```
 
-#### How union-target loading works
-
-When populating a union-target collection, MikroORM runs one query against the pivot table to read the owner FK, discriminator, and target FK per row, then bulk-loads each target table in a single additional query (one per distinct target type that appears in the pivot). For most cases this means at most `1 + N` queries where `N` is the number of target types that actually have rows, not the number of target types declared.
-
 #### Inverse side
 
-Each target entity can declare its own inverse collection pointing back at the owner. Those are regular M:N inverse sides and load correctly — MikroORM filters the shared pivot by the target's discriminator value automatically:
+Each target entity can declare its own inverse collection pointing back at the owner. MikroORM filters the shared pivot by the target's discriminator value automatically, so `Image.posts` and `Video.posts` are cleanly separated:
 
 ```ts
-@Entity()
-class Image {
-  // ...
-  @ManyToMany(() => Post, p => p.attachments)
-  posts = new Collection<Post>(this);
-}
-
-@Entity()
-class Video {
-  // ...
-  @ManyToMany(() => Post, p => p.attachments)
-  posts = new Collection<Post>(this);
-}
-
-// Usage
 const img = await em.findOneOrFail(Image, id, { populate: ['posts'] });
-// img.posts contains only posts where this image is attached — the pivot is filtered
+// img.posts contains only posts where this image is attached — pivot is filtered
 // by attachable_type='image' automatically.
 ```
 
-The inverse collection on each target only sees pivot rows for that target class, so `Image.posts` and `Video.posts` are cleanly separated.
+#### Merged inverse collection
+
+On the inverse side of the Rails-style polymorphic M:N (where multiple owners share one pivot pointing at a single target), you can declare a single union collection that combines all owner types instead of separate per-type collections:
+
+```ts
+@Entity()
+class Tag {
+  // Separate per-type collections (always available)
+  @ManyToMany(() => Post, post => post.tags)
+  posts = new Collection<Post>(this);
+
+  @ManyToMany(() => Video, video => video.tags)
+  videos = new Collection<Video>(this);
+
+  // Merged union collection — loads all owner types at once
+  @ManyToMany(() => [Post, Video], 'tags')
+  owners = new Collection<Post | Video>(this);
+}
+```
 
 #### Caveats
 
-1. **TypeScript limitation** — `Collection<Image | Video>.add()` is typed against the first union member, so you may need a `@ts-expect-error` or cast when adding mixed types until TypeScript's distributive behavior is expanded. This mirrors the known limitation of polymorphic `@ManyToOne(() => [A, B])`.
-2. **Shared discriminator values** — all declared targets must have distinct `tableName`s, since the discriminator column is populated from `tableName`.
-3. **Merged inverse-side collection not yet supported** — if you want the inverse side of the Rails-style pivot (multiple owners → one target, e.g. `Post.tags` / `Video.tags`) to collapse into a single `Collection<Post | Video>` on `Tag`, you still declare separate `Tag.posts` / `Tag.videos` collections for now. Planned as a follow-up.
+1. All declared targets must have distinct `tableName`s, since the discriminator column is populated from `tableName`.
+2. The collection element order in union-target M:N reflects the pivot table order, grouped by target type.

--- a/docs/docs/relationships.md
+++ b/docs/docs/relationships.md
@@ -1797,7 +1797,8 @@ class Post {
   @Property()
   title!: string;
 
-  @ManyToMany(() => [Image, Video], {
+  @ManyToMany({
+    entity: () => [Image, Video] as any,
     pivotTable: 'attachables',
     discriminator: 'attachable',
     owner: true,
@@ -1842,7 +1843,8 @@ class Post {
   @Property()
   title!: string;
 
-  @ManyToMany(() => [Image, Video], {
+  @ManyToMany({
+    entity: () => [Image, Video] as any,
     pivotTable: 'attachables',
     discriminator: 'attachable',
     owner: true,

--- a/docs/docs/relationships.md
+++ b/docs/docs/relationships.md
@@ -1745,8 +1745,28 @@ console.log(loadedTag.videos.length); // 1
 
 1. **Shared pivot table** - Multiple entity types share the same pivot table, distinguished by the discriminator column.
 2. **No FK constraint on polymorphic side** - The pivot table cannot have a foreign key constraint on the polymorphic columns since they point to different tables.
-3. **Separate inverse collections** - On the inverse side (Tag), you need separate collections for each entity type (`posts`, `videos`) rather than a single polymorphic collection.
+3. **Separate inverse collections** - On the inverse side (Tag), you need separate collections for each entity type (`posts`, `videos`), or a single [merged inverse collection](#merged-inverse-collection).
 4. **Same discriminator property** - All entities sharing a pivot table must use the same `discriminator` property name.
+
+#### Merged inverse collection
+
+Instead of separate per-type inverse collections, you can declare a single union collection that combines all owner types on the inverse side of the Rails-style polymorphic M:N:
+
+```ts
+@Entity()
+class Tag {
+  // Separate per-type collections (always available)
+  @ManyToMany(() => Post, post => post.tags)
+  posts = new Collection<Post>(this);
+
+  @ManyToMany(() => Video, video => video.tags)
+  videos = new Collection<Video>(this);
+
+  // Merged union collection — loads all owner types at once
+  @ManyToMany(() => [Post, Video], 'tags')
+  owners = new Collection<Post | Video>(this);
+}
+```
 
 ### Union-target M:N Polymorphic Relations
 
@@ -1924,26 +1944,6 @@ Each target entity can declare its own inverse collection pointing back at the o
 const img = await em.findOneOrFail(Image, id, { populate: ['posts'] });
 // img.posts contains only posts where this image is attached — pivot is filtered
 // by attachable_type='image' automatically.
-```
-
-#### Merged inverse collection
-
-On the inverse side of the Rails-style polymorphic M:N (where multiple owners share one pivot pointing at a single target), you can declare a single union collection that combines all owner types instead of separate per-type collections:
-
-```ts
-@Entity()
-class Tag {
-  // Separate per-type collections (always available)
-  @ManyToMany(() => Post, post => post.tags)
-  posts = new Collection<Post>(this);
-
-  @ManyToMany(() => Video, video => video.tags)
-  videos = new Collection<Video>(this);
-
-  // Merged union collection — loads all owner types at once
-  @ManyToMany(() => [Post, Video], 'tags')
-  owners = new Collection<Post | Video>(this);
-}
 ```
 
 #### Caveats

--- a/docs/docs/relationships.md
+++ b/docs/docs/relationships.md
@@ -1818,7 +1818,7 @@ class Post {
   title!: string;
 
   @ManyToMany({
-    entity: () => [Image, Video] as any,
+    entity: () => [Image, Video],
     pivotTable: 'attachables',
     discriminator: 'attachable',
     owner: true,
@@ -1864,7 +1864,7 @@ class Post {
   title!: string;
 
   @ManyToMany({
-    entity: () => [Image, Video] as any,
+    entity: () => [Image, Video],
     pivotTable: 'attachables',
     discriminator: 'attachable',
     owner: true,

--- a/docs/docs/relationships.md
+++ b/docs/docs/relationships.md
@@ -1747,3 +1747,96 @@ console.log(loadedTag.videos.length); // 1
 2. **No FK constraint on polymorphic side** - The pivot table cannot have a foreign key constraint on the polymorphic columns since they point to different tables.
 3. **Separate inverse collections** - On the inverse side (Tag), you need separate collections for each entity type (`posts`, `videos`) rather than a single polymorphic collection.
 4. **Same discriminator property** - All entities sharing a pivot table must use the same `discriminator` property name.
+
+### Union-target M:N Polymorphic Relations
+
+The previous section covers the case where several owner types (`Post`, `Video`) share one pivot pointing at a single target (`Tag`) — the discriminator identifies the owner type. The mirror shape is also supported: a single owner holding a **union collection** of multiple target types, where the discriminator identifies the target type on each pivot row.
+
+```ts
+@Entity()
+class Image {
+  @PrimaryKey() id!: number;
+  @Property()    url!: string;
+}
+
+@Entity()
+class Video {
+  @PrimaryKey() id!: number;
+  @Property()    src!: string;
+}
+
+@Entity()
+class Post {
+  @PrimaryKey() id!: number;
+  @Property()   title!: string;
+
+  @ManyToMany(() => [Image, Video], undefined, {
+    pivotTable: 'attachables',
+    discriminator: 'attachable',
+    owner: true,
+  })
+  attachments = new Collection<Image | Video>(this);
+}
+```
+
+The pivot table stores `(post_id, attachable_type, attachable_id)` — `attachable_type` holds the target discriminator (`'image'` or `'video'`), and `attachable_id` points at the row in the corresponding target table. There is no FK constraint on `attachable_id` since it spans multiple target tables.
+
+```sql
+CREATE TABLE attachables (
+  post_id         INTEGER,     -- FK to post.id
+  attachable_type VARCHAR(255),-- 'image' or 'video'
+  attachable_id   INTEGER,     -- FK to image.id or video.id
+  PRIMARY KEY (post_id, attachable_type, attachable_id)
+);
+```
+
+Use it like a regular collection — you can mix target types freely, and loaded items come back as instances of the correct concrete class:
+
+```ts
+const post = new Post();
+post.attachments.add(new Image(), new Video());
+await em.persist(post).flush();
+
+const loaded = await em.findOneOrFail(Post, post.id, { populate: ['attachments'] });
+for (const a of loaded.attachments) {
+  if (a instanceof Image) { /* ... */ }
+  if (a instanceof Video) { /* ... */ }
+}
+```
+
+#### How union-target loading works
+
+When populating a union-target collection, MikroORM runs one query against the pivot table to read the owner FK, discriminator, and target FK per row, then bulk-loads each target table in a single additional query (one per distinct target type that appears in the pivot). For most cases this means at most `1 + N` queries where `N` is the number of target types that actually have rows, not the number of target types declared.
+
+#### Inverse side
+
+Each target entity can declare its own inverse collection pointing back at the owner. Those are regular M:N inverse sides and load correctly — MikroORM filters the shared pivot by the target's discriminator value automatically:
+
+```ts
+@Entity()
+class Image {
+  // ...
+  @ManyToMany(() => Post, p => p.attachments)
+  posts = new Collection<Post>(this);
+}
+
+@Entity()
+class Video {
+  // ...
+  @ManyToMany(() => Post, p => p.attachments)
+  posts = new Collection<Post>(this);
+}
+
+// Usage
+const img = await em.findOneOrFail(Image, id, { populate: ['posts'] });
+// img.posts contains only posts where this image is attached — the pivot is filtered
+// by attachable_type='image' automatically.
+```
+
+The inverse collection on each target only sees pivot rows for that target class, so `Image.posts` and `Video.posts` are cleanly separated.
+
+#### Caveats
+
+1. **TypeScript limitation** — `Collection<Image | Video>.add()` is typed against the first union member, so you may need a `@ts-expect-error` or cast when adding mixed types until TypeScript's distributive behavior is expanded. This mirrors the known limitation of polymorphic `@ManyToOne(() => [A, B])`.
+2. **Shared discriminator values** — all declared targets must have distinct `tableName`s, since the discriminator column is populated from `tableName`.
+3. **Merged inverse-side collection not yet supported** — if you want the inverse side of the Rails-style pivot (multiple owners → one target, e.g. `Post.tags` / `Video.tags`) to collapse into a single `Collection<Post | Video>` on `Tag`, you still declare separate `Tag.posts` / `Tag.videos` collections for now. Planned as a follow-up.

--- a/packages/core/src/entity/Collection.ts
+++ b/packages/core/src/entity/Collection.ts
@@ -227,9 +227,9 @@ export class Collection<T extends object, O extends object = object> {
   /** Adds one or more items to the collection, propagating the change to the inverse side. Returns the number of items added. */
   add<TT extends T>(
     entity: TT | Reference<TT> | Iterable<TT | Reference<TT>>,
-    ...entities: (TT | Reference<TT>)[]
+    ...entities: (T | Reference<T>)[]
   ): number {
-    entities = Utils.asArray(entity).concat(entities);
+    entities = (Utils.asArray(entity) as (T | Reference<T>)[]).concat(entities);
     const unwrapped = entities.map(i => Reference.unwrapReference(i)) as T[];
     this.validateModification(unwrapped);
     const em = this.getEntityManager(entities as T[], false);
@@ -264,14 +264,14 @@ export class Collection<T extends object, O extends object = object> {
    * which tells the ORM we don't want orphaned entities to exist, so we know those should be removed.
    */
   remove<TT extends T>(
-    entity: TT | Reference<TT> | Iterable<TT | Reference<TT>> | ((item: TT) => boolean),
-    ...entities: (TT | Reference<TT>)[]
+    entity: TT | Reference<TT> | Iterable<TT | Reference<TT>> | ((item: T) => boolean),
+    ...entities: (T | Reference<T>)[]
   ): number {
     if (entity instanceof Function) {
       let removed = 0;
 
       for (const item of this.#items) {
-        if (entity(item as TT)) {
+        if (entity(item as T)) {
           removed += this.remove(item);
         }
       }
@@ -280,7 +280,7 @@ export class Collection<T extends object, O extends object = object> {
     }
 
     this.checkInitialized();
-    entities = Utils.asArray(entity).concat(entities);
+    entities = (Utils.asArray(entity) as (T | Reference<T>)[]).concat(entities);
     const unwrapped = entities.map(i => Reference.unwrapReference(i)) as T[];
     this.validateModification(unwrapped);
     const em = this.getEntityManager(entities as T[], false);

--- a/packages/core/src/entity/EntityLoader.ts
+++ b/packages/core/src/entity/EntityLoader.ts
@@ -902,18 +902,27 @@ export class EntityLoader {
       pivotJoin,
     );
     const children: AnyEntity[][] = [];
+    // For union-target polymorphic M:N the driver marks each item with its concrete class
+    // via a non-enumerable `constructor` property, so we dispatch to the right factory call per item.
+    const isUnionTargetMN = prop.polymorphic && (prop.polymorphTargets?.length ?? 0) > 1;
+    const classFor = (item: Dictionary): EntityName<any> => {
+      if (isUnionTargetMN && item.constructor && item.constructor !== Object) {
+        return item.constructor as EntityName<any>;
+      }
+      return prop.targetMeta!.class;
+    };
 
     for (let i = 0; i < filtered.length; i++) {
       const entity = filtered[i] as AnyEntity;
       const items = map[Utils.getPrimaryKeyHash(ids[i] as string[])].map(item => {
         if (pivotJoin) {
-          return this.#em.getReference(prop.targetMeta!.class, item, {
+          return this.#em.getReference(classFor(item as Dictionary), item, {
             convertCustomTypes: true,
             schema: options.schema ?? this.#em.config.get('schema'),
           });
         }
 
-        const entity = this.#em.getEntityFactory().create(prop.targetMeta!.class, item, {
+        const entity = this.#em.getEntityFactory().create(classFor(item as Dictionary), item, {
           refresh,
           merge: true,
           convertCustomTypes: true,

--- a/packages/core/src/entity/EntityLoader.ts
+++ b/packages/core/src/entity/EntityLoader.ts
@@ -902,15 +902,14 @@ export class EntityLoader {
       pivotJoin,
     );
     const children: AnyEntity[][] = [];
-    // For union-target polymorphic M:N the driver marks each item with its concrete class
-    // via a non-enumerable `constructor` property, so we dispatch to the right factory call per item.
-    const isUnionTargetMN = prop.polymorphic && (prop.polymorphTargets?.length ?? 0) > 1;
-    const classFor = (item: Dictionary): EntityName<any> => {
-      if (isUnionTargetMN && item.constructor && item.constructor !== Object) {
-        return item.constructor as EntityName<any>;
-      }
-      return prop.targetMeta!.class;
-    };
+    // For union-target polymorphic M:N the driver marks each item with its concrete class via a
+    // non-enumerable `constructor` property (same trick used for polymorphic @ManyToOne targets),
+    // so dispatch to the right factory call per item.
+    const isUnionTargetMN = QueryHelper.isUnionTargetPolymorphic(prop);
+    const classFor = (item: Dictionary): EntityName<any> =>
+      isUnionTargetMN && item.constructor && item.constructor !== Object
+        ? (item.constructor as EntityName<any>)
+        : prop.targetMeta!.class;
 
     for (let i = 0; i < filtered.length; i++) {
       const entity = filtered[i] as AnyEntity;

--- a/packages/core/src/entity/EntityLoader.ts
+++ b/packages/core/src/entity/EntityLoader.ts
@@ -902,26 +902,24 @@ export class EntityLoader {
       pivotJoin,
     );
     const children: AnyEntity[][] = [];
-    // For union-target polymorphic M:N the driver marks each item with its concrete class via a
-    // non-enumerable `constructor` property (same trick used for polymorphic @ManyToOne targets),
-    // so dispatch to the right factory call per item.
     const isUnionTargetMN = QueryHelper.isUnionTargetPolymorphic(prop);
-    const classFor = (item: Dictionary): EntityName<any> =>
-      isUnionTargetMN && item.constructor && item.constructor !== Object
-        ? (item.constructor as EntityName<any>)
-        : prop.targetMeta!.class;
 
     for (let i = 0; i < filtered.length; i++) {
       const entity = filtered[i] as AnyEntity;
       const items = map[Utils.getPrimaryKeyHash(ids[i] as string[])].map(item => {
         if (pivotJoin) {
-          return this.#em.getReference(classFor(item as Dictionary), item, {
+          return this.#em.getReference(prop.targetMeta!.class, item, {
             convertCustomTypes: true,
             schema: options.schema ?? this.#em.config.get('schema'),
           });
         }
 
-        const entity = this.#em.getEntityFactory().create(classFor(item as Dictionary), item, {
+        // Union-target items carry their concrete class via `constructor` — dispatch to the right factory call.
+        const targetClass =
+          isUnionTargetMN && (item as Dictionary).constructor !== Object
+            ? ((item as Dictionary).constructor as EntityName<any>)
+            : prop.targetMeta!.class;
+        const entity = this.#em.getEntityFactory().create(targetClass, item, {
           refresh,
           merge: true,
           convertCustomTypes: true,

--- a/packages/core/src/metadata/EntitySchema.ts
+++ b/packages/core/src/metadata/EntitySchema.ts
@@ -522,7 +522,7 @@ export class EntitySchema<Entity = any, Base = never, Class extends EntityCtor =
   private normalizeType(
     options: PropertyOptions<Entity> | EntityProperty | EmbeddedOptions<Entity, any>,
     type?: string | any | Constructor<Type>,
-  ) {
+  ): { type: string; target?: unknown } {
     if ('entity' in options) {
       /* v8 ignore next */
       if (typeof options.entity === 'string') {

--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -634,8 +634,11 @@ export class MetadataDiscovery {
       meta.primaryKeys.map(primaryKey => meta.properties[primaryKey].fieldNames),
     );
 
-    // For polymorphic M:N, use discriminator base name for FK column (e.g., taggable_id instead of post_id)
-    if (prop.polymorphic && prop.discriminator) {
+    // Union-target polymorphic M:N: owner side is fixed (real FK), target side uses discriminator-derived names.
+    const isUnionTargetMN = prop.polymorphic && prop.polymorphTargets && prop.polymorphTargets.length > 1;
+
+    if (prop.polymorphic && prop.discriminator && !isUnionTargetMN) {
+      // Rails-style: owner side is polymorphic, uses discriminator base name (e.g. taggable_id instead of post_id)
       prop.joinColumns ??= prop.referencedColumnNames.map(referencedColumnName =>
         this.#namingStrategy.joinKeyColumnName(
           prop.discriminator!,
@@ -649,7 +652,15 @@ export class MetadataDiscovery {
       );
     }
 
-    prop.inverseJoinColumns ??= this.initManyToOneFieldName(prop, meta2.root.className);
+    if (isUnionTargetMN) {
+      // Target side uses discriminator base name (e.g. attachable_id — shared across Image/Video)
+      const targetPkCols = Utils.flatten(meta2.primaryKeys.map(pk => meta2.properties[pk].fieldNames));
+      prop.inverseJoinColumns ??= targetPkCols.map(fieldName =>
+        this.#namingStrategy.joinKeyColumnName(prop.discriminator!, fieldName, targetPkCols.length > 1),
+      );
+    } else {
+      prop.inverseJoinColumns ??= this.initManyToOneFieldName(prop, meta2.root.className);
+    }
   }
 
   private isExplicitTableName(meta: EntityMetadata): boolean {
@@ -936,8 +947,11 @@ export class MetadataDiscovery {
       }
     }
 
-    // For polymorphic M:N, create discriminator column and polymorphic FK
-    if (prop.polymorphic && prop.discriminatorColumn) {
+    // Union-target polymorphic M:N: discriminator + target FK share the pivot across multiple target types
+    if (prop.polymorphic && prop.discriminatorColumn && prop.polymorphTargets && prop.polymorphTargets.length > 1) {
+      this.defineUnionTargetPolymorphicPivotProperties(pivotMeta2, meta, prop);
+    } else if (prop.polymorphic && prop.discriminatorColumn) {
+      // Rails-style polymorphic M:N: multiple owners share the pivot, single target type
       this.definePolymorphicPivotProperties(pivotMeta2, meta, prop, targetMeta);
     } else {
       pivotMeta2.properties[meta.name + '_owner'] = this.definePivotProperty(
@@ -1080,6 +1094,91 @@ export class MetadataDiscovery {
 
     pivotMeta.polymorphicDiscriminatorMap ??= {};
     pivotMeta.polymorphicDiscriminatorMap[prop.discriminatorValue!] = meta.class;
+  }
+
+  /**
+   * Mirror of definePolymorphicPivotProperties for union-target M:N
+   * (e.g. Post.attachments -> Image | Video via shared pivot with a target-side discriminator).
+   *
+   * Pivot shape:
+   *   (owner_fk..., discriminator_column, target_fk...)
+   *   - owner side is a normal M:1 to the single owner entity
+   *   - target side is a discriminator column + per-target-type virtual M:1 relations
+   */
+  private defineUnionTargetPolymorphicPivotProperties(
+    pivotMeta: EntityMetadata,
+    meta: EntityMetadata,
+    prop: EntityProperty,
+  ): void {
+    const discriminatorColumn = prop.discriminatorColumn!;
+    const targets = prop.polymorphTargets!;
+    const isOwnerCompositePK = meta.compositePK;
+    const needFixedOrder = isOwnerCompositePK || targets.some(t => t.compositePK || t.primaryKeys.length > 1);
+
+    // Composite PK owners (or composite PK targets) force fixedOrder auto-increment PK
+    // because a composite PK across (owner_cols, discriminator, target_cols) gets unwieldy.
+    if (needFixedOrder && !prop.fixedOrder) {
+      prop.fixedOrder = true;
+      const primaryProp = this.defineFixedOrderProperty(prop, targets[0]);
+      pivotMeta.properties[primaryProp.name] = primaryProp;
+      pivotMeta.compositePK = false;
+    }
+
+    // Owner side: normal M:1 (single entity type)
+    pivotMeta.properties[meta.name + '_owner'] = this.definePivotProperty(
+      prop,
+      meta.name + '_owner',
+      meta.class,
+      prop.discriminator!,
+      true,
+      false,
+    );
+
+    // Discriminator column — nullable=false, part of composite PK unless fixedOrder kicked in
+    const discriminatorProp = this.createPivotScalarProperty(
+      discriminatorColumn,
+      [this.#platform.getVarcharTypeDeclarationSQL(prop)],
+      [discriminatorColumn],
+      { type: 'string', primary: !prop.fixedOrder, nullable: false },
+    );
+    this.initFieldName(discriminatorProp);
+    pivotMeta.properties[discriminatorColumn] = discriminatorProp;
+
+    // Target-side ID column(s) — nullable because different target types may have different PK column shapes
+    const firstTargetColumnTypes = this.getPrimaryKeyColumnTypes(targets[0]);
+
+    if (targets.some(t => t.compositePK)) {
+      // Composite target PKs: emit separate nullable scalar cols, plus a virtual combined prop
+      for (let i = 0; i < prop.inverseJoinColumns.length; i++) {
+        pivotMeta.properties[prop.inverseJoinColumns[i]] = this.createPivotScalarProperty(prop.inverseJoinColumns[i], [
+          firstTargetColumnTypes[i],
+        ]);
+      }
+      pivotMeta.properties[prop.discriminator!] = this.createPivotScalarProperty(
+        prop.discriminator!,
+        firstTargetColumnTypes,
+        [...prop.inverseJoinColumns],
+        { type: targets[0].className, persist: false },
+      );
+    } else {
+      pivotMeta.properties[prop.discriminator!] = this.createPivotScalarProperty(
+        prop.discriminator!,
+        firstTargetColumnTypes,
+        [...prop.inverseJoinColumns],
+        { type: targets[0].className, primary: !prop.fixedOrder, nullable: false },
+      );
+    }
+
+    // Per-target virtual M:1 relations enable single-query JOIN loading (one LEFT JOIN per target)
+    pivotMeta.polymorphicDiscriminatorMap ??= {};
+
+    for (const targetMeta of targets) {
+      const relationName = `${prop.discriminator}_${targetMeta.tableName}`;
+      const relation = this.definePolymorphicOwnerRelation(prop, relationName, targetMeta);
+      relation.joinColumns = relation.fieldNames = relation.ownColumns = [...prop.inverseJoinColumns];
+      pivotMeta.properties[relationName] = relation;
+      pivotMeta.polymorphicDiscriminatorMap[targetMeta.tableName] = targetMeta.class;
+    }
   }
 
   /**
@@ -1371,8 +1470,9 @@ export class MetadataDiscovery {
     prop.createForeignKeyConstraint = false;
 
     const isToOne = [ReferenceKind.MANY_TO_ONE, ReferenceKind.ONE_TO_ONE].includes(prop.kind);
+    const isUnionTargetMN = prop.kind === ReferenceKind.MANY_TO_MANY && Array.isArray(prop.target);
 
-    if (isToOne) {
+    if (isToOne || isUnionTargetMN) {
       const types = prop.type.split(/ ?\| ?/);
       prop.polymorphTargets = discovered.filter(m => types.includes(m.className) && !m.embeddable);
       prop.targetMeta = prop.polymorphTargets[0];
@@ -1397,7 +1497,7 @@ export class MetadataDiscovery {
       }
 
       prop.discriminatorMap = normalizedMap;
-    } else if (isToOne) {
+    } else if (isToOne || isUnionTargetMN) {
       prop.discriminatorMap = {};
       const tableNameToTarget = new Map<string, EntityMetadata>();
       for (const target of prop.polymorphTargets!) {

--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -627,7 +627,9 @@ export class MetadataDiscovery {
       prop.polymorphic = prop2.polymorphic;
       prop.discriminator = prop2.discriminator;
       prop.discriminatorColumn = prop2.discriminatorColumn;
-      prop.discriminatorValue = prop2.discriminatorValue;
+      // For a union-target pivot each inverse side sits on one specific target class, so its
+      // discriminator value is that class's tableName. For Rails-style, prop2 has a single fixed value.
+      prop.discriminatorValue = QueryHelper.isUnionTargetPolymorphic(prop2) ? meta.tableName : prop2.discriminatorValue;
     }
 
     prop.referencedColumnNames ??= Utils.flatten(
@@ -635,7 +637,7 @@ export class MetadataDiscovery {
     );
 
     // Union-target polymorphic M:N: owner side is fixed (real FK), target side uses discriminator-derived names.
-    const isUnionTargetMN = prop.polymorphic && prop.polymorphTargets && prop.polymorphTargets.length > 1;
+    const isUnionTargetMN = QueryHelper.isUnionTargetPolymorphic(prop);
 
     if (prop.polymorphic && prop.discriminator && !isUnionTargetMN) {
       // Rails-style: owner side is polymorphic, uses discriminator base name (e.g. taggable_id instead of post_id)
@@ -776,6 +778,24 @@ export class MetadataDiscovery {
 
           if (prop.inversedBy) {
             prop.targetMeta!.properties[prop.inversedBy].pivotEntity = pivotMeta.class;
+          }
+
+          // Union-target polymorphic M:N may have inverse collections on every target type;
+          // autoWireBidirectionalProperties only records one inversedBy, so propagate pivotEntity
+          // to every target's mappedBy prop pointing at this owner.
+          if (QueryHelper.isUnionTargetPolymorphic(prop)) {
+            for (const targetMeta of prop.polymorphTargets!) {
+              for (const inverseProp of Object.values(targetMeta.properties)) {
+                if (
+                  inverseProp.kind === ReferenceKind.MANY_TO_MANY &&
+                  inverseProp.mappedBy === prop.name &&
+                  inverseProp.type === meta.className
+                ) {
+                  inverseProp.pivotEntity = pivotMeta.class;
+                  inverseProp.pivotTable = pivotMeta.tableName;
+                }
+              }
+            }
           }
 
           return pivotMeta;
@@ -948,7 +968,7 @@ export class MetadataDiscovery {
     }
 
     // Union-target polymorphic M:N: discriminator + target FK share the pivot across multiple target types
-    if (prop.polymorphic && prop.discriminatorColumn && prop.polymorphTargets && prop.polymorphTargets.length > 1) {
+    if (prop.discriminatorColumn && QueryHelper.isUnionTargetPolymorphic(prop)) {
       this.defineUnionTargetPolymorphicPivotProperties(pivotMeta2, meta, prop);
     } else if (prop.polymorphic && prop.discriminatorColumn) {
       // Rails-style polymorphic M:N: multiple owners share the pivot, single target type
@@ -1115,8 +1135,8 @@ export class MetadataDiscovery {
     const isOwnerCompositePK = meta.compositePK;
     const needFixedOrder = isOwnerCompositePK || targets.some(t => t.compositePK || t.primaryKeys.length > 1);
 
-    // Composite PK owners (or composite PK targets) force fixedOrder auto-increment PK
-    // because a composite PK across (owner_cols, discriminator, target_cols) gets unwieldy.
+    // Composite PKs on either side force fixedOrder — a composite PK across
+    // (owner_cols, discriminator, target_cols) gets unwieldy.
     if (needFixedOrder && !prop.fixedOrder) {
       prop.fixedOrder = true;
       const primaryProp = this.defineFixedOrderProperty(prop, targets[0]);
@@ -1124,7 +1144,6 @@ export class MetadataDiscovery {
       pivotMeta.compositePK = false;
     }
 
-    // Owner side: normal M:1 (single entity type)
     pivotMeta.properties[meta.name + '_owner'] = this.definePivotProperty(
       prop,
       meta.name + '_owner',
@@ -1134,7 +1153,6 @@ export class MetadataDiscovery {
       false,
     );
 
-    // Discriminator column — nullable=false, part of composite PK unless fixedOrder kicked in
     const discriminatorProp = this.createPivotScalarProperty(
       discriminatorColumn,
       [this.#platform.getVarcharTypeDeclarationSQL(prop)],
@@ -1144,11 +1162,11 @@ export class MetadataDiscovery {
     this.initFieldName(discriminatorProp);
     pivotMeta.properties[discriminatorColumn] = discriminatorProp;
 
-    // Target-side ID column(s) — nullable because different target types may have different PK column shapes
     const firstTargetColumnTypes = this.getPrimaryKeyColumnTypes(targets[0]);
 
     if (targets.some(t => t.compositePK)) {
       // Composite target PKs: emit separate nullable scalar cols, plus a virtual combined prop
+      // so individual columns can live nullable while the combined prop still appears in metadata.
       for (let i = 0; i < prop.inverseJoinColumns.length; i++) {
         pivotMeta.properties[prop.inverseJoinColumns[i]] = this.createPivotScalarProperty(prop.inverseJoinColumns[i], [
           firstTargetColumnTypes[i],
@@ -1169,7 +1187,6 @@ export class MetadataDiscovery {
       );
     }
 
-    // Per-target virtual M:1 relations enable single-query JOIN loading (one LEFT JOIN per target)
     pivotMeta.polymorphicDiscriminatorMap ??= {};
 
     for (const targetMeta of targets) {

--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -780,20 +780,26 @@ export class MetadataDiscovery {
             prop.targetMeta!.properties[prop.inversedBy].pivotEntity = pivotMeta.class;
           }
 
-          // Union-target polymorphic M:N may have inverse collections on every target type;
-          // autoWireBidirectionalProperties only records one inversedBy, so propagate pivotEntity
-          // to every target's mappedBy prop pointing at this owner.
-          if (QueryHelper.isUnionTargetPolymorphic(prop)) {
-            for (const targetMeta of prop.polymorphTargets!) {
-              for (const inverseProp of Object.values(targetMeta.properties)) {
-                if (
-                  inverseProp.kind === ReferenceKind.MANY_TO_MANY &&
-                  inverseProp.mappedBy === prop.name &&
-                  inverseProp.type === meta.className
-                ) {
-                  inverseProp.pivotEntity = pivotMeta.class;
-                  inverseProp.pivotTable = pivotMeta.tableName;
-                }
+          // Propagate pivotEntity to ALL inverse collections using mappedBy pointing at this
+          // owner prop. Covers three cases:
+          //   - regular inverse (Tag.posts mappedBy Post.tags) — handled by inversedBy above
+          //   - union-target inverse (Image.posts mappedBy Post.attachments) — on each polymorph target
+          //   - merged inverse (Tag.owners mappedBy [Post,Video].tags) — union collection on the target
+          const inverseCandidates = QueryHelper.isUnionTargetPolymorphic(prop)
+            ? prop.polymorphTargets!
+            : prop.targetMeta
+              ? [prop.targetMeta]
+              : [];
+
+          for (const targetMeta of inverseCandidates) {
+            for (const inverseProp of Object.values(targetMeta.properties)) {
+              if (
+                inverseProp.kind === ReferenceKind.MANY_TO_MANY &&
+                inverseProp.mappedBy === prop.name &&
+                !inverseProp.pivotEntity
+              ) {
+                inverseProp.pivotEntity = pivotMeta.class;
+                inverseProp.pivotTable = pivotMeta.tableName;
               }
             }
           }

--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -1132,17 +1132,6 @@ export class MetadataDiscovery {
   ): void {
     const discriminatorColumn = prop.discriminatorColumn!;
     const targets = prop.polymorphTargets!;
-    const isOwnerCompositePK = meta.compositePK;
-    const needFixedOrder = isOwnerCompositePK || targets.some(t => t.compositePK || t.primaryKeys.length > 1);
-
-    // Composite PKs on either side force fixedOrder — a composite PK across
-    // (owner_cols, discriminator, target_cols) gets unwieldy.
-    if (needFixedOrder && !prop.fixedOrder) {
-      prop.fixedOrder = true;
-      const primaryProp = this.defineFixedOrderProperty(prop, targets[0]);
-      pivotMeta.properties[primaryProp.name] = primaryProp;
-      pivotMeta.compositePK = false;
-    }
 
     pivotMeta.properties[meta.name + '_owner'] = this.definePivotProperty(
       prop,
@@ -1157,35 +1146,18 @@ export class MetadataDiscovery {
       discriminatorColumn,
       [this.#platform.getVarcharTypeDeclarationSQL(prop)],
       [discriminatorColumn],
-      { type: 'string', primary: !prop.fixedOrder, nullable: false },
+      { type: 'string', primary: true, nullable: false },
     );
     this.initFieldName(discriminatorProp);
     pivotMeta.properties[discriminatorColumn] = discriminatorProp;
 
     const firstTargetColumnTypes = this.getPrimaryKeyColumnTypes(targets[0]);
-
-    if (targets.some(t => t.compositePK)) {
-      // Composite target PKs: emit separate nullable scalar cols, plus a virtual combined prop
-      // so individual columns can live nullable while the combined prop still appears in metadata.
-      for (let i = 0; i < prop.inverseJoinColumns.length; i++) {
-        pivotMeta.properties[prop.inverseJoinColumns[i]] = this.createPivotScalarProperty(prop.inverseJoinColumns[i], [
-          firstTargetColumnTypes[i],
-        ]);
-      }
-      pivotMeta.properties[prop.discriminator!] = this.createPivotScalarProperty(
-        prop.discriminator!,
-        firstTargetColumnTypes,
-        [...prop.inverseJoinColumns],
-        { type: targets[0].className, persist: false },
-      );
-    } else {
-      pivotMeta.properties[prop.discriminator!] = this.createPivotScalarProperty(
-        prop.discriminator!,
-        firstTargetColumnTypes,
-        [...prop.inverseJoinColumns],
-        { type: targets[0].className, primary: !prop.fixedOrder, nullable: false },
-      );
-    }
+    pivotMeta.properties[prop.discriminator!] = this.createPivotScalarProperty(
+      prop.discriminator!,
+      firstTargetColumnTypes,
+      [...prop.inverseJoinColumns],
+      { type: targets[0].className, primary: true, nullable: false },
+    );
 
     pivotMeta.polymorphicDiscriminatorMap ??= {};
 

--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -1470,6 +1470,12 @@ export class MetadataDiscovery {
       prop.polymorphTargets = discovered.filter(m => types.includes(m.className) && !m.embeddable);
       prop.targetMeta = prop.polymorphTargets[0];
       prop.referencedPKs = prop.targetMeta?.primaryKeys;
+
+      if (isUnionTargetMN && prop.polymorphTargets.length < 2) {
+        throw new MetadataError(
+          `${meta.className}.${prop.name} union-target polymorphic M:N requires at least two target entity types; use a regular M:N relation for a single target.`,
+        );
+      }
     }
 
     if (prop.discriminatorMap) {

--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -787,9 +787,7 @@ export class MetadataDiscovery {
           //   - merged inverse (Tag.owners mappedBy [Post,Video].tags) — union collection on the target
           const inverseCandidates = QueryHelper.isUnionTargetPolymorphic(prop)
             ? prop.polymorphTargets!
-            : prop.targetMeta
-              ? [prop.targetMeta]
-              : [];
+            : [prop.targetMeta!];
 
           for (const targetMeta of inverseCandidates) {
             for (const inverseProp of Object.values(targetMeta.properties)) {

--- a/packages/core/src/metadata/MetadataValidator.ts
+++ b/packages/core/src/metadata/MetadataValidator.ts
@@ -235,6 +235,22 @@ export class MetadataValidator {
   private validatePolymorphicTargets(meta: EntityMetadata, prop: EntityProperty): void {
     const targets = prop.polymorphTargets!;
 
+    // Union-target M:N stores one scalar target FK per pivot row, so composite-PK targets
+    // can't round-trip through this schema.
+    if (prop.kind === ReferenceKind.MANY_TO_MANY && targets.length > 1) {
+      for (const target of targets) {
+        if (target.compositePK) {
+          throw MetadataError.incompatiblePolymorphicTargets(
+            meta,
+            prop,
+            targets[0],
+            target,
+            `${target.className} has a composite primary key; union-target polymorphic M:N does not support composite-PK targets.`,
+          );
+        }
+      }
+    }
+
     // Validate targetKey exists and is compatible across all targets
     if (prop.targetKey) {
       for (const target of targets) {

--- a/packages/core/src/metadata/types.ts
+++ b/packages/core/src/metadata/types.ts
@@ -368,7 +368,7 @@ export interface PropertyOptions<Owner> {
 
 export interface ReferenceOptions<Owner, Target> extends PropertyOptions<Owner> {
   /** Set target entity type. For polymorphic relations, pass an array of entity types. */
-  entity?: () => EntityName<Target> | EntityName<Target>[];
+  entity?: () => EntityName<Target> | EntityName[];
 
   /** Set what actions on owning entity should be cascaded to the relationship. Defaults to [Cascade.PERSIST, Cascade.MERGE] (see {@doclink cascading}). */
   cascade?: Cascade[];

--- a/packages/core/src/utils/QueryHelper.ts
+++ b/packages/core/src/utils/QueryHelper.ts
@@ -24,6 +24,15 @@ export class QueryHelper {
   static readonly SUPPORTED_OPERATORS = ['>', '<', '<=', '>=', '!', '!='];
 
   /**
+   * True when the property is a polymorphic M:N with multiple target types sharing a single pivot
+   * (e.g. `Post.attachments: Collection<Image | Video>`), as opposed to Rails-style polymorphic
+   * M:N where multiple owners share one pivot pointing at a single target.
+   */
+  static isUnionTargetPolymorphic(prop: { polymorphic?: boolean; polymorphTargets?: readonly unknown[] }): boolean {
+    return !!prop.polymorphic && (prop.polymorphTargets?.length ?? 0) > 1;
+  }
+
+  /**
    * Finds the discriminator value (key) for a given entity class in a discriminator map.
    * Walks up the prototype chain so TPT subclasses resolve to their root's key.
    */

--- a/packages/core/src/utils/QueryHelper.ts
+++ b/packages/core/src/utils/QueryHelper.ts
@@ -24,9 +24,16 @@ export class QueryHelper {
   static readonly SUPPORTED_OPERATORS = ['>', '<', '<=', '>=', '!', '!='];
 
   /**
-   * True when the property is a polymorphic M:N with multiple target types sharing a single pivot
-   * (e.g. `Post.attachments: Collection<Image | Video>`), as opposed to Rails-style polymorphic
-   * M:N where multiple owners share one pivot pointing at a single target.
+   * True when the property has multiple polymorph target types. Covers two structurally-equivalent
+   * shapes routed through the same loading path:
+   *   1. Union-target owner side — `Post.attachments: Collection<Image | Video>` (one owner, many
+   *      target types, shared pivot with target-side discriminator).
+   *   2. Merged inverse of Rails-style polymorphic M:N — `Tag.owners: Collection<Post | Video>`
+   *      (many owner types pointing at one target, viewed from the target where "owners" looks
+   *      like a union of multiple types).
+   *
+   * Both cases are loaded via `loadFromUnionTargetPolymorphicPivotTable`, which buckets pivot rows
+   * by discriminator and hydrates each target class separately.
    */
   static isUnionTargetPolymorphic(prop: { polymorphic?: boolean; polymorphTargets?: readonly unknown[] }): boolean {
     return !!prop.polymorphic && (prop.polymorphTargets?.length ?? 0) > 1;

--- a/packages/decorators/src/es/ManyToMany.ts
+++ b/packages/decorators/src/es/ManyToMany.ts
@@ -11,7 +11,7 @@ import { prepareMetadataContext, processDecoratorParameters } from '../utils.js'
 
 /** Defines a many-to-many relationship (TC39 decorator). */
 export function ManyToMany<Target extends object, Owner extends object>(
-  entity?: ManyToManyOptions<Owner, Target> | string | (() => EntityName<Target>),
+  entity?: ManyToManyOptions<Owner, Target> | string | (() => EntityName<Target> | EntityName<Target>[]),
   mappedBy?: (string & keyof Target) | ((e: Target) => any),
   options: Partial<ManyToManyOptions<Owner, Target>> = {},
 ): (_: unknown, context: ClassFieldDecoratorContext<Owner, Collection<Target> | undefined>) => void {

--- a/packages/decorators/src/legacy/ManyToMany.ts
+++ b/packages/decorators/src/legacy/ManyToMany.ts
@@ -9,7 +9,7 @@ import { processDecoratorParameters, validateSingleDecorator, getMetadataFromDec
 
 /** Defines a many-to-many relationship (legacy TypeScript decorator). */
 export function ManyToMany<Target extends object, Owner extends object>(
-  entity: () => EntityName<Target>,
+  entity: () => EntityName<Target> | EntityName<Target>[],
   mappedBy?: (string & keyof Target) | ((e: Target) => any),
   options?: Partial<ManyToManyOptions<Owner, Target>>,
 ): (target: Owner, propertyName: keyof Owner) => void;
@@ -18,7 +18,7 @@ export function ManyToMany<Target extends object, Owner extends object>(
   options?: ManyToManyOptions<Owner, Target>,
 ): (target: Owner, propertyName: keyof Owner) => void;
 export function ManyToMany<Target extends object, Owner extends object>(
-  entity?: ManyToManyOptions<Owner, Target> | (() => EntityName<Target>),
+  entity?: ManyToManyOptions<Owner, Target> | (() => EntityName<Target> | EntityName<Target>[]),
   mappedBy?: (string & keyof Target) | ((e: Target) => any),
   options: Partial<ManyToManyOptions<Owner, Target>> = {},
 ) {

--- a/packages/sql/src/AbstractSqlDriver.ts
+++ b/packages/sql/src/AbstractSqlDriver.ts
@@ -1660,11 +1660,18 @@ export abstract class AbstractSqlDriver<
           return keys;
         }
         let disc = classToDisc.get(item.constructor);
-        if (disc === undefined) {
+        if (!classToDisc.has(item.constructor)) {
           disc = QueryHelper.findDiscriminatorValue(coll.property.discriminatorMap!, item.constructor) as Primary<any>;
+
+          if (disc === undefined) {
+            throw new Error(
+              `Cannot resolve discriminator value for ${item.constructor.name} in ${coll.property.name}; the class is not part of the union target list.`,
+            );
+          }
+
           classToDisc.set(item.constructor, disc);
         }
-        return [disc, ...keys];
+        return [disc as Primary<any>, ...keys];
       };
       const snapshot = snap ? snap.map(toDiff) : [];
       const current = coll.getItems(false).map(toDiff);
@@ -2008,10 +2015,17 @@ export abstract class AbstractSqlDriver<
     orderBy?: OrderDefinition<T>,
     ctx?: Transaction,
     options: FindOptions<T, any, any, any> = {} as FindOptions<T, any, any, any>,
-    // pivotJoin (:ref hints) is not supported for union-target — EntityLoader.getReference needs
-    // both a concrete class and a PK per item, but the ref-mode map only carries flat PK values.
-    _pivotJoin?: boolean,
+    pivotJoin?: boolean,
   ): Promise<Dictionary<T[]>> {
+    // :ref hints cannot be honored for union-target — EntityLoader.getReference needs a concrete
+    // class per item, but the ref-mode map only carries flat PK values and would hydrate every
+    // row as the first polymorph target. Fail loudly instead of silently corrupting the collection.
+    if (pivotJoin) {
+      throw new Error(
+        `The ':ref' populate hint is not supported for union-target polymorphic M:N on ${prop.name}. Use a regular populate hint instead.`,
+      );
+    }
+
     const pivotMeta = this.metadata.get(prop.pivotEntity);
     const targets = prop.polymorphTargets!;
     const ownerProp = pivotMeta.relations.find(r => r.persist !== false && !r.polymorphic)!;
@@ -2059,19 +2073,27 @@ export abstract class AbstractSqlDriver<
 
     // Strip the outer find's orderBy/fields/exclude before bulk-loading targets by PK — those apply
     // to the owner query, not each polymorph target (Image and Video wouldn't share an orderBy field).
+    // populateFilter is a filter on the populated collection; since union-target splits the pivot
+    // and target queries, we merge it into the target-level `where` instead of wrapping it on the
+    // pivot query (where joins to target tables aren't available).
     // Hoisted above the loop since `options` doesn't change per target.
-    const { orderBy: _o, fields: _f, exclude: _e, ...childOptions } = options as Dictionary;
+    const { orderBy: _o, fields: _f, exclude: _e, populateFilter, ...childOptions } = options as Dictionary;
     const populate = (options.populate as PopulateOptions<T>[]) ?? [];
+    const orphanedRows = new Set<EntityData<any>>();
 
     for (const [targetMeta, rows] of rowsByTarget) {
       const targetIds = rows.map(r => (r as Dictionary)[prop.discriminator!]);
-      const pkCol = targetMeta.compositePK
-        ? Utils.getPrimaryKeyHash(targetMeta.primaryKeys)
-        : targetMeta.primaryKeys[0];
+      // Union-target pivot stores one scalar FK per row; composite-PK targets are rejected at
+      // metadata validation time, so a single primary key column is guaranteed here.
+      const pkCol = targetMeta.primaryKeys[0];
       let cond: Dictionary = { [pkCol]: { $in: targetIds } };
 
       if (!Utils.isEmpty(where)) {
         cond = { $and: [cond, where] };
+      }
+
+      if (!Utils.isEmpty(populateFilter)) {
+        cond = { $and: [cond, populateFilter] };
       }
 
       const results = (await this.find<any>(targetMeta.class, cond as FilterQuery<any>, {
@@ -2086,17 +2108,14 @@ export abstract class AbstractSqlDriver<
           enumerable: false,
           configurable: true,
         });
-        const pk = targetMeta.compositePK
-          ? targetMeta.primaryKeys.map(k => (row as Dictionary)[k])
-          : [(row as Dictionary)[targetMeta.primaryKeys[0]]];
-        byPk.set(Utils.getPrimaryKeyHash(pk as string[]), row);
+        byPk.set(Utils.getPrimaryKeyHash([(row as Dictionary)[pkCol]] as string[]), row);
       }
       for (const row of rows) {
-        const pkHash = Utils.getPrimaryKeyHash(Utils.asArray((row as Dictionary)[prop.discriminator!]));
+        const pkHash = Utils.getPrimaryKeyHash([(row as Dictionary)[prop.discriminator!]] as string[]);
         const entity = byPk.get(pkHash);
 
         if (entity == null) {
-          pivotRows.splice(pivotRows.indexOf(row), 1);
+          orphanedRows.add(row);
           continue;
         }
 
@@ -2104,7 +2123,8 @@ export abstract class AbstractSqlDriver<
       }
     }
 
-    return this.buildPivotResultMap<T, O>(owners, pivotRows, ownerProp.name, prop.discriminator!);
+    const result = orphanedRows.size > 0 ? pivotRows.filter(r => !orphanedRows.has(r)) : pivotRows;
+    return this.buildPivotResultMap<T, O>(owners, result, ownerProp.name, prop.discriminator!);
   }
 
   /**
@@ -2274,6 +2294,13 @@ export abstract class AbstractSqlDriver<
 
       if (ref && [ReferenceKind.ONE_TO_ONE, ReferenceKind.MANY_TO_ONE].includes(prop.kind)) {
         return true;
+      }
+
+      // Union-target polymorphic M:N cannot be loaded via a single JOIN because rows span multiple
+      // target tables; fall through to SELECT_IN which dispatches through `loadFromPivotTable`.
+      // Polymorphic M:1 (to-one with target_type discriminator) is handled via LEFT JOINs elsewhere.
+      if (prop.kind === ReferenceKind.MANY_TO_MANY && QueryHelper.isUnionTargetPolymorphic(prop) && prop.owner) {
+        return false;
       }
 
       // skip redundant joins for 1:1 owner population hints when using `mapToPk`

--- a/packages/sql/src/AbstractSqlDriver.ts
+++ b/packages/sql/src/AbstractSqlDriver.ts
@@ -2004,11 +2004,11 @@ export abstract class AbstractSqlDriver<
   protected async loadFromUnionTargetPolymorphicPivotTable<T extends object, O extends object>(
     prop: EntityProperty,
     owners: Primary<O>[][],
-    where: FilterQuery<any> = {} as FilterQuery<any>,
+    _where: FilterQuery<any> = {} as FilterQuery<any>,
     orderBy?: OrderDefinition<T>,
     ctx?: Transaction,
     options?: FindOptions<T, any, any, any>,
-    pivotJoin?: boolean,
+    _pivotJoin?: boolean,
   ): Promise<Dictionary<T[]>> {
     const pivotMeta = this.metadata.get(prop.pivotEntity);
     const targets = prop.polymorphTargets!;
@@ -2031,15 +2031,12 @@ export abstract class AbstractSqlDriver<
       _populateWhere: 'infer',
     })) as EntityData<any>[];
 
-    if (pivotJoin) {
-      return this.buildPivotResultMap<T, O>(owners, pivotRows, ownerProp.name, prop.discriminator!);
-    }
-
+    const classMeta = new Map(targets.map(t => [t.class, t]));
     const rowsByTarget = new Map<EntityMetadata, EntityData<any>[]>();
     for (const row of pivotRows) {
       const discValue = (row as Dictionary)[discriminatorColumn] as string;
       const targetClass = prop.discriminatorMap![discValue];
-      const targetMeta = targets.find(t => t.class === targetClass);
+      const targetMeta = classMeta.get(targetClass);
 
       /* v8 ignore next 3 - defensive: unknown discriminator value */
       if (!targetMeta) {
@@ -2060,11 +2057,6 @@ export abstract class AbstractSqlDriver<
     for (const [targetMeta, rows] of rowsByTarget) {
       const targetIds = rows.map(r => (r as Dictionary)[prop.discriminator!]);
       const cond = { [targetMeta.primaryKeys[0]]: { $in: targetIds } };
-
-      if (!Utils.isEmpty(where)) {
-        Object.assign(cond, where);
-      }
-
       const results = (await this.find<any>(targetMeta.class, cond as FilterQuery<any>, {
         ctx,
         ...childOptions,

--- a/packages/sql/src/AbstractSqlDriver.ts
+++ b/packages/sql/src/AbstractSqlDriver.ts
@@ -1648,8 +1648,20 @@ export abstract class AbstractSqlDriver<
       const pks = wrapped.getPrimaryKeys(true)!;
       const snap = coll.getSnapshot();
       const includes = <T>(arr: T[][], item: T[]) => !!arr.find(i => this.comparePrimaryKeyArrays(i, item));
-      const snapshot = snap ? snap.map(item => helper(item).getPrimaryKeys(true)!) : [];
-      const current = coll.getItems(false).map(item => helper(item).getPrimaryKeys(true)!);
+      // For union-target polymorphic M:N, prepend the per-row discriminator value so the pivot
+      // persister can write it alongside the FK id. Same prototype-walking helper that handles
+      // TPT subclasses in polymorphic M:1 (QueryHelper.findDiscriminatorValue).
+      const isUnionTargetMN = coll.property.polymorphic && (coll.property.polymorphTargets?.length ?? 0) > 1;
+      const toDiff = (item: AnyEntity) => {
+        const keys = helper(item).getPrimaryKeys(true)!;
+        if (!isUnionTargetMN) {
+          return keys;
+        }
+        const disc = QueryHelper.findDiscriminatorValue(coll.property.discriminatorMap!, item.constructor);
+        return [disc as Primary<any>, ...keys];
+      };
+      const snapshot = snap ? snap.map(toDiff) : [];
+      const current = coll.getItems(false).map(toDiff);
       const deleteDiff = snap ? snapshot.filter(item => !includes(current, item)) : true;
       const insertDiff = current.filter(item => !includes(snapshot, item));
       const target = snapshot.filter(item => includes(current, item)).concat(...insertDiff);
@@ -1751,6 +1763,10 @@ export abstract class AbstractSqlDriver<
     }
 
     const pivotMeta = this.metadata.get(prop.pivotEntity);
+
+    if (prop.polymorphic && prop.discriminatorColumn && prop.polymorphTargets && prop.polymorphTargets.length > 1) {
+      return this.loadFromUnionTargetPolymorphicPivotTable(prop, owners, where, orderBy, ctx, options, pivotJoin);
+    }
 
     if (prop.polymorphic && prop.discriminatorColumn && prop.discriminatorValue) {
       return this.loadFromPolymorphicPivotTable(prop, owners, where, orderBy, ctx, options, pivotJoin);
@@ -1983,6 +1999,110 @@ export abstract class AbstractSqlDriver<
     });
 
     return this.buildPivotResultMap(owners, res, tagProp.name, ownerRelationName);
+  }
+
+  /**
+   * Load a union-target polymorphic M:N pivot (e.g. Post.attachments -> Image | Video).
+   * Each pivot row's discriminator column selects which target table to hydrate.
+   */
+  protected async loadFromUnionTargetPolymorphicPivotTable<T extends object, O extends object>(
+    prop: EntityProperty,
+    owners: Primary<O>[][],
+    where: FilterQuery<any> = {} as FilterQuery<any>,
+    orderBy?: OrderDefinition<T>,
+    ctx?: Transaction,
+    options?: FindOptions<T, any, any, any>,
+    pivotJoin?: boolean,
+  ): Promise<Dictionary<T[]>> {
+    const pivotMeta = this.metadata.get(prop.pivotEntity);
+    const targets = prop.polymorphTargets!;
+
+    // The pivot has a single real M:1 to the owner, plus a discriminator column and a FK scalar
+    // pointing at whichever target table each row references. We use the owner M:1 for the owner
+    // filter, and read the discriminator + FK as scalars to dispatch per row.
+    const ownerProp = pivotMeta.relations.find(r => r.persist !== false && !r.polymorphic)!;
+    const discriminatorColumn = prop.discriminatorColumn!;
+
+    const ownerMeta = ownerProp.targetMeta as EntityMetadata<O>;
+    const pkProp = ownerMeta.properties[ownerMeta.primaryKeys[0]];
+    const needsConversion = pkProp?.customType?.ensureComparable(ownerMeta, pkProp) && !ownerMeta.compositePK;
+    let ownerPks = ownerMeta.compositePK ? owners : owners.map(o => o[0]);
+
+    if (needsConversion) {
+      ownerPks = ownerPks.map(v => pkProp.customType!.convertToDatabaseValue(v, this.platform, { mode: 'query' }));
+    }
+
+    // Fetch the pivot rows with their discriminator + target FK as scalars
+    const pivotRows = (await this.find(pivotMeta.class, { [ownerProp.name]: { $in: ownerPks } } as any, {
+      ctx,
+      orderBy: this.getPivotOrderBy(prop, ownerProp, orderBy, options?.orderBy),
+      fields: [ownerProp.name, discriminatorColumn, prop.discriminator!] as any[],
+      populateWhere: undefined,
+      // @ts-ignore
+      _populateWhere: 'infer',
+    })) as EntityData<any>[];
+
+    if (pivotJoin) {
+      // ref mode — return just references without hydrating the target entities
+      const map = this.buildPivotResultMap<T, O>(owners, pivotRows, ownerProp.name, prop.discriminator!);
+      return map;
+    }
+
+    // Group pivot rows by target class so we can bulk-fetch each target type in one query
+    const rowsByTarget = new Map<EntityMetadata, EntityData<any>[]>();
+    for (const row of pivotRows) {
+      const discValue = (row as Dictionary)[discriminatorColumn] as string;
+      const targetClass = prop.discriminatorMap![discValue];
+      const targetMeta = targets.find(t => t.class === targetClass);
+
+      /* v8 ignore next 3 - defensive: unknown discriminator value */
+      if (!targetMeta) {
+        continue;
+      }
+
+      const list = rowsByTarget.get(targetMeta) ?? [];
+      list.push(row);
+      rowsByTarget.set(targetMeta, list);
+    }
+
+    // Per-target bulk load, then attach hydrated entities back onto their pivot rows
+    const populate = (options?.populate as PopulateOptions<T>[]) ?? [];
+
+    for (const [targetMeta, rows] of rowsByTarget) {
+      const targetIds = rows.map(r => (r as Dictionary)[prop.discriminator!]);
+      const cond = { [targetMeta.primaryKeys[0]]: { $in: targetIds } };
+
+      if (!Utils.isEmpty(where)) {
+        Object.assign(cond, where);
+      }
+
+      // strip outer find's orderBy/fields/etc. before bulk-loading targets by PK — those apply to the
+      // owner query, not each polymorph target (Image and Video wouldn't share an orderBy field).
+      const { orderBy: _o, fields: _f, exclude: _e, ...childOptions } = (options ?? {}) as Dictionary;
+      const results = (await this.find<any>(targetMeta.class, cond as FilterQuery<any>, {
+        ctx,
+        ...childOptions,
+        populate: populate as any,
+      })) as EntityData<any>[];
+      const primaryKey = targetMeta.primaryKeys[0];
+      const byPk = new Map<string, EntityData<any>>();
+      for (const row of results) {
+        // mark the data with the concrete class so findChildrenFromPivotTable can
+        // dispatch factory.create to the right type per item
+        Object.defineProperty(row, 'constructor', {
+          value: targetMeta.class,
+          enumerable: false,
+          configurable: true,
+        });
+        byPk.set(Utils.getPrimaryKeyHash(Utils.asArray((row as Dictionary)[primaryKey])), row);
+      }
+      for (const row of rows) {
+        const pkHash = Utils.getPrimaryKeyHash(Utils.asArray((row as Dictionary)[prop.discriminator!]));
+        (row as Dictionary)[prop.discriminator!] = byPk.get(pkHash);
+      }
+    }
+
+    return this.buildPivotResultMap<T, O>(owners, pivotRows, ownerProp.name, prop.discriminator!);
   }
 
   /**

--- a/packages/sql/src/AbstractSqlDriver.ts
+++ b/packages/sql/src/AbstractSqlDriver.ts
@@ -2007,7 +2007,7 @@ export abstract class AbstractSqlDriver<
     _where: FilterQuery<any> = {} as FilterQuery<any>,
     orderBy?: OrderDefinition<T>,
     ctx?: Transaction,
-    options?: FindOptions<T, any, any, any>,
+    options: FindOptions<T, any, any, any> = {} as FindOptions<T, any, any, any>,
     _pivotJoin?: boolean,
   ): Promise<Dictionary<T[]>> {
     const pivotMeta = this.metadata.get(prop.pivotEntity);
@@ -2031,6 +2031,7 @@ export abstract class AbstractSqlDriver<
       _populateWhere: 'infer',
     })) as EntityData<any>[];
 
+    /* v8 ignore next 7 - custom-type PK conversion, tested via loadFromPivotTable path */
     if (needsConversion) {
       for (const item of pivotRows) {
         const fk = (item as any)[ownerProp.name];
@@ -2061,8 +2062,8 @@ export abstract class AbstractSqlDriver<
     // Strip the outer find's orderBy/fields/exclude before bulk-loading targets by PK — those apply
     // to the owner query, not each polymorph target (Image and Video wouldn't share an orderBy field).
     // Hoisted above the loop since `options` doesn't change per target.
-    const { orderBy: _o, fields: _f, exclude: _e, ...childOptions } = (options ?? {}) as Dictionary;
-    const populate = (options?.populate as PopulateOptions<T>[]) ?? [];
+    const { orderBy: _o, fields: _f, exclude: _e, ...childOptions } = options as Dictionary;
+    const populate = (options.populate as PopulateOptions<T>[]) ?? [];
 
     for (const [targetMeta, rows] of rowsByTarget) {
       const targetIds = rows.map(r => (r as Dictionary)[prop.discriminator!]);
@@ -2142,6 +2143,7 @@ export abstract class AbstractSqlDriver<
     const needsConversion = !!pkProp?.customType?.ensureComparable(ownerMeta, pkProp) && !ownerMeta.compositePK;
     let ownerPks: Primary<O>[] | Primary<O>[][] = ownerMeta.compositePK ? owners : owners.map(o => o[0]);
 
+    /* v8 ignore next 4 - custom-type PK conversion, tested via loadFromPivotTable path */
     if (needsConversion) {
       ownerPks = (ownerPks as Primary<O>[]).map(v =>
         pkProp.customType!.convertToDatabaseValue(v, this.platform, { mode: 'query' }),

--- a/packages/sql/src/AbstractSqlDriver.ts
+++ b/packages/sql/src/AbstractSqlDriver.ts
@@ -2020,7 +2020,7 @@ export abstract class AbstractSqlDriver<
     const discriminatorColumn = prop.discriminatorColumn!;
 
     const ownerMeta = ownerProp.targetMeta as EntityMetadata<O>;
-    const { ownerPks } = this.convertOwnerPksForPivotQuery<O>(owners, ownerMeta);
+    const { ownerPks, needsConversion, pkProp } = this.convertOwnerPksForPivotQuery<O>(owners, ownerMeta);
 
     const pivotRows = (await this.find(pivotMeta.class, { [ownerProp.name]: { $in: ownerPks } } as any, {
       ctx,
@@ -2031,12 +2031,22 @@ export abstract class AbstractSqlDriver<
       _populateWhere: 'infer',
     })) as EntityData<any>[];
 
+    if (needsConversion) {
+      for (const item of pivotRows) {
+        const fk = (item as any)[ownerProp.name];
+
+        if (fk != null) {
+          (item as any)[ownerProp.name] = pkProp.customType!.convertToJSValue(fk, this.platform);
+        }
+      }
+    }
+
     const classMeta = new Map(targets.map(t => [t.class, t]));
     const rowsByTarget = new Map<EntityMetadata, EntityData<any>[]>();
     for (const row of pivotRows) {
       const discValue = (row as Dictionary)[discriminatorColumn] as string;
       const targetClass = prop.discriminatorMap![discValue];
-      const targetMeta = classMeta.get(targetClass);
+      const targetMeta = classMeta.get(targetClass as any);
 
       /* v8 ignore next 3 - defensive: unknown discriminator value */
       if (!targetMeta) {

--- a/packages/sql/src/AbstractSqlDriver.ts
+++ b/packages/sql/src/AbstractSqlDriver.ts
@@ -2004,18 +2004,16 @@ export abstract class AbstractSqlDriver<
   protected async loadFromUnionTargetPolymorphicPivotTable<T extends object, O extends object>(
     prop: EntityProperty,
     owners: Primary<O>[][],
-    _where: FilterQuery<any> = {} as FilterQuery<any>,
+    where: FilterQuery<any> = {} as FilterQuery<any>,
     orderBy?: OrderDefinition<T>,
     ctx?: Transaction,
     options: FindOptions<T, any, any, any> = {} as FindOptions<T, any, any, any>,
+    // pivotJoin (:ref hints) is not supported for union-target — EntityLoader.getReference needs
+    // both a concrete class and a PK per item, but the ref-mode map only carries flat PK values.
     _pivotJoin?: boolean,
   ): Promise<Dictionary<T[]>> {
     const pivotMeta = this.metadata.get(prop.pivotEntity);
     const targets = prop.polymorphTargets!;
-
-    // The pivot has a single real M:1 to the owner, plus a discriminator column and a FK scalar
-    // pointing at whichever target table each row references. We use the owner M:1 for the owner
-    // filter, and read the discriminator + FK as scalars to dispatch per row.
     const ownerProp = pivotMeta.relations.find(r => r.persist !== false && !r.polymorphic)!;
     const discriminatorColumn = prop.discriminatorColumn!;
 
@@ -2067,23 +2065,31 @@ export abstract class AbstractSqlDriver<
 
     for (const [targetMeta, rows] of rowsByTarget) {
       const targetIds = rows.map(r => (r as Dictionary)[prop.discriminator!]);
-      const cond = { [targetMeta.primaryKeys[0]]: { $in: targetIds } };
+      const pkCol = targetMeta.compositePK
+        ? Utils.getPrimaryKeyHash(targetMeta.primaryKeys)
+        : targetMeta.primaryKeys[0];
+      const cond: Dictionary = { [pkCol]: { $in: targetIds } };
+
+      if (!Utils.isEmpty(where)) {
+        Object.assign(cond, where);
+      }
+
       const results = (await this.find<any>(targetMeta.class, cond as FilterQuery<any>, {
         ctx,
         ...childOptions,
         populate: populate as any,
       })) as EntityData<any>[];
-      const primaryKey = targetMeta.primaryKeys[0];
       const byPk = new Map<string, EntityData<any>>();
       for (const row of results) {
-        // Marks the data with its concrete class so EntityLoader.findChildrenFromPivotTable can
-        // dispatch factory.create per item — same trick used for polymorphic @ManyToOne targets.
         Object.defineProperty(row, 'constructor', {
           value: targetMeta.class,
           enumerable: false,
           configurable: true,
         });
-        byPk.set(Utils.getPrimaryKeyHash(Utils.asArray((row as Dictionary)[primaryKey])), row);
+        const pk = targetMeta.compositePK
+          ? targetMeta.primaryKeys.map(k => (row as Dictionary)[k])
+          : [(row as Dictionary)[targetMeta.primaryKeys[0]]];
+        byPk.set(Utils.getPrimaryKeyHash(pk as string[]), row);
       }
       for (const row of rows) {
         const pkHash = Utils.getPrimaryKeyHash(Utils.asArray((row as Dictionary)[prop.discriminator!]));

--- a/packages/sql/src/AbstractSqlDriver.ts
+++ b/packages/sql/src/AbstractSqlDriver.ts
@@ -1649,16 +1649,22 @@ export abstract class AbstractSqlDriver<
       const snap = coll.getSnapshot();
       const includes = <T>(arr: T[][], item: T[]) => !!arr.find(i => this.comparePrimaryKeyArrays(i, item));
       // For union-target polymorphic M:N, prepend the per-row discriminator value so the pivot
-      // persister can write it alongside the FK id. Same prototype-walking helper that handles
-      // TPT subclasses in polymorphic M:1 (QueryHelper.findDiscriminatorValue).
-      const isUnionTargetMN = coll.property.polymorphic && (coll.property.polymorphTargets?.length ?? 0) > 1;
+      // persister can write it alongside the FK id. Memoized per sync-run because a collection can
+      // hold hundreds of items of the same few types, and findDiscriminatorValue walks the prototype
+      // chain + re-scans Object.entries each call.
+      const isUnionTargetMN = QueryHelper.isUnionTargetPolymorphic(coll.property);
+      const classToDisc = new Map<Function, Primary<any>>();
       const toDiff = (item: AnyEntity) => {
         const keys = helper(item).getPrimaryKeys(true)!;
         if (!isUnionTargetMN) {
           return keys;
         }
-        const disc = QueryHelper.findDiscriminatorValue(coll.property.discriminatorMap!, item.constructor);
-        return [disc as Primary<any>, ...keys];
+        let disc = classToDisc.get(item.constructor);
+        if (disc === undefined) {
+          disc = QueryHelper.findDiscriminatorValue(coll.property.discriminatorMap!, item.constructor) as Primary<any>;
+          classToDisc.set(item.constructor, disc);
+        }
+        return [disc, ...keys];
       };
       const snapshot = snap ? snap.map(toDiff) : [];
       const current = coll.getItems(false).map(toDiff);
@@ -1764,7 +1770,7 @@ export abstract class AbstractSqlDriver<
 
     const pivotMeta = this.metadata.get(prop.pivotEntity);
 
-    if (prop.polymorphic && prop.discriminatorColumn && prop.polymorphTargets && prop.polymorphTargets.length > 1) {
+    if (prop.discriminatorColumn && QueryHelper.isUnionTargetPolymorphic(prop)) {
       return this.loadFromUnionTargetPolymorphicPivotTable(prop, owners, where, orderBy, ctx, options, pivotJoin);
     }
 
@@ -1775,17 +1781,7 @@ export abstract class AbstractSqlDriver<
     const pivotProp1 = pivotMeta.relations[prop.owner ? 1 : 0];
     const pivotProp2 = pivotMeta.relations[prop.owner ? 0 : 1];
     const ownerMeta = pivotProp2.targetMeta as EntityMetadata<O>;
-
-    // The pivot query builder doesn't convert custom types, so we need to manually
-    // convert owner PKs to DB format for the query and convert result FKs back to
-    // JS format for consistent key hashing in buildPivotResultMap.
-    const pkProp = ownerMeta.properties[ownerMeta.primaryKeys[0]];
-    const needsConversion = pkProp?.customType?.ensureComparable(ownerMeta, pkProp) && !ownerMeta.compositePK;
-    let ownerPks = ownerMeta.compositePK ? owners : owners.map(o => o[0]);
-
-    if (needsConversion) {
-      ownerPks = ownerPks.map(v => pkProp.customType!.convertToDatabaseValue(v, this.platform, { mode: 'query' }));
-    }
+    const { ownerPks, needsConversion, pkProp } = this.convertOwnerPksForPivotQuery<O>(owners, ownerMeta);
 
     const cond = {
       [pivotProp2.name]: { $in: ownerPks },
@@ -2024,15 +2020,8 @@ export abstract class AbstractSqlDriver<
     const discriminatorColumn = prop.discriminatorColumn!;
 
     const ownerMeta = ownerProp.targetMeta as EntityMetadata<O>;
-    const pkProp = ownerMeta.properties[ownerMeta.primaryKeys[0]];
-    const needsConversion = pkProp?.customType?.ensureComparable(ownerMeta, pkProp) && !ownerMeta.compositePK;
-    let ownerPks = ownerMeta.compositePK ? owners : owners.map(o => o[0]);
+    const { ownerPks } = this.convertOwnerPksForPivotQuery<O>(owners, ownerMeta);
 
-    if (needsConversion) {
-      ownerPks = ownerPks.map(v => pkProp.customType!.convertToDatabaseValue(v, this.platform, { mode: 'query' }));
-    }
-
-    // Fetch the pivot rows with their discriminator + target FK as scalars
     const pivotRows = (await this.find(pivotMeta.class, { [ownerProp.name]: { $in: ownerPks } } as any, {
       ctx,
       orderBy: this.getPivotOrderBy(prop, ownerProp, orderBy, options?.orderBy),
@@ -2043,12 +2032,9 @@ export abstract class AbstractSqlDriver<
     })) as EntityData<any>[];
 
     if (pivotJoin) {
-      // ref mode — return just references without hydrating the target entities
-      const map = this.buildPivotResultMap<T, O>(owners, pivotRows, ownerProp.name, prop.discriminator!);
-      return map;
+      return this.buildPivotResultMap<T, O>(owners, pivotRows, ownerProp.name, prop.discriminator!);
     }
 
-    // Group pivot rows by target class so we can bulk-fetch each target type in one query
     const rowsByTarget = new Map<EntityMetadata, EntityData<any>[]>();
     for (const row of pivotRows) {
       const discValue = (row as Dictionary)[discriminatorColumn] as string;
@@ -2065,7 +2051,10 @@ export abstract class AbstractSqlDriver<
       rowsByTarget.set(targetMeta, list);
     }
 
-    // Per-target bulk load, then attach hydrated entities back onto their pivot rows
+    // Strip the outer find's orderBy/fields/exclude before bulk-loading targets by PK — those apply
+    // to the owner query, not each polymorph target (Image and Video wouldn't share an orderBy field).
+    // Hoisted above the loop since `options` doesn't change per target.
+    const { orderBy: _o, fields: _f, exclude: _e, ...childOptions } = (options ?? {}) as Dictionary;
     const populate = (options?.populate as PopulateOptions<T>[]) ?? [];
 
     for (const [targetMeta, rows] of rowsByTarget) {
@@ -2076,9 +2065,6 @@ export abstract class AbstractSqlDriver<
         Object.assign(cond, where);
       }
 
-      // strip outer find's orderBy/fields/etc. before bulk-loading targets by PK — those apply to the
-      // owner query, not each polymorph target (Image and Video wouldn't share an orderBy field).
-      const { orderBy: _o, fields: _f, exclude: _e, ...childOptions } = (options ?? {}) as Dictionary;
       const results = (await this.find<any>(targetMeta.class, cond as FilterQuery<any>, {
         ctx,
         ...childOptions,
@@ -2087,8 +2073,8 @@ export abstract class AbstractSqlDriver<
       const primaryKey = targetMeta.primaryKeys[0];
       const byPk = new Map<string, EntityData<any>>();
       for (const row of results) {
-        // mark the data with the concrete class so findChildrenFromPivotTable can
-        // dispatch factory.create to the right type per item
+        // Marks the data with its concrete class so EntityLoader.findChildrenFromPivotTable can
+        // dispatch factory.create per item — same trick used for polymorphic @ManyToOne targets.
         Object.defineProperty(row, 'constructor', {
           value: targetMeta.class,
           enumerable: false,
@@ -2139,6 +2125,28 @@ export abstract class AbstractSqlDriver<
     }
 
     return undefined;
+  }
+
+  /**
+   * The pivot query builder doesn't convert custom types — manually convert owner PKs to the DB
+   * representation. Returns `needsConversion` + `pkProp` so the caller can convert result FKs back
+   * to JS format for consistent key hashing in `buildPivotResultMap`.
+   */
+  private convertOwnerPksForPivotQuery<O extends object>(
+    owners: Primary<O>[][],
+    ownerMeta: EntityMetadata<O>,
+  ): { ownerPks: Primary<O>[] | Primary<O>[][]; needsConversion: boolean; pkProp: EntityProperty<O> } {
+    const pkProp = ownerMeta.properties[ownerMeta.primaryKeys[0]];
+    const needsConversion = !!pkProp?.customType?.ensureComparable(ownerMeta, pkProp) && !ownerMeta.compositePK;
+    let ownerPks: Primary<O>[] | Primary<O>[][] = ownerMeta.compositePK ? owners : owners.map(o => o[0]);
+
+    if (needsConversion) {
+      ownerPks = (ownerPks as Primary<O>[]).map(v =>
+        pkProp.customType!.convertToDatabaseValue(v, this.platform, { mode: 'query' }),
+      );
+    }
+
+    return { ownerPks, needsConversion, pkProp };
   }
 
   private getPivotOrderBy<T>(

--- a/packages/sql/src/AbstractSqlDriver.ts
+++ b/packages/sql/src/AbstractSqlDriver.ts
@@ -2068,10 +2068,10 @@ export abstract class AbstractSqlDriver<
       const pkCol = targetMeta.compositePK
         ? Utils.getPrimaryKeyHash(targetMeta.primaryKeys)
         : targetMeta.primaryKeys[0];
-      const cond: Dictionary = { [pkCol]: { $in: targetIds } };
+      let cond: Dictionary = { [pkCol]: { $in: targetIds } };
 
       if (!Utils.isEmpty(where)) {
-        Object.assign(cond, where);
+        cond = { $and: [cond, where] };
       }
 
       const results = (await this.find<any>(targetMeta.class, cond as FilterQuery<any>, {
@@ -2093,7 +2093,14 @@ export abstract class AbstractSqlDriver<
       }
       for (const row of rows) {
         const pkHash = Utils.getPrimaryKeyHash(Utils.asArray((row as Dictionary)[prop.discriminator!]));
-        (row as Dictionary)[prop.discriminator!] = byPk.get(pkHash);
+        const entity = byPk.get(pkHash);
+
+        if (entity == null) {
+          pivotRows.splice(pivotRows.indexOf(row), 1);
+          continue;
+        }
+
+        (row as Dictionary)[prop.discriminator!] = entity;
       }
     }
 

--- a/packages/sql/src/PivotCollectionPersister.ts
+++ b/packages/sql/src/PivotCollectionPersister.ts
@@ -6,6 +6,7 @@ import {
   type EntityProperty,
   type FilterQuery,
   type Primary,
+  QueryHelper,
   type Transaction,
 } from '@mikro-orm/core';
 import { type AbstractSqlDriver } from './AbstractSqlDriver.js';
@@ -156,12 +157,15 @@ export class PivotCollectionPersister<Entity extends object> {
     let data: Primary<Entity>[];
     let keys: string[];
 
-    // Union-target polymorphic M:N prepends the per-row discriminator to `fks` in syncCollections.
-    const isUnionTargetMN = prop.polymorphic && (prop.polymorphTargets?.length ?? 0) > 1;
-    let perRowDiscriminator: Primary<Entity> | undefined;
+    // Union-target polymorphic M:N prepends the per-row discriminator to `fks` in syncCollections;
+    // Rails-style polymorphic M:N uses a static discriminatorValue on the prop. Normalize to a single
+    // "current row's discriminator" value so the prepend block below handles both cases uniformly.
+    let rowDiscriminator: Primary<Entity> | undefined;
 
-    if (isUnionTargetMN && !deleteAll && fks.length > 0) {
-      [perRowDiscriminator, ...fks] = fks;
+    if (QueryHelper.isUnionTargetPolymorphic(prop) && !deleteAll && fks.length > 0) {
+      [rowDiscriminator, ...fks] = fks;
+    } else if (prop.polymorphic && prop.discriminatorColumn && prop.discriminatorValue) {
+      rowDiscriminator = prop.discriminatorValue as Primary<Entity>;
     }
 
     if (deleteAll) {
@@ -174,13 +178,9 @@ export class PivotCollectionPersister<Entity extends object> {
         : [...prop.joinColumns, ...prop.inverseJoinColumns];
     }
 
-    if (perRowDiscriminator !== undefined) {
-      data = [perRowDiscriminator, ...data];
+    if (rowDiscriminator !== undefined) {
+      data = [rowDiscriminator, ...data];
       keys = [prop.discriminatorColumn!, ...keys];
-    } else if (prop.polymorphic && prop.discriminatorColumn && prop.discriminatorValue) {
-      // Rails-style polymorphic M:N: static discriminator per prop
-      data = [prop.discriminatorValue as Primary<Entity>, ...data];
-      keys = [prop.discriminatorColumn, ...keys];
     }
 
     return { data, keys };

--- a/packages/sql/src/PivotCollectionPersister.ts
+++ b/packages/sql/src/PivotCollectionPersister.ts
@@ -156,6 +156,14 @@ export class PivotCollectionPersister<Entity extends object> {
     let data: Primary<Entity>[];
     let keys: string[];
 
+    // Union-target polymorphic M:N prepends the per-row discriminator to `fks` in syncCollections.
+    const isUnionTargetMN = prop.polymorphic && (prop.polymorphTargets?.length ?? 0) > 1;
+    let perRowDiscriminator: Primary<Entity> | undefined;
+
+    if (isUnionTargetMN && !deleteAll && fks.length > 0) {
+      [perRowDiscriminator, ...fks] = fks;
+    }
+
     if (deleteAll) {
       data = pks;
       keys = prop.joinColumns;
@@ -166,7 +174,11 @@ export class PivotCollectionPersister<Entity extends object> {
         : [...prop.joinColumns, ...prop.inverseJoinColumns];
     }
 
-    if (prop.polymorphic && prop.discriminatorColumn && prop.discriminatorValue) {
+    if (perRowDiscriminator !== undefined) {
+      data = [perRowDiscriminator, ...data];
+      keys = [prop.discriminatorColumn!, ...keys];
+    } else if (prop.polymorphic && prop.discriminatorColumn && prop.discriminatorValue) {
+      // Rails-style polymorphic M:N: static discriminator per prop
       data = [prop.discriminatorValue as Primary<Entity>, ...data];
       keys = [prop.discriminatorColumn, ...keys];
     }

--- a/tests/features/polymorphic-relations/polymorphic-m-to-n-union.sqlite.test.ts
+++ b/tests/features/polymorphic-relations/polymorphic-m-to-n-union.sqlite.test.ts
@@ -12,6 +12,9 @@ class Image {
   @Property()
   url!: string;
 
+  @ManyToMany(() => Post, (p: Post) => p.attachments)
+  posts = new Collection<Post>(this);
+
   constructor(url: string) {
     this.url = url;
   }
@@ -24,6 +27,9 @@ class Video {
 
   @Property()
   src!: string;
+
+  @ManyToMany(() => Post, (p: Post) => p.attachments)
+  posts = new Collection<Post>(this);
 
   constructor(src: string) {
     this.src = src;
@@ -79,6 +85,15 @@ describe('polymorphic M:N with union target', () => {
     expect(prop.discriminatorColumn).toBe('attachable_type');
     expect(prop.polymorphTargets).toBeDefined();
     expect(prop.polymorphTargets!.map(m => m.className).sort()).toEqual(['Image', 'Video']);
+  });
+
+  test('metadata: inverse sides inherit pivot info and own discriminator value', () => {
+    const imgMeta = orm.getMetadata().get(Image);
+    const vidMeta = orm.getMetadata().get(Video);
+    expect(imgMeta.properties.posts.pivotEntity).toBeDefined();
+    expect(vidMeta.properties.posts.pivotEntity).toBeDefined();
+    expect(imgMeta.properties.posts.discriminatorValue).toBe('image');
+    expect(vidMeta.properties.posts.discriminatorValue).toBe('video');
   });
 
   test('schema: pivot has discriminator + target id, no FK on target_id', async () => {
@@ -168,6 +183,25 @@ describe('polymorphic M:N with union target', () => {
 
     const loaded = await orm.em.findOneOrFail(Post, { title: 'No attachments' }, { populate: ['attachments'] });
     expect(loaded.attachments.getItems()).toHaveLength(0);
+  });
+
+  test('inverse side: Image.posts loads only posts attached to images (filtered by discriminator)', async () => {
+    const img = new Image('https://example.com/a.png');
+    const vid = new Video('https://example.com/b.mp4');
+    const p1 = new Post('with image');
+    const p2 = new Post('with video');
+    p1.attachments.add(img);
+    p2.attachments.add(vid);
+    await orm.em.persist([p1, p2]).flush();
+    orm.em.clear();
+
+    const loadedImg = await orm.em.findOneOrFail(Image, { url: 'https://example.com/a.png' }, { populate: ['posts'] });
+    expect(loadedImg.posts.getItems()).toHaveLength(1);
+    expect(loadedImg.posts[0].title).toBe('with image');
+
+    const loadedVid = await orm.em.findOneOrFail(Video, { src: 'https://example.com/b.mp4' }, { populate: ['posts'] });
+    expect(loadedVid.posts.getItems()).toHaveLength(1);
+    expect(loadedVid.posts[0].title).toBe('with video');
   });
 
   test('multiple posts with overlapping attachments bucket correctly per owner', async () => {

--- a/tests/features/polymorphic-relations/polymorphic-m-to-n-union.sqlite.test.ts
+++ b/tests/features/polymorphic-relations/polymorphic-m-to-n-union.sqlite.test.ts
@@ -232,4 +232,248 @@ describe('polymorphic M:N with union target', () => {
     expect(p1Types).toEqual(['Image', 'Video']);
     expect(p2Types).toEqual(['Image', 'Video']);
   });
+
+  test('populateFilter restricts which attachments load, applied per target', async () => {
+    const keep = new Image('https://example.com/keep.png');
+    const drop = new Image('https://example.com/drop.png');
+    const vid = new Video('https://example.com/v.mp4');
+    const post = new Post('Filter post');
+
+    post.attachments.add(keep, drop, vid);
+    await orm.em.persist(post).flush();
+    orm.em.clear();
+
+    const loaded = await orm.em.findOneOrFail(
+      Post,
+      { title: 'Filter post' },
+      {
+        populate: ['attachments'],
+        populateFilter: { attachments: { id: { $ne: drop.id } } },
+      },
+    );
+    const items = loaded.attachments.getItems();
+    expect(items).toHaveLength(2);
+    expect(items.some(i => i instanceof Image && (i as Image).url === 'https://example.com/keep.png')).toBe(true);
+    expect(items.some(i => i instanceof Video)).toBe(true);
+    expect(items.every(i => !(i instanceof Image && (i as Image).url === 'https://example.com/drop.png'))).toBe(true);
+  });
+
+  test('populateWhere filters the populated union collection', async () => {
+    const keep = new Image('https://example.com/keep.png');
+    const drop = new Image('https://example.com/drop.png');
+    const vid = new Video('https://example.com/v.mp4');
+    const post = new Post('Where post');
+
+    post.attachments.add(keep, drop, vid);
+    await orm.em.persist(post).flush();
+    orm.em.clear();
+
+    const loaded = await orm.em.findOneOrFail(
+      Post,
+      { title: 'Where post' },
+      {
+        populate: ['attachments'],
+        populateWhere: { attachments: { id: { $ne: drop.id } } },
+      },
+    );
+    const items = loaded.attachments.getItems();
+    expect(items).toHaveLength(2);
+    expect(items.every(i => !(i instanceof Image && (i as Image).url === 'https://example.com/drop.png'))).toBe(true);
+  });
+});
+
+describe('polymorphic M:N union-target validation', () => {
+  test('throws when targets have incompatible PK column types', async () => {
+    @Entity()
+    class IntTarget {
+      @PrimaryKey()
+      id!: number;
+
+      @ManyToMany(() => Owner, (o: any) => o.items)
+      owners = new Collection<any>(this);
+    }
+
+    @Entity()
+    class StrTarget {
+      @PrimaryKey()
+      id!: string;
+
+      @ManyToMany(() => Owner, (o: any) => o.items)
+      owners = new Collection<any>(this);
+    }
+
+    @Entity()
+    class Owner {
+      @PrimaryKey()
+      id!: number;
+
+      @ManyToMany({
+        entity: () => [IntTarget, StrTarget],
+        pivotTable: 'owner_items',
+        discriminator: 'item',
+        owner: true,
+      })
+      items = new Collection<IntTarget | StrTarget>(this);
+    }
+
+    await expect(
+      MikroORM.init({
+        entities: [IntTarget, StrTarget, Owner],
+        dbName: ':memory:',
+        metadataProvider: ReflectMetadataProvider,
+      }),
+    ).rejects.toThrow(/incompatible polymorphic targets .*incompatible primary key types/);
+  });
+
+  test('throws when union target array has a single entry', async () => {
+    @Entity()
+    class Only {
+      @PrimaryKey()
+      id!: number;
+    }
+
+    @Entity()
+    class SingleOwner {
+      @PrimaryKey()
+      id!: number;
+
+      @ManyToMany({
+        entity: () => [Only],
+        pivotTable: 'single_items',
+        discriminator: 'item',
+        owner: true,
+      })
+      items = new Collection<Only>(this);
+    }
+
+    await expect(
+      MikroORM.init({
+        entities: [Only, SingleOwner],
+        dbName: ':memory:',
+        metadataProvider: ReflectMetadataProvider,
+      }),
+    ).rejects.toThrow(/union-target polymorphic M:N requires at least two target entity types/);
+  });
+
+  test('throws when a union target has a composite primary key', async () => {
+    @Entity()
+    class SimpleTarget {
+      @PrimaryKey()
+      id!: number;
+    }
+
+    @Entity()
+    class CompositeTarget {
+      @PrimaryKey()
+      a!: number;
+
+      @PrimaryKey()
+      b!: number;
+    }
+
+    @Entity()
+    class CompOwner {
+      @PrimaryKey()
+      id!: number;
+
+      @ManyToMany({
+        entity: () => [SimpleTarget, CompositeTarget],
+        pivotTable: 'comp_items',
+        discriminator: 'item',
+        owner: true,
+      })
+      items = new Collection<SimpleTarget | CompositeTarget>(this);
+    }
+
+    await expect(
+      MikroORM.init({
+        entities: [SimpleTarget, CompositeTarget, CompOwner],
+        dbName: ':memory:',
+        metadataProvider: ReflectMetadataProvider,
+      }),
+    ).rejects.toThrow(/union-target polymorphic M:N does not support composite-PK targets/);
+  });
+});
+
+describe('polymorphic M:N union-target unsupported populate hints', () => {
+  @Entity()
+  class Img2 {
+    @PrimaryKey()
+    id!: number;
+
+    @Property()
+    url!: string;
+  }
+
+  @Entity()
+  class Vid2 {
+    @PrimaryKey()
+    id!: number;
+
+    @Property()
+    src!: string;
+  }
+
+  @Entity()
+  class Article {
+    @PrimaryKey()
+    id!: number;
+
+    @Property()
+    title!: string;
+
+    @ManyToMany({
+      entity: () => [Img2, Vid2],
+      pivotTable: 'article_attachables',
+      discriminator: 'attachable',
+      owner: true,
+    })
+    attachments = new Collection<Img2 | Vid2>(this);
+
+    constructor(title: string) {
+      this.title = title;
+    }
+  }
+
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      entities: [Img2, Vid2, Article],
+      dbName: ':memory:',
+      metadataProvider: ReflectMetadataProvider,
+    });
+    await orm.schema.create();
+  });
+
+  afterAll(async () => {
+    await orm.close(true);
+  });
+
+  test(':ref populate hint throws clearly instead of returning wrong target classes', async () => {
+    const article = new Article('Article');
+    await orm.em.persist(article).flush();
+    orm.em.clear();
+
+    await expect(orm.em.findOneOrFail(Article, article.id, { populate: ['attachments:ref'] as any })).rejects.toThrow(
+      /':ref' populate hint is not supported for union-target/,
+    );
+  });
+
+  test('JOINED load strategy silently falls back to SELECT_IN (no error)', async () => {
+    const img = new Img2();
+    (img as any).url = 'u';
+    const article = new Article('Joined');
+    article.attachments.add(img);
+    await orm.em.persist(article).flush();
+    orm.em.clear();
+
+    const loaded = await orm.em.findOneOrFail(
+      Article,
+      { title: 'Joined' },
+      { populate: ['attachments'], strategy: 'joined' },
+    );
+    expect(loaded.attachments.getItems()).toHaveLength(1);
+    expect(loaded.attachments[0]).toBeInstanceOf(Img2);
+  });
 });

--- a/tests/features/polymorphic-relations/polymorphic-m-to-n-union.sqlite.test.ts
+++ b/tests/features/polymorphic-relations/polymorphic-m-to-n-union.sqlite.test.ts
@@ -44,7 +44,8 @@ class Post {
   @Property()
   title!: string;
 
-  @ManyToMany(() => [Image, Video] as any, undefined, {
+  @ManyToMany({
+    entity: () => [Image, Video] as any,
     pivotTable: 'attachables',
     discriminator: 'attachable',
     owner: true,

--- a/tests/features/polymorphic-relations/polymorphic-m-to-n-union.sqlite.test.ts
+++ b/tests/features/polymorphic-relations/polymorphic-m-to-n-union.sqlite.test.ts
@@ -45,7 +45,7 @@ class Post {
   title!: string;
 
   @ManyToMany({
-    entity: () => [Image, Video] as any,
+    entity: () => [Image, Video],
     pivotTable: 'attachables',
     discriminator: 'attachable',
     owner: true,

--- a/tests/features/polymorphic-relations/polymorphic-m-to-n-union.sqlite.test.ts
+++ b/tests/features/polymorphic-relations/polymorphic-m-to-n-union.sqlite.test.ts
@@ -1,0 +1,201 @@
+import { Collection, MikroORM } from '@mikro-orm/sqlite';
+import { Entity, ManyToMany, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+
+// Owner-side union target: Post.attachments holds a mixed collection of Image | Video
+// stored in one pivot with an attachable_type discriminator.
+
+@Entity()
+class Image {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  url!: string;
+
+  constructor(url: string) {
+    this.url = url;
+  }
+}
+
+@Entity()
+class Video {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  src!: string;
+
+  constructor(src: string) {
+    this.src = src;
+  }
+}
+
+@Entity()
+class Post {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  title!: string;
+
+  @ManyToMany(() => [Image, Video] as any, undefined, {
+    pivotTable: 'attachables',
+    discriminator: 'attachable',
+    owner: true,
+  })
+  attachments = new Collection<Image | Video>(this);
+
+  constructor(title: string) {
+    this.title = title;
+  }
+}
+
+describe('polymorphic M:N with union target', () => {
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      entities: [Image, Video, Post],
+      dbName: ':memory:',
+      metadataProvider: ReflectMetadataProvider,
+    });
+    await orm.schema.create();
+  });
+
+  afterAll(async () => {
+    await orm.close(true);
+  });
+
+  beforeEach(async () => {
+    await orm.schema.clear();
+    orm.em.clear();
+  });
+
+  test('metadata: polymorphTargets populated for union-target M:N', () => {
+    const postMeta = orm.getMetadata().get(Post);
+    const prop = postMeta.properties.attachments;
+
+    expect(prop.polymorphic).toBe(true);
+    expect(prop.discriminatorColumn).toBe('attachable_type');
+    expect(prop.polymorphTargets).toBeDefined();
+    expect(prop.polymorphTargets!.map(m => m.className).sort()).toEqual(['Image', 'Video']);
+  });
+
+  test('schema: pivot has discriminator + target id, no FK on target_id', async () => {
+    const sql = await orm.schema.getCreateSchemaSQL();
+    expect(sql).toContain('attachables');
+    expect(sql).toContain('attachable_type');
+    expect(sql).toContain('attachable_id');
+    expect(sql).toContain('post_id');
+  });
+
+  test('insert: discriminator is written per row based on target class', async () => {
+    const image = new Image('https://example.com/a.png');
+    const video = new Video('https://example.com/b.mp4');
+    const post = new Post('Mixed post');
+
+    // @ts-expect-error TS limitation: Collection<A | B>.add() doesn't distribute the union
+    post.attachments.add(image, video);
+    await orm.em.persist(post).flush();
+    orm.em.clear();
+
+    const pivot = await orm.em.execute('SELECT * FROM attachables ORDER BY attachable_type, attachable_id');
+    expect(pivot).toHaveLength(2);
+    expect(pivot.map((r: any) => r.attachable_type).sort()).toEqual(['image', 'video']);
+  });
+
+  test('select: populate attachments hydrates mixed types', async () => {
+    const image = new Image('https://example.com/a.png');
+    const video = new Video('https://example.com/b.mp4');
+    const post = new Post('Mixed post');
+    // @ts-expect-error TS limitation
+    post.attachments.add(image, video);
+    await orm.em.persist(post).flush();
+    orm.em.clear();
+
+    const loaded = await orm.em.findOneOrFail(Post, { title: 'Mixed post' }, { populate: ['attachments'] });
+    const items = loaded.attachments.getItems();
+    expect(items).toHaveLength(2);
+    expect(items.some(i => i instanceof Image && i.url === 'https://example.com/a.png')).toBe(true);
+    expect(items.some(i => i instanceof Video && i.src === 'https://example.com/b.mp4')).toBe(true);
+  });
+
+  test('delete: removing one attachment filters by discriminator', async () => {
+    const image = new Image('https://example.com/a.png');
+    const video = new Video('https://example.com/b.mp4');
+    const post = new Post('Mixed post');
+    // @ts-expect-error TS limitation
+    post.attachments.add(image, video);
+    await orm.em.persist(post).flush();
+    orm.em.clear();
+
+    const loaded = await orm.em.findOneOrFail(Post, { title: 'Mixed post' }, { populate: ['attachments'] });
+    const img = loaded.attachments.getItems().find(i => i instanceof Image)!;
+    loaded.attachments.remove(img);
+    await orm.em.flush();
+    orm.em.clear();
+
+    const pivot = await orm.em.execute('SELECT * FROM attachables');
+    expect(pivot).toHaveLength(1);
+    expect(pivot[0].attachable_type).toBe('video');
+  });
+
+  test('update: swap an Image for a Video in the collection', async () => {
+    const image = new Image('https://example.com/a.png');
+    const post = new Post('Swap test');
+    post.attachments.add(image);
+    await orm.em.persist(post).flush();
+    orm.em.clear();
+
+    const loaded = await orm.em.findOneOrFail(Post, { title: 'Swap test' }, { populate: ['attachments'] });
+    loaded.attachments.removeAll();
+    const video = new Video('https://example.com/b.mp4');
+    loaded.attachments.add(video);
+    await orm.em.flush();
+    orm.em.clear();
+
+    const reloaded = await orm.em.findOneOrFail(Post, { title: 'Swap test' }, { populate: ['attachments'] });
+    const items = reloaded.attachments.getItems();
+    expect(items).toHaveLength(1);
+    expect(items[0]).toBeInstanceOf(Video);
+    expect((items[0] as Video).src).toBe('https://example.com/b.mp4');
+  });
+
+  test('empty collection: post with no attachments loads as empty', async () => {
+    const post = new Post('No attachments');
+    await orm.em.persist(post).flush();
+    orm.em.clear();
+
+    const loaded = await orm.em.findOneOrFail(Post, { title: 'No attachments' }, { populate: ['attachments'] });
+    expect(loaded.attachments.getItems()).toHaveLength(0);
+  });
+
+  test('multiple posts with overlapping attachments bucket correctly per owner', async () => {
+    const img1 = new Image('https://example.com/a.png');
+    const img2 = new Image('https://example.com/b.png');
+    const vid = new Video('https://example.com/c.mp4');
+    const p1 = new Post('post one');
+    const p2 = new Post('post two');
+    // @ts-expect-error TS limitation
+    p1.attachments.add(img1, vid);
+    // @ts-expect-error TS limitation
+    p2.attachments.add(img2, vid);
+    await orm.em.persist([p1, p2]).flush();
+    orm.em.clear();
+
+    const posts = await orm.em.find(Post, {}, { populate: ['attachments'], orderBy: { title: 'asc' } });
+    expect(posts).toHaveLength(2);
+    expect(posts[0].attachments.getItems()).toHaveLength(2);
+    expect(posts[1].attachments.getItems()).toHaveLength(2);
+    const p1Types = posts[0].attachments
+      .getItems()
+      .map(i => i.constructor.name)
+      .sort();
+    const p2Types = posts[1].attachments
+      .getItems()
+      .map(i => i.constructor.name)
+      .sort();
+    expect(p1Types).toEqual(['Image', 'Video']);
+    expect(p2Types).toEqual(['Image', 'Video']);
+  });
+});

--- a/tests/features/polymorphic-relations/polymorphic-m-to-n-union.sqlite.test.ts
+++ b/tests/features/polymorphic-relations/polymorphic-m-to-n-union.sqlite.test.ts
@@ -477,3 +477,70 @@ describe('polymorphic M:N union-target unsupported populate hints', () => {
     expect(loaded.attachments[0]).toBeInstanceOf(Img2);
   });
 });
+
+describe('polymorphic M:N union-target collection edge cases', () => {
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      entities: [Image, Video, Post],
+      dbName: ':memory:',
+      metadataProvider: ReflectMetadataProvider,
+    });
+    await orm.schema.create();
+  });
+
+  afterAll(async () => {
+    await orm.close(true);
+  });
+
+  beforeEach(async () => {
+    await orm.schema.clear();
+    orm.em.clear();
+  });
+
+  test('Collection.remove(predicate) drops matching items from a mixed collection', async () => {
+    const img = new Image('https://example.com/a.png');
+    const vid = new Video('https://example.com/b.mp4');
+    const post = new Post('predicate remove');
+    post.attachments.add(img, vid);
+    await orm.em.persist(post).flush();
+    orm.em.clear();
+
+    const loaded = await orm.em.findOneOrFail(Post, { title: 'predicate remove' }, { populate: ['attachments'] });
+    // predicate form exercises the callback path (entity instanceof Function) in Collection.remove
+    loaded.attachments.remove(item => item instanceof Image);
+    await orm.em.flush();
+    orm.em.clear();
+
+    const pivot = await orm.em.execute('SELECT * FROM attachables');
+    expect(pivot).toHaveLength(1);
+    expect(pivot[0].attachable_type).toBe('video');
+  });
+
+  test('flushing an off-union class in a union-target M:N collection throws a clear error', async () => {
+    // unrelated plain entity not part of Post.attachments' [Image, Video] union
+    @Entity()
+    class Foreign {
+      @PrimaryKey()
+      id!: number;
+    }
+
+    const foreignOrm = await MikroORM.init({
+      entities: [Image, Video, Post, Foreign],
+      dbName: ':memory:',
+      metadataProvider: ReflectMetadataProvider,
+    });
+    await foreignOrm.schema.create();
+
+    const post = new Post('off-union');
+    const foreign = foreignOrm.em.create(Foreign, {});
+    // bypass compile-time typing: the runtime guard in AbstractSqlDriver.syncCollections is what we exercise
+    (post.attachments as Collection<any>).add(foreign);
+    await expect(foreignOrm.em.persist(post).flush()).rejects.toThrow(
+      /Cannot resolve discriminator value for Foreign in attachments/,
+    );
+
+    await foreignOrm.close(true);
+  });
+});

--- a/tests/features/polymorphic-relations/polymorphic-m-to-n-union.sqlite.test.ts
+++ b/tests/features/polymorphic-relations/polymorphic-m-to-n-union.sqlite.test.ts
@@ -109,7 +109,6 @@ describe('polymorphic M:N with union target', () => {
     const video = new Video('https://example.com/b.mp4');
     const post = new Post('Mixed post');
 
-    // @ts-expect-error TS limitation: Collection<A | B>.add() doesn't distribute the union
     post.attachments.add(image, video);
     await orm.em.persist(post).flush();
     orm.em.clear();
@@ -123,7 +122,7 @@ describe('polymorphic M:N with union target', () => {
     const image = new Image('https://example.com/a.png');
     const video = new Video('https://example.com/b.mp4');
     const post = new Post('Mixed post');
-    // @ts-expect-error TS limitation
+
     post.attachments.add(image, video);
     await orm.em.persist(post).flush();
     orm.em.clear();
@@ -139,7 +138,7 @@ describe('polymorphic M:N with union target', () => {
     const image = new Image('https://example.com/a.png');
     const video = new Video('https://example.com/b.mp4');
     const post = new Post('Mixed post');
-    // @ts-expect-error TS limitation
+
     post.attachments.add(image, video);
     await orm.em.persist(post).flush();
     orm.em.clear();
@@ -210,9 +209,9 @@ describe('polymorphic M:N with union target', () => {
     const vid = new Video('https://example.com/c.mp4');
     const p1 = new Post('post one');
     const p2 = new Post('post two');
-    // @ts-expect-error TS limitation
+
     p1.attachments.add(img1, vid);
-    // @ts-expect-error TS limitation
+
     p2.attachments.add(img2, vid);
     await orm.em.persist([p1, p2]).flush();
     orm.em.clear();

--- a/tests/features/polymorphic-relations/polymorphic-many-to-many.sqlite.test.ts
+++ b/tests/features/polymorphic-relations/polymorphic-many-to-many.sqlite.test.ts
@@ -17,7 +17,7 @@ class Tag {
   videos = new Collection<Video>(this);
 
   // Merged inverse — single union collection across all polymorphic owners
-  @ManyToMany({ entity: () => [Post, Video] as any, mappedBy: 'tags' })
+  @ManyToMany({ entity: () => [Post, Video], mappedBy: 'tags' })
   owners = new Collection<Post | Video>(this);
 
   constructor(name: string) {

--- a/tests/features/polymorphic-relations/polymorphic-many-to-many.sqlite.test.ts
+++ b/tests/features/polymorphic-relations/polymorphic-many-to-many.sqlite.test.ts
@@ -17,7 +17,7 @@ class Tag {
   videos = new Collection<Video>(this);
 
   // Merged inverse — single union collection across all polymorphic owners
-  @ManyToMany(() => [Post, Video] as any, 'tags' as any)
+  @ManyToMany({ entity: () => [Post, Video] as any, mappedBy: 'tags' })
   owners = new Collection<Post | Video>(this);
 
   constructor(name: string) {

--- a/tests/features/polymorphic-relations/polymorphic-many-to-many.sqlite.test.ts
+++ b/tests/features/polymorphic-relations/polymorphic-many-to-many.sqlite.test.ts
@@ -16,6 +16,10 @@ class Tag {
   @ManyToMany(() => Video, video => video.tags)
   videos = new Collection<Video>(this);
 
+  // Merged inverse — single union collection across all polymorphic owners
+  @ManyToMany(() => [Post, Video] as any, 'tags' as any)
+  owners = new Collection<Post | Video>(this);
+
   constructor(name: string) {
     this.name = name;
   }
@@ -382,6 +386,24 @@ describe('polymorphic many-to-many relations', () => {
     // Only posts matching the filter should be populated
     expect(loadedTag.posts).toHaveLength(1);
     expect(loadedTag.posts[0].title).toBe('Post Alpha');
+  });
+
+  test('merged inverse: Tag.owners loads all owner types in one collection', async () => {
+    const tag = new Tag('Shared');
+    const post = new Post('Post 1');
+    const video = new Video('https://example.com/v1.mp4');
+
+    post.tags.add(tag);
+    video.tags.add(tag);
+
+    await orm.em.persist([post, video]).flush();
+    orm.em.clear();
+
+    const loaded = await orm.em.findOneOrFail(Tag, tag.id, { populate: ['owners'] });
+    const owners = loaded.owners.getItems();
+    expect(owners).toHaveLength(2);
+    expect(owners.some(o => o instanceof Post)).toBe(true);
+    expect(owners.some(o => o instanceof Video)).toBe(true);
   });
 });
 

--- a/tests/features/polymorphic-relations/polymorphic-many-to-many.sqlite.test.ts
+++ b/tests/features/polymorphic-relations/polymorphic-many-to-many.sqlite.test.ts
@@ -405,6 +405,55 @@ describe('polymorphic many-to-many relations', () => {
     expect(owners.some(o => o instanceof Post)).toBe(true);
     expect(owners.some(o => o instanceof Video)).toBe(true);
   });
+
+  test('merged inverse: adding via Tag.owners propagates to owning side', async () => {
+    const tag = new Tag('Propagated');
+    const post = new Post('Post via inverse');
+    await orm.em.persist([tag, post]).flush();
+    orm.em.clear();
+
+    const loaded = await orm.em.findOneOrFail(Tag, tag.id, { populate: ['owners'] });
+    expect(loaded.owners).toHaveLength(0);
+
+    const existingPost = await orm.em.findOneOrFail(Post, post.id, { populate: ['tags'] });
+    loaded.owners.add(existingPost);
+
+    // Propagation should add tag to the owning side
+    expect(existingPost.tags.contains(loaded)).toBe(true);
+
+    await orm.em.flush();
+    orm.em.clear();
+
+    // Verify persisted via owning side
+    const reloaded = await orm.em.findOneOrFail(Tag, tag.id, { populate: ['owners'] });
+    expect(reloaded.owners).toHaveLength(1);
+    expect(reloaded.owners[0]).toBeInstanceOf(Post);
+  });
+
+  test('merged inverse: removing via Tag.owners propagates to owning side', async () => {
+    const tag = new Tag('Removable');
+    const post = new Post('Post to remove');
+    const video = new Video('https://example.com/keep.mp4');
+
+    post.tags.add(tag);
+    video.tags.add(tag);
+    await orm.em.persist([post, video]).flush();
+    orm.em.clear();
+
+    const loaded = await orm.em.findOneOrFail(Tag, tag.id, { populate: ['owners'] });
+    expect(loaded.owners).toHaveLength(2);
+
+    const postOwner = loaded.owners.getItems().find(o => o instanceof Post)!;
+    loaded.owners.remove(postOwner);
+
+    await orm.em.flush();
+    orm.em.clear();
+
+    // Only the video should remain
+    const reloaded = await orm.em.findOneOrFail(Tag, tag.id, { populate: ['owners'] });
+    expect(reloaded.owners).toHaveLength(1);
+    expect(reloaded.owners[0]).toBeInstanceOf(Video);
+  });
 });
 
 // Test for custom discriminator map in polymorphic M:N


### PR DESCRIPTION
Adds the mirror shape of the Rails-style polymorphic M:N that shipped in v7.0: a single owner holding a `Collection<A | B>` where each pivot row's discriminator selects the target table.

```ts
@ManyToMany(() => [Image, Video], undefined, {
  pivotTable: 'attachables',
  discriminator: 'attachable',
  owner: true,
})
attachments = new Collection<Image | Video>(this);
```

Pivot: `(post_id, attachable_type, attachable_id)`, composite PK, no FK on `attachable_id`. Each target can also declare an inverse collection pointing back — those automatically filter the shared pivot by the target's own discriminator value (`Image.posts` sees only `attachable_type='image'` rows).

Reuses the existing polymorphic pivot machinery throughout — new metadata builder mirrors `definePolymorphicPivotProperties`, loader reuses `buildPivotResultMap` / `getPivotOrderBy` / the per-row `constructor` trick, persister's `buildPivotKeysAndData` now handles both static (Rails-style) and per-row discriminators via one code path, and `QueryHelper.findDiscriminatorValue`'s prototype walk (from #7564) means TPT subclasses as union targets resolve to their root's discriminator for free.

Docs: new section under relationships.md > Many-to-Many Polymorphic Relations covering the new API and its inverse side; remaining gap (merged inverse collection on the Rails-style pivot, e.g. `Tag.owners: Collection<Post | Video>` collapsing `Tag.posts` + `Tag.videos`) called out as a follow-up.

Tests: new `polymorphic-m-to-n-union.sqlite.test.ts` covering insert/select/delete/update/empty/multi-owner bucketing/inverse side. All 621 sqlite tests pass.

Based on #7564 (TPT polymorphic to-one). Once that merges this branch needs a rebase.