### PR TITLE
fix(core): expand polymorphic entity refs inside scalar operators

### DIFF
--- a/packages/core/src/utils/QueryHelper.ts
+++ b/packages/core/src/utils/QueryHelper.ts
@@ -496,15 +496,22 @@ export class QueryHelper {
         polymorphic
           ? this.extractPolymorphicJoinColumnValues(entity, prop)
           : this.extractJoinColumnValues(entity, prop);
+      const expandItem = (item: unknown) => {
+        const entity = Reference.isReference(item) ? item.unwrap() : item;
+        return Utils.isEntity(entity) ? expand(entity) : item;
+      };
       const w = where[k];
+      const expanded = expandItem(w);
 
-      if (Utils.isEntity(w)) {
-        where[k] = expand(w);
+      if (expanded !== w) {
+        where[k] = expanded;
       } else if (Utils.isPlainObject(w)) {
         for (const op of Object.keys(w)) {
-          if (Utils.isOperator(op, false) && Array.isArray(w[op])) {
-            w[op] = w[op].map((item: unknown) => (Utils.isEntity(item) ? expand(item) : item));
+          if (!Utils.isOperator(op, false)) {
+            continue;
           }
+
+          w[op] = Array.isArray(w[op]) ? w[op].map(expandItem) : expandItem(w[op]);
         }
       }
     }

--- a/tests/features/polymorphic-relations/polymorphic-relations.sqlite.test.ts
+++ b/tests/features/polymorphic-relations/polymorphic-relations.sqlite.test.ts
@@ -482,7 +482,7 @@ describe('polymorphic relations in sqlite', () => {
     const comment1 = new Comment('Comment 1');
     const like1 = orm.em.create(UserLike, { likeable: post1 });
     const like2 = orm.em.create(UserLike, { likeable: post2 });
-    orm.em.create(UserLike, { likeable: comment1 });
+    const like3 = orm.em.create(UserLike, { likeable: comment1 });
     await orm.em.flush();
     orm.em.clear();
 
@@ -496,6 +496,25 @@ describe('polymorphic relations in sqlite', () => {
       likeable: { $in: [post1Reloaded, post2Reloaded] },
     });
     expect(inResult.map(r => r.id).sort()).toEqual([like1.id, like2.id].sort());
+
+    const neResult = await orm.em.find(UserLike, { likeable: { $ne: post1Reloaded } });
+    expect(neResult.map(r => r.id).sort()).toEqual([like2.id, like3.id].sort());
+
+    const ninResult = await orm.em.find(UserLike, {
+      likeable: { $nin: [post1Reloaded, post2Reloaded] },
+    });
+    expect(ninResult.map(r => r.id).sort()).toEqual([like3.id]);
+
+    const isNullResult = await orm.em.find(UserLike, { likeable: null });
+    expect(isNullResult).toHaveLength(0);
+
+    const notNullResult = await orm.em.find(UserLike, { likeable: { $ne: null } });
+    expect(notNullResult).toHaveLength(3);
+
+    const refResult = await orm.em.find(UserLike, {
+      likeable: orm.em.getReference(Post, post1.id),
+    });
+    expect(refResult.map(r => r.id).sort()).toEqual([like1.id]);
   });
 });
 


### PR DESCRIPTION
Follow-up to #7579. That PR expanded polymorphic entity refs for top-level values (`{ source: entity }`) and array-valued operators (`$in`/`$nin`), but scalar operators like `{ source: { $ne: entity } }` still fell through and emitted `source_type = 1`. Expand scalar operator payloads the same way, and unwrap `Reference` wrappers so `{ source: ref }` matches via the composite tuple too.

Added regression coverage for `$ne: entity`, `$nin: [entity]`, `null`, `$ne: null`, and `Reference` wrappers.

Refs #7578