### PR TITLE
fix(core): link TPT subclass iterated before its abstract parent

### DIFF
--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -1714,11 +1714,10 @@ export class MetadataDiscovery {
       meta.root = metadata.find(m => m.class === meta.root.class)!;
     }
 
-    const inheritance = (meta as Dictionary).inheritance;
-
-    if (inheritance === 'tpt' && meta.root === meta) {
-      meta.inheritanceType = 'tpt';
-      meta.tptChildren = [];
+    // init the root eagerly so children iterated before the root (e.g. alphabetical glob order) still get linked
+    if ((meta.root as Dictionary).inheritance === 'tpt' && meta.root.inheritanceType !== 'tpt') {
+      meta.root.inheritanceType = 'tpt';
+      meta.root.tptChildren ??= [];
     }
 
     if (meta.root.inheritanceType !== 'tpt') {

--- a/tests/issues/GH7609.test.ts
+++ b/tests/issues/GH7609.test.ts
@@ -1,4 +1,3 @@
-import 'reflect-metadata';
 import { Entity, ManyToOne, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
 import { MikroORM } from '@mikro-orm/sqlite';
 
@@ -57,7 +56,6 @@ test('GH #7609: TPT subclass is linked even when registered before its abstract 
     dbName: ':memory:',
     entities: [Avatar, Comment, CommentLike, Like, PostLike, Post],
     metadataProvider: ReflectMetadataProvider,
-    allowGlobalContext: true,
   });
 
   const sql = await orm.schema.getCreateSchemaSQL();

--- a/tests/issues/GH7609.test.ts
+++ b/tests/issues/GH7609.test.ts
@@ -1,0 +1,73 @@
+import 'reflect-metadata';
+import { Entity, ManyToOne, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+import { MikroORM } from '@mikro-orm/sqlite';
+
+@Entity({ tableName: 'avatars' })
+class Avatar {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  nickname!: string;
+}
+
+@Entity({ tableName: 'posts' })
+class Post {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  content!: string;
+}
+
+@Entity({ tableName: 'comments' })
+class Comment {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  content!: string;
+}
+
+@Entity({ tableName: 'likes', inheritance: 'tpt' })
+abstract class Like {
+  @PrimaryKey()
+  id!: number;
+
+  @ManyToOne(() => Avatar, { deleteRule: 'cascade' })
+  avatar!: Avatar;
+}
+
+@Entity({ tableName: 'post_likes' })
+class PostLike extends Like {
+  @ManyToOne(() => Post, { deleteRule: 'cascade' })
+  post!: Post;
+}
+
+@Entity({ tableName: 'comment_likes' })
+class CommentLike extends Like {
+  @ManyToOne(() => Comment, { deleteRule: 'cascade' })
+  comment!: Comment;
+}
+
+test('GH #7609: TPT subclass is linked even when registered before its abstract parent', async () => {
+  // mirrors glob-based discovery where alphabetical file order can place a child
+  // (e.g. comment-like.entity.js) before its abstract parent (like.entity.js)
+  const orm = await MikroORM.init({
+    dbName: ':memory:',
+    entities: [Avatar, Comment, CommentLike, Like, PostLike, Post],
+    metadataProvider: ReflectMetadataProvider,
+    allowGlobalContext: true,
+  });
+
+  const sql = await orm.schema.getCreateSchemaSQL();
+  expect(sql).toContain('create table `likes`');
+  expect(sql).toContain('create table `post_likes`');
+  expect(sql).toContain('create table `comment_likes`');
+
+  const commentLikeMeta = orm.getMetadata().get(CommentLike);
+  expect(commentLikeMeta.inheritanceType).toBe('tpt');
+  expect(commentLikeMeta.tptParent?.class).toBe(Like);
+
+  await orm.close(true);
+});


### PR DESCRIPTION
## Summary

`initTPTRelationships` returned early for child entities when `root.inheritanceType` was still `undefined` at the moment the child was iterated. That happened whenever the child came before the abstract parent in the discovery order — the typical case with glob-based entity discovery (`entities: ['dist/**/*.entity.js']`), because alphabetical file order places e.g. `comment-like.entity.js` before `like.entity.js`. The subclass was silently dropped from schema generation with no error.

Fix: initialize the root's TPT state eagerly off the raw `inheritance` option (present before discovery), so children iterated first still get linked into `tptChildren`. Guard keeps it idempotent.

Closes #7609