### PR TITLE
fix(core): drop entity from persist/remove stacks in uow.unsetIdentity()

### DIFF
--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -1412,9 +1412,6 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
       }
 
       if (!helper(data).__managed) {
-        // the entity might have been created via `em.create()`, which adds it to the persist stack automatically
-        em.unitOfWork.getPersistStack().delete(data);
-        // it can be also in the identity map if it had a PK value already
         em.unitOfWork.unsetIdentity(data);
       }
 
@@ -1461,10 +1458,6 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
         }
 
         if (!helper(row).__managed) {
-          // the entity might have been created via `em.create()`, which adds it to the persist stack automatically
-          em.unitOfWork.getPersistStack().delete(row);
-
-          // it can be also in the identity map if it had a PK value already
           em.unitOfWork.unsetIdentity(row);
         }
 

--- a/packages/core/src/unit-of-work/UnitOfWork.ts
+++ b/packages/core/src/unit-of-work/UnitOfWork.ts
@@ -480,6 +480,9 @@ export class UnitOfWork {
 
   unsetIdentity(entity: AnyEntity): void {
     this.identityMap.delete(entity);
+    this.persistStack.delete(entity);
+    this.removeStack.delete(entity);
+    this.orphanRemoveStack.delete(entity);
     const wrapped = helper(entity);
     const serializedPK = wrapped.getSerializedPrimaryKey();
 

--- a/tests/issues/GHx45.test.ts
+++ b/tests/issues/GHx45.test.ts
@@ -1,0 +1,98 @@
+import { Collection, Entity, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property, Ref, ref } from '@mikro-orm/sqlite';
+
+// Repro for em.transactional leaving residue on the parent EM:
+// when parent's OneToMany was populated on the outer EM before
+// `em.transactional`, the populated children get added to the outer EM's
+// persist stack (Collection.add for OneToMany calls em.persist). Removing
+// the child inside the transactional callback then unsets the identity on
+// the parent EM via the deletion handler, but the child stayed in the
+// outer persist stack with no `__originalEntityData` — so the next
+// `em.flush()` re-INSERTed it.
+
+@Entity()
+class Parent {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @OneToMany(() => Child, c => c.parent, { orphanRemoval: true })
+  children = new Collection<Child>(this);
+
+}
+
+@Entity()
+class Child {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @ManyToOne(() => Parent, { ref: true })
+  parent!: Ref<Parent>;
+
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    dbName: ':memory:',
+    entities: [Parent, Child],
+    allowGlobalContext: true,
+  });
+  await orm.schema.refreshDatabase();
+});
+
+afterAll(() => orm.close(true));
+
+beforeEach(() => orm.schema.clearDatabase());
+
+async function seed() {
+  const em = orm.em.fork();
+  const p = em.create(Parent, { name: 'P' });
+  await em.flush();
+  const c = em.create(Child, { name: 'C', parent: ref(Parent, p.id) });
+  await em.flush();
+  return { parentId: p.id, childId: c.id };
+}
+
+const childExists = async (id: number) => (await orm.em.fork().count(Child, { id })) === 1;
+
+test('SANITY: txn commits the DELETE', async () => {
+  const { childId } = await seed();
+  const em = orm.em.fork();
+  const child = await em.findOneOrFail(Child, { id: childId });
+  await em.transactional(async txEm => {
+    txEm.remove(child);
+  });
+  expect(await childExists(childId)).toBe(false);
+});
+
+test('CONTROL: no parent populate — outer flush is a no-op', async () => {
+  const { childId } = await seed();
+  const em = orm.em.fork();
+  const child = await em.findOneOrFail(Child, { id: childId });
+  await em.transactional(async txEm => {
+    txEm.remove(child);
+  });
+  expect(await childExists(childId)).toBe(false);
+  await em.flush();
+  expect(await childExists(childId)).toBe(false);
+});
+
+test('GHx45: populate parent.children + remove inside transactional + outer flush should be a no-op', async () => {
+  const { childId } = await seed();
+  const em = orm.em.fork();
+  const child = await em.findOneOrFail(Child, { id: childId }, { populate: ['parent.children'] });
+  await em.transactional(async txEm => {
+    txEm.remove(child);
+  });
+  expect(await childExists(childId)).toBe(false);
+  await em.flush();
+  expect(await childExists(childId)).toBe(false);
+});


### PR DESCRIPTION
Backport of #7639 to 6.x.

`unsetIdentity` only removed the entity from the identity map, leaving stale references in `persistStack`/`removeStack`/`orphanRemoveStack`. After a nested `em.transactional` removed a populated child, the outer EM still had it queued for persist with no `__originalEntityData`, causing a re-INSERT on the next outer flush. This makes `unsetIdentity` clean up all stacks atomically and drops the now-redundant manual `getPersistStack().delete()` calls in `em.insert`/`em.insertMany`.