### PR TITLE
fix(core): avoid duplicate queries when `:ref` populate overlaps with `fields`

### DIFF
--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -2544,9 +2544,14 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
 
     const meta = this.metadata.find(entityName)!;
 
-    // infer populate hints from `fields` when present; merge with explicit `populate` if both are set
+    // infer populate hints from `fields` when present; merge with explicit `populate` if both are set.
+    // `populateArray` is only kept when the entries are user-provided strings — when this method runs a
+    // second time (e.g. from `lockAndPopulate`) the populate is already normalized and merging would be a no-op.
     const fields = options.fields ? this.buildFields(options.fields) : undefined;
-    const populateArray = Array.isArray(options.populate) ? (options.populate as string[]) : undefined;
+    const populateArray =
+      Array.isArray(options.populate) && options.populate.every(p => typeof p === 'string')
+        ? (options.populate as string[])
+        : undefined;
     const hasNestedFields = fields?.some(f => f.includes('.')) ?? false;
     const shouldInfer = fields !== undefined && options.populate === undefined;
     const shouldMerge =
@@ -2607,8 +2612,11 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
         options.populate = fromFields as any;
       } else {
         // with an explicit populate, only nested paths (e.g. `item.id`) need to be merged in — they
-        // require a JOIN to access sub-fields, whereas bare names are already handled by the driver
-        const extras = fromFields.filter(f => f.includes('.'));
+        // require a JOIN to access sub-fields, whereas bare names are already handled by the driver.
+        // skip paths already in user's `populate` (regardless of `:ref` modifier) to avoid producing
+        // both a `:ref` and a non-`:ref` entry for the same relation
+        const existing = new Set(populateArray!.map(p => p.split(':')[0]));
+        const extras = fromFields.filter(f => f.includes('.') && !existing.has(f));
         options.populate = [...populateArray!, ...extras] as any;
       }
     }

--- a/packages/core/src/entity/EntityLoader.ts
+++ b/packages/core/src/entity/EntityLoader.ts
@@ -535,7 +535,7 @@ export class EntityLoader {
     options: Required<EntityLoaderOptions<Entity>>,
     ref: boolean,
   ): Promise<{ items: AnyEntity[]; partial: boolean }> {
-    const children = Utils.unique(this.getChildReferences<Entity>(entities, prop, options, ref));
+    const children = Utils.unique(this.getChildReferences<Entity>(entities, prop, options, ref, populate));
     const meta = prop.targetMeta!;
     // When targetKey is set, use it for FK lookup instead of the PK
     let fk: string | string[] = prop.targetKey ?? Utils.getPrimaryKeyHash(meta.primaryKeys);
@@ -1036,6 +1036,7 @@ export class EntityLoader {
     prop: EntityProperty<Entity>,
     options: Required<EntityLoaderOptions<Entity>>,
     ref: boolean,
+    populate?: PopulateOptions<Entity>,
   ): AnyEntity[] {
     const filtered = this.filterCollections(entities, prop.name, options, ref);
 
@@ -1056,7 +1057,7 @@ export class EntityLoader {
     }
 
     // MANY_TO_ONE or ONE_TO_ONE
-    return this.filterReferences(entities, prop.name, options, ref) as AnyEntity[];
+    return this.filterReferences(entities, prop.name, options, ref, populate) as AnyEntity[];
   }
 
   private filterCollections<Entity extends object>(
@@ -1104,6 +1105,7 @@ export class EntityLoader {
     field: keyof Entity & string,
     options: Required<EntityLoaderOptions<Entity>>,
     ref: boolean,
+    populate?: PopulateOptions<Entity>,
   ): Entity[keyof Entity][] {
     if (ref) {
       return [];
@@ -1116,13 +1118,21 @@ export class EntityLoader {
     }
 
     if (options.fields) {
+      // `:ref` populate children are satisfied by FK/PK and will be loaded lazily — they don't force a parent reload
+      const refChildren = new Set(
+        (populate?.children ?? [])
+          .map(c => c.field.split(':'))
+          .filter(parts => parts[1] === 'ref')
+          .map(parts => parts[0]),
+      );
       return children
         .map(e => Reference.unwrapReference(e[field] as AnyEntity) as Entity)
         .filter(target => {
           const wrapped = helper(target);
           const childFields = (options.fields as unknown as string[])
             .filter(f => f.startsWith(`${field}.`))
-            .map(f => f.substring(field.length + 1));
+            .map(f => f.substring(field.length + 1))
+            .filter(cf => !refChildren.has(cf.split('.')[0]));
 
           return !wrapped.__initialized || !childFields.every(cf => this.isPropertyLoaded(target, cf));
         }) as Entity[keyof Entity][];

--- a/tests/issues/GHx49.test.ts
+++ b/tests/issues/GHx49.test.ts
@@ -1,0 +1,93 @@
+import { Collection, wrap } from '@mikro-orm/core';
+import { defineEntity, MikroORM, p } from '@mikro-orm/sqlite';
+import { mockLogger } from '../helpers.js';
+
+const ProductAttribute = defineEntity({
+  name: 'ProductAttribute',
+  properties: {
+    id: p.integer().primary(),
+    value: p.string(),
+  },
+});
+
+const ProductPackage = defineEntity({
+  name: 'ProductPackage',
+  properties: {
+    id: p.integer().primary(),
+    title: p.string(),
+    product: () => p.oneToOne(Product),
+  },
+});
+
+const Product = defineEntity({
+  name: 'Product',
+  properties: {
+    id: p.integer().primary(),
+    title: p.string(),
+    package: () =>
+      p
+        .oneToOne(ProductPackage)
+        .mappedBy(pkg => pkg.product)
+        .nullable(),
+    attributes: () => p.manyToMany(ProductAttribute).owner(),
+  },
+});
+
+const ClientProduct = defineEntity({
+  name: 'ClientProduct',
+  properties: {
+    id: p.integer().primary(),
+    shortName: p.string(),
+    product: () => p.manyToOne(Product),
+  },
+});
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    entities: [ClientProduct, Product, ProductPackage, ProductAttribute],
+    dbName: ':memory:',
+  });
+  await orm.schema.refresh();
+});
+
+afterAll(() => orm.close(true));
+
+beforeEach(async () => {
+  await orm.schema.clear();
+  orm.em.clear();
+});
+
+test('combining `:ref` populate hints with overlapping `fields` does not duplicate queries', async () => {
+  const product = orm.em.create(Product, {
+    title: 'foo',
+    package: { title: 'box' },
+    attributes: [{ value: 'red' }],
+  });
+  const cp = orm.em.create(ClientProduct, { shortName: 'bar', product });
+  await orm.em.flush();
+  orm.em.clear();
+
+  const mock = mockLogger(orm);
+  const loaded = await orm.em.findOneOrFail(ClientProduct, cp.id, {
+    fields: ['shortName', 'product.title', 'product.package', 'product.attributes'],
+    populate: ['product.package:ref', 'product.attributes:ref'],
+  });
+  const queries = mock.mock.calls.map(([msg]) => String(msg));
+
+  expect(loaded.product.title).toBe('foo');
+  expect(loaded.product.package?.id).toBe(product.package?.id);
+  expect(wrap(loaded.product.package!).isInitialized()).toBe(false);
+  expect(loaded.product.attributes).toBeInstanceOf(Collection);
+  expect(loaded.product.attributes).toHaveLength(1);
+  expect(loaded.product.attributes.isInitialized()).toBe(true);
+  expect(loaded.product.attributes.isInitialized(true)).toBe(false);
+  expect(wrap(loaded.product.attributes[0]).isInitialized()).toBe(false);
+
+  // product is loaded once via the join in the main query — no separate refetch
+  expect(queries.filter(query => query.includes('from `product` as'))).toHaveLength(0);
+  // attributes pivot is fetched exactly once (ref-only, no join into product_attribute)
+  expect(queries.filter(query => query.includes('from `product_attributes` as'))).toHaveLength(1);
+  expect(queries.some(query => query.includes('join `product_attribute`'))).toBe(false);
+});


### PR DESCRIPTION
## Summary

Combining `populate: ['relation:ref']` with `fields: ['relation']` (the latter is needed for type-level access) produced two redundant queries: a duplicate parent refetch and a full join for what should have been a `:ref` pivot fetch.

## Changes

- `preparePopulate`: when merging fields-derived populate paths with the user's `populate`, skip paths that are already covered (with or without a `:ref` modifier). Also skip the merge entirely when `populate` is already normalized (so the second call from `lockAndPopulate` is a no-op).
- `filterReferences`: treat `:ref` populate children as satisfied when deciding whether to reload a parent — they will be loaded later as references / pivot-only fetches and shouldn't trigger a redundant SELECT.