### PR TITLE
fix(sql): avoid duplicate result cache write on `em.find()`

### DIFF
--- a/packages/sql/src/AbstractSqlDriver.ts
+++ b/packages/sql/src/AbstractSqlDriver.ts
@@ -154,7 +154,9 @@ export abstract class AbstractSqlDriver<
       options.logging,
       undefined,
       options.em as any,
-    ).withSchema(schema);
+    )
+      .withSchema(schema)
+      .cache(false);
     const fields = this.buildFields(meta, populate, joinedProps, qb, qb.alias, options, schema);
     const orderBy = this.buildOrderBy(qb, meta, populate, options);
     const populateWhere = this.buildPopulateWhere(meta, joinedProps, options);

--- a/tests/issues/GH7644.test.ts
+++ b/tests/issues/GH7644.test.ts
@@ -1,0 +1,56 @@
+import { CacheAdapter, defineEntity, MikroORM, p } from '@mikro-orm/sqlite';
+
+const Foo = defineEntity({
+  name: 'Foo',
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+  },
+});
+
+const setCalls: string[] = [];
+
+class RecordingAdapter implements CacheAdapter {
+  get() {
+    return undefined;
+  }
+
+  set(name: string): void {
+    setCalls.push(name);
+  }
+
+  remove(): void {
+    // no-op
+  }
+
+  clear(): void {
+    // no-op
+  }
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    entities: [Foo],
+    dbName: ':memory:',
+    resultCache: { adapter: RecordingAdapter, global: 100 },
+  });
+  await orm.schema.refresh();
+});
+
+afterAll(() => orm.close(true));
+
+beforeEach(() => {
+  setCalls.length = 0;
+});
+
+test('GH #7644: single em.find writes the cache once', async () => {
+  await orm.em.fork().find(Foo, {});
+  expect(setCalls).toHaveLength(1);
+});
+
+test('GH #7644: single em.findOne writes the cache once', async () => {
+  await orm.em.fork().findOne(Foo, { id: 1 });
+  expect(setCalls).toHaveLength(1);
+});


### PR DESCRIPTION
PR #6923 (streaming) began passing `options.em` into the internal `createQueryBuilder()` call in `AbstractSqlDriver.find()`, which activated the QB-level `tryCache`/`storeCache` calls in `QueryBuilder.execute()`. With `resultCache.global` enabled, this stacked on top of the EM-level cache that already wraps `em.find()`, producing two `cache.set()` calls per query (keyed `qb.execute` and `em.find`).

The QB-level cache is still useful when users drive `em.qb()` directly, so we just disable it on the driver-internal QB via `qb.cache(false)`. This restores v6 single-write behavior without affecting the streaming path (`qb.stream()` doesn't touch the cache) or virtual-entity subqueries (they don't call `qb.execute()`).

Closes #7644