### PR TITLE
fix(cli): don't auto-register extensions on CLI-passed options

### DIFF
--- a/packages/cli/src/CLIHelper.ts
+++ b/packages/cli/src/CLIHelper.ts
@@ -41,7 +41,6 @@ export class CLIHelper {
 
     contextName ??= process.env.MIKRO_ORM_CONTEXT_NAME ?? 'default';
     const env = await this.loadEnvironmentVars();
-    await loadOptionalDependencies(options);
 
     // oxfmt-ignore
     const configFinder = (cfg: unknown) => {
@@ -55,13 +54,13 @@ export class CLIHelper {
     const result = await this.getConfigFile(paths);
     if (!result[0]) {
       if (Utils.hasObjectKeys(env)) {
-        return new Configuration(
-          Utils.mergeConfig(
-            { contextName },
-            options.preferEnvVars ? options : env,
-            options.preferEnvVars ? env : options,
-          ),
+        const merged = Utils.mergeConfig(
+          { contextName },
+          options.preferEnvVars ? options : env,
+          options.preferEnvVars ? env : options,
         );
+        await loadOptionalDependencies(merged);
+        return new Configuration(merged);
       }
       throw new Error(`MikroORM config file not found in ['${paths.join(`', '`)}']`);
     }

--- a/tests/features/cli/CLIHelper.test.ts
+++ b/tests/features/cli/CLIHelper.test.ts
@@ -3,6 +3,7 @@ import { MikroORM } from '@mikro-orm/core';
 import { configure, CLIHelper } from '@mikro-orm/cli';
 import { fs } from '@mikro-orm/core/fs-utils';
 import { Configuration, Options, Utils, MongoDriver } from '@mikro-orm/mongodb';
+import { Migrator as MongoMigrator } from '@mikro-orm/migrations-mongodb';
 import { SchemaCommandFactory } from '../../../packages/cli/src/commands/SchemaCommandFactory.js';
 
 const pkg = { type: 'module', 'mikro-orm': {} } as any;
@@ -411,6 +412,28 @@ Maybe you want to check, or regenerate your yarn.lock or package-lock.json file?
     const orm = await CLIHelper.getORM(undefined, undefined, { discovery: { warnWhenNoEntities: false } });
     expect(orm).toBeInstanceOf(MikroORM);
     expect(orm.config.get('preferTs')).toBe(true);
+    await orm.close(true);
+  });
+
+  test('preserves user-provided extensions when passing CLI opts (GH #7613)', async () => {
+    const mongoConfig = { ...config, extensions: [MongoMigrator] };
+    dynamicImportMock.mockImplementation(id => {
+      const str = id as string;
+      if (/\/mikro-orm\.config\.(ts|js)$/.test(str)) {
+        return mongoConfig;
+      }
+      return resolve(id);
+    });
+    pathExistsMock.mockImplementation(async path => {
+      const str = path as string;
+      return str.includes('/mikro-orm.config.js') && !str.includes('/src/mikro-orm.config.js');
+    });
+    delete pkg['mikro-orm'].preferTs;
+    const orm = await CLIHelper.getORM(undefined, undefined, {
+      pool: { min: 1, max: 2 },
+      discovery: { warnWhenNoEntities: false },
+    });
+    expect(orm.migrator).toBeInstanceOf(MongoMigrator);
     await orm.close(true);
   });
 


### PR DESCRIPTION
`CLIHelper.getConfiguration` was auto-registering missing extensions (SeedManager, Migrator, EntityGenerator) on the raw CLI-passed options before loading the user's config file. Since CLI opts are merged LAST (to let CLI flags win over config values), the auto-registered SQL `Migrator` on `options.extensions` overwrote the user's explicit `extensions: [MongoMigrator]` from their mongo config, causing `orm.migrator` to be the SQL migrator for MongoDB projects.

Now we only auto-register extensions on the user's config (`tmp`) and on the final merged options in the no-config-file path, so CLI opts stay untouched and don't clobber the config.

Closes #7613