### PR TITLE
docs(migrations): replace removed `Migration.getKnex()` reference

### DIFF
--- a/docs/docs/migrations.md
+++ b/docs/docs/migrations.md
@@ -45,7 +45,7 @@ Migrations are by default wrapped in a transaction. You can override this behavi
 
 `Configuration` object and driver instance are available in the `Migration` class context.
 
-You can execute queries in the migration via `Migration.execute()` method, which will run queries in the same transaction as the rest of the migration. The `Migration.addSql()` method also accepts instances of knex. Knex instance can be accessed via `Migration.getKnex()`;
+You can execute queries in the migration via `Migration.execute()` method, which will run queries in the same transaction as the rest of the migration. Both `Migration.execute()` and `Migration.addSql()` accept a raw SQL string, a `raw()` SQL fragment, or a native query builder instance built via `Migration.getEntityManager().getKysely()`.
 
 ### Working with `EntityManager`
 


### PR DESCRIPTION
Closes #7668.

`Migration.getKnex()` no longer exists - knex was replaced with kysely as the query runner in v7 (see `upgrading-v6-to-v7.md`). The line in `docs/docs/migrations.md` describing how `Migration.addSql()` accepts knex instances and pointing at `Migration.getKnex()` has been wrong since that migration; this rewrites it to describe what `Migration.addSql()` and `Migration.execute()` actually accept today (string SQL, `raw()` fragment, or a native query builder instance built via `getEntityManager().getKysely()`).

Per @B4nan's note on the issue, other docs (e.g. `raw-queries.md`, `schema-first-guide.md`, `usage-with-nestjs.md`) still reference `getKnex()` / `@mikro-orm/knex` / `Knex` types in ways that are no longer accurate. Those touch separate sections; happy to send follow-up PRs once direction here is confirmed (each one is a small replacement, but they vary in tone - some reference the new `@mikro-orm/knex-compat` raw helper, some need full kysely rewrites).