### PR TITLE
fix(mssql): use `set offline` instead of `set single_user` to drop databases

### DIFF
--- a/packages/mssql/src/MsSqlSchemaHelper.ts
+++ b/packages/mssql/src/MsSqlSchemaHelper.ts
@@ -33,8 +33,11 @@ export class MsSqlSchemaHelper extends SchemaHelper {
   }
 
   override getDropDatabaseSQL(name: string): string {
+    // `set offline` rejects all connections including the issuing session, so there is no
+    // single-user race window where a torn-down pool connection can reconnect between the
+    // mode switch and the drop (SQL Server error 3702 "currently in use").
     const quoted = this.quote(name);
-    return `if db_id(${this.platform.quoteValue(name)}) is not null begin alter database ${quoted} set single_user with rollback immediate; drop database ${quoted}; end`;
+    return `if db_id(${this.platform.quoteValue(name)}) is not null begin alter database ${quoted} set offline with rollback immediate; drop database ${quoted}; end`;
   }
 
   override disableForeignKeysSQL(): string {

--- a/tests/globalSetup.ts
+++ b/tests/globalSetup.ts
@@ -154,10 +154,9 @@ async function dropExtras(t: SqlTarget, extras: string[]): Promise<string[]> {
           for (const name of extras) {
             const q = name.replace(/]/g, ']]');
             try {
-              await mssqlQuery(
-                c,
-                `ALTER DATABASE [${q}] SET SINGLE_USER WITH ROLLBACK IMMEDIATE; DROP DATABASE [${q}]`,
-              );
+              // `set offline` over `set single_user` to avoid the 3702 race where a torn-down
+              // pool connection grabs the single-user slot before the drop executes.
+              await mssqlQuery(c, `ALTER DATABASE [${q}] SET OFFLINE WITH ROLLBACK IMMEDIATE; DROP DATABASE [${q}]`);
               dropped.push(name);
             } catch {
               /* skip */


### PR DESCRIPTION
`set single_user with rollback immediate` kicks all sessions but leaves the single-user slot open for one connection. A pool connection torn down by `dropDatabase`'s `reconnect()` to the management DB can re-establish itself into that slot between the mode switch and the `drop database`, surfacing as SQL Server error 3702 "currently in use" mid-test (e.g. [this CI run](https://github.com/mikro-orm/mikro-orm/actions/runs/24925742410/job/72995281822)).

`set offline with rollback immediate` rejects all subsequent connections — including from the issuing session — so the drop runs without contention. Mirror the change in the parallel test cleanup path in `globalSetup.ts` for consistency.