### PR TITLE
fix(core): merge nested `fields` paths into explicit `populate`

### DIFF
--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -2532,8 +2532,15 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
 
     const meta = this.metadata.find(entityName)!;
 
-    // infer populate hint if only `fields` are available
-    if (!options.populate && options.fields) {
+    // infer populate hints from `fields` when present; merge with explicit `populate` if both are set
+    const fields = options.fields ? this.buildFields(options.fields) : undefined;
+    const populateArray = Array.isArray(options.populate) ? (options.populate as string[]) : undefined;
+    const hasNestedFields = fields?.some(f => f.includes('.')) ?? false;
+    const shouldInfer = fields !== undefined && options.populate === undefined;
+    const shouldMerge =
+      fields !== undefined && populateArray !== undefined && populateArray.length > 0 && hasNestedFields;
+
+    if (shouldInfer || shouldMerge) {
       // we need to prune the `populate` hint from to-one relations, as partially loading them does not require their population, we want just the FK
       const pruneToOneRelations = (meta: EntityMetadata, fields: string[]): string[] => {
         const ret: string[] = [];
@@ -2582,7 +2589,16 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
         return Utils.unique(ret);
       };
 
-      options.populate = pruneToOneRelations(meta, this.buildFields(options.fields)) as any;
+      const fromFields = pruneToOneRelations(meta, fields!);
+
+      if (shouldInfer) {
+        options.populate = fromFields as any;
+      } else {
+        // with an explicit populate, only nested paths (e.g. `item.id`) need to be merged in — they
+        // require a JOIN to access sub-fields, whereas bare names are already handled by the driver
+        const extras = fromFields.filter(f => f.includes('.'));
+        options.populate = [...populateArray!, ...extras] as any;
+      }
     }
 
     if (!options.populate) {

--- a/tests/issues/GHx42.test.ts
+++ b/tests/issues/GHx42.test.ts
@@ -1,0 +1,90 @@
+import { defineEntity, MikroORM, p } from '@mikro-orm/postgresql';
+
+const OrderSchema = defineEntity({
+  name: 'OrderGHx42',
+  properties: {
+    id: p.integer().primary(),
+    name: p.text(),
+    item: () => p.oneToOne(OrderItem),
+    note: () => p.oneToOne(OrderNote),
+  },
+});
+class Order extends OrderSchema.class {}
+OrderSchema.setClass(Order);
+
+const OrderItemSchema = defineEntity({
+  name: 'OrderItemGHx42',
+  schema: 'inventory_ghx42',
+  properties: {
+    id: p.integer().primary(),
+    name: p.text(),
+  },
+});
+class OrderItem extends OrderItemSchema.class {}
+OrderItemSchema.setClass(OrderItem);
+
+const OrderNoteSchema = defineEntity({
+  name: 'OrderNoteGHx42',
+  schema: 'notes_ghx42',
+  properties: {
+    id: p.integer().primary(),
+    name: p.text(),
+  },
+});
+class OrderNote extends OrderNoteSchema.class {}
+OrderNoteSchema.setClass(OrderNote);
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    entities: [Order, OrderItem, OrderNote],
+    dbName: 'mikro_orm_test_ghx42',
+  });
+  await orm.schema.refresh({ dropDb: true });
+
+  orm.em.create(Order, {
+    id: 1,
+    name: 'Order #1',
+    item: { id: 1, name: 'Item #1' },
+    note: { id: 1, name: 'Note #1' },
+  });
+  await orm.em.flush();
+  orm.em.clear();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+test('find order with fields returns order and item data correctly', async () => {
+  const order = await orm.em.findOneOrFail(
+    Order,
+    { id: 1 },
+    {
+      fields: ['id', 'name', 'item.id', 'item.name'],
+    },
+  );
+
+  expect(order.id).toBe(1);
+  expect(order.name).toBe('Order #1');
+  expect(order.item.id).toBe(1);
+  expect(order.item.name).toBe('Item #1');
+});
+
+test('find order with fields and populate note returns item data', async () => {
+  orm.em.clear();
+  const order = await orm.em.findOneOrFail(
+    Order,
+    { id: 1 },
+    {
+      fields: ['id', 'name', 'item.id', 'item.name'],
+      populate: ['note'],
+    },
+  );
+
+  expect(order.id).toBe(1);
+  expect(order.name).toBe('Order #1');
+  expect(order.item.id).toBe(1);
+  expect(order.item.name).toBe('Item #1');
+});


### PR DESCRIPTION
## Summary

When `em.find`/`em.findOne` is called with both a dotted `fields` path (e.g. `fields: ['id', 'item.name']`) and an explicit `populate: ['other']`, the join required to read the nested field was silently dropped. The fields→populate inference in `preparePopulate` only ran when `populate` was absent, so `item` never got joined when `other` was populated.

The fix merges any nested (dotted) paths from `fields` into the explicit populate list. Bare field names are left alone — they are either already handled by the driver or belong to explicit populate semantics (so merging them in would flip a `books:ref` into a full population, which is what `mongo` relies on for partial loading).

Reproduction added in `tests/issues/GHx42.test.ts` (based on a user-supplied repro).