### PR TITLE
docs: add version sidebar to changelog page and polish rendering

### DIFF
--- a/docs/plugins/changelog/Changelog.jsx
+++ b/docs/plugins/changelog/Changelog.jsx
@@ -1,6 +1,5 @@
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import Layout from '@theme/Layout';
-import Link from '@docusaurus/Link';
 import styles from './styles.module.css';
 
 function formatDate(iso) {
@@ -35,53 +34,132 @@ function groupByMajor(releases) {
   return ordered;
 }
 
+function Sidebar({ groups }) {
+  const [expandedMajor, setExpandedMajor] = useState(() => groups[0]?.[0] ?? null);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.location.hash) {
+      return;
+    }
+    const id = decodeURIComponent(window.location.hash.slice(1));
+    const major = majorOf(id);
+    if (major && major !== 'other') {
+      setExpandedMajor(major);
+    }
+  }, []);
+
+  const toggle = key => {
+    setExpandedMajor(prev => (prev === key ? null : key));
+  };
+
+  return (
+    <aside className={styles.sidebar} aria-label="Versions">
+      <nav>
+        <ul className={styles.sidebarList}>
+          {groups.map(([major, items]) => {
+            const isOpen = expandedMajor === major;
+            return (
+              <li key={major} className={styles.sidebarMajor}>
+                <button
+                  type="button"
+                  className={styles.sidebarMajorButton}
+                  onClick={() => toggle(major)}
+                  aria-expanded={isOpen}>
+                  <span className={styles.sidebarCaret} aria-hidden="true">{isOpen ? '▾' : '▸'}</span>
+                  <span className={styles.sidebarMajorLabel}>{major}</span>
+                  <span className={styles.sidebarCount}>{items.length}</span>
+                </button>
+                {isOpen && (
+                  <ul className={styles.sidebarVersions}>
+                    {items.map(release => (
+                      <li key={release.tagName}>
+                        <a href={`#${release.tagName}`} className={styles.sidebarVersionLink}>
+                          {release.tagName}
+                        </a>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      </nav>
+    </aside>
+  );
+}
+
+function useScrollToHashAfterMount() {
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.location.hash) {
+      return;
+    }
+    const id = decodeURIComponent(window.location.hash.slice(1));
+    // Wait for layout/paint to settle so `content-visibility: auto`
+    // sections can lay out at their real height before we anchor.
+    const raf1 = requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        const el = document.getElementById(id);
+        if (el) {
+          el.scrollIntoView({ block: 'start' });
+        }
+      });
+    });
+    return () => cancelAnimationFrame(raf1);
+  }, []);
+}
+
 export default function Changelog({ releases = [] }) {
   const groups = useMemo(() => groupByMajor(releases), [releases]);
+  useScrollToHashAfterMount();
 
   return (
     <Layout
       title="Changelog"
       description="MikroORM release changelog, sourced from GitHub Releases."
       permalink="/changelog">
-      <div className="container margin-vert--xl">
-        <h1>Changelog</h1>
-        <p>
-          Release notes are sourced from{' '}
-          <Link to="https://github.com/mikro-orm/mikro-orm/releases">GitHub Releases</Link>{' '}
-          across the entire monorepo.
-        </p>
+      <div className={styles.layout}>
+        <Sidebar groups={groups} />
+        <main className={styles.content}>
+          <h1>Changelog</h1>
+          <p>
+            Release notes are sourced from{' '}
+            <a
+              href="https://github.com/mikro-orm/mikro-orm/releases"
+              target="_blank"
+              rel="noopener noreferrer">
+              GitHub Releases
+            </a>{' '}
+            across the entire monorepo.
+          </p>
 
-        {groups.length > 1 && (
-          <nav className={styles.toc} aria-label="Major versions">
-            <span className={styles.tocLabel}>Jump to:</span>
-            {groups.map(([major]) => (
-              <a key={major} href={`#${major}`} className={styles.tocLink}>{major}</a>
-            ))}
-          </nav>
-        )}
-
-        {groups.map(([major, items]) => (
-          <section key={major} className={styles.majorSection}>
-            <h2 id={major} className={styles.majorHeading}>{major}</h2>
-            {items.map(release => (
-              <article key={release.tagName} className={styles.release} id={release.tagName}>
-                <h3 className={styles.releaseHeading}>
-                  <Link to={release.htmlUrl} className={styles.releaseTitle}>
-                    {release.name || release.tagName}
-                  </Link>
-                  <span className={styles.releaseMeta}>
-                    {release.prerelease && <span className={styles.prereleaseBadge}>pre-release</span>}
-                    <time dateTime={release.publishedAt}>{formatDate(release.publishedAt)}</time>
-                  </span>
-                </h3>
-                <div
-                  className={styles.releaseBody}
-                  dangerouslySetInnerHTML={{ __html: release.bodyHtml }}
-                />
-              </article>
-            ))}
-          </section>
-        ))}
+          {groups.map(([major, items]) => (
+            <section key={major} className={styles.majorSection}>
+              <h2 id={major} className={styles.majorHeading}>{major}</h2>
+              {items.map(release => (
+                <article key={release.tagName} className={styles.release} id={release.tagName}>
+                  <h3 className={styles.releaseHeading}>
+                    <a
+                      href={release.htmlUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className={styles.releaseTitle}>
+                      {release.name || release.tagName}
+                    </a>
+                    <span className={styles.releaseMeta}>
+                      {release.prerelease && <span className={styles.prereleaseBadge}>pre-release</span>}
+                      <time dateTime={release.publishedAt}>{formatDate(release.publishedAt)}</time>
+                    </span>
+                  </h3>
+                  <div
+                    className={styles.releaseBody}
+                    dangerouslySetInnerHTML={{ __html: release.bodyHtml }}
+                  />
+                </article>
+              ))}
+            </section>
+          ))}
+        </main>
       </div>
     </Layout>
   );

--- a/docs/plugins/changelog/index.js
+++ b/docs/plugins/changelog/index.js
@@ -4,7 +4,11 @@ const path = require('node:path');
 const { marked } = require('marked');
 const { fetchReleases } = require('./fetch-releases');
 
-marked.setOptions({ gfm: true, breaks: false });
+marked.setOptions({ gfm: true, breaks: true });
+
+function externalizeLinks(html) {
+  return html.replace(/<a (?![^>]*\btarget=)/g, '<a target="_blank" rel="noopener noreferrer" ');
+}
 
 module.exports = function changelogPlugin(context, options = {}) {
   const cachePath = path.resolve(__dirname, 'releases.json');
@@ -25,7 +29,7 @@ module.exports = function changelogPlugin(context, options = {}) {
           publishedAt: r.publishedAt,
           htmlUrl: r.htmlUrl,
           prerelease: !!r.prerelease,
-          bodyHtml: marked.parse(r.body || ''),
+          bodyHtml: externalizeLinks(marked.parse(r.body || '')),
         }));
     },
 

--- a/docs/plugins/changelog/styles.module.css
+++ b/docs/plugins/changelog/styles.module.css
@@ -1,21 +1,100 @@
-.toc {
+.layout {
   display: flex;
-  flex-wrap: wrap;
+  align-items: flex-start;
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 2rem 1rem;
+  gap: 2rem;
+}
+
+.sidebar {
+  flex: 0 0 240px;
+  position: sticky;
+  top: calc(var(--ifm-navbar-height, 60px) + 1rem);
+  max-height: calc(100vh - var(--ifm-navbar-height, 60px) - 2rem);
+  overflow-y: auto;
+  padding-right: 0.5rem;
+  border-right: 1px solid var(--ifm-color-emphasis-200);
+}
+
+.sidebarList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.sidebarMajor {
+  margin-bottom: 0.25rem;
+}
+
+.sidebarMajorButton {
+  display: flex;
   align-items: center;
-  gap: 0.5rem 0.75rem;
-  padding: 0.75rem 1rem;
-  margin-bottom: 2rem;
-  background: var(--ifm-color-emphasis-100);
+  width: 100%;
+  padding: 0.4rem 0.5rem;
+  background: none;
+  border: none;
   border-radius: var(--ifm-global-radius);
+  color: var(--ifm-font-color-base);
+  font-size: 0.95rem;
+  font-weight: 600;
+  text-align: left;
+  cursor: pointer;
+  transition: background-color 0.15s ease;
 }
 
-.tocLabel {
-  font-weight: 600;
+.sidebarMajorButton:hover {
+  background: var(--ifm-color-emphasis-100);
+}
+
+.sidebarCaret {
+  display: inline-block;
+  width: 1rem;
+  margin-right: 0.25rem;
+  font-size: 0.7rem;
+  color: var(--ifm-color-emphasis-600);
+}
+
+.sidebarMajorLabel {
+  flex: 1;
+}
+
+.sidebarCount {
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--ifm-color-emphasis-600);
+}
+
+.sidebarVersions {
+  list-style: none;
+  padding: 0;
+  margin: 0.25rem 0 0.5rem 1.25rem;
+  border-left: 1px solid var(--ifm-color-emphasis-200);
+}
+
+.sidebarVersions li {
+  margin: 0;
+}
+
+.sidebarVersionLink {
+  display: block;
+  padding: 0.25rem 0.75rem;
+  font-size: 0.85rem;
   color: var(--ifm-color-emphasis-700);
+  text-decoration: none;
+  border-left: 2px solid transparent;
+  margin-left: -1px;
 }
 
-.tocLink {
-  font-weight: 600;
+.sidebarVersionLink:hover {
+  color: var(--ifm-link-color);
+  background: var(--ifm-color-emphasis-100);
+  text-decoration: none;
+}
+
+.content {
+  flex: 1;
+  min-width: 0;
 }
 
 .majorSection {
@@ -26,11 +105,15 @@
   margin-top: 0;
   padding-bottom: 0.5rem;
   border-bottom: 2px solid var(--ifm-color-emphasis-200);
+  scroll-margin-top: calc(var(--ifm-navbar-height, 60px) + 1rem);
 }
 
 .release {
   padding: 1rem 0 1.5rem;
   border-bottom: 1px solid var(--ifm-color-emphasis-200);
+  scroll-margin-top: calc(var(--ifm-navbar-height, 60px) + 1rem);
+  content-visibility: auto;
+  contain-intrinsic-size: auto 600px;
 }
 
 .release:last-child {
@@ -82,4 +165,21 @@
 
 .releaseBody ul {
   padding-left: 1.5rem;
+}
+
+@media (max-width: 996px) {
+  .layout {
+    flex-direction: column;
+  }
+
+  .sidebar {
+    position: static;
+    flex: 1 1 auto;
+    width: 100%;
+    max-height: none;
+    padding-right: 0;
+    padding-bottom: 1rem;
+    border-right: none;
+    border-bottom: 1px solid var(--ifm-color-emphasis-200);
+  }
 }


### PR DESCRIPTION
Follow-up to #7628 — the polish iterations on the new `/changelog` page never made it into that PR. Bundling them here.

## Changes

- **Version sidebar (left)** replaces the top "Jump to" bar. Sticky, scrolls independently, accordion behaviour (only one major open at a time). The major matching the URL hash auto-expands on load.
- **External links open in a new tab** — both the release titles (→ GitHub) and every link inside release bodies (issue / PR / commit links).
- **Enable `breaks: true` in marked** so soft line breaks render as `<br>`, matching how GitHub renders the same release markdown. Fixes major-release intros where the blog post / upgrading guide / etc. were collapsed onto one line.
- **Perf:** `content-visibility: auto` + `contain-intrinsic-size: auto 600px` on release cards so jumping around the ~220-section page doesn't stall on layout/paint. A short post-mount `scrollIntoView` re-anchors to the URL hash once content-visibility sections have laid out at their real height.