### PR TITLE
chore(claude): auto-format and lint TS files on Write/Edit

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_response.filePath // .tool_input.file_path' | { read -r f; case \"$f\" in *.ts|*.tsx|*.js) [ -f \"$f\" ] && ./node_modules/.bin/oxfmt --write --no-error-on-unmatched-pattern \"$f\" && ./node_modules/.bin/oxlint --fix \"$f\" ;; esac; } 2>/dev/null || true"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Adds a project-level `.claude/settings.json` with a `PostToolUse` hook on `Write|Edit` that runs `oxfmt --write` and `oxlint --fix` on just the changed file when its extension is `.ts`/`.tsx`/`.js`.

Single-file invocations keep it sub-30ms per write, matching the per-file `lint-staged` config in `package.json`. With this in place, Claude-driven edits land formatted and lint-clean without needing a manual `yarn format` pass before commit (the kind of CI failure that motivated this).

The hook is silent on success and `|| true` on failure, so it never blocks a write.