### PR TITLE
fix(core): expand polymorphic entity refs in where filters

### DIFF
--- a/packages/core/src/utils/QueryHelper.ts
+++ b/packages/core/src/utils/QueryHelper.ts
@@ -485,21 +485,25 @@ export class QueryHelper {
       }
 
       const prop = meta.properties[k as EntityKey<T>];
+      const polymorphic = !!prop?.polymorphic && (prop.fieldNames?.length ?? 0) > 1;
+      const composite = (prop?.joinColumns?.length ?? 0) > 1;
 
-      if (!prop?.joinColumns || prop.joinColumns.length <= 1) {
+      if (!polymorphic && !composite) {
         continue;
       }
 
+      const expand = (entity: any) =>
+        polymorphic
+          ? this.extractPolymorphicJoinColumnValues(entity, prop)
+          : this.extractJoinColumnValues(entity, prop);
       const w = where[k];
 
       if (Utils.isEntity(w)) {
-        where[k] = this.extractJoinColumnValues(w, prop);
+        where[k] = expand(w);
       } else if (Utils.isPlainObject(w)) {
         for (const op of Object.keys(w)) {
           if (Utils.isOperator(op, false) && Array.isArray(w[op])) {
-            w[op] = w[op].map((item: unknown) =>
-              Utils.isEntity(item) ? this.extractJoinColumnValues(item, prop) : item,
-            );
+            w[op] = w[op].map((item: unknown) => (Utils.isEntity(item) ? expand(item) : item));
           }
         }
       }
@@ -514,6 +518,15 @@ export class QueryHelper {
     return prop.referencedColumnNames.map(refCol => {
       return this.extractColumnValue(entity, prop.targetMeta!, refCol);
     });
+  }
+
+  /**
+   * Expands a polymorphic entity reference to `[discriminatorValue, ...joinColumnValues]`,
+   * matching the column order of `prop.fieldNames`.
+   */
+  private static extractPolymorphicJoinColumnValues(entity: any, prop: EntityProperty): any[] {
+    const discriminator = this.findDiscriminatorValue(prop.discriminatorMap!, entity.constructor);
+    return [discriminator, ...this.extractJoinColumnValues(entity, prop)];
   }
 
   /**

--- a/packages/sql/src/query/CriteriaNode.ts
+++ b/packages/sql/src/query/CriteriaNode.ts
@@ -72,7 +72,16 @@ export class CriteriaNode<T extends object> implements ICriteriaNode<T> {
 
   shouldRename(payload: any): boolean {
     const type = this.prop ? this.prop.kind : null;
-    const composite = this.prop?.joinColumns ? this.prop.joinColumns.length > 1 : false;
+    // Polymorphic relations have a composite column set (discriminator + FK), but we only
+    // need tuple-renaming when the payload is itself a tuple (entity ref expanded by
+    // `convertCompositeEntityRefs`) or an array-valued operator like `$in`. Scalar payloads
+    // such as `null` or `{ $ne: null }` keep single-column semantics against `fieldNames[0]`.
+    const polymorphicComposite =
+      !!this.prop?.polymorphic &&
+      (this.prop.fieldNames?.length ?? 0) > 1 &&
+      (Array.isArray(payload) ||
+        (Utils.isPlainObject(payload) && Object.values(payload as Dictionary).some(v => Array.isArray(v))));
+    const composite = polymorphicComposite || (this.prop?.joinColumns ? this.prop.joinColumns.length > 1 : false);
     const rawField = RawQueryFragment.isKnownFragmentSymbol(this.key);
     const scalar =
       payload === null ||
@@ -111,7 +120,8 @@ export class CriteriaNode<T extends object> implements ICriteriaNode<T> {
       this.prop!.owner
     ) {
       const alias = qb.getAliasForJoinPath(this.parent.getPath()) ?? ownerAlias ?? qb.alias;
-      return Utils.getPrimaryKeyHash(this.prop!.joinColumns.map(col => `${alias}.${col}`));
+      const columns = this.prop!.polymorphic ? this.prop!.fieldNames : this.prop!.joinColumns;
+      return Utils.getPrimaryKeyHash(columns.map(col => `${alias}.${col}`));
     }
 
     const alias = joinAlias ?? ownerAlias ?? qb.alias;

--- a/tests/features/polymorphic-relations/polymorphic-relations.sqlite.test.ts
+++ b/tests/features/polymorphic-relations/polymorphic-relations.sqlite.test.ts
@@ -474,6 +474,29 @@ describe('polymorphic relations in sqlite', () => {
     expect(likes[1].likeable).toBeInstanceOf(Post);
     expect(likes[2].likeable).toBeInstanceOf(Comment);
   });
+
+  // github: https://github.com/mikro-orm/mikro-orm/issues/7578
+  test('can filter polymorphic relation by entity reference', async () => {
+    const post1 = new Post('Post 1', 'Content 1');
+    const post2 = new Post('Post 2', 'Content 2');
+    const comment1 = new Comment('Comment 1');
+    const like1 = orm.em.create(UserLike, { likeable: post1 });
+    const like2 = orm.em.create(UserLike, { likeable: post2 });
+    orm.em.create(UserLike, { likeable: comment1 });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const post1Reloaded = await orm.em.findOneOrFail(Post, post1.id);
+    const post2Reloaded = await orm.em.findOneOrFail(Post, post2.id);
+
+    const eqResult = await orm.em.find(UserLike, { likeable: post1Reloaded });
+    expect(eqResult.map(r => r.id).sort()).toEqual([like1.id]);
+
+    const inResult = await orm.em.find(UserLike, {
+      likeable: { $in: [post1Reloaded, post2Reloaded] },
+    });
+    expect(inResult.map(r => r.id).sort()).toEqual([like1.id, like2.id].sort());
+  });
 });
 
 // Test polymorphic with Ref wrapper


### PR DESCRIPTION
## Summary

Filtering a polymorphic to-one relation by an entity reference (`{ source: entity }` or `{ source: { $in: [entity] } }`) previously produced SQL that compared the discriminator column to the target's primary key (e.g. `source_type = 1`) because the entity was collapsed to its PK and mapped onto `fieldNames[0]`.

`convertCompositeEntityRefs` now expands polymorphic entity refs into `[discriminatorValue, ...joinColumnValues]`, and `CriteriaNode` renames the key to the `(discriminator, ...fk)` tuple when the payload is array-shaped. Scalar payloads (`null`, `{ $ne: null }`) keep the existing single-column semantics against `fieldNames[0]`.

Closes #7578