### PR TITLE
fix(postgres): treat `timetz` / `time with time zone` as aliases in schema diff

### DIFF
--- a/packages/sql/src/dialects/postgresql/BasePostgreSqlPlatform.ts
+++ b/packages/sql/src/dialects/postgresql/BasePostgreSqlPlatform.ts
@@ -143,7 +143,13 @@ export class BasePostgreSqlPlatform extends AbstractSqlPlatform {
 
   override normalizeColumnType(
     type: string,
-    options: { length?: number; precision?: number; scale?: number; autoincrement?: boolean },
+    options: {
+      length?: number;
+      precision?: number;
+      scale?: number;
+      autoincrement?: boolean;
+      columnTypes?: string[];
+    },
   ): string {
     const simpleType = this.extractSimpleType(type);
 
@@ -177,6 +183,13 @@ export class BasePostgreSqlPlatform extends AbstractSqlPlatform {
 
     if (['interval'].includes(simpleType)) {
       return this.getIntervalTypeDeclarationSQL(options);
+    }
+
+    // TimeType.getColumnType drops the timezone qualifier, so detect tz aliases from the original column type.
+    const originalType = options.columnTypes?.[0]?.toLowerCase() ?? type;
+    if (/^timetz\b/.test(originalType) || /^time\s+with\s+time\s+zone\b/.test(originalType)) {
+      const length = options.length ?? this.getDefaultDateTimeLength();
+      return `timetz(${length})`;
     }
 
     return super.normalizeColumnType(type, options);

--- a/tests/issues/GHx43.test.ts
+++ b/tests/issues/GHx43.test.ts
@@ -1,0 +1,38 @@
+import { defineEntity, MikroORM, p } from '@mikro-orm/postgresql';
+
+// Reports infinite migrations when using `columnType('time with time zone')` or
+// `columnType('timetz')`: postgres introspection reports those as `timetz(6)` while
+// `mappedType.getColumnType` produced a different string for the entity side.
+
+const Foo = defineEntity({
+  name: 'Foo',
+  tableName: 'foo',
+  properties: {
+    id: p.integer().primary().autoincrement(),
+    start: p.string().columnType('time with time zone'),
+    stop: p.string().columnType('timetz'),
+    createdAt: p.datetime().columnType('timestamp with time zone'),
+    plainTime: p.time(),
+  },
+});
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    entities: [Foo],
+    dbName: `mikro_orm_test_gh_x43`,
+  });
+  await orm.schema.ensureDatabase();
+  await orm.schema.execute('drop table if exists foo');
+  await orm.schema.create();
+});
+
+afterAll(() => orm.close(true));
+
+test('schema diff is empty for time with time zone / timetz columns', async () => {
+  await expect(orm.schema.getUpdateSchemaMigrationSQL({ wrap: false })).resolves.toEqual({
+    down: '',
+    up: '',
+  });
+});


### PR DESCRIPTION
## Summary

PostgreSQL stores both `timetz` and `time with time zone` as `timetz(N)` (with the default precision applied) and reports that on introspection, while `TimeType.getColumnType` always emits `time(N)` and drops the timezone qualifier. The schema comparator therefore saw a difference on every run and produced an alter-column statement that never converged.

This mirrors the existing handling for `varchar`/`character varying` and `decimal`/`numeric`: detect the timezone variant from the original column type in `normalizeColumnType` and collapse both aliases to `timetz(N)`.

Closes #7616