### PR TITLE
chore(ci): dump container state when `docker compose up --wait` fails

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -166,7 +166,27 @@ jobs:
           wait
 
       - name: Init docker
-        run: docker compose up -d --wait
+        run: |
+          if docker compose up -d --wait; then
+            exit 0
+          fi
+          rc=$?
+          set +e
+          echo "::group::docker compose ps -a"
+          docker compose ps -a
+          echo "::endgroup::"
+          for s in mongo mysql9 mariadb postgre postgis cockroachdb mssql oracledb; do
+            cid=$(docker compose ps -aq "$s")
+            echo "::group::$s logs"
+            docker compose logs --tail=200 --no-color "$s"
+            echo "::endgroup::"
+            if [ -n "$cid" ]; then
+              echo "::group::$s state"
+              docker inspect "$cid" --format '{{json .State}}' | jq .
+              echo "::endgroup::"
+            fi
+          done
+          exit $rc
 
       - name: Set CC Required env vars
         run: export GIT_BRANCH=$GITHUB_HEAD_REF && export GIT_COMMIT_SHA=$(git rev-parse origin/$GITHUB_HEAD_REF)


### PR DESCRIPTION
We've patched the recurring `container mikro-orm-mssql-1 is unhealthy` flake at the `Init docker` step twice (#7623 and earlier) without ever seeing what mssql is actually doing in the moment compose gives up — the workflow only prints the one-line verdict and exits.

Wrap the step so on failure it dumps `docker compose ps -a`, the last 200 log lines per service, and `docker inspect ... .State` (which includes `Health.Status`, `Health.Log`, `ExitCode`, `RestartCount`, `StartedAt`, `FinishedAt`). No behavior change on the success path.

Recent reproductions: jobs [73466410920](https://github.com/mikro-orm/mikro-orm/actions/runs/25075367235/job/73466410920) and [73467877350](https://github.com/mikro-orm/mikro-orm/actions/runs/25075791288/job/73467877350) — both reported mssql unhealthy 47s and 52s after start, well inside its 60s `start_period`, at the exact tick oracledb flips to Healthy. Likely culprit (per moby `daemon/monitor.go` + compose `pkg/compose/convergence.go`): when a container with `restart: always` exits, `stopHealthchecks` writes `Health.Status=Unhealthy` unconditionally, then `SetRestarting` makes `State.Status` report `restarting`. Compose's `isServiceHealthy` only treats `StateExited` as "exited" and falls through to the health check, surfacing the stale `Unhealthy` as `is unhealthy` instead of `exited (N)` (closest filed issue: docker/compose#11030). `RestartCount > 0` in the dump will confirm.