### PR TITLE
docs: remove stale knex references from migrations page

### DIFF
--- a/docs/docs/deployment.md
+++ b/docs/docs/deployment.md
@@ -197,7 +197,6 @@ for (const devDependency of Object.keys(devDependencies)) {
 // And anything MikroORM's packaging can be ignored if it's not on disk.
 // Later we check these dynamically and tell webpack to ignore the ones we don't have.
 const optionalModules = new Set([
-  ...Object.keys(require('knex/package.json').browser),
   ...Object.keys(require('@mikro-orm/core/package.json').peerDependencies),
   ...Object.keys(require('@mikro-orm/core/package.json').devDependencies || {})
 ]);
@@ -300,22 +299,6 @@ To run Webpack execute `webpack` (or `npx webpack` if not installed globally) in
 ## Deploy a bundle of entities and dependencies with `esbuild`
 
 [`esbuild`](https://esbuild.github.io/) can be used to bundle MikroORM entities and dependencies: you get a single file that contains every required module/file. Due to how the bundling works, there are few issues that needs to be properly addressed to make `esbuild` work with MikroORM.
-
-### Required shim for Knex with esbuild
-
-[Knex](https://knexjs.org/) has a known incompatibility with esbuild - Knex attempts to use dynamic imports to handle the various possible database dialects (mySQL, MongoDB, Oracle, etc.) but esbuild does not provide support for dynamic import functionality (see [this GitHub issue](https://github.com/evanw/esbuild/issues/473)).
-
-In order to work around this issue, you can define a shim module as shown below which intercepts Knex's client resolution at runtime and handles the operation itself (thus avoiding the dynamic import code). This enables `esbuild` bundling to work correctly.
-
-Define a file `knex.d.ts` as follows:
-
-```ts
-declare module 'knex/lib/dialects/postgres' {
-  import { Knex } from 'esbuild-support/knex';
-  const client: Knex.Client;
-  export = client;
-}
-```
 
 ### Excluding dependencies from esbuild
 

--- a/docs/docs/events.md
+++ b/docs/docs/events.md
@@ -494,7 +494,7 @@ Transaction events fire at transaction boundaries:
 
 ```ts
 interface TransactionEventArgs extends Omit<EventArgs<unknown>, 'entity' | 'changeSet'> {
-  transaction?: Transaction;  // Native transaction (e.g., Knex client for SQL)
+  transaction?: Transaction;  // Native transaction (e.g., Kysely instance for SQL)
   uow?: UnitOfWork;
 }
 ```

--- a/docs/docs/guide/03-project-setup.md
+++ b/docs/docs/guide/03-project-setup.md
@@ -186,7 +186,7 @@ export async function bootstrap(port = 3001) {
 
 :::info Importing `EntityManager` and `EntityRepository` from driver package
 
-While [`EntityManager`](/api/core/class/EntityManager) and [`EntityRepository`](/api/core/class/EntityRepository) classes are provided by the `@mikro-orm/core` package, those are only the base - driver agnostic - implementations. One example of what that means is the `QueryBuilder` - as an SQL concept, it has no place in the `@mikro-orm/core` package, instead, an extension of the [`EntityManager`](/api/core/class/EntityManager) called `SqlEntityManager` is provided by the SQL driver packages (it is defined in `@mikro-orm/knex` package and reexported in every SQL driver packages that depend on it). This `SqlEntityManager` class provides the additional SQL related methods, like `em.createQueryBuilder()`.
+While [`EntityManager`](/api/core/class/EntityManager) and [`EntityRepository`](/api/core/class/EntityRepository) classes are provided by the `@mikro-orm/core` package, those are only the base - driver agnostic - implementations. One example of what that means is the `QueryBuilder` - as an SQL concept, it has no place in the `@mikro-orm/core` package, instead, an extension of the [`EntityManager`](/api/core/class/EntityManager) called `SqlEntityManager` is provided by the SQL driver packages (it is defined in `@mikro-orm/sql` package and reexported in every SQL driver packages that depend on it). This `SqlEntityManager` class provides the additional SQL related methods, like `em.createQueryBuilder()`.
 
 For convenience, the `SqlEntityManager` class is also reexported under [`EntityManager`](/api/core/class/EntityManager) alias. This means you can do `import { EntityManager } from '@mikro-orm/sqlite'` to access it.
 
@@ -533,7 +533,7 @@ MikroORM will generate the down migrations automatically (although not for the i
 
 :::
 
-> You can also execute queries inside the `up()`/`down()` method via `this.execute('...')`, which will run queries in the same transaction as the rest of the migration. The `this.addSql('...)` method also accepts instances of knex. Knex instance can be accessed via `this.getKnex()`;
+> You can also execute queries inside the `up()`/`down()` method via `this.execute('...')`, which will run queries in the same transaction as the rest of the migration. The `this.addSql('...)` method also accepts instances of the native query builder or `raw()` SQL fragments.
 
 Read more about migrations in the [documentation](../migrations).
 

--- a/docs/docs/guide/04-advanced.md
+++ b/docs/docs/guide/04-advanced.md
@@ -912,7 +912,7 @@ export class ArticleRepository extends EntityRepository<IArticle> {
     const totalComments = this.em.createQueryBuilder(CommentSchema)
       .count()
       .where({ article: sql.ref('a.id') })
-      // by calling `qb.as()` we convert the QB instance to Knex instance
+      // by calling `qb.as()` we alias the sub-query
       .as('totalComments');
 
     // sub-query for all used tags

--- a/docs/docs/migrations.md
+++ b/docs/docs/migrations.md
@@ -45,7 +45,7 @@ Migrations are by default wrapped in a transaction. You can override this behavi
 
 `Configuration` object and driver instance are available in the `Migration` class context.
 
-You can execute queries in the migration via `Migration.execute()` method, which will run queries in the same transaction as the rest of the migration. The `Migration.addSql()` method also accepts instances of knex. Knex instance can be accessed via `Migration.getKnex()`;
+You can execute queries in the migration via `Migration.execute()` method, which will run queries in the same transaction as the rest of the migration. The `Migration.addSql()` method also accepts instances of the native query builder or `raw()` SQL fragments.
 
 ### Working with `EntityManager`
 

--- a/docs/docs/raw-queries.md
+++ b/docs/docs/raw-queries.md
@@ -58,15 +58,16 @@ export class Author { ... }
 
 ## `raw` queries with `QueryBuilder`
 
-You can use the `raw` helper for `QueryBuilder` or `Knex.QueryBuilder` instances too. Note that this is only available in the `raw` helper exported from SQL drivers, not with the one exported from the `@mikro-orm/core` package.
+You can use the `raw` helper for `QueryBuilder` or Kysely query builder instances too. Note that this is only available in the `raw` helper exported from SQL drivers, not with the one exported from the `@mikro-orm/core` package.
 
 ```ts
 import { raw } from '@mikro-orm/postgresql';
 
-const knexRaw = em.getKnex().raw('select 1');
+const kysely = em.getKysely();
+const subQuery = kysely.selectFrom('user').select('id').where('active', '=', true);
 
 const r = await em.find(User, {
-  id: raw(knexRaw),
+  id: raw(subQuery),
 });
 ```
 

--- a/docs/docs/schema-first-guide.md
+++ b/docs/docs/schema-first-guide.md
@@ -2913,13 +2913,13 @@ And let's regenerate the entities. Lastly, let's ensure we add it to the listing
 ...
 ```
 
-## Using the query builder during entity generation
+## Constructing the formula from metadata
 
-Notice that the full query had to be written as a string. So what happens if the columns are renamed in the future? No entity generation or build errors of any kind. You would only get an error at runtime, if you populate the property. That's not good. You can remedy that by constructing the query dynamically based on the metadata, and do the final replacement of the alias at the end. This will ensure you get errors during entity generation if you've renamed the involved table or columns.
+Notice that the full query had to be written as a string. So what happens if the columns are renamed in the future? No entity generation or build errors of any kind. You would only get an error at runtime, if you populate the property. That's not good. You can remedy that by constructing the query dynamically based on the metadata. This will ensure you get errors during entity generation if you've renamed the involved table or columns. Use `platform.quoteIdentifier()` to get database-specific quoting for the table and column names.
 
 ```diff title="src/modules/article/article.gen.ts"
-import type { GenerateOptions } from '@mikro-orm/core';
-+import { type SqlEntityManager, Utils } from '@mikro-orm/mysql';
+-import type { GenerateOptions } from '@mikro-orm/core';
++import { Utils, type GenerateOptions } from '@mikro-orm/core';
 ...
       textProp.lazy = true;
 
@@ -2927,15 +2927,12 @@ import type { GenerateOptions } from '@mikro-orm/core';
 +      if (!commentEntity) {
 +        return;
 +      }
-+      const em = (platform.getConfig().getDriver().createEntityManager() as SqlEntityManager);
-+      const qb = em.getKnex().queryBuilder().count().from(commentEntity.tableName).where(
-+        commentEntity.properties.article.fieldNames[0],
-+        '=',
-+        em.getKnex().raw('??.??', [em.getKnex().raw('??'), commentEntity.properties.id.fieldNames[0]])
-+      );
++      const tableName = platform.quoteIdentifier(commentEntity.tableName);
++      const articleCol = platform.quoteIdentifier(commentEntity.properties.article.fieldNames[0]);
++      const idCol = platform.quoteIdentifier(commentEntity.properties.id.fieldNames[0]);
 +      const formula = Utils.createFunction(
 +        new Map(),
-+        `return (alias) => ${JSON.stringify(`(${qb.toSQL().sql})`)}.replaceAll('??', alias)`
++        `return (alias) => \`(select count(*) from ${tableName} where ${articleCol} = \${alias}.${idCol})\``
 +      );
 +
       articleEntity.addProperty({

--- a/docs/docs/usage-with-nestjs.md
+++ b/docs/docs/usage-with-nestjs.md
@@ -62,7 +62,7 @@ Afterward, the `EntityManager` will be available to inject across entire project
 
 ```ts
 import { MikroORM } from '@mikro-orm/core';
-import { EntityManager } from '@mikro-orm/mysql'; // Import EntityManager from your driver package or `@mikro-orm/knex`
+import { EntityManager } from '@mikro-orm/mysql'; // Import EntityManager from your driver package or `@mikro-orm/sql`
 
 @Injectable()
 export class MyService {
@@ -76,7 +76,7 @@ export class MyService {
 
 > Notice that the `EntityManager` is imported from the `@mikro-orm/driver` package, where driver is `mysql`, `sqlite`, `postgres` or whatever driver you are using.
 >
-> In case you have `@mikro-orm/knex` installed as a dependency, you can also import the `EntityManager` from there.
+> In case you have `@mikro-orm/sql` installed as a dependency, you can also import the `EntityManager` from there.
 
 ## Repositories
 
@@ -144,7 +144,7 @@ export class Author {
 `**./author.repository.ts**`
 
 ```ts
-import { EntityRepository } from '@mikro-orm/mysql'; // Import EntityManager from your driver package or `@mikro-orm/knex`
+import { EntityRepository } from '@mikro-orm/mysql'; // Import EntityManager from your driver package or `@mikro-orm/sql`
 
 export class AuthorRepository extends EntityRepository<Author> {
 

--- a/docs/versioned_docs/version-7.0/deployment.md
+++ b/docs/versioned_docs/version-7.0/deployment.md
@@ -197,7 +197,6 @@ for (const devDependency of Object.keys(devDependencies)) {
 // And anything MikroORM's packaging can be ignored if it's not on disk.
 // Later we check these dynamically and tell webpack to ignore the ones we don't have.
 const optionalModules = new Set([
-  ...Object.keys(require('knex/package.json').browser),
   ...Object.keys(require('@mikro-orm/core/package.json').peerDependencies),
   ...Object.keys(require('@mikro-orm/core/package.json').devDependencies || {})
 ]);
@@ -300,22 +299,6 @@ To run Webpack execute `webpack` (or `npx webpack` if not installed globally) in
 ## Deploy a bundle of entities and dependencies with `esbuild`
 
 [`esbuild`](https://esbuild.github.io/) can be used to bundle MikroORM entities and dependencies: you get a single file that contains every required module/file. Due to how the bundling works, there are few issues that needs to be properly addressed to make `esbuild` work with MikroORM.
-
-### Required shim for Knex with esbuild
-
-[Knex](https://knexjs.org/) has a known incompatibility with esbuild - Knex attempts to use dynamic imports to handle the various possible database dialects (mySQL, MongoDB, Oracle, etc.) but esbuild does not provide support for dynamic import functionality (see [this GitHub issue](https://github.com/evanw/esbuild/issues/473)).
-
-In order to work around this issue, you can define a shim module as shown below which intercepts Knex's client resolution at runtime and handles the operation itself (thus avoiding the dynamic import code). This enables `esbuild` bundling to work correctly.
-
-Define a file `knex.d.ts` as follows:
-
-```ts
-declare module 'knex/lib/dialects/postgres' {
-  import { Knex } from 'esbuild-support/knex';
-  const client: Knex.Client;
-  export = client;
-}
-```
 
 ### Excluding dependencies from esbuild
 

--- a/docs/versioned_docs/version-7.0/events.md
+++ b/docs/versioned_docs/version-7.0/events.md
@@ -494,7 +494,7 @@ Transaction events fire at transaction boundaries:
 
 ```ts
 interface TransactionEventArgs extends Omit<EventArgs<unknown>, 'entity' | 'changeSet'> {
-  transaction?: Transaction;  // Native transaction (e.g., Knex client for SQL)
+  transaction?: Transaction;  // Native transaction (e.g., Kysely instance for SQL)
   uow?: UnitOfWork;
 }
 ```

--- a/docs/versioned_docs/version-7.0/guide/03-project-setup.md
+++ b/docs/versioned_docs/version-7.0/guide/03-project-setup.md
@@ -186,7 +186,7 @@ export async function bootstrap(port = 3001) {
 
 :::info Importing `EntityManager` and `EntityRepository` from driver package
 
-While [`EntityManager`](/api/core/class/EntityManager) and [`EntityRepository`](/api/core/class/EntityRepository) classes are provided by the `@mikro-orm/core` package, those are only the base - driver agnostic - implementations. One example of what that means is the `QueryBuilder` - as an SQL concept, it has no place in the `@mikro-orm/core` package, instead, an extension of the [`EntityManager`](/api/core/class/EntityManager) called `SqlEntityManager` is provided by the SQL driver packages (it is defined in `@mikro-orm/knex` package and reexported in every SQL driver packages that depend on it). This `SqlEntityManager` class provides the additional SQL related methods, like `em.createQueryBuilder()`.
+While [`EntityManager`](/api/core/class/EntityManager) and [`EntityRepository`](/api/core/class/EntityRepository) classes are provided by the `@mikro-orm/core` package, those are only the base - driver agnostic - implementations. One example of what that means is the `QueryBuilder` - as an SQL concept, it has no place in the `@mikro-orm/core` package, instead, an extension of the [`EntityManager`](/api/core/class/EntityManager) called `SqlEntityManager` is provided by the SQL driver packages (it is defined in `@mikro-orm/sql` package and reexported in every SQL driver packages that depend on it). This `SqlEntityManager` class provides the additional SQL related methods, like `em.createQueryBuilder()`.
 
 For convenience, the `SqlEntityManager` class is also reexported under [`EntityManager`](/api/core/class/EntityManager) alias. This means you can do `import { EntityManager } from '@mikro-orm/sqlite'` to access it.
 
@@ -533,7 +533,7 @@ MikroORM will generate the down migrations automatically (although not for the i
 
 :::
 
-> You can also execute queries inside the `up()`/`down()` method via `this.execute('...')`, which will run queries in the same transaction as the rest of the migration. The `this.addSql('...)` method also accepts instances of knex. Knex instance can be accessed via `this.getKnex()`;
+> You can also execute queries inside the `up()`/`down()` method via `this.execute('...')`, which will run queries in the same transaction as the rest of the migration. The `this.addSql('...)` method also accepts instances of the native query builder or `raw()` SQL fragments.
 
 Read more about migrations in the [documentation](../migrations).
 

--- a/docs/versioned_docs/version-7.0/guide/04-advanced.md
+++ b/docs/versioned_docs/version-7.0/guide/04-advanced.md
@@ -912,7 +912,7 @@ export class ArticleRepository extends EntityRepository<IArticle> {
     const totalComments = this.em.createQueryBuilder(CommentSchema)
       .count()
       .where({ article: sql.ref('a.id') })
-      // by calling `qb.as()` we convert the QB instance to Knex instance
+      // by calling `qb.as()` we alias the sub-query
       .as('totalComments');
 
     // sub-query for all used tags

--- a/docs/versioned_docs/version-7.0/migrations.md
+++ b/docs/versioned_docs/version-7.0/migrations.md
@@ -45,7 +45,7 @@ Migrations are by default wrapped in a transaction. You can override this behavi
 
 `Configuration` object and driver instance are available in the `Migration` class context.
 
-You can execute queries in the migration via `Migration.execute()` method, which will run queries in the same transaction as the rest of the migration. The `Migration.addSql()` method also accepts instances of knex. Knex instance can be accessed via `Migration.getKnex()`;
+You can execute queries in the migration via `Migration.execute()` method, which will run queries in the same transaction as the rest of the migration. The `Migration.addSql()` method also accepts instances of the native query builder or `raw()` SQL fragments.
 
 ### Working with `EntityManager`
 

--- a/docs/versioned_docs/version-7.0/raw-queries.md
+++ b/docs/versioned_docs/version-7.0/raw-queries.md
@@ -58,15 +58,16 @@ export class Author { ... }
 
 ## `raw` queries with `QueryBuilder`
 
-You can use the `raw` helper for `QueryBuilder` or `Knex.QueryBuilder` instances too. Note that this is only available in the `raw` helper exported from SQL drivers, not with the one exported from the `@mikro-orm/core` package.
+You can use the `raw` helper for `QueryBuilder` or Kysely query builder instances too. Note that this is only available in the `raw` helper exported from SQL drivers, not with the one exported from the `@mikro-orm/core` package.
 
 ```ts
 import { raw } from '@mikro-orm/postgresql';
 
-const knexRaw = em.getKnex().raw('select 1');
+const kysely = em.getKysely();
+const subQuery = kysely.selectFrom('user').select('id').where('active', '=', true);
 
 const r = await em.find(User, {
-  id: raw(knexRaw),
+  id: raw(subQuery),
 });
 ```
 

--- a/docs/versioned_docs/version-7.0/schema-first-guide.md
+++ b/docs/versioned_docs/version-7.0/schema-first-guide.md
@@ -2913,13 +2913,13 @@ And let's regenerate the entities. Lastly, let's ensure we add it to the listing
 ...
 ```
 
-## Using the query builder during entity generation
+## Constructing the formula from metadata
 
-Notice that the full query had to be written as a string. So what happens if the columns are renamed in the future? No entity generation or build errors of any kind. You would only get an error at runtime, if you populate the property. That's not good. You can remedy that by constructing the query dynamically based on the metadata, and do the final replacement of the alias at the end. This will ensure you get errors during entity generation if you've renamed the involved table or columns.
+Notice that the full query had to be written as a string. So what happens if the columns are renamed in the future? No entity generation or build errors of any kind. You would only get an error at runtime, if you populate the property. That's not good. You can remedy that by constructing the query dynamically based on the metadata. This will ensure you get errors during entity generation if you've renamed the involved table or columns. Use `platform.quoteIdentifier()` to get database-specific quoting for the table and column names.
 
 ```diff title="src/modules/article/article.gen.ts"
-import type { GenerateOptions } from '@mikro-orm/core';
-+import { type SqlEntityManager, Utils } from '@mikro-orm/mysql';
+-import type { GenerateOptions } from '@mikro-orm/core';
++import { Utils, type GenerateOptions } from '@mikro-orm/core';
 ...
       textProp.lazy = true;
 
@@ -2927,15 +2927,12 @@ import type { GenerateOptions } from '@mikro-orm/core';
 +      if (!commentEntity) {
 +        return;
 +      }
-+      const em = (platform.getConfig().getDriver().createEntityManager() as SqlEntityManager);
-+      const qb = em.getKnex().queryBuilder().count().from(commentEntity.tableName).where(
-+        commentEntity.properties.article.fieldNames[0],
-+        '=',
-+        em.getKnex().raw('??.??', [em.getKnex().raw('??'), commentEntity.properties.id.fieldNames[0]])
-+      );
++      const tableName = platform.quoteIdentifier(commentEntity.tableName);
++      const articleCol = platform.quoteIdentifier(commentEntity.properties.article.fieldNames[0]);
++      const idCol = platform.quoteIdentifier(commentEntity.properties.id.fieldNames[0]);
 +      const formula = Utils.createFunction(
 +        new Map(),
-+        `return (alias) => ${JSON.stringify(`(${qb.toSQL().sql})`)}.replaceAll('??', alias)`
++        `return (alias) => \`(select count(*) from ${tableName} where ${articleCol} = \${alias}.${idCol})\``
 +      );
 +
       articleEntity.addProperty({

--- a/docs/versioned_docs/version-7.0/usage-with-nestjs.md
+++ b/docs/versioned_docs/version-7.0/usage-with-nestjs.md
@@ -62,7 +62,7 @@ Afterward, the `EntityManager` will be available to inject across entire project
 
 ```ts
 import { MikroORM } from '@mikro-orm/core';
-import { EntityManager } from '@mikro-orm/mysql'; // Import EntityManager from your driver package or `@mikro-orm/knex`
+import { EntityManager } from '@mikro-orm/mysql'; // Import EntityManager from your driver package or `@mikro-orm/sql`
 
 @Injectable()
 export class MyService {
@@ -76,7 +76,7 @@ export class MyService {
 
 > Notice that the `EntityManager` is imported from the `@mikro-orm/driver` package, where driver is `mysql`, `sqlite`, `postgres` or whatever driver you are using.
 >
-> In case you have `@mikro-orm/knex` installed as a dependency, you can also import the `EntityManager` from there.
+> In case you have `@mikro-orm/sql` installed as a dependency, you can also import the `EntityManager` from there.
 
 ## Repositories
 
@@ -144,7 +144,7 @@ export class Author {
 `**./author.repository.ts**`
 
 ```ts
-import { EntityRepository } from '@mikro-orm/mysql'; // Import EntityManager from your driver package or `@mikro-orm/knex`
+import { EntityRepository } from '@mikro-orm/mysql'; // Import EntityManager from your driver package or `@mikro-orm/sql`
 
 export class AuthorRepository extends EntityRepository<Author> {
 


### PR DESCRIPTION
The `Migration.getKnex()` method was removed in v7 along with the knex dependency. Updates the v7 and next migrations docs to describe what `addSql()` actually accepts now: native query builder or `raw()` SQL fragments.

Also cleans up other stale knex references in v7+ docs:
- `@mikro-orm/knex` → `@mikro-orm/sql` in `usage-with-nestjs.md` and `guide/03-project-setup.md`
- `em.getKnex().raw(...)` example replaced with `em.getKysely()` in `raw-queries.md`
- `Knex client` → `Kysely instance` comment in `events.md`
- Removed the obsolete `??` qb-to-knex comment in `guide/04-advanced.md`
- Removed the no-longer-applicable "Required shim for Knex with esbuild" section and the `knex/package.json` reference in `deployment.md`
- Ported the `em.getKnex().queryBuilder()` formula example in `schema-first-guide.md` to use `platform.quoteIdentifier()`, which gives database-specific quoting without needing a query builder

The "Migrating from Knex" section in `query-builder.md` is intentionally kept as it documents the `@mikro-orm/knex-compat` package for users upgrading from v6.

Closes #7668