### PR TITLE
fix(mysql): resolve password callback per-connection for short-lived tokens

### DIFF
--- a/packages/mysql/src/MySqlConnection.ts
+++ b/packages/mysql/src/MySqlConnection.ts
@@ -1,20 +1,42 @@
-import { type ControlledTransaction, MysqlDialect } from 'kysely';
-import { createPool, type PoolOptions } from 'mysql2';
-import { type ConnectionConfig, Utils, AbstractSqlConnection, type TransactionEventBroadcaster } from '@mikro-orm/sql';
+import { type ControlledTransaction, type MysqlPool, type MysqlPoolConnection, MysqlDialect } from 'kysely';
+import { createPool, type Pool, type PoolOptions } from 'mysql2';
+import {
+  type ConnectionConfig,
+  type Dictionary,
+  Utils,
+  AbstractSqlConnection,
+  type TransactionEventBroadcaster,
+} from '@mikro-orm/sql';
 
 /** MySQL database connection using the `mysql2` driver. */
 export class MySqlConnection extends AbstractSqlConnection {
-  override createKyselyDialect(overrides: PoolOptions): MysqlDialect {
+  override async createKyselyDialect(overrides: PoolOptions): Promise<MysqlDialect> {
     const options = this.mapOptions(overrides);
     const password = options.password as ConnectionConfig['password'];
 
     if (typeof password === 'function') {
+      const initialPassword = await password();
+      const innerPool = createPool({ ...options, password: initialPassword });
+
+      // mysql2 reads pool.config.connectionConfig.password when creating new physical
+      // connections, so updating it before getConnection() ensures fresh tokens are used.
+      // Existing idle connections are already authenticated and unaffected.
+      const pool: MysqlPool = {
+        getConnection(cb: (error: unknown, connection: MysqlPoolConnection) => void) {
+          Promise.resolve(password())
+            .then(pw => {
+              ((innerPool as Dictionary).config.connectionConfig as Dictionary).password = pw;
+              innerPool.getConnection(cb as Parameters<Pool['getConnection']>[0]);
+            })
+            .catch(err => cb(err, undefined as unknown as MysqlPoolConnection));
+        },
+        end(cb: (error: unknown) => void) {
+          innerPool.end(cb as Parameters<Pool['end']>[0]);
+        },
+      };
+
       return new MysqlDialect({
-        pool: async () =>
-          createPool({
-            ...options,
-            password: await password(),
-          }) as any,
+        pool,
         onCreateConnection: this.options.onCreateConnection ?? this.config.get('onCreateConnection'),
       });
     }

--- a/packages/oracledb/src/OracleConnection.ts
+++ b/packages/oracledb/src/OracleConnection.ts
@@ -23,10 +23,11 @@ export class OracleConnection extends AbstractSqlConnection {
     const password = options.password as ConnectionConfig['password'];
     const onCreateConnection = this.options.onCreateConnection ?? this.config.get('onCreateConnection');
 
+    const initialPassword = typeof password === 'function' ? await password() : password;
+
     const poolOptions = {
       ...options,
-      /* v8 ignore next: password-as-function branch requires mocking pool creation */
-      password: typeof password === 'function' ? await password() : password,
+      password: initialPassword,
       sessionCallback: onCreateConnection as PoolAttributes['sessionCallback'],
     };
 
@@ -71,8 +72,20 @@ export class OracleConnection extends AbstractSqlConnection {
       },
     };
 
+    // When password is a callback, wrap the pool to resolve it per-connection.
+    // oracledb supports per-connection password override via getConnection({ password }).
+    const wrappedPool =
+      typeof password === 'function'
+        ? {
+            async getConnection() {
+              return pool.getConnection({ password: await password() });
+            },
+            close: (drainTime?: number) => pool.close(drainTime),
+          }
+        : pool;
+
     return new OracleDialect({
-      pool,
+      pool: wrappedPool,
       executeOptions: executeOptions as Record<string, unknown>,
     });
   }

--- a/tests/MikroORM.test.ts
+++ b/tests/MikroORM.test.ts
@@ -8,6 +8,7 @@ import { Author2, Car2, CarOwner2, Sandwich, User2 } from './entities-sql/index.
 import { BaseEntity2 } from './entities-sql/BaseEntity2.js';
 import { MsSqlDriver } from '@mikro-orm/mssql';
 import { MySqlDriver } from '@mikro-orm/mysql';
+import { PostgreSqlDriver } from '@mikro-orm/postgresql';
 import { SqliteDriver } from '@mikro-orm/sqlite';
 import { MongoDriver, MikroORM as MongoMikroORM } from '@mikro-orm/mongodb';
 import { SeedManager } from '@mikro-orm/seeder';
@@ -365,33 +366,47 @@ describe('MikroORM', () => {
   });
 
   test('should work with dynamic passwords/tokens [mysql]', async () => {
-    const options = {
+    const passwordFn = vi.fn(async () => 'pass1');
+    const o = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
       entities: [Test],
       driver: MySqlDriver,
       dbName: 'mikro-orm-test',
       port: 3308,
       ensureDatabase: false,
-    };
-
-    const o = await MikroORM.init({
-      metadataProvider: ReflectMetadataProvider,
-      ...options,
-      password: async () => 'pass1',
+      password: passwordFn,
     });
     await expect(() => o.driver.execute('select 1')).rejects.toThrow('Access denied');
+    await expect(() => o.driver.execute('select 1')).rejects.toThrow('Access denied');
+    expect(passwordFn.mock.calls.length).toBeGreaterThanOrEqual(3);
+    await o.close();
+  });
+
+  test('should work with dynamic passwords/tokens [postgresql]', async () => {
+    // pg natively supports password-as-function, calling it per-connection during auth.
+    // The docker PostgreSQL uses trust auth so the callback won't fire, but we verify
+    // that passing a function doesn't break the connection.
+    const o = new MikroORM({
+      metadataProvider: ReflectMetadataProvider,
+      entities: [Test],
+      driver: PostgreSqlDriver,
+      dbName: 'postgres',
+      port: 5432,
+      ensureDatabase: false,
+      password: async () => 'Root.Root',
+    });
+    const r = await o.driver.execute('select 1 as foo');
+    expect(r).toEqual([{ foo: 1 }]);
+    await o.close();
   });
 
   test('should work with dynamic passwords/tokens [mssql]', async () => {
-    const options = {
+    const o = new MikroORM({
+      metadataProvider: ReflectMetadataProvider,
       entities: [Test],
       driver: MsSqlDriver,
       dbName: 'mikro-orm-test',
       ensureDatabase: false,
-    };
-
-    const o = new MikroORM({
-      metadataProvider: ReflectMetadataProvider,
-      ...options,
       password: async () => 'Root.Root',
     });
     const r = await o.driver.execute('select 1 as foo');

--- a/tests/MikroORM.test.ts
+++ b/tests/MikroORM.test.ts
@@ -8,6 +8,7 @@ import { Author2, Car2, CarOwner2, Sandwich, User2 } from './entities-sql/index.
 import { BaseEntity2 } from './entities-sql/BaseEntity2.js';
 import { MsSqlDriver } from '@mikro-orm/mssql';
 import { MySqlDriver } from '@mikro-orm/mysql';
+import { OracleDriver } from '@mikro-orm/oracledb';
 import { PostgreSqlDriver } from '@mikro-orm/postgresql';
 import { SqliteDriver } from '@mikro-orm/sqlite';
 import { MongoDriver, MikroORM as MongoMikroORM } from '@mikro-orm/mongodb';
@@ -382,6 +383,24 @@ describe('MikroORM', () => {
     await o.close();
   });
 
+  test('should propagate password callback errors [mysql]', async () => {
+    const passwordFn = vi
+      .fn()
+      .mockResolvedValueOnce('pass1') // initial pool creation
+      .mockRejectedValue(new Error('token refresh failed'));
+    const o = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      entities: [Test],
+      driver: MySqlDriver,
+      dbName: 'mikro-orm-test',
+      port: 3308,
+      ensureDatabase: false,
+      password: passwordFn,
+    });
+    await expect(() => o.driver.execute('select 1')).rejects.toThrow('token refresh failed');
+    await o.close();
+  });
+
   test('should work with dynamic passwords/tokens [postgresql]', async () => {
     // pg natively supports password-as-function, calling it per-connection during auth.
     // The docker PostgreSQL uses trust auth so the callback won't fire, but we verify
@@ -397,6 +416,22 @@ describe('MikroORM', () => {
     });
     const r = await o.driver.execute('select 1 as foo');
     expect(r).toEqual([{ foo: 1 }]);
+    await o.close();
+  });
+
+  test('should work with dynamic passwords/tokens [oracle]', async () => {
+    const passwordFn = vi.fn(async () => 'oracle123');
+    const o = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      entities: [Test],
+      driver: OracleDriver,
+      dbName: 'system',
+      ensureDatabase: false,
+      password: passwordFn,
+    });
+    const r = await o.driver.execute('select 1 as foo from dual');
+    expect(r).toEqual([{ foo: 1 }]);
+    expect(passwordFn).toHaveBeenCalled();
     await o.close();
   });
 


### PR DESCRIPTION
## Summary

- When `password` is a callback (e.g. for AWS RDS IAM auth), resolve it before each connection acquisition instead of only once at pool creation time
- **MySQL**: wrap the pool to update `pool.config.connectionConfig.password` before each `getConnection()` so new physical connections use a fresh token
- **Oracle**: wrap the pool to pass a freshly resolved password via `pool.getConnection({ password })` on each acquisition
- **PostgreSQL**: already works natively (pg supports password-as-function), added a verification test
- **MSSQL**: already works via `connectionFactory`, no changes needed

Closes #7576

🤖 Generated with [Claude Code](https://claude.com/claude-code)