### PR TITLE
fix(core): apply array customType to scalar arrays defined via property chain

### DIFF
--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -2204,7 +2204,7 @@ export class MetadataDiscovery {
       prop.customType = new t.enumArray(`${meta.className}.${prop.name}`, prop.items);
     }
 
-    const isArray = prop.type?.toLowerCase() === 'array' || prop.type?.toString().endsWith('[]');
+    const isArray = prop.array || prop.type?.toLowerCase() === 'array' || prop.type?.toString().endsWith('[]');
 
     if (objectEmbeddable && !prop.customType && isArray) {
       prop.customType = new t.json();

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -1228,7 +1228,9 @@ export class EntityMetadata<Entity = any, Class extends EntityCtor<Entity> = Ent
         return false;
       }
 
-      return prop.kind === ReferenceKind.SCALAR && ['string', 'number', 'boolean', 'Date'].includes(prop.type);
+      return (
+        prop.kind === ReferenceKind.SCALAR && !prop.array && ['string', 'number', 'boolean', 'Date'].includes(prop.type)
+      );
     });
     this.hydrateProps = this.props.filter(prop => {
       // `prop.userDefined` is either `undefined` or `false`

--- a/packages/core/src/utils/EntityComparator.ts
+++ b/packages/core/src/utils/EntityComparator.ts
@@ -780,7 +780,7 @@ export class EntityComparator {
 
     ret += `) {\n`;
 
-    if (['number', 'string', 'boolean'].includes(prop.type.toLowerCase())) {
+    if (!prop.array && ['number', 'string', 'boolean'].includes(prop.type.toLowerCase())) {
       return ret + `    ret${dataKey} = entity${entityKey}${unwrap};\n  }\n`;
     }
 

--- a/tests/issues/GH7688.test.ts
+++ b/tests/issues/GH7688.test.ts
@@ -1,0 +1,46 @@
+// GH #7688 - defineEntity with `p.string().array().nullable()` throws ValidationError on insert
+import { defineEntity, MikroORM, p } from '@mikro-orm/sqlite';
+
+const User = defineEntity({
+  name: 'User7688',
+  properties: {
+    id: p.integer().primary(),
+    tags: p.string().array().nullable(),
+    aliases: p.string().array(),
+  },
+});
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    dbName: ':memory:',
+    entities: [User],
+    allowGlobalContext: true,
+  });
+  await orm.schema.refresh();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+test('GH #7688 - insert and update string array properties', async () => {
+  const user = orm.em.create(User, {
+    tags: ['foo', 'bar'],
+    aliases: ['a', 'b'],
+  });
+  await orm.em.flush();
+
+  orm.em.clear();
+  const found = await orm.em.findOneOrFail(User, user.id);
+  expect(found.tags).toEqual(['foo', 'bar']);
+  expect(found.aliases).toEqual(['a', 'b']);
+
+  found.tags = ['baz'];
+  await orm.em.flush();
+
+  orm.em.clear();
+  const reloaded = await orm.em.findOneOrFail(User, user.id);
+  expect(reloaded.tags).toEqual(['baz']);
+});


### PR DESCRIPTION
`p.string().array()` (and the equivalent `EntitySchema` shape with `type: 'string', array: true`) was marking the property as `array: true` but never resolving an `ArrayType` customType, so values were neither validated as arrays nor marshalled to a single column. Inserts crashed with `ValidationError` (`Trying to set ... of type 'string' to ... of type 'Array'`) or, past validation, with `2 values for 1 columns`.

- skip array properties from the scalar `validateProps` filter so the validator does not compare an array value against the inner type
- include `prop.array` in `isArray` so `t.array()` is wired up as the default customType for `array: true` scalars
- bypass the snapshot fast path for array props so the customType's `convertToDatabaseValue()` runs before insert/update

Closes #7688

🤖 Generated with [Claude Code](https://claude.com/claude-code)