### PR TITLE
fix(core): avoid crash on STI subclass @ManyToOne override targeting same hierarchy

### DIFF
--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -1550,6 +1550,19 @@ export class MetadataDiscovery {
     }
   }
 
+  private sameRelationTargetRoot(rootProp: EntityProperty | undefined, prop: EntityProperty): boolean {
+    if (!rootProp || rootProp.kind !== prop.kind) {
+      return false;
+    }
+
+    if (prop.kind !== ReferenceKind.MANY_TO_ONE && prop.kind !== ReferenceKind.ONE_TO_ONE) {
+      return false;
+    }
+
+    const aRoot = this.#metadata.getByClassName(prop.type, false)?.root;
+    return aRoot != null && aRoot === this.#metadata.getByClassName(rootProp.type, false)?.root;
+  }
+
   private initSingleTableInheritance(meta: EntityMetadata, metadata: EntityMetadata[]): void {
     if (meta.root !== meta && !(meta as Dictionary).__processed) {
       meta.root = metadata.find(m => m.class === meta.root.class)!;
@@ -1601,6 +1614,14 @@ export class MetadataDiscovery {
     Object.values(meta.properties).forEach(prop => {
       const newProp = { ...prop };
       const rootProp = meta.root.properties[prop.name];
+
+      // Relation overrides narrowing to the same STI root share the FK column;
+      // leave the root's declaration alone so it keeps the full target union
+      // (otherwise populates via the abstract root would only resolve the last
+      // child processed).
+      if (this.sameRelationTargetRoot(rootProp, prop)) {
+        return;
+      }
 
       // stiMerged is set during inlineProperties when a property was merged
       // from multiple polymorphic variants with different types. The flag is

--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -1615,19 +1615,18 @@ export class MetadataDiscovery {
       const newProp = { ...prop };
       const rootProp = meta.root.properties[prop.name];
 
-      // Relation overrides narrowing to the same STI root share the FK column;
-      // leave the root's declaration alone so it keeps the full target union
-      // (otherwise populates via the abstract root would only resolve the last
-      // child processed).
-      if (this.sameRelationTargetRoot(rootProp, prop)) {
-        return;
-      }
+      // A child that narrows a relation to a subclass of the root's declared
+      // target (same STI hierarchy) shares the FK column with the root; treat
+      // that as matching so the rename branch below doesn't run (which would
+      // crash — `targetMeta` is only populated later, in `initRelation`).
+      const narrowedRelationOverride =
+        rootProp != null && rootProp.type !== prop.type && this.sameRelationTargetRoot(rootProp, prop);
 
       // stiMerged is set during inlineProperties when a property was merged
       // from multiple polymorphic variants with different types. The flag is
       // cleared implicitly when the first child claims the root property via
       // addProperty below, so subsequent children correctly trigger renaming.
-      const typesMatch = rootProp?.type === prop.type || rootProp?.stiMerged === true;
+      const typesMatch = rootProp?.type === prop.type || rootProp?.stiMerged === true || narrowedRelationOverride;
 
       if (
         rootProp &&
@@ -1689,6 +1688,14 @@ export class MetadataDiscovery {
 
       newProp.nullable = true;
       newProp.inherited = !rootProp;
+
+      // For narrowed relation overrides, keep the root's declaration intact so
+      // the full target union (e.g. `Food`) is preserved for populates from the
+      // abstract root — otherwise the last child processed would win.
+      if (narrowedRelationOverride) {
+        return;
+      }
+
       meta.root.addProperty(newProp);
     });
 

--- a/tests/issues/GH7598.test.ts
+++ b/tests/issues/GH7598.test.ts
@@ -1,0 +1,79 @@
+import 'reflect-metadata';
+import { Entity, Enum, ManyToOne, PrimaryKey, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+import { MikroORM, Reference, type Ref } from '@mikro-orm/sqlite';
+
+enum Species {
+  DOG = 'DOG',
+  CAT = 'CAT',
+}
+
+@Entity({ tableName: 'food', abstract: true, discriminatorColumn: 'species' })
+abstract class Food {
+  @PrimaryKey()
+  id!: number;
+
+  @Enum(() => Species)
+  species!: Species;
+}
+
+@Entity({ discriminatorValue: Species.DOG })
+class DogFood extends Food {}
+
+@Entity({ discriminatorValue: Species.CAT })
+class CatFood extends Food {}
+
+@Entity({ tableName: 'pet', abstract: true, discriminatorColumn: 'species' })
+abstract class Pet {
+  @PrimaryKey()
+  id!: number;
+
+  @Enum(() => Species)
+  species!: Species;
+
+  @ManyToOne(() => Food)
+  favoriteFood!: Ref<Food>;
+}
+
+@Entity({ discriminatorValue: Species.DOG })
+class Dog extends Pet {
+  @ManyToOne(() => DogFood)
+  declare favoriteFood: Ref<DogFood>;
+}
+
+@Entity({ discriminatorValue: Species.CAT })
+class Cat extends Pet {
+  @ManyToOne(() => CatFood)
+  declare favoriteFood: Ref<CatFood>;
+}
+
+test('STI subclass @ManyToOne override does not crash metadata discovery (GH #7598)', async () => {
+  const orm = await MikroORM.init({
+    dbName: ':memory:',
+    entities: [Food, DogFood, CatFood, Pet, Dog, Cat],
+    metadataProvider: ReflectMetadataProvider,
+  });
+  const meta = orm.getMetadata();
+  expect(meta.get(Dog).discriminatorValue).toBe(Species.DOG);
+  expect(meta.get(Cat).discriminatorValue).toBe(Species.CAT);
+  expect(meta.get(Pet).properties.favoriteFood.fieldNames).toEqual(['favorite_food_id']);
+  expect(meta.get(Dog).properties.favoriteFood.fieldNames).toEqual(['favorite_food_id']);
+  expect(meta.get(Cat).properties.favoriteFood.fieldNames).toEqual(['favorite_food_id']);
+  // root declaration must retain the abstract target so populates from the root resolve all children
+  expect(meta.get(Pet).properties.favoriteFood.targetMeta?.className).toBe('Food');
+
+  await orm.schema.refresh();
+
+  const kibble = orm.em.create(DogFood, { id: 1, species: Species.DOG });
+  const tuna = orm.em.create(CatFood, { id: 2, species: Species.CAT });
+  orm.em.create(Dog, { id: 10, species: Species.DOG, favoriteFood: Reference.create(kibble) });
+  orm.em.create(Cat, { id: 20, species: Species.CAT, favoriteFood: Reference.create(tuna) });
+  await orm.em.flush();
+  orm.em.clear();
+
+  const pets = await orm.em.find(Pet, {}, { populate: ['favoriteFood'], orderBy: { id: 'asc' } });
+  expect(pets).toHaveLength(2);
+  expect(pets[0].favoriteFood).toMatchObject({ id: 1, species: Species.DOG });
+  expect(pets[1].favoriteFood).toMatchObject({ id: 2, species: Species.CAT });
+
+  await orm.close(true);
+});


### PR DESCRIPTION
## Summary
STI children that override a `@ManyToOne` to narrow its target into the same STI hierarchy (e.g. `Dog extends Pet` narrows `favoriteFood: Food` to `DogFood`) crashed during metadata discovery with `Cannot read properties of undefined (reading 'primaryKeys')` because the rename branch in `initSingleTableInheritance` expects `targetMeta` to be set, but `initRelation` only runs later.

The narrowed relation shares the FK column with the root, so discovery now treats such overrides as matching and skips the rename path — and, importantly, leaves the root's declaration untouched so populates via the abstract root keep resolving all children (the previous in-progress fix would have let the last processed child overwrite the root's `targetMeta`).

Closes #7598