### PR TITLE
fix(core): TPT metadata drop when subclass registered before abstract

### DIFF
--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -1718,10 +1718,10 @@ export class MetadataDiscovery {
 
     if (inheritance === 'tpt' && meta.root === meta) {
       meta.inheritanceType = 'tpt';
-      meta.tptChildren = [];
+      meta.tptChildren ??= [];
     }
 
-    if (meta.root.inheritanceType !== 'tpt') {
+    if (meta.root.inheritanceType !== 'tpt' && (meta.root as Dictionary).inheritance !== 'tpt') {
       return;
     }
 

--- a/packages/decorators/src/es/Entity.ts
+++ b/packages/decorators/src/es/Entity.ts
@@ -11,7 +11,7 @@ export function Entity<Owner extends EntityClass<unknown> & EntityCtor>(
     Utils.mergeConfig(meta, metadata, options);
     meta.class = target as unknown as Constructor<Owner>;
 
-    if (!options.abstract || meta.discriminatorColumn) {
+    if (!options.abstract || meta.discriminatorColumn || options.inheritance === 'tpt') {
       meta.name = context.name;
     }
   };

--- a/packages/decorators/src/legacy/Entity.ts
+++ b/packages/decorators/src/legacy/Entity.ts
@@ -8,7 +8,7 @@ export function Entity<T extends EntityClass<unknown>>(options: EntityOptions<T>
     Utils.mergeConfig(meta, options);
     meta.class = target as any;
 
-    if (!options.abstract || meta.discriminatorColumn) {
+    if (!options.abstract || meta.discriminatorColumn || options.inheritance === 'tpt') {
       meta.name = target.name;
     }
   };

--- a/tests/features/table-per-type-inheritance/table-per-type-inheritance.test.ts
+++ b/tests/features/table-per-type-inheritance/table-per-type-inheritance.test.ts
@@ -3451,4 +3451,54 @@ describe('GH #7469 - populate 1:1 on TPT leaf entity with reverse declared', () 
 
     await orm.close();
   });
+
+  // https://github.com/mikro-orm/mikro-orm/issues/7609
+  test('GH #7609: TPT subclass registered before abstract parent must not be silently dropped from MetadataStorage', async () => {
+    @Entity({ tableName: 'tpt7609_likes', abstract: true, inheritance: 'tpt' })
+    abstract class Like7609 {
+      @PrimaryKey()
+      id!: number;
+
+      @Property()
+      createdAt: Date = new Date();
+    }
+
+    // Alphabetically before Like7609 to reproduce the ordering bug
+    @Entity({ tableName: 'tpt7609_comment_likes' })
+    class CommentLike7609 extends Like7609 {
+      @Property()
+      commentId!: number;
+    }
+
+    @Entity({ tableName: 'tpt7609_post_likes' })
+    class PostLike7609 extends Like7609 {
+      @Property()
+      postId!: number;
+    }
+
+    // Intentionally pass subclasses before the abstract base to exercise the ordering bug
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      dbName: ':memory:',
+      entities: [CommentLike7609, PostLike7609, Like7609],
+    });
+
+    // All three entities must be present in MetadataStorage
+    expect(() => orm.em.getRepository(Like7609)).not.toThrow();
+    expect(() => orm.em.getRepository(CommentLike7609)).not.toThrow();
+    expect(() => orm.em.getRepository(PostLike7609)).not.toThrow();
+
+    const meta = orm.getMetadata();
+    expect(meta.has(Like7609)).toBe(true);
+    expect(meta.has(CommentLike7609)).toBe(true);
+    expect(meta.has(PostLike7609)).toBe(true);
+
+    // Schema must include all three tables
+    const sql = await orm.schema.getCreateSchemaSQL();
+    expect(sql).toContain('tpt7609_likes');
+    expect(sql).toContain('tpt7609_comment_likes');
+    expect(sql).toContain('tpt7609_post_likes');
+
+    await orm.close();
+  });
 });


### PR DESCRIPTION

When using @Entity({ abstract: true, inheritance: 'tpt' }), the @Entity decorator did not set meta.name (it was skipped for abstract entities). As a result the TPT root entity had name=undefined, causing the MetadataDiscovery filter (meta.root.name) to silently drop the entire TPT hierarchy — root and all concrete subclasses.

Two fixes:
- @Entity decorator (legacy + ES): set meta.name even for abstract entities when inheritance: 'tpt' is present, since TPT root entities always have their own table.
- MetadataDiscovery.initTPTRelationships: mirror the STI pattern by checking the raw `inheritance` decorator option (always available) alongside inheritanceType (set later during discovery), so child entities are handled correctly regardless of registration order. Also use `??=` for tptChildren to avoid clearing already-registered children.

Closes #7609