### PR TITLE
fix(core): recognize TypeScript's __esDecorate helper in decorator path lookup

### DIFF
--- a/packages/core/src/utils/Utils.ts
+++ b/packages/core/src/utils/Utils.ts
@@ -852,8 +852,9 @@ export class Utils {
     // In some situations (e.g. swc 1.3.4+), the presence of a source map can obscure the call to
     // __decorate(), replacing it with the constructor name. To support these cases we look for
     // Reflect.decorate() as well. Also when babel is used, we need to check
-    // the `_applyDecoratedDescriptor` method instead.
-    let line = stack.findIndex(line => line.match(/__decorate|Reflect\.decorate|_applyDecoratedDescriptor/));
+    // the `_applyDecoratedDescriptor` method instead. TypeScript 5+ emits `__esDecorate`
+    // (inlined into the user file) for TC39 stage-3 native decorators.
+    let line = stack.findIndex(line => line.match(/__decorate|__esDecorate|Reflect\.decorate|_applyDecoratedDescriptor/));
 
     // bun does not have those lines at all, only the DecorateProperty/DecorateConstructor,
     // but those are also present in node, so we need to check this only if they weren't found.

--- a/tests/Utils.test.ts
+++ b/tests/Utils.test.ts
@@ -522,6 +522,20 @@ describe('Utils', () => {
       '    at Module.m._compile (/opt/app/node_modules/ts-node/src/index.ts:1618:23)',
       '    at Module.m._compile (/opt/app/node_modules/ts-node/src/index.ts:1618:23)',
     ])).toBe('/opt/app/entity/requirement.ts');
+
+    // TypeScript 5+ native ES decorators use `__esDecorate` helper (inlined into the user file)
+    // @see https://github.com/mikro-orm/mikro-orm/issues/7583
+    expect(Utils.lookupPathFromDecorator('Hello', [
+      'Error',
+      '    at lookupPathFromDecorator (file:///private/tmp/app/node_modules/@mikro-orm/core/utils/Utils.js:86:20)',
+      '    at getMetadataFromDecorator (file:///private/tmp/app/node_modules/@mikro-orm/core/metadata/MetadataStorage.js:131:14)',
+      '    at file:///private/tmp/app/node_modules/@mikro-orm/core/decorators/Entity.js:6:18',
+      '    at __esDecorate (file:///private/tmp/app/dist/entities/Hello.entity.js:12:40)',
+      '    at <static_initializer> (file:///private/tmp/app/dist/entities/Hello.entity.js:56:13)',
+      '    at file:///private/tmp/app/dist/entities/Hello.entity.js:48:17',
+      '    at file:///private/tmp/app/dist/entities/Hello.entity.js:69:3',
+      '    at ModuleJob.run (node:internal/modules/esm/module_job:430:25)',
+    ])).toBe('/private/tmp/app/dist/entities/Hello.entity.js');
   });
 
   test('lookup path from decorator with bun', () => {


### PR DESCRIPTION
Backport of #7584 to 6.x.

TypeScript 5+ emits `__esDecorate` (inlined into the user file) when compiling TC39 stage-3 native decorators (`experimentalDecorators: false`). `lookupPathFromDecorator`'s regex did not match `__esDecorate`, so the function fell through to the fallback and returned the bare class name. With `TsMorphMetadataProvider`, this surfaced as `MetadataError: Source file './Hello' not found` when running compiled output.

Closes #7583