### PR TITLE
feat(core): expose embedded sub-columns to check constraint callbacks

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -65,6 +65,7 @@ export type {
   FormulaTable,
   SchemaTable,
   SchemaColumns,
+  SchemaColumnRef,
   EntityDataPropValue,
   SimpleColumnMeta,
   Rel,

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -929,13 +929,26 @@ export type SchemaTable = { name: string; schema?: string; qualifiedName: string
 export type FormulaColumns<T> = Record<PropertyName<T>, string> & { toString(): string };
 
 /**
+ * Column reference for schema callbacks. Behaves like a string (coercible via `toString()`),
+ * with arbitrary nested property access for embedded sub-columns (e.g. `cols.address.city`).
+ */
+export type SchemaColumnRef = string & { readonly [key: string]: SchemaColumnRef };
+
+/**
  * Column mapping for schema callbacks (indexes, checks, generated columns).
  * Maps property names to field names. For TPT entities, only includes properties
  * that belong to the current table (not inherited properties from parent tables).
+ * Embedded properties expose their sub-columns via nested access (e.g. `cols.address.city`),
+ * while coercing to the embedded property's own column name via `toString()` (matches the
+ * pre-7712 behaviour, regardless of any custom `prefix`).
  */
-export type SchemaColumns<T> = Record<PropertyName<T>, string>;
+export type SchemaColumns<T> = Record<PropertyName<T>, SchemaColumnRef>;
 
-/** Callback for custom index expressions. Receives column mappings, table info, and the index name. */
+/**
+ * Callback for custom index expressions. Receives column mappings, table info, and the index name.
+ * The runtime `columns` object includes nested entries for embedded properties (see `SchemaColumnRef`);
+ * cast to `SchemaColumns<T>` if you need typed nested access.
+ */
 export type IndexCallback<T> = (
   columns: Record<PropertyName<T>, string>,
   table: SchemaTable,
@@ -945,9 +958,13 @@ export type IndexCallback<T> = (
 export type FormulaCallback<T> = (columns: FormulaColumns<T>, table: FormulaTable) => string | Raw;
 
 /** Callback for CHECK constraint expressions. Receives column mappings and table info. */
-export type CheckCallback<T> = (columns: Record<PropertyName<T>, string>, table: SchemaTable) => string | Raw;
+export type CheckCallback<T> = (columns: SchemaColumns<T>, table: SchemaTable) => string | Raw;
 
-/** Callback for generated (computed) column expressions. Receives column mappings and table info. */
+/**
+ * Callback for generated (computed) column expressions. Receives column mappings and table info.
+ * The runtime `columns` object includes nested entries for embedded properties (see `SchemaColumnRef`);
+ * cast to `SchemaColumns<T>` if you need typed nested access.
+ */
 export type GeneratedColumnCallback<T> = (columns: Record<PropertyName<T>, string>, table: SchemaTable) => string | Raw;
 
 /** Definition of a CHECK constraint on a table or property. */
@@ -1182,19 +1199,46 @@ export class EntityMetadata<Entity = any, Class extends EntityCtor<Entity> = Ent
   /**
    * Creates a column mapping for schema callbacks (indexes, checks, generated columns).
    * For TPT entities, only includes properties that belong to the current table (ownProps).
+   * Embedded properties expose their sub-columns via nested access (e.g. `cols.address.city`),
+   * while still coercing to the embedded column prefix when used as a string (GH #7712).
    */
   createSchemaColumnMappingObject(): SchemaColumns<Entity> {
     // For TPT entities, only include properties that belong to this entity's table
     const props =
       this.inheritanceType === 'tpt' && this.ownProps ? this.ownProps : Object.values<EntityProperty>(this.properties);
+    const result: Dictionary = {};
 
-    return props.reduce((o, prop) => {
-      if (prop.fieldNames) {
-        o[prop.name as PropertyName<Entity>] = prop.fieldNames[0];
+    for (const prop of props) {
+      if (!prop.fieldNames) {
+        continue;
       }
 
-      return o;
-    }, {} as SchemaColumns<Entity>);
+      if (prop.kind === ReferenceKind.EMBEDDED && prop.embeddedProps) {
+        result[prop.name] = EntityMetadata.buildEmbeddedColumnMapping(prop);
+        continue;
+      }
+
+      result[prop.name] = prop.fieldNames[0];
+    }
+
+    return result as SchemaColumns<Entity>;
+  }
+
+  /** @internal Recursively builds a column mapping for an embedded property's sub-columns. */
+  private static buildEmbeddedColumnMapping(embeddedProp: EntityProperty): Dictionary {
+    const result: Dictionary = {};
+
+    for (const [name, sub] of Object.entries(embeddedProp.embeddedProps)) {
+      result[name] =
+        sub.kind === ReferenceKind.EMBEDDED && sub.embeddedProps
+          ? EntityMetadata.buildEmbeddedColumnMapping(sub)
+          : sub.fieldNames[0];
+    }
+
+    const prefix = embeddedProp.fieldNames[0];
+    Object.defineProperty(result, 'toString', { value: () => prefix, enumerable: false });
+
+    return result;
   }
 
   get tableName(): string {

--- a/tests/issues/GH7712.test.ts
+++ b/tests/issues/GH7712.test.ts
@@ -1,0 +1,59 @@
+// GH #7712 - schema callbacks should expose nested column names for embedded properties
+import { defineEntity, MikroORM, p, quote, raw } from '@mikro-orm/sqlite';
+
+const Address = defineEntity({
+  name: 'Address7712',
+  embeddable: true,
+  properties: {
+    street: p.string(),
+    city: p.string(),
+  },
+});
+
+const Profile = defineEntity({
+  name: 'Profile7712',
+  embeddable: true,
+  properties: p => ({
+    nickname: p.string(),
+    address: p.embedded(Address),
+  }),
+});
+
+const User = defineEntity({
+  name: 'User7712',
+  properties: p => ({
+    id: p.integer().primary(),
+    name: p.string(),
+    address: p.embedded(Address),
+    profile: p.embedded(Profile).prefix('profile_'),
+  }),
+  checks: [
+    {
+      name: 'user7712_address_city_check',
+      expression: columns => quote`length(${columns.address.city}) > 1`,
+    },
+    {
+      name: 'user7712_profile_addr_street_check',
+      expression: columns => quote`length(${columns.profile.address.street}) > 0`,
+    },
+    {
+      // legacy ${columns.embedded} access still resolves to the embedded column prefix
+      name: 'user7712_address_prefix_check',
+      expression: columns => raw(`?? is not null`, [`${columns.address}_street`]),
+    },
+  ],
+});
+
+test('check callback receives nested column mapping for embedded properties', async () => {
+  const orm = await MikroORM.init({
+    dbName: ':memory:',
+    entities: [Address, Profile, User],
+  });
+
+  const sql = await orm.schema.getCreateSchemaSQL({ wrap: false });
+  expect(sql).toContain('constraint `user7712_address_city_check` check (length(`address_city`) > 1)');
+  expect(sql).toContain('constraint `user7712_profile_addr_street_check` check (length(`profile_address_street`) > 0)');
+  expect(sql).toContain('constraint `user7712_address_prefix_check` check (`address_street` is not null)');
+
+  await orm.close();
+});


### PR DESCRIPTION
## Summary
- Schema callbacks (`CheckCallback`) now expose embedded properties as nested maps, so `expression: cols => quote\`length(\${cols.address.city}) > 1\`` works without manual column name plumbing.
- The `cols.embedded` value still coerces to the embedded property's column name via `toString()`, preserving the pre-existing \`\${cols.embedded}_sub\` pattern.
- Recursive descent supports nested embedded entities (`cols.profile.address.street`).

`IndexCallback` and `GeneratedColumnCallback` go through the same runtime path and receive the same nested object, but widening their static signatures broke decorator inference (`@Index({...})` started failing with `TS1238`). Their callback types remain `Record<PropertyName<T>, string>`; users can cast to `SchemaColumns<T>` if they need typed nested access.

Closes #7712