### PR TITLE
refactor: preserve JsonType for json/jsonb properties with array TS type

### DIFF
--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -2333,6 +2333,7 @@ export class MetadataDiscovery {
       prop.customType &&
       !(prop.customType instanceof t.array) &&
       !(prop.customType instanceof t.enumArray) &&
+      !(prop.customType instanceof t.json) &&
       prop.kind === ReferenceKind.SCALAR
     ) {
       const innerType = prop.customType;

--- a/tests/issues/GH7641.test.ts
+++ b/tests/issues/GH7641.test.ts
@@ -1,0 +1,35 @@
+import { JsonType, MikroORM } from '@mikro-orm/sqlite';
+import { TsMorphMetadataProvider } from '@mikro-orm/reflection';
+import { Entity, PrimaryKey, Property } from '@mikro-orm/decorators/legacy';
+
+@Entity()
+class A {
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ type: 'json' })
+  features!: string[];
+}
+
+@Entity()
+class B {
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ type: 'jsonb' })
+  features!: string[];
+}
+
+test('GH issue 7641: json/jsonb properties with array TS type stay mapped to JsonType under TsMorph', async () => {
+  const orm = await MikroORM.init({
+    metadataProvider: TsMorphMetadataProvider,
+    metadataCache: { enabled: false },
+    entities: [A, B],
+    dbName: ':memory:',
+  });
+
+  expect(orm.getMetadata().get(A).properties.features.customType).toBeInstanceOf(JsonType);
+  expect(orm.getMetadata().get(B).properties.features.customType).toBeInstanceOf(JsonType);
+
+  await orm.close(true);
+});


### PR DESCRIPTION
The `array: true` wrap pass added in #7378 re-wraps any already-set
customType in ArrayType. With TsMorphMetadataProvider, reflection sets
`prop.array = true` from the TS array type, so a `@Property({ type: 'json' })`
on `string[]` had its JsonType silently re-wrapped — inserts then went
through `Platform.marshallArray()` and produced invalid JSON in the
column (hard SQL error on Postgres/MySQL, silent corruption on
SQLite/MSSQL).

Closes #7641
