### PR TITLE
fix(mysql): default maxIdle when pool.idleTimeoutMillis is set

### DIFF
--- a/packages/mysql/src/MySqlConnection.ts
+++ b/packages/mysql/src/MySqlConnection.ts
@@ -59,6 +59,15 @@ export class MySqlConnection extends AbstractSqlConnection {
     ret.connectionLimit = pool?.max;
     ret.idleTimeout = pool?.idleTimeoutMillis;
 
+    // mysql2 only runs idle cleanup when `maxIdle < connectionLimit`; its default has
+    // them equal, so `idleTimeout` alone is a no-op. When the user opts into idle
+    // cleanup via `pool.idleTimeoutMillis`, default `maxIdle` to `pool.min ?? 0` so
+    // idle connections actually drain. Explicit `driverOptions.maxIdle` still wins
+    // because `overrides` is merged in last.
+    if (pool?.idleTimeoutMillis != null) {
+      ret.maxIdle = pool.min ?? 0;
+    }
+
     if (this.config.get('multipleStatements')) {
       ret.multipleStatements = this.config.get('multipleStatements');
     }

--- a/packages/mysql/src/MySqlConnection.ts
+++ b/packages/mysql/src/MySqlConnection.ts
@@ -62,10 +62,13 @@ export class MySqlConnection extends AbstractSqlConnection {
     // mysql2 only runs idle cleanup when `maxIdle < connectionLimit`; its default has
     // them equal, so `idleTimeout` alone is a no-op. When the user opts into idle
     // cleanup via `pool.idleTimeoutMillis`, default `maxIdle` to `pool.min ?? 0` so
-    // idle connections actually drain. Explicit `driverOptions.maxIdle` still wins
-    // because `overrides` is merged in last.
+    // idle connections actually drain. A misconfigured `pool.min > pool.max` is
+    // clamped below `pool.max` so cleanup still runs. Explicit `driverOptions.maxIdle`
+    // still wins because `overrides` is merged in last.
     if (pool?.idleTimeoutMillis != null) {
-      ret.maxIdle = pool.min ?? 0;
+      const min = pool.min ?? 0;
+      const max = pool.max;
+      ret.maxIdle = max != null && min > max ? Math.max(0, max - 1) : min;
     }
 
     if (this.config.get('multipleStatements')) {

--- a/tests/features/entity-manager/EntityManager.mysql.test.ts
+++ b/tests/features/entity-manager/EntityManager.mysql.test.ts
@@ -106,6 +106,41 @@ describe('EntityManagerMySql', () => {
     });
   });
 
+  test('pool.idleTimeoutMillis enables mysql2 idle cleanup via maxIdle', async () => {
+    const baseOpts = {
+      driver: MySqlDriver,
+      clientUrl: 'mysql://root@127.0.0.1:3308/db_name',
+      logger: vi.fn(),
+    } as any;
+
+    // without pool config, maxIdle is left untouched (mysql2 default keeps conns warm)
+    const driverDefault = new MySqlDriver(new Configuration({ ...baseOpts }, false));
+    expect(driverDefault.getConnection().mapOptions({})).not.toHaveProperty('maxIdle');
+
+    // setting only idleTimeoutMillis defaults maxIdle to 0 so cleanup actually runs
+    const driverIdle = new MySqlDriver(new Configuration({ ...baseOpts, pool: { idleTimeoutMillis: 30_000 } }, false));
+    expect(driverIdle.getConnection().mapOptions({})).toMatchObject({ idleTimeout: 30_000, maxIdle: 0 });
+
+    // pool.min is honored when set, mirroring tarn/knex semantics from v6
+    const driverMin = new MySqlDriver(
+      new Configuration({ ...baseOpts, pool: { min: 2, max: 10, idleTimeoutMillis: 30_000 } }, false),
+    );
+    expect(driverMin.getConnection().mapOptions({})).toMatchObject({
+      connectionLimit: 10,
+      idleTimeout: 30_000,
+      maxIdle: 2,
+    });
+
+    // explicit driverOptions.maxIdle wins over the default
+    const driverOverride = new MySqlDriver(
+      new Configuration({ ...baseOpts, pool: { idleTimeoutMillis: 30_000 } }, false),
+    );
+    expect(driverOverride.getConnection().mapOptions({ maxIdle: 5 })).toMatchObject({
+      idleTimeout: 30_000,
+      maxIdle: 5,
+    });
+  });
+
   test('raw query with array param', async () => {
     const q1 = orm.em.getPlatform().formatQuery(`select * from author2 where id in (?) limit ?`, [[1, 2, 3], 3]);
     expect(q1).toBe('select * from author2 where id in (1, 2, 3) limit 3');

--- a/tests/features/entity-manager/EntityManager.mysql.test.ts
+++ b/tests/features/entity-manager/EntityManager.mysql.test.ts
@@ -139,6 +139,28 @@ describe('EntityManagerMySql', () => {
       idleTimeout: 30_000,
       maxIdle: 5,
     });
+
+    // misconfigured pool.min > pool.max is clamped below pool.max so cleanup still runs
+    // (otherwise maxIdle would equal connectionLimit and silently disable mysql2 cleanup)
+    const driverInvalid = new MySqlDriver(
+      new Configuration({ ...baseOpts, pool: { min: 20, max: 10, idleTimeoutMillis: 30_000 } }, false),
+    );
+    expect(driverInvalid.getConnection().mapOptions({})).toMatchObject({
+      connectionLimit: 10,
+      idleTimeout: 30_000,
+      maxIdle: 9,
+    });
+
+    // pool.min === pool.max is a legitimate fixed pool — leave maxIdle = min so mysql2
+    // keeps the configured size warm (cleanup intentionally not engaged)
+    const driverFixed = new MySqlDriver(
+      new Configuration({ ...baseOpts, pool: { min: 5, max: 5, idleTimeoutMillis: 30_000 } }, false),
+    );
+    expect(driverFixed.getConnection().mapOptions({})).toMatchObject({
+      connectionLimit: 5,
+      idleTimeout: 30_000,
+      maxIdle: 5,
+    });
   });
 
   test('raw query with array param', async () => {


### PR DESCRIPTION
## Summary

`pool.idleTimeoutMillis` was silently inert on v7 because mysql2 only registers its idle-cleanup callback when `maxIdle < connectionLimit`, and the default leaves them equal. v6 (knex/tarn) honored the option directly, so upgrades regressed connection counts under load — connections ramped up and never drained.

When the user opts into idle cleanup via `pool.idleTimeoutMillis`, this defaults `maxIdle` to `pool.min ?? 0` so cleanup actually runs. Explicit `driverOptions.maxIdle` still wins because overrides merge in last.

Reported in #7672.