### PR TITLE
feat(core): accept enum references directly in `items`

### DIFF
--- a/docs/docs/decorators.md
+++ b/docs/docs/decorators.md
@@ -198,15 +198,15 @@ id!: string;
 
 See [Defining Entities](./defining-entities.md#enums).
 
-| Parameter | Type                                                   | Optional | Description                    |
-|-----------|--------------------------------------------------------|----------|--------------------------------|
-| `items`   | `number[]` &#124; `string[]` &#124; `() => Dictionary` | yes      | Specify enum items explicitly. |
+| Parameter | Type                                                                         | Optional | Description                    |
+|-----------|------------------------------------------------------------------------------|----------|--------------------------------|
+| `items`   | `number[]` &#124; `string[]` &#124; `Dictionary` &#124; `() => Dictionary`   | yes      | Specify enum items explicitly. |
 
 ```ts
 @Enum() // with ts-morph metadata provider we do not need to specify anything
 enum0 = MyEnum1.VALUE_1;
 
-@Enum(() => MyEnum1) // or @Enum({ items: () => MyEnum1 })
+@Enum(() => MyEnum1) // or @Enum({ items: MyEnum1 }) / @Enum({ items: () => MyEnum1 })
 enum1 = MyEnum1.VALUE_1;
 
 @Enum({ type: 'MyEnum2', nullable: true })

--- a/docs/docs/defining-entities.md
+++ b/docs/docs/defining-entities.md
@@ -638,7 +638,7 @@ To define an enum property, use `@Enum()` decorator. Enums can be either numeric
 
 For schema generator to work properly in case of string enums, you need to define the enum in the same file as where it is used, so its values can be automatically discovered. If you want to define the enum in another file, you should re-export it also in place where you use it.
 
-You can also provide the reference to the enum implementation in the decorator via `@Enum(() => UserRole)`.
+You can also provide the reference to the enum implementation in the decorator via `@Enum(() => UserRole)`, or pass the enum object directly via `@Enum({ items: UserRole })` — the callback form is only needed when the enum is declared after the class it's used in.
 
 > You can also set enum items manually via `items: string[]` attribute.
 

--- a/docs/docs/using-decorators.md
+++ b/docs/docs/using-decorators.md
@@ -172,7 +172,7 @@ export class Article {
 | `Ref<T>` wrapper    | Automatic            | Requires `ref: true`            |
 | `LazyRef<T>` marker | Automatic (type-only, no wrapper) | No metadata flag — type-only |
 | Array element types | Automatic            | Requires explicit `type`        |
-| Enums               | Automatic            | Requires `items: () => Enum`    |
+| Enums               | Automatic            | Requires `items: Enum`          |
 | Union types         | Supported            | Not supported                   |
 
 :::warning ES Spec Decorators

--- a/packages/core/src/entity/defineEntity.ts
+++ b/packages/core/src/entity/defineEntity.ts
@@ -1123,9 +1123,15 @@ const propertyBuilders: PropertyBuilders = {
   type: <T extends PropertyValueType>(type: T) =>
     new UniversalPropertyOptionsBuilder<InferPropertyValueType<T>, EmptyOptions, IncludeKeysForProperty>({ type }),
 
-  enum: <const T extends readonly (number | string)[] | (() => Dictionary)>(items?: T) =>
+  enum: <const T extends readonly (number | string)[] | Dictionary | (() => Dictionary)>(items?: T) =>
     new UniversalPropertyOptionsBuilder<
-      T extends () => Dictionary ? ValueOf<ReturnType<T>> : T extends readonly (infer Value)[] ? Value : T,
+      T extends () => Dictionary
+        ? ValueOf<ReturnType<T>>
+        : T extends readonly (infer Value)[]
+          ? Value
+          : T extends Dictionary
+            ? ValueOf<T>
+            : T,
       EmptyOptions,
       IncludeKeysForEnumOptions
     >({
@@ -1213,10 +1219,16 @@ export type PropertyBuilders = {
   type: <T extends PropertyValueType>(
     type: T,
   ) => UniversalPropertyOptionsBuilder<InferPropertyValueType<T>, EmptyOptions, IncludeKeysForProperty>;
-  enum: <const T extends readonly (number | string)[] | (() => Dictionary)>(
+  enum: <const T extends readonly (number | string)[] | Dictionary | (() => Dictionary)>(
     items?: T,
   ) => UniversalPropertyOptionsBuilder<
-    T extends () => Dictionary ? ValueOf<ReturnType<T>> : T extends readonly (infer Value)[] ? Value : T,
+    T extends () => Dictionary
+      ? ValueOf<ReturnType<T>>
+      : T extends readonly (infer Value)[]
+        ? Value
+        : T extends Dictionary
+          ? ValueOf<T>
+          : T,
     EmptyOptions,
     IncludeKeysForEnumOptions
   >;

--- a/packages/core/src/metadata/EntitySchema.ts
+++ b/packages/core/src/metadata/EntitySchema.ts
@@ -175,11 +175,16 @@ export class EntitySchema<Entity = any, Base = never, Class extends EntityCtor =
   addEnum(name: EntityKey<Entity>, type?: TypeType, options: EnumOptions<Entity> = {}): void {
     if (options.items instanceof Function) {
       options.items = Utils.extractEnumValues(options.items());
+    } else if (options.items && !Array.isArray(options.items) && typeof options.items === 'object') {
+      options.items = Utils.extractEnumValues(options.items as Dictionary);
     }
 
     // enum arrays are simple numeric/string arrays, the constraint is enforced in the custom type only
     if (options.array && !options.type) {
-      options.type = new EnumArrayType(`${this._meta.className}.${name}`, options.items);
+      options.type = new EnumArrayType(
+        `${this._meta.className}.${name}`,
+        options.items as readonly (number | string)[],
+      );
       (options as EntityProperty).enum = false;
     }
 

--- a/packages/core/src/metadata/types.ts
+++ b/packages/core/src/metadata/types.ts
@@ -719,7 +719,7 @@ export interface EmbeddableOptions<Owner> {
 }
 
 export interface EnumOptions<T> extends PropertyOptions<T> {
-  items?: readonly (number | string)[] | (() => Dictionary);
+  items?: readonly (number | string)[] | Dictionary | (() => Dictionary);
   array?: boolean;
   /** for postgres, by default it uses text column with check constraint */
   nativeEnumName?: string;

--- a/tests/defineEntity.test.ts
+++ b/tests/defineEntity.test.ts
@@ -705,6 +705,35 @@ describe('defineEntity', () => {
     assert<IsExact<IFoo['status'], Status7446>>(true);
   });
 
+  it('should define entity with enum passed directly', () => {
+    enum BaZ {
+      FOO = 'foo',
+      BAR = 'bar',
+      BAZ = 1,
+    }
+
+    const Foo = defineEntity({
+      name: 'Foo',
+      properties: p => ({
+        id: p.integer().primary().autoincrement(),
+        baz: p.enum(BaZ),
+      }),
+    });
+
+    type IFoo = InferEntity<typeof Foo>;
+    assert<IsExact<IFoo['baz'], BaZ>>(true);
+
+    const FooSchema = new EntitySchema({
+      name: 'Foo',
+      properties: {
+        id: { type: types.integer, primary: true, autoincrement: true },
+        baz: { enum: true, items: BaZ },
+      },
+    });
+
+    expect(Foo.meta).toEqual(asSnapshot(FooSchema.meta));
+  });
+
   it('should define entity with embedded', () => {
     const Address = defineEntity({
       name: 'Address',

--- a/tests/issues/GHx43.test.ts
+++ b/tests/issues/GHx43.test.ts
@@ -1,0 +1,76 @@
+import { Entity, Enum, PrimaryKey, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+import { EntitySchema, MikroORM } from '@mikro-orm/sqlite';
+
+// Allow passing enum references directly instead of wrapping them in a callback
+// (see comment on GH #7500).
+
+enum Status {
+  ACTIVE = 'active',
+  INACTIVE = 'inactive',
+  PENDING = 'pending',
+}
+
+enum Priority {
+  LOW = 1,
+  MEDIUM = 2,
+  HIGH = 3,
+}
+
+@Entity()
+class Task {
+  @PrimaryKey()
+  id!: number;
+
+  @Enum({ items: Status })
+  status!: Status;
+
+  @Enum({ items: Priority })
+  priority!: Priority;
+}
+
+interface ITaskSchema {
+  id: number;
+  status: Status;
+  priority: Priority;
+}
+
+const TaskSchema = new EntitySchema<ITaskSchema>({
+  name: 'TaskSchema',
+  properties: {
+    id: { type: Number, primary: true },
+    status: { enum: true, items: Status },
+    priority: { enum: true, items: Priority },
+  },
+});
+
+test('decorator accepts enum reference directly via items', async () => {
+  const orm = await MikroORM.init({
+    metadataProvider: ReflectMetadataProvider,
+    entities: [Task],
+    dbName: ':memory:',
+  });
+
+  const meta = orm.getMetadata().get(Task);
+  expect(meta.properties.status.items).toEqual(['active', 'inactive', 'pending']);
+  expect(meta.properties.priority.items).toEqual([1, 2, 3]);
+
+  await orm.schema.refresh();
+  await orm.em.insertMany(Task, [{ status: Status.ACTIVE, priority: Priority.HIGH }]);
+  const row = await orm.em.fork().findOneOrFail(Task, { status: Status.ACTIVE });
+  expect(row.priority).toBe(Priority.HIGH);
+
+  await orm.close(true);
+});
+
+test('EntitySchema accepts enum reference directly via items', async () => {
+  const orm = await MikroORM.init({
+    entities: [TaskSchema],
+    dbName: ':memory:',
+  });
+
+  const meta = orm.getMetadata().get(TaskSchema);
+  expect(meta.properties.status.items).toEqual(['active', 'inactive', 'pending']);
+  expect(meta.properties.priority.items).toEqual([1, 2, 3]);
+
+  await orm.close(true);
+});


### PR DESCRIPTION
## Summary

Follow-up to [a comment on #7500](https://github.com/mikro-orm/mikro-orm/issues/7500#issuecomment-4198605542) asking why enums had to be passed as callbacks. They don't — the callback form was only used to defer evaluation, but enum objects have no circular-reference risk, so wrapping is unnecessary.

After this change, enum references can be passed directly on `items`:

```ts
@Enum({ items: MyEnum })
// same as
@Enum({ items: () => MyEnum })

new EntitySchema({ properties: { status: { enum: true, items: MyEnum } } });
p.enum(MyEnum);
```

The callback form is still supported for backwards compatibility.

The single choke point is `EntitySchema.addEnum`, which routes decorator, `defineEntity`, and `EntitySchema` usage through `Utils.extractEnumValues` — this PR extends the normalization to also accept a plain dictionary and updates `EnumOptions.items` / `p.enum()` typings accordingly.