### PR TITLE
fix(sql): forward ignoreBranch options for M2M pivot alias resolution

### DIFF
--- a/packages/sql/src/query/CriteriaNode.ts
+++ b/packages/sql/src/query/CriteriaNode.ts
@@ -110,8 +110,8 @@ export class CriteriaNode<T extends object> implements ICriteriaNode<T> {
     }
   }
 
-  renameFieldToPK<T>(qb: IQueryBuilder<T>, ownerAlias?: string): string {
-    const joinAlias = qb.getAliasForJoinPath(this.getPath(), { matchPopulateJoins: true });
+  renameFieldToPK<T>(qb: IQueryBuilder<T>, ownerAlias?: string, options?: ICriteriaNodeProcessOptions): string {
+    const joinAlias = qb.getAliasForJoinPath(this.getPath(), { ...options, matchPopulateJoins: true });
 
     if (
       !joinAlias &&

--- a/packages/sql/src/query/ObjectCriteriaNode.ts
+++ b/packages/sql/src/query/ObjectCriteriaNode.ts
@@ -140,7 +140,7 @@ export class ObjectCriteriaNode<T extends object> extends CriteriaNode<T> {
         const a = qb.helper.isTableNameAliasRequired(qb.type) ? alias : undefined;
         this.inlineChildPayload(o, payload, field as EntityKey, a, childAlias);
       } else if (childNode.shouldRename(payload)) {
-        this.inlineCondition(childNode.renameFieldToPK(qb, alias), o, payload);
+        this.inlineCondition(childNode.renameFieldToPK(qb, alias, options), o, payload);
       } else if (isRawField) {
         const rawField = RawQueryFragment.getKnownFragment(field)!;
         o[raw(rawField.sql.replaceAll(ALIAS_REPLACEMENT, alias!), rawField.params) as any] = payload;

--- a/packages/sql/src/typings.ts
+++ b/packages/sql/src/typings.ts
@@ -259,7 +259,7 @@ export interface ICriteriaNode<T extends object> {
   shouldInline(payload: any): boolean;
   willAutoJoin(qb: IQueryBuilder<T>, alias?: string, options?: ICriteriaNodeProcessOptions): boolean;
   shouldRename(payload: any): boolean;
-  renameFieldToPK<T>(qb: IQueryBuilder<T>, ownerAlias?: string): string;
+  renameFieldToPK<T>(qb: IQueryBuilder<T>, ownerAlias?: string, options?: ICriteriaNodeProcessOptions): string;
   getPath(opts?: { addIndex?: boolean }): string;
   getPivotPath(path: string): string;
 }

--- a/tests/issues/GH7590.test.ts
+++ b/tests/issues/GH7590.test.ts
@@ -1,0 +1,75 @@
+import 'reflect-metadata';
+import { Entity, ManyToMany, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+import { Collection, MikroORM, PopulateHint } from '@mikro-orm/sqlite';
+
+@Entity()
+class User {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name: string;
+
+  @ManyToMany(() => Role, 'users', { owner: true })
+  roles = new Collection<Role>(this);
+
+  constructor(name: string) {
+    this.name = name;
+  }
+}
+
+@Entity()
+class Role {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  title: string;
+
+  @ManyToMany(() => User, 'roles')
+  users = new Collection<User>(this);
+
+  constructor(title: string) {
+    this.title = title;
+  }
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    dbName: ':memory:',
+    entities: [User, Role],
+    metadataProvider: ReflectMetadataProvider,
+    debug: ['query', 'query-params'],
+    allowGlobalContext: true, // only for testing
+  });
+  await orm.schema.refresh();
+});
+
+beforeEach(async () => {
+  const role1 = orm.em.create(Role, { title: 'Admin' });
+  const role2 = orm.em.create(Role, { title: 'User' });
+
+  orm.em.create(User, { name: 'User 1', roles: [role1, role2] });
+  orm.em.create(User, { name: 'User 2', roles: [role2] });
+
+  await orm.em.flush();
+  orm.em.clear();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+test('many-to-many filter in multi-condition $and resolves pivot join alias correctly when using joined strategy and populateWhere INFER', async () => {
+  const filteredQuery = await orm.em.findAll(User, {
+    where: {
+      $and: [{ roles: { id: { $in: [1] } } }, { name: { $like: 'User%' } }],
+    },
+    populate: ['roles'],
+    strategy: 'joined',
+    populateWhere: PopulateHint.INFER,
+  });
+  expect(filteredQuery.length).toBe(1);
+});

--- a/tests/issues/GH7590.test.ts
+++ b/tests/issues/GH7590.test.ts
@@ -41,8 +41,6 @@ beforeAll(async () => {
     dbName: ':memory:',
     entities: [User, Role],
     metadataProvider: ReflectMetadataProvider,
-    debug: ['query', 'query-params'],
-    allowGlobalContext: true, // only for testing
   });
   await orm.schema.refresh();
 });


### PR DESCRIPTION
### Description

Fixes an `InvalidFieldNameException` thrown when querying a many-to-many relation inside a `$and` clause with two or more conditions, while using `strategy: 'joined'` and `populateWhere: PopulateHint.INFER`.

```ts
@Entity()
class User {
  @PrimaryKey()
  id!: number;

  @Property()
  name: string;

  @ManyToMany(() => Role, 'users', { owner: true })
  roles = new Collection<Role>(this);

  constructor(name: string) {
    this.name = name;
  }
}

@Entity()
class Role {
  @PrimaryKey()
  id!: number;

  @Property()
  title: string;

  @ManyToMany(() => User, 'roles')
  users = new Collection<User>(this);

  constructor(title: string) {
    this.title = title;
  }
}

// throws InvalidFieldNameException
await em.findAll(User, {
  where: {
    $and: [
      { roles: { id: { $in: [1] } } },
      { name: { $like: 'User%' } },
    ],
  },
  populate: ['roles'],
  strategy: 'joined',
  populateWhere: PopulateHint.INFER,
});
```

Generated SQL for the above example:

```sql
select `u0`.*, `r1`.`id` as `r1__id`, `r1`.`title` as `r1__title`
from `user` as `u0`
left join `user_roles` as `u2` on `u0`.`id` = `u2`.`user_id`
left join `role` as `r1` on `u2`.`role_id` = `r1`.`id
where `u0`.`role_id` in (1) and `u0`.`name` like 'User%'
```

Fixes #7590

---

### Fix

Two-line change: add an `options?: ICriteriaNodeProcessOptions` parameter to `renameFieldToPK` and spread it into `getAliasForJoinPath` (keeping `matchPopulateJoins: true`). Then pass `options` through at the call site in `ObjectCriteriaNode.process`.

```
getAliasForJoinPath('User[0].roles[pivot]', { matchPopulateJoins: true, ignoreBranching: true })
  ignoreBranching: strips [0]  =>  'User.roles[pivot]' = 'User.roles[pivot]'  =>  alias: 'u2'
```

The resolved column is now `u2.role_id`, which is a valid column on the `user_roles` pivot join.

<details>

<summary><strong>Root Cause</strong></summary>

<div>

**Branch indexing.** When `CriteriaNodeFactory` processes a `$and` with >=2 conditions, it tags each branch node with an index so that join paths are distinct across branches ([CriteriaNodeFactory.ts:80](packages/sql/src/query/CriteriaNodeFactory.ts#L80)) - `$and[0]`, `$and[1]`, etc. A many-to-many relation property inside `$and[0]` therefore gets a path like `User[0].roles[pivot]` rather than `User.roles[pivot]`.

**Populate join registration.** Populate joins (`populate: ['roles']`) are resolved independently of the `WHERE` clause -- they're registered upfront as part of building the SELECT structure, before the criteria tree is walked. At that point, no branch indices have been assigned yet, so the pivot join is stored under the pre-indexed path `User.roles[pivot]`. Later, when `WHERE` processing walks the `$and` branches and assigns `[0]` to the first one, the many-to-many property inside it gets the indexed path `User[0].roles[pivot]` -- which no longer matches anything in the registry:

```
registered:  'User.roles[pivot]'   =>  alias 'u2'  (user_roles)
looked up:   'User[0].roles[pivot]' =>  no match
```

**`populateWhere: PopulateHint.INFER`** Without `INFER`, `ignoreBranching` is not set, so `nestedAlias` lookup for `User[0].roles[pivot]` fails. `shouldAutoJoin` ([ObjectCriteriaNode.ts:306](packages/sql/src/query/ObjectCriteriaNode.ts#L306)) sees no existing alias and returns `true`, so `autoJoin` ([ObjectCriteriaNode.ts:363](packages/sql/src/query/ObjectCriteriaNode.ts#L363)) runs -- creating a new join registered under the **indexed** path `User[0].roles[pivot]` => `u3`. When `renameFieldToPK` then looks up `User[0].roles[pivot]`, it finds that exact entry and resolves `u3.role_id` correctly.

With `INFER`, `QueryBuilder` sets `ignoreBranching: true` ([QueryBuilder.ts:1533](packages/sql/src/query/QueryBuilder.ts#L1533)) on the options passed to criteria processing. `getAliasForJoinPath` ([QueryBuilder.ts:2267](packages/sql/src/query/QueryBuilder.ts#L2267)) strips `[\d+]` indices before matching ([QueryBuilder.ts:2299](packages/sql/src/query/QueryBuilder.ts#L2299)), so `nestedAlias` now finds the pre-registered `User.roles[pivot]` => `u2`. `shouldAutoJoin` returns `false` -- populate join exists, skip auto-join. But this means **no join ever gets registered under the indexed path** `User[0].roles[pivot]`. When `renameFieldToPK` ([CriteriaNode.ts:113](packages/sql/src/query/CriteriaNode.ts#L113)) then calls `getAliasForJoinPath('User[0].roles[pivot]', ...)` without `ignoreBranching`, it finds nothing and falls back to `u0`. The root issue is that `renameFieldToPK` isn't passed the same options; and it needs `ignoreBranching` too, since it also does a join path lookup against a registry that only holds the unindexed path.

**The gap: `renameFieldToPK`.** Once `ObjectCriteriaNode.process` determines the child node `shouldRename` ([CriteriaNode.ts:73](packages/sql/src/query/CriteriaNode.ts#L73)) (which is true for many-to-many scalar/operator payloads -- `{ id: { $in: [1] } }` is inlined to `{ $in: [1] }` by `inlinePrimaryKeyObjects`), it calls `renameFieldToPK` to resolve the actual pivot column. That call however, does not forward the `ignoreBranching` option ([ObjectCriteriaNode.ts:143](packages/sql/src/query/ObjectCriteriaNode.ts#L143)):

```ts
this.inlineCondition(childNode.renameFieldToPK(qb, alias), o, payload);
```

Inside `renameFieldToPK`, the alias lookup therefore runs without `ignoreBranching`:

```
getAliasForJoinPath('User[0].roles[pivot]', { matchPopulateJoins: true })
  exact match:        'User[0].roles[pivot]' =/= 'User.roles[pivot]'  =>  miss
  matchPopulateJoins: strips [populate] suffix only  =>  still 'User[0].roles[pivot]'  =>  miss
  ignoreBranching:    not set  =>  skipped
  result: undefined  => falls back to ownerAlias 'u0'
```

With alias `u0` (the `User` table), the resolved column becomes `u0.role_id` -- a column that doesn't exist on `user`, only on the `user_roles` pivot table -- triggering `InvalidFieldNameException`.

</div>
</details>