### PR TITLE
fix(core): infer FK column from accessor name for backing-field relations

### DIFF
--- a/docs/docs/defining-entities.md
+++ b/docs/docs/defining-entities.md
@@ -1643,7 +1643,9 @@ console.log(populatedReport.reportParameters.$);
 
 When using a private property backed by a public get/set pair, use the `accessor` option to point to the other side.
 
-> The `fieldName` will be inferred based on the accessor name unless specified explicitly.
+> For scalar/embedded properties, the column name is inferred from the accessor name (e.g. `_email` with `accessor: 'email'` produces column `email`, not `_email`). For to-one relations, this inference only kicks in when the property name follows the conventional `_`-prefixed backing-field shape — `_draft` with `accessor: 'draft'` produces FK column `draft_id`, while a non-prefixed property name is kept as-is.
+
+> Relying on the convention is fragile. Prefer setting the column name explicitly via `fieldName` (scalars) or `joinColumn` (to-one relations) — both override the inferred value.
 
 If the `accessor` option points to something, the ORM will use the backing property directly:
 

--- a/docs/versioned_docs/version-7.0/defining-entities.md
+++ b/docs/versioned_docs/version-7.0/defining-entities.md
@@ -1643,7 +1643,9 @@ console.log(populatedReport.reportParameters.$);
 
 When using a private property backed by a public get/set pair, use the `accessor` option to point to the other side.
 
-> The `fieldName` will be inferred based on the accessor name unless specified explicitly.
+> For scalar/embedded properties, the column name is inferred from the accessor name (e.g. `_email` with `accessor: 'email'` produces column `email`, not `_email`). For to-one relations, this inference only kicks in when the property name follows the conventional `_`-prefixed backing-field shape — `_draft` with `accessor: 'draft'` produces FK column `draft_id`, while a non-prefixed property name is kept as-is.
+
+> Relying on the convention is fragile. Prefer setting the column name explicitly via `fieldName` (scalars) or `joinColumn` (to-one relations) — both override the inferred value.
 
 If the `accessor` option points to something, the ORM will use the backing property directly:
 

--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -160,7 +160,12 @@ export class MetadataDiscovery {
       } else {
         const name = prop.name;
 
-        if (prop.kind === ReferenceKind.SCALAR || prop.kind === ReferenceKind.EMBEDDED) {
+        // For to-one relations, only swap to the accessor for the documented
+        // backing-field convention (a `_`-prefixed property like `_draft` paired
+        // with `accessor: 'draft'`). The non-prefixed sibling-helper pattern
+        // (`author` + `accessor: 'authorId'`) keeps the property name as the
+        // canonical FK column source, so this stays non-breaking.
+        if (prop.kind === ReferenceKind.SCALAR || prop.kind === ReferenceKind.EMBEDDED || name.startsWith('_')) {
           prop.name = prop.accessor;
         }
 

--- a/tests/issues/GHx44.test.ts
+++ b/tests/issues/GHx44.test.ts
@@ -1,0 +1,73 @@
+import { MikroORM } from '@mikro-orm/sqlite';
+import {
+  Entity,
+  ManyToOne,
+  OneToOne,
+  PrimaryKey,
+  Property,
+  ReflectMetadataProvider,
+} from '@mikro-orm/decorators/legacy';
+
+// docs/docs/defining-entities.md says:
+// > The `fieldName` will be inferred based on the accessor name unless specified explicitly.
+// This held for scalars/embeddeds but not for relations — the FK column was derived from
+// the underscore-prefixed backing name (`_draft_id`) instead of the accessor (`draft_id`).
+
+@Entity()
+class Customization {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+}
+
+@Entity()
+class Course {
+  @PrimaryKey()
+  id!: number;
+
+  @OneToOne({ entity: () => Customization, accessor: 'draft', nullable: true })
+  private _draft?: Customization;
+
+  @ManyToOne({ entity: () => Customization, accessor: 'main', nullable: true })
+  private _main?: Customization;
+
+  get draft(): Customization | undefined {
+    return this._draft;
+  }
+
+  get main(): Customization | undefined {
+    return this._main;
+  }
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    metadataProvider: ReflectMetadataProvider,
+    entities: [Course, Customization],
+    dbName: ':memory:',
+  });
+});
+
+afterAll(() => orm.close(true));
+
+test('relation FK column inferred from accessor name on a backing field', async () => {
+  const meta = orm.getMetadata().get(Course);
+  const props = meta.properties as any;
+  const draft = props._draft;
+  const main = props._main;
+
+  expect(draft.fieldNames).toEqual(['draft_id']);
+  expect(draft.joinColumns).toEqual(['draft_id']);
+  expect(main.fieldNames).toEqual(['main_id']);
+  expect(main.joinColumns).toEqual(['main_id']);
+
+  const sql = await orm.schema.getCreateSchemaSQL();
+  expect(sql).toContain('`draft_id`');
+  expect(sql).toContain('`main_id`');
+  expect(sql).not.toContain('`_draft_id`');
+  expect(sql).not.toContain('`_main_id`');
+});


### PR DESCRIPTION
`docs/docs/defining-entities.md` says *"the `fieldName` will be inferred based on the accessor name unless specified explicitly"*, but `initAccessors` only honored that for SCALAR/EMBEDDED kinds. A relation declared as

```ts
@OneToOne({ entity: () => Customization, accessor: 'draft' })
private _draft?: Customization;

get draft() { return this._draft; }
```

ended up with FK column `_draft_id` instead of `draft_id` — the underscore-prefixed backing name leaked into the schema, and the user had to hand-spell `joinColumn` and `referencedColumnNames` to escape it.

The accessor-name swap around `initFieldName` now also fires for to-one relations when the property name follows the documented backing-field convention (`_`-prefixed). The non-prefixed sibling-helper pattern (`author` + `accessor: 'authorId'`, covered by `tests/features/accessors/fk-by-name.test.ts`) keeps using the property name as the canonical FK column source, so this stays non-breaking.