### PR TITLE
fix(core): drop entity from persist/remove stacks in `uow.unsetIdentity()`

### DIFF
--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -1660,9 +1660,6 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
       }
 
       if (!helper(data).__managed) {
-        // the entity might have been created via `em.create()`, which adds it to the persist stack automatically
-        em.#unitOfWork.getPersistStack().delete(data);
-        // it can be also in the identity map if it had a PK value already
         em.#unitOfWork.unsetIdentity(data);
       }
 
@@ -1716,10 +1713,6 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
         }
 
         if (!helper(row).__managed) {
-          // the entity might have been created via `em.create()`, which adds it to the persist stack automatically
-          em.#unitOfWork.getPersistStack().delete(row);
-
-          // it can be also in the identity map if it had a PK value already
           em.#unitOfWork.unsetIdentity(row);
         }
 

--- a/packages/core/src/unit-of-work/UnitOfWork.ts
+++ b/packages/core/src/unit-of-work/UnitOfWork.ts
@@ -645,6 +645,9 @@ export class UnitOfWork {
 
   unsetIdentity(entity: AnyEntity): void {
     this.#identityMap.delete(entity);
+    this.#persistStack.delete(entity);
+    this.#removeStack.delete(entity);
+    this.#orphanRemoveStack.delete(entity);
     const wrapped = helper(entity);
     const serializedPK = wrapped.getSerializedPrimaryKey();
 

--- a/tests/issues/GHx45.test.ts
+++ b/tests/issues/GHx45.test.ts
@@ -1,0 +1,103 @@
+import { Collection, MikroORM, Ref, ref } from '@mikro-orm/sqlite';
+import {
+  Entity,
+  ManyToOne,
+  OneToMany,
+  PrimaryKey,
+  Property,
+  ReflectMetadataProvider,
+} from '@mikro-orm/decorators/legacy';
+
+// Repro for em.transactional leaving residue on the parent EM:
+// when parent's OneToMany was populated on the outer EM before
+// `em.transactional`, the populated children get added to the outer EM's
+// persist stack (Collection.add for OneToMany calls em.persist). Removing
+// the child inside the transactional callback then unsets the identity on
+// the parent EM via the deletion handler, but the child stayed in the
+// outer persist stack with no `__originalEntityData` — so the next
+// `em.flush()` re-INSERTed it.
+
+@Entity()
+class Parent {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @OneToMany(() => Child, c => c.parent, { orphanRemoval: true })
+  children = new Collection<Child>(this);
+}
+
+@Entity()
+class Child {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @ManyToOne(() => Parent, { ref: true })
+  parent!: Ref<Parent>;
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    dbName: ':memory:',
+    entities: [Parent, Child],
+    metadataProvider: ReflectMetadataProvider,
+    allowGlobalContext: true,
+  });
+  await orm.schema.refresh();
+});
+
+afterAll(() => orm.close(true));
+
+beforeEach(() => orm.schema.clear());
+
+async function seed() {
+  const em = orm.em.fork();
+  const p = em.create(Parent, { name: 'P' });
+  await em.flush();
+  const c = em.create(Child, { name: 'C', parent: ref(Parent, p.id) });
+  await em.flush();
+  return { parentId: p.id, childId: c.id };
+}
+
+const childExists = async (id: number) => (await orm.em.fork().count(Child, { id })) === 1;
+
+test('SANITY: txn commits the DELETE', async () => {
+  const { childId } = await seed();
+  const em = orm.em.fork();
+  const child = await em.findOneOrFail(Child, { id: childId });
+  await em.transactional(async txEm => {
+    txEm.remove(child);
+  });
+  expect(await childExists(childId)).toBe(false);
+});
+
+test('CONTROL: no parent populate — outer flush is a no-op', async () => {
+  const { childId } = await seed();
+  const em = orm.em.fork();
+  const child = await em.findOneOrFail(Child, { id: childId });
+  await em.transactional(async txEm => {
+    txEm.remove(child);
+  });
+  expect(await childExists(childId)).toBe(false);
+  await em.flush();
+  expect(await childExists(childId)).toBe(false);
+});
+
+test('GHx45: populate parent.children + remove inside transactional + outer flush should be a no-op', async () => {
+  const { childId } = await seed();
+  const em = orm.em.fork();
+  const child = await em.findOneOrFail(Child, { id: childId }, { populate: ['parent.children'] });
+  await em.transactional(async txEm => {
+    txEm.remove(child);
+  });
+  expect(await childExists(childId)).toBe(false);
+  await em.flush();
+  expect(await childExists(childId)).toBe(false);
+});


### PR DESCRIPTION
## Summary

Fixes #7638. When `em.transactional` runs after `populate: ['parent.children']` on a OneToMany, the deleted child was re-INSERTed by the next outer `em.flush()`.

Root cause: `Collection.add` for OneToMany calls `em.persist(items)`, so populated children land in the outer EM's persist stack. After the fork commits the DELETE, `TransactionManager`'s `afterFlush` handler calls `parent.unsetIdentity(child)` — which only cleared the identity map and `__originalEntityData`/`__managed`. The child stayed in the parent's persist stack with no original data, so the next flush saw a "new" entity and re-INSERTed it.

`unsetIdentity` now symmetrically drops the entity from the persist, remove, and orphan-remove stacks alongside the identity map, matching the "untrack this entity completely" semantics already used by `postCommitCleanup`.

The follow-up commit removes the now-redundant `getPersistStack().delete(data)` workarounds in `EntityManager.insert`/`insertMany`.