### PR TITLE
fix(postgres): schema-qualify generated drop index statements

### DIFF
--- a/packages/postgresql/src/PostgreSqlSchemaHelper.ts
+++ b/packages/postgresql/src/PostgreSqlSchemaHelper.ts
@@ -641,6 +641,17 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
     return `alter index ${oldIndexName} rename to ${keyName}`;
   }
 
+  override getDropIndexSQL(tableName: string, index: IndexDef): string {
+    const [schemaName] = this.splitTableName(tableName);
+    const indexName = this.platform.quoteIdentifier(index.keyName);
+
+    if (schemaName && schemaName !== this.platform.getDefaultSchemaName()) {
+      return `drop index ${this.platform.quoteIdentifier(schemaName)}.${indexName}`;
+    }
+
+    return `drop index ${indexName}`;
+  }
+
   private getIndexesSQL(tables: Table[]): string {
     return `select indrelid::regclass as table_name, ns.nspname as schema_name, relname as constraint_name, idx.indisunique as unique, idx.indisprimary as primary, contype, condeferrable, condeferred,
       array(

--- a/tests/issues/GHx41.test.ts
+++ b/tests/issues/GHx41.test.ts
@@ -1,0 +1,76 @@
+import { defineEntity, MikroORM, p } from '@mikro-orm/postgresql';
+
+const ItemSchema = defineEntity({
+  name: 'ItemGHx41',
+  tableName: 'item_ghx41',
+  indexes: [
+    {
+      name: 'item_ghx41_deleted_at_idx',
+      expression: (table, columns) =>
+        `create index item_ghx41_deleted_at_idx on "${table.name}" ("${columns.code}") where "${columns.deletedAt}" is null`,
+    },
+  ],
+  properties: {
+    id: p.integer().primary(),
+    code: p.text(),
+    deletedAt: p.datetime().nullable(),
+  },
+});
+
+const UserSchema = defineEntity({
+  name: 'UserGHx41',
+  tableName: 'user_ghx41',
+  schema: 'auth_ghx41',
+  indexes: [
+    {
+      name: 'user_ghx41_deleted_at_idx',
+      expression: (table, columns) =>
+        `create index user_ghx41_deleted_at_idx on "${table.schema}"."${table.name}" ("${columns.code}") where "${columns.deletedAt}" is null`,
+    },
+  ],
+  properties: {
+    id: p.integer().primary(),
+    code: p.text(),
+    deletedAt: p.datetime().nullable(),
+  },
+});
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    entities: [ItemSchema, UserSchema],
+    dbName: 'mikro_orm_test_ghx41',
+  });
+  await orm.schema.refreshDatabase({ dropDb: true });
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+test('dropping custom-expression index on public-schema entity produces clean diff', async () => {
+  const meta = orm.getMetadata().get(ItemSchema);
+  meta.indexes = [];
+
+  const sql = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+  expect(sql).toContain('drop index');
+  expect(sql).toContain('item_ghx41_deleted_at_idx');
+  await orm.schema.updateSchema();
+
+  const after = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+  expect(after).toBe('');
+});
+
+test('dropping custom-expression index on non-public schema entity produces clean diff', async () => {
+  const meta = orm.getMetadata().get(UserSchema);
+  meta.indexes = [];
+
+  const sql = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+  expect(sql).toContain('drop index');
+  expect(sql).toContain('user_ghx41_deleted_at_idx');
+  await orm.schema.updateSchema();
+
+  const after = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+  expect(after).toBe('');
+});


### PR DESCRIPTION
Backport of #7603 to 6.x.

Dropping a custom-expression index on a non-default schema failed with `index "..." does not exist` because the generated `drop index` statement was unqualified. 6.x had no postgres-specific override of `getDropIndexSQL`, so it fell through to the generic helper that emits `drop index "name"`. This adds an override on `PostgreSqlSchemaHelper` that prepends the schema when it's not the default one, mirroring the v7 fix.