### PR TITLE
docs: fix default propagation in `@Transactional()` examples

### DIFF
--- a/docs/docs/transactions.md
+++ b/docs/docs/transactions.md
@@ -164,7 +164,7 @@ class BookService {
     await this.addAuthor(); // Nested call creates savepoint
   }
   
-  @Transactional()
+  @Transactional({ propagation: TransactionPropagation.NESTED })
   async addAuthor() {
     const author = new Author(...);
     author.name = 'Eric Evans';
@@ -249,7 +249,7 @@ class LibraryService {
     await this.addBook(author); // Will throw error
   }
   
-  @Transactional({ propagation: TransactionPropagation.REQUIRED })
+  @Transactional()
   async addBook(author: Author) {
     const book = new Book(...);
     book.title = 'Clean Code';

--- a/docs/versioned_docs/version-7.0/transactions.md
+++ b/docs/versioned_docs/version-7.0/transactions.md
@@ -164,7 +164,7 @@ class BookService {
     await this.addAuthor(); // Nested call creates savepoint
   }
   
-  @Transactional()
+  @Transactional({ propagation: TransactionPropagation.NESTED })
   async addAuthor() {
     const author = new Author(...);
     author.name = 'Eric Evans';
@@ -249,7 +249,7 @@ class LibraryService {
     await this.addBook(author); // Will throw error
   }
   
-  @Transactional({ propagation: TransactionPropagation.REQUIRED })
+  @Transactional()
   async addBook(author: Author) {
     const book = new Book(...);
     book.title = 'Clean Code';


### PR DESCRIPTION
Since v7, `TransactionPropagation.NESTED` is not anymore the default when using the `@Transactional()` decorator. Fix related examples to reflect that change.