### PR TITLE
chore(ci): publish v7.1+ canaries from the next branch under next-v7 dist-tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,7 +151,8 @@ jobs:
       - name: Bump version
         run: |
           PREID=${{ inputs.dist-tag == 'rc' && 'rc' || 'dev' }}
-          yarn lerna run copy -- -- --canary=patch --preid=$PREID
+          BUMP=${{ startsWith(inputs.dist-tag, 'next-v') && 'minor' || 'patch' }}
+          yarn lerna run copy -- -- --canary=$BUMP --preid=$PREID
           git commit -am 'chore: bump ${{ inputs.dist-tag }} versions [skip ci]'
           git fetch --depth=1 origin +refs/tags/*:refs/tags/*
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,11 @@ on:
         required: false
         type: string
         default: 'prod'
+      canary-bump:
+        description: Canary bump strategy (patch for patch canaries, minor for upcoming-minor dev builds)
+        required: false
+        type: string
+        default: 'patch'
       ref:
         description: Git ref to publish (branch, tag, or commit SHA)
         type: string
@@ -32,6 +37,10 @@ on:
       dist-tag:
         description: NPM dist-tag (prod, rc, or any next* canary tag like next / next-v7)
         type: string
+      canary-bump:
+        description: Canary bump strategy (patch / minor / major)
+        type: string
+        default: 'patch'
 
 permissions:
   contents: write
@@ -151,8 +160,7 @@ jobs:
       - name: Bump version
         run: |
           PREID=${{ inputs.dist-tag == 'rc' && 'rc' || 'dev' }}
-          BUMP=${{ startsWith(inputs.dist-tag, 'next-v') && 'minor' || 'patch' }}
-          yarn lerna run copy -- -- --canary=$BUMP --preid=$PREID
+          yarn lerna run copy -- -- --canary=${{ inputs.canary-bump }} --preid=$PREID
           git commit -am 'chore: bump ${{ inputs.dist-tag }} versions [skip ci]'
           git fetch --depth=1 origin +refs/tags/*:refs/tags/*
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ on:
         required: false
         type: string
       dist-tag:
-        description: NPM dist-tag (prod, next, or rc)
+        description: NPM dist-tag (prod, rc, or any next* canary tag like next / next-v7)
         required: false
         type: string
         default: 'prod'
@@ -30,7 +30,7 @@ on:
         required: true
         type: string
       dist-tag:
-        description: NPM dist-tag (prod, next, or rc)
+        description: NPM dist-tag (prod, rc, or any next* canary tag like next / next-v7)
         type: string
 
 permissions:
@@ -113,7 +113,7 @@ jobs:
         run: yarn publish:jsr
 
   canary-release:
-    if: inputs.dist-tag == 'next' || inputs.dist-tag == 'rc'
+    if: startsWith(inputs.dist-tag, 'next') || inputs.dist-tag == 'rc'
     name: Release ${{ inputs.dist-tag == 'rc' && 'RC' || 'canary' }}
     runs-on: ubuntu-latest
 
@@ -156,7 +156,7 @@ jobs:
           git fetch --depth=1 origin +refs/tags/*:refs/tags/*
 
       - name: Publish to npm
-        run: yarn publish:${{ inputs.dist-tag }} --yes
+        run: yarn lerna publish from-package --contents dist --dist-tag ${{ inputs.dist-tag }} --force-publish --yes
 
       - name: Create git tag
         if: inputs.dist-tag == 'rc'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,9 +2,9 @@ name: tests
 
 on:
   push:
-    branches: [ master, renovate/** ]
+    branches: [ master, next, renovate/** ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, next ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
@@ -381,10 +381,19 @@ jobs:
 
   release:
     name: Release
-    if: github.ref == 'refs/heads/master' && github.repository_owner == 'mikro-orm'
+    if: (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/next') && github.repository_owner == 'mikro-orm'
     runs-on: ubuntu-latest
     needs: [ build, typecheck, test, lint, docs ]
     steps:
+      - name: Determine dist-tag
+        id: tag
+        run: |
+          if [[ "${{ github.ref }}" == "refs/heads/next" ]]; then
+            echo "value=next-v7" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=next" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Publish packages
         uses: apify/workflows/execute-workflow@main
         with:
@@ -392,5 +401,5 @@ jobs:
           inputs: >
             {
               "ref": "${{ steps.commit.outputs.commit_long_sha || github.sha }}",
-              "dist-tag": "next"
+              "dist-tag": "${{ steps.tag.outputs.value }}"
             }

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -385,13 +385,15 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ build, typecheck, test, lint, docs ]
     steps:
-      - name: Determine dist-tag
+      - name: Determine dist-tag and canary bump
         id: tag
         run: |
           if [[ "${{ github.ref }}" == "refs/heads/next" ]]; then
-            echo "value=next-v7" >> "$GITHUB_OUTPUT"
+            echo "dist-tag=next-v7" >> "$GITHUB_OUTPUT"
+            echo "canary-bump=minor" >> "$GITHUB_OUTPUT"
           else
-            echo "value=next" >> "$GITHUB_OUTPUT"
+            echo "dist-tag=next" >> "$GITHUB_OUTPUT"
+            echo "canary-bump=patch" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Publish packages
@@ -401,5 +403,6 @@ jobs:
           inputs: >
             {
               "ref": "${{ steps.commit.outputs.commit_long_sha || github.sha }}",
-              "dist-tag": "${{ steps.tag.outputs.value }}"
+              "dist-tag": "${{ steps.tag.outputs.dist-tag }}",
+              "canary-bump": "${{ steps.tag.outputs.canary-bump }}"
             }

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -385,11 +385,17 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ build, typecheck, test, lint, docs ]
     steps:
+      - uses: actions/checkout@v6
+        with:
+          sparse-checkout: lerna.json
+          sparse-checkout-cone-mode: false
+
       - name: Determine dist-tag and canary bump
         id: tag
         run: |
           if [[ "${{ github.ref }}" == "refs/heads/next" ]]; then
-            echo "dist-tag=next-v7" >> "$GITHUB_OUTPUT"
+            MAJOR=$(jq -r '.version | split(".")[0]' lerna.json)
+            echo "dist-tag=next-v${MAJOR}" >> "$GITHUB_OUTPUT"
             echo "canary-bump=minor" >> "$GITHUB_OUTPUT"
           else
             echo "dist-tag=next" >> "$GITHUB_OUTPUT"

--- a/docs/docs/canary-builds.md
+++ b/docs/docs/canary-builds.md
@@ -1,0 +1,66 @@
+---
+title: Canary & dev builds
+---
+
+Every push to the main development branches is automatically published to npm as a canary build. This lets you try unreleased bug fixes and upcoming features without waiting for an official release.
+
+## npm dist-tags
+
+MikroORM publishes under several [dist-tags](https://docs.npmjs.com/cli/v10/commands/npm-dist-tag):
+
+| Tag            | Source branch | Contents                                                                             |
+|----------------|---------------|--------------------------------------------------------------------------------------|
+| `latest`       | —             | Latest stable release. What `npm install @mikro-orm/core` resolves to by default.    |
+| `latest-v{N}`  | —             | Latest stable release of a previous major line (e.g. `latest-v6` for the 6.x line).  |
+| `next`         | `master`      | Canary build of the current stable line. Every push to `master` publishes a new one. |
+| `next-v{N}`    | `next`        | Canary build of the upcoming minor in the `v{N}` major line (e.g. `next-v7` = v7.1-dev while v7.0 is stable). |
+| `rc`           | —             | Release candidates, published manually before a major.                               |
+
+> Tags move. `npm install @mikro-orm/core@next` today and tomorrow may install different versions. See [pinning](#pin-exact-versions) below.
+
+## Install a canary build
+
+Install a specific tag:
+
+```bash
+npm install @mikro-orm/core@next-v7 @mikro-orm/mysql@next-v7
+# or
+yarn add @mikro-orm/core@next-v7 @mikro-orm/mysql@next-v7
+```
+
+Find the exact version behind a tag:
+
+```bash
+npm view @mikro-orm/core dist-tags
+```
+
+## Use the same tag across all packages
+
+:::warning
+
+All `@mikro-orm/*` packages in your project **must be installed from the same dist-tag and resolve to the same version**. Mixing e.g. `@mikro-orm/core@next-v7` with `@mikro-orm/mysql@latest` will lead to duplicate copies of the core runtime, broken `instanceof` checks, metadata mismatches, and hard-to-debug runtime errors.
+
+:::
+
+That includes indirect ORM dependencies you have installed directly (e.g. `@mikro-orm/migrations`, `@mikro-orm/seeder`, `@mikro-orm/reflection`, `@mikro-orm/entity-generator`).
+
+## Pin exact versions
+
+Dev tags are moving targets — `next` and `next-v{N}` float to the latest canary on every push. To avoid surprise updates (and to make your `lockfile`/`package.json` reproducible for teammates and CI), **pin the exact version** once you have installed a working canary:
+
+```json
+{
+  "dependencies": {
+    "@mikro-orm/core": "7.1.0-dev.20",
+    "@mikro-orm/mysql": "7.1.0-dev.20"
+  }
+}
+```
+
+Never ship a production build against a floating `@next`/`@next-v7` specifier. Always pin.
+
+When you want to move to a newer canary, bump the version explicitly so the change is visible in your git history.
+
+## Reporting issues
+
+If you hit a bug on a canary, please include the exact version (`7.x.y-dev.N`) in your issue report — not the tag name. That lets us pinpoint the commit it was built from.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -129,12 +129,12 @@ module.exports = {
       items: [
         'logging',
         'deployment',
-        'canary-builds',
         'define-entity',
         'using-decorators',
         'folder-based-discovery',
         'metadata-providers',
         'metadata-cache',
+        'canary-builds',
       ],
     },
     {

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -129,6 +129,7 @@ module.exports = {
       items: [
         'logging',
         'deployment',
+        'canary-builds',
         'define-entity',
         'using-decorators',
         'folder-based-discovery',


### PR DESCRIPTION
## Summary

Sets up a two-branch release flow so work on v7.1 (and future minors) can land on a dedicated `next` branch while `master` stays focused on 7.0.x bug fixes.

- `master` pushes keep publishing canaries under the `next` dist-tag (unchanged).
- `next` pushes now run the full CI matrix and publish canaries under the `next-v7` dist-tag.
- `canary-release` job accepts any `next*` tag, so future lines slot in without workflow edits.
- Publish step switched to an inline `lerna publish --dist-tag …` so there is no per-tag yarn script.
- Added a Configuration docs page describing the dist-tags, how to install canaries, the requirement to keep all `@mikro-orm/*` packages on the same tag, and a pin-your-versions recommendation.

Prod release flow is unchanged: when `next` is ready, rebase-merge into `master` and trigger `release.yml` manually with `ref=master`.