### PR TITLE
fix(core): apply filters to inverse 1:1 populate joins instead of duplicating them

### DIFF
--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -553,7 +553,9 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
         prop.strategy || hint.strategy || options.strategy || this.config.get('loadStrategy'),
         prop.kind,
       );
-      const joined = strategy === LoadStrategy.JOINED && prop.kind !== ReferenceKind.SCALAR;
+      const joined =
+        (strategy === LoadStrategy.JOINED || (prop.kind === ReferenceKind.ONE_TO_ONE && !prop.owner)) &&
+        prop.kind !== ReferenceKind.SCALAR;
 
       if (!joined && !hint.filter) {
         continue;
@@ -645,16 +647,18 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
         let found = false;
 
         for (const hint of populated) {
-          if (!hint.all) {
-            hint.filter = true;
-          }
-
           const strategy = getLoadingStrategy(
             prop.strategy || hint.strategy || options.strategy || this.config.get('loadStrategy'),
             prop.kind,
           );
+          // inverse 1:1 always produces a JOIN (forced by `joinedProps()`), regardless of strategy
+          const willJoin = strategy === LoadStrategy.JOINED || (prop.kind === ReferenceKind.ONE_TO_ONE && !prop.owner);
 
-          if (hint.field === `${prop.name}:ref` || (hint.filter && strategy === LoadStrategy.JOINED)) {
+          if (!hint.all || willJoin) {
+            hint.filter = true;
+          }
+
+          if (hint.field === `${prop.name}:ref` || (hint.filter && willJoin)) {
             found = true;
           }
         }

--- a/tests/issues/GH7680.test.ts
+++ b/tests/issues/GH7680.test.ts
@@ -1,0 +1,65 @@
+import { defineEntity, MikroORM, p } from '@mikro-orm/sqlite';
+
+const PersonSchema = defineEntity({
+  name: 'Person',
+  abstract: true,
+  inheritance: 'tpt',
+  filters: {
+    excludeDeleted: { name: 'excludeDeleted', cond: { deletedAt: null }, default: true },
+  },
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+    deletedAt: p.datetime().nullable(),
+  },
+});
+
+const BadgeSchema = defineEntity({
+  name: 'Badge',
+  properties: {
+    id: p.integer().primary(),
+    code: p.string(),
+    parentEmployee: () => p.oneToOne(EmployeeSchema).mappedBy('badge').ref().nullable(),
+    parentContractor: () => p.oneToOne(ContractorSchema).mappedBy('temporaryBadge').ref().nullable(),
+  },
+});
+
+const EmployeeSchema = defineEntity({
+  name: 'Employee',
+  extends: PersonSchema,
+  properties: {
+    badge: () => p.oneToOne(BadgeSchema).owner().eager(),
+  },
+});
+
+const ContractorSchema = defineEntity({
+  name: 'Contractor',
+  extends: PersonSchema,
+  properties: {
+    temporaryBadge: () => p.oneToOne(BadgeSchema).owner().eager().nullable(),
+  },
+});
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    dbName: ':memory:',
+    entities: [PersonSchema, BadgeSchema, EmployeeSchema, ContractorSchema],
+  });
+  await orm.schema.create();
+});
+
+afterAll(() => orm.close(true));
+
+test('eager OneToOne is populated when filter is set on TPT base (#7680)', async () => {
+  const badge = orm.em.create(BadgeSchema, { id: 1, code: 'B-001' });
+  orm.em.create(EmployeeSchema, { id: 1, name: 'Alice', badge });
+  await orm.em.flush();
+  orm.em.clear();
+
+  const found = await orm.em.findOneOrFail(EmployeeSchema, { id: 1 }, { populate: ['*'] });
+  expect(found.badge).not.toBeNull();
+  expect(found.badge!.id).toBe(1);
+  expect(found.badge!.code).toBe('B-001');
+});


### PR DESCRIPTION
## Summary

When a filter was active on the target of an inverse OneToOne relation, the existing populate hint produced a JOIN (forced by `joinedProps()`) but the filter was applied via a separate `:ref` hint that created a redundant JOIN. With TPT inheritance the duplicate joins confused hydration, so the eager relation was hydrated as `null`.

The fix recognises that inverse OneToOne always produces a JOIN regardless of the load strategy, so the filter can be applied to the existing JOIN without needing a duplicate `:ref` join.

Closes #7680