### PR TITLE
fix(core): avoid crash on STI subclass with 1:M override

### DIFF
--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -1560,7 +1560,12 @@ export class MetadataDiscovery {
       return false;
     }
 
-    if (prop.kind !== ReferenceKind.MANY_TO_ONE && prop.kind !== ReferenceKind.ONE_TO_ONE) {
+    if (
+      prop.kind !== ReferenceKind.MANY_TO_ONE &&
+      prop.kind !== ReferenceKind.ONE_TO_ONE &&
+      prop.kind !== ReferenceKind.ONE_TO_MANY &&
+      prop.kind !== ReferenceKind.MANY_TO_MANY
+    ) {
       return false;
     }
 
@@ -1633,8 +1638,17 @@ export class MetadataDiscovery {
       // addProperty below, so subsequent children correctly trigger renaming.
       const typesMatch = rootProp?.type === prop.type || rootProp?.stiMerged === true || narrowedRelationOverride;
 
+      // Inverse-side relations (1:m, inverse m:n) have no FK column on this
+      // entity, so the rename branch — which exists to disambiguate physical
+      // columns shared across STI children — doesn't apply. Skipping it also
+      // avoids crashing on `[...rootProp.fieldNames]` since fieldNames is
+      // never populated for inverse-side properties.
+      const isInverseSideRelation =
+        prop.kind === ReferenceKind.ONE_TO_MANY || (prop.kind === ReferenceKind.MANY_TO_MANY && !prop.owner);
+
       if (
         rootProp &&
+        !isInverseSideRelation &&
         (!typesMatch ||
           (rootProp.fieldNames && prop.fieldNames && !compareArrays(rootProp.fieldNames, prop.fieldNames)))
       ) {
@@ -1698,6 +1712,15 @@ export class MetadataDiscovery {
       // the full target union (e.g. `Food`) is preserved for populates from the
       // abstract root — otherwise the last child processed would win.
       if (narrowedRelationOverride) {
+        return;
+      }
+
+      // STI siblings can declare the same property name on inverse-side relations
+      // pointing to disjoint targets (e.g. `Dog.items → DogItem` and
+      // `Cat.items → CatItem` with no shared base). There's no physical column
+      // to manage at root, and propagating would clobber the first child's
+      // declaration; each child keeps its local typed property instead.
+      if (isInverseSideRelation && rootProp && rootProp.type !== prop.type) {
         return;
       }
 

--- a/tests/issues/GH7635.test.ts
+++ b/tests/issues/GH7635.test.ts
@@ -1,0 +1,124 @@
+import 'reflect-metadata';
+import {
+  Entity,
+  Enum,
+  ManyToOne,
+  OneToMany,
+  PrimaryKey,
+  ReflectMetadataProvider,
+} from '@mikro-orm/decorators/legacy';
+import { Collection, MikroORM } from '@mikro-orm/sqlite';
+
+enum Species {
+  DOG = 'DOG',
+  CAT = 'CAT',
+}
+
+@Entity({ tableName: 'pet', abstract: true, discriminatorColumn: 'species' })
+abstract class Pet {
+  @PrimaryKey()
+  id!: number;
+
+  @Enum(() => Species)
+  species!: Species;
+
+  // Narrowed inverse-side: root declares broad target, children narrow within the same hierarchy.
+  @OneToMany(() => Toy, t => t.owner)
+  toys = new Collection<Toy>(this);
+}
+
+@Entity({ discriminatorValue: Species.DOG })
+class Dog extends Pet {
+  @OneToMany(() => DogToy, t => t.owner)
+  declare toys: Collection<DogToy>;
+
+  // Disjoint inverse-side: same property name on each child, targets share no base.
+  @OneToMany(() => DogItem, i => i.dog)
+  items = new Collection<DogItem>(this);
+}
+
+@Entity({ discriminatorValue: Species.CAT })
+class Cat extends Pet {
+  @OneToMany(() => CatToy, t => t.owner)
+  declare toys: Collection<CatToy>;
+
+  @OneToMany(() => CatItem, i => i.cat)
+  items = new Collection<CatItem>(this);
+}
+
+@Entity({ tableName: 'toy', abstract: true, discriminatorColumn: 'species' })
+abstract class Toy {
+  @PrimaryKey()
+  id!: number;
+
+  @Enum(() => Species)
+  species!: Species;
+
+  @ManyToOne(() => Pet)
+  owner!: Pet;
+}
+
+@Entity({ discriminatorValue: Species.DOG })
+class DogToy extends Toy {}
+
+@Entity({ discriminatorValue: Species.CAT })
+class CatToy extends Toy {}
+
+@Entity()
+class DogItem {
+  @PrimaryKey()
+  id!: number;
+
+  @ManyToOne(() => Dog)
+  dog!: Dog;
+}
+
+@Entity()
+class CatItem {
+  @PrimaryKey()
+  id!: number;
+
+  @ManyToOne(() => Cat)
+  cat!: Cat;
+}
+
+test('STI subclass @OneToMany override does not crash metadata discovery (GH #7635)', async () => {
+  const orm = await MikroORM.init({
+    dbName: ':memory:',
+    entities: [Pet, Dog, Cat, Toy, DogToy, CatToy, DogItem, CatItem],
+    metadataProvider: ReflectMetadataProvider,
+  });
+  const meta = orm.getMetadata();
+
+  // narrowed override: children resolve to subtypes; root keeps the abstract target so populates from the root resolve all children
+  expect(meta.get(Dog).properties.toys.type).toBe('DogToy');
+  expect(meta.get(Cat).properties.toys.type).toBe('CatToy');
+  expect(meta.get(Pet).properties.toys.type).toBe('Toy');
+
+  // disjoint override: each child keeps its own typed inverse-side relation
+  expect(meta.get(Dog).properties.items.type).toBe('DogItem');
+  expect(meta.get(Cat).properties.items.type).toBe('CatItem');
+
+  await orm.schema.refresh();
+
+  const dog = orm.em.create(Dog, { id: 1, species: Species.DOG });
+  const cat = orm.em.create(Cat, { id: 2, species: Species.CAT });
+  orm.em.create(DogToy, { id: 10, species: Species.DOG, owner: dog });
+  orm.em.create(CatToy, { id: 20, species: Species.CAT, owner: cat });
+  orm.em.create(DogItem, { id: 100, dog });
+  orm.em.create(CatItem, { id: 200, cat });
+  await orm.em.flush();
+  orm.em.clear();
+
+  const dogs = await orm.em.find(Dog, {}, { populate: ['toys', 'items'] });
+  expect(dogs).toHaveLength(1);
+  expect(dogs[0].toys.map(t => t.id)).toEqual([10]);
+  expect(dogs[0].items.map(i => i.id)).toEqual([100]);
+
+  const cats = await orm.em.find(Cat, {}, { populate: ['toys', 'items'] });
+  expect(cats).toHaveLength(1);
+  expect(cats[0].toys.map(t => t.id)).toEqual([20]);
+  expect(cats[0].items.map(i => i.id)).toEqual([200]);
+
+  await orm.close(true);
+});

--- a/tests/issues/GH7635.test.ts
+++ b/tests/issues/GH7635.test.ts
@@ -1,12 +1,5 @@
 import 'reflect-metadata';
-import {
-  Entity,
-  Enum,
-  ManyToOne,
-  OneToMany,
-  PrimaryKey,
-  ReflectMetadataProvider,
-} from '@mikro-orm/decorators/legacy';
+import { Entity, Enum, ManyToOne, OneToMany, PrimaryKey, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
 import { Collection, MikroORM } from '@mikro-orm/sqlite';
 
 enum Species {


### PR DESCRIPTION
STI children that declare an `@OneToMany` with a different target than the root crashed during metadata discovery with `TypeError: rootProp.fieldNames is not iterable`. The rename branch in `initSingleTableInheritance`, which exists to disambiguate physical FK columns across STI children, was being entered for inverse-side relations — but inverse-side properties never populate `fieldNames`, so spreading them blew up.

This handles both narrowing within the same hierarchy (e.g. `Dog extends Pet` narrows `toys: Toy` to `DogToy`) and disjoint targets (e.g. `Dog.items: DogItem` / `Cat.items: CatItem` with no shared base). `sameRelationTargetRoot` now recognizes 1:m and inverse m:n so narrowed overrides flow through the existing `narrowedRelationOverride` path and preserve the root's broad target; for disjoint overrides, each child keeps its own local typed property rather than letting the last-processed child clobber the root's declaration.

Closes #7635