### PR TITLE
chore(ci): stop tagging v6 releases as `latest`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,8 +92,18 @@ jobs:
           git diff-index --quiet HEAD || git commit -m 'chore(release): update internal dependencies [skip ci]'
           git push
 
+      - name: Determine dist-tag
+        id: dist-tag
+        run: |
+          if [[ "${{ inputs.ref }}" == "master" ]]; then
+            echo "tag=" >> "$GITHUB_OUTPUT"
+          else
+            MAJOR=$(echo "${{ inputs.ref }}" | grep -oP '^\d+')
+            echo "tag=--dist-tag latest-v${MAJOR}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Publish to npm
-        run: yarn publish:prod --yes
+        run: yarn publish:prod ${{ steps.dist-tag.outputs.tag }} --yes
 
   canary-release:
     if: inputs.dist-tag == 'next-v6'


### PR DESCRIPTION
The 6.x release workflow runs `yarn publish:prod --yes` with no `--dist-tag`, so lerna defaults to `latest`. Every v6 patch release thus knocks v7 off `latest`.

Ports the dist-tag detection step from master's `release.yml`: `ref: master` → default `latest`, anything else → `latest-v<major>` parsed from the branch name.