### PR TITLE
fix(sql): nest auto-joins inside a join cond's target to avoid forward references

### DIFF
--- a/packages/sql/src/query/QueryBuilder.ts
+++ b/packages/sql/src/query/QueryBuilder.ts
@@ -2996,6 +2996,7 @@ export class QueryBuilder<
       aliased: [QueryType.SELECT, QueryType.COUNT].includes(this.type),
     })!;
     const criteriaNode = CriteriaNodeFactory.createNode<Entity>(this.metadata, prop.targetMeta!.class, cond);
+    const joinCountBefore = Object.keys(this.#state.joins).length;
     cond = criteriaNode.process(this as IQueryBuilder<Entity>, { ignoreBranching: true, alias });
     let aliasedName = `${fromAlias}.${prop.name}#${alias}`;
     path ??= `${Object.values(this.#state.joins).find(j => j.alias === fromAlias)?.path ?? Utils.className(entityName)}.${prop.name}`;
@@ -3025,6 +3026,35 @@ export class QueryBuilder<
       // MANY_TO_ONE
       this.#state.joins[aliasedName] = this.helper.joinManyToOneReference(prop, ownerAlias, alias, type, cond, schema);
       this.#state.joins[aliasedName].path ??= path;
+    }
+
+    // auto-joins added by cond processing that depend on the new alias would otherwise produce a
+    // forward reference (the auto-join's ON refers to alias, while alias's ON refers back to it);
+    // fold them into the new join so both aliases share scope in the outer ON clause (issue #7681)
+    const condJoin = this.#state.joins[aliasedName];
+    const joinKeys = Object.keys(this.#state.joins);
+
+    for (let i = joinCountBefore; i < joinKeys.length; i++) {
+      const j = this.#state.joins[joinKeys[i]];
+
+      if (j === condJoin || j.ownerAlias !== alias) {
+        continue;
+      }
+
+      const nestedType =
+        j.type === JoinType.innerJoin
+          ? JoinType.nestedInnerJoin
+          : j.type === JoinType.leftJoin
+            ? JoinType.nestedLeftJoin
+            : undefined;
+
+      if (!nestedType) {
+        continue;
+      }
+
+      const nested = (condJoin.nested ??= new Set());
+      j.type = nestedType;
+      nested.add(j);
     }
 
     return { prop, key: aliasedName };

--- a/packages/sql/src/query/QueryBuilder.ts
+++ b/packages/sql/src/query/QueryBuilder.ts
@@ -3041,19 +3041,8 @@ export class QueryBuilder<
         continue;
       }
 
-      const nestedType =
-        j.type === JoinType.innerJoin
-          ? JoinType.nestedInnerJoin
-          : j.type === JoinType.leftJoin
-            ? JoinType.nestedLeftJoin
-            : undefined;
-
-      if (!nestedType) {
-        continue;
-      }
-
       const nested = (condJoin.nested ??= new Set());
-      j.type = nestedType;
+      j.type = j.type === JoinType.innerJoin ? JoinType.nestedInnerJoin : JoinType.nestedLeftJoin;
       nested.add(j);
     }
 

--- a/tests/issues/GH7681.test.ts
+++ b/tests/issues/GH7681.test.ts
@@ -34,6 +34,9 @@ class User {
 
   @ManyToOne(() => Company, { nullable: true })
   belongsTo?: Rel<Company> | null;
+
+  @ManyToOne(() => Company)
+  primaryCompany!: Rel<Company>;
 }
 
 let orm: MikroORM;
@@ -46,12 +49,28 @@ beforeAll(async () => {
   });
   await orm.schema.refresh();
 
-  const owner = orm.em.create(User, { id: 'owner-1', name: 'Owner' });
-  const otherOwner = orm.em.create(User, { id: 'owner-2', name: 'Other Owner' });
+  const placeholder = orm.em.create(Company, { id: 'placeholder', title: 'Placeholder' });
+  await orm.em.flush();
+  const owner = orm.em.create(User, { id: 'owner-1', name: 'Owner', primaryCompany: placeholder });
+  const otherOwner = orm.em.create(User, {
+    id: 'owner-2',
+    name: 'Other Owner',
+    primaryCompany: placeholder,
+  });
   const matchingCompany = orm.em.create(Company, { id: 'matching', title: 'Matching', owner });
   const otherCompany = orm.em.create(Company, { id: 'other', title: 'Other', owner: otherOwner });
-  orm.em.create(User, { id: 'emp-match', name: 'Matched Employee', belongsTo: matchingCompany });
-  orm.em.create(User, { id: 'emp-other', name: 'Other Employee', belongsTo: otherCompany });
+  orm.em.create(User, {
+    id: 'emp-match',
+    name: 'Matched Employee',
+    belongsTo: matchingCompany,
+    primaryCompany: matchingCompany,
+  });
+  orm.em.create(User, {
+    id: 'emp-other',
+    name: 'Other Employee',
+    belongsTo: otherCompany,
+    primaryCompany: otherCompany,
+  });
   orm.em.create(Company, { id: 'company-1', title: 'C1', owner });
   await orm.em.flush();
   orm.em.clear();
@@ -68,9 +87,34 @@ test('GH #7681: leftJoinAndSelect with relation-traversing ON cond produces vali
     .orderBy({ id: 'asc' });
 
   expect(qb.getQuery()).toBe(
-    'select `c0`.*, `emp0`.`id` as `emp0__id`, `emp0`.`name` as `emp0__name`, `emp0`.`belongs_to_id` as `emp0__belongs_to_id` ' +
+    'select `c0`.*, `emp0`.`id` as `emp0__id`, `emp0`.`name` as `emp0__name`, `emp0`.`belongs_to_id` as `emp0__belongs_to_id`, `emp0`.`primary_company_id` as `emp0__primary_company_id` ' +
       'from `company` as `c0` ' +
       'left join (`user` as `emp0` left join `company` as `c1` on `emp0`.`belongs_to_id` = `c1`.`id`) ' +
+      'on `c0`.`id` = `emp0`.`belongs_to_id` and `c1`.`owner_id` = ? ' +
+      'where `c0`.`id` in (?, ?) ' +
+      'order by `c0`.`id` asc',
+  );
+
+  const res = await qb.getResult();
+  expect(res).toHaveLength(2);
+  expect(res[0].id).toBe('matching');
+  expect(res[0].employees.getItems().map(e => e.id)).toEqual(['emp-match']);
+  expect(res[1].id).toBe('other');
+  expect(res[1].employees.getItems()).toEqual([]);
+});
+
+test('GH #7681: non-nullable to-one cond traversal nests as inner join', async () => {
+  const qb = orm.em
+    .createQueryBuilder(Company, 'c0')
+    .select('*')
+    .where({ id: { $in: ['matching', 'other'] } })
+    .leftJoinAndSelect('employees', 'emp0', { primaryCompany: { owner: 'owner-1' } })
+    .orderBy({ id: 'asc' });
+
+  expect(qb.getQuery()).toBe(
+    'select `c0`.*, `emp0`.`id` as `emp0__id`, `emp0`.`name` as `emp0__name`, `emp0`.`belongs_to_id` as `emp0__belongs_to_id`, `emp0`.`primary_company_id` as `emp0__primary_company_id` ' +
+      'from `company` as `c0` ' +
+      'left join (`user` as `emp0` inner join `company` as `c1` on `emp0`.`primary_company_id` = `c1`.`id`) ' +
       'on `c0`.`id` = `emp0`.`belongs_to_id` and `c1`.`owner_id` = ? ' +
       'where `c0`.`id` in (?, ?) ' +
       'order by `c0`.`id` asc',

--- a/tests/issues/GH7681.test.ts
+++ b/tests/issues/GH7681.test.ts
@@ -1,0 +1,85 @@
+import 'reflect-metadata';
+import {
+  Entity,
+  ManyToOne,
+  OneToMany,
+  PrimaryKey,
+  Property,
+  ReflectMetadataProvider,
+} from '@mikro-orm/decorators/legacy';
+import { Collection, MikroORM, type Rel } from '@mikro-orm/sqlite';
+
+@Entity()
+class Company {
+  @PrimaryKey({ type: 'string' })
+  id!: string;
+
+  @Property()
+  title!: string;
+
+  @ManyToOne(() => User, { nullable: true })
+  owner?: Rel<User> | null;
+
+  @OneToMany(() => User, u => u.belongsTo)
+  employees = new Collection<User>(this);
+}
+
+@Entity()
+class User {
+  @PrimaryKey({ type: 'string' })
+  id!: string;
+
+  @Property()
+  name!: string;
+
+  @ManyToOne(() => Company, { nullable: true })
+  belongsTo?: Rel<Company> | null;
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    dbName: ':memory:',
+    entities: [Company, User],
+    metadataProvider: ReflectMetadataProvider,
+  });
+  await orm.schema.refresh();
+
+  const owner = orm.em.create(User, { id: 'owner-1', name: 'Owner' });
+  const otherOwner = orm.em.create(User, { id: 'owner-2', name: 'Other Owner' });
+  const matchingCompany = orm.em.create(Company, { id: 'matching', title: 'Matching', owner });
+  const otherCompany = orm.em.create(Company, { id: 'other', title: 'Other', owner: otherOwner });
+  orm.em.create(User, { id: 'emp-match', name: 'Matched Employee', belongsTo: matchingCompany });
+  orm.em.create(User, { id: 'emp-other', name: 'Other Employee', belongsTo: otherCompany });
+  orm.em.create(Company, { id: 'company-1', title: 'C1', owner });
+  await orm.em.flush();
+  orm.em.clear();
+});
+
+afterAll(() => orm.close(true));
+
+test('GH #7681: leftJoinAndSelect with relation-traversing ON cond produces valid SQL', async () => {
+  const qb = orm.em
+    .createQueryBuilder(Company, 'c0')
+    .select('*')
+    .where({ id: { $in: ['matching', 'other'] } })
+    .leftJoinAndSelect('employees', 'emp0', { belongsTo: { owner: 'owner-1' } })
+    .orderBy({ id: 'asc' });
+
+  expect(qb.getQuery()).toBe(
+    'select `c0`.*, `emp0`.`id` as `emp0__id`, `emp0`.`name` as `emp0__name`, `emp0`.`belongs_to_id` as `emp0__belongs_to_id` ' +
+      'from `company` as `c0` ' +
+      'left join (`user` as `emp0` left join `company` as `c1` on `emp0`.`belongs_to_id` = `c1`.`id`) ' +
+      'on `c0`.`id` = `emp0`.`belongs_to_id` and `c1`.`owner_id` = ? ' +
+      'where `c0`.`id` in (?, ?) ' +
+      'order by `c0`.`id` asc',
+  );
+
+  const res = await qb.getResult();
+  expect(res).toHaveLength(2);
+  expect(res[0].id).toBe('matching');
+  expect(res[0].employees.getItems().map(e => e.id)).toEqual(['emp-match']);
+  expect(res[1].id).toBe('other');
+  expect(res[1].employees.getItems()).toEqual([]);
+});


### PR DESCRIPTION
## Summary

`QueryBuilder.leftJoinAndSelect(field, alias, cond)` produced invalid SQL when `cond` traversed a relation, e.g. `leftJoinAndSelect('employees', 'emp0', { belongsTo: { owner: 'X' } })`. The auto-join triggered by `criteriaNode.process` had its `ownerAlias` set to the very alias we were about to register, so both ON clauses ended up cross-referencing each other:

```sql
LEFT JOIN company AS c1   ON emp0.belongs_to_id = c1.id            -- refs emp0
LEFT JOIN user    AS emp0 ON c0.id = emp0.belongs_to_id AND c1.owner_id = ?  -- refs c1
```

Both Postgres and SQLite rejected the query. The two ON clauses can't be reordered out of the cycle.

The fix folds any auto-join with `ownerAlias === alias` into the new join's `nested` set (and switches its type to the matching `nested*Join` variant). Both aliases now share scope inside a single parenthesised join expression:

```sql
LEFT JOIN (`user` AS `emp0` LEFT JOIN `company` AS `c1` ON `emp0`.`belongs_to_id` = `c1`.`id`)
       ON `c0`.`id` = `emp0`.`belongs_to_id` AND `c1`.`owner_id` = ?
```

Only `innerJoin`/`leftJoin` are folded; `pivotJoin`, lateral, and already-nested types are left alone.

Closes #7681