### PR TITLE
chore(deps): update knex to v3.2.10 (6.x)

### DIFF
--- a/packages/knex/package.json
+++ b/packages/knex/package.json
@@ -59,7 +59,7 @@
   },
   "dependencies": {
     "fs-extra": "11.3.3",
-    "knex": "3.2.8",
+    "knex": "3.2.10",
     "sqlstring": "2.3.3"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1801,7 +1801,7 @@ __metadata:
   dependencies:
     "@mikro-orm/core": "npm:^6.6.13"
     fs-extra: "npm:11.3.3"
-    knex: "npm:3.2.8"
+    knex: "npm:3.2.10"
     sqlstring: "npm:2.3.3"
   peerDependencies:
     "@mikro-orm/core": ^6.0.0
@@ -8350,9 +8350,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"knex@npm:3.2.8":
-  version: 3.2.8
-  resolution: "knex@npm:3.2.8"
+"knex@npm:3.2.10":
+  version: 3.2.10
+  resolution: "knex@npm:3.2.10"
   dependencies:
     colorette: "npm:2.0.19"
     commander: "npm:^10.0.0"
@@ -8362,7 +8362,7 @@ __metadata:
     get-package-type: "npm:^0.1.0"
     getopts: "npm:2.3.0"
     interpret: "npm:^2.2.0"
-    lodash: "npm:^4.17.21"
+    lodash: "npm:^4.18.1"
     pg-connection-string: "npm:2.6.2"
     rechoir: "npm:^0.8.0"
     resolve-from: "npm:^5.0.0"
@@ -8389,7 +8389,7 @@ __metadata:
       optional: true
   bin:
     knex: bin/cli.js
-  checksum: 10/7a61ca1276701f5b740d516f4cce455bbae5c7af3e46f155a17214f823d58df0eafc2247d72b32c5fd0fabeb5470781bed7f113f6011da495f830522badee587
+  checksum: 10/6d043d0d55bee2d6ecc977dd67fbff61121f8832d70a635f490a3979bf82cae001ee0b53a1d1222ef46c3f1bf5afac39b1fb918aaefabcc7a7a57d7c97e3cf7f
   languageName: node
   linkType: hard
 
@@ -8771,10 +8771,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.17.21":
-  version: 4.17.21
-  resolution: "lodash@npm:4.17.21"
-  checksum: 10/c08619c038846ea6ac754abd6dd29d2568aa705feb69339e836dfa8d8b09abbb2f859371e86863eda41848221f9af43714491467b5b0299122431e202bb0c532
+"lodash@npm:^4.18.1":
+  version: 4.18.1
+  resolution: "lodash@npm:4.18.1"
+  checksum: 10/306fea53dfd39dad1f03d45ba654a2405aebd35797b673077f401edb7df2543623dc44b9effbb98f69b32152295fff725a4cec99c684098947430600c6af0c3f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Bumps knex from 3.2.8 → 3.2.10 in `@mikro-orm/knex`. Patch range; no API changes.