### PR TITLE
fix(core): recognize TypeScript's `__esDecorate` helper in decorator path lookup

### DIFF
--- a/packages/decorators/src/utils.ts
+++ b/packages/decorators/src/utils.ts
@@ -136,9 +136,10 @@ export function lookupPathFromDecorator(name: string, stack?: string[]): string 
   // In some situations (e.g. swc 1.3.4+), the presence of a source map can obscure the call to
   // __decorate(), replacing it with the constructor name. To support these cases we look for
   // Reflect.decorate() as well. Also when babel is used, we need to check
-  // the `_applyDecoratedDescriptor` method instead.
+  // the `_applyDecoratedDescriptor` method instead. TypeScript 5+ emits `__esDecorate`
+  // (inlined into the user file) for TC39 stage-3 native decorators.
   let line = stack.findIndex(line =>
-    /__decorate|Reflect\.decorate|_applyDecoratedDescriptor|applyClassDecs/.exec(line),
+    /__decorate|__esDecorate|Reflect\.decorate|_applyDecoratedDescriptor|applyClassDecs/.exec(line),
   );
 
   // Bun can skip decorator helper frames. Native ES decorators expose the entity

--- a/tests/Utils.win.test.ts
+++ b/tests/Utils.win.test.ts
@@ -498,6 +498,22 @@ describe('Utils', () => {
         '    at Module.m._compile (/opt/app/node_modules/ts-node/src/index.ts:1618:23)',
       ]),
     ).toBe('/opt/app/entity/requirement.ts');
+
+    // TypeScript 5+ native ES decorators use `__esDecorate` helper (inlined into the user file)
+    // @see https://github.com/mikro-orm/mikro-orm/issues/7583
+    expect(
+      lookupPathFromDecorator('Hello', [
+        'Error',
+        '    at lookupPathFromDecorator (file:///private/tmp/app/node_modules/@mikro-orm/decorators/utils.js:86:20)',
+        '    at getMetadataFromDecorator (file:///private/tmp/app/node_modules/@mikro-orm/decorators/utils.js:131:14)',
+        '    at file:///private/tmp/app/node_modules/@mikro-orm/decorators/es/Entity.js:6:18',
+        '    at __esDecorate (file:///private/tmp/app/dist/entities/Hello.entity.js:12:40)',
+        '    at <static_initializer> (file:///private/tmp/app/dist/entities/Hello.entity.js:56:13)',
+        '    at file:///private/tmp/app/dist/entities/Hello.entity.js:48:17',
+        '    at file:///private/tmp/app/dist/entities/Hello.entity.js:69:3',
+        '    at ModuleJob.run (node:internal/modules/esm/module_job:430:25)',
+      ]),
+    ).toBe('file:///private/tmp/app/dist/entities/Hello.entity.js');
   });
 
   test('lookup path from decorator with bun', () => {


### PR DESCRIPTION
## Summary

TypeScript 5+ emits `__esDecorate` (inlined into the user file) when compiling TC39 stage-3 native decorators (`experimentalDecorators: false`). `lookupPathFromDecorator`'s regex only matched `__decorate` / `Reflect.decorate` / `_applyDecoratedDescriptor` / `applyClassDecs`, so the function fell through to the fallback and returned the bare class name.

With `TsMorphMetadataProvider`, this surfaced as `MetadataError: Source file './Hello' not found` when running compiled output — the path was `./Hello` (class name) instead of the actual entity file.

Verified against the user's repro (`@mikro-orm/decorators/es` + TypeScript 5.9 + Node 24 + `target: ES2024`, `experimentalDecorators: false`): the server now starts successfully.

Closes #7583

🤖 Generated with [Claude Code](https://claude.com/claude-code)