### PR TITLE
fix(mssql): clean up `.mdf/.ldf` files on drop

### DIFF
--- a/packages/mssql/src/MsSqlSchemaHelper.ts
+++ b/packages/mssql/src/MsSqlSchemaHelper.ts
@@ -35,9 +35,29 @@ export class MsSqlSchemaHelper extends SchemaHelper {
   override getDropDatabaseSQL(name: string): string {
     // `set offline` rejects all connections including the issuing session, so there is no
     // single-user race window where a torn-down pool connection can reconnect between the
-    // mode switch and the drop (SQL Server error 3702 "currently in use").
+    // mode switch and the drop (SQL Server error 3702 "currently in use"). Dropping an
+    // offline database leaves the underlying `.mdf`/`.ldf` files behind though, which
+    // makes a subsequent `create database` with the same name fail with error 5170
+    // ("file already exists"). Capture the physical paths up front and call
+    // `master.sys.xp_delete_files` after the drop to clean them up.
     const quoted = this.quote(name);
-    return `if db_id(${this.platform.quoteValue(name)}) is not null begin alter database ${quoted} set offline with rollback immediate; drop database ${quoted}; end`;
+    const literal = this.platform.quoteValue(name);
+    return (
+      `if db_id(${literal}) is not null begin ` +
+      `declare @drop_files table (path nvarchar(260)); ` +
+      `insert into @drop_files (path) select physical_name from sys.master_files where database_id = db_id(${literal}); ` +
+      `alter database ${quoted} set offline with rollback immediate; ` +
+      `drop database ${quoted}; ` +
+      `declare @drop_path nvarchar(260); ` +
+      `declare drop_files_cursor cursor local fast_forward for select path from @drop_files; ` +
+      `open drop_files_cursor; fetch next from drop_files_cursor into @drop_path; ` +
+      `while @@fetch_status = 0 begin ` +
+      `begin try exec master.sys.xp_delete_files @drop_path; end try begin catch end catch; ` +
+      `fetch next from drop_files_cursor into @drop_path; ` +
+      `end ` +
+      `close drop_files_cursor; deallocate drop_files_cursor; ` +
+      `end`
+    );
   }
 
   override disableForeignKeysSQL(): string {

--- a/tests/features/cli/CLIHelper.test.ts
+++ b/tests/features/cli/CLIHelper.test.ts
@@ -1,4 +1,5 @@
 import { type MockInstance } from 'vitest';
+import os from 'node:os';
 import { MikroORM } from '@mikro-orm/core';
 import { configure, CLIHelper } from '@mikro-orm/cli';
 import { fs } from '@mikro-orm/core/fs-utils';
@@ -573,8 +574,10 @@ Maybe you want to check, or regenerate your yarn.lock or package-lock.json file?
     const ret1 = fs.getPackageConfig(import.meta.dirname);
     expect(ret1['mikro-orm'].preferTs).toBe(true);
 
-    // check we fallback to `{}` if we reach root folder
-    const ret2 = fs.getPackageConfig(process.cwd() + '/../..');
+    // check we fallback to `{}` if we reach root folder. Use `os.tmpdir()` so the
+    // upward walk reaches FS root regardless of where the repo is checked out
+    // (e.g. when running from a git worktree nested inside the main repo).
+    const ret2 = fs.getPackageConfig(os.tmpdir());
     expect(ret2).toEqual({});
 
     pkg['mikro-orm'] = undefined;

--- a/tests/globalSetup.ts
+++ b/tests/globalSetup.ts
@@ -155,8 +155,26 @@ async function dropExtras(t: SqlTarget, extras: string[]): Promise<string[]> {
             const q = name.replace(/]/g, ']]');
             try {
               // `set offline` over `set single_user` to avoid the 3702 race where a torn-down
-              // pool connection grabs the single-user slot before the drop executes.
-              await mssqlQuery(c, `ALTER DATABASE [${q}] SET OFFLINE WITH ROLLBACK IMMEDIATE; DROP DATABASE [${q}]`);
+              // pool connection grabs the single-user slot before the drop executes. Dropping
+              // an offline database leaves the underlying `.mdf`/`.ldf` files behind, so
+              // capture the physical paths first and explicitly remove them after the drop —
+              // otherwise a subsequent run that creates the same DB name fails with error
+              // 5170 ("file already exists").
+              await mssqlQuery(
+                c,
+                `declare @drop_files table (path nvarchar(260)); ` +
+                  `insert into @drop_files (path) select physical_name from sys.master_files where database_id = db_id(N'${q}'); ` +
+                  `alter database [${q}] set offline with rollback immediate; ` +
+                  `drop database [${q}]; ` +
+                  `declare @drop_path nvarchar(260); ` +
+                  `declare drop_files_cursor cursor local fast_forward for select path from @drop_files; ` +
+                  `open drop_files_cursor; fetch next from drop_files_cursor into @drop_path; ` +
+                  `while @@fetch_status = 0 begin ` +
+                  `begin try exec master.sys.xp_delete_files @drop_path; end try begin catch end catch; ` +
+                  `fetch next from drop_files_cursor into @drop_path; ` +
+                  `end ` +
+                  `close drop_files_cursor; deallocate drop_files_cursor`,
+              );
               dropped.push(name);
             } catch {
               /* skip */
@@ -177,6 +195,46 @@ async function dropExtras(t: SqlTarget, extras: string[]): Promise<string[]> {
 // developer's hand-made DB on a shared instance is never touched at startup. Tests using other
 // names (e.g. GH-issue numbers) are still cleaned up by the diff-baseline teardown below.
 const STALE_TEST_DB_PATTERN = /^mikro[_-]orm[_-]test/i;
+
+// Default data directory inside the official `mssql/server` images. Orphan `.mdf`/`.ldf`
+// files accumulate here when previous runs aborted between `set offline` and `drop database`,
+// or when `drop database` was issued against an offline DB (which keeps the files). Subsequent
+// `create database` calls with the same name then fail with SQL Server error 5170 ("file
+// already exists"), cascading skips across the affected mssql test files.
+const MSSQL_DEFAULT_DATA_DIR = '/var/opt/mssql/data/';
+
+async function cleanupMssqlOrphanFiles(t: SqlTarget): Promise<number> {
+  try {
+    return await withMssql(t.port, async c => {
+      const sql =
+        `declare @path nvarchar(260) = N'${MSSQL_DEFAULT_DATA_DIR}'; ` +
+        `declare @files table (subdirectory nvarchar(260), depth int, isfile bit); ` +
+        `insert into @files exec master.sys.xp_dirtree @path, 1, 1; ` +
+        `declare @full nvarchar(260); ` +
+        `declare @count int = 0; ` +
+        `declare orphan_cursor cursor local fast_forward for ` +
+        `select @path + subdirectory from @files f ` +
+        `where isfile = 1 ` +
+        `and (subdirectory like N'%.mdf' or subdirectory like N'%.ldf') ` +
+        `and (lower(subdirectory) like N'mikro[_-]orm[_-]test%') ` +
+        `and not exists ( ` +
+        `select 1 from sys.master_files mf where mf.physical_name = @path + f.subdirectory ` +
+        `); ` +
+        `open orphan_cursor; fetch next from orphan_cursor into @full; ` +
+        `while @@fetch_status = 0 begin ` +
+        `begin try exec master.sys.xp_delete_files @full; set @count = @count + 1; end try begin catch end catch; ` +
+        `fetch next from orphan_cursor into @full; ` +
+        `end ` +
+        `close orphan_cursor; deallocate orphan_cursor; ` +
+        `select @count as deleted`;
+      const rows = await mssqlQuery(c, sql);
+      const deleted = rows.length > 0 ? Number((rows[0] as any)[0].value) : 0;
+      return deleted;
+    });
+  } catch {
+    return 0;
+  }
+}
 
 export async function setup() {
   if (!(globalThis as any).__MONGOINSTANCE) {
@@ -215,6 +273,16 @@ export async function setup() {
           // eslint-disable-next-line no-console
           console.log(
             `[globalSetup] ${t.kind}:${t.port} dropped ${dropped.length} stale test DB(s): ${preview}${suffix}`,
+          );
+        }
+      }
+
+      if (t.kind === 'mssql') {
+        const orphanFiles = await cleanupMssqlOrphanFiles(t);
+        if (orphanFiles > 0) {
+          // eslint-disable-next-line no-console
+          console.log(
+            `[globalSetup] ${t.kind}:${t.port} deleted ${orphanFiles} orphan .mdf/.ldf file(s) under ${MSSQL_DEFAULT_DATA_DIR}`,
           );
         }
       }


### PR DESCRIPTION
Two related stability improvements:

**`fix(mssql)`: delete `.mdf`/`.ldf` files when dropping a database.** The `set offline → drop database` path used in `getDropDatabaseSQL` (chosen over `set single_user` to avoid the 3702 race) leaves the underlying data files behind. The next `create database` with the same name then fails with error 5170 ("Cannot create file ... because it already exists") and cascades through every mssql test file that hits the same name. Capture the physical paths from `sys.master_files` before the drop and call `master.sys.xp_delete_files` after, so the file system stays in sync with the catalog.

**`chore(tests)`: stabilize two flakes the suite hits in worktrees and parallel runs.**

- `CLIHelper > getPackageConfig checks parent folders for package.json` walked up from `process.cwd() + '/../..'`. Inside a git worktree under `.claude/worktrees/<name>` that path lands inside the main repo, which has its own `package.json` — the "reached FS root" fallback never fires. Use `os.tmpdir()` instead, which is outside the repo wherever the checkout lives.
- Mirror the new `xp_delete_files` cleanup in `tests/globalSetup.ts:dropExtras` so test DBs we drop at startup also remove their files.
- Add `cleanupMssqlOrphanFiles` as a defence-in-depth pass — scans `/var/opt/mssql/data/` for `mikro_orm_test_*.mdf`/`.ldf` files with no matching row in `sys.master_files` and deletes them. Handles the case where a prior run was killed between `set offline` and `drop database`.

Verified locally: the cascading 5170 errors are gone (orphan cleanup deleted 16 stale files on first run), CLIHelper test passes from this worktree, sqlite/postgres/mysql/mariadb suites are clean.

Pre-existing mssql connection timeouts under heavy load are unaffected by this change — they reproduce identically on master.