### PR TITLE
fix(core): validate TPT leaf entity indexes against own properties

### DIFF
--- a/packages/core/src/metadata/MetadataValidator.ts
+++ b/packages/core/src/metadata/MetadataValidator.ts
@@ -389,9 +389,13 @@ export class MetadataValidator {
   ): void {
     for (const index of indexes) {
       for (const propName of Utils.asArray(index.properties)) {
-        const prop = meta.root.properties[propName];
+        const prop = meta.properties[propName] ?? meta.root.properties[propName];
 
-        if (!prop && !Object.values(meta.root.properties).some(p => propName.startsWith(p.name + '.'))) {
+        if (
+          !prop &&
+          !Object.values(meta.properties).some(p => propName.startsWith(p.name + '.')) &&
+          !Object.values(meta.root.properties).some(p => propName.startsWith(p.name + '.'))
+        ) {
           throw MetadataError.unknownIndexProperty(meta, propName, type);
         }
       }

--- a/tests/issues/GH7570.test.ts
+++ b/tests/issues/GH7570.test.ts
@@ -1,0 +1,38 @@
+import { Entity, Index, PrimaryKey, Property, ReflectMetadataProvider, Unique } from '@mikro-orm/decorators/legacy';
+import { MikroORM } from '@mikro-orm/sqlite';
+
+// GH #7570 - Cannot set TPT entity indexes (and unique indexes) on TPT leaf properties
+
+@Entity({ inheritance: 'tpt' })
+abstract class Person7570 {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+}
+
+@Entity()
+@Index({ properties: ['department'] })
+@Unique({ properties: ['employeeId'] })
+class Employee7570 extends Person7570 {
+  @Property()
+  department!: string;
+
+  @Property()
+  employeeId!: string;
+}
+
+test('GH #7570 - TPT leaf entity indexes on own properties', async () => {
+  const orm = await MikroORM.init({
+    metadataProvider: ReflectMetadataProvider,
+    dbName: ':memory:',
+    entities: [Person7570, Employee7570],
+  });
+
+  const diff = await orm.schema.getCreateSchemaSQL();
+  expect(diff).toContain('index `employee7570_department_index`');
+  expect(diff).toContain('unique index `employee7570_employee_id_unique`');
+
+  await orm.close();
+});


### PR DESCRIPTION
## Summary

- Index/unique validation in `MetadataValidator.validateIndexes()` only checked `meta.root.properties`, which for TPT inheritance contains only the root entity's properties. Leaf-specific properties (e.g. `department` on an `Employee` extending `Person`) were not found, causing a false `MetadataError: Entity Employee has wrong index definition: 'department' does not exist`.
- Now also checks `meta.properties` which includes both inherited and own properties, fixing index/unique definitions on TPT leaf entities.

Closes #7570