### PR TITLE
feat(core): add `LazyRef<T>`, `Loadable` mixin, and `unref()` escape hatch

### DIFF
--- a/docs/docs/define-entity.md
+++ b/docs/docs/define-entity.md
@@ -187,6 +187,24 @@ const properties = {
 };
 ```
 
+### Relation modifiers: `.ref()` and `.lazyRef()`
+
+For `m:1` / `1:1` relations, you can opt into compile-time populate-state safety:
+
+- **`.ref()`** wraps the runtime value in a `Reference`, exposing `.$` / `.get()` / `.load()` — see [`Ref<T>`](./type-safe-relations.md#reference-wrapper).
+- **`.lazyRef()`** is a type-only marker — the runtime stays a plain entity (no wrapper), but TypeScript hides non-PK access until `Loaded<>` narrows it. See [`LazyRef<T>`](./type-safe-relations.md#lazyreft--type-only-reference).
+
+```ts
+const BookSchema = defineEntity({
+  name: 'Book',
+  properties: {
+    id: p.integer().primary(),
+    author: () => p.manyToOne(AuthorSchema).ref(),       // `Ref<Author>`
+    publisher: () => p.manyToOne(PublisherSchema).lazyRef(), // `LazyRef<Publisher>`
+  },
+});
+```
+
 ## MongoDB example
 
 <Tabs

--- a/docs/docs/defining-entities.md
+++ b/docs/docs/defining-entities.md
@@ -133,6 +133,8 @@ export class Book extends CustomBaseEntity {
 
 > Including `{ ref: true }` in your `Ref` property definitions will wrap the reference, providing access to helper methods like `.load` and `.unwrap`, which can be helpful for loading data and changing the type of your references where you plan to use them.
 
+> For a type-only alternative that keeps the runtime value as a plain entity (no `Reference` wrapper, no `.$` indirection) while still restricting access until `Loaded<>` narrows it, declare the property as `LazyRef<T>` instead. See [Type-safe Relations → `LazyRef<T>`](./type-safe-relations.md#lazyreft--type-only-reference).
+
 Here is another example of `Author` entity, that was referenced from the `Book` one, this time defined for mongo:
 
 <Tabs

--- a/docs/docs/entity-constructors.md
+++ b/docs/docs/entity-constructors.md
@@ -96,6 +96,18 @@ constructor(dto: { title: string; author: number }) {
 }
 ```
 
+Or, to keep the runtime as a plain entity (no wrapper) while still getting compile-time populate-state safety, declare the property as [`LazyRef<T>`](./type-safe-relations.md#lazyreft--type-only-reference) and assign with `rel()`:
+
+```ts
+@ManyToOne({ entity: () => Author })
+author: LazyRef<Author>;
+
+constructor(dto: { title: string; author: number }) {
+  this.title = dto.title;
+  this.author = rel(Author, dto.author);
+}
+```
+
 The `rel` and `ref` helpers will accept both primary key and entity instance, as well as empty value (`null` or `undefined`).
 
 ```ts

--- a/docs/docs/guide/05-type-safety.md
+++ b/docs/docs/guide/05-type-safety.md
@@ -127,6 +127,25 @@ await article.author.load(); // no additional query, already loaded
 
 > As opposed to `wrap(e).init()` which always refreshes the entity, `Reference.load()` will query the database only if the entity is not already loaded in the Identity Map.
 
+### `LazyRef<T>` — type-only alternative
+
+If the `.$` / `.get()` indirection of `Reference` doesn't fit your style (e.g. when migrating from a non-`Ref` codebase), use `LazyRef<T>` instead. The runtime stays a plain entity — `article.author instanceof User` is `true`, no wrapper — but TypeScript still restricts non-PK access until `Loaded<>` narrows it:
+
+```ts title='article.entity.ts'
+author: () => p.manyToOne(UserSchema).lazyRef(),
+```
+
+```ts
+const article1 = await em.findOne(ArticleSchema, 1);
+article1.author.id;       // ok — PK always accessible
+article1.author.fullName; // type error — not loaded
+
+const article2 = await em.findOne(ArticleSchema, 1, { populate: ['author'] });
+article2.author.fullName; // ok — Loaded<> strips the LazyRef brand, no `.$` needed
+```
+
+See [Type-safe Relations → `LazyRef<T>`](../type-safe-relations.md#lazyreft--type-only-reference) for the full comparison with `Ref<T>` and the `unref()` escape hatch.
+
 ### `ScalarReference` wrapper
 
 Similarly to the `Reference` wrapper, you can also wrap scalars with `Ref` into a `ScalarReference` object. This is handy for lazy scalar properties.

--- a/docs/docs/metadata-providers.md
+++ b/docs/docs/metadata-providers.md
@@ -97,6 +97,13 @@ books = new Collection<Book>(this);
 publisher!: Ref<Publisher>;
 ```
 
+For type-only references without a runtime `Reference` wrapper, use [`LazyRef<T>`](./type-safe-relations.md#lazyreft--type-only-reference):
+
+```ts
+@ManyToOne(() => Publisher)
+publisher!: LazyRef<Publisher>;
+```
+
 #### Optional properties
 
 Reading property nullability is not supported, you need to explicitly set `nullable` attribute:

--- a/docs/docs/populating-relations.md
+++ b/docs/docs/populating-relations.md
@@ -65,6 +65,8 @@ const tags = await em.find(BookTag, {}, {
 
 > This will always use select-in strategy to deal with possible cycles.
 
+> The `Loaded` type also narrows [`Ref<T>`](./type-safe-relations.md#reference-wrapper) and [`LazyRef<T>`](./type-safe-relations.md#lazyreft--type-only-reference) relations correctly — after `populate: ['*']` a `Ref<T>` becomes a `LoadedReference<T>` and a `LazyRef<T>` becomes the full `T`.
+
 ## Inferring populate hint from filter
 
 If you want to automatically select all the relations that are part of your filter query, use `populate: ['$infer']`:

--- a/docs/docs/relationships.md
+++ b/docs/docs/relationships.md
@@ -103,6 +103,16 @@ export class Book {
 
 You can also specify how operations on given entity should [cascade](./cascading.md) to the referred entity.
 
+### Making the relation type-safe
+
+By default, a `@ManyToOne` property is typed as the bare entity, which means TypeScript does not know whether it has been populated. Three ways to add compile-time safety:
+
+- **`Ref<T>`** — wraps the entity in a `Reference` at runtime, adds `.$` / `.get()` / `.load()` accessors. Use via `{ ref: true }` or `.ref()`. See [Type-safe Relations → `Ref` Wrapper](./type-safe-relations.md#reference-wrapper).
+- **`LazyRef<T>`** — type-only marker, runtime value stays a plain entity (no wrapper). Restricts non-PK access until `Loaded<>` narrows it, no `.$` indirection when loaded. Use via `.lazyRef()` or declare the property as `LazyRef<T>`. See [`LazyRef<T>`](./type-safe-relations.md#lazyreft--type-only-reference).
+- **Plain relation** — no compile-time populate-state safety, most familiar to users coming from other ORMs.
+
+The same applies to `@OneToOne`.
+
 ## OneToMany
 
 > One instance of the current Entity has Many instances (references) to the referred Entity.

--- a/docs/docs/type-safe-relations.md
+++ b/docs/docs/type-safe-relations.md
@@ -188,6 +188,108 @@ book.author.getProperty('name');   // OK
 
 > Unlike `wrap(entity).init()` which always refreshes from the database, `Reference.load()` only queries if the entity is not already in the Identity Map.
 
+## `LazyRef<T>` — type-only reference
+
+When you want **compile-time populate-state safety** without the `.$` / `.get()` indirection that `Reference` requires, use `LazyRef<T>`. It is a **type-only** marker — at runtime the property holds the entity instance directly (same as a plain relation without `ref: true`), but TypeScript restricts access to the primary key until `Loaded<>` narrows it.
+
+```ts
+@ManyToOne(() => Author)
+author!: LazyRef<Author>;
+```
+
+Or with `defineEntity`:
+
+```ts
+const BookSchema = defineEntity({
+  name: 'Book',
+  properties: {
+    author: () => p.manyToOne(AuthorSchema).lazyRef(),
+  },
+});
+```
+
+### Semantics
+
+| | `LazyRef<T>` | `Ref<T>` |
+|---|---|---|
+| Runtime value | entity instance (stub or hydrated) | `Reference` wrapper |
+| `instanceof T` (runtime) | `true` | `false` |
+| Access unloaded PK | `ref.id` ✅ | `ref.id` ✅ |
+| Access unloaded non-PK | compile error ✅ | compile error ✅ |
+| Access loaded prop | `loaded.author.name` (no `.$`) | `loaded.author.$.name` |
+| `load()` / `loadOrFail()` method | ❌ — use `Loadable` mixin on the target | ✅ built-in |
+
+> **Note on `instanceof`**: the table's `instanceof T` row is about the runtime JS check — `book.author instanceof Author` returns `true` at runtime. TypeScript's control-flow narrowing through `instanceof`, however, does **not** strip `LazyRef<T>`'s brand, so `if (book.author instanceof Author) { /* book.author.name is still a compile error here */ }` still won't give you full entity access. Use `unref()` or `Loaded<>` narrowing for compile-time access.
+
+### Usage
+
+```ts
+const book = await em.findOneOrFail(Book, 1);
+book.author.id;     // ok — PK is always accessible
+book.author.name;   // compile error — not loaded
+
+const loaded = await em.findOneOrFail(Book, 1, { populate: ['author'] });
+loaded.author.name; // ok — Loaded<Book, 'author'> narrows LazyRef<Author> to Author
+```
+
+> **Scope**: `LazyRef<T>` is for to-one relations only (`@ManyToOne`, `@OneToOne`). Collections already have their own indirection via `Collection<T>`.
+>
+> **Caveat**: the safety is purely compile-time. JS code, `as any` casts, or code paths that bypass `Loaded<>` can freely read any property at runtime — and on an *unpopulated* relation (a stub with only the PK set) those reads will return `undefined`. If the relation has already been populated, the underlying entity is fully hydrated and reads behave normally; the caveat applies only to the stub case. Same footgun as plain non-`Ref` relations.
+>
+> **Type performance**: `LazyRef<T>` adds one conditional branch in the `Loaded<>` / `AutoPath` narrowing paths. The cost is comparable to `Ref<T>` (in fact slightly cheaper for loaded narrowing, since no `LoadedReference` intersection is produced). See `tests/bench/types/lazy-ref.ts` for measurements.
+
+### `unref()` — escape hatch when you can't thread `Loaded<>` through
+
+When you know a relation is populated but the surrounding code is typed as bare `Book` rather than `Loaded<Book, 'author'>`, use `unref()` to narrow a `LazyRef<T>` (or `Ref<T>`) back to `T`.
+
+```ts
+import { unref } from '@mikro-orm/core';
+
+function logAuthor(book: Book) {
+  // `book.author` is `LazyRef<Author>` — `.name` would be a compile error
+  console.log(unref(book.author).name);
+}
+```
+
+`unref()` is the inverse of `ref()` and works on any of:
+
+- `Ref<T>` / `Reference<T>` (entity) — calls `.unwrap()`, returns `T`
+- `LazyRef<T>` — identity cast at runtime (the underlying value is already `T`), returns `T`
+- plain `T` — passthrough, returns `T`
+- `ScalarReference<V>` / `ScalarRef<V>` — calls `.unwrap()`, returns `V | undefined` (the scalar may be unbound)
+- `null` / `undefined` — passthrough
+
+Like a plain `as` cast, `unref()` is a compile-time narrowing only for entity relations — if the entity is a stub that was never populated, non-PK properties are still `undefined` at runtime. Use it when you're confident the relation is loaded; prefer threading `Loaded<>` through signatures when you can.
+
+## `Loadable` mixin — `load()` / `loadOrFail()` on entities
+
+If you are using plain relations or `LazyRef<T>` and want the `load()` / `loadOrFail()` ergonomics that `Reference` provides on the wrapper, opt into the `Loadable` mixin on your entity class. It adds the two methods to the entity prototype so you can call them directly on the relation target.
+
+```ts
+import { BaseEntity, Loadable, LoadableBaseEntity } from '@mikro-orm/core';
+
+// convenience: BaseEntity pre-composed with the mixin
+class User extends LoadableBaseEntity {
+  // ...
+}
+
+// standalone — no inherited base
+class Product extends Loadable() {
+  // ...
+}
+
+// or compose with your own base class
+class Article extends Loadable(MyBase) {
+  // ...
+}
+
+const user = orm.em.getReference(User, 1);
+const loaded = await user.load();          // Promise<User | null>
+const loadedOrThrows = await user.loadOrFail(); // Promise<User>
+```
+
+Opt-in by design: `BaseEntity` itself does **not** gain these methods, so entities with existing `load` / `loadOrFail` properties are unaffected.
+
 ## `Loaded` Type
 
 The `Loaded<Entity, Hints>` type tracks which relations are populated at compile time. All `em.find*` methods return this type:

--- a/docs/docs/using-decorators.md
+++ b/docs/docs/using-decorators.md
@@ -170,6 +170,7 @@ export class Article {
 | Optional properties | Inferred as nullable | Requires `nullable: true`       |
 | Relation targets    | Automatic            | Requires `entity: () => Entity` |
 | `Ref<T>` wrapper    | Automatic            | Requires `ref: true`            |
+| `LazyRef<T>` marker | Automatic (type-only, no wrapper) | No metadata flag — type-only |
 | Array element types | Automatic            | Requires explicit `type`        |
 | Enums               | Automatic            | Requires `items: () => Enum`    |
 | Union types         | Supported            | Not supported                   |

--- a/packages/core/src/entity/BaseEntity.ts
+++ b/packages/core/src/entity/BaseEntity.ts
@@ -1,4 +1,4 @@
-import { Reference, type Ref } from './Reference.js';
+import { Reference, type LoadReferenceOptions, type LoadReferenceOrFailOptions, type Ref } from './Reference.js';
 import type {
   AutoPath,
   EntityData,
@@ -179,3 +179,114 @@ export abstract class BaseEntity {
 }
 
 Object.defineProperty(BaseEntity.prototype, '__baseEntity', { value: true, writable: false, enumerable: false });
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+type EntityConstructor<T extends object = object> = abstract new (...args: any[]) => T;
+
+/**
+ * The `load()` / `loadOrFail()` methods added by the {@link Loadable} mixin. Declared as an interface so the
+ * mixin function can have an explicit return type (required by JSR fast-check).
+ */
+export interface LoadableEntity {
+  /**
+   * Ensures this entity is loaded (without reloading it if it already is). Returns the entity, or `null` if it
+   * was not found in the database (e.g. it was deleted in the meantime, or active filters disallow loading it).
+   * Use `loadOrFail()` if you want an error to be thrown in such a case.
+   */
+  load<
+    Entity extends this = this,
+    Hint extends string = never,
+    Fields extends string = never,
+    Excludes extends string = never,
+  >(
+    options?: LoadReferenceOptions<Entity, Hint, Fields, Excludes>,
+  ): Promise<Loaded<Entity, Hint, Fields, Excludes> | null>;
+
+  /**
+   * Ensures this entity is loaded (without reloading it if it already is). Returns the entity, or throws an error
+   * just like `em.findOneOrFail()` (and respects the same config options) if it was not found.
+   */
+  loadOrFail<
+    Entity extends this = this,
+    Hint extends string = never,
+    Fields extends string = never,
+    Excludes extends string = never,
+  >(
+    options?: LoadReferenceOrFailOptions<Entity, Hint, Fields, Excludes>,
+  ): Promise<Loaded<Entity, Hint, Fields, Excludes>>;
+}
+
+/** Return-type shape of {@link Loadable} — a constructor that produces instances of `TBase` enriched with {@link LoadableEntity}. */
+export type LoadableConstructor<TBase extends EntityConstructor> = abstract new (
+  ...args: any[]
+) => InstanceType<TBase> & LoadableEntity;
+
+/** Internal: rejects a base class that already defines `load` or `loadOrFail` to prevent silent override. */
+type EnsureNoLoadConflict<TBase extends EntityConstructor> =
+  InstanceType<TBase> extends {
+    load: any;
+  }
+    ? 'Loadable: base class already defines `load` — remove it or do not apply the mixin'
+    : InstanceType<TBase> extends { loadOrFail: any }
+      ? 'Loadable: base class already defines `loadOrFail` — remove it or do not apply the mixin'
+      : TBase;
+
+/** Empty base for {@link Loadable} when called without arguments — standalone mixin, no inherited base. */
+abstract class EmptyBase {}
+
+/**
+ * Mixin that adds `load()` / `loadOrFail()` methods to an entity class. These methods ensure the entity is loaded
+ * from the database without reloading it if it already is — unlike `init()`, which always refreshes.
+ *
+ * Useful when migrating from a non-`Ref`-based codebase where lazy loading support is desired without the
+ * `.$` / `.get()` indirection that the `Reference` wrapper requires. Opt-in so it does not conflict with entities
+ * that already define a `load` or `loadOrFail` property — applying the mixin to a base class that already has
+ * either method is a compile error to prevent silent override.
+ *
+ * Call without arguments (`Loadable()`) for a standalone base with no other inheritance, or pass a base class
+ * (`Loadable(BaseEntity)`) to compose. The convenience alias {@link LoadableBaseEntity} is shorthand for the
+ * latter.
+ *
+ * @example
+ * ```ts
+ * // compose with BaseEntity
+ * class User extends Loadable(BaseEntity) {
+ *   ＠PrimaryKey()
+ *   id!: number;
+ * }
+ *
+ * // standalone — no inherited base
+ * class Product extends Loadable() {
+ *   ＠PrimaryKey()
+ *   id!: number;
+ * }
+ *
+ * const user = orm.em.getReference(User, 1);
+ * await user.load();
+ * ```
+ */
+export function Loadable(): LoadableConstructor<typeof EmptyBase> & typeof EmptyBase;
+export function Loadable<TBase extends EntityConstructor>(
+  Base: EnsureNoLoadConflict<TBase> extends TBase ? TBase : never,
+): LoadableConstructor<TBase> & TBase;
+export function Loadable<TBase extends EntityConstructor>(
+  Base: TBase = EmptyBase as unknown as TBase,
+): LoadableConstructor<TBase> & TBase {
+  abstract class LoadableMixin extends Base {
+    async load(options?: LoadReferenceOptions<object>): Promise<object | null> {
+      return Reference.create(this).load(options) as Promise<object | null>;
+    }
+
+    async loadOrFail(options?: LoadReferenceOrFailOptions<object>): Promise<object> {
+      return Reference.create(this).loadOrFail(options) as Promise<object>;
+    }
+  }
+
+  return LoadableMixin as unknown as LoadableConstructor<TBase> & TBase;
+}
+
+const LoadableBaseEntityBase: LoadableConstructor<typeof BaseEntity> & typeof BaseEntity = Loadable(BaseEntity);
+
+/** Convenience: `BaseEntity` pre-composed with the `Loadable` mixin. */
+export abstract class LoadableBaseEntity extends LoadableBaseEntityBase {}

--- a/packages/core/src/entity/Reference.ts
+++ b/packages/core/src/entity/Reference.ts
@@ -5,6 +5,7 @@ import type {
   EntityClass,
   EntityKey,
   EntityProperty,
+  LazyRef,
   Loaded,
   LoadedReference,
   Primary,
@@ -445,6 +446,64 @@ export function ref<T, PKV extends Primary<T> = Primary<T>>(
   }
 
   return Reference.createFromPK(entityOrType as EntityClass<T>, pk as PKV) as Ref<T>;
+}
+
+/**
+ * Unwraps a reference to its underlying value, returning the entity or scalar. Works on any of:
+ *
+ * - `Ref<T>` / `Reference<T>` (entity) — calls `.unwrap()` to extract the wrapped entity, returns `T`.
+ * - `LazyRef<T>` — type-only marker; runtime value is already `T`, so returned as-is.
+ * - plain entity `T` — returned as-is.
+ * - `ScalarReference<V>` / `ScalarRef<V>` — calls `.unwrap()` to extract the scalar value, returns `V | undefined`
+ *   (a scalar reference may be bound without an initial value).
+ *
+ * Inverse of the {@link ref} helper. Use as a typed escape hatch when you know a relation is populated
+ * but don't want to (or can't) thread `Loaded<T, 'relation'>` through a function signature.
+ *
+ * ```ts
+ * function logAuthor(book: Book) {
+ *   // `book.author` is typed as `LazyRef<Author>`, so `.name` is not directly accessible
+ *   console.log(unref(book.author).name);
+ * }
+ *
+ * // Scalar reference:
+ * const scalar = ref('hello');
+ * unref(scalar); // 'hello' (type: string | undefined)
+ * ```
+ *
+ * Note: `unref` is a compile-time narrowing only for entity refs. On a `LazyRef<T>` or plain entity
+ * relation that is a stub (PK only, never populated), reads of non-PK properties will still return
+ * `undefined` at runtime — same footgun as a plain non-`Ref` relation.
+ */
+export function unref<V>(value: ScalarReference<V>): V | undefined;
+
+export function unref<T extends object>(value: Ref<T> | LazyRef<T> | T): T;
+
+/**
+ * Unwraps a reference to its underlying value. Nullable variant — returns `null` unchanged.
+ */
+export function unref<T extends object>(value: Ref<T> | LazyRef<T> | T | null): T | null;
+
+/**
+ * Unwraps a reference to its underlying value. Optional variant — returns `undefined` unchanged.
+ */
+export function unref<T extends object>(value: Ref<T> | LazyRef<T> | T | undefined): T | undefined;
+
+/**
+ * Unwraps a reference to its underlying value. Nullable variant — returns `null`/`undefined` unchanged.
+ */
+export function unref<T extends object>(value: Ref<T> | LazyRef<T> | T | null | undefined): T | null | undefined;
+
+export function unref(value: any): any {
+  if (value == null) {
+    return value;
+  }
+
+  if (ScalarReference.isScalarReference(value)) {
+    return value.unwrap();
+  }
+
+  return Reference.unwrapReference(value);
 }
 
 /**

--- a/packages/core/src/entity/defineEntity.ts
+++ b/packages/core/src/entity/defineEntity.ts
@@ -30,6 +30,7 @@ import type {
   InferEntity,
   MaybeReturnType,
   Ref,
+  LazyRef,
   IndexCallback,
   TriggerCallback,
   FormulaCallback,
@@ -71,7 +72,7 @@ export type UniversalPropertyKeys =
   | keyof OneToOneOptions<any, any>
   | keyof ManyToManyOptions<any, any>;
 
-type BuilderExtraKeys = '~options' | '~type' | '$type' | 'strictNullable';
+type BuilderExtraKeys = '~options' | '~type' | '$type' | 'strictNullable' | 'lazyRef';
 type ExcludeKeys = 'entity' | 'items';
 type BuilderKeys = Exclude<UniversalPropertyKeys, ExcludeKeys> | BuilderExtraKeys;
 
@@ -107,7 +108,17 @@ export interface PropertyChain<Value, Options> {
     Value,
     Omit<Options, 'nullable' | 'strictNullable'> & { nullable: true; strictNullable: true }
   >;
-  ref(): PropertyChain<Value, Omit<Options, 'ref'> & { ref: true }>;
+  ref(): Options extends { lazyRef: true } ? never : PropertyChain<Value, Omit<Options, 'ref'> & { ref: true }>;
+  /**
+   * Mark a to-one relation (`m:1`/`1:1`) as a {@apilink LazyRef} — direct entity at runtime, type-restricted
+   * until `Loaded<>` narrows it. Type-level only, no `ref: true` wrapping. Not compatible with `.ref()` or
+   * `.mapToPk()` — those chains are rejected in both directions at compile time.
+   */
+  lazyRef(): HasKind<Options, 'm:1' | '1:1'> extends true
+    ? Options extends { ref: true } | { mapToPk: true }
+      ? never
+      : PropertyChain<Value, Omit<Options, 'lazyRef'> & { lazyRef: true }>
+    : never;
   primary(): PropertyChain<Value, Omit<Options, 'primary'> & { primary: true }>;
   hidden(): PropertyChain<Value, Omit<Options, 'hidden'> & { hidden: true }>;
   autoincrement(): PropertyChain<Value, Omit<Options, 'autoincrement'> & { autoincrement: true }>;
@@ -186,7 +197,9 @@ export interface PropertyChain<Value, Options> {
     ? PropertyChain<Value, Omit<Options, 'owner'> & { owner: true }>
     : never;
   mapToPk(): HasKind<Options, 'm:1' | '1:1'> extends true
-    ? PropertyChain<Value, Omit<Options, 'mapToPk'> & { mapToPk: true }>
+    ? Options extends { lazyRef: true }
+      ? never
+      : PropertyChain<Value, Omit<Options, 'mapToPk'> & { mapToPk: true }>
     : never;
   orphanRemoval(
     orphanRemoval?: boolean,
@@ -577,8 +590,25 @@ export class UniversalPropertyOptionsBuilder<Value, Options, IncludeKeys extends
   /**
    * Enable `ScalarReference` wrapper for lazy values. Use this in combination with `lazy: true` to have a type-safe accessor object in place of the value.
    */
-  ref(): UniversalPropertyOptionsBuilder<Value, Omit<Options, 'ref'> & { ref: true }, IncludeKeys> {
-    return this.assignOptions({ ref: true });
+  ref(): Options extends { lazyRef: true }
+    ? never
+    : UniversalPropertyOptionsBuilder<Value, Omit<Options, 'ref'> & { ref: true }, IncludeKeys> {
+    return this.assignOptions({ ref: true }) as any;
+  }
+
+  /**
+   * Mark a to-one relation (`m:1`/`1:1`) as a {@apilink LazyRef} — the runtime value stays a plain entity
+   * (no `Reference` wrapper) but the TypeScript type restricts access to the primary key until `Loaded<>`
+   * narrows it. Type-level only; does not set `ref: true`. Not compatible with `.ref()` or `.mapToPk()` —
+   * those chains are rejected in both directions at compile time.
+   */
+  lazyRef(): HasKind<Options, 'm:1' | '1:1'> extends true
+    ? Options extends { ref: true } | { mapToPk: true }
+      ? never
+      : UniversalPropertyOptionsBuilder<Value, Omit<Options, 'lazyRef'> & { lazyRef: true }, IncludeKeys>
+    : never {
+    // purely type-level — no runtime metadata change
+    return this as any;
   }
 
   /**
@@ -963,11 +993,13 @@ export class UniversalPropertyOptionsBuilder<Value, Options, IncludeKeys extends
   }
 
   /** Map this relation to the primary key value instead of an entity. */
-  mapToPk(): Pick<
-    UniversalPropertyOptionsBuilder<Value, Omit<Options, 'mapToPk'> & { mapToPk: true }, IncludeKeys>,
-    IncludeKeys
-  > {
-    return this.assignOptions({ mapToPk: true });
+  mapToPk(): Options extends { lazyRef: true }
+    ? never
+    : Pick<
+        UniversalPropertyOptionsBuilder<Value, Omit<Options, 'mapToPk'> & { mapToPk: true }, IncludeKeys>,
+        IncludeKeys
+      > {
+    return this.assignOptions({ mapToPk: true }) as any;
   }
 
   /** Set the constraint type. Immediate constraints are checked for each statement, while deferred ones are only checked at the end of the transaction. Only for postgres unique constraints. */
@@ -1590,23 +1622,27 @@ type MaybeNullable<Value, Options> = Options extends { nullable: true }
 
 type MaybeRelationRef<Value, Options> = Options extends { mapToPk: true }
   ? Value
-  : Options extends { ref: true; kind: '1:1' }
+  : Options extends { lazyRef: true; kind: '1:1' | 'm:1' }
     ? Value extends object
-      ? Ref<Value>
+      ? LazyRef<Value>
       : never
-    : Options extends { ref: true; kind: 'm:1' }
+    : Options extends { ref: true; kind: '1:1' }
       ? Value extends object
         ? Ref<Value>
         : never
-      : Options extends { kind: '1:m' }
+      : Options extends { ref: true; kind: 'm:1' }
         ? Value extends object
-          ? Collection<Value>
+          ? Ref<Value>
           : never
-        : Options extends { kind: 'm:n' }
+        : Options extends { kind: '1:m' }
           ? Value extends object
             ? Collection<Value>
             : never
-          : Value;
+          : Options extends { kind: 'm:n' }
+            ? Value extends object
+              ? Collection<Value>
+              : never
+            : Value;
 
 type MaybeScalarRef<Value, Options> = Options extends { kind: '1:1' | 'm:1' | '1:m' | 'm:n' }
   ? Value

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -74,6 +74,7 @@ export type {
   SimpleColumnMeta,
   Rel,
   Ref,
+  LazyRef,
   ScalarRef,
   EntityRef,
   ISchemaGenerator,

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -150,7 +150,7 @@ type LoadedReferenceShape<T = any> = ReferenceShape & { $: T };
  * Using this instead of `Loadable<any>` in conditional type checks prevents
  * TypeScript from evaluating the full Collection/Reference interfaces.
  */
-type LoadableShape = CollectionShape | ReferenceShape | readonly any[];
+type LoadableShape = CollectionShape | ReferenceShape | LazyRef.Brand<any> | readonly any[];
 
 /** Gets all keys from all members of a union type (distributes over the union). */
 export type UnionKeys<T> = T extends any ? keyof T : never;
@@ -692,15 +692,17 @@ export type EntityDataProp<T, C extends boolean> = T extends Date
         ? C extends true
           ? Raw
           : Runtime
-        : T extends ReferenceShape<infer U>
+        : T extends LazyRef.Brand<infer U>
           ? EntityDataNested<U, C>
-          : T extends CollectionShape<infer U>
-            ? U | U[] | EntityDataNested<U & object, C> | EntityDataNested<U & object, C>[]
-            : T extends readonly (infer U)[]
-              ? U extends NonArrayObject
-                ? U | U[] | EntityDataNested<U, C> | EntityDataNested<U, C>[]
-                : U[] | EntityDataNested<U, C>[]
-              : EntityDataNested<T, C>;
+          : T extends ReferenceShape<infer U>
+            ? EntityDataNested<U, C>
+            : T extends CollectionShape<infer U>
+              ? U | U[] | EntityDataNested<U & object, C> | EntityDataNested<U & object, C>[]
+              : T extends readonly (infer U)[]
+                ? U extends NonArrayObject
+                  ? U | U[] | EntityDataNested<U, C> | EntityDataNested<U, C>[]
+                  : U[] | EntityDataNested<U, C>[]
+                : EntityDataNested<T, C>;
 
 /** Like `EntityDataProp` but used in `RequiredEntityData` context with required/optional key distinction. */
 export type RequiredEntityDataProp<T, O, C extends boolean> = T extends Date
@@ -715,15 +717,17 @@ export type RequiredEntityDataProp<T, O, C extends boolean> = T extends Date
           ? C extends true
             ? Raw
             : Runtime
-          : T extends ReferenceShape<infer U>
+          : T extends LazyRef.Brand<infer U>
             ? RequiredEntityDataNested<U, O, C>
-            : T extends CollectionShape<infer U>
-              ? U | U[] | RequiredEntityDataNested<U & object, O, C> | RequiredEntityDataNested<U & object, O, C>[]
-              : T extends readonly (infer U)[]
-                ? U extends NonArrayObject
-                  ? U | U[] | RequiredEntityDataNested<U, O, C> | RequiredEntityDataNested<U, O, C>[]
-                  : U[] | RequiredEntityDataNested<U, O, C>[]
-                : RequiredEntityDataNested<T, O, C>;
+            : T extends ReferenceShape<infer U>
+              ? RequiredEntityDataNested<U, O, C>
+              : T extends CollectionShape<infer U>
+                ? U | U[] | RequiredEntityDataNested<U & object, O, C> | RequiredEntityDataNested<U & object, O, C>[]
+                : T extends readonly (infer U)[]
+                  ? U extends NonArrayObject
+                    ? U | U[] | RequiredEntityDataNested<U, O, C> | RequiredEntityDataNested<U, O, C>[]
+                    : U[] | RequiredEntityDataNested<U, O, C>[]
+                  : RequiredEntityDataNested<T, O, C>;
 
 /** Nested entity data shape for embedded or related entities within `EntityData`. */
 export type EntityDataNested<T, C extends boolean = false> = T extends undefined
@@ -810,6 +814,37 @@ export type Rel<T> = T;
 
 /** Alias for `ScalarReference` (see {@apilink Ref}). */
 export type ScalarRef<T> = ScalarReference<T>;
+
+/**
+ * Type-level marker for a to-one relation that is **direct at runtime** (no `Reference` wrapper) but
+ * **restricted at compile time** until narrowed via `Loaded<>`.
+ *
+ * Use as the property type on a `@ManyToOne`/`@OneToOne` relation that does **not** have `ref: true`:
+ *
+ * ```ts
+ * @ManyToOne(() => User)
+ * author!: LazyRef<User>;
+ * ```
+ *
+ * Semantics:
+ * - **Runtime**: identical to a plain direct relation — `article.author` is a `User` instance (stub or hydrated),
+ *   `article.author instanceof User` is `true`, no `Reference` object is created.
+ * - **Type (unloaded view)**: only the primary key is accessible. Accessing other properties is a compile error.
+ * - **Type (loaded view)**: once the relation is in the populate hint of a `Loaded<Entity, 'author'>`, it narrows
+ *   back to the full entity — no `.$` or `.get()` indirection needed.
+ *
+ * Note: the safety is purely compile-time. JS code or `as any` casts bypass it.
+ */
+export type LazyRef<T extends object> =
+  IsAny<T> extends true ? LazyRef.Brand<T> : { [K in PrimaryProperty<T> & keyof T]: T[K] } & LazyRef.Brand<T>;
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export declare namespace LazyRef {
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  const __lazyRef: unique symbol;
+  export interface Brand<T> {
+    [__lazyRef]?: (arg: T) => T;
+  }
+}
 
 /** Alias for `Reference<T> & { id: number }` (see {@apilink Ref}). */
 export type EntityRef<T extends object> =
@@ -1976,14 +2011,24 @@ type ExtractType<T> =
           ? U
           : T;
 
+/**
+ * Like {@link ExtractType} but also unwraps {@link LazyRef}. Kept separate so {@link ExtractType}'s
+ * hot path (used by `IsOptional`, `EntityData`, `RequiredEntityData`) doesn't pay the cost of the
+ * extra branch — those contexts handle `LazyRef` in their own earlier branches (see
+ * `EntityDataProp` / `RequiredEntityDataProp`) before delegating to `ExtractType`.
+ */
+type ExtractTypeWithLazyRef<T> = T extends LazyRef.Brand<infer U> ? U : ExtractType<T>;
+
 type ExtractStringKeys<T> = { [K in keyof T]-?: CleanKeys<T, K> }[keyof T] & {};
 /**
  * Extracts string keys from an entity type, handling Collection/Reference wrappers.
  * Simplified to just check `T extends object` since ExtractType handles the unwrapping.
  */
-type StringKeys<T, E extends string = never> = T extends object ? ExtractStringKeys<ExtractType<T>> | E : never;
+type StringKeys<T, E extends string = never> = T extends object
+  ? ExtractStringKeys<ExtractTypeWithLazyRef<T>> | E
+  : never;
 type GetStringKey<T, K extends StringKeys<T, string>, E extends string> = K extends keyof T
-  ? ExtractType<T[K]>
+  ? ExtractTypeWithLazyRef<T[K]>
   : K extends E
     ? keyof T
     : never;
@@ -2033,27 +2078,31 @@ export type ArrayElement<ArrayType extends unknown[]> = ArrayType extends (infer
 
 /** Unwraps a property type from its wrapper (Reference, Collection, or array) to the inner entity type. */
 export type ExpandProperty<T> =
-  T extends ReferenceShape<infer U>
+  T extends LazyRef.Brand<infer U>
     ? NonNullable<U>
-    : T extends CollectionShape<infer U>
+    : T extends ReferenceShape<infer U>
       ? NonNullable<U>
-      : T extends (infer U)[]
+      : T extends CollectionShape<infer U>
         ? NonNullable<U>
-        : NonNullable<T>;
+        : T extends (infer U)[]
+          ? NonNullable<U>
+          : NonNullable<T>;
 
 type LoadedLoadable<T, E extends object> = T extends CollectionShape
   ? LoadedCollection<E>
   : T extends ScalarReference<infer U>
     ? LoadedScalarReference<U>
-    : T extends ReferenceShape
-      ? T & LoadedReference<E> // intersect with T (which is `Ref`) to include the PK props
-      : T extends Scalar
-        ? T
-        : T extends (infer U)[]
-          ? U extends Scalar
-            ? T // preserve scalar arrays (e.g., string[]) without Loaded<> wrapping
-            : E[]
-          : E;
+    : T extends LazyRef.Brand<any>
+      ? E // LazyRef narrows directly to the loaded entity (no wrapper at type level)
+      : T extends ReferenceShape
+        ? T & LoadedReference<E> // intersect with T (which is `Ref`) to include the PK props
+        : T extends Scalar
+          ? T
+          : T extends (infer U)[]
+            ? U extends Scalar
+              ? T // preserve scalar arrays (e.g., string[]) without Loaded<> wrapping
+              : E[]
+            : E;
 
 type IsTrue<T> = IsNever<T> extends true ? false : T extends boolean ? (T extends true ? true : false) : false;
 type StringLiteral<T> = T extends string ? (string extends T ? never : T) : never;
@@ -2129,7 +2178,7 @@ export type AddOptional<T> = undefined | null extends T
       : never;
 type LoadedProp<T, L extends string = never, F extends string = '*', E extends string = never> = LoadedLoadable<
   T,
-  Loaded<ExtractType<T>, L, F, E>
+  Loaded<ExtractTypeWithLazyRef<T>, L, F, E>
 >;
 /** Extracts the eager-loaded property names declared via `[EagerProps]` as a string union. */
 export type AddEager<T> = ExtractEagerProps<T> & string;

--- a/packages/reflection/src/TsMorphMetadataProvider.ts
+++ b/packages/reflection/src/TsMorphMetadataProvider.ts
@@ -108,6 +108,18 @@ export class TsMorphMetadataProvider extends MetadataProvider {
     this.processWrapper(prop, 'EntityRef');
     this.processWrapper(prop, 'ScalarRef');
     this.processWrapper(prop, 'ScalarReference');
+    // `LazyRef<T>` is a type-only marker — unwrap the type for metadata but do NOT set `ref: true`
+    // (there is no `Reference` wrapper at runtime for `LazyRef`). If the user also set `ref: true`
+    // explicitly via options, that's a contradiction — the property type promises a plain entity
+    // with PK access, but `ref: true` would produce a `Reference` wrapper at runtime.
+    const hadLazyRef = /(?:^|[.( ])LazyRef</.test(prop.type.replace(/import\(.*\)\./g, ''));
+    this.processWrapper(prop, 'LazyRef');
+
+    if (hadLazyRef && prop.ref) {
+      throw new MetadataError(
+        `Property '${meta.className}.${prop.name}' is typed as 'LazyRef<T>' but also has 'ref: true' set — these are incompatible. Remove 'ref: true' to keep 'LazyRef' semantics, or change the type to 'Ref<T>'.`,
+      );
+    }
     this.processWrapper(prop, 'Collection');
     prop.runtimeType ??= prop.type;
 

--- a/tests/bench/types/api-methods.ts
+++ b/tests/bench/types/api-methods.ts
@@ -70,19 +70,19 @@ bench('em.find() return type - no options', () => {
   type R = ReturnType<typeof em.find<Author>>;
   const x = {} as R;
   void x;
-}).types([745, 'instantiations']);
+}).types([743, 'instantiations']);
 
 bench('em.find() return type - with populate', () => {
   type R = ReturnType<typeof em.find<Author, 'books'>>;
   const x = {} as R;
   void x;
-}).types([745, 'instantiations']);
+}).types([743, 'instantiations']);
 
 bench('em.find() return type - with populate and fields', () => {
   type R = ReturnType<typeof em.find<Author, 'books', 'name' | 'email'>>;
   const x = {} as R;
   void x;
-}).types([739, 'instantiations']);
+}).types([737, 'instantiations']);
 
 // ============================================
 // em.create() - input and return type computation
@@ -92,32 +92,32 @@ bench('em.create() return type', () => {
   type R = ReturnType<typeof em.create<Author>>;
   const x = {} as R;
   void x;
-}).types([2442, 'instantiations']);
+}).types([2473, 'instantiations']);
 
 bench('RequiredEntityData - Author', () => {
   type R = RequiredEntityData<Author>;
   const x = {} as R;
   void x;
-}).types([1503, 'instantiations']);
+}).types([1534, 'instantiations']);
 
 bench('RequiredEntityData - Book', () => {
   type R = RequiredEntityData<Book>;
   const x = {} as R;
   void x;
-}).types([1309, 'instantiations']);
+}).types([1340, 'instantiations']);
 
 // New<T> type (used as create return type)
 bench('New<Author>', () => {
   type R = New<Author>;
   const x = {} as R;
   void x;
-}).types([583, 'instantiations']);
+}).types([581, 'instantiations']);
 
 bench('New<Author, "books">', () => {
   type R = New<Author, 'books'>;
   const x = {} as R;
   void x;
-}).types([1003, 'instantiations']);
+}).types([1028, 'instantiations']);
 
 // ============================================
 // em.populate() - return type computation
@@ -149,13 +149,13 @@ bench('EntityDTO<Loaded<Author, "books">>', () => {
   type R = EntityDTO<Loaded<Author, 'books'>>;
   const x = {} as R;
   void x;
-}).types([3620, 'instantiations']);
+}).types([3645, 'instantiations']);
 
 bench('EntityDTO<Loaded<Author, "books.publisher">>', () => {
   type R = EntityDTO<Loaded<Author, 'books.publisher'>>;
   const x = {} as R;
   void x;
-}).types([3620, 'instantiations']);
+}).types([3645, 'instantiations']);
 
 // ============================================
 // FilterQuery - used in where clauses
@@ -165,19 +165,19 @@ bench('FilterQuery<Author>', () => {
   type R = FilterQuery<Author>;
   const x = {} as R;
   void x;
-}).types([548, 'instantiations']);
+}).types([546, 'instantiations']);
 
 bench('FilterQuery<Book>', () => {
   type R = FilterQuery<Book>;
   const x = {} as R;
   void x;
-}).types([517, 'instantiations']);
+}).types([515, 'instantiations']);
 
 bench('FilterQuery<Loaded<Author, "books">>', () => {
   type R = FilterQuery<Loaded<Author, 'books'>>;
   const x = {} as R;
   void x;
-}).types([2479, 'instantiations']);
+}).types([2502, 'instantiations']);
 
 // ============================================
 // EntityData - used in em.assign()
@@ -187,13 +187,13 @@ bench('EntityData<Author>', () => {
   type R = EntityData<Author>;
   const x = {} as R;
   void x;
-}).types([216, 'instantiations']);
+}).types([235, 'instantiations']);
 
 bench('EntityData<Loaded<Author, "books">>', () => {
   type R = EntityData<Loaded<Author, 'books'>>;
   const x = {} as R;
   void x;
-}).types([1848, 'instantiations']);
+}).types([1892, 'instantiations']);
 
 // ============================================
 // Simulating wrap(e).toObject()
@@ -212,7 +212,7 @@ bench('wrap(loadedAuthor).toObject() return type', () => {
   type R = ToObjectReturn<Loaded<Author, 'books'>>;
   const x = {} as R;
   void x;
-}).types([3622, 'instantiations']);
+}).types([3647, 'instantiations']);
 
 // ============================================
 // Complex scenarios
@@ -224,4 +224,4 @@ bench('find result then EntityDTO', () => {
   type DTOResult = EntityDTO<FindResult>;
   const x = {} as DTOResult;
   void x;
-}).types([3620, 'instantiations']);
+}).types([3645, 'instantiations']);

--- a/tests/bench/types/assign-types.ts
+++ b/tests/bench/types/assign-types.ts
@@ -68,7 +68,7 @@ bench('FromEntityType - plain entity', () => {
 
 bench('FromEntityType - Loaded entity', () => {
   useFromEntityType<Loaded<Author, 'books'>>({} as FromEntityType<Loaded<Author, 'books'>>);
-}).types([1121, 'instantiations']);
+}).types([1146, 'instantiations']);
 
 // ============================================
 // IsSubset benchmarks
@@ -103,7 +103,7 @@ bench('MergeSelected - Loaded entity', () => {
   type R = MergeSelected<Loaded<Author, 'books'>, Author, 'name'>;
   const x = {} as R;
   void x;
-}).types([1645, 'instantiations']);
+}).types([1670, 'instantiations']);
 
 // ============================================
 // Full assign signature simulation
@@ -122,7 +122,7 @@ bench('assign return type - Loaded entity', () => {
   type R = AssignReturnType<Loaded<Author, 'books'>, { name: string }>;
   const x = {} as R;
   void x;
-}).types([1664, 'instantiations']);
+}).types([1689, 'instantiations']);
 
 // ============================================
 // Data parameter type computation
@@ -136,10 +136,10 @@ bench('assign data type - plain entity', () => {
   type R = AssignDataType<Author>;
   const x = {} as R;
   void x;
-}).types([2374, 'instantiations']);
+}).types([2480, 'instantiations']);
 
 bench('assign data type - Loaded entity', () => {
   type R = AssignDataType<Loaded<Author, 'books'>>;
   const x = {} as R;
   void x;
-}).types([3445, 'instantiations']);
+}).types([3576, 'instantiations']);

--- a/tests/bench/types/asterisk-hints.ts
+++ b/tests/bench/types/asterisk-hints.ts
@@ -59,24 +59,24 @@ function useLoaded<T, L extends string = never, F extends string = '*'>(_entity:
 
 bench('Loaded<Author, "*"> - asterisk populate all', () => {
   useLoaded<Author, '*'>({} as Loaded<Author, '*'>);
-}).types([1360, 'instantiations']);
+}).types([1405, 'instantiations']);
 
 bench('Loaded<Book, "*"> - asterisk populate all', () => {
   useLoaded<Book, '*'>({} as Loaded<Book, '*'>);
-}).types([1890, 'instantiations']);
+}).types([1955, 'instantiations']);
 
 bench('Loaded<Publisher, "*"> - asterisk populate all', () => {
   useLoaded<Publisher, '*'>({} as Loaded<Publisher, '*'>);
-}).types([1037, 'instantiations']);
+}).types([1069, 'instantiations']);
 
 // Compare with explicit paths
 bench('Loaded<Author, "books"> - single relation', () => {
   useLoaded<Author, 'books'>({} as Loaded<Author, 'books'>);
-}).types([1134, 'instantiations']);
+}).types([1159, 'instantiations']);
 
 bench('Loaded<Author, "books" | "friends"> - multiple relations', () => {
   useLoaded<Author, 'books' | 'friends'>({} as Loaded<Author, 'books' | 'friends'>);
-}).types([1253, 'instantiations']);
+}).types([1284, 'instantiations']);
 
 // ============================================
 // Loaded with asterisk fields (F parameter)
@@ -84,7 +84,7 @@ bench('Loaded<Author, "books" | "friends"> - multiple relations', () => {
 
 bench('Loaded<Author, "books", "*"> - default fields', () => {
   useLoaded<Author, 'books', '*'>({} as Loaded<Author, 'books', '*'>);
-}).types([994, 'instantiations']);
+}).types([1019, 'instantiations']);
 
 bench('Loaded<Author, "books", "name" | "email"> - specific fields', () => {
   useLoaded<Author, 'books', 'name' | 'email'>({} as Loaded<Author, 'books', 'name' | 'email'>);

--- a/tests/bench/types/autopath-loaded-isolated.ts
+++ b/tests/bench/types/autopath-loaded-isolated.ts
@@ -61,15 +61,15 @@ function validatePath<T, P extends string>(_path: AutoPath<T, P, PopulatePath.AL
 
 bench('AutoPath LINEAR - 1 level', () => {
   validatePath<Person, 'address'>('address');
-}).types([714, 'instantiations']);
+}).types([729, 'instantiations']);
 
 bench('AutoPath LINEAR - 2 levels', () => {
   validatePath<Person, 'address.city'>('address.city');
-}).types([895, 'instantiations']);
+}).types([922, 'instantiations']);
 
 bench('AutoPath LINEAR - 3 levels', () => {
   validatePath<Person, 'address.city.country'>('address.city.country');
-}).types([1042, 'instantiations']);
+}).types([1081, 'instantiations']);
 
 // ============================================
 // Loaded with LINEAR entities (Ref only)
@@ -80,19 +80,19 @@ function useLoaded<T, L extends string = never>(_entity: Loaded<T, L>): void {}
 
 bench('Loaded LINEAR - no populate', () => {
   useLoaded<Person>({} as Person);
-}).types([505, 'instantiations']);
+}).types([503, 'instantiations']);
 
 bench('Loaded LINEAR - 1 level (Ref)', () => {
   useLoaded<Person, 'address'>({} as Loaded<Person, 'address'>);
-}).types([901, 'instantiations']);
+}).types([927, 'instantiations']);
 
 bench('Loaded LINEAR - 2 levels (Ref)', () => {
   useLoaded<Person, 'address.city'>({} as Loaded<Person, 'address.city'>);
-}).types([901, 'instantiations']);
+}).types([927, 'instantiations']);
 
 bench('Loaded LINEAR - 3 levels (Ref)', () => {
   useLoaded<Person, 'address.city.country'>({} as Loaded<Person, 'address.city.country'>);
-}).types([901, 'instantiations']);
+}).types([927, 'instantiations']);
 
 // ============================================
 // SELF-REFERENCING entity (single type circular)
@@ -108,27 +108,27 @@ interface TreeNode {
 
 bench('AutoPath SELF-REF - 1 level', () => {
   validatePath<TreeNode, 'parent'>('parent');
-}).types([781, 'instantiations']);
+}).types([808, 'instantiations']);
 
 bench('AutoPath SELF-REF - 2 levels', () => {
   validatePath<TreeNode, 'parent.parent'>('parent.parent');
-}).types([843, 'instantiations']);
+}).types([870, 'instantiations']);
 
 bench('AutoPath SELF-REF - children (Collection)', () => {
   validatePath<TreeNode, 'children'>('children');
-}).types([606, 'instantiations']);
+}).types([615, 'instantiations']);
 
 bench('Loaded SELF-REF - 1 level (Ref)', () => {
   useLoaded<TreeNode, 'parent'>({} as Loaded<TreeNode, 'parent'>);
-}).types([923, 'instantiations']);
+}).types([949, 'instantiations']);
 
 bench('Loaded SELF-REF - 2 levels (Ref)', () => {
   useLoaded<TreeNode, 'parent.parent'>({} as Loaded<TreeNode, 'parent.parent'>);
-}).types([923, 'instantiations']);
+}).types([949, 'instantiations']);
 
 bench('Loaded SELF-REF - children (Collection)', () => {
   useLoaded<TreeNode, 'children'>({} as Loaded<TreeNode, 'children'>);
-}).types([894, 'instantiations']);
+}).types([919, 'instantiations']);
 
 // ============================================
 // TWO-WAY circular reference (A <-> B)
@@ -151,35 +151,35 @@ interface Department {
 
 bench('AutoPath CIRCULAR - simple', () => {
   validatePath<Employee, 'department'>('department');
-}).types([726, 'instantiations']);
+}).types([741, 'instantiations']);
 
 bench('AutoPath CIRCULAR - 2 levels', () => {
   validatePath<Employee, 'department.manager'>('department.manager');
-}).types([903, 'instantiations']);
+}).types([930, 'instantiations']);
 
 bench('AutoPath CIRCULAR - 3 levels', () => {
   validatePath<Employee, 'department.manager.department'>('department.manager.department');
-}).types([951, 'instantiations']);
+}).types([984, 'instantiations']);
 
 bench('Loaded CIRCULAR - simple (Ref)', () => {
   useLoaded<Employee, 'department'>({} as Loaded<Employee, 'department'>);
-}).types([901, 'instantiations']);
+}).types([927, 'instantiations']);
 
 bench('Loaded CIRCULAR - 2 levels (Ref)', () => {
   useLoaded<Employee, 'department.manager'>({} as Loaded<Employee, 'department.manager'>);
-}).types([901, 'instantiations']);
+}).types([927, 'instantiations']);
 
 bench('Loaded CIRCULAR - back to start (Ref)', () => {
   useLoaded<Employee, 'department.manager.department'>({} as Loaded<Employee, 'department.manager.department'>);
-}).types([901, 'instantiations']);
+}).types([927, 'instantiations']);
 
 bench('Loaded CIRCULAR - collection', () => {
   useLoaded<Department, 'employees'>({} as Loaded<Department, 'employees'>);
-}).types([894, 'instantiations']);
+}).types([919, 'instantiations']);
 
 bench('Loaded CIRCULAR - collection nested', () => {
   useLoaded<Department, 'employees.department'>({} as Loaded<Department, 'employees.department'>);
-}).types([894, 'instantiations']);
+}).types([919, 'instantiations']);
 
 // ============================================
 // Entity with many properties (width test)
@@ -227,22 +227,22 @@ interface WideWithRefs {
 
 bench('AutoPath WIDE - 20 scalar props', () => {
   validatePath<WideSimple, 'f1'>('f1');
-}).types([830, 'instantiations']);
+}).types([841, 'instantiations']);
 
 bench('AutoPath WIDE - 5 refs', () => {
   validatePath<WideWithRefs, 'r1'>('r1');
-}).types([787, 'instantiations']);
+}).types([802, 'instantiations']);
 
 bench('Loaded WIDE - 20 scalar props', () => {
   useLoaded<WideSimple>({} as WideSimple);
-}).types([865, 'instantiations']);
+}).types([863, 'instantiations']);
 
 bench('Loaded WIDE - 5 refs no populate', () => {
   useLoaded<WideWithRefs>({} as WideWithRefs);
-}).types([665, 'instantiations']);
+}).types([663, 'instantiations']);
 
 bench('Loaded WIDE - 5 refs all populated', () => {
   useLoaded<WideWithRefs, 'r1' | 'r2' | 'r3' | 'r4' | 'r5'>(
     {} as Loaded<WideWithRefs, 'r1' | 'r2' | 'r3' | 'r4' | 'r5'>,
   );
-}).types([1554, 'instantiations']);
+}).types([1580, 'instantiations']);

--- a/tests/bench/types/autopath-loaded.ts
+++ b/tests/bench/types/autopath-loaded.ts
@@ -58,27 +58,27 @@ function validatePath<T, P extends string>(_path: AutoPath<T, P, PopulatePath.AL
 
 bench('AutoPath - simple property access', () => {
   validatePath<Author, 'name'>('name');
-}).types([682, 'instantiations']);
+}).types([693, 'instantiations']);
 
 bench('AutoPath - single relation', () => {
   validatePath<Author, 'books'>('books');
-}).types([772, 'instantiations']);
+}).types([787, 'instantiations']);
 
 bench('AutoPath - nested relation (2 levels)', () => {
   validatePath<Author, 'books.publisher'>('books.publisher');
-}).types([999, 'instantiations']);
+}).types([1038, 'instantiations']);
 
 bench('AutoPath - nested relation (3 levels)', () => {
   validatePath<Author, 'books.publisher.books'>('books.publisher.books');
-}).types([1042, 'instantiations']);
+}).types([1087, 'instantiations']);
 
 bench('AutoPath - nested relation (4 levels)', () => {
   validatePath<Author, 'books.publisher.books.author'>('books.publisher.books.author');
-}).types([1105, 'instantiations']);
+}).types([1156, 'instantiations']);
 
 bench('AutoPath - collection with :ref', () => {
   validatePath<Author, 'books:ref'>('books:ref');
-}).types([581, 'instantiations']);
+}).types([599, 'instantiations']);
 
 // ============================================
 // Loaded benchmarks
@@ -89,29 +89,29 @@ function useLoaded<T, L extends string = never>(_entity: Loaded<T, L>): void {}
 
 bench('Loaded - no populate', () => {
   useLoaded<Author>({} as Author);
-}).types([585, 'instantiations']);
+}).types([583, 'instantiations']);
 
 bench('Loaded - single relation', () => {
   useLoaded<Author, 'books'>({} as Loaded<Author, 'books'>);
-}).types([960, 'instantiations']);
+}).types([985, 'instantiations']);
 
 bench('Loaded - nested relation (2 levels)', () => {
   useLoaded<Author, 'books.publisher'>({} as Loaded<Author, 'books.publisher'>);
-}).types([960, 'instantiations']);
+}).types([985, 'instantiations']);
 
 bench('Loaded - nested relation (3 levels)', () => {
   useLoaded<Author, 'books.publisher.books'>({} as Loaded<Author, 'books.publisher.books'>);
-}).types([960, 'instantiations']);
+}).types([985, 'instantiations']);
 
 bench('Loaded - multiple relations', () => {
   useLoaded<Author, 'books' | 'friends' | 'favouriteBook'>({} as Loaded<Author, 'books' | 'friends' | 'favouriteBook'>);
-}).types([1240, 'instantiations']);
+}).types([1278, 'instantiations']);
 
 bench('Loaded - complex nested paths', () => {
   useLoaded<Author, 'books.tags' | 'books.publisher' | 'friends.books'>(
     {} as Loaded<Author, 'books.tags' | 'books.publisher' | 'friends.books'>,
   );
-}).types([1117, 'instantiations']);
+}).types([1148, 'instantiations']);
 
 // ============================================
 // Deep hierarchy tests
@@ -163,13 +163,13 @@ interface DeepRoot {
 
 bench('AutoPath - deep hierarchy (6 levels)', () => {
   validatePath<DeepRoot, 'level1.level2.level3.level4.level5'>('level1.level2.level3.level4.level5');
-}).types([1402, 'instantiations']);
+}).types([1465, 'instantiations']);
 
 bench('Loaded - deep hierarchy (6 levels)', () => {
   useLoaded<DeepRoot, 'level1.level2.level3.level4.level5'>(
     {} as Loaded<DeepRoot, 'level1.level2.level3.level4.level5'>,
   );
-}).types([923, 'instantiations']);
+}).types([949, 'instantiations']);
 
 // ============================================
 // Wide entity (many properties) tests
@@ -197,11 +197,11 @@ interface WideEntity {
 
 bench('AutoPath - wide entity (15 properties)', () => {
   validatePath<WideEntity, 'rel1'>('rel1');
-}).types([843, 'instantiations']);
+}).types([858, 'instantiations']);
 
 bench('Loaded - wide entity (15 properties)', () => {
   useLoaded<WideEntity, 'rel1' | 'rel2' | 'rel3'>({} as Loaded<WideEntity, 'rel1' | 'rel2' | 'rel3'>);
-}).types([1390, 'instantiations']);
+}).types([1416, 'instantiations']);
 
 // ============================================
 // Eager props tests
@@ -218,7 +218,7 @@ interface EntityWithEager {
 
 bench('Loaded - with eager props', () => {
   useLoaded<EntityWithEager, 'normalRel'>({} as Loaded<EntityWithEager, 'normalRel'>);
-}).types([1001, 'instantiations']);
+}).types([1027, 'instantiations']);
 
 // ============================================
 // Fields selection tests
@@ -232,4 +232,4 @@ bench('Loaded - with fields selection', () => {
 bench('Loaded - with exclude', () => {
   const entity = {} as Loaded<Author, 'books', '*', 'age'>;
   void entity;
-}).types([591, 'instantiations']);
+}).types([589, 'instantiations']);

--- a/tests/bench/types/defineEntity-extends.ts
+++ b/tests/bench/types/defineEntity-extends.ts
@@ -19,7 +19,7 @@ bench('entity extends entity', () => {
       extra: p.string(),
     },
   });
-}).types([1472, 'instantiations']);
+}).types([1479, 'instantiations']);
 
 bench('entity extends entity with discriminator', () => {
   const base = defineEntity({
@@ -40,7 +40,7 @@ bench('entity extends entity with discriminator', () => {
       extra: p.string(),
     },
   });
-}).types([1493, 'instantiations']);
+}).types([1500, 'instantiations']);
 
 bench('embeddable extends embeddable', () => {
   const base = defineEntity({
@@ -60,7 +60,7 @@ bench('embeddable extends embeddable', () => {
       bar: p.string(),
     },
   });
-}).types([926, 'instantiations']);
+}).types([930, 'instantiations']);
 
 bench('embeddable extends embeddable with discriminator', () => {
   const base = defineEntity({
@@ -83,7 +83,7 @@ bench('embeddable extends embeddable with discriminator', () => {
       bar: p.string(),
     },
   });
-}).types([947, 'instantiations']);
+}).types([951, 'instantiations']);
 
 bench('polymorphic embeddables', () => {
   const base = defineEntity({
@@ -198,7 +198,7 @@ bench('polymorphic embeddables', () => {
       data: () => p.embedded([documentDataAwEdCard, documentDataCoCheckMig, documentDataMvDiCard]).object(),
     },
   });
-}).types([3650, 'instantiations']);
+}).types([3657, 'instantiations']);
 
 bench('realistic entity (~20 props, relations, extends)', () => {
   const base = defineEntity({
@@ -270,7 +270,7 @@ bench('realistic entity (~20 props, relations, extends)', () => {
       tags: () => p.manyToMany(Tag),
     },
   });
-}).types([7890, 'instantiations']);
+}).types([8120, 'instantiations']);
 
 bench('realistic entity - InferEntity usage', () => {
   const base = defineEntity({
@@ -350,7 +350,7 @@ bench('realistic entity - InferEntity usage', () => {
 
   // Force evaluation of all entity types
   const _check: [IAuthor, IBook, ITag, IPublisher] = {} as any;
-}).types([7998, 'instantiations']);
+}).types([8228, 'instantiations']);
 
 bench('realistic entity - setClass pattern', () => {
   const BaseSchema = defineEntity({
@@ -436,4 +436,4 @@ bench('realistic entity - setClass pattern', () => {
   PublisherSchema.setClass(Publisher);
   AuthorSchema.setClass(Author);
   BookSchema.setClass(Book);
-}).types([8049, 'instantiations']);
+}).types([8289, 'instantiations']);

--- a/tests/bench/types/defineEntity.ts
+++ b/tests/bench/types/defineEntity.ts
@@ -19,7 +19,7 @@ bench('defineEntity with relations', () => {
       strictNullRef: () => p.oneToOne(Foo).strictNullable(),
     },
   });
-}).types([7349, 'instantiations']);
+}).types([7590, 'instantiations']);
 
 bench('defineEntity with ref and nullable', () => {
   const Foo = defineEntity({
@@ -36,7 +36,7 @@ bench('defineEntity with ref and nullable', () => {
       scalarRefNullable: p.string().ref().nullable(),
     },
   });
-}).types([6839, 'instantiations']);
+}).types([7080, 'instantiations']);
 
 bench('defineEntity only with ref and nullable', () => {
   const Foo = defineEntity({
@@ -46,7 +46,7 @@ bench('defineEntity only with ref and nullable', () => {
       toOneRefNullable: () => p.oneToOne(Foo).ref().nullable(),
     },
   });
-}).types([1848, 'instantiations']);
+}).types([1861, 'instantiations']);
 
 bench('defineEntity only with nullable and ref', () => {
   const Foo = defineEntity({
@@ -56,7 +56,7 @@ bench('defineEntity only with nullable and ref', () => {
       toOneRefNullable: () => p.oneToOne(Foo).nullable().ref(),
     },
   });
-}).types([1848, 'instantiations']);
+}).types([1864, 'instantiations']);
 
 bench('defineEntity with relations using class', () => {
   class Foo {
@@ -88,7 +88,7 @@ bench('defineEntity with relations using class', () => {
       scalarRefNullable: p.string().ref().nullable(),
     },
   });
-}).types([7329, 'instantiations']);
+}).types([7573, 'instantiations']);
 
 bench('defineEntity with ref and nullable using class', () => {
   class Foo {
@@ -120,7 +120,7 @@ bench('defineEntity with ref and nullable using class', () => {
       scalarRefNullable: p.string().ref().nullable(),
     },
   });
-}).types([7329, 'instantiations']);
+}).types([7573, 'instantiations']);
 
 bench('defineEntity only with ref and nullable using class', () => {
   class Foo {
@@ -138,7 +138,7 @@ bench('defineEntity only with ref and nullable using class', () => {
       toOneRefNullable: () => p.oneToOne(Foo).ref().nullable(),
     },
   });
-}).types([2363, 'instantiations']);
+}).types([2379, 'instantiations']);
 
 bench('defineEntity only with nullable and ref using class', () => {
   class Foo {
@@ -156,7 +156,7 @@ bench('defineEntity only with nullable and ref using class', () => {
       toOneRefNullable: () => p.oneToOne(Foo).nullable().ref(),
     },
   });
-}).types([2363, 'instantiations']);
+}).types([2382, 'instantiations']);
 
 bench('EntitySchema', () => {
   interface IFoo {
@@ -205,7 +205,7 @@ bench('EntitySchema', () => {
       },
     } as any,
   });
-}).types([341, 'instantiations']);
+}).types([344, 'instantiations']);
 
 bench('defineEntity with setClass pattern (circular relations)', () => {
   const AuthorSchema = defineEntity({
@@ -241,7 +241,7 @@ bench('defineEntity with setClass pattern (circular relations)', () => {
 
   AuthorSchema.setClass(Author);
   BookSchema.setClass(Book);
-}).types([5796, 'instantiations']);
+}).types([6036, 'instantiations']);
 
 bench('defineEntity with indexes', () => {
   const Bar = defineEntity({
@@ -255,4 +255,4 @@ bench('defineEntity with indexes', () => {
     },
     indexes: [{ name: 'idx_status_views', properties: ['status', 'views'] }],
   });
-}).types([1931, 'instantiations']);
+}).types([1938, 'instantiations']);

--- a/tests/bench/types/entitydto-isolated.ts
+++ b/tests/bench/types/entitydto-isolated.ts
@@ -59,23 +59,23 @@ bench('EntityDTO<EntityWithCollection> - with Collection', () => {
 
 bench('EntityDTO<Loaded<SimpleEntity>> - loaded no relations', () => {
   useDTO<Loaded<SimpleEntity>>({} as EntityDTO<Loaded<SimpleEntity>>);
-}).types([2142, 'instantiations']);
+}).types([2140, 'instantiations']);
 
 bench('EntityDTO<Loaded<EntityWithRef>> - loaded with Ref', () => {
   useDTO<Loaded<EntityWithRef>>({} as EntityDTO<Loaded<EntityWithRef>>);
-}).types([1930, 'instantiations']);
+}).types([1928, 'instantiations']);
 
 bench('EntityDTO<Loaded<EntityWithRef, "parent">> - loaded with populated Ref', () => {
   useDTO<Loaded<EntityWithRef, 'parent'>>({} as EntityDTO<Loaded<EntityWithRef, 'parent'>>);
-}).types([2411, 'instantiations']);
+}).types([2437, 'instantiations']);
 
 bench('EntityDTO<Loaded<EntityWithCollection>> - loaded with Collection', () => {
   useDTO<Loaded<EntityWithCollection>>({} as EntityDTO<Loaded<EntityWithCollection>>);
-}).types([1740, 'instantiations']);
+}).types([1738, 'instantiations']);
 
 bench('EntityDTO<Loaded<EntityWithCollection, "items">> - loaded with populated Collection', () => {
   useDTO<Loaded<EntityWithCollection, 'items'>>({} as EntityDTO<Loaded<EntityWithCollection, 'items'>>);
-}).types([2369, 'instantiations']);
+}).types([2394, 'instantiations']);
 
 // ============================================
 // Comparison: EntityDTO vs direct Loaded
@@ -86,4 +86,4 @@ function useLoaded<T, L extends string = never>(_entity: Loaded<T, L>): void {}
 
 bench('Loaded<EntityWithCollection, "items"> - without EntityDTO', () => {
   useLoaded<EntityWithCollection, 'items'>({} as Loaded<EntityWithCollection, 'items'>);
-}).types([872, 'instantiations']);
+}).types([897, 'instantiations']);

--- a/tests/bench/types/filter-query.ts
+++ b/tests/bench/types/filter-query.ts
@@ -76,7 +76,7 @@ bench('EntityKey<Loaded<Author, "books">>', () => {
   type R = EntityKey<Loaded<Author, 'books'>>;
   const x = {} as R;
   void x;
-}).types([1727, 'instantiations']);
+}).types([1752, 'instantiations']);
 
 // ============================================
 // FilterObject benchmarks
@@ -86,13 +86,13 @@ bench('FilterObject<Author>', () => {
   type R = FilterObject<Author>;
   const x = {} as R;
   void x;
-}).types([332, 'instantiations']);
+}).types([330, 'instantiations']);
 
 bench('FilterObject<Book>', () => {
   type R = FilterObject<Book>;
   const x = {} as R;
   void x;
-}).types([303, 'instantiations']);
+}).types([301, 'instantiations']);
 
 // ============================================
 // FilterQuery benchmarks (already in api-methods but more detailed here)
@@ -102,19 +102,19 @@ bench('FilterQuery<Author> - plain', () => {
   type R = FilterQuery<Author>;
   const x = {} as R;
   void x;
-}).types([548, 'instantiations']);
+}).types([546, 'instantiations']);
 
 bench('FilterQuery<Book> - plain', () => {
   type R = FilterQuery<Book>;
   const x = {} as R;
   void x;
-}).types([517, 'instantiations']);
+}).types([515, 'instantiations']);
 
 bench('FilterQuery<Tag> - simple entity', () => {
   type R = FilterQuery<Tag>;
   const x = {} as R;
   void x;
-}).types([458, 'instantiations']);
+}).types([456, 'instantiations']);
 
 // ============================================
 // Union entity tests
@@ -126,7 +126,7 @@ bench('FilterQuery<Author | Book> - union', () => {
   type R = FilterQuery<AuthorOrBook>;
   const x = {} as R;
   void x;
-}).types([492, 'instantiations']);
+}).types([490, 'instantiations']);
 
 // ============================================
 // Nested filter access simulation
@@ -137,10 +137,10 @@ bench('FilterQuery nested - author.books', () => {
   type R = FilterObject<Author>['books'];
   const x = {} as R;
   void x;
-}).types([1026, 'instantiations']);
+}).types([1033, 'instantiations']);
 
 bench('FilterQuery nested - book.author', () => {
   type R = FilterObject<Book>['author'];
   const x = {} as R;
   void x;
-}).types([1035, 'instantiations']);
+}).types([1042, 'instantiations']);

--- a/tests/bench/types/filterquery-deep.ts
+++ b/tests/bench/types/filterquery-deep.ts
@@ -64,19 +64,19 @@ function useFilter<T>(_filter: FilterQuery<T>): void {}
 
 bench('FilterQuery<Tag> - simple entity', () => {
   useFilter<Tag>({ name: 'test' });
-}).types([442, 'instantiations']);
+}).types([449, 'instantiations']);
 
 bench('FilterQuery<Publisher> - entity with collection', () => {
   useFilter<Publisher>({ name: 'test' });
-}).types([469, 'instantiations']);
+}).types([476, 'instantiations']);
 
 bench('FilterQuery<Book> - entity with relations', () => {
   useFilter<Book>({ title: 'test' });
-}).types([501, 'instantiations']);
+}).types([508, 'instantiations']);
 
 bench('FilterQuery<Author> - complex entity', () => {
   useFilter<Author>({ name: 'test' });
-}).types([532, 'instantiations']);
+}).types([539, 'instantiations']);
 
 // ============================================
 // Nested query benchmarks
@@ -84,15 +84,15 @@ bench('FilterQuery<Author> - complex entity', () => {
 
 bench('FilterQuery<Author> - nested 1 level', () => {
   useFilter<Author>({ books: { title: 'test' } });
-}).types([1062, 'instantiations']);
+}).types([1074, 'instantiations']);
 
 bench('FilterQuery<Author> - nested 2 levels', () => {
   useFilter<Author>({ books: { publisher: { name: 'test' } } });
-}).types([1356, 'instantiations']);
+}).types([1383, 'instantiations']);
 
 bench('FilterQuery<Author> - nested 3 levels', () => {
   useFilter<Author>({ books: { publisher: { books: { title: 'test' } } } });
-}).types([1388, 'instantiations']);
+}).types([1415, 'instantiations']);
 
 // ============================================
 // Component type benchmarks
@@ -103,14 +103,14 @@ function useFilterObject<T>(_filter: FilterObject<T>): void {}
 
 bench('FilterObject<Author> - direct', () => {
   useFilterObject<Author>({ name: 'test' });
-}).types([450, 'instantiations']);
+}).types([457, 'instantiations']);
 
 // eslint-disable-next-line
 function useExpandQuery<T>(_filter: ExpandQuery<T>): void {}
 
 bench('ExpandQuery<Author> - direct', () => {
   useExpandQuery<Author>({ name: 'test' });
-}).types([602, 'instantiations']);
+}).types([609, 'instantiations']);
 
 // ============================================
 // EntityKey benchmarks

--- a/tests/bench/types/lazy-ref.ts
+++ b/tests/bench/types/lazy-ref.ts
@@ -1,0 +1,201 @@
+#!/usr/bin/env -S node --import=tsx
+
+import { bench } from '@ark/attest';
+import {
+  type AutoPath,
+  type Collection,
+  type LazyRef,
+  type Loaded,
+  type PopulatePath,
+  type Ref,
+  EagerProps,
+  PrimaryKeyProp,
+} from '@mikro-orm/core';
+
+// ============================================
+// Entities with LazyRef-based relations
+// ============================================
+
+interface LRTag {
+  id: number;
+  name: string;
+  [PrimaryKeyProp]?: 'id';
+}
+
+interface LRPublisher {
+  id: number;
+  name: string;
+  books: Collection<LRBook>;
+  [PrimaryKeyProp]?: 'id';
+}
+
+interface LRBook {
+  id: number;
+  title: string;
+  author: LazyRef<LRAuthor>;
+  publisher?: LazyRef<LRPublisher> | null;
+  tags: Collection<LRTag>;
+  [PrimaryKeyProp]?: 'id';
+}
+
+interface LRAuthor {
+  id: number;
+  name: string;
+  email: string;
+  age?: number;
+  books: Collection<LRBook>;
+  favouriteBook?: LazyRef<LRBook> | null;
+  friends: Collection<LRAuthor>;
+  [PrimaryKeyProp]?: 'id';
+}
+
+// ============================================
+// AutoPath benchmarks — paths traversing LazyRef
+// ============================================
+
+function validatePath<T, P extends string>(_path: AutoPath<T, P, PopulatePath.ALL>): void {
+  /* empty */
+}
+
+bench('AutoPath LazyRef - single relation', () => {
+  validatePath<LRBook, 'author'>('author');
+}).types([792, 'instantiations']);
+
+bench('AutoPath LazyRef - nested (2 levels)', () => {
+  validatePath<LRBook, 'author.books'>('author.books');
+}).types([861, 'instantiations']);
+
+bench('AutoPath LazyRef - nested (3 levels)', () => {
+  validatePath<LRBook, 'author.books.publisher'>('author.books.publisher');
+}).types([1079, 'instantiations']);
+
+bench('AutoPath LazyRef - collection with :ref', () => {
+  validatePath<LRBook, 'author:ref'>('author:ref');
+}).types([550, 'instantiations']);
+
+// ============================================
+// Loaded benchmarks — narrowing LazyRef
+// ============================================
+
+// eslint-disable-next-line
+function useLoaded<T, L extends string = never>(_entity: Loaded<T, L>): void {}
+
+bench('Loaded LazyRef - no populate', () => {
+  useLoaded<LRBook>({} as LRBook);
+}).types([543, 'instantiations']);
+
+bench('Loaded LazyRef - single to-one', () => {
+  useLoaded<LRBook, 'author'>({} as Loaded<LRBook, 'author'>);
+}).types([954, 'instantiations']);
+
+bench('Loaded LazyRef - nested to-one (2 levels)', () => {
+  useLoaded<LRBook, 'author.favouriteBook'>({} as Loaded<LRBook, 'author.favouriteBook'>);
+}).types([954, 'instantiations']);
+
+bench('Loaded LazyRef - mixed LazyRef + Collection', () => {
+  useLoaded<LRBook, 'author' | 'tags'>({} as Loaded<LRBook, 'author' | 'tags'>);
+}).types([1077, 'instantiations']);
+
+// ============================================
+// Baseline comparison — same entity shape but using Ref instead of LazyRef
+// ============================================
+
+interface RefBook {
+  id: number;
+  title: string;
+  author: Ref<RefAuthor>;
+  publisher?: Ref<RefPublisher> | null;
+  tags: Collection<RefTag>;
+  [PrimaryKeyProp]?: 'id';
+}
+
+interface RefAuthor {
+  id: number;
+  name: string;
+  email: string;
+  age?: number;
+  books: Collection<RefBook>;
+  favouriteBook?: Ref<RefBook> | null;
+  friends: Collection<RefAuthor>;
+  [PrimaryKeyProp]?: 'id';
+}
+
+interface RefPublisher {
+  id: number;
+  name: string;
+  books: Collection<RefBook>;
+  [PrimaryKeyProp]?: 'id';
+}
+
+interface RefTag {
+  id: number;
+  name: string;
+  [PrimaryKeyProp]?: 'id';
+}
+
+bench('AutoPath Ref (baseline) - nested (2 levels)', () => {
+  validatePath<RefBook, 'author.books'>('author.books');
+}).types([871, 'instantiations']);
+
+bench('Loaded Ref (baseline) - single to-one', () => {
+  useLoaded<RefBook, 'author'>({} as Loaded<RefBook, 'author'>);
+}).types([971, 'instantiations']);
+
+// ============================================
+// Deep chain of LazyRef relations
+// ============================================
+
+interface L5 {
+  id: number;
+  value: string;
+  [PrimaryKeyProp]?: 'id';
+}
+
+interface L4 {
+  id: number;
+  next: LazyRef<L5>;
+  [PrimaryKeyProp]?: 'id';
+}
+
+interface L3 {
+  id: number;
+  next: LazyRef<L4>;
+  [PrimaryKeyProp]?: 'id';
+}
+
+interface L2 {
+  id: number;
+  next: LazyRef<L3>;
+  [PrimaryKeyProp]?: 'id';
+}
+
+interface L1 {
+  id: number;
+  next: LazyRef<L2>;
+  [PrimaryKeyProp]?: 'id';
+}
+
+bench('AutoPath LazyRef - deep chain (5 levels)', () => {
+  validatePath<L1, 'next.next.next.next'>('next.next.next.next');
+}).types([1165, 'instantiations']);
+
+bench('Loaded LazyRef - deep chain (5 levels)', () => {
+  useLoaded<L1, 'next.next.next.next'>({} as Loaded<L1, 'next.next.next.next'>);
+}).types([902, 'instantiations']);
+
+// ============================================
+// Eager LazyRef
+// ============================================
+
+interface LREntityWithEager {
+  id: number;
+  name: string;
+  eagerRel: LazyRef<LRTag>;
+  normalRel: LazyRef<LRTag>;
+  [PrimaryKeyProp]?: 'id';
+  [EagerProps]?: 'eagerRel';
+}
+
+bench('Loaded LazyRef - with eager props', () => {
+  useLoaded<LREntityWithEager, 'normalRel'>({} as Loaded<LREntityWithEager, 'normalRel'>);
+}).types([1024, 'instantiations']);

--- a/tests/bench/types/other-types.ts
+++ b/tests/bench/types/other-types.ts
@@ -70,19 +70,19 @@ function useFilter<T>(_filter: FilterQuery<T>): void {}
 
 bench('FilterQuery<Author> - simple', () => {
   useFilter<Author>({ name: 'test' });
-}).types([543, 'instantiations']);
+}).types([550, 'instantiations']);
 
 bench('FilterQuery<Author> - with relation', () => {
   useFilter<Author>({ books: { title: 'test' } });
-}).types([1084, 'instantiations']);
+}).types([1096, 'instantiations']);
 
 bench('FilterQuery<Author> - with operators', () => {
   useFilter<Author>({ age: { $gt: 18 }, name: { $like: '%test%' } });
-}).types([700, 'instantiations']);
+}).types([717, 'instantiations']);
 
 bench('FilterQuery<Book> - nested relations', () => {
   useFilter<Book>({ author: { books: { publisher: { name: 'test' } } } });
-}).types([1482, 'instantiations']);
+}).types([1514, 'instantiations']);
 
 // ============================================
 // EntityData benchmarks
@@ -93,7 +93,7 @@ function useEntityData<T>(_data: EntityData<T>): void {}
 
 bench('EntityData<Author> - simple', () => {
   useEntityData<Author>({ name: 'test', email: 'test@test.com' });
-}).types([213, 'instantiations']);
+}).types([244, 'instantiations']);
 
 bench('EntityData<Book> - with relations', () => {
   useEntityData<Book>({
@@ -101,7 +101,7 @@ bench('EntityData<Book> - with relations', () => {
     price: 10,
     author: { name: 'test' } as any,
   });
-}).types([628, 'instantiations']);
+}).types([688, 'instantiations']);
 
 // ============================================
 // RequiredEntityData benchmarks
@@ -112,11 +112,11 @@ function useRequiredData<T>(_data: RequiredEntityData<T>): void {}
 
 bench('RequiredEntityData<Author> - simple', () => {
   useRequiredData<Author>({ name: 'test', email: 'test@test.com' });
-}).types([2147, 'instantiations']);
+}).types([2190, 'instantiations']);
 
 bench('RequiredEntityData<Book> - with required relations', () => {
   useRequiredData<Book>({ title: 'test', price: 10, author: {} as Author });
-}).types([3518, 'instantiations']);
+}).types([3590, 'instantiations']);
 
 // ============================================
 // Primary type benchmarks
@@ -146,4 +146,4 @@ bench('EntityDTO<Author> - simple', () => {
 
 bench('EntityDTO<Loaded<Author, "books">> - with loaded hint', () => {
   useDTO<Loaded<Author, 'books'>>({} as EntityDTO<Loaded<Author, 'books'>>);
-}).types([3891, 'instantiations']);
+}).types([3916, 'instantiations']);

--- a/tests/bench/types/populate-all.ts
+++ b/tests/bench/types/populate-all.ts
@@ -71,8 +71,8 @@ bench('AutoPath<Publisher, true> - populate all', () => {
 // Compare with string paths
 bench('AutoPath<Author, "books"> - string path', () => {
   validatePath<Author, 'books'>('books');
-}).types([794, 'instantiations']);
+}).types([809, 'instantiations']);
 
 bench('AutoPath<Author, "books.publisher"> - nested string', () => {
   validatePath<Author, 'books.publisher'>('books.publisher');
-}).types([1032, 'instantiations']);
+}).types([1071, 'instantiations']);

--- a/tests/bench/types/querybuilder.ts
+++ b/tests/bench/types/querybuilder.ts
@@ -76,22 +76,22 @@ function useField<E, R extends string, C>(_field: Field<E, R, C>): void {}
 
 bench('Field<Author, "a", never> - no context', () => {
   useField<Author, 'a', never>('name');
-}).types([138, 'instantiations']);
+}).types([137, 'instantiations']);
 
 bench('Field<Author, "a", never> - wildcard', () => {
   useField<Author, 'a', never>('*');
-}).types([138, 'instantiations']);
+}).types([137, 'instantiations']);
 
 bench('Field<Author, "a", never> - alias wildcard', () => {
   useField<Author, 'a', never>('a.*');
-}).types([138, 'instantiations']);
+}).types([137, 'instantiations']);
 
 // Context uses tuple format: [Path, Alias, Type, Select]
 type SimpleContext = { b: ['books', 'b', Book, false] };
 
 bench('Field<Author, "a", SimpleContext> - with one join', () => {
   useField<Author, 'a', SimpleContext>('b.title');
-}).types([202, 'instantiations']);
+}).types([201, 'instantiations']);
 
 type TwoJoinContext = {
   b: ['books', 'b', Book, false];
@@ -100,7 +100,7 @@ type TwoJoinContext = {
 
 bench('Field<Author, "a", TwoJoinContext> - with two joins', () => {
   useField<Author, 'a', TwoJoinContext>('t.name');
-}).types([247, 'instantiations']);
+}).types([246, 'instantiations']);
 
 // ============================================
 // ModifyHint benchmarks
@@ -140,11 +140,11 @@ function useOrderBy<E, R extends string, C>(_order: ContextOrderByMap<E, R, C>):
 
 bench('ContextOrderByMap<Author, "a", never> - no context', () => {
   useOrderBy<Author, 'a', never>({ name: 'asc' });
-}).types([557, 'instantiations']);
+}).types([598, 'instantiations']);
 
 bench('ContextOrderByMap<Author, "a", SimpleContext> - with join', () => {
   useOrderBy<Author, 'a', SimpleContext>({ 'b.title': 'asc' });
-}).types([594, 'instantiations']);
+}).types([635, 'instantiations']);
 
 // ============================================
 // QBFilterQuery benchmarks
@@ -154,17 +154,17 @@ function useFilter<E, R extends string, C>(_filter: QBFilterQuery<E, R, C>): voi
 
 bench('QBFilterQuery<Author, "a", never> - no context', () => {
   useFilter<Author, 'a', never>({ name: 'test' });
-}).types([281, 'instantiations']);
+}).types([287, 'instantiations']);
 
 bench('QBFilterQuery<Author, "a", SimpleContext> - with join', () => {
   useFilter<Author, 'a', SimpleContext>({ 'b.title': 'test' });
-}).types([297, 'instantiations']);
+}).types([303, 'instantiations']);
 
 bench('QBFilterQuery<Author, "a", SimpleContext> - with $and', () => {
   useFilter<Author, 'a', SimpleContext>({
     $and: [{ 'b.title': 'test' }, { name: 'foo' }],
   });
-}).types([417, 'instantiations']);
+}).types([423, 'instantiations']);
 
 // ============================================
 // ModifyFields benchmarks (Fields tracking)
@@ -282,7 +282,7 @@ bench('execute() return - 3-level nested with fields', () => {
   >;
   const _: number = r.id;
   void _;
-}).types([1709, 'instantiations']);
+}).types([1716, 'instantiations']);
 
 // ============================================
 // EntityDTOFlat vs EntityDTO comparison (wide entities)
@@ -346,25 +346,25 @@ bench('EntityDTO<Loaded<WideAuthor, "books">> - 2-pass recursive', () => {
   const r = {} as EntityDTO<Loaded<WideAuthor, 'books'>>;
   const _: string = r.name;
   void _;
-}).types([5088, 'instantiations']);
+}).types([5104, 'instantiations']);
 
 bench('EntityDTOFlat<Loaded<WideAuthor, "books">> - 1-pass recursive', () => {
   const r = {} as EntityDTOFlat<Loaded<WideAuthor, 'books'>>;
   const _: string = r.name;
   void _;
-}).types([4079, 'instantiations']);
+}).types([4095, 'instantiations']);
 
 bench('EntityDTO<Loaded<WideAuthor, "books.publisher">> - 2-pass recursive 2-level', () => {
   const r = {} as EntityDTO<Loaded<WideAuthor, 'books' | 'books.publisher'>>;
   const _: string = r.name;
   void _;
-}).types([5120, 'instantiations']);
+}).types([5136, 'instantiations']);
 
 bench('EntityDTOFlat<Loaded<WideAuthor, "books.publisher">> - 1-pass recursive 2-level', () => {
   const r = {} as EntityDTOFlat<Loaded<WideAuthor, 'books' | 'books.publisher'>>;
   const _: string = r.name;
   void _;
-}).types([4111, 'instantiations']);
+}).types([4127, 'instantiations']);
 
 // ============================================
 // CTE type safety benchmarks
@@ -431,4 +431,4 @@ bench('with().from() then select() - type-safe field access', () => {
   // After from(), select should accept 'c.title' as a valid field for Book
   fromQb.select('c.title');
   void fromQb;
-}).types([2354, 'instantiations']);
+}).types([2455, 'instantiations']);

--- a/tests/bench/types/scalar-test.ts
+++ b/tests/bench/types/scalar-test.ts
@@ -27,9 +27,9 @@ bench('AutoPath - scalar Date property should not expand', () => {
   // If this compiles with 'createdAt.' it means Date properties are being suggested
   // @ts-expect-error - createdAt is a Date, should not have nested paths
   validatePath<Author, 'createdAt.'>('createdAt.');
-}).types([1501, 'instantiations']);
+}).types([1531, 'instantiations']);
 
 bench('AutoPath - relation should expand', () => {
   // Use 'books.title' - a valid nested path (not 'books.' which is just a prefix)
   validatePath<Author, 'books.title'>('books.title');
-}).types([870, 'instantiations']);
+}).types([893, 'instantiations']);

--- a/tests/features/lazy-ref.test.ts
+++ b/tests/features/lazy-ref.test.ts
@@ -1,0 +1,390 @@
+import {
+  defineEntity,
+  EntitySchema,
+  p,
+  ref,
+  ScalarReference,
+  unref,
+  type LazyRef,
+  type InferEntity,
+  type Loaded,
+  type Ref,
+} from '@mikro-orm/core';
+import {
+  Entity,
+  ManyToOne,
+  OneToOne,
+  PrimaryKey,
+  Property,
+  ReflectMetadataProvider,
+} from '@mikro-orm/decorators/legacy';
+import { MikroORM } from '@mikro-orm/sqlite';
+
+@Entity()
+class Author {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @Property({ nullable: true })
+  email?: string;
+}
+
+@Entity()
+class Profile {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  bio!: string;
+}
+
+@Entity()
+class Book {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  title!: string;
+
+  @ManyToOne(() => Author)
+  author!: LazyRef<Author>;
+
+  @OneToOne(() => Profile, { owner: true, nullable: true })
+  profile?: LazyRef<Profile>;
+}
+
+describe('LazyRef', () => {
+  let orm: MikroORM;
+  let authorId: number;
+  let bookId: number;
+  let profileId: number;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      entities: [Author, Book, Profile],
+      dbName: ':memory:',
+    });
+    await orm.schema.refresh();
+
+    const author = orm.em.create(Author, { name: 'Stephen King' });
+    const profile = orm.em.create(Profile, { bio: 'horror author' });
+    const book = orm.em.create(Book, { title: 'It', author, profile });
+    await orm.em.flush();
+    authorId = author.id;
+    bookId = book.id;
+    profileId = profile.id;
+  });
+
+  afterAll(() => orm.close(true));
+  beforeEach(() => orm.em.clear());
+
+  test('runtime value is an entity instance, not a Reference wrapper', async () => {
+    const book = await orm.em.findOneOrFail(Book, bookId);
+    expect(book.author).toBeInstanceOf(Author);
+    // no `.$` / `.unwrap()` at runtime — direct entity
+    expect((book.author as any).unwrap).toBeUndefined();
+  });
+
+  test('PK is accessible on an unpopulated LazyRef field', async () => {
+    const book = await orm.em.findOneOrFail(Book, bookId);
+    // id is the PK — accessible without populate
+    expect(book.author.id).toBe(authorId);
+  });
+
+  test('populate narrows LazyRef to the full entity type at runtime', async () => {
+    const book = await orm.em.findOneOrFail(Book, bookId, { populate: ['author'] });
+    // compile-time: `book.author` is `Loaded<Author>` thanks to Loaded<Book, 'author'> narrowing
+    // runtime: full entity is hydrated
+    const author: Loaded<Author> = book.author;
+    expect(author.name).toBe('Stephen King');
+  });
+
+  test('populate works on 1:1 LazyRef', async () => {
+    const book = await orm.em.findOneOrFail(Book, bookId, { populate: ['profile'] });
+    expect(book.profile).toBeInstanceOf(Profile);
+    const profile: Loaded<Profile> = book.profile!;
+    expect(profile.bio).toBe('horror author');
+  });
+
+  test('em.populate() narrows LazyRef as well', async () => {
+    const book = await orm.em.findOneOrFail(Book, bookId);
+    const [populated] = await orm.em.populate([book], ['author']);
+    const author: Loaded<Author> = populated.author;
+    expect(author.name).toBe('Stephen King');
+  });
+
+  test('LazyRef path-based populate works transitively', async () => {
+    const book = await orm.em.findOneOrFail(Book, bookId, { populate: ['author.email'] });
+    const author: Loaded<Author> = book.author;
+    expect(author.name).toBe('Stephen King');
+  });
+
+  test('type-level: non-PK access is rejected on unloaded LazyRef', async () => {
+    const book = await orm.em.findOneOrFail(Book, bookId);
+    // id is the PK and is exposed
+    const id: number = book.author.id;
+    // @ts-expect-error non-PK access on an unloaded LazyRef must be a compile error
+    const _name: string = book.author.name;
+    expect(id).toBe(authorId);
+  });
+
+  test('type-level: loaded narrowing restores full entity access', async () => {
+    const book = await orm.em.findOneOrFail(Book, bookId, { populate: ['author'] });
+    // after Loaded<Book, 'author'>, non-PK access compiles fine
+    const name: string = book.author.name;
+    expect(name).toBe('Stephen King');
+  });
+
+  test('unref() narrows a populated LazyRef to the underlying entity', async () => {
+    const book = await orm.em.findOneOrFail(Book, bookId, { populate: ['author'] });
+    // even though `book.author` is typed as `LazyRef<Author>` in a bare `Book`, unref escapes the brand
+    function logAuthor(b: Book) {
+      return unref(b.author).name;
+    }
+    expect(logAuthor(book)).toBe('Stephen King');
+  });
+
+  test('unref() also unwraps a Ref<T> wrapper (runtime calls .unwrap())', async () => {
+    const author = await orm.em.findOneOrFail(Author, authorId);
+    const wrapped: Ref<Author> = ref(author);
+    expect(unref(wrapped)).toBe(author);
+    expect(unref(wrapped).name).toBe('Stephen King');
+  });
+
+  test('unref() is identity for a plain entity', async () => {
+    const author = await orm.em.findOneOrFail(Author, authorId);
+    expect(unref(author)).toBe(author);
+  });
+
+  test('unref() passes null/undefined through unchanged', () => {
+    expect(unref(null)).toBeNull();
+    expect(unref(undefined)).toBeUndefined();
+  });
+
+  test('unref() narrows return type for non-nullable / null-only / undefined-only inputs', async () => {
+    const author = await orm.em.findOneOrFail(Author, authorId);
+    const nonNullable: Author = author;
+    const nullable: Author | null = author;
+    const optional: Author | undefined = author;
+
+    // type-level: each input kind should produce a correspondingly narrow return type
+    const a: Author = unref(nonNullable);
+    const b: Author | null = unref(nullable);
+    const c: Author | undefined = unref(optional);
+
+    expect(a).toBe(author);
+    expect(b).toBe(author);
+    expect(c).toBe(author);
+  });
+
+  test('unref() unwraps ScalarReference to its value (inverse of ref(scalar))', () => {
+    const scalar = new ScalarReference('hello');
+    const out = unref(scalar);
+    expect(out).toBe('hello');
+
+    // type-level: return is `V | undefined` (since a scalar reference may be unbound)
+    type Out = typeof out;
+    type IsStringOrUndefined = [Out] extends [string | undefined] ? true : false;
+    const typeCheck: IsStringOrUndefined = true;
+    expect(typeCheck).toBe(true);
+  });
+
+  test('unref() on an unbound ScalarReference returns undefined', () => {
+    const scalar = new ScalarReference<string>();
+    expect(unref(scalar)).toBeUndefined();
+  });
+
+  test('em.create() accepts nested data for a LazyRef-typed relation', async () => {
+    // regression: EntityData / RequiredEntityData must unwrap LazyRef to the underlying entity
+    // shape so nested object literals type-check on create/assign
+    const book = orm.em.create(Book, { title: 'nested-create', author: { name: 'Nested Author' } });
+    await orm.em.flush();
+    expect(book.author).toBeInstanceOf(Author);
+    expect(book.author.id).toBeDefined();
+  });
+
+  test("populate: ['*'] narrows LazyRef fields to their loaded type", async () => {
+    // regression: LoadableShape must include LazyRef so populate: '*' sees it
+    const book = await orm.em.findOneOrFail(Book, bookId, { populate: ['*'] });
+    const author: Loaded<Author> = book.author;
+    expect(author.name).toBe('Stephen King');
+  });
+});
+
+describe('LazyRef via defineEntity builder .lazyRef()', () => {
+  const User = defineEntity({
+    name: 'LREntityUser',
+    properties: {
+      id: p.integer().primary().autoincrement(),
+      name: p.string(),
+    },
+  });
+
+  const Article = defineEntity({
+    name: 'LREntityArticle',
+    properties: {
+      id: p.integer().primary().autoincrement(),
+      title: p.string(),
+      author: () => p.manyToOne(User).lazyRef(),
+    },
+  });
+
+  type ArticleEntity = InferEntity<typeof Article>;
+  type UserEntity = InferEntity<typeof User>;
+
+  let orm: MikroORM;
+  let authorId: number;
+  let articleId: number;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      entities: [User, Article],
+      dbName: ':memory:',
+    });
+    await orm.schema.refresh();
+
+    const author = orm.em.create(User, { name: 'Ursula' });
+    const article = orm.em.create(Article, { title: 'A Wizard of Earthsea', author });
+    await orm.em.flush();
+    authorId = author.id;
+    articleId = article.id;
+  });
+
+  afterAll(() => orm.close(true));
+  beforeEach(() => orm.em.clear());
+
+  test('inferred entity uses LazyRef for the relation type', () => {
+    // type-only assertion — ArticleEntity['author'] should be LazyRef<UserEntity>
+    const assertType = (_: ArticleEntity['author']) => 0 as unknown as LazyRef<UserEntity>;
+    expect(assertType).toBeDefined();
+  });
+
+  test('runtime: .lazyRef() does not create a Reference wrapper', async () => {
+    const article = await orm.em.findOneOrFail(Article, articleId);
+    expect((article.author as any).unwrap).toBeUndefined();
+    expect(article.author.id).toBe(authorId);
+  });
+
+  test('runtime + type: populate narrows LazyRef to full entity', async () => {
+    const article = await orm.em.findOneOrFail(Article, articleId, { populate: ['author'] });
+    const author: Loaded<UserEntity> = article.author;
+    expect(author.name).toBe('Ursula');
+  });
+
+  test('type-level: .lazyRef() is gated by builder kind and ref chain', () => {
+    type IsNever<T> = [T] extends [never] ? true : false;
+    type AssertTrue<T extends true> = T;
+
+    // scalars (no kind) → `.lazyRef()` returns never
+    type _scalarGate = AssertTrue<IsNever<ReturnType<ReturnType<typeof p.string>['lazyRef']>>>;
+
+    // 1:m → returns never
+    type _oneToManyGate = AssertTrue<IsNever<ReturnType<ReturnType<typeof p.oneToMany<typeof User>>['lazyRef']>>>;
+
+    // m:n → returns never
+    type _manyToManyGate = AssertTrue<IsNever<ReturnType<ReturnType<typeof p.manyToMany<typeof User>>['lazyRef']>>>;
+
+    // .ref().lazyRef() → returns never (ref conflict)
+    type _refChain = AssertTrue<
+      IsNever<ReturnType<ReturnType<ReturnType<typeof p.manyToOne<typeof User>>['ref']>['lazyRef']>>
+    >;
+
+    // .lazyRef().ref() → returns never (reverse direction also rejected)
+    type _lazyRefThenRef = AssertTrue<
+      IsNever<ReturnType<ReturnType<ReturnType<typeof p.manyToOne<typeof User>>['lazyRef']>['ref']>>
+    >;
+
+    // .lazyRef().mapToPk() → returns never (mapToPk also conflicts with lazyRef)
+    type _lazyRefThenMapToPk = AssertTrue<
+      IsNever<ReturnType<ReturnType<ReturnType<typeof p.manyToOne<typeof User>>['lazyRef']>['mapToPk']>>
+    >;
+
+    // .mapToPk().lazyRef() → returns never (forward direction also rejected)
+    type _mapToPkThenLazyRef = AssertTrue<
+      IsNever<ReturnType<ReturnType<ReturnType<typeof p.manyToOne<typeof User>>['mapToPk']>['lazyRef']>>
+    >;
+
+    // m:1 without ref → valid, returns a builder
+    type _ok = AssertTrue<
+      IsNever<ReturnType<ReturnType<typeof p.manyToOne<typeof User>>['lazyRef']>> extends true ? false : true
+    >;
+
+    expect(true).toBe(true);
+  });
+});
+
+describe('LazyRef with EntitySchema', () => {
+  interface ESAuthor {
+    id: number;
+    name: string;
+  }
+
+  interface ESBook {
+    id: number;
+    title: string;
+    author: LazyRef<ESAuthor>;
+  }
+
+  const ESAuthorSchema = new EntitySchema<ESAuthor>({
+    name: 'ESAuthor',
+    properties: {
+      id: { type: 'number', primary: true, autoincrement: true },
+      name: { type: 'string' },
+    },
+  });
+
+  const ESBookSchema: EntitySchema<ESBook> = new EntitySchema<ESBook>({
+    name: 'ESBook',
+    properties: {
+      id: { type: 'number', primary: true, autoincrement: true },
+      title: { type: 'string' },
+      author: { kind: 'm:1', entity: () => ESAuthorSchema },
+    },
+  });
+
+  let orm: MikroORM;
+  let authorId: number;
+  let bookId: number;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      entities: [ESAuthorSchema, ESBookSchema],
+      dbName: ':memory:',
+    });
+    await orm.schema.refresh();
+
+    const author = orm.em.create(ESAuthorSchema, { name: 'Ursula' });
+    const book = orm.em.create(ESBookSchema, { title: 'A Wizard of Earthsea', author });
+    await orm.em.flush();
+    authorId = author.id;
+    bookId = book.id;
+  });
+
+  afterAll(() => orm.close(true));
+  beforeEach(() => orm.em.clear());
+
+  test('runtime: EntitySchema-defined LazyRef relation works', async () => {
+    const book = await orm.em.findOneOrFail(ESBookSchema, bookId);
+    expect(book.author.id).toBe(authorId);
+    // runtime value is a plain entity stub, not a Reference wrapper
+    expect((book.author as any).unwrap).toBeUndefined();
+  });
+
+  test('runtime + type: populate narrows LazyRef via EntitySchema', async () => {
+    const book = await orm.em.findOneOrFail(ESBookSchema, bookId, { populate: ['author'] });
+    const author: Loaded<ESAuthor> = book.author;
+    expect(author.name).toBe('Ursula');
+  });
+
+  test('type-level: non-PK access is rejected on an unloaded LazyRef via EntitySchema', async () => {
+    const book = await orm.em.findOneOrFail(ESBookSchema, bookId);
+    const id: number = book.author.id;
+    // @ts-expect-error non-PK access on an unloaded LazyRef must be a compile error
+    const _name: string = book.author.name;
+    expect(id).toBe(authorId);
+  });
+});

--- a/tests/features/loadable-mixin.test.ts
+++ b/tests/features/loadable-mixin.test.ts
@@ -1,0 +1,187 @@
+import { BaseEntity, Loadable, LoadableBaseEntity, NotFoundError, ref, type Ref } from '@mikro-orm/core';
+import { Entity, ManyToOne, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+import { MikroORM } from '@mikro-orm/sqlite';
+
+@Entity()
+class Author extends LoadableBaseEntity {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+}
+
+@Entity()
+class Book extends LoadableBaseEntity {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  title!: string;
+
+  @ManyToOne(() => Author, { ref: true })
+  author!: Ref<Author>;
+}
+
+// verify the mixin form also works when used directly on a plain class that does not extend BaseEntity
+class PlainBase {}
+@Entity()
+class Tag extends Loadable(PlainBase) {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+}
+
+// verify the zero-argument form works as a standalone base (no other inheritance)
+@Entity()
+class Category extends Loadable() {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  label!: string;
+}
+
+describe('Loadable mixin', () => {
+  let orm: MikroORM;
+  let authorId: number;
+  let bookId: number;
+  let tagId: number;
+  let categoryId: number;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      entities: [Author, Book, Tag, Category],
+      dbName: ':memory:',
+    });
+    await orm.schema.refresh();
+
+    const author = orm.em.create(Author, { name: 'Stephen King' });
+    const book = orm.em.create(Book, { title: 'It', author });
+    const tag = orm.em.create(Tag, { name: 'horror' });
+    const category = orm.em.create(Category, { label: 'fiction' });
+    await orm.em.flush();
+    authorId = author.id;
+    bookId = book.id;
+    tagId = tag.id;
+    categoryId = category.id;
+  });
+
+  afterAll(() => orm.close(true));
+  beforeEach(() => orm.em.clear());
+
+  test('load() returns the same instance when already initialized', async () => {
+    const author = await orm.em.findOneOrFail(Author, authorId);
+    const loaded = await author.load();
+    expect(loaded).toBe(author);
+    expect(loaded!.name).toBe('Stephen King');
+  });
+
+  test('load() hydrates an uninitialized entity reference', async () => {
+    const naked = orm.em.getReference(Author, authorId);
+    expect(naked.isInitialized()).toBe(false);
+
+    const loaded = await naked.load();
+    expect(loaded).toBe(naked);
+    expect(naked.isInitialized()).toBe(true);
+    expect(loaded!.name).toBe('Stephen King');
+  });
+
+  test('load() returns null when the entity is missing in the database', async () => {
+    const naked = orm.em.getReference(Author, 999_999);
+    const loaded = await naked.load();
+    expect(loaded).toBeNull();
+  });
+
+  test('load() can populate a relation on an already loaded entity', async () => {
+    const book = await orm.em.findOneOrFail(Book, bookId);
+    expect(book.author.isInitialized()).toBe(false);
+
+    const loaded = await book.load({ populate: ['author'] });
+    expect(loaded).toBe(book);
+    expect(book.author.isInitialized()).toBe(true);
+    expect(loaded!.author.$.name).toBe('Stephen King');
+  });
+
+  test('load({ refresh: true }) reloads even when already initialized', async () => {
+    const author = await orm.em.findOneOrFail(Author, authorId);
+    author.name = 'mutated locally';
+
+    const reloaded = await author.load({ refresh: true });
+    expect(reloaded).toBe(author);
+    expect(author.name).toBe('Stephen King');
+  });
+
+  test('loadOrFail() returns the entity when found', async () => {
+    const naked = orm.em.getReference(Author, authorId);
+    const loaded = await naked.loadOrFail();
+    expect(loaded).toBe(naked);
+    expect(loaded.name).toBe('Stephen King');
+  });
+
+  test('loadOrFail() throws NotFoundError when the entity is missing', async () => {
+    const naked = orm.em.getReference(Author, 999_999);
+    await expect(naked.loadOrFail()).rejects.toThrow(NotFoundError);
+  });
+
+  test('loadOrFail() honors a custom failHandler', async () => {
+    const naked = orm.em.getReference(Author, 999_999);
+    await expect(naked.loadOrFail({ failHandler: name => new Error(`missing ${name}`) })).rejects.toThrow(
+      'missing Author',
+    );
+  });
+
+  test('load() works on a Reference wrapper as well (regression for shared codepath)', async () => {
+    const author = await orm.em.findOneOrFail(Author, authorId);
+    const wrapped = ref(author);
+    const loaded = await wrapped.load();
+    expect(loaded).toBe(author);
+  });
+
+  test('Loadable(PlainBase) works without BaseEntity', async () => {
+    const naked = orm.em.getReference(Tag, tagId);
+    expect(naked).toBeInstanceOf(Tag);
+
+    const loaded = await naked.loadOrFail();
+    expect(loaded).toBe(naked);
+    expect(loaded.name).toBe('horror');
+  });
+
+  test('Loadable() (no argument) works as a standalone base', async () => {
+    const naked = orm.em.getReference(Category, categoryId);
+    expect(naked).toBeInstanceOf(Category);
+
+    const loaded = await naked.loadOrFail();
+    expect(loaded).toBe(naked);
+    expect(loaded.label).toBe('fiction');
+  });
+
+  test('BaseEntity (without mixin) does not expose load/loadOrFail', () => {
+    // sanity: BaseEntity itself must remain clean to preserve non-breaking guarantee
+    expect((BaseEntity.prototype as any).load).toBeUndefined();
+    expect((BaseEntity.prototype as any).loadOrFail).toBeUndefined();
+  });
+
+  test('type-level: Loadable() rejects a base class that already defines `load` or `loadOrFail`', () => {
+    class HasLoad {
+      async load() {
+        return 'custom';
+      }
+    }
+    class HasLoadOrFail {
+      async loadOrFail() {
+        return 'custom';
+      }
+    }
+
+    // @ts-expect-error Loadable must reject a base with an existing `load` method
+    Loadable(HasLoad);
+    // @ts-expect-error Loadable must reject a base with an existing `loadOrFail` method
+    Loadable(HasLoadOrFail);
+
+    expect(true).toBe(true);
+  });
+});

--- a/tests/features/reflection/lazy-ref.tsmorph.test.ts
+++ b/tests/features/reflection/lazy-ref.tsmorph.test.ts
@@ -1,0 +1,64 @@
+import { LazyRef } from '@mikro-orm/core';
+import { Entity, ManyToOne, PrimaryKey, Property } from '@mikro-orm/decorators/legacy';
+import { MikroORM } from '@mikro-orm/sqlite';
+import { TsMorphMetadataProvider } from '@mikro-orm/reflection';
+
+@Entity()
+class Author {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+}
+
+@Entity()
+class Book {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  title!: string;
+
+  // LazyRef<Author> — type-only marker; tsmorph must unwrap to `Author` and must NOT set `ref: true`
+  @ManyToOne(() => Author)
+  author!: LazyRef<Author>;
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    entities: [Author, Book],
+    dbName: ':memory:',
+    metadataProvider: TsMorphMetadataProvider,
+    metadataCache: { enabled: false },
+  });
+  await orm.schema.create();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+describe('TsMorphMetadataProvider + LazyRef', () => {
+  test('tsmorph unwraps LazyRef to the target entity type and does not set ref=true', () => {
+    const meta = orm.getMetadata().get(Book);
+    const authorProp = meta.properties.author;
+
+    expect(authorProp.type).toBe('Author');
+    expect(authorProp.ref).toBeFalsy();
+  });
+
+  test('runtime persists and loads via a LazyRef relation (no Reference wrapper)', async () => {
+    const author = orm.em.create(Author, { name: 'Ursula' });
+    const book = orm.em.create(Book, { title: 'A Wizard of Earthsea', author });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const found = await orm.em.findOneOrFail(Book, book.id, { populate: ['author'] });
+    expect(found.author).toBeInstanceOf(Author);
+    expect((found.author as any).unwrap).toBeUndefined();
+    expect(found.author.name).toBe('Ursula');
+  });
+});


### PR DESCRIPTION
## Summary

Three additive, non-breaking features for to-one relations, prompted by [discussion #7585](https://github.com/mikro-orm/mikro-orm/discussions/7585).

### `LazyRef<T>`

Type-only marker for `@ManyToOne` / `@OneToOne`. Runtime is a plain entity (no `Reference` wrapper, `instanceof User` returns `true`). TypeScript restricts access to the primary key until `Loaded<>` narrows it back to the full entity — no `.$` / `.get()` indirection needed on loaded relations.

```ts
@ManyToOne(() => Author)
author!: LazyRef<Author>;

// or via defineEntity:
author: () => p.manyToOne(AuthorSchema).lazyRef()

book.author.id;                          // ok — PK always accessible
book.author.name;                        // compile error — not loaded
const loaded = await em.findOneOrFail(Book, 1, { populate: ['author'] });
loaded.author.name;                      // ok — Loaded<> strips the brand
```

Scope is to-one only. Collections keep `Collection<T>`.

### `Loadable` mixin

Adds `load()` / `loadOrFail()` to an entity's prototype — Reference-style ergonomics for direct and LazyRef-typed relations. Ships as `Loadable(Base)` plus pre-composed `LoadableBaseEntity`. `BaseEntity` itself is deliberately untouched so `load` / `loadOrFail` aren't reserved on existing subclasses.

```ts
class User extends LoadableBaseEntity { /* ... */ }
await user.load();          // Promise<User | null>
await user.loadOrFail();    // Promise<User>
```

### `unref()`

Typed escape hatch — inverse of the existing `ref()` helper. Narrows `Ref<T>` | `LazyRef<T>` | `T` down to `T` for cases where you know the relation is populated but can't thread `Loaded<>` through a function signature.

```ts
import { unref } from '@mikro-orm/core';

function logAuthor(book: Book) {
  // `book.author` is typed as `LazyRef<Author>` — `.name` would be a compile error
  console.log(unref(book.author).name);
}
```

Works for `Ref<T>` (calls `.unwrap()`), `LazyRef<T>` (identity cast), plain `T` (passthrough), and `null` / `undefined` (passthrough).

### Non-breaking

- `BaseEntity`, `Ref<T>`, plain relations, and `@ManyToOne({ ref: true })` all unchanged.
- `LazyRef<T>` is opt-in per property.
- `.lazyRef()` is opt-in per builder chain and leaves runtime metadata untouched.

### Type performance

`LazyRef` integration is isolated to `AutoPath` / `Loaded<>` narrowing via a new `ExtractTypeWithLazyRef` helper — the existing `ExtractType` hot path (`EntityData`, `RequiredEntityData`, `IsOptional`) pays no cost. New benches in `tests/bench/types/lazy-ref.ts` compare like-for-like against `Ref<T>`; LazyRef is slightly cheaper for loaded narrowing (no `LoadedReference` intersection). All existing benchmark baselines have been refreshed and the full `yarn bench:types` run shows 0% delta.