### PR TITLE
fix(core): respect `hidden` flag with `populate: ['*']` in `serialize()`

### DIFF
--- a/packages/core/src/serialization/EntitySerializer.ts
+++ b/packages/core/src/serialization/EntitySerializer.ts
@@ -37,7 +37,7 @@ function isVisible<T extends object>(
 
   if (
     Array.isArray(options.populate) &&
-    options.populate?.find(item => item === propName || item.startsWith(propName + '.') || item === '*')
+    options.populate?.find(item => item === propName || item.startsWith(propName + '.'))
   ) {
     return true;
   }

--- a/tests/issues/GH7634.test.ts
+++ b/tests/issues/GH7634.test.ts
@@ -1,0 +1,76 @@
+import { defineEntity, MikroORM, p, wrap } from '@mikro-orm/sqlite';
+
+const AddressSchema = defineEntity({
+  name: 'Address',
+  properties: {
+    id: p.integer().primary(),
+    street: p.string(),
+  },
+});
+
+const EmployeeSchema = defineEntity({
+  name: 'Employee',
+  properties: {
+    id: p.integer().primary(),
+    name: p.string().hidden(),
+    department: p.string(),
+    address: () => p.oneToOne(AddressSchema).hidden(),
+  },
+});
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    dbName: ':memory:',
+    entities: [AddressSchema, EmployeeSchema],
+  });
+  await orm.schema.refresh();
+
+  orm.em.create(EmployeeSchema, {
+    id: 1,
+    name: 'John Doe',
+    department: 'Engineering',
+    address: { id: 1, street: '1 Main Road' },
+  });
+  await orm.em.flush();
+  orm.em.clear();
+});
+
+afterAll(() => orm.close(true));
+
+test(`GH #7634: serialize() with populate: ['*'] respects hidden() unless includeHidden is true`, async () => {
+  const employee = await orm.em.findOneOrFail(EmployeeSchema, 1, { populate: ['*'] });
+  const dto = wrap(employee).serialize({ populate: ['*'] });
+
+  expect(dto).toEqual({
+    id: 1,
+    department: 'Engineering',
+  });
+  expect(dto).not.toHaveProperty('name');
+  expect(dto).not.toHaveProperty('address');
+});
+
+test(`GH #7634: includeHidden: true still surfaces hidden props with populate: ['*']`, async () => {
+  const employee = await orm.em.findOneOrFail(EmployeeSchema, 1, { populate: ['*'] });
+  const dto = wrap(employee).serialize({ populate: ['*'], includeHidden: true });
+
+  expect(dto).toMatchObject({
+    id: 1,
+    name: 'John Doe',
+    department: 'Engineering',
+    address: { id: 1, street: '1 Main Road' },
+  });
+});
+
+test(`GH #7634: explicit named populate hint still overrides hidden (whitelist semantics preserved)`, async () => {
+  const employee = await orm.em.findOneOrFail(EmployeeSchema, 1, { populate: ['*'] });
+  const dto = wrap(employee).serialize({ populate: ['name', 'address'] });
+
+  expect(dto).toMatchObject({
+    id: 1,
+    name: 'John Doe',
+    department: 'Engineering',
+    address: { id: 1, street: '1 Main Road' },
+  });
+});


### PR DESCRIPTION
## Summary

In `EntitySerializer.isVisible`, the populate-hint match short-circuited and returned `true` for any property when `populate` contained `'*'` — bypassing the `hidden && !includeHidden` check. This meant `wrap(e).serialize({ populate: ['*'] })` (or `populate: ['*']` paired with the default `includeHidden: false`) force-included every hidden scalar and hidden relation.

The fix is scoped: drop `'*'` from the early-return match. Named populate hints (`populate: ['name']`, `populate: ['address']`) keep their whitelist-override semantics — explicit naming still forces a hidden property into the output. Only the wildcard now falls through to the normal hidden check, so `includeHidden: true` becomes the single way `'*'` surfaces hidden props.

This is a behavior change for callers who relied on `populate: ['*']` to coincidentally surface hidden fields; they need to switch to `includeHidden: true`, which is what that flag is for.

Closes #7634