### PR TITLE
chore(ci): retry docker pulls and give mssql a startup grace period

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -193,7 +193,7 @@ jobs:
 
       - name: Install & pull docker images
         run: |
-          docker compose pull &
+          for i in 1 2 3; do docker compose pull && break || sleep $((i*15)); done &
           yarn
           wait
 
@@ -360,7 +360,7 @@ jobs:
 
       - name: Install & build & pull docker images
         run: |
-          docker compose pull mongo &
+          for i in 1 2 3; do docker compose pull mongo && break || sleep $((i*15)); done &
           yarn
           yarn build
           wait

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,6 +87,10 @@ services:
       ACCEPT_EULA: 1
     healthcheck:
       test: /opt/mssql-tools18/bin/sqlcmd -b -C -S tcp:localhost -U sa -P 'Root.Root' -Q 'select 1'
+      start_period: 60s
+      interval: 5s
+      timeout: 10s
+      retries: 24
 
   oracledb:
     image: container-registry.oracle.com/database/free:latest-lite


### PR DESCRIPTION
Two unrelated CI flakes from a recent run, both addressable in the workflow + compose:

**MCR WAF block on `docker compose pull`.** Saw it in [run 24936502745, job 73022881482](https://github.com/mikro-orm/mikro-orm/actions/runs/24936502745/job/73022881482):

```
mssql Error pull access denied for mcr.microsoft.com/mssql/server, ...
denied: <!DOCTYPE html ...><h2>The request is blocked.</h2>
Ref A: B6BD44D4F6504EB08697F5B564FE4B0C Ref B: BY1AA1072318042
```

That's Azure Front Door's WAF returning an HTML page in place of the registry's JSON response — Microsoft intermittently flags certain runner IPs as bot traffic. The block is per-request and clears on retry, so wrap each `docker compose pull` in a three-attempt loop with linear backoff (15/30/45s, max ~45s downside).

**mssql healthcheck inherits docker defaults.** Same run, [job 73022881480](https://github.com/mikro-orm/mikro-orm/actions/runs/24936502745/job/73022881480) failed with `container mikro-orm-mssql-1 is unhealthy`. The existing healthcheck has no `start_period`, so it falls back to the docker default of 30s × 3 retries = 90s before declaring unhealthy. mssql 2025 usually takes 60-90s before `sqlcmd` accepts logins on a loaded runner, so first-run init occasionally loses the race. Compare oracledb right below it which already has `start_period: 300s`.

Adding `start_period: 60s` plus tighter `interval: 5s`/`timeout: 10s`/`retries: 24` keeps the fast path fast (probes every 5s once startup is done) while extending the slow-path ceiling to ~3 minutes.

No new secrets needed — this is all transient-mitigation, not auth. Docker Hub rate-limit auth would be a separate change if/when we start seeing `toomanyrequests`, but the linked failures are MCR-side, not Docker Hub.