### PR TITLE
fix(core): allow `targetKey` to point at a primary key

### DIFF
--- a/packages/core/src/metadata/MetadataValidator.ts
+++ b/packages/core/src/metadata/MetadataValidator.ts
@@ -221,7 +221,7 @@ export class MetadataValidator {
    * Composite unique constraints are not sufficient for targetKey.
    */
   private isPropertyUnique(prop: EntityProperty, meta: EntityMetadata): boolean {
-    if (prop.unique) {
+    if (prop.unique || (prop.primary && meta.primaryKeys.length === 1)) {
       return true;
     }
 

--- a/tests/MetadataValidator.test.ts
+++ b/tests/MetadataValidator.test.ts
@@ -694,6 +694,42 @@ describe('MetadataValidator', () => {
       expect(() => validator.validateEntityDefinition(new MetadataStorage(meta), Book, options)).not.toThrow();
     });
 
+    test('does not throw when targetKey references a primary key', async () => {
+      class Author {}
+      class Book {}
+      const meta = {
+        Author: {
+          name: 'Author',
+          className: 'Author',
+          class: Author,
+          primaryKeys: ['id'],
+          properties: {
+            id: { name: 'id', kind: ReferenceKind.SCALAR, type: 'number', primary: true },
+          },
+        },
+        Book: {
+          name: 'Book',
+          className: 'Book',
+          class: Book,
+          primaryKeys: ['id'],
+          properties: {
+            id: { name: 'id', kind: ReferenceKind.SCALAR, type: 'number', primary: true },
+            author: {
+              name: 'author',
+              kind: ReferenceKind.MANY_TO_ONE,
+              type: 'Author',
+              targetKey: 'id',
+            },
+          },
+        },
+      } as any;
+      meta.Author.root = meta.Author;
+      meta.Book.root = meta.Book;
+      meta.Book.properties.author.targetMeta = meta.Author;
+
+      expect(() => validator.validateEntityDefinition(new MetadataStorage(meta), Book, options)).not.toThrow();
+    });
+
     test('throws when targetKey references property in composite unique index (not sufficient)', async () => {
       class Author {}
       class Book {}


### PR DESCRIPTION
## Summary

`MetadataValidator.isPropertyUnique` only treated properties as unique when they had `unique: true` or a single-property `@Unique` decorator. A primary key is inherently unique but wasn't recognized, so `targetKey` pointing at the PK falsely failed validation with "is not marked as unique".

The check now also accepts a property that is the sole primary key of its entity. Composite PKs are intentionally excluded — individual columns of a composite PK are not unique on their own.

Closes #7625