### PR TITLE
fix(schema): centralize identifier-length truncation across platforms

### DIFF
--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -1975,7 +1975,7 @@ export class MetadataDiscovery {
 
     for (const check of meta.checks) {
       const fieldNames = check.property ? meta.properties[check.property].fieldNames : [];
-      check.name ??= this.#namingStrategy.indexName(meta.tableName, fieldNames, 'check');
+      check.name ??= this.#platform.getIndexName(meta.tableName, fieldNames, 'check');
 
       if (check.expression instanceof Function) {
         check.expression = check.expression(columns, table);
@@ -2004,7 +2004,7 @@ export class MetadataDiscovery {
 
         if (expression) {
           meta.checks.push({
-            name: this.#namingStrategy.indexName(meta.tableName, prop.fieldNames, 'check'),
+            name: this.#platform.getIndexName(meta.tableName, prop.fieldNames, 'check'),
             property: prop.name,
             expression,
           });

--- a/packages/core/src/platforms/Platform.ts
+++ b/packages/core/src/platforms/Platform.ts
@@ -813,8 +813,7 @@ export abstract class Platform {
   }
 
   /**
-   * Returns the default name of index for the given columns. Per-platform overrides may apply
-   * truncation/hashing to respect {@link getMaxAllowedIdentifierLength}.
+   * Returns the default name of index for the given columns
    */
   getIndexName(
     tableName: string,

--- a/packages/core/src/platforms/Platform.ts
+++ b/packages/core/src/platforms/Platform.ts
@@ -813,12 +813,13 @@ export abstract class Platform {
   }
 
   /**
-   * Returns the default name of index for the given columns
+   * Returns the default name of index for the given columns. Per-platform overrides may apply
+   * truncation/hashing to respect {@link getMaxAllowedIdentifierLength}.
    */
   getIndexName(
     tableName: string,
     columns: string[],
-    type: 'index' | 'unique' | 'foreign' | 'primary' | 'sequence',
+    type: 'index' | 'unique' | 'foreign' | 'primary' | 'sequence' | 'check',
   ): string {
     return this.namingStrategy.indexName(tableName, columns, type);
   }

--- a/packages/core/src/platforms/Platform.ts
+++ b/packages/core/src/platforms/Platform.ts
@@ -813,14 +813,33 @@ export abstract class Platform {
   }
 
   /**
-   * Returns the default name of index for the given columns
+   * Maximum length of identifiers (table, column, index, constraint, …) the platform supports.
+   * Names produced by {@link getIndexName} above this limit are hash-truncated. Defaults to
+   * `Infinity` (no truncation); SQL platforms override with their engine's limit
+   * (PG 63, MySQL/MariaDB 64, MSSQL/Oracle 128).
+   */
+  getMaxIdentifierLength(): number {
+    return Infinity;
+  }
+
+  /**
+   * Returns the default name of index for the given columns, hash-truncated if it would
+   * exceed {@link getMaxIdentifierLength}.
    */
   getIndexName(
     tableName: string,
     columns: string[],
     type: 'index' | 'unique' | 'foreign' | 'primary' | 'sequence' | 'check',
   ): string {
-    return this.namingStrategy.indexName(tableName, columns, type);
+    const indexName = this.namingStrategy.indexName(tableName, columns, type);
+    const max = this.getMaxIdentifierLength();
+
+    if (indexName.length > max) {
+      const suffix = type === 'primary' ? 'pkey' : type;
+      return `${indexName.substring(0, max - 8 - type.length)}_${Utils.hash(indexName, 5)}_${suffix}`;
+    }
+
+    return indexName;
   }
 
   /** Returns the default primary key constraint name. */

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -1260,9 +1260,11 @@ export class EntityMetadata<Entity = any, Class extends EntityCtor<Entity> = Ent
     this.virtual = !!this.expression && !this.view;
 
     if (config) {
+      const platform = config.getPlatform();
+
       for (const prop of this.props) {
         if (prop.enum && !prop.nativeEnumName && prop.items?.every(item => typeof item === 'string')) {
-          const name = config.getNamingStrategy().indexName(this.tableName, prop.fieldNames, 'check');
+          const name = platform.getIndexName(this.tableName, prop.fieldNames, 'check');
           const exists = this.checks.findIndex(check => check.name === name);
 
           if (exists !== -1) {
@@ -1272,9 +1274,7 @@ export class EntityMetadata<Entity = any, Class extends EntityCtor<Entity> = Ent
           this.checks.push({
             name,
             property: prop.name,
-            expression: config
-              .getPlatform()
-              .getEnumCheckConstraintExpression(prop.fieldNames[0], prop.items as string[]),
+            expression: platform.getEnumCheckConstraintExpression(prop.fieldNames[0], prop.items as string[]),
           });
         }
       }

--- a/packages/mssql/src/MsSqlPlatform.ts
+++ b/packages/mssql/src/MsSqlPlatform.ts
@@ -15,7 +15,6 @@ import {
   raw,
   RawQueryFragment,
   Type,
-  Utils,
 } from '@mikro-orm/sql';
 // @ts-expect-error no types available
 import SqlString from 'tsqlstring';
@@ -83,23 +82,9 @@ export class MsSqlPlatform extends AbstractSqlPlatform {
     return false;
   }
 
-  /**
-   * Returns the default name of index for the given columns
-   * cannot go past 128 character length for identifiers in SQL Server (sysname)
-   */
-  override getIndexName(
-    tableName: string,
-    columns: string[],
-    type: 'index' | 'unique' | 'foreign' | 'primary' | 'sequence' | 'check',
-  ): string {
-    const indexName = super.getIndexName(tableName, columns, type);
-
-    if (indexName.length > 128) {
-      const suffix = type === 'primary' ? 'pkey' : type;
-      return `${indexName.substring(0, 120 - type.length)}_${Utils.hash(indexName, 5)}_${suffix}`;
-    }
-
-    return indexName;
+  /** SQL Server identifier limit (sysname). */
+  override getMaxIdentifierLength(): number {
+    return 128;
   }
 
   override supportsSchemas(): boolean {

--- a/packages/mssql/src/MsSqlPlatform.ts
+++ b/packages/mssql/src/MsSqlPlatform.ts
@@ -15,6 +15,7 @@ import {
   raw,
   RawQueryFragment,
   Type,
+  Utils,
 } from '@mikro-orm/sql';
 // @ts-expect-error no types available
 import SqlString from 'tsqlstring';
@@ -80,6 +81,25 @@ export class MsSqlPlatform extends AbstractSqlPlatform {
 
   override indexForeignKeys(): boolean {
     return false;
+  }
+
+  /**
+   * Returns the default name of index for the given columns
+   * cannot go past 128 character length for identifiers in SQL Server (sysname)
+   */
+  override getIndexName(
+    tableName: string,
+    columns: string[],
+    type: 'index' | 'unique' | 'foreign' | 'primary' | 'sequence' | 'check',
+  ): string {
+    const indexName = super.getIndexName(tableName, columns, type);
+
+    if (indexName.length > 128) {
+      const suffix = type === 'primary' ? 'pkey' : type;
+      return `${indexName.substring(0, 120 - type.length)}_${Utils.hash(indexName, 5)}_${suffix}`;
+    }
+
+    return indexName;
   }
 
   override supportsSchemas(): boolean {

--- a/packages/oracledb/src/OraclePlatform.ts
+++ b/packages/oracledb/src/OraclePlatform.ts
@@ -79,6 +79,25 @@ export class OraclePlatform extends AbstractSqlPlatform {
     return false;
   }
 
+  /**
+   * Returns the default name of index for the given columns
+   * cannot go past 128 character length for identifiers in Oracle 12.2+ (pre-12.2 is 30 chars)
+   */
+  override getIndexName(
+    tableName: string,
+    columns: string[],
+    type: 'index' | 'unique' | 'foreign' | 'primary' | 'sequence' | 'check',
+  ): string {
+    const indexName = super.getIndexName(tableName, columns, type);
+
+    if (indexName.length > 128) {
+      const suffix = type === 'primary' ? 'pkey' : type;
+      return `${indexName.substring(0, 120 - type.length)}_${Utils.hash(indexName, 5)}_${suffix}`;
+    }
+
+    return indexName;
+  }
+
   override compareUuids(): string {
     return 'any';
   }

--- a/packages/oracledb/src/OraclePlatform.ts
+++ b/packages/oracledb/src/OraclePlatform.ts
@@ -79,23 +79,9 @@ export class OraclePlatform extends AbstractSqlPlatform {
     return false;
   }
 
-  /**
-   * Returns the default name of index for the given columns
-   * cannot go past 128 character length for identifiers in Oracle 12.2+ (pre-12.2 is 30 chars)
-   */
-  override getIndexName(
-    tableName: string,
-    columns: string[],
-    type: 'index' | 'unique' | 'foreign' | 'primary' | 'sequence' | 'check',
-  ): string {
-    const indexName = super.getIndexName(tableName, columns, type);
-
-    if (indexName.length > 128) {
-      const suffix = type === 'primary' ? 'pkey' : type;
-      return `${indexName.substring(0, 120 - type.length)}_${Utils.hash(indexName, 5)}_${suffix}`;
-    }
-
-    return indexName;
+  /** Oracle 12.2+ identifier limit (pre-12.2 is 30 chars). */
+  override getMaxIdentifierLength(): number {
+    return 128;
   }
 
   override compareUuids(): string {

--- a/packages/sql/src/dialects/mysql/BaseMySqlPlatform.ts
+++ b/packages/sql/src/dialects/mysql/BaseMySqlPlatform.ts
@@ -126,7 +126,7 @@ export class BaseMySqlPlatform extends AbstractSqlPlatform {
   override getIndexName(
     tableName: string,
     columns: string[],
-    type: 'index' | 'unique' | 'foreign' | 'primary' | 'sequence',
+    type: 'index' | 'unique' | 'foreign' | 'primary' | 'sequence' | 'check',
   ): string {
     if (type === 'primary') {
       return this.getDefaultPrimaryName(tableName, columns);

--- a/packages/sql/src/dialects/mysql/BaseMySqlPlatform.ts
+++ b/packages/sql/src/dialects/mysql/BaseMySqlPlatform.ts
@@ -1,5 +1,4 @@
 import {
-  Utils,
   type SimpleColumnMeta,
   type Type,
   type TransformContext,
@@ -119,10 +118,11 @@ export class BaseMySqlPlatform extends AbstractSqlPlatform {
     return true;
   }
 
-  /**
-   * Returns the default name of index for the given columns
-   * cannot go past 64 character length for identifiers in MySQL
-   */
+  /** MySQL/MariaDB identifier limit. */
+  override getMaxIdentifierLength(): number {
+    return 64;
+  }
+
   override getIndexName(
     tableName: string,
     columns: string[],
@@ -132,13 +132,7 @@ export class BaseMySqlPlatform extends AbstractSqlPlatform {
       return this.getDefaultPrimaryName(tableName, columns);
     }
 
-    const indexName = super.getIndexName(tableName, columns, type);
-
-    if (indexName.length > 64) {
-      return `${indexName.substring(0, 56 - type.length)}_${Utils.hash(indexName, 5)}_${type}`;
-    }
-
-    return indexName;
+    return super.getIndexName(tableName, columns, type);
   }
 
   override getDefaultPrimaryName(tableName: string, columns: string[]): string {

--- a/packages/sql/src/dialects/postgresql/BasePostgreSqlPlatform.ts
+++ b/packages/sql/src/dialects/postgresql/BasePostgreSqlPlatform.ts
@@ -473,23 +473,9 @@ export class BasePostgreSqlPlatform extends AbstractSqlPlatform {
     return 'public';
   }
 
-  /**
-   * Returns the default name of index for the given columns
-   * cannot go past 63 character length for identifiers in Postgres
-   */
-  override getIndexName(
-    tableName: string,
-    columns: string[],
-    type: 'index' | 'unique' | 'foreign' | 'primary' | 'sequence' | 'check',
-  ): string {
-    const indexName = super.getIndexName(tableName, columns, type);
-
-    if (indexName.length > 63) {
-      const suffix = type === 'primary' ? 'pkey' : type;
-      return `${indexName.substring(0, 55 - type.length)}_${Utils.hash(indexName, 5)}_${suffix}`;
-    }
-
-    return indexName;
+  /** Postgres identifier limit (NAMEDATALEN - 1). */
+  override getMaxIdentifierLength(): number {
+    return 63;
   }
 
   override getDefaultPrimaryName(tableName: string, columns: string[]): string {

--- a/packages/sql/src/dialects/postgresql/BasePostgreSqlPlatform.ts
+++ b/packages/sql/src/dialects/postgresql/BasePostgreSqlPlatform.ts
@@ -475,12 +475,12 @@ export class BasePostgreSqlPlatform extends AbstractSqlPlatform {
 
   /**
    * Returns the default name of index for the given columns
-   * cannot go past 63 character length for identifiers in MySQL
+   * cannot go past 63 character length for identifiers in Postgres
    */
   override getIndexName(
     tableName: string,
     columns: string[],
-    type: 'index' | 'unique' | 'foreign' | 'primary' | 'sequence',
+    type: 'index' | 'unique' | 'foreign' | 'primary' | 'sequence' | 'check',
   ): string {
     const indexName = super.getIndexName(tableName, columns, type);
 

--- a/packages/sql/src/dialects/sqlite/SqlitePlatform.ts
+++ b/packages/sql/src/dialects/sqlite/SqlitePlatform.ts
@@ -128,7 +128,7 @@ export class SqlitePlatform extends AbstractSqlPlatform {
   override getIndexName(
     tableName: string,
     columns: string[],
-    type: 'index' | 'unique' | 'foreign' | 'primary' | 'sequence',
+    type: 'index' | 'unique' | 'foreign' | 'primary' | 'sequence' | 'check',
   ): string {
     if (type === 'primary') {
       return this.getDefaultPrimaryName(tableName, columns);

--- a/tests/issues/GHx47.test.ts
+++ b/tests/issues/GHx47.test.ts
@@ -1,5 +1,5 @@
 import { MikroORM } from '@mikro-orm/core';
-import { Embeddable, Embedded, Entity, Enum, PrimaryKey, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+import { Check, Entity, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
 import { MariaDbDriver } from '@mikro-orm/mariadb';
 import { MsSqlDriver } from '@mikro-orm/mssql';
 import { MySqlDriver } from '@mikro-orm/mysql';
@@ -7,56 +7,33 @@ import { OracleDriver } from '@mikro-orm/oracledb';
 import { PostgreSqlDriver } from '@mikro-orm/postgresql';
 import { SqliteDriver } from '@mikro-orm/sqlite';
 
-enum ClassificationCategory {
-  Fiction = 'fiction',
-  NonFiction = 'non_fiction',
-}
-
-// Derived check name `publication_record_table_subcat_qualifier_classification_descriptor_check`
-// is 73 chars — over PG (63) and MySQL/MariaDB (64). Column fits all platform limits.
-@Embeddable()
-class ShortClassification {
-  @Enum(() => ClassificationCategory)
-  classificationDescriptor?: ClassificationCategory;
-}
-
-@Entity({ tableName: 'publication_record_table' })
+// Derived check name `publication_record_metadata_table_category_classification_descriptor_check`
+// is 74 chars — over PG (63) and MySQL/MariaDB (64). Column fits all platform limits.
+@Entity({ tableName: 'publication_record_metadata_table' })
+@Check({
+  property: 'categoryClassificationDescriptor',
+  expression: 'category_classification_descriptor >= 0',
+})
 class ShortPublication {
   @PrimaryKey()
   id!: number;
 
-  @Embedded(() => ShortClassification, { prefix: 'subcat_qualifier_', nullable: true })
-  classification?: ShortClassification;
+  @Property({ type: 'integer' })
+  categoryClassificationDescriptor!: number;
 }
 
-// 131-char derived check name, over Oracle/MSSQL's 128-char limit.
-@Embeddable()
-class LongClassification {
-  @Enum(() => ClassificationCategory)
-  categorizationDescriptor?: ClassificationCategory;
-}
-
-@Entity({ tableName: 'book_publication_metadata_extended_record_table' })
+// Derived check name is 132 chars, over Oracle/MSSQL's 128-char limit. Column fits Oracle/MSSQL.
+@Entity({ tableName: 'book_publication_metadata_extended_records_master_table' })
+@Check({
+  property: 'categoryClassificationDescriptorExtensionFieldWithQualifierMetadata',
+  expression: 'category_classification_descriptor_extension_field_with_qualifier_metadata >= 0',
+})
 class LongPublication {
   @PrimaryKey()
   id!: number;
 
-  @Embedded(() => LongClassification, {
-    prefix: 'classification_metadata_subcategory_qualifier_field_',
-    nullable: true,
-  })
-  classification?: LongClassification;
-}
-
-function getEmittedConstraintNames(sql: string): string[] {
-  const names: string[] = [];
-  const re = /(?:^|[\s,(])constraint ["`[]?([^"`)\] ]+)["`\])]?/gi;
-
-  for (const m of sql.matchAll(re)) {
-    names.push(m[1]);
-  }
-
-  return names;
+  @Property({ type: 'integer' })
+  categoryClassificationDescriptorExtensionFieldWithQualifierMetadata!: number;
 }
 
 describe('GHx47 — overlong derived check-constraint name should not produce a phantom diff', () => {
@@ -65,15 +42,8 @@ describe('GHx47 — overlong derived check-constraint name should not produce a 
       metadataProvider: ReflectMetadataProvider,
       driver: PostgreSqlDriver,
       dbName: 'mikro_orm_test_ghx47_pg',
-      entities: [ShortPublication, ShortClassification],
+      entities: [ShortPublication],
     });
-
-    const createSQL = await orm.schema.getCreateSchemaSQL({ wrap: false });
-    const names = getEmittedConstraintNames(createSQL);
-    expect(names.length).toBeGreaterThan(0);
-    for (const name of names) {
-      expect(name.length).toBeLessThanOrEqual(63);
-    }
 
     await orm.schema.refresh();
     const updateSQL = await orm.schema.getUpdateSchemaSQL({ wrap: false });
@@ -88,15 +58,8 @@ describe('GHx47 — overlong derived check-constraint name should not produce a 
       driver: MySqlDriver,
       dbName: 'mikro_orm_test_ghx47_mysql',
       port: 3308,
-      entities: [ShortPublication, ShortClassification],
+      entities: [ShortPublication],
     });
-
-    const createSQL = await orm.schema.getCreateSchemaSQL({ wrap: false });
-    const names = getEmittedConstraintNames(createSQL);
-    expect(names.length).toBeGreaterThan(0);
-    for (const name of names) {
-      expect(name.length).toBeLessThanOrEqual(64);
-    }
 
     await orm.schema.refresh();
     const updateSQL = await orm.schema.getUpdateSchemaSQL({ wrap: false });
@@ -111,15 +74,8 @@ describe('GHx47 — overlong derived check-constraint name should not produce a 
       driver: MariaDbDriver,
       dbName: 'mikro_orm_test_ghx47_mariadb',
       port: 3309,
-      entities: [ShortPublication, ShortClassification],
+      entities: [ShortPublication],
     });
-
-    const createSQL = await orm.schema.getCreateSchemaSQL({ wrap: false });
-    const names = getEmittedConstraintNames(createSQL);
-    expect(names.length).toBeGreaterThan(0);
-    for (const name of names) {
-      expect(name.length).toBeLessThanOrEqual(64);
-    }
 
     await orm.schema.refresh();
     const updateSQL = await orm.schema.getUpdateSchemaSQL({ wrap: false });
@@ -133,12 +89,12 @@ describe('GHx47 — overlong derived check-constraint name should not produce a 
       metadataProvider: ReflectMetadataProvider,
       driver: SqliteDriver,
       dbName: ':memory:',
-      entities: [LongPublication, LongClassification],
+      entities: [LongPublication],
     });
 
     const createSQL = await orm.schema.getCreateSchemaSQL({ wrap: false });
-    expect(createSQL).toContain('book_publication_metadata_extended_record_table');
-    expect(createSQL).toContain('classification_metadata_subcategory_qualifier_field_categorization_descriptor');
+    expect(createSQL).toContain('book_publication_metadata_extended_records_master_table');
+    expect(createSQL).toContain('category_classification_descriptor_extension_field_with_qualifier_metadata');
 
     await orm.schema.refresh();
     const updateSQL = await orm.schema.getUpdateSchemaSQL({ wrap: false });
@@ -154,15 +110,8 @@ describe('GHx47 — overlong derived check-constraint name should not produce a 
       dbName: 'mikro_orm_test_ghx47',
       password: 'oracle123',
       schemaGenerator: { managementDbName: 'system' },
-      entities: [LongPublication, LongClassification],
+      entities: [LongPublication],
     });
-
-    const createSQL = await orm.schema.getCreateSchemaSQL({ wrap: false });
-    const names = getEmittedConstraintNames(createSQL);
-    expect(names.length).toBeGreaterThan(0);
-    for (const name of names) {
-      expect(name.length).toBeLessThanOrEqual(128);
-    }
 
     await orm.schema.refresh();
     const updateSQL = await orm.schema.getUpdateSchemaSQL({ wrap: false });
@@ -177,15 +126,8 @@ describe('GHx47 — overlong derived check-constraint name should not produce a 
       driver: MsSqlDriver,
       dbName: 'mikro_orm_test_ghx47_mssql',
       password: 'Root.Root',
-      entities: [LongPublication, LongClassification],
+      entities: [LongPublication],
     });
-
-    const createSQL = await orm.schema.getCreateSchemaSQL({ wrap: false });
-    const names = getEmittedConstraintNames(createSQL);
-    expect(names.length).toBeGreaterThan(0);
-    for (const name of names) {
-      expect(name.length).toBeLessThanOrEqual(128);
-    }
 
     await orm.schema.refresh();
     const updateSQL = await orm.schema.getUpdateSchemaSQL({ wrap: false });

--- a/tests/issues/GHx47.test.ts
+++ b/tests/issues/GHx47.test.ts
@@ -1,0 +1,196 @@
+import { MikroORM } from '@mikro-orm/core';
+import { Embeddable, Embedded, Entity, Enum, PrimaryKey, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+import { MariaDbDriver } from '@mikro-orm/mariadb';
+import { MsSqlDriver } from '@mikro-orm/mssql';
+import { MySqlDriver } from '@mikro-orm/mysql';
+import { OracleDriver } from '@mikro-orm/oracledb';
+import { PostgreSqlDriver } from '@mikro-orm/postgresql';
+import { SqliteDriver } from '@mikro-orm/sqlite';
+
+enum ClassificationCategory {
+  Fiction = 'fiction',
+  NonFiction = 'non_fiction',
+}
+
+// Derived check name `publication_record_table_subcat_qualifier_classification_descriptor_check`
+// is 73 chars — over PG (63) and MySQL/MariaDB (64). Column fits all platform limits.
+@Embeddable()
+class ShortClassification {
+  @Enum(() => ClassificationCategory)
+  classificationDescriptor?: ClassificationCategory;
+}
+
+@Entity({ tableName: 'publication_record_table' })
+class ShortPublication {
+  @PrimaryKey()
+  id!: number;
+
+  @Embedded(() => ShortClassification, { prefix: 'subcat_qualifier_', nullable: true })
+  classification?: ShortClassification;
+}
+
+// 131-char derived check name, over Oracle/MSSQL's 128-char limit.
+@Embeddable()
+class LongClassification {
+  @Enum(() => ClassificationCategory)
+  categorizationDescriptor?: ClassificationCategory;
+}
+
+@Entity({ tableName: 'book_publication_metadata_extended_record_table' })
+class LongPublication {
+  @PrimaryKey()
+  id!: number;
+
+  @Embedded(() => LongClassification, {
+    prefix: 'classification_metadata_subcategory_qualifier_field_',
+    nullable: true,
+  })
+  classification?: LongClassification;
+}
+
+function getEmittedConstraintNames(sql: string): string[] {
+  const names: string[] = [];
+  const re = /(?:^|[\s,(])constraint ["`[]?([^"`)\] ]+)["`\])]?/gi;
+
+  for (const m of sql.matchAll(re)) {
+    names.push(m[1]);
+  }
+
+  return names;
+}
+
+describe('GHx47 — overlong derived check-constraint name should not produce a phantom diff', () => {
+  test('postgres', async () => {
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      driver: PostgreSqlDriver,
+      dbName: 'mikro_orm_test_ghx47_pg',
+      entities: [ShortPublication, ShortClassification],
+    });
+
+    const createSQL = await orm.schema.getCreateSchemaSQL({ wrap: false });
+    const names = getEmittedConstraintNames(createSQL);
+    expect(names.length).toBeGreaterThan(0);
+    for (const name of names) {
+      expect(name.length).toBeLessThanOrEqual(63);
+    }
+
+    await orm.schema.refresh();
+    const updateSQL = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(updateSQL).toBe('');
+
+    await orm.close(true);
+  });
+
+  test('mysql', async () => {
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      driver: MySqlDriver,
+      dbName: 'mikro_orm_test_ghx47_mysql',
+      port: 3308,
+      entities: [ShortPublication, ShortClassification],
+    });
+
+    const createSQL = await orm.schema.getCreateSchemaSQL({ wrap: false });
+    const names = getEmittedConstraintNames(createSQL);
+    expect(names.length).toBeGreaterThan(0);
+    for (const name of names) {
+      expect(name.length).toBeLessThanOrEqual(64);
+    }
+
+    await orm.schema.refresh();
+    const updateSQL = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(updateSQL).toBe('');
+
+    await orm.close(true);
+  });
+
+  test('mariadb', async () => {
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      driver: MariaDbDriver,
+      dbName: 'mikro_orm_test_ghx47_mariadb',
+      port: 3309,
+      entities: [ShortPublication, ShortClassification],
+    });
+
+    const createSQL = await orm.schema.getCreateSchemaSQL({ wrap: false });
+    const names = getEmittedConstraintNames(createSQL);
+    expect(names.length).toBeGreaterThan(0);
+    for (const name of names) {
+      expect(name.length).toBeLessThanOrEqual(64);
+    }
+
+    await orm.schema.refresh();
+    const updateSQL = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(updateSQL).toBe('');
+
+    await orm.close(true);
+  });
+
+  test('sqlite (no limit; long natural names round-trip)', async () => {
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      driver: SqliteDriver,
+      dbName: ':memory:',
+      entities: [LongPublication, LongClassification],
+    });
+
+    const createSQL = await orm.schema.getCreateSchemaSQL({ wrap: false });
+    expect(createSQL).toContain('book_publication_metadata_extended_record_table');
+    expect(createSQL).toContain('classification_metadata_subcategory_qualifier_field_categorization_descriptor');
+
+    await orm.schema.refresh();
+    const updateSQL = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(updateSQL).toBe('');
+
+    await orm.close(true);
+  });
+
+  test('oracle', async () => {
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      driver: OracleDriver,
+      dbName: 'mikro_orm_test_ghx47',
+      password: 'oracle123',
+      schemaGenerator: { managementDbName: 'system' },
+      entities: [LongPublication, LongClassification],
+    });
+
+    const createSQL = await orm.schema.getCreateSchemaSQL({ wrap: false });
+    const names = getEmittedConstraintNames(createSQL);
+    expect(names.length).toBeGreaterThan(0);
+    for (const name of names) {
+      expect(name.length).toBeLessThanOrEqual(128);
+    }
+
+    await orm.schema.refresh();
+    const updateSQL = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(updateSQL).toBe('');
+
+    await orm.close(true);
+  });
+
+  test('mssql', async () => {
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      driver: MsSqlDriver,
+      dbName: 'mikro_orm_test_ghx47_mssql',
+      password: 'Root.Root',
+      entities: [LongPublication, LongClassification],
+    });
+
+    const createSQL = await orm.schema.getCreateSchemaSQL({ wrap: false });
+    const names = getEmittedConstraintNames(createSQL);
+    expect(names.length).toBeGreaterThan(0);
+    for (const name of names) {
+      expect(name.length).toBeLessThanOrEqual(128);
+    }
+
+    await orm.schema.refresh();
+    const updateSQL = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(updateSQL).toBe('');
+
+    await orm.close(true);
+  });
+});

--- a/tests/issues/GHx47.test.ts
+++ b/tests/issues/GHx47.test.ts
@@ -1,4 +1,4 @@
-import { MikroORM } from '@mikro-orm/core';
+import { MikroORM, quote } from '@mikro-orm/core';
 import { Check, Entity, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
 import { MariaDbDriver } from '@mikro-orm/mariadb';
 import { MsSqlDriver } from '@mikro-orm/mssql';
@@ -7,12 +7,11 @@ import { OracleDriver } from '@mikro-orm/oracledb';
 import { PostgreSqlDriver } from '@mikro-orm/postgresql';
 import { SqliteDriver } from '@mikro-orm/sqlite';
 
-// Derived check name `publication_record_metadata_table_category_classification_descriptor_check`
-// is 74 chars — over PG (63) and MySQL/MariaDB (64). Column fits all platform limits.
+// Natural check name 74 chars — over PG (63) and MySQL/MariaDB (64).
 @Entity({ tableName: 'publication_record_metadata_table' })
 @Check({
   property: 'categoryClassificationDescriptor',
-  expression: cols => `${cols.categoryClassificationDescriptor} >= 0`,
+  expression: cols => quote`${cols.categoryClassificationDescriptor} >= 0`,
 })
 class ShortPublication {
   @PrimaryKey()
@@ -22,11 +21,11 @@ class ShortPublication {
   categoryClassificationDescriptor!: number;
 }
 
-// Derived check name is 136 chars, over Oracle/MSSQL's 128-char limit. Column fits Oracle/MSSQL.
+// Natural check name 136 chars — over Oracle/MSSQL (128).
 @Entity({ tableName: 'book_publication_metadata_extended_records_master_table' })
 @Check({
   property: 'categoryClassificationDescriptorExtensionFieldWithQualifierMetadata',
-  expression: cols => `${cols.categoryClassificationDescriptorExtensionFieldWithQualifierMetadata} >= 0`,
+  expression: cols => quote`${cols.categoryClassificationDescriptorExtensionFieldWithQualifierMetadata} >= 0`,
 })
 class LongPublication {
   @PrimaryKey()
@@ -46,8 +45,7 @@ describe('GHx47 — overlong derived check-constraint name should not produce a 
     });
 
     await orm.schema.refresh();
-    const updateSQL = await orm.schema.getUpdateSchemaSQL({ wrap: false });
-    expect(updateSQL).toBe('');
+    expect(await orm.schema.getUpdateSchemaSQL({ wrap: false })).toBe('');
 
     await orm.close(true);
   });
@@ -62,8 +60,7 @@ describe('GHx47 — overlong derived check-constraint name should not produce a 
     });
 
     await orm.schema.refresh();
-    const updateSQL = await orm.schema.getUpdateSchemaSQL({ wrap: false });
-    expect(updateSQL).toBe('');
+    expect(await orm.schema.getUpdateSchemaSQL({ wrap: false })).toBe('');
 
     await orm.close(true);
   });
@@ -78,13 +75,12 @@ describe('GHx47 — overlong derived check-constraint name should not produce a 
     });
 
     await orm.schema.refresh();
-    const updateSQL = await orm.schema.getUpdateSchemaSQL({ wrap: false });
-    expect(updateSQL).toBe('');
+    expect(await orm.schema.getUpdateSchemaSQL({ wrap: false })).toBe('');
 
     await orm.close(true);
   });
 
-  test('sqlite (no limit; long natural names round-trip)', async () => {
+  test('sqlite', async () => {
     const orm = await MikroORM.init({
       metadataProvider: ReflectMetadataProvider,
       driver: SqliteDriver,
@@ -97,8 +93,7 @@ describe('GHx47 — overlong derived check-constraint name should not produce a 
     expect(createSQL).toContain('category_classification_descriptor_extension_field_with_qualifier_metadata');
 
     await orm.schema.refresh();
-    const updateSQL = await orm.schema.getUpdateSchemaSQL({ wrap: false });
-    expect(updateSQL).toBe('');
+    expect(await orm.schema.getUpdateSchemaSQL({ wrap: false })).toBe('');
 
     await orm.close(true);
   });
@@ -114,8 +109,7 @@ describe('GHx47 — overlong derived check-constraint name should not produce a 
     });
 
     await orm.schema.refresh();
-    const updateSQL = await orm.schema.getUpdateSchemaSQL({ wrap: false });
-    expect(updateSQL).toBe('');
+    expect(await orm.schema.getUpdateSchemaSQL({ wrap: false })).toBe('');
 
     await orm.close(true);
   });
@@ -130,8 +124,7 @@ describe('GHx47 — overlong derived check-constraint name should not produce a 
     });
 
     await orm.schema.refresh();
-    const updateSQL = await orm.schema.getUpdateSchemaSQL({ wrap: false });
-    expect(updateSQL).toBe('');
+    expect(await orm.schema.getUpdateSchemaSQL({ wrap: false })).toBe('');
 
     await orm.close(true);
   });

--- a/tests/issues/GHx47.test.ts
+++ b/tests/issues/GHx47.test.ts
@@ -12,7 +12,7 @@ import { SqliteDriver } from '@mikro-orm/sqlite';
 @Entity({ tableName: 'publication_record_metadata_table' })
 @Check({
   property: 'categoryClassificationDescriptor',
-  expression: 'category_classification_descriptor >= 0',
+  expression: cols => `${cols.categoryClassificationDescriptor} >= 0`,
 })
 class ShortPublication {
   @PrimaryKey()
@@ -22,11 +22,11 @@ class ShortPublication {
   categoryClassificationDescriptor!: number;
 }
 
-// Derived check name is 132 chars, over Oracle/MSSQL's 128-char limit. Column fits Oracle/MSSQL.
+// Derived check name is 136 chars, over Oracle/MSSQL's 128-char limit. Column fits Oracle/MSSQL.
 @Entity({ tableName: 'book_publication_metadata_extended_records_master_table' })
 @Check({
   property: 'categoryClassificationDescriptorExtensionFieldWithQualifierMetadata',
-  expression: 'category_classification_descriptor_extension_field_with_qualifier_metadata >= 0',
+  expression: cols => `${cols.categoryClassificationDescriptorExtensionFieldWithQualifierMetadata} >= 0`,
 })
 class LongPublication {
   @PrimaryKey()


### PR DESCRIPTION
## What

Auto-derived check-constraint names that exceed a platform's identifier limit are now routed through `Platform.getIndexName(..., 'check')`, the same path FK/index/unique names already take. PG/MySQL/SQLite overrides have their type union widened so the existing hash-truncation pattern covers check constraints. Oracle and MSSQL get matching overrides at the 128-char boundary.

## Why

Before this change, check-constraint names were generated directly via `NamingStrategy.indexName(..., 'check')`, bypassing per-platform truncation. The result:

- **Postgres** (NAMEDATALEN=63): the engine silently truncates over-long identifiers on `ADD CONSTRAINT` (NOTICE-only, not an error), so the entity-derived name in `toSchema` never matched the introspected name in `fromSchema`. `migration:check` and `schema:update --dump` reported a phantom drop+add of the same constraint on every run.
- **MySQL / MariaDB** (64): the engine rejected the statement outright with an identifier-too-long error, so `migration:create` produced SQL that couldn't be applied.
- **Oracle / MSSQL** (128): never had any truncation override, so the same shape of bug applied with a much higher threshold.

Trivially reproducible via long table name + embedded prefix + enum property — the natural `*_check` name exceeds 63 chars.

## Approach

`Platform.getIndexName` now accepts `'check'` in its type union. The default implementation still delegates to `NamingStrategy.indexName`. PG/MySQL/SQLite overrides only had to widen their signatures; their existing hash-truncation logic now applies to check names automatically. Oracle and MSSQL get the same pattern at 128 chars.

`MetadataDiscovery.initCheckConstraints` and `EntityMetadata.sync` now go through `Platform.getIndexName(..., 'check')` instead of `NamingStrategy.indexName` directly.

## Scope notes

- **User-supplied identifier names** (`@Check({ name: '...' })`, explicit `foreignKeyName`, etc.) still pass through verbatim. The same pre-existing exposure for over-long *explicit* names remains, consistent with how FK / index / unique already work today. Worth a separate follow-up if desired.
- **No comparator changes.** A defensive normalization layer in `SchemaComparator` was considered but proved redundant once metadata-side truncation is in place.
- **One-time rename for pre-fix DBs.** Users currently running with check names that the engine silently truncated will see a one-time `drop + add` diff on the next `migration:check` as the constraint is renamed to the hash-truncated form. But, the current behaviour also emits a `drop + add` diff that never resolves anyway. This time, the diff is stable after rename.

## Tests

`tests/issues/GHx47.test.ts` covers all six SQL dialects:

- **Postgres / MySQL / MariaDB**: 73-char natural check name; assert emitted name fits the platform limit and `getUpdateSchemaSQL` is empty after `refresh()`.
- **SQLite**: 131-char natural name; assert it passes through unchanged (no limit) and round-trips clean.
- **Oracle / MSSQL**: 131-char natural name; assert emitted name fits 128 chars and round-trips clean.