### PR TITLE
fix(mysql): skip password callback when reusing a pooled connection

### DIFF
--- a/packages/mysql/src/MySqlConnection.ts
+++ b/packages/mysql/src/MySqlConnection.ts
@@ -20,12 +20,18 @@ export class MySqlConnection extends AbstractSqlConnection {
 
       // mysql2 reads pool.config.connectionConfig.password when creating new physical
       // connections, so updating it before getConnection() ensures fresh tokens are used.
-      // Existing idle connections are already authenticated and unaffected.
+      // Existing idle connections are already authenticated and unaffected, so we skip
+      // the callback when the pool has a free connection to reuse.
       const pool: MysqlPool = {
         getConnection(cb: (error: unknown, connection: MysqlPoolConnection) => void) {
+          const inner = innerPool as Dictionary;
+          if ((inner._freeConnections?.length ?? 0) > 0) {
+            innerPool.getConnection(cb as Parameters<Pool['getConnection']>[0]);
+            return;
+          }
           Promise.resolve(password())
             .then(pw => {
-              ((innerPool as Dictionary).config.connectionConfig as Dictionary).password = pw;
+              (inner.config.connectionConfig as Dictionary).password = pw;
               innerPool.getConnection(cb as Parameters<Pool['getConnection']>[0]);
             })
             .catch(err => cb(err, undefined as unknown as MysqlPoolConnection));

--- a/tests/MikroORM.test.ts
+++ b/tests/MikroORM.test.ts
@@ -383,6 +383,25 @@ describe('MikroORM', () => {
     await o.close();
   });
 
+  test('should not re-invoke password callback when reusing pooled connections [mysql]', async () => {
+    const passwordFn = vi.fn(async () => '');
+    const o = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      entities: [Test],
+      driver: MySqlDriver,
+      dbName: 'mysql',
+      port: 3308,
+      ensureDatabase: false,
+      password: passwordFn,
+    });
+    await o.driver.execute('select 1');
+    const callsAfterFirst = passwordFn.mock.calls.length;
+    await o.driver.execute('select 1');
+    // reusing the pooled connection must not re-invoke the callback
+    expect(passwordFn.mock.calls.length).toBe(callsAfterFirst);
+    await o.close();
+  });
+
   test('should propagate password callback errors [mysql]', async () => {
     const passwordFn = vi
       .fn()


### PR DESCRIPTION
## Summary

- mysql2 only authenticates when creating a new physical connection; reused free connections are already authenticated, so calling `password()` on every `getConnection()` meant an unnecessary IAM round-trip per query.
- Check `_freeConnections` on mysql2's pool before resolving a fresh password — fall back to the existing refresh path when the pool needs to open a new connection.

Closes #7576