### PR TITLE
feat(postgres): support `driverOptions.onPoolCreated` hook for `pg.Pool`

### DIFF
--- a/packages/postgresql/src/PostgreSqlConnection.ts
+++ b/packages/postgresql/src/PostgreSqlConnection.ts
@@ -7,9 +7,14 @@ import { AbstractSqlConnection, Utils } from '@mikro-orm/sql';
 /** PostgreSQL database connection using the `pg` driver. */
 export class PostgreSqlConnection extends AbstractSqlConnection {
   override createKyselyDialect(overrides: PoolConfig): PostgresDialect {
-    const options = this.mapOptions(overrides);
+    const { onPoolCreated, ...poolOverrides } = (overrides ?? {}) as PoolConfig & {
+      onPoolCreated?: (pool: Pool) => unknown;
+    };
+    const options = this.mapOptions(poolOverrides);
+    const pool = new Pool(options);
+    void onPoolCreated?.(pool);
     return new PostgresDialect({
-      pool: new Pool(options),
+      pool,
       cursor: Cursor,
       onCreateConnection: this.options.onCreateConnection ?? this.config.get('onCreateConnection'),
     });

--- a/tests/features/entity-manager/EntityManager.postgre.test.ts
+++ b/tests/features/entity-manager/EntityManager.postgre.test.ts
@@ -35,6 +35,7 @@ import {
   wrap,
 } from '@mikro-orm/postgresql';
 import knex from 'knex';
+import { Pool } from 'pg';
 import { raw as rawKnex } from '@mikro-orm/knex-compat';
 import {
   Address2,
@@ -125,6 +126,30 @@ describe('EntityManagerPostgre', () => {
       port: 1234,
       user: 'user',
     });
+  });
+
+  test('driverOptions.onPoolCreated receives the pg.Pool', async () => {
+    let receivedPool: Pool | undefined;
+    const config = new Configuration(
+      {
+        driver: PostgreSqlDriver,
+        clientUrl: 'postgre://root@127.0.0.1:1234/db_name',
+        logger: vi.fn(),
+      } as any,
+      false,
+    );
+    const driver = new PostgreSqlDriver(config);
+    driver.getConnection().createKyselyDialect({
+      onPoolCreated: (pool: Pool) => {
+        receivedPool = pool;
+        pool.on('error', () => void 0);
+      },
+    } as any);
+
+    expect(receivedPool).toBeInstanceOf(Pool);
+    expect(receivedPool!.listenerCount('error')).toBe(1);
+    // the hook key must not be forwarded into the pg PoolConfig
+    expect(Object.prototype.hasOwnProperty.call((receivedPool as any).options, 'onPoolCreated')).toBe(false);
   });
 
   test('raw query with array param', async () => {


### PR DESCRIPTION
The `pg` driver re-emits errors from idle pool connections as `pool.on('error', ...)`. Without a Pool-level listener, errors from idle connections the server closes (failover, maintenance) surface as uncaught exceptions and crash the process. `onCreateConnection` can't solve this — it hands you a checked-out `Client`, not the `Pool`, and the pool re-emits regardless of what listeners exist on the client.

Today the only workaround is constructing a `PostgresDialect` manually and passing it via `driverOptions`, which forces callers to duplicate the `TypeOverrides` setup `PostgreSqlConnection.mapOptions` already does.

This adds an optional `driverOptions.onPoolCreated(pool)` callback, invoked once with the `pg.Pool` right after construction:

```ts
import { MikroORM, PostgreSqlDriver } from '@mikro-orm/postgresql';
import type { Pool } from 'pg';

MikroORM.init({
  driver: PostgreSqlDriver,
  driverOptions: {
    onPoolCreated: (pool: Pool) => {
      pool.on('error', err => logger.warn('idle pg pool error', err));
    },
  },
});
```

Follows the same convention as MySQL's `driverOptions.maxIdle` (`packages/mysql/src/MySqlConnection.ts`): an undocumented-in-types driver-specific key that the connection class extracts before merging the rest into the underlying pool config. No changes to `@mikro-orm/core` or to the exported `PostgreSqlOptions` surface.