### PR TITLE
chore(test): add missing `.js` extensions to relative imports

### DIFF
--- a/tests/defineEntity.test.ts
+++ b/tests/defineEntity.test.ts
@@ -27,7 +27,7 @@ import {
   p,
   ScalarRef,
 } from '@mikro-orm/core';
-import type { PropertyChain, UniversalPropertyOptionsBuilder } from '../packages/core/src/entity/defineEntity';
+import type { PropertyChain, UniversalPropertyOptionsBuilder } from '../packages/core/src/entity/defineEntity.js';
 import { IsExact, assert } from 'conditional-type-checks';
 import { ObjectId } from 'bson';
 

--- a/tests/features/embeddables/GH6522.test.ts
+++ b/tests/features/embeddables/GH6522.test.ts
@@ -1,5 +1,5 @@
 import { MikroORM } from '@mikro-orm/sqlite';
-import { mockLogger } from '../../helpers';
+import { mockLogger } from '../../helpers.js';
 import {
   Embeddable,
   Embedded,

--- a/tests/features/embeddables/GH6523.test.ts
+++ b/tests/features/embeddables/GH6523.test.ts
@@ -1,6 +1,6 @@
 import { MikroORM } from '@mikro-orm/sqlite';
 import { TsMorphMetadataProvider } from '@mikro-orm/reflection';
-import { mockLogger } from '../../helpers';
+import { mockLogger } from '../../helpers.js';
 import { Embeddable, Embedded, Entity, Enum, PrimaryKey, Property } from '@mikro-orm/decorators/legacy';
 
 enum ChangeType {

--- a/tests/issues/GH7436.test.ts
+++ b/tests/issues/GH7436.test.ts
@@ -1,5 +1,5 @@
 import { MikroORM, PrimaryKeyProp, Ref, ref } from '@mikro-orm/sqlite';
-import { mockLogger } from '../helpers';
+import { mockLogger } from '../helpers.js';
 import {
   Entity,
   ManyToOne,


### PR DESCRIPTION
Four test files were using extensionless relative imports (`from '../helpers'`) — the rest of the codebase consistently uses `.js`. Couldn't enforce via oxlint yet (see [oxc-project/oxc#21261](https://github.com/oxc-project/oxc/issues/21261) and [#17693](https://github.com/oxc-project/oxc/issues/17693) — both still open).