### PR TITLE
fix(core): escape JSON path keys in getSearchJsonPropertyKey

### DIFF
--- a/packages/mssql/src/MsSqlPlatform.ts
+++ b/packages/mssql/src/MsSqlPlatform.ts
@@ -225,13 +225,14 @@ export class MsSqlPlatform extends AbstractSqlPlatform {
       boolean: 'bit',
     } as Dictionary;
     const cast = (key: string) => raw(type in types ? `cast(${key} as ${types[type]})` : key);
+    const jsonPath = this.quoteValue(`$.${b.map(this.quoteJsonKey).join('.')}`);
 
     /* v8 ignore next */
     if (path.length === 0) {
-      return cast(`json_value(${root}, '$.${b.map(this.quoteJsonKey).join('.')}')`);
+      return cast(`json_value(${root}, ${jsonPath})`);
     }
 
-    return cast(`json_value(${root}, '$.${b.map(this.quoteJsonKey).join('.')}')`);
+    return cast(`json_value(${root}, ${jsonPath})`);
   }
 
   override getJsonArrayFromSQL(column: string, alias: string, properties: { name: string; type: string }[]): string {

--- a/packages/oracledb/src/OraclePlatform.ts
+++ b/packages/oracledb/src/OraclePlatform.ts
@@ -313,7 +313,7 @@ export class OraclePlatform extends AbstractSqlPlatform {
       return raw(`json_equal(${root}, json(?))`, [value]);
     }
 
-    return raw(`json_value(${root}, '$.${b.map(this.quoteJsonKey).join('.')}')`);
+    return raw(`json_value(${root}, ${this.quoteValue(`$.${b.map(this.quoteJsonKey).join('.')}`)})`);
   }
 
   override processJsonCondition<T extends object>(

--- a/packages/sql/src/AbstractSqlPlatform.ts
+++ b/packages/sql/src/AbstractSqlPlatform.ts
@@ -107,23 +107,27 @@ export abstract class AbstractSqlPlatform extends Platform {
     value?: unknown,
   ): string | RawQueryFragment {
     const [a, ...b] = path;
+    const jsonPath = this.quoteValue(`$.${b.map(this.quoteJsonKey).join('.')}`);
 
     if (aliased) {
-      return raw(
-        alias => `json_extract(${this.quoteIdentifier(`${alias}.${a}`)}, '$.${b.map(this.quoteJsonKey).join('.')}')`,
-      );
+      return raw(alias => `json_extract(${this.quoteIdentifier(`${alias}.${a}`)}, ${jsonPath})`);
     }
 
-    return raw(`json_extract(${this.quoteIdentifier(a)}, '$.${b.map(this.quoteJsonKey).join('.')}')`);
+    return raw(`json_extract(${this.quoteIdentifier(a)}, ${jsonPath})`);
   }
 
   /**
    * Quotes a key for use inside a JSON path expression (e.g. `$.key`).
-   * Simple alphanumeric keys are left unquoted; others are wrapped in double quotes.
+   * Simple alphanumeric keys are left unquoted; others are wrapped in double quotes
+   * with embedded `\` and `"` escaped per the JSON path string syntax.
    * @internal
    */
   quoteJsonKey(key: string): string {
-    return /^[a-z]\w*$/i.exec(key) ? key : `"${key}"`;
+    if (/^[a-z]\w*$/i.test(key)) {
+      return key;
+    }
+
+    return `"${key.replaceAll('\\', '\\\\').replaceAll('"', '\\"')}"`;
   }
 
   override getJsonIndexDefinition(index: IndexDef): string[] {

--- a/packages/sql/src/dialects/postgresql/BasePostgreSqlPlatform.ts
+++ b/packages/sql/src/dialects/postgresql/BasePostgreSqlPlatform.ts
@@ -359,10 +359,10 @@ export class BasePostgreSqlPlatform extends AbstractSqlPlatform {
     }
 
     if (path.length === 0) {
-      return cast(`${root}${lastOperator}'${last}'`);
+      return cast(`${root}${lastOperator}${this.quoteValue(last)}`);
     }
 
-    return cast(`${root}->${path.map(a => this.quoteValue(a)).join('->')}${lastOperator}'${last}'`);
+    return cast(`${root}->${path.map(a => this.quoteValue(a)).join('->')}${lastOperator}${this.quoteValue(last)}`);
   }
 
   override getJsonIndexDefinition(index: IndexDef): string[] {

--- a/tests/platforms/json-path-keys.test.ts
+++ b/tests/platforms/json-path-keys.test.ts
@@ -1,0 +1,71 @@
+import { MySqlPlatform } from '@mikro-orm/mysql';
+import { MariaDbPlatform } from '@mikro-orm/mariadb';
+import { SqlitePlatform } from '@mikro-orm/sqlite';
+import { PostgreSqlPlatform } from '@mikro-orm/postgresql';
+import { MsSqlPlatform } from '@mikro-orm/mssql';
+import { OraclePlatform } from '@mikro-orm/oracledb';
+
+describe('quoteJsonKey escapes JSON path specials', () => {
+  test.each([
+    ['mysql', new MySqlPlatform()],
+    ['mariadb', new MariaDbPlatform()],
+    ['sqlite', new SqlitePlatform()],
+    ['mssql', new MsSqlPlatform()],
+    ['oracle', new OraclePlatform()],
+  ])('[%s]', (_, platform) => {
+    expect(platform.quoteJsonKey('foo')).toBe('foo');
+    expect(platform.quoteJsonKey('foo_bar1')).toBe('foo_bar1');
+    expect(platform.quoteJsonKey('with space')).toBe('"with space"');
+    expect(platform.quoteJsonKey("with'quote")).toBe(`"with'quote"`);
+    expect(platform.quoteJsonKey('with"dq')).toBe('"with\\"dq"');
+    expect(platform.quoteJsonKey('with\\bs')).toBe('"with\\\\bs"');
+  });
+});
+
+describe('quoteValue escapes embedded single quotes per dialect', () => {
+  const evil = "x') OR 1=1 -- ";
+
+  test('mysql / mariadb (backslash escape)', () => {
+    expect(new MySqlPlatform().quoteValue(evil)).toBe(`'x\\') OR 1=1 -- '`);
+    expect(new MariaDbPlatform().quoteValue(evil)).toBe(`'x\\') OR 1=1 -- '`);
+  });
+
+  test('sqlite / mssql / oracle / postgres (doubled-quote escape)', () => {
+    expect(new SqlitePlatform().quoteValue(evil)).toBe(`'x'') OR 1=1 -- '`);
+    expect(new MsSqlPlatform().quoteValue(evil)).toBe(`'x'') OR 1=1 -- '`);
+    expect(new OraclePlatform().quoteValue(evil)).toBe(`'x'') OR 1=1 -- '`);
+    expect(new PostgreSqlPlatform().quoteValue(evil)).toBe(`'x'') OR 1=1 -- '`);
+  });
+});
+
+describe('getSearchJsonPropertyKey embeds attacker keys via quoteValue', () => {
+  const evil = "x') OR 1=1 -- ";
+
+  test('mysql', () => {
+    const sql = (new MySqlPlatform().getSearchJsonPropertyKey(['meta', evil], 'string', false) as { sql: string }).sql;
+    expect(sql).toBe("json_extract(`meta`, '$.\\\"x\\') OR 1=1 -- \\\"')");
+  });
+
+  test('mariadb', () => {
+    const sql = (new MariaDbPlatform().getSearchJsonPropertyKey(['meta', evil], 'string', false) as { sql: string })
+      .sql;
+    expect(sql).toBe("json_extract(`meta`, '$.\\\"x\\') OR 1=1 -- \\\"')");
+  });
+
+  test('sqlite', () => {
+    const sql = (new SqlitePlatform().getSearchJsonPropertyKey(['meta', evil], 'string', false) as { sql: string }).sql;
+    expect(sql).toBe(`json_extract(\`meta\`, '$."x'') OR 1=1 -- "')`);
+  });
+
+  test('mssql', () => {
+    const sql = (new MsSqlPlatform().getSearchJsonPropertyKey(['meta', evil], 'string', false) as { sql: string }).sql;
+    expect(sql).toBe(`json_value([meta], '$."x'') OR 1=1 -- "')`);
+  });
+
+  test('oracle', () => {
+    const sql = (
+      new OraclePlatform().getSearchJsonPropertyKey(['meta', evil], 'string', false) as unknown as { sql: string }
+    ).sql;
+    expect(sql).toBe(`json_value("meta", '$."x'') OR 1=1 -- "')`);
+  });
+});


### PR DESCRIPTION
JSON-property filter keys (e.g. `em.find(Entity, { jsonCol: { foo: 1 } })`) are now escaped through `quoteJsonKey` for JSON path specials, and the assembled path is wrapped via `quoteValue` so each dialect's own SQL string-literal escape applies.

Postgres's `->>` operand is similarly routed through `quoteValue` instead of bare interpolation, matching the existing pattern in `getJsonIndexDefinition`.

Adds a unit-level regression test covering all SQL dialects.