### PR TITLE
fix(core): narrow inherited discriminator to literal value in `defineEntity`

### DIFF
--- a/packages/core/src/entity/defineEntity.ts
+++ b/packages/core/src/entity/defineEntity.ts
@@ -1205,6 +1205,9 @@ export interface EntityMetadataWithProperties<
   TBase = never,
   TRepository = never,
   TForceObject extends boolean = false,
+  TDiscriminatorColumn extends string | undefined = undefined,
+  TDiscriminatorValue extends string | number | undefined = undefined,
+  TBaseDiscriminatorColumn extends string | undefined = undefined,
 > extends Omit<
   Partial<EntityMetadata<InferEntityFromProperties<TProperties, TPK, TBase, TRepository>>>,
   | 'properties'
@@ -1212,6 +1215,7 @@ export interface EntityMetadataWithProperties<
   | 'primaryKeys'
   | 'hooks'
   | 'discriminatorColumn'
+  | 'discriminatorValue'
   | 'versionProperty'
   | 'concurrencyCheckKeys'
   | 'serializedPrimaryKey'
@@ -1223,9 +1227,12 @@ export interface EntityMetadataWithProperties<
 > {
   name: TName;
   tableName?: TTableName;
-  // Uses ~entity marker for fast type inference (avoids expensive EntitySchema matching)
-  // Also accepts entity constructors for compatibility with class-based entities
-  extends?: { '~entity': TBase } | EntityCtor<TBase>;
+  // Uses ~entity marker for fast type inference (avoids expensive EntitySchema matching).
+  // Also accepts entity constructors for class-based entities. The optional `~discriminatorColumn`
+  // marker lets the child narrow the inherited discriminator property to its literal value (GH #7677).
+  extends?:
+    | { '~entity': TBase; '~discriminatorColumn'?: TBaseDiscriminatorColumn }
+    | (EntityCtor<TBase> & { '~discriminatorColumn'?: TBaseDiscriminatorColumn });
   properties: TProperties | ((properties: PropertyBuilders) => TProperties);
   primaryKeys?: TPK & InferPrimaryKeyConstraint<TProperties>[];
   hooks?: DefineEntityHooks;
@@ -1257,7 +1264,10 @@ export interface EntityMetadataWithProperties<
   orderBy?:
     | { [K in Extract<AllKeys<TProperties, TBase>, string>]?: QueryOrderKeysFlat }
     | { [K in Extract<AllKeys<TProperties, TBase>, string>]?: QueryOrderKeysFlat }[];
-  discriminatorColumn?: string;
+  // Captured as const literals (overriding `EntityMetadata`'s broad types) so children form a
+  // proper discriminated union narrowed to their `discriminatorValue` (GH #7677).
+  discriminatorColumn?: TDiscriminatorColumn;
+  discriminatorValue?: TDiscriminatorValue;
   versionProperty?: AllKeys<TProperties, TBase>;
   concurrencyCheckKeys?: Set<AllKeys<TProperties, TBase>>;
   serializedPrimaryKey?: AllKeys<TProperties, TBase>;
@@ -1296,14 +1306,48 @@ export function defineEntity<
   const TBase = never,
   const TRepository = never,
   const TForceObject extends boolean = false,
+  const TDiscriminatorColumn extends string | undefined = undefined,
+  const TDiscriminatorValue extends string | number | undefined = undefined,
+  const TBaseDiscriminatorColumn extends string | undefined = undefined,
 >(
-  meta: EntityMetadataWithProperties<TName, TTableName, TProperties, TPK, TBase, TRepository, TForceObject>,
+  meta: EntityMetadataWithProperties<
+    TName,
+    TTableName,
+    TProperties,
+    TPK,
+    TBase,
+    TRepository,
+    TForceObject,
+    TDiscriminatorColumn,
+    TDiscriminatorValue,
+    TBaseDiscriminatorColumn
+  >,
 ): EntitySchemaWithMeta<
   TName,
   TTableName,
-  InferEntityFromProperties<TProperties, TPK, TBase, TRepository, TForceObject>,
+  InferEntityFromProperties<
+    TProperties,
+    TPK,
+    TBase,
+    TRepository,
+    TForceObject,
+    TBaseDiscriminatorColumn,
+    TDiscriminatorValue
+  >,
   TBase,
-  TProperties
+  TProperties,
+  EntityCtor<
+    InferEntityFromProperties<
+      TProperties,
+      TPK,
+      TBase,
+      TRepository,
+      TForceObject,
+      TBaseDiscriminatorColumn,
+      TDiscriminatorValue
+    >
+  >,
+  TDiscriminatorColumn
 >;
 
 /** Defines an entity schema for an existing class, combining the class with property builders. */
@@ -1480,6 +1524,8 @@ export type InferEntityFromProperties<
   Base = never,
   Repository = never,
   ForceObject extends boolean = false,
+  BaseDiscriminatorColumn extends string | undefined = undefined,
+  DiscriminatorValue extends string | number | undefined = undefined,
 > = (IsNever<Base> extends true
   ? {}
   : Base extends { toObject(...args: any[]): any }
@@ -1492,7 +1538,7 @@ export type InferEntityFromProperties<
           } & (IsNever<Repository> extends true
               ? {}
               : { [EntityRepositoryType]?: Repository extends Constructor<infer R> ? R : Repository }) &
-            Omit<Base, typeof PrimaryKeyProp>
+            NarrowDiscriminator<Omit<Base, typeof PrimaryKeyProp>, BaseDiscriminatorColumn, DiscriminatorValue>
         >,
         BaseEntityMethodKeys
       >
@@ -1503,8 +1549,21 @@ export type InferEntityFromProperties<
 } & (IsNever<Repository> extends true
     ? {}
     : { [EntityRepositoryType]?: Repository extends Constructor<infer R> ? R : Repository }) &
-  (IsNever<Base> extends true ? {} : Omit<Base, typeof PrimaryKeyProp>) &
+  (IsNever<Base> extends true
+    ? {}
+    : NarrowDiscriminator<Omit<Base, typeof PrimaryKeyProp>, BaseDiscriminatorColumn, DiscriminatorValue>) &
   (ForceObject extends true ? { [Config]?: DefineConfig<{ forceObject: true }> } : {});
+
+// Narrows the inherited discriminator property on `Base` to the literal `DiscValue` so a union
+// of sibling subtypes forms a proper discriminated union (GH #7677). Falls through to `Base`
+// when either marker is absent (parent without `discriminatorColumn`, or self-defined entity).
+type NarrowDiscriminator<Base, DiscColumn extends string | undefined, DiscValue> = DiscColumn extends string
+  ? DiscColumn extends keyof Base
+    ? DiscValue extends string | number
+      ? Omit<Base, DiscColumn> & { [K in DiscColumn]: DiscValue }
+      : Base
+    : Base
+  : Base;
 
 // Combines primary keys from child properties and base entity
 type InferCombinedPrimaryKey<Properties extends Record<string, any>, PK, Base> = PK extends undefined

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -2143,14 +2143,17 @@ export interface EntitySchemaWithMeta<
   TBase = never,
   TProperties extends Record<string, any> = Record<string, any>,
   TClass extends EntityCtor = EntityCtor<TEntity>,
+  TDiscriminatorColumn extends string | undefined = undefined,
 > extends EntitySchema<TEntity, TBase, TClass> {
   readonly name: TName;
   readonly properties: TProperties;
   readonly tableName: TTableName;
   /** @internal Direct entity type access - avoids expensive pattern matching */
   readonly '~entity': TEntity;
+  /** @internal Type-level marker carrying the discriminator column name, used by `defineEntity()` to narrow inherited discriminator properties to the literal `discriminatorValue` of each child schema. */
+  readonly '~discriminatorColumn'?: TDiscriminatorColumn;
   /** @internal */
-  readonly class: TClass & { '~entityName'?: TName };
+  readonly class: TClass & { '~entityName'?: TName; '~discriminatorColumn'?: TDiscriminatorColumn };
 }
 
 /**

--- a/tests/bench/types/api-methods.ts
+++ b/tests/bench/types/api-methods.ts
@@ -92,19 +92,19 @@ bench('em.create() return type', () => {
   type R = ReturnType<typeof em.create<Author>>;
   const x = {} as R;
   void x;
-}).types([2442, 'instantiations']);
+}).types([2473, 'instantiations']);
 
 bench('RequiredEntityData - Author', () => {
   type R = RequiredEntityData<Author>;
   const x = {} as R;
   void x;
-}).types([1503, 'instantiations']);
+}).types([1534, 'instantiations']);
 
 bench('RequiredEntityData - Book', () => {
   type R = RequiredEntityData<Book>;
   const x = {} as R;
   void x;
-}).types([1309, 'instantiations']);
+}).types([1340, 'instantiations']);
 
 // New<T> type (used as create return type)
 bench('New<Author>', () => {
@@ -187,13 +187,13 @@ bench('EntityData<Author>', () => {
   type R = EntityData<Author>;
   const x = {} as R;
   void x;
-}).types([216, 'instantiations']);
+}).types([235, 'instantiations']);
 
 bench('EntityData<Loaded<Author, "books">>', () => {
   type R = EntityData<Loaded<Author, 'books'>>;
   const x = {} as R;
   void x;
-}).types([1848, 'instantiations']);
+}).types([1867, 'instantiations']);
 
 // ============================================
 // Simulating wrap(e).toObject()

--- a/tests/bench/types/assign-types.ts
+++ b/tests/bench/types/assign-types.ts
@@ -136,10 +136,10 @@ bench('assign data type - plain entity', () => {
   type R = AssignDataType<Author>;
   const x = {} as R;
   void x;
-}).types([2374, 'instantiations']);
+}).types([2451, 'instantiations']);
 
 bench('assign data type - Loaded entity', () => {
   type R = AssignDataType<Loaded<Author, 'books'>>;
   const x = {} as R;
   void x;
-}).types([3445, 'instantiations']);
+}).types([3522, 'instantiations']);

--- a/tests/bench/types/defineEntity-extends.ts
+++ b/tests/bench/types/defineEntity-extends.ts
@@ -19,7 +19,7 @@ bench('entity extends entity', () => {
       extra: p.string(),
     },
   });
-}).types([1459, 'instantiations']);
+}).types([1501, 'instantiations']);
 
 bench('entity extends entity with discriminator', () => {
   const base = defineEntity({
@@ -40,7 +40,7 @@ bench('entity extends entity with discriminator', () => {
       extra: p.string(),
     },
   });
-}).types([1480, 'instantiations']);
+}).types([1562, 'instantiations']);
 
 bench('embeddable extends embeddable', () => {
   const base = defineEntity({
@@ -60,7 +60,7 @@ bench('embeddable extends embeddable', () => {
       bar: p.string(),
     },
   });
-}).types([913, 'instantiations']);
+}).types([955, 'instantiations']);
 
 bench('embeddable extends embeddable with discriminator', () => {
   const base = defineEntity({
@@ -83,7 +83,7 @@ bench('embeddable extends embeddable with discriminator', () => {
       bar: p.string(),
     },
   });
-}).types([934, 'instantiations']);
+}).types([1016, 'instantiations']);
 
 bench('polymorphic embeddables', () => {
   const base = defineEntity({
@@ -198,7 +198,7 @@ bench('polymorphic embeddables', () => {
       data: () => p.embedded([documentDataAwEdCard, documentDataCoCheckMig, documentDataMvDiCard]).object(),
     },
   });
-}).types([3252, 'instantiations']);
+}).types([3511, 'instantiations']);
 
 bench('realistic entity (~20 props, relations, extends)', () => {
   const base = defineEntity({
@@ -270,7 +270,7 @@ bench('realistic entity (~20 props, relations, extends)', () => {
       tags: () => p.manyToMany(Tag),
     },
   });
-}).types([7310, 'instantiations']);
+}).types([7376, 'instantiations']);
 
 bench('realistic entity - InferEntity usage', () => {
   const base = defineEntity({
@@ -350,7 +350,7 @@ bench('realistic entity - InferEntity usage', () => {
 
   // Force evaluation of all entity types
   const _check: [IAuthor, IBook, ITag, IPublisher] = {} as any;
-}).types([7402, 'instantiations']);
+}).types([7468, 'instantiations']);
 
 bench('realistic entity - setClass pattern', () => {
   const BaseSchema = defineEntity({
@@ -436,4 +436,4 @@ bench('realistic entity - setClass pattern', () => {
   PublisherSchema.setClass(Publisher);
   AuthorSchema.setClass(Author);
   BookSchema.setClass(Book);
-}).types([7425, 'instantiations']);
+}).types([7491, 'instantiations']);

--- a/tests/bench/types/defineEntity.ts
+++ b/tests/bench/types/defineEntity.ts
@@ -19,7 +19,7 @@ bench('defineEntity with relations', () => {
       strictNullRef: () => p.oneToOne(Foo).strictNullable(),
     },
   });
-}).types([7117, 'instantiations']);
+}).types([7131, 'instantiations']);
 
 bench('defineEntity with ref and nullable', () => {
   const Foo = defineEntity({
@@ -36,7 +36,7 @@ bench('defineEntity with ref and nullable', () => {
       scalarRefNullable: p.string().ref().nullable(),
     },
   });
-}).types([6607, 'instantiations']);
+}).types([6621, 'instantiations']);
 
 bench('defineEntity only with ref and nullable', () => {
   const Foo = defineEntity({
@@ -46,7 +46,7 @@ bench('defineEntity only with ref and nullable', () => {
       toOneRefNullable: () => p.oneToOne(Foo).ref().nullable(),
     },
   });
-}).types([1836, 'instantiations']);
+}).types([1850, 'instantiations']);
 
 bench('defineEntity only with nullable and ref', () => {
   const Foo = defineEntity({
@@ -56,7 +56,7 @@ bench('defineEntity only with nullable and ref', () => {
       toOneRefNullable: () => p.oneToOne(Foo).nullable().ref(),
     },
   });
-}).types([1836, 'instantiations']);
+}).types([1850, 'instantiations']);
 
 bench('defineEntity with relations using class', () => {
   class Foo {
@@ -88,7 +88,7 @@ bench('defineEntity with relations using class', () => {
       scalarRefNullable: p.string().ref().nullable(),
     },
   });
-}).types([7105, 'instantiations']);
+}).types([7131, 'instantiations']);
 
 bench('defineEntity with ref and nullable using class', () => {
   class Foo {
@@ -120,7 +120,7 @@ bench('defineEntity with ref and nullable using class', () => {
       scalarRefNullable: p.string().ref().nullable(),
     },
   });
-}).types([7105, 'instantiations']);
+}).types([7131, 'instantiations']);
 
 bench('defineEntity only with ref and nullable using class', () => {
   class Foo {
@@ -138,7 +138,7 @@ bench('defineEntity only with ref and nullable using class', () => {
       toOneRefNullable: () => p.oneToOne(Foo).ref().nullable(),
     },
   });
-}).types([2359, 'instantiations']);
+}).types([2385, 'instantiations']);
 
 bench('defineEntity only with nullable and ref using class', () => {
   class Foo {
@@ -156,7 +156,7 @@ bench('defineEntity only with nullable and ref using class', () => {
       toOneRefNullable: () => p.oneToOne(Foo).nullable().ref(),
     },
   });
-}).types([2359, 'instantiations']);
+}).types([2385, 'instantiations']);
 
 bench('EntitySchema', () => {
   interface IFoo {
@@ -241,4 +241,4 @@ bench('defineEntity with setClass pattern (circular relations)', () => {
 
   AuthorSchema.setClass(Author);
   BookSchema.setClass(Book);
-}).types([5571, 'instantiations']);
+}).types([5591, 'instantiations']);

--- a/tests/bench/types/other-types.ts
+++ b/tests/bench/types/other-types.ts
@@ -93,7 +93,7 @@ function useEntityData<T>(_data: EntityData<T>): void {}
 
 bench('EntityData<Author> - simple', () => {
   useEntityData<Author>({ name: 'test', email: 'test@test.com' });
-}).types([213, 'instantiations']);
+}).types([244, 'instantiations']);
 
 bench('EntityData<Book> - with relations', () => {
   useEntityData<Book>({
@@ -101,7 +101,7 @@ bench('EntityData<Book> - with relations', () => {
     price: 10,
     author: { name: 'test' } as any,
   });
-}).types([628, 'instantiations']);
+}).types([674, 'instantiations']);
 
 // ============================================
 // RequiredEntityData benchmarks
@@ -112,11 +112,11 @@ function useRequiredData<T>(_data: RequiredEntityData<T>): void {}
 
 bench('RequiredEntityData<Author> - simple', () => {
   useRequiredData<Author>({ name: 'test', email: 'test@test.com' });
-}).types([2147, 'instantiations']);
+}).types([2190, 'instantiations']);
 
 bench('RequiredEntityData<Book> - with required relations', () => {
   useRequiredData<Book>({ title: 'test', price: 10, author: {} as Author });
-}).types([3518, 'instantiations']);
+}).types([3576, 'instantiations']);
 
 // ============================================
 // Primary type benchmarks

--- a/tests/issues/GH7677.test.ts
+++ b/tests/issues/GH7677.test.ts
@@ -1,0 +1,101 @@
+import { defineEntity, MikroORM, p } from '@mikro-orm/sqlite';
+
+enum AnimalType {
+  CAT = 'cat',
+  DOG = 'dog',
+}
+
+const AnimalSchema = defineEntity({
+  name: 'Animal',
+  embeddable: true,
+  abstract: true,
+  discriminatorColumn: 'type',
+  properties: {
+    type: p.enum(() => AnimalType),
+    name: p.string(),
+  },
+});
+
+class Animal extends AnimalSchema.class {}
+AnimalSchema.setClass(Animal);
+
+const CatSchema = defineEntity({
+  name: 'Cat',
+  embeddable: true,
+  // matches the original repro: child extends the parent *class*, not the schema —
+  // exercises the `EntityCtor<TBase> & { '~discriminatorColumn'?: … }` arm of `extends?`.
+  extends: Animal,
+  discriminatorValue: AnimalType.CAT,
+  properties: {
+    canMeow: p.boolean().nullable(),
+  },
+});
+
+class Cat extends CatSchema.class {}
+CatSchema.setClass(Cat);
+
+const DogSchema = defineEntity({
+  name: 'Dog',
+  embeddable: true,
+  extends: Animal,
+  discriminatorValue: AnimalType.DOG,
+  properties: {
+    canBark: p.boolean().nullable(),
+  },
+});
+
+class Dog extends DogSchema.class {}
+DogSchema.setClass(Dog);
+
+const OwnerSchema = defineEntity({
+  name: 'Owner',
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+    pet: () => p.embedded([Cat, Dog]),
+  },
+});
+
+class Owner extends OwnerSchema.class {}
+OwnerSchema.setClass(Owner);
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    dbName: ':memory:',
+    entities: [Owner],
+  });
+  await orm.schema.refresh();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+test('discriminator on embedded inheritance narrows the union', async () => {
+  orm.em.create(Owner, { id: 1, name: 'Foo', pet: { type: AnimalType.CAT, name: 'Whiskers', canMeow: true } });
+  orm.em.create(Owner, { id: 2, name: 'Bar', pet: { type: AnimalType.DOG, name: 'Rex', canBark: true } });
+  await orm.em.flush();
+  orm.em.clear();
+
+  const owners = await orm.em.findAll(Owner, { orderBy: { id: 'asc' } });
+
+  let meows = 0;
+  let barks = 0;
+
+  // The `owner.pet.type === ...` checks must narrow `Cat | Dog` so the subtype-only
+  // properties (`canMeow`, `canBark`) compile without a cast — that's the bug under test.
+  for (const owner of owners) {
+    if (owner.pet.type === AnimalType.CAT) {
+      if (owner.pet.canMeow) {
+        meows++;
+      }
+    } else if (owner.pet.canBark) {
+      barks++;
+    }
+  }
+
+  expect(meows).toBe(1);
+  expect(barks).toBe(1);
+});


### PR DESCRIPTION
## Summary

Closes #7677.

When a child schema declared via `defineEntity()` extends a parent with `discriminatorColumn` and provides its own `discriminatorValue`, the inherited discriminator property is now typed as the **literal value** rather than the parent's broad enum/string. A union of sibling subtypes (e.g. `Cat | Dog`) therefore forms a proper discriminated union, so `pet.type === AnimalType.CAT` correctly narrows `pet` and exposes child-only properties without a cast.

## Approach

Purely a type-level change — no runtime behavior was touched.

- `EntitySchemaWithMeta` gains a `'~discriminatorColumn'?` phantom marker (mirrors the existing `'~entityName'` placement: schema-side and `class`-side).
- `defineEntity()`'s first overload captures three new const generics (`TDiscriminatorColumn`, `TDiscriminatorValue`, `TBaseDiscriminatorColumn`) and threads them through `EntityMetadataWithProperties` and `InferEntityFromProperties`.
- A small `NarrowDiscriminator` helper replaces the inherited column type with the literal `discriminatorValue` when both markers are present; falls through to `Base` otherwise.

Both `extends: ParentSchema` and `extends: ParentClass` propagate the marker — the regression test exercises the class form (matching the original report).

Bench instantiation baselines were bumped accordingly (the new generics add a small fixed cost per schema).