### PR TITLE
fix(core): pass entity instance to `beforeUpsert` hook and propagate mutations to SQL

### DIFF
--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -1186,7 +1186,15 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
     validateParams(data, 'insert data');
 
     if (em.eventManager.hasListeners(EventType.beforeUpsert, meta)) {
-      await em.eventManager.dispatchEvent(EventType.beforeUpsert, { entity: data as Entity, em, meta }, meta);
+      await em.eventManager.dispatchEvent(
+        EventType.beforeUpsert,
+        { entity: entity ?? (data as Entity), em, meta },
+        meta,
+      );
+
+      if (entity) {
+        data = em.#comparator.prepareEntity(entity);
+      }
     }
 
     const ret = await em.driver.nativeUpdate(entityName, where, data, {
@@ -1326,6 +1334,7 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
     const allWhere: FilterQuery<Entity>[] = [];
     const entities = new Map<Entity, EntityData<Entity>>();
     const entitiesByData = new Map<EntityData<Entity>, Entity>();
+    const entitiesByAllDataIdx = new Map<number, Entity>();
 
     for (let i = 0; i < data.length; i++) {
       let row = data[i];
@@ -1343,6 +1352,7 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
 
         where = helper(entity).getPrimaryKey() as FilterQuery<Entity>;
         em.#entityFactory.assignDefaultValues(entity, meta);
+        entitiesByAllDataIdx.set(allData.length, entity);
         row = em.#comparator.prepareEntity(entity);
       } else {
         row = data[i] = Utils.copy(QueryHelper.processParams(row));
@@ -1396,6 +1406,10 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
       for (const dto of data) {
         const entity = entitiesByData.get(dto) ?? (dto as Entity);
         await em.eventManager.dispatchEvent(EventType.beforeUpsert, { entity, em, meta }, meta);
+      }
+
+      for (const [idx, entity] of entitiesByAllDataIdx) {
+        allData[idx] = em.#comparator.prepareEntity(entity);
       }
     }
 

--- a/tests/features/upsert/upsert.mssql.test.ts
+++ b/tests/features/upsert/upsert.mssql.test.ts
@@ -412,11 +412,11 @@ test('em.upsert(entity)', async () => {
     ['onInit', 'Author'],
     ['onInit', 'Author'],
     ['onInit', 'Author'],
-    ['beforeUpsert', 'Object'],
+    ['beforeUpsert', 'Author'],
     ['afterUpsert', 'Author'],
-    ['beforeUpsert', 'Object'],
+    ['beforeUpsert', 'Author'],
     ['afterUpsert', 'Author'],
-    ['beforeUpsert', 'Object'],
+    ['beforeUpsert', 'Author'],
     ['afterUpsert', 'Author'],
   ]);
 
@@ -522,11 +522,11 @@ test('em.upsert(Type, entity, options) with advanced options', async () => {
     ['onInit', 'Author'],
     ['onInit', 'Author'],
     ['onInit', 'Author'],
-    ['beforeUpsert', 'Object'],
+    ['beforeUpsert', 'Author'],
     ['afterUpsert', 'Author'],
-    ['beforeUpsert', 'Object'],
+    ['beforeUpsert', 'Author'],
     ['afterUpsert', 'Author'],
-    ['beforeUpsert', 'Object'],
+    ['beforeUpsert', 'Author'],
     ['afterUpsert', 'Author'],
   ]);
 

--- a/tests/features/upsert/upsert.test.ts
+++ b/tests/features/upsert/upsert.test.ts
@@ -443,11 +443,11 @@ describe.each(Utils.keys(options))('em.upsert [%s]', type => {
       ['onInit', 'Author'],
       ['onInit', 'Author'],
       ['onInit', 'Author'],
-      ['beforeUpsert', 'Object'],
+      ['beforeUpsert', 'Author'],
       ['afterUpsert', 'Author'],
-      ['beforeUpsert', 'Object'],
+      ['beforeUpsert', 'Author'],
       ['afterUpsert', 'Author'],
-      ['beforeUpsert', 'Object'],
+      ['beforeUpsert', 'Author'],
       ['afterUpsert', 'Author'],
     ]);
 
@@ -570,11 +570,11 @@ describe.each(Utils.keys(options))('em.upsert [%s]', type => {
       ['onInit', 'Author'],
       ['onInit', 'Author'],
       ['onInit', 'Author'],
-      ['beforeUpsert', 'Object'],
+      ['beforeUpsert', 'Author'],
       ['afterUpsert', 'Author'],
-      ['beforeUpsert', 'Object'],
+      ['beforeUpsert', 'Author'],
       ['afterUpsert', 'Author'],
-      ['beforeUpsert', 'Object'],
+      ['beforeUpsert', 'Author'],
       ['afterUpsert', 'Author'],
     ]);
 

--- a/tests/issues/GHx48.test.ts
+++ b/tests/issues/GHx48.test.ts
@@ -1,0 +1,93 @@
+import { defineEntity, EventArgs, EventSubscriber, MikroORM, p } from '@mikro-orm/sqlite';
+
+const ProductSchema = defineEntity({
+  name: 'Product',
+  properties: {
+    id: p.integer().primary(),
+    title: p.string(),
+    context: p.json<{ mode: string; timestamp: string }>().nullable(),
+  },
+  uniques: [{ properties: ['title'] }],
+});
+class Product extends ProductSchema.class {}
+ProductSchema.setClass(Product);
+
+class EntityContextSubscriber implements EventSubscriber<Product> {
+  beforeUpsertCalls = 0;
+  afterUpsertCalls = 0;
+
+  beforeUpsert(args: EventArgs<Product>) {
+    this.beforeUpsertCalls++;
+    args.entity.context = { mode: 'flush', timestamp: 'fixed' };
+  }
+
+  afterUpsert() {
+    this.afterUpsertCalls++;
+  }
+}
+
+describe('GHx48 — beforeUpsert receives the entity instance when upsert input is an entity', () => {
+  let orm: MikroORM;
+  let subscriber: EntityContextSubscriber;
+
+  beforeAll(async () => {
+    subscriber = new EntityContextSubscriber();
+    orm = await MikroORM.init({
+      dbName: ':memory:',
+      entities: [Product],
+      subscribers: [subscriber],
+    });
+    await orm.schema.refresh();
+  });
+
+  afterAll(() => orm.close(true));
+
+  test('beforeUpsert/afterUpsert fire when upserting an entity created via em.create()', async () => {
+    const product = orm.em.create(Product, {
+      title: 'Test Product Valid',
+      context: undefined,
+    });
+
+    const upserted = await orm.em.upsert(Product, product, {
+      onConflictAction: 'merge',
+      onConflictFields: ['title'],
+      onConflictMergeFields: ['title', 'context'],
+    });
+
+    expect(subscriber.beforeUpsertCalls).toBe(1);
+    expect(subscriber.afterUpsertCalls).toBe(1);
+    expect(upserted.context).toEqual({ mode: 'flush', timestamp: 'fixed' });
+
+    orm.em.clear();
+    const reloaded = await orm.em.findOneOrFail(Product, { title: 'Test Product Valid' });
+    expect(reloaded.context).toEqual({ mode: 'flush', timestamp: 'fixed' });
+  });
+
+  test('beforeUpsert/afterUpsert fire when upsertMany is called with entity instances', async () => {
+    subscriber.beforeUpsertCalls = 0;
+    subscriber.afterUpsertCalls = 0;
+
+    const products = [
+      orm.em.create(Product, { title: 'Bulk Product A', context: undefined }),
+      orm.em.create(Product, { title: 'Bulk Product B', context: undefined }),
+    ];
+
+    const upserted = await orm.em.upsertMany(Product, products, {
+      onConflictAction: 'merge',
+      onConflictFields: ['title'],
+      onConflictMergeFields: ['title', 'context'],
+    });
+
+    expect(subscriber.beforeUpsertCalls).toBe(2);
+    expect(subscriber.afterUpsertCalls).toBe(2);
+    expect(upserted[0].context).toEqual({ mode: 'flush', timestamp: 'fixed' });
+    expect(upserted[1].context).toEqual({ mode: 'flush', timestamp: 'fixed' });
+
+    orm.em.clear();
+    const reloaded = await orm.em.find(Product, { title: { $in: ['Bulk Product A', 'Bulk Product B'] } });
+    expect(reloaded).toHaveLength(2);
+    for (const product of reloaded) {
+      expect(product.context).toEqual({ mode: 'flush', timestamp: 'fixed' });
+    }
+  });
+});


### PR DESCRIPTION
When `em.upsert(Type, entity)` or `em.upsertMany(Type, [entity])` was called with an entity instance, `beforeUpsert` received the prepared data snapshot (a plain `Object`) as `args.entity` rather than the entity instance. That violated the `EventArgs<T>.entity: T` type contract and was inconsistent with how `upsertMany` passed the entity in some code paths.

Worse, mutations performed inside `beforeUpsert` did not reach the SQL for `upsertMany`, and were not reflected on the returned managed entity for `upsert`, because `allData` / `data` snapshots had already been prepared before the hook ran.

This change:

- passes the entity instance to `beforeUpsert` whenever the input was an entity (single + many)
- re-extracts the data snapshot from the entity after the hook runs, so hook mutations reach the SQL and the returned entity

For plain-data input the existing behavior is preserved.