### PR TITLE
feat(sql): bind `getKysely()` to the current transaction context

### DIFF
--- a/docs/docs/kysely.md
+++ b/docs/docs/kysely.md
@@ -29,6 +29,35 @@ const kysely = orm.em.getKysely({
 
 These options are described in detail in the [Plugin Options](#plugin-options) section below.
 
+## Transaction Context
+
+`getKysely()` automatically uses the EntityManager's current transaction context. When called inside `em.transactional(...)` (or after `em.begin()`), the returned Kysely instance is bound to the active transaction, so any query executed via Kysely's own `.execute()` / `.executeTakeFirst*()` participates in that transaction and will be rolled back together with it.
+
+```ts
+await orm.em.transactional(async em => {
+  const kysely = em.getKysely({ tableNamingStrategy: 'entity', convertValues: true });
+
+  // runs inside the transaction
+  await kysely.insertInto('Doc').values({ title: 't', content: 'hello' }).execute();
+
+  throw new Error('boom'); // rolls back the insert above
+});
+```
+
+If you need a Kysely instance that is **not** bound to the current transaction — e.g. to read from the pool while you're inside a transactional block — fork the EntityManager first. A forked EM has no transaction context, so `getKysely()` falls back to the pool client:
+
+```ts
+await orm.em.transactional(async em => {
+  // bound to the current transaction
+  await em.getKysely().selectFrom('user').selectAll().execute();
+
+  // bound to the pool, runs outside the transaction
+  await em.fork().getKysely().selectFrom('audit_log').selectAll().execute();
+});
+```
+
+The `type` option (`'read'` / `'write'`) is only honored outside a transaction — inside a transaction the connection is already pinned.
+
 ## Using Entity and Property Names in Queries
 
 One of the most useful plugin features is the ability to write Kysely queries using your entity and property names instead of raw table and column names. This works regardless of how you define your entities — decorators, `EntitySchema`, or `defineEntity`.

--- a/packages/sql/src/SqlEntityManager.ts
+++ b/packages/sql/src/SqlEntityManager.ts
@@ -80,7 +80,28 @@ export class SqlEntityManager<Driver extends AbstractSqlDriver = AbstractSqlDriv
   }
 
   /**
-   * Returns configured Kysely instance.
+   * Returns a configured Kysely instance bound to this EntityManager.
+   *
+   * When the EntityManager is inside a transaction (e.g. within `em.transactional(...)`, or after
+   * `em.begin()`), the returned Kysely instance automatically uses the transaction context, so any
+   * queries executed via Kysely's own `.execute()` / `.executeTakeFirst*()` participate in the
+   * current transaction.
+   *
+   * If you need a Kysely instance that is **not** bound to the current transaction (e.g. to perform
+   * a side query against the pool while inside a transactional block), fork the EntityManager first:
+   *
+   * ```ts
+   * await em.transactional(async em => {
+   *   // bound to the current transaction
+   *   await em.getKysely().selectFrom('user').selectAll().execute();
+   *
+   *   // bound to the pool, runs outside the transaction
+   *   await em.fork().getKysely().selectFrom('audit_log').selectAll().execute();
+   * });
+   * ```
+   *
+   * The `options.type` (`'read'` / `'write'`) is only honored outside a transaction — inside a
+   * transaction the connection is already pinned.
    */
   getKysely<TDB = undefined, TOptions extends GetKyselyOptions = GetKyselyOptions>(
     options: TOptions = {} as TOptions,
@@ -89,7 +110,9 @@ export class SqlEntityManager<Driver extends AbstractSqlDriver = AbstractSqlDriv
       ? InferKyselyDB<EntitiesFromManager<this>, TOptions> & InferClassEntityDB<AllEntitiesFromManager<this>, TOptions>
       : TDB
   > {
-    let kysely = this.getConnection(options.type).getClient();
+    const context = this.getContext(false);
+    const ctx = context.getTransactionContext<Kysely<any>>();
+    let kysely: Kysely<any> = ctx ?? this.getConnection(options.type).getClient();
     if (
       options.columnNamingStrategy != null ||
       options.tableNamingStrategy != null ||

--- a/tests/features/get-kysely-transaction-context.test.ts
+++ b/tests/features/get-kysely-transaction-context.test.ts
@@ -1,0 +1,116 @@
+import { defineEntity, p } from '@mikro-orm/core';
+import { MikroORM, Type } from '@mikro-orm/sqlite';
+
+class HexEncodedType extends Type<string | null, string | null> {
+  override convertToJSValueSQL(key: string): string {
+    return `hex(${key})`;
+  }
+
+  override convertToJSValue(value: string | null): string | null {
+    if (value == null) {
+      return value;
+    }
+    return Buffer.from(value, 'hex').toString('utf8');
+  }
+
+  override convertToDatabaseValueSQL(key: string): string {
+    return `unhex(${key})`;
+  }
+
+  override convertToDatabaseValue(value: string | null): string | null {
+    if (value == null) {
+      return value;
+    }
+    return Buffer.from(value, 'utf8').toString('hex');
+  }
+}
+
+const Doc = defineEntity({
+  name: 'Doc',
+  properties: {
+    id: p.integer().primary().autoincrement(),
+    title: p.string(),
+    content: p.type(HexEncodedType),
+  },
+});
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = new MikroORM({
+    entities: [Doc],
+    dbName: ':memory:',
+  });
+  await orm.schema.refresh();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+beforeEach(async () => {
+  await orm.em.getKysely<{ Doc: object }>({ tableNamingStrategy: 'entity' }).deleteFrom('Doc').execute();
+});
+
+test('getKysely() inside transactional commits writes via Kysely .execute()', async () => {
+  await orm.em.transactional(async em => {
+    const kysely = em.getKysely<{ Doc: { id: number; title: string; content: string } }>({
+      tableNamingStrategy: 'entity',
+      convertValues: true,
+    });
+
+    await kysely.insertInto('Doc').values({ id: 1, title: 't', content: 'committed' }).execute();
+  });
+
+  const row = await orm.em
+    .fork()
+    .getKysely<{ Doc: { id: number; title: string; content: string } }>({
+      tableNamingStrategy: 'entity',
+      convertValues: true,
+    })
+    .selectFrom('Doc')
+    .selectAll()
+    .where('id', '=', 1)
+    .executeTakeFirstOrThrow();
+
+  expect(row.content).toBe('committed');
+});
+
+test('getKysely() inside transactional rolls back writes when the tx throws', async () => {
+  await expect(
+    orm.em.transactional(async em => {
+      const kysely = em.getKysely<{ Doc: { id: number; title: string; content: string } }>({
+        tableNamingStrategy: 'entity',
+        convertValues: true,
+      });
+
+      await kysely.insertInto('Doc').values({ id: 2, title: 't', content: 'rolled-back' }).execute();
+
+      // sanity check: visible inside the same tx
+      const inside = await kysely.selectFrom('Doc').selectAll().where('id', '=', 2).executeTakeFirstOrThrow();
+      expect(inside.content).toBe('rolled-back');
+
+      throw new Error('boom');
+    }),
+  ).rejects.toThrow('boom');
+
+  const after = await orm.em
+    .fork()
+    .getKysely<{ Doc: { id: number; title: string; content: string } }>({ tableNamingStrategy: 'entity' })
+    .selectFrom('Doc')
+    .selectAll()
+    .where('id', '=', 2)
+    .executeTakeFirst();
+
+  expect(after).toBeUndefined();
+});
+
+test('em.fork().getKysely() inside transactional returns a non-tx-bound instance', async () => {
+  await orm.em.transactional(async em => {
+    const trxKysely = em.getKysely<{ Doc: object }>({ tableNamingStrategy: 'entity' });
+    const forkKysely = em.fork().getKysely<{ Doc: object }>({ tableNamingStrategy: 'entity' });
+    // the forked EM has no tx context, so its kysely is a fresh plugin-wrapped instance
+    // over the pool client — not the same instance as the tx-bound kysely returned above.
+    expect(trxKysely).not.toBe(forkKysely);
+  });
+});


### PR DESCRIPTION
## Summary

`em.getKysely()` now uses the EM's transaction context when present, so queries built via the returned Kysely instance (and executed via `.execute()` / `.executeTakeFirst*()`) participate in the active transaction instead of silently running on the pool.

Previously the only way to keep a kysely-built query inside an `em.transactional(...)` block was to compile and route through `em.execute(raw(query))`, which bypasses Kysely's executor and therefore the plugin's result-side transforms (`convertToJSValue`, `columnNamingStrategy: 'property'`). Surfaced from the follow-up repro on #7679.

## Opting out

A forked EM has no transaction context, so `getKysely()` falls back to the pool client:

```ts
await em.transactional(async em => {
  await em.getKysely().selectFrom('user').selectAll().execute();          // in the tx
  await em.fork().getKysely().selectFrom('audit_log').selectAll().execute(); // pool
});
```

`options.type` (`'read'`/`'write'`) is only honored outside a transaction — inside a transaction the connection is already pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)