### PR TITLE
fix(core): resolve polymorphic TPT-child filter columns to parent table

### DIFF
--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -561,6 +561,14 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
         continue;
       }
 
+      // Polymorphic to-one relations are already filtered via per-target LEFT JOINs created
+      // for the `:ref filter` hint; emitting a populate-filter entry here would auto-join only
+      // the first target meta and either drop rows pointing to other targets or reference
+      // parent-table-only columns on the child sub-table alias for TPT children.
+      if (prop.polymorphic && [ReferenceKind.MANY_TO_ONE, ReferenceKind.ONE_TO_ONE].includes(prop.kind)) {
+        continue;
+      }
+
       const filters = QueryHelper.mergePropertyFilters(prop.filters, options.filters);
       const where = await this.applyFilters<Entity>(prop.targetMeta!.class, {}, filters, 'read', {
         ...options,

--- a/packages/sql/src/AbstractSqlDriver.ts
+++ b/packages/sql/src/AbstractSqlDriver.ts
@@ -2132,6 +2132,14 @@ export abstract class AbstractSqlDriver<
             schema,
           );
 
+          // For polymorphic targets that are TPT child entities, INNER JOIN parent tables so that
+          // filter conditions referencing parent-table columns resolve to the correct alias. The
+          // INNER JOINs get nested inside the polymorphic LEFT JOIN by processNestedJoins, which
+          // keeps the resulting query valid for rows pointing to other polymorphic targets.
+          if (targetMeta.inheritanceType === 'tpt' && targetMeta.tptParent) {
+            this.addTPTParentJoinsForRelation(qb, targetMeta as EntityMetadata<T>, tableAlias, targetPath);
+          }
+
           // For polymorphic targets that are TPT base classes, also LEFT JOIN
           // all descendant tables so child-specific fields can be selected.
           if (targetMeta.inheritanceType === 'tpt' && targetMeta.tptChildren?.length && !ref) {
@@ -2192,23 +2200,7 @@ export abstract class AbstractSqlDriver<
 
       // For relations to TPT child entities, INNER JOIN parent tables (GH #7469)
       if (meta2.inheritanceType === 'tpt' && meta2.tptParent) {
-        let childAlias = tableAlias;
-        let childMeta: EntityMetadata = meta2;
-        while (childMeta.tptParent) {
-          const parentMeta = childMeta.tptParent;
-          const parentAlias = qb.getNextAlias(parentMeta.className);
-          qb.createAlias(parentMeta.class, parentAlias);
-          qb.state.tptAlias[`${tableAlias}:${parentMeta.className}`] = parentAlias;
-          qb.addPropertyJoin(
-            childMeta.tptParentProp!,
-            childAlias,
-            parentAlias,
-            JoinType.innerJoin,
-            `${path}.[tpt]${childMeta.className}`,
-          );
-          childAlias = parentAlias;
-          childMeta = parentMeta;
-        }
+        this.addTPTParentJoinsForRelation(qb, meta2, tableAlias, path);
       }
 
       // For relations to TPT base classes, add LEFT JOINs for all child tables (polymorphic loading)
@@ -2280,6 +2272,38 @@ export abstract class AbstractSqlDriver<
     }
 
     return fields;
+  }
+
+  /**
+   * Walks the TPT inheritance chain of `leafMeta` and INNER JOINs each parent table.
+   * Registers the parent aliases in `qb.state.tptAlias` so column resolution finds them
+   * when filter conditions reference parent-table columns.
+   * @internal
+   */
+  protected addTPTParentJoinsForRelation<T extends object>(
+    qb: AnyQueryBuilder<T>,
+    leafMeta: EntityMetadata,
+    leafAlias: string,
+    basePath: string,
+  ): void {
+    let childAlias = leafAlias;
+    let childMeta: EntityMetadata = leafMeta;
+
+    while (childMeta.tptParent) {
+      const parentMeta = childMeta.tptParent;
+      const parentAlias = qb.getNextAlias(parentMeta.className);
+      qb.createAlias(parentMeta.class, parentAlias);
+      qb.state.tptAlias[`${leafAlias}:${parentMeta.className}`] = parentAlias;
+      qb.addPropertyJoin(
+        childMeta.tptParentProp!,
+        childAlias,
+        parentAlias,
+        JoinType.innerJoin,
+        `${basePath}.[tpt]${childMeta.className}`,
+      );
+      childAlias = parentAlias;
+      childMeta = parentMeta;
+    }
   }
 
   /**

--- a/tests/issues/GH7717.test.ts
+++ b/tests/issues/GH7717.test.ts
@@ -1,0 +1,121 @@
+// GH #7717 - Polymorphic manyToOne targeting TPT sub-class entities resolves
+// default filter conditions against the child sub-table alias instead of the
+// parent table. Any filter column that lives only on the TPT parent table is
+// emitted as `<child_alias>.<col>` which does not exist on the child sub-table.
+import { defineEntity, MikroORM, p } from '@mikro-orm/sqlite';
+
+const AuditEmbeddableSchema = defineEntity({
+  name: 'AuditEmbeddable',
+  embeddable: true,
+  properties: {
+    deletedAt: p.datetime().nullable(),
+  },
+});
+class AuditEmbeddable extends AuditEmbeddableSchema.class {}
+AuditEmbeddableSchema.setClass(AuditEmbeddable);
+
+const DeviceSchema = defineEntity({
+  name: 'Device',
+  tableName: 'device',
+  abstract: true,
+  inheritance: 'tpt',
+  filters: {
+    excludeSoftDeleted: {
+      name: 'excludeSoftDeleted',
+      cond: { audit: { deletedAt: null } },
+      default: true,
+    },
+  },
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+    audit: () => p.embedded(AuditEmbeddable).onCreate(() => new AuditEmbeddable()),
+  },
+});
+class Device extends DeviceSchema.class {}
+DeviceSchema.setClass(Device);
+
+const DeviceASchema = defineEntity({
+  name: 'DeviceA',
+  tableName: 'device_a',
+  extends: Device,
+  properties: {
+    id: p.integer().primary(),
+    parts: () => p.oneToMany(Part).mappedBy('parentDevice'),
+  },
+});
+class DeviceA extends DeviceASchema.class {}
+DeviceASchema.setClass(DeviceA);
+
+const DeviceBSchema = defineEntity({
+  name: 'DeviceB',
+  tableName: 'device_b',
+  extends: Device,
+  properties: { id: p.integer().primary() },
+});
+class DeviceB extends DeviceBSchema.class {}
+DeviceBSchema.setClass(DeviceB);
+
+const PartSchema = defineEntity({
+  name: 'Part',
+  tableName: 'part',
+  properties: {
+    id: p.integer().primary(),
+    parentDevice: () => p.manyToOne([DeviceA, DeviceB]).ref(),
+  },
+});
+class Part extends PartSchema.class {}
+PartSchema.setClass(Part);
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    dbName: ':memory:',
+    entities: [AuditEmbeddable, Device, DeviceA, DeviceB, Part],
+    allowGlobalContext: true,
+  });
+  await orm.schema.refresh();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+beforeEach(async () => {
+  await orm.schema.clear();
+  orm.em.clear();
+});
+
+test('populating inverse collection on polymorphic TPT target with parent-table default filter does not reference column on child sub-table', async () => {
+  const deviceA = orm.em.create(DeviceA, { id: 1, name: 'A' });
+  orm.em.create(Part, { id: 1, parentDevice: deviceA });
+  await orm.em.flush();
+  orm.em.clear();
+
+  // Must not throw "no such column: <alias>.audit_deleted_at"
+  const loaded = await orm.em.find(DeviceA, {}, { populate: ['parts'] });
+  expect(loaded).toHaveLength(1);
+  expect(loaded[0].parts).toHaveLength(1);
+  expect(loaded[0].parts[0].id).toBe(1);
+});
+
+test('default filter on TPT parent excludes parts pointing to soft-deleted polymorphic targets', async () => {
+  const deviceA1 = orm.em.create(DeviceA, { id: 1, name: 'A1' });
+  const deviceA2 = orm.em.create(DeviceA, { id: 2, name: 'A2' });
+  const deviceB1 = orm.em.create(DeviceB, { id: 3, name: 'B1' });
+  orm.em.create(Part, { id: 1, parentDevice: deviceA1 });
+  orm.em.create(Part, { id: 2, parentDevice: deviceA2 });
+  orm.em.create(Part, { id: 3, parentDevice: deviceB1 });
+  await orm.em.flush();
+
+  // soft-delete A2 (parent-table column)
+  deviceA2.audit.deletedAt = new Date();
+  await orm.em.flush();
+  orm.em.clear();
+
+  // parts pointing to non-deleted targets remain; the part pointing to the soft-deleted
+  // DeviceA2 must be excluded by the default filter
+  const parts = await orm.em.find(Part, {}, { orderBy: { id: 'ASC' } });
+  expect(parts.map(p => p.id)).toEqual([1, 3]);
+});


### PR DESCRIPTION
## Summary

When a polymorphic `manyToOne` targeted a TPT sub-class whose default filter referenced a column on the TPT parent table (e.g. an embedded audit field), populating the inverse collection threw `column <alias>.audit_deleted_at does not exist`.

Two paths contributed:
- The per-target polymorphic LEFT JOINs did not INNER JOIN the parent table, so column resolution had no parent alias to rewrite to.
- `getJoinedFilters` also auto-joined the first polymorphic target via `populateFilter`, redundantly applying the filter against the child alias (and silently dropping rows pointing to other targets when the relation was not nullable).

## Fix

- Reuse the existing TPT-parent walk for polymorphic TPT-child targets so the parent table is INNER JOINed and registered in `tptAlias`; `processNestedJoins` nests it inside the polymorphic LEFT JOIN so rows pointing to other polymorphic targets are not dropped.
- Skip emitting populate-filter entries for polymorphic to-one relations; they are already handled per-target via the `:ref filter` hint with discriminator-scoped WHERE checks.

Closes #7717