### PR TITLE
fix(core): skip getter-only properties in assignDefaultValues

### DIFF
--- a/packages/core/src/entity/EntityFactory.ts
+++ b/packages/core/src/entity/EntityFactory.ts
@@ -345,6 +345,9 @@ export class EntityFactory {
 
   private assignDefaultValues<T extends object>(entity: T, meta: EntityMetadata<T>): void {
     for (const prop of meta.props) {
+      if (prop.getter && !prop.setter) {
+        continue;
+      }
       if (prop.onCreate) {
         entity[prop.name] ??= prop.onCreate(entity, this.em);
       }

--- a/tests/issues/GHx40.test.ts
+++ b/tests/issues/GHx40.test.ts
@@ -1,0 +1,64 @@
+import { Entity, ManyToOne, PrimaryKey, Property, type Ref, ref } from '@mikro-orm/core';
+import { MikroORM } from '@mikro-orm/sqlite';
+
+@Entity()
+class Building7574 {
+
+  @PrimaryKey() id!: number;
+  @Property() reference!: number;
+  @Property() name!: string;
+
+}
+
+@Entity()
+class Unit7574 {
+
+  @PrimaryKey() id!: number;
+  @Property() reference!: number;
+
+  @ManyToOne(() => Building7574, { ref: true })
+  building!: Ref<Building7574>;
+
+  // getter-only virtual property that accesses a relation
+  @Property({ persist: false })
+  get buildingReference(): number {
+    if (!this.building?.isInitialized()) {
+      return 0;
+    }
+    return this.building.getEntity().reference;
+  }
+
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    dbName: ':memory:',
+    entities: [Building7574, Unit7574],
+  });
+  await orm.schema.refreshDatabase();
+  orm.em.create(Building7574, { id: 1, reference: 900000, name: 'Test Building' });
+  await orm.em.flush();
+  orm.em.clear();
+});
+
+afterAll(() => orm.close(true));
+
+// assignDefaultValues should not try to set getter-only properties
+test('em.create() with plain-object FK and getter-only property should not throw', () => {
+  orm.em.clear();
+  expect(() => {
+    orm.em.create(Unit7574, { id: 1, reference: 42, building: { id: 1 } } as any, { persist: false, partial: true });
+  }).not.toThrow();
+});
+
+test('em.create() with ref() FK and getter-only property should not throw', () => {
+  orm.em.clear();
+  expect(() => {
+    orm.em.create(Unit7574, { id: 2, reference: 42, building: ref(Building7574, 1) } as any, {
+      persist: false,
+      partial: true,
+    });
+  }).not.toThrow();
+});


### PR DESCRIPTION
Backport of #7575 to 6.x.

`assignDefaultValues` was trying to set default values on getter-only properties (those with `@Property({ persist: false })` on a getter), causing `TypeError: Cannot set property ... which has only a getter`. The hydrator already had this guard; this adds it to `assignDefaultValues` too.