### PR TITLE
chore(core): keep `@Index`/`@Unique` `where` type-safe without explicit type args

### DIFF
--- a/packages/core/src/metadata/types.ts
+++ b/packages/core/src/metadata/types.ts
@@ -776,7 +776,7 @@ interface BaseOptions<T, H extends string> {
    * where the predicate holds). MariaDB is not supported — it has no inline expression indexes;
    * define a virtual generated column and index that instead.
    */
-  where?: string | (T extends EntityClass<infer P> ? FilterQuery<P> : FilterQuery<T>);
+  where?: string | FilterQuery<NoInfer<T> extends EntityClass<infer P> ? P : NoInfer<T>>;
 }
 
 export interface UniqueOptions<T, H extends string = string> extends BaseOptions<T, H> {


### PR DESCRIPTION
`BaseOptions.where` let TS infer `T` from the option itself, so `FilterQuery<T>` collapsed to `never` when no explicit type args were supplied — the class-level decorator form documented in `indexes.md` and introduced in #7593 (e.g. `@Unique({ properties: ['email'], where: '...' })`) did not compile.

Wrapping the type parameter in `NoInfer<T>` stops the field from driving `T`'s inference while preserving full structural validation when callers do pass type args — `@Unique<typeof User, 'email'>({ where: { wrongField: null } })` still fails the `FilterQuery` check.

Same pattern already used across `EntityManager.find` / `findOne` with `FilterQuery<NoInfer<Entity>>`.