### PR TITLE
fix(core): treat `LockMode.NONE` like `undefined` in `em.findOne()`

### DIFF
--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -982,7 +982,8 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
     where = await em.processWhere(entityName, where, options, 'read');
     validateEmptyWhere(where);
     em.checkLockRequirements(options.lockMode, meta);
-    const isOptimisticLocking = options.lockMode == null || options.lockMode === LockMode.OPTIMISTIC;
+    const isOptimisticLocking =
+      options.lockMode == null || options.lockMode === LockMode.NONE || options.lockMode === LockMode.OPTIMISTIC;
 
     if (entity && !em.shouldRefresh(meta, entity, options) && isOptimisticLocking) {
       return em.lockAndPopulate(meta, entity, where, options);

--- a/tests/issues/GH7702.test.ts
+++ b/tests/issues/GH7702.test.ts
@@ -1,0 +1,42 @@
+// GH #7702 - `LockMode.NONE` should behave like `lockMode: undefined` and serve `findOne` from the identity map
+import { defineEntity, LockMode, MikroORM, p } from '@mikro-orm/sqlite';
+import { mockLogger } from '../helpers';
+
+const User = defineEntity({
+  name: 'User7702',
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+  },
+});
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    dbName: ':memory:',
+    entities: [User],
+    allowGlobalContext: true,
+  });
+  await orm.schema.refresh();
+  orm.em.create(User, { id: 1, name: 'Alice' });
+  await orm.em.flush();
+  orm.em.clear();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+test('GH #7702 - LockMode.NONE serves findOne from identity map (matches undefined)', async () => {
+  await orm.em.findOneOrFail(User, 1);
+
+  const mock = mockLogger(orm);
+
+  await orm.em.findOneOrFail(User, 1);
+  await orm.em.findOneOrFail(User, 1, { lockMode: undefined });
+  await orm.em.findOneOrFail(User, 1, { lockMode: LockMode.NONE });
+
+  const selectCount = mock.mock.calls.filter(([msg]) => /select/i.test(String(msg))).length;
+  expect(selectCount).toBe(0);
+});


### PR DESCRIPTION
`findOne` was reaching for a fresh DB query whenever `lockMode: LockMode.NONE` was passed, because `LockMode.NONE === 0` failed both the `== null` and `=== LockMode.OPTIMISTIC` checks that guard the identity-map fast path. `lockMode: undefined` worked correctly, so `NONE` and "not specified" were silently divergent.

Closes #7702