### PR TITLE
chore(tests): drop stale test DBs at startup to stabilise parallel runs

### DIFF
--- a/tests/globalSetup.ts
+++ b/tests/globalSetup.ts
@@ -173,6 +173,12 @@ async function dropExtras(t: SqlTarget, extras: string[]): Promise<string[]> {
   return dropped;
 }
 
+// Matches test DB names created by `bootstrap.ts` and most ad-hoc test files.
+// Conservative on purpose — only drops names that clearly came from a previous test run, so a
+// developer's hand-made DB on a shared instance is never touched at startup. Tests using other
+// names (e.g. GH-issue numbers) are still cleaned up by the diff-baseline teardown below.
+const STALE_TEST_DB_PATTERN = /^mikro[_-]orm[_-]test/i;
+
 export async function setup() {
   if (!(globalThis as any).__MONGOINSTANCE) {
     try {
@@ -190,13 +196,32 @@ export async function setup() {
     }
   }
 
+  // Drop test DBs leftover from prior crashed runs. MSSQL in particular spends idle CPU on
+  // every attached DB, so accumulated leftovers slow the container enough to cause connection
+  // drops mid-run; cleaning them here stabilises parallel test execution.
   const baseline: Record<string, string[]> = {};
   await Promise.all(
     SQL_TARGETS.map(async t => {
-      const dbs = await listDbs(t);
-      if (dbs) {
-        baseline[`${t.kind}:${t.port}`] = dbs;
+      const initial = await listDbs(t);
+      if (!initial) {
+        return;
       }
+
+      const stale = initial.filter(name => STALE_TEST_DB_PATTERN.test(name));
+      if (stale.length > 0) {
+        const dropped = await dropExtras(t, stale);
+        if (dropped.length > 0) {
+          const preview = dropped.slice(0, 3).join(', ');
+          const suffix = dropped.length > 3 ? `, ...+${dropped.length - 3} more` : '';
+          // eslint-disable-next-line no-console
+          console.log(
+            `[globalSetup] ${t.kind}:${t.port} dropped ${dropped.length} stale test DB(s): ${preview}${suffix}`,
+          );
+        }
+      }
+
+      const cleaned = await listDbs(t);
+      baseline[`${t.kind}:${t.port}`] = cleaned ?? initial;
     }),
   );
   (globalThis as any)[BASELINE_KEY] = baseline;


### PR DESCRIPTION
Crashed runs leave `mikro_orm_test*` databases behind. Over time they accumulate on shared instances, and MSSQL spends idle CPU on every attached DB — once the pile is large enough the container starts dropping connections mid-run (`socket hang up`, `Connection lost`, `Timeout: Request`). The existing global teardown diffs against a start-of-run baseline, so leftovers from prior crashed runs were never cleaned automatically; the docs called for a manual `sqlcmd` drop.

`globalSetup` now drops them before recording the baseline. Pattern is restricted to `mikro_orm_test` / `mikro-orm-test` so a developer's hand-made DBs on a shared instance are never touched at startup. Test DBs that don't follow that prefix (GH-issue-numbered names, etc.) are still cleaned by the existing baseline-diff teardown.

Local results across three back-to-back `yarn test:fast` runs (against a long-accumulated MSSQL instance):

| Run | Failures | Notes |
|---|---|---|
| Before fix | 71 | All MSSQL `Connection lost` / `socket hang up` / `Timeout: Request` |
| After fix, first run | 37 | Cleanup happens at startup — by run end most DBs gone |
| After fix, second run | 1 | Pre-existing unrelated `CLIHelper` test |
| After fix, third run | 3 | Same `CLIHelper` + 2 MSSQL flakes (residual concurrency, separate scope) |