### PR TITLE
fix(core): escape embedded quote characters in quoteIdentifier

### DIFF
--- a/packages/core/src/platforms/Platform.ts
+++ b/packages/core/src/platforms/Platform.ts
@@ -477,7 +477,8 @@ export abstract class Platform {
   }
 
   quoteIdentifier(id: string | { toString: () => string }, quote = '`'): string {
-    return `${quote}${id.toString().replace('.', `${quote}.${quote}`)}${quote}`;
+    const escaped = id.toString().replaceAll(quote, quote + quote);
+    return `${quote}${escaped.replace('.', `${quote}.${quote}`)}${quote}`;
   }
 
   quoteValue(value: any): string {

--- a/packages/mssql/src/MsSqlPlatform.ts
+++ b/packages/mssql/src/MsSqlPlatform.ts
@@ -196,7 +196,7 @@ export class MsSqlPlatform extends AbstractSqlPlatform {
   override getSearchJsonPropertyKey(path: string[], type: string, aliased: boolean, value?: unknown): string {
     const [a, ...b] = path;
     /* istanbul ignore next */
-    const root = this.quoteIdentifier(aliased ? `${ALIAS_REPLACEMENT}.${a}` : a);
+    const root = aliased ? `[${ALIAS_REPLACEMENT}].${this.quoteIdentifier(a)}` : this.quoteIdentifier(a);
     const types = {
       boolean: 'bit',
     } as Dictionary;
@@ -229,7 +229,7 @@ export class MsSqlPlatform extends AbstractSqlPlatform {
   }
 
   override quoteIdentifier(id: string | { toString: () => string }): string {
-    return `[${id.toString().replace('.', `].[`)}]`;
+    return `[${id.toString().replaceAll(']', ']]').replace('.', `].[`)}]`;
   }
 
   override escape(value: any): string {

--- a/packages/postgresql/src/PostgreSqlPlatform.ts
+++ b/packages/postgresql/src/PostgreSqlPlatform.ts
@@ -320,7 +320,8 @@ export class PostgreSqlPlatform extends AbstractSqlPlatform {
   }
 
   override quoteIdentifier(id: string | { toString: () => string }, quote = '"'): string {
-    return `${quote}${id.toString().replace('.', `${quote}.${quote}`)}${quote}`;
+    const escaped = id.toString().replaceAll(quote, quote + quote);
+    return `${quote}${escaped.replace('.', `${quote}.${quote}`)}${quote}`;
   }
 
   override escape(value: any): string {

--- a/tests/platforms/identifier-quoting.test.ts
+++ b/tests/platforms/identifier-quoting.test.ts
@@ -1,0 +1,34 @@
+import { MySqlPlatform } from '@mikro-orm/mysql';
+import { MariaDbPlatform } from '@mikro-orm/mariadb';
+import { SqlitePlatform } from '@mikro-orm/sqlite';
+import { PostgreSqlPlatform } from '@mikro-orm/postgresql';
+import { MsSqlPlatform } from '@mikro-orm/mssql';
+
+describe('quoteIdentifier escapes embedded quote characters', () => {
+  test.each([
+    ['mysql', new MySqlPlatform()],
+    ['mariadb', new MariaDbPlatform()],
+    ['sqlite', new SqlitePlatform()],
+  ])('backtick dialect [%s]', (_, platform) => {
+    expect(platform.quoteIdentifier('table')).toBe('`table`');
+    expect(platform.quoteIdentifier('schema.table')).toBe('`schema`.`table`');
+    expect(platform.quoteIdentifier('a`b')).toBe('`a``b`');
+    expect(platform.quoteIdentifier('a`.b')).toBe('`a```.`b`');
+  });
+
+  test('double-quote dialect [postgres]', () => {
+    const platform = new PostgreSqlPlatform();
+    expect(platform.quoteIdentifier('table')).toBe('"table"');
+    expect(platform.quoteIdentifier('schema.table')).toBe('"schema"."table"');
+    expect(platform.quoteIdentifier('a"b')).toBe('"a""b"');
+    expect(platform.quoteIdentifier('a".b')).toBe('"a"""."b"');
+  });
+
+  test('bracket dialect [mssql]', () => {
+    const platform = new MsSqlPlatform();
+    expect(platform.quoteIdentifier('table')).toBe('[table]');
+    expect(platform.quoteIdentifier('schema.table')).toBe('[schema].[table]');
+    expect(platform.quoteIdentifier('a]b')).toBe('[a]]b]');
+    expect(platform.quoteIdentifier('a].b')).toBe('[a]]].[b]');
+  });
+});


### PR DESCRIPTION
Identifiers containing the dialect's quote character (backtick, double quote, or right bracket) are now doubled before wrapping in `Platform.quoteIdentifier` and the postgres/mssql overrides, so they round-trip losslessly across all SQL dialects.

Adds a unit-level regression test covering all dialects.