### PR TITLE
fix(core): reset stale collections on upserted entities

### DIFF
--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -11,6 +11,7 @@ import { validateEmptyWhere, validateParams, validatePrimaryKey, validatePropert
 import { type EntityRepository } from './entity/EntityRepository.js';
 import { EntityLoader, type EntityLoaderOptions } from './entity/EntityLoader.js';
 import { Reference } from './entity/Reference.js';
+import { Collection } from './entity/Collection.js';
 import { helper } from './entity/wrap.js';
 import { ChangeSet, ChangeSetType } from './unit-of-work/ChangeSet.js';
 import { UnitOfWork } from './unit-of-work/UnitOfWork.js';
@@ -1253,7 +1254,7 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
     }
 
     // recompute the data as there might be some values missing (e.g. those with db column defaults)
-    em.resetUntouchedPivotCollections(meta, entity, data as EntityData<Entity>);
+    em.resetUntouchedCollections(meta, entity, data as EntityData<Entity>);
     const snapshot = this.#comparator.prepareEntity(entity);
     em.#unitOfWork.register(entity, snapshot, { refresh: true });
 
@@ -1538,7 +1539,7 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
 
     for (const [entity] of entities) {
       // recompute the data as there might be some values missing (e.g. those with db column defaults)
-      em.resetUntouchedPivotCollections(meta, entity, entities.get(entity)!);
+      em.resetUntouchedCollections(meta, entity, entities.get(entity)!);
       const snapshot = this.#comparator.prepareEntity(entity);
       em.#unitOfWork.register(entity, snapshot, { refresh: true });
     }
@@ -1552,28 +1553,33 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
     return [...entities.keys()];
   }
 
-  private resetUntouchedPivotCollections<Entity extends object>(
+  private resetUntouchedCollections<Entity extends object>(
     meta: EntityMetadata<Entity>,
     entity: Entity,
     data: EntityData<Entity>,
   ): void {
-    if (!this.getPlatform().usesPivotTable()) {
-      return;
-    }
-
+    // for entities passed in via `em.create()` and then upserted, collection-kind relations
+    // were initialized as empty-but-initialized by the hydrator (newEntity=true). once the
+    // upsert resolves the entity to a possibly existing row, that state is stale and would
+    // cause `em.populate()` to skip those collections. replace them with a fresh
+    // uninitialized collection so populate can load them.
     if (helper(entity).__originalEntityData) {
       return;
     }
 
     for (const prop of meta.relations) {
-      if (prop.kind !== ReferenceKind.MANY_TO_MANY || prop.name in data) {
+      if (prop.kind !== ReferenceKind.MANY_TO_MANY && prop.kind !== ReferenceKind.ONE_TO_MANY) {
+        continue;
+      }
+
+      if (prop.name in data) {
         continue;
       }
 
       const collection = entity[prop.name];
 
       if (Utils.isCollection(collection) && collection.isInitialized() && !collection.isDirty()) {
-        collection.reset();
+        Collection.create(entity, prop.name, undefined, false);
       }
     }
   }

--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -1253,6 +1253,7 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
     }
 
     // recompute the data as there might be some values missing (e.g. those with db column defaults)
+    em.resetUntouchedPivotCollections(meta, entity, data as EntityData<Entity>);
     const snapshot = this.#comparator.prepareEntity(entity);
     em.#unitOfWork.register(entity, snapshot, { refresh: true });
 
@@ -1537,6 +1538,7 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
 
     for (const [entity] of entities) {
       // recompute the data as there might be some values missing (e.g. those with db column defaults)
+      em.resetUntouchedPivotCollections(meta, entity, entities.get(entity)!);
       const snapshot = this.#comparator.prepareEntity(entity);
       em.#unitOfWork.register(entity, snapshot, { refresh: true });
     }
@@ -1548,6 +1550,32 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
     }
 
     return [...entities.keys()];
+  }
+
+  private resetUntouchedPivotCollections<Entity extends object>(
+    meta: EntityMetadata<Entity>,
+    entity: Entity,
+    data: EntityData<Entity>,
+  ): void {
+    if (!this.getPlatform().usesPivotTable()) {
+      return;
+    }
+
+    if (helper(entity).__originalEntityData) {
+      return;
+    }
+
+    for (const prop of meta.relations) {
+      if (prop.kind !== ReferenceKind.MANY_TO_MANY || prop.name in data) {
+        continue;
+      }
+
+      const collection = entity[prop.name];
+
+      if (Utils.isCollection(collection) && collection.isInitialized() && !collection.isDirty()) {
+        collection.reset();
+      }
+    }
   }
 
   /**

--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -1,5 +1,5 @@
 import { type Configuration } from './utils/Configuration.js';
-import { getOnConflictReturningFields, getWhereCondition } from './utils/upsert-utils.js';
+import { getOnConflictReturningFields, getWhereCondition, resetUntouchedCollections } from './utils/upsert-utils.js';
 import { Utils } from './utils/Utils.js';
 import { Cursor } from './utils/Cursor.js';
 import { QueryHelper } from './utils/QueryHelper.js';
@@ -11,7 +11,6 @@ import { validateEmptyWhere, validateParams, validatePrimaryKey, validatePropert
 import { type EntityRepository } from './entity/EntityRepository.js';
 import { EntityLoader, type EntityLoaderOptions } from './entity/EntityLoader.js';
 import { Reference } from './entity/Reference.js';
-import { Collection } from './entity/Collection.js';
 import { helper } from './entity/wrap.js';
 import { ChangeSet, ChangeSetType } from './unit-of-work/ChangeSet.js';
 import { UnitOfWork } from './unit-of-work/UnitOfWork.js';
@@ -1254,7 +1253,7 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
     }
 
     // recompute the data as there might be some values missing (e.g. those with db column defaults)
-    em.resetUntouchedCollections(meta, entity, data as EntityData<Entity>);
+    resetUntouchedCollections(meta, entity, data as EntityData<Entity>);
     const snapshot = this.#comparator.prepareEntity(entity);
     em.#unitOfWork.register(entity, snapshot, { refresh: true });
 
@@ -1539,7 +1538,7 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
 
     for (const [entity] of entities) {
       // recompute the data as there might be some values missing (e.g. those with db column defaults)
-      em.resetUntouchedCollections(meta, entity, entities.get(entity)!);
+      resetUntouchedCollections(meta, entity, entities.get(entity)!);
       const snapshot = this.#comparator.prepareEntity(entity);
       em.#unitOfWork.register(entity, snapshot, { refresh: true });
     }
@@ -1551,37 +1550,6 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
     }
 
     return [...entities.keys()];
-  }
-
-  private resetUntouchedCollections<Entity extends object>(
-    meta: EntityMetadata<Entity>,
-    entity: Entity,
-    data: EntityData<Entity>,
-  ): void {
-    // for entities passed in via `em.create()` and then upserted, collection-kind relations
-    // were initialized as empty-but-initialized by the hydrator (newEntity=true). once the
-    // upsert resolves the entity to a possibly existing row, that state is stale and would
-    // cause `em.populate()` to skip those collections. replace them with a fresh
-    // uninitialized collection so populate can load them.
-    if (helper(entity).__originalEntityData) {
-      return;
-    }
-
-    for (const prop of meta.relations) {
-      if (prop.kind !== ReferenceKind.MANY_TO_MANY && prop.kind !== ReferenceKind.ONE_TO_MANY) {
-        continue;
-      }
-
-      if (prop.name in data) {
-        continue;
-      }
-
-      const collection = entity[prop.name];
-
-      if (Utils.isCollection(collection) && collection.isInitialized() && !collection.isDirty()) {
-        Collection.create(entity, prop.name, undefined, false);
-      }
-    }
   }
 
   /**

--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -1253,7 +1253,7 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
     }
 
     // recompute the data as there might be some values missing (e.g. those with db column defaults)
-    resetUntouchedCollections(meta, entity, data as EntityData<Entity>);
+    resetUntouchedCollections(meta, entity);
     const snapshot = this.#comparator.prepareEntity(entity);
     em.#unitOfWork.register(entity, snapshot, { refresh: true });
 
@@ -1538,7 +1538,7 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
 
     for (const [entity] of entities) {
       // recompute the data as there might be some values missing (e.g. those with db column defaults)
-      resetUntouchedCollections(meta, entity, entities.get(entity)!);
+      resetUntouchedCollections(meta, entity);
       const snapshot = this.#comparator.prepareEntity(entity);
       em.#unitOfWork.register(entity, snapshot, { refresh: true });
     }

--- a/packages/core/src/entity/Collection.ts
+++ b/packages/core/src/entity/Collection.ts
@@ -631,6 +631,22 @@ export class Collection<T extends object, O extends object = object> {
   /**
    * @internal
    */
+  reset(): void {
+    for (let i = 0; i < this.#items.size; i++) {
+      delete this[i];
+    }
+
+    this.#initialized = false;
+    this.#dirty = false;
+    this.#partial = false;
+    this.#snapshot = [];
+    this.#items.clear();
+    this.#count = undefined;
+  }
+
+  /**
+   * @internal
+   */
   hydrate(items: T[], forcePropagate?: boolean, partial?: boolean): void {
     for (let i = 0; i < this.#items.size; i++) {
       delete this[i];

--- a/packages/core/src/entity/Collection.ts
+++ b/packages/core/src/entity/Collection.ts
@@ -631,22 +631,6 @@ export class Collection<T extends object, O extends object = object> {
   /**
    * @internal
    */
-  reset(): void {
-    for (let i = 0; i < this.#items.size; i++) {
-      delete this[i];
-    }
-
-    this.#initialized = false;
-    this.#dirty = false;
-    this.#partial = false;
-    this.#snapshot = [];
-    this.#items.clear();
-    this.#count = undefined;
-  }
-
-  /**
-   * @internal
-   */
   hydrate(items: T[], forcePropagate?: boolean, partial?: boolean): void {
     for (let i = 0; i < this.#items.size; i++) {
       delete this[i];

--- a/packages/core/src/utils/upsert-utils.ts
+++ b/packages/core/src/utils/upsert-utils.ts
@@ -202,11 +202,7 @@ export function getWhereCondition<T extends object>(
 }
 
 /** @internal */
-export function resetUntouchedCollections<Entity extends object>(
-  meta: EntityMetadata<Entity>,
-  entity: Entity,
-  data: EntityData<Entity>,
-): void {
+export function resetUntouchedCollections<Entity extends object>(meta: EntityMetadata<Entity>, entity: Entity): void {
   // for entities passed in via `em.create()` and then upserted, collection-kind relations
   // were initialized as empty-but-initialized by the hydrator (newEntity=true). once the
   // upsert resolves the entity to a possibly existing row, that state is stale and would
@@ -218,10 +214,6 @@ export function resetUntouchedCollections<Entity extends object>(
 
   for (const prop of meta.relations) {
     if (prop.kind !== ReferenceKind.MANY_TO_MANY && prop.kind !== ReferenceKind.ONE_TO_MANY) {
-      continue;
-    }
-
-    if (prop.name in data) {
       continue;
     }
 

--- a/packages/core/src/utils/upsert-utils.ts
+++ b/packages/core/src/utils/upsert-utils.ts
@@ -76,7 +76,9 @@ export function getOnConflictFields<T>(
   }
 
   const keys = Object.keys(data).flatMap(f => {
-    if (!(Array.isArray(uniqueFields) && !uniqueFields.includes(f as keyof T))) {
+    // skip explicitly listed unique fields; for raw onConflictFields we can't introspect the
+    // fragment, so merge all data keys (the user is responsible for not corrupting them).
+    if (Array.isArray(uniqueFields) && uniqueFields.includes(f as keyof T)) {
       return [];
     }
 

--- a/packages/core/src/utils/upsert-utils.ts
+++ b/packages/core/src/utils/upsert-utils.ts
@@ -2,6 +2,9 @@ import type { Dictionary, EntityData, EntityKey, EntityMetadata, EntityProperty,
 import type { UpsertOptions } from '../drivers/IDatabaseDriver.js';
 import { isRaw, type Raw } from '../utils/RawQueryFragment.js';
 import { Utils } from './Utils.js';
+import { ReferenceKind } from '../enums.js';
+import { Collection } from '../entity/Collection.js';
+import { helper } from '../entity/wrap.js';
 
 function expandEmbeddedProperties<T>(prop: EntityProperty<T>, key?: string): (keyof T)[] {
   if (prop.object) {
@@ -196,4 +199,36 @@ export function getWhereCondition<T extends object>(
   }
 
   return { where, propIndex };
+}
+
+/** @internal */
+export function resetUntouchedCollections<Entity extends object>(
+  meta: EntityMetadata<Entity>,
+  entity: Entity,
+  data: EntityData<Entity>,
+): void {
+  // for entities passed in via `em.create()` and then upserted, collection-kind relations
+  // were initialized as empty-but-initialized by the hydrator (newEntity=true). once the
+  // upsert resolves the entity to a possibly existing row, that state is stale and would
+  // cause `em.populate()` to skip those collections. replace them with a fresh
+  // uninitialized collection so populate can load them.
+  if (helper(entity).__originalEntityData) {
+    return;
+  }
+
+  for (const prop of meta.relations) {
+    if (prop.kind !== ReferenceKind.MANY_TO_MANY && prop.kind !== ReferenceKind.ONE_TO_MANY) {
+      continue;
+    }
+
+    if (prop.name in data) {
+      continue;
+    }
+
+    const collection = entity[prop.name];
+
+    if (Utils.isCollection(collection) && collection.isInitialized() && !collection.isDirty()) {
+      Collection.create(entity, prop.name, undefined, false);
+    }
+  }
 }

--- a/tests/issues/populate-mn-after-upsert.test.ts
+++ b/tests/issues/populate-mn-after-upsert.test.ts
@@ -20,6 +20,16 @@ const ProductPackage = defineEntity({
   },
 });
 
+const ProductReview = defineEntity({
+  name: 'ProductReview',
+  tableName: 'product_reviews',
+  properties: {
+    id: p.integer().primary(),
+    body: p.string(),
+    product: () => p.manyToOne(Product).deleteRule('cascade'),
+  },
+});
+
 const Product = defineEntity({
   name: 'Product',
   tableName: 'products',
@@ -41,6 +51,7 @@ const Product = defineEntity({
         .pivotTable('_join_products_attributes')
         .joinColumn('product_id')
         .inverseJoinColumn('attribute_id'),
+    reviews: () => p.oneToMany(ProductReview).mappedBy(r => r.product),
   },
   indexes: [
     {
@@ -55,7 +66,7 @@ let orm: MikroORM;
 
 beforeAll(async () => {
   orm = await MikroORM.init({
-    entities: [Product, ProductPackage, ProductAttribute],
+    entities: [Product, ProductPackage, ProductAttribute, ProductReview],
     dbName: ':memory:',
   });
   await orm.schema.refresh();
@@ -203,20 +214,32 @@ test('populate after upsertMany does not insert duplicate pivot rows when settin
   expect(reloaded.attributes[0].id).toBe(attr.id);
 });
 
-test('Collection.reset clears stale M:N collection state', () => {
+test('populate after upsertMany loads existing 1:M references', async () => {
   const product = orm.em.create(Product, {
-    title: 'Product With Stale State',
+    title: 'Product With Reviews',
     externalId: 'EXT000000005',
     category: 'Category',
   });
-  const attr = orm.em.create(ProductAttribute, { value: 'White' });
+  orm.em.create(ProductReview, { body: 'great', product });
+  orm.em.create(ProductReview, { body: 'good', product });
+  await flushAndClear();
 
-  product.attributes.add(attr);
-  product.attributes.reset();
+  const [upserted] = await upsertProducts(
+    orm.em.create(Product, {
+      title: 'Product With Reviews Updated',
+      externalId: 'EXT000000005',
+      category: 'Updated Category',
+    }),
+  );
 
-  expect(product.attributes.isInitialized()).toBe(false);
-  expect(product.attributes.isDirty()).toBe(false);
-  expect(product.attributes.getItems(false)).toEqual([]);
-  expect(product.attributes.getSnapshot()).toEqual([]);
-  expect(product.attributes[0]).toBeUndefined();
+  await orm.em.populate(upserted, ['reviews']);
+
+  expect(upserted.reviews).toBeInstanceOf(Collection);
+  expect(upserted.reviews).toHaveLength(2);
+  expect(
+    upserted.reviews
+      .getItems()
+      .map(r => r.body)
+      .sort(),
+  ).toEqual(['good', 'great']);
 });

--- a/tests/issues/populate-mn-after-upsert.test.ts
+++ b/tests/issues/populate-mn-after-upsert.test.ts
@@ -243,3 +243,61 @@ test('populate after upsertMany loads existing 1:M references', async () => {
       .sort(),
   ).toEqual(['good', 'great']);
 });
+
+test('upsertMany on a managed entity preserves already-loaded collections', async () => {
+  const attr = orm.em.create(ProductAttribute, { value: 'Pink' });
+  const product = orm.em.create(Product, {
+    title: 'Loaded Product',
+    externalId: 'EXT000000007',
+    category: 'cat',
+    attributes: [attr],
+  });
+  await flushAndClear();
+
+  // re-load with the M:N relation populated — __originalEntityData is now set and the
+  // collection holds real items. with `upsertManaged: true`, the entity is routed
+  // through the full upsert flow, so `resetUntouchedCollections` must early-return
+  // and leave the loaded collection alone.
+  orm.config.set('upsertManaged', true);
+
+  try {
+    const loaded = await orm.em.findOneOrFail(Product, { externalId: 'EXT000000007' }, { populate: ['attributes'] });
+
+    Object.assign(loaded, { title: 'Loaded Product Updated' });
+    const [upserted] = await upsertProducts(loaded);
+
+    expect(upserted).toBe(loaded);
+    expect(upserted.attributes.isInitialized()).toBe(true);
+    expect(upserted.attributes).toHaveLength(1);
+    expect(upserted.attributes[0].value).toBe('Pink');
+  } finally {
+    orm.config.set('upsertManaged', false);
+  }
+});
+
+test('upsertMany with plain data does not touch already-managed collections', async () => {
+  const attr = orm.em.create(ProductAttribute, { value: 'Yellow' });
+  await flushAndClear();
+
+  // pass plain data — the entity is constructed by the factory with refresh:true,
+  // so __originalEntityData is already set and resetUntouchedCollections should bail out early.
+  const [upserted] = await orm.em.upsertMany(
+    Product,
+    [{ title: 'Plain Data Product', externalId: 'EXT000000006', category: 'cat' }],
+    {
+      onConflictFields: sql`(external_id) where external_id is not null`,
+      onConflictAction: 'merge',
+      onConflictMergeFields: ['title', 'category'],
+    },
+  );
+
+  await orm.em.populate(upserted, ['attributes:ref']);
+  expect(upserted.attributes).toHaveLength(0);
+
+  upserted.attributes.add(orm.em.getReference(ProductAttribute, attr.id));
+  await orm.em.flush();
+  orm.em.clear();
+
+  const reloaded = await orm.em.findOneOrFail(Product, { externalId: 'EXT000000006' }, { populate: ['attributes'] });
+  expect(reloaded.attributes).toHaveLength(1);
+});

--- a/tests/issues/populate-mn-after-upsert.test.ts
+++ b/tests/issues/populate-mn-after-upsert.test.ts
@@ -1,0 +1,204 @@
+import { Collection } from '@mikro-orm/core';
+import { defineEntity, MikroORM, p, quote, sql } from '@mikro-orm/sqlite';
+
+const ProductAttribute = defineEntity({
+  name: 'ProductAttribute',
+  tableName: 'product_attributes',
+  properties: {
+    id: p.integer().primary(),
+    value: p.string(),
+  },
+});
+
+const ProductPackage = defineEntity({
+  name: 'ProductPackage',
+  tableName: 'product_packages',
+  properties: {
+    id: p.integer().primary(),
+    title: p.string(),
+    product: () => p.oneToOne(Product).deleteRule('cascade'),
+  },
+});
+
+const Product = defineEntity({
+  name: 'Product',
+  tableName: 'products',
+  properties: {
+    id: p.integer().primary(),
+    title: p.string(),
+    externalId: p.string().length(12).nullable(),
+    category: p.string().default('default'),
+    package: () =>
+      p
+        .oneToOne(ProductPackage)
+        .mappedBy(pkg => pkg.product)
+        .nullable()
+        .orphanRemoval(),
+    attributes: () =>
+      p
+        .manyToMany(ProductAttribute)
+        .owner()
+        .pivotTable('_join_products_attributes')
+        .joinColumn('product_id')
+        .inverseJoinColumn('attribute_id'),
+  },
+  indexes: [
+    {
+      name: 'products_external_id_unique',
+      expression: (columns, table, indexName) =>
+        quote`CREATE UNIQUE INDEX IF NOT EXISTS ${indexName} ON ${table} (${columns.externalId}) WHERE ${columns.externalId} IS NOT NULL`,
+    },
+  ],
+});
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    entities: [Product, ProductPackage, ProductAttribute],
+    dbName: ':memory:',
+  });
+  await orm.schema.refresh();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+beforeEach(async () => {
+  await orm.schema.clear();
+  orm.em.clear();
+});
+
+async function flushAndClear() {
+  await orm.em.flush();
+  orm.em.clear();
+}
+
+function upsertProducts(...products: any[]) {
+  return orm.em.upsertMany(Product, products, {
+    onConflictFields: sql`(external_id) where external_id is not null`,
+    onConflictAction: 'merge',
+    onConflictMergeFields: ['title', 'category'],
+  });
+}
+
+test('populate after upsertMany loads existing M:N references via attributes:ref', async () => {
+  const attr1 = orm.em.create(ProductAttribute, { value: 'Black' });
+  const attr2 = orm.em.create(ProductAttribute, { value: 'Red' });
+  await flushAndClear();
+
+  const attrs = await orm.em.find(ProductAttribute, {});
+  orm.em.create(Product, {
+    title: 'Test Product',
+    externalId: 'EXT000000001',
+    category: 'Test Category',
+    package: { title: 'Box' },
+    attributes: attrs.map(attr => attr.id),
+  });
+  await flushAndClear();
+
+  const [upserted] = await upsertProducts(
+    orm.em.create(Product, {
+      title: 'Test Product Updated',
+      externalId: 'EXT000000001',
+      category: 'Updated Category',
+    }),
+  );
+
+  await orm.em.populate(upserted, ['package', 'attributes:ref']);
+
+  expect(upserted.package?.title).toBe('Box');
+  expect(upserted.attributes).toBeInstanceOf(Collection);
+  expect(upserted.attributes).toHaveLength(2);
+  expect(
+    upserted.attributes
+      .getItems()
+      .map(attr => attr.id)
+      .sort(),
+  ).toEqual([attr1.id, attr2.id].sort());
+});
+
+test('populate after upsertMany still fully loads M:N objects via attributes', async () => {
+  const attr = orm.em.create(ProductAttribute, { value: 'Green' });
+  await flushAndClear();
+
+  orm.em.create(Product, {
+    title: 'Product With Attr',
+    externalId: 'EXT000000002',
+    category: 'Cat',
+    attributes: [attr.id],
+  });
+  await flushAndClear();
+
+  const [upserted] = await upsertProducts(
+    orm.em.create(Product, {
+      title: 'Product With Attr Updated',
+      externalId: 'EXT000000002',
+      category: 'Cat Updated',
+    }),
+  );
+
+  await orm.em.populate(upserted, ['attributes']);
+
+  expect(upserted.attributes).toBeInstanceOf(Collection);
+  expect(upserted.attributes).toHaveLength(1);
+  expect(upserted.attributes[0].value).toBe('Green');
+});
+
+test('populate after upsertMany initializes an empty M:N collection for inserted rows', async () => {
+  const attr = orm.em.create(ProductAttribute, { value: 'Blue' });
+  await flushAndClear();
+
+  const [upserted] = await upsertProducts(
+    orm.em.create(Product, {
+      title: 'Brand New Product',
+      externalId: 'EXT000000003',
+      category: 'New Category',
+    }),
+  );
+
+  await orm.em.populate(upserted, ['package', 'attributes:ref']);
+
+  expect(upserted.attributes).toBeInstanceOf(Collection);
+  expect(upserted.attributes).toHaveLength(0);
+
+  upserted.attributes.set([orm.em.getReference(ProductAttribute, attr.id)]);
+  await orm.em.flush();
+
+  orm.em.clear();
+  const reloaded = await orm.em.findOneOrFail(Product, { externalId: 'EXT000000003' }, { populate: ['attributes'] });
+  expect(reloaded.attributes).toHaveLength(1);
+  expect(reloaded.attributes[0].value).toBe('Blue');
+});
+
+test('populate after upsertMany does not insert duplicate pivot rows when setting the same reference', async () => {
+  const attr = orm.em.create(ProductAttribute, { value: 'Black' });
+  await orm.em.flush();
+
+  const existing = orm.em.create(Product, {
+    title: 'Existing Product',
+    category: 'Old Category',
+    externalId: 'EXT000000004',
+  });
+  existing.attributes.add(attr);
+  await flushAndClear();
+
+  const [upserted] = await upsertProducts(
+    orm.em.create(Product, {
+      title: 'Existing Product Updated',
+      category: 'New Category',
+      externalId: 'EXT000000004',
+    }),
+  );
+
+  await orm.em.populate(upserted, ['attributes:ref']);
+  upserted.attributes.set([orm.em.getReference(ProductAttribute, attr.id)]);
+
+  await expect(orm.em.flush()).resolves.toBeUndefined();
+
+  orm.em.clear();
+  const reloaded = await orm.em.findOneOrFail(Product, { externalId: 'EXT000000004' }, { populate: ['attributes'] });
+  expect(reloaded.attributes).toHaveLength(1);
+  expect(reloaded.attributes[0].id).toBe(attr.id);
+});

--- a/tests/issues/populate-mn-after-upsert.test.ts
+++ b/tests/issues/populate-mn-after-upsert.test.ts
@@ -202,3 +202,21 @@ test('populate after upsertMany does not insert duplicate pivot rows when settin
   expect(reloaded.attributes).toHaveLength(1);
   expect(reloaded.attributes[0].id).toBe(attr.id);
 });
+
+test('Collection.reset clears stale M:N collection state', () => {
+  const product = orm.em.create(Product, {
+    title: 'Product With Stale State',
+    externalId: 'EXT000000005',
+    category: 'Category',
+  });
+  const attr = orm.em.create(ProductAttribute, { value: 'White' });
+
+  product.attributes.add(attr);
+  product.attributes.reset();
+
+  expect(product.attributes.isInitialized()).toBe(false);
+  expect(product.attributes.isDirty()).toBe(false);
+  expect(product.attributes.getItems(false)).toEqual([]);
+  expect(product.attributes.getSnapshot()).toEqual([]);
+  expect(product.attributes[0]).toBeUndefined();
+});

--- a/tests/issues/populate-mn-after-upsert.test.ts
+++ b/tests/issues/populate-mn-after-upsert.test.ts
@@ -90,6 +90,13 @@ function upsertProducts(...products: any[]) {
   return orm.em.upsertMany(Product, products, {
     onConflictFields: sql`(external_id) where external_id is not null`,
     onConflictAction: 'merge',
+  });
+}
+
+function upsertProductsWithMergeFields(...products: any[]) {
+  return orm.em.upsertMany(Product, products, {
+    onConflictFields: sql`(external_id) where external_id is not null`,
+    onConflictAction: 'merge',
     onConflictMergeFields: ['title', 'category'],
   });
 }
@@ -119,7 +126,47 @@ test('populate after upsertMany loads existing M:N references via attributes:ref
 
   await orm.em.populate(upserted, ['package', 'attributes:ref']);
 
+  expect(upserted.title).toBe('Test Product Updated');
+  expect(upserted.category).toBe('Updated Category');
   expect(upserted.package?.title).toBe('Box');
+  expect(upserted.attributes).toBeInstanceOf(Collection);
+  expect(upserted.attributes).toHaveLength(2);
+  expect(
+    upserted.attributes
+      .getItems()
+      .map(attr => attr.id)
+      .sort(),
+  ).toEqual([attr1.id, attr2.id].sort());
+});
+
+test('populate after upsertMany loads existing M:N references via attributes:ref with explicit merge fields', async () => {
+  const attr1 = orm.em.create(ProductAttribute, { value: 'Orange' });
+  const attr2 = orm.em.create(ProductAttribute, { value: 'Yellow' });
+  await flushAndClear();
+
+  const attrs = await orm.em.find(ProductAttribute, {});
+  orm.em.create(Product, {
+    title: 'Explicit Merge Product',
+    externalId: 'EXT000000006',
+    category: 'Explicit Category',
+    package: { title: 'Crate' },
+    attributes: attrs.map(attr => attr.id),
+  });
+  await flushAndClear();
+
+  const [upserted] = await upsertProductsWithMergeFields(
+    orm.em.create(Product, {
+      title: 'Explicit Merge Product Updated',
+      externalId: 'EXT000000006',
+      category: 'Explicit Category Updated',
+    }),
+  );
+
+  await orm.em.populate(upserted, ['package', 'attributes:ref']);
+
+  expect(upserted.title).toBe('Explicit Merge Product Updated');
+  expect(upserted.category).toBe('Explicit Category Updated');
+  expect(upserted.package?.title).toBe('Crate');
   expect(upserted.attributes).toBeInstanceOf(Collection);
   expect(upserted.attributes).toHaveLength(2);
   expect(


### PR DESCRIPTION
When an entity created via `em.create()` is passed to `upsert`/`upsertMany`, its 1:m and m:n collections start out as empty-but-initialized (because the hydrator runs with `newEntity=true`). If the upsert resolves into an existing row, `em.populate()` then sees those collections as already loaded and skips them, leaving stale empty data on the entity.

The fix swaps in a fresh uninitialized collection for any collection-kind relation the user didn't dirty, so populate works as expected.