### PR TITLE
fix(core): escape embedded quote characters in quoteIdentifier

### DIFF
--- a/packages/core/src/platforms/Platform.ts
+++ b/packages/core/src/platforms/Platform.ts
@@ -707,7 +707,8 @@ export abstract class Platform {
       return this.formatQuery(raw.sql, raw.params);
     }
 
-    return `${quote}${id.toString().replace('.', `${quote}.${quote}`)}${quote}`;
+    const escaped = id.toString().replaceAll(quote, quote + quote);
+    return `${quote}${escaped.replace('.', `${quote}.${quote}`)}${quote}`;
   }
 
   /** Quotes a literal value for safe embedding in SQL. */

--- a/packages/mssql/src/MsSqlPlatform.ts
+++ b/packages/mssql/src/MsSqlPlatform.ts
@@ -220,7 +220,7 @@ export class MsSqlPlatform extends AbstractSqlPlatform {
   ): string | RawQueryFragment {
     const [a, ...b] = path;
     /* v8 ignore next */
-    const root = this.quoteIdentifier(aliased ? `${ALIAS_REPLACEMENT}.${a}` : a);
+    const root = aliased ? `[${ALIAS_REPLACEMENT}].${this.quoteIdentifier(a)}` : this.quoteIdentifier(a);
     const types = {
       boolean: 'bit',
     } as Dictionary;
@@ -273,7 +273,7 @@ export class MsSqlPlatform extends AbstractSqlPlatform {
       return super.quoteIdentifier(id);
     }
 
-    return `[${id.toString().replace('.', `].[`)}]`;
+    return `[${id.toString().replaceAll(']', ']]').replace('.', `].[`)}]`;
   }
 
   override escape(value: any): string {

--- a/packages/sql/src/dialects/postgresql/BasePostgreSqlPlatform.ts
+++ b/packages/sql/src/dialects/postgresql/BasePostgreSqlPlatform.ts
@@ -388,7 +388,8 @@ export class BasePostgreSqlPlatform extends AbstractSqlPlatform {
       return super.quoteIdentifier(id);
     }
 
-    return `${quote}${id.toString().replace('.', `${quote}.${quote}`)}${quote}`;
+    const escaped = id.toString().replaceAll(quote, quote + quote);
+    return `${quote}${escaped.replace('.', `${quote}.${quote}`)}${quote}`;
   }
 
   private pad(number: number, digits: number): string {

--- a/tests/platforms/identifier-quoting.test.ts
+++ b/tests/platforms/identifier-quoting.test.ts
@@ -1,0 +1,37 @@
+import { MySqlPlatform } from '@mikro-orm/mysql';
+import { MariaDbPlatform } from '@mikro-orm/mariadb';
+import { SqlitePlatform } from '@mikro-orm/sqlite';
+import { PostgreSqlPlatform } from '@mikro-orm/postgresql';
+import { MsSqlPlatform } from '@mikro-orm/mssql';
+import { OraclePlatform } from '@mikro-orm/oracledb';
+
+describe('quoteIdentifier escapes embedded quote characters', () => {
+  test.each([
+    ['mysql', new MySqlPlatform()],
+    ['mariadb', new MariaDbPlatform()],
+    ['sqlite', new SqlitePlatform()],
+  ])('backtick dialect [%s]', (_, platform) => {
+    expect(platform.quoteIdentifier('table')).toBe('`table`');
+    expect(platform.quoteIdentifier('schema.table')).toBe('`schema`.`table`');
+    expect(platform.quoteIdentifier('a`b')).toBe('`a``b`');
+    expect(platform.quoteIdentifier('a`.b')).toBe('`a```.`b`');
+  });
+
+  test.each([
+    ['postgres', new PostgreSqlPlatform()],
+    ['oracle', new OraclePlatform()],
+  ])('double-quote dialect [%s]', (_, platform) => {
+    expect(platform.quoteIdentifier('table')).toBe('"table"');
+    expect(platform.quoteIdentifier('schema.table')).toBe('"schema"."table"');
+    expect(platform.quoteIdentifier('a"b')).toBe('"a""b"');
+    expect(platform.quoteIdentifier('a".b')).toBe('"a"""."b"');
+  });
+
+  test('bracket dialect [mssql]', () => {
+    const platform = new MsSqlPlatform();
+    expect(platform.quoteIdentifier('table')).toBe('[table]');
+    expect(platform.quoteIdentifier('schema.table')).toBe('[schema].[table]');
+    expect(platform.quoteIdentifier('a]b')).toBe('[a]]b]');
+    expect(platform.quoteIdentifier('a].b')).toBe('[a]]].[b]');
+  });
+});


### PR DESCRIPTION
Identifiers containing the dialect's quote character (backtick, double quote, or right bracket) are now doubled before wrapping in `Platform.quoteIdentifier` and the postgres/mssql overrides, so they round-trip losslessly across all SQL dialects.

Adds a unit-level regression test covering all dialects.