### PR TITLE
fix(core): escape JSON path keys in getSearchJsonPropertyKey

### DIFF
--- a/packages/knex/src/AbstractSqlPlatform.ts
+++ b/packages/knex/src/AbstractSqlPlatform.ts
@@ -88,13 +88,16 @@ export abstract class AbstractSqlPlatform extends Platform {
 
   override getSearchJsonPropertyKey(path: string[], type: string, aliased: boolean, value?: unknown): string {
     const [a, ...b] = path;
-    const quoteKey = (key: string) => key.match(/^[a-z]\w*$/i) ? key : `"${key}"`;
+    const quoteKey = (key: string) => key.match(/^[a-z]\w*$/i)
+      ? key
+      : `"${key.replaceAll('\\', '\\\\').replaceAll('"', '\\"')}"`;
+    const jsonPath = this.quoteValue(`$.${b.map(quoteKey).join('.')}`);
 
     if (aliased) {
-      return raw(alias => `json_extract(${this.quoteIdentifier(`${alias}.${a}`)}, '$.${b.map(quoteKey).join('.')}')`);
+      return raw(alias => `json_extract(${this.quoteIdentifier(`${alias}.${a}`)}, ${jsonPath})`);
     }
 
-    return raw(`json_extract(${this.quoteIdentifier(a)}, '$.${b.map(quoteKey).join('.')}')`);
+    return raw(`json_extract(${this.quoteIdentifier(a)}, ${jsonPath})`);
   }
 
   override getJsonIndexDefinition(index: IndexDef): string[] {

--- a/packages/mssql/src/MsSqlPlatform.ts
+++ b/packages/mssql/src/MsSqlPlatform.ts
@@ -201,14 +201,17 @@ export class MsSqlPlatform extends AbstractSqlPlatform {
       boolean: 'bit',
     } as Dictionary;
     const cast = (key: string) => raw(type in types ? `cast(${key} as ${types[type]})` : key);
-    const quoteKey = (key: string) => key.match(/^[a-z]\w*$/i) ? key : `"${key}"`;
+    const quoteKey = (key: string) => key.match(/^[a-z]\w*$/i)
+      ? key
+      : `"${key.replaceAll('\\', '\\\\').replaceAll('"', '\\"')}"`;
+    const jsonPath = this.quoteValue(`$.${b.map(quoteKey).join('.')}`);
 
     /* istanbul ignore if */
     if (path.length === 0) {
-      return cast(`json_value(${root}, '$.${b.map(quoteKey).join('.')}')`);
+      return cast(`json_value(${root}, ${jsonPath})`);
     }
 
-    return cast(`json_value(${root}, '$.${b.map(quoteKey).join('.')}')`);
+    return cast(`json_value(${root}, ${jsonPath})`);
   }
 
   override normalizePrimaryKey<T extends number | string = number | string>(data: Primary<T> | IPrimaryKey | string): T {

--- a/packages/postgresql/src/PostgreSqlPlatform.ts
+++ b/packages/postgresql/src/PostgreSqlPlatform.ts
@@ -294,10 +294,10 @@ export class PostgreSqlPlatform extends AbstractSqlPlatform {
     }
 
     if (path.length === 0) {
-      return cast(`${root}${lastOperator}'${last}'`);
+      return cast(`${root}${lastOperator}${this.quoteValue(last)}`);
     }
 
-    return cast(`${root}->${path.map(a => this.quoteValue(a)).join('->')}${lastOperator}'${last}'`);
+    return cast(`${root}->${path.map(a => this.quoteValue(a)).join('->')}${lastOperator}${this.quoteValue(last)}`);
   }
 
   override getJsonIndexDefinition(index: IndexDef): string[] {

--- a/tests/platforms/json-path-keys.test.ts
+++ b/tests/platforms/json-path-keys.test.ts
@@ -1,0 +1,44 @@
+import { MySqlPlatform } from '@mikro-orm/mysql';
+import { MariaDbPlatform } from '@mikro-orm/mariadb';
+import { SqlitePlatform } from '@mikro-orm/sqlite';
+import { PostgreSqlPlatform } from '@mikro-orm/postgresql';
+import { MsSqlPlatform } from '@mikro-orm/mssql';
+
+describe('quoteValue escapes embedded single quotes per dialect', () => {
+  const evil = "x') OR 1=1 -- ";
+
+  test('mysql / mariadb (backslash escape)', () => {
+    expect(new MySqlPlatform().quoteValue(evil)).toBe(`'x\\') OR 1=1 -- '`);
+    expect(new MariaDbPlatform().quoteValue(evil)).toBe(`'x\\') OR 1=1 -- '`);
+  });
+
+  test('sqlite / mssql / postgres (doubled-quote escape)', () => {
+    expect(new SqlitePlatform().quoteValue(evil)).toBe(`'x'') OR 1=1 -- '`);
+    expect(new MsSqlPlatform().quoteValue(evil)).toBe(`'x'') OR 1=1 -- '`);
+    expect(new PostgreSqlPlatform().quoteValue(evil)).toBe(`'x'') OR 1=1 -- '`);
+  });
+});
+
+describe('getSearchJsonPropertyKey embeds attacker keys via quoteValue', () => {
+  const evil = "x') OR 1=1 -- ";
+
+  test('mysql', () => {
+    const sql = (new MySqlPlatform().getSearchJsonPropertyKey(['meta', evil], 'string', false) as unknown as { sql: string }).sql;
+    expect(sql).toBe('json_extract(`meta`, \'$.\\"x\\\') OR 1=1 -- \\"\')');
+  });
+
+  test('mariadb', () => {
+    const sql = (new MariaDbPlatform().getSearchJsonPropertyKey(['meta', evil], 'string', false) as unknown as { sql: string }).sql;
+    expect(sql).toBe('json_extract(`meta`, \'$.\\"x\\\') OR 1=1 -- \\"\')');
+  });
+
+  test('sqlite', () => {
+    const sql = (new SqlitePlatform().getSearchJsonPropertyKey(['meta', evil], 'string', false) as unknown as { sql: string }).sql;
+    expect(sql).toBe(`json_extract(\`meta\`, '$."x'') OR 1=1 -- "')`);
+  });
+
+  test('mssql', () => {
+    const sql = (new MsSqlPlatform().getSearchJsonPropertyKey(['meta', evil], 'string', false) as unknown as { sql: string }).sql;
+    expect(sql).toBe(`json_value([meta], '$."x'') OR 1=1 -- "')`);
+  });
+});


### PR DESCRIPTION
JSON-property filter keys (e.g. `em.find(Entity, { jsonCol: { foo: 1 } })`) are now escaped for JSON path specials, and the assembled path is wrapped via `quoteValue` so each dialect's own SQL string-literal escape applies.

Postgres's `->>` operand is similarly routed through `quoteValue` instead of bare interpolation, matching the existing pattern in `getJsonIndexDefinition`.

Adds a regression test covering MySQL, MariaDB, SQLite, and MSSQL.