### PR TITLE
feat(sql): add `MikroORM` and `defineConfig` variants in `@mikro-orm/sql`

### DIFF
--- a/packages/libsql/src/LibSqlMikroORM.ts
+++ b/packages/libsql/src/LibSqlMikroORM.ts
@@ -3,13 +3,13 @@ import {
   type EntityClass,
   type EntitySchema,
   defineConfig,
-  MikroORM,
+  type MikroORM,
   type Options,
   type IDatabaseDriver,
   type EntityManager,
   type EntityManagerType,
 } from '@mikro-orm/core';
-import type { SqlEntityManager } from '@mikro-orm/sql';
+import { SqlMikroORM, type SqlEntityManager } from '@mikro-orm/sql';
 import { LibSqlDriver } from './LibSqlDriver.js';
 
 /** Configuration options for the libSQL driver. */
@@ -44,7 +44,7 @@ export class LibSqlMikroORM<
     | EntityClass<AnyEntity>
     | EntitySchema
   )[],
-> extends MikroORM<LibSqlDriver, EM, Entities> {
+> extends SqlMikroORM<LibSqlDriver, EM, Entities> {
   /**
    * @inheritDoc
    */

--- a/packages/mariadb/src/MariaDbMikroORM.ts
+++ b/packages/mariadb/src/MariaDbMikroORM.ts
@@ -3,13 +3,13 @@ import {
   type EntityClass,
   type EntitySchema,
   defineConfig,
-  MikroORM,
+  type MikroORM,
   type Options,
   type IDatabaseDriver,
   type EntityManager,
   type EntityManagerType,
 } from '@mikro-orm/core';
-import type { SqlEntityManager } from '@mikro-orm/mysql';
+import { SqlMikroORM, type SqlEntityManager } from '@mikro-orm/mysql';
 import { MariaDbDriver } from './MariaDbDriver.js';
 
 /** Configuration options for the MariaDB driver. */
@@ -44,7 +44,7 @@ export class MariaDbMikroORM<
     | EntityClass<AnyEntity>
     | EntitySchema
   )[],
-> extends MikroORM<MariaDbDriver, EM, Entities> {
+> extends SqlMikroORM<MariaDbDriver, EM, Entities> {
   /**
    * @inheritDoc
    */

--- a/packages/mssql/src/MsSqlMikroORM.ts
+++ b/packages/mssql/src/MsSqlMikroORM.ts
@@ -3,13 +3,13 @@ import {
   type EntityClass,
   type EntitySchema,
   defineConfig,
-  MikroORM,
+  type MikroORM,
   type Options,
   type IDatabaseDriver,
   type EntityManager,
   type EntityManagerType,
 } from '@mikro-orm/core';
-import type { SqlEntityManager } from '@mikro-orm/sql';
+import { SqlMikroORM, type SqlEntityManager } from '@mikro-orm/sql';
 import { MsSqlDriver } from './MsSqlDriver.js';
 
 /** Configuration options for the MSSQL driver. */
@@ -44,7 +44,7 @@ export class MsSqlMikroORM<
     | EntityClass<AnyEntity>
     | EntitySchema
   )[],
-> extends MikroORM<MsSqlDriver, EM, Entities> {
+> extends SqlMikroORM<MsSqlDriver, EM, Entities> {
   /**
    * @inheritDoc
    */

--- a/packages/mysql/src/MySqlMikroORM.ts
+++ b/packages/mysql/src/MySqlMikroORM.ts
@@ -3,13 +3,13 @@ import {
   type EntityClass,
   type EntitySchema,
   defineConfig,
-  MikroORM,
+  type MikroORM,
   type Options,
   type IDatabaseDriver,
   type EntityManager,
   type EntityManagerType,
 } from '@mikro-orm/core';
-import type { SqlEntityManager } from '@mikro-orm/sql';
+import { SqlMikroORM, type SqlEntityManager } from '@mikro-orm/sql';
 import { MySqlDriver } from './MySqlDriver.js';
 
 /** Configuration options for the MySQL driver. */
@@ -44,7 +44,7 @@ export class MySqlMikroORM<
     | EntityClass<AnyEntity>
     | EntitySchema
   )[],
-> extends MikroORM<MySqlDriver, EM, Entities> {
+> extends SqlMikroORM<MySqlDriver, EM, Entities> {
   /**
    * @inheritDoc
    */

--- a/packages/oracledb/src/OracleMikroORM.ts
+++ b/packages/oracledb/src/OracleMikroORM.ts
@@ -1,6 +1,6 @@
 import {
   defineConfig,
-  MikroORM,
+  type MikroORM,
   type Options,
   type IDatabaseDriver,
   type EntityManager,
@@ -9,7 +9,7 @@ import {
   type AnyEntity,
   type EntitySchema,
 } from '@mikro-orm/core';
-import type { SqlEntityManager } from '@mikro-orm/sql';
+import { SqlMikroORM, type SqlEntityManager } from '@mikro-orm/sql';
 import { OracleDriver } from './OracleDriver.js';
 
 /** Configuration options for the Oracle driver. */
@@ -44,7 +44,7 @@ export class OracleMikroORM<
     | EntityClass<AnyEntity>
     | EntitySchema
   )[],
-> extends MikroORM<OracleDriver, EM, Entities> {
+> extends SqlMikroORM<OracleDriver, EM, Entities> {
   /**
    * @inheritDoc
    */

--- a/packages/postgresql/src/PostgreSqlMikroORM.ts
+++ b/packages/postgresql/src/PostgreSqlMikroORM.ts
@@ -3,12 +3,13 @@ import {
   type EntityClass,
   type EntitySchema,
   defineConfig,
-  MikroORM,
+  type MikroORM,
   type Options,
   type IDatabaseDriver,
   type EntityManager,
   type EntityManagerType,
 } from '@mikro-orm/core';
+import { SqlMikroORM } from '@mikro-orm/sql';
 import { PostgreSqlDriver } from './PostgreSqlDriver.js';
 import type { PostgreSqlEntityManager } from './PostgreSqlEntityManager.js';
 
@@ -44,7 +45,7 @@ export class PostgreSqlMikroORM<
     | EntityClass<AnyEntity>
     | EntitySchema
   )[],
-> extends MikroORM<PostgreSqlDriver, EM, Entities> {
+> extends SqlMikroORM<PostgreSqlDriver, EM, Entities> {
   /**
    * @inheritDoc
    */

--- a/packages/sql/src/SqlMikroORM.ts
+++ b/packages/sql/src/SqlMikroORM.ts
@@ -1,0 +1,72 @@
+import {
+  type AnyEntity,
+  type EntityClass,
+  type EntityManager,
+  type EntityManagerType,
+  type EntitySchema,
+  type IDatabaseDriver,
+  defineConfig,
+  MikroORM,
+  type Options,
+} from '@mikro-orm/core';
+import type { AbstractSqlDriver } from './AbstractSqlDriver.js';
+import type { SqlEntityManager } from './SqlEntityManager.js';
+
+/** Configuration options shared by all SQL drivers. */
+export type SqlOptions<
+  D extends AbstractSqlDriver = AbstractSqlDriver,
+  EM extends SqlEntityManager<D> = SqlEntityManager<D>,
+  Entities extends (string | EntityClass<AnyEntity> | EntitySchema)[] = (
+    | string
+    | EntityClass<AnyEntity>
+    | EntitySchema
+  )[],
+> = Partial<Options<D, EM, Entities>>;
+
+/**
+ * Creates a type-safe configuration object for any SQL driver. The driver class
+ * must be passed via `options.driver` (e.g. `SqliteDriver`, `MySqlDriver`, …).
+ */
+export function defineSqlConfig<
+  D extends AbstractSqlDriver = AbstractSqlDriver,
+  EM extends SqlEntityManager<D> = SqlEntityManager<D>,
+  Entities extends (string | EntityClass<AnyEntity> | EntitySchema)[] = (
+    | string
+    | EntityClass<AnyEntity>
+    | EntitySchema
+  )[],
+>(options: Partial<Options<D, EM, Entities>>): Partial<Options<D, EM, Entities>> {
+  return defineConfig(options);
+}
+
+/**
+ * Generic entry point for SQL drivers. Use this when consuming `@mikro-orm/sql`
+ * directly with a Kysely dialect; for the bundled driver packages prefer
+ * `@mikro-orm/sqlite`, `@mikro-orm/postgresql`, etc.
+ *
+ * @inheritDoc
+ */
+export class SqlMikroORM<
+  D extends AbstractSqlDriver = AbstractSqlDriver,
+  EM extends SqlEntityManager<D> = SqlEntityManager<D>,
+  Entities extends (string | EntityClass<AnyEntity> | EntitySchema)[] = (
+    | string
+    | EntityClass<AnyEntity>
+    | EntitySchema
+  )[],
+> extends MikroORM<D, EM, Entities> {
+  /**
+   * @inheritDoc
+   */
+  static override async init<
+    D extends IDatabaseDriver = AbstractSqlDriver,
+    EM extends EntityManager<D> = D[typeof EntityManagerType] & EntityManager<D>,
+    Entities extends (string | EntityClass<AnyEntity> | EntitySchema)[] = (
+      | string
+      | EntityClass<AnyEntity>
+      | EntitySchema
+    )[],
+  >(options: Partial<Options<D, EM, Entities>>): Promise<MikroORM<D, EM, Entities>> {
+    return super.init(options);
+  }
+}

--- a/packages/sql/src/index.ts
+++ b/packages/sql/src/index.ts
@@ -17,3 +17,5 @@ export type * from './typings.js';
 export * from './plugin/index.js';
 export { SqlEntityManager as EntityManager } from './SqlEntityManager.js';
 export { SqlEntityRepository as EntityRepository } from './SqlEntityRepository.js';
+export * from './SqlMikroORM.js';
+export { SqlMikroORM as MikroORM, type SqlOptions as Options, defineSqlConfig as defineConfig } from './SqlMikroORM.js';

--- a/packages/sqlite/src/SqliteMikroORM.ts
+++ b/packages/sqlite/src/SqliteMikroORM.ts
@@ -3,13 +3,13 @@ import {
   type EntityClass,
   type EntitySchema,
   defineConfig,
-  MikroORM,
+  type MikroORM,
   type Options,
   type IDatabaseDriver,
   type EntityManager,
   type EntityManagerType,
 } from '@mikro-orm/core';
-import type { SqlEntityManager } from '@mikro-orm/sql';
+import { SqlMikroORM, type SqlEntityManager } from '@mikro-orm/sql';
 import { SqliteDriver } from './SqliteDriver.js';
 
 /** Configuration options for the SQLite driver. */
@@ -44,7 +44,7 @@ export class SqliteMikroORM<
     | EntityClass<AnyEntity>
     | EntitySchema
   )[],
-> extends MikroORM<SqliteDriver, EM, Entities> {
+> extends SqlMikroORM<SqliteDriver, EM, Entities> {
   /**
    * @inheritDoc
    */

--- a/tests/issues/GHx46.test.ts
+++ b/tests/issues/GHx46.test.ts
@@ -1,0 +1,50 @@
+import { defineEntity, p } from '@mikro-orm/core';
+import { MikroORM, SqliteDriver, NodeSqliteDialect, defineConfig, type SqlEntityManager } from '@mikro-orm/sql';
+
+// Importing `MikroORM` and `defineConfig` from `@mikro-orm/sql` must yield a
+// SQL-aware EM type — specifically, `orm.em.createQueryBuilder` and the rest
+// of `SqlEntityManager` must be reachable via both call paths:
+//   1) MikroORM.init({ ... }) directly,
+//   2) defineConfig({ ... }) followed by MikroORM.init(config).
+// Previously path (2) collapsed the EM to plain `EntityManager<D>` because
+// core's generic `defineConfig` defaults `EM = EntityManager<D>`, dropping the
+// `D[typeof EntityManagerType]` intersection that `MikroORM.init` requires.
+
+const User = defineEntity({
+  name: 'User',
+  properties: {
+    id: p.integer().primary().autoincrement(),
+    name: p.string(),
+  },
+});
+
+test('GHx46: defineConfig + MikroORM.init from @mikro-orm/sql preserves SqlEntityManager type', async () => {
+  const config = defineConfig({
+    driver: SqliteDriver,
+    dbName: ':memory:',
+    entities: [User],
+    driverOptions: new NodeSqliteDialect(':memory:'),
+  });
+
+  const orm = await MikroORM.init(config);
+  const em: SqlEntityManager = orm.em;
+  const qb = em.createQueryBuilder(User);
+  expect(typeof qb.getQuery).toBe('function');
+
+  await orm.close();
+});
+
+test('GHx46: MikroORM.init from @mikro-orm/sql infers SqlEntityManager directly', async () => {
+  const orm = await MikroORM.init({
+    driver: SqliteDriver,
+    dbName: ':memory:',
+    entities: [User],
+    driverOptions: new NodeSqliteDialect(':memory:'),
+  });
+
+  const em: SqlEntityManager = orm.em;
+  const qb = em.createQueryBuilder(User);
+  expect(typeof qb.getQuery).toBe('function');
+
+  await orm.close();
+});

--- a/tests/issues/GHx46.test.ts
+++ b/tests/issues/GHx46.test.ts
@@ -1,5 +1,5 @@
 import { defineEntity, p } from '@mikro-orm/core';
-import { MikroORM, SqliteDriver, NodeSqliteDialect, defineConfig, type SqlEntityManager } from '@mikro-orm/sql';
+import { MikroORM, SqliteDriver, NodeSqliteDialect, defineConfig } from '@mikro-orm/sql';
 
 // Importing `MikroORM` and `defineConfig` from `@mikro-orm/sql` must yield a
 // SQL-aware EM type — specifically, `orm.em.createQueryBuilder` and the rest
@@ -27,8 +27,7 @@ test('GHx46: defineConfig + MikroORM.init from @mikro-orm/sql preserves SqlEntit
   });
 
   const orm = await MikroORM.init(config);
-  const em: SqlEntityManager = orm.em;
-  const qb = em.createQueryBuilder(User);
+  const qb = orm.em.createQueryBuilder(User);
   expect(typeof qb.getQuery).toBe('function');
 
   await orm.close();
@@ -42,8 +41,7 @@ test('GHx46: MikroORM.init from @mikro-orm/sql infers SqlEntityManager directly'
     driverOptions: new NodeSqliteDialect(':memory:'),
   });
 
-  const em: SqlEntityManager = orm.em;
-  const qb = em.createQueryBuilder(User);
+  const qb = orm.em.createQueryBuilder(User);
   expect(typeof qb.getQuery).toBe('function');
 
   await orm.close();


### PR DESCRIPTION
## Summary

Importing `MikroORM` and `defineConfig` from `@mikro-orm/sql` previously re-exported the core helpers, whose generic `defineConfig` defaults `EM` to `EntityManager<D>` — losing the `D[typeof EntityManagerType]` intersection. As a result this snippet collapsed `orm.em` to a plain `EntityManager`, so SQL-only methods such as `createQueryBuilder` were missing:

```ts
import { MikroORM, SqliteDriver, defineConfig } from '@mikro-orm/sql';

const config = defineConfig({
  driver: SqliteDriver,
  dbName: 'my-database.sqlite3',
  driverOptions: new BunSqliteDialect({ database: new Database('my-database.sqlite3') }),
});

await MikroORM.init(config);
```

Adds an SQL-specific `SqlMikroORM` and `defineSqlConfig` (re-exported as `MikroORM`/`defineConfig` from `@mikro-orm/sql`) that default `EM` to `SqlEntityManager<D>`, mirroring the pattern already used by `@mikro-orm/sqlite`, `@mikro-orm/postgresql`, etc.