### PR TITLE
fix(core): scope auto-joined filter refs to fields shared by all polymorphic targets

### DIFF
--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -675,11 +675,31 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
 
       if (prop && !ref) {
         hint.children ??= [];
-        await this.autoJoinRefsForFilters(
-          prop.targetMeta!,
-          { ...options, populate: hint.children },
-          { class: meta.root.class, propName: prop.name },
-        );
+        const targets = prop.polymorphic && prop.polymorphTargets?.length ? prop.polymorphTargets : [prop.targetMeta!];
+
+        for (const targetMeta of targets) {
+          const before = hint.children.length;
+          await this.autoJoinRefsForFilters(
+            targetMeta,
+            { ...options, populate: hint.children },
+            { class: meta.root.class, propName: prop.name },
+          );
+
+          // For polymorphic relations, `hint.children` is applied to every polymorph target during
+          // population, so drop any auto-added hint whose field does not exist on every target —
+          // otherwise the shared `:ref` would crash when applied to a target lacking it (GH #7722).
+          if (targets.length > 1 && hint.children.length > before) {
+            const added = hint.children.splice(before);
+
+            for (const h of added) {
+              const f = h.field.split(':')[0];
+
+              if (targets.every(t => f in t.properties)) {
+                hint.children.push(h);
+              }
+            }
+          }
+        }
       }
     }
   }

--- a/tests/issues/GH7722.test.ts
+++ b/tests/issues/GH7722.test.ts
@@ -1,0 +1,115 @@
+import { Collection, MikroORM } from '@mikro-orm/sqlite';
+import {
+  Entity,
+  Filter,
+  ManyToOne,
+  OneToMany,
+  PrimaryKey,
+  Property,
+  ReflectMetadataProvider,
+} from '@mikro-orm/decorators/legacy';
+
+@Filter({ name: 'softDelete', cond: { deletedAt: null }, default: true })
+@Entity()
+class Author {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @Property({ nullable: true })
+  deletedAt?: Date;
+}
+
+@Entity()
+class Post {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  title!: string;
+
+  // ManyToOne to a soft-deletable entity — Comment does NOT have this
+  @ManyToOne(() => Author)
+  author!: Author;
+
+  @OneToMany(() => UserLike, like => like.likeable)
+  likes = new Collection<UserLike>(this);
+}
+
+@Entity()
+class Comment {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  text!: string;
+
+  @OneToMany(() => UserLike, like => like.likeable)
+  likes = new Collection<UserLike>(this);
+}
+
+@Entity()
+class User {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @OneToMany(() => UserLike, like => like.user)
+  likes = new Collection<UserLike>(this);
+}
+
+@Entity()
+class UserLike {
+  @PrimaryKey()
+  id!: number;
+
+  @ManyToOne(() => User)
+  user!: User;
+
+  @ManyToOne(() => [Post, Comment], {
+    strategy: 'select-in',
+    discriminatorMap: {
+      UserPost: 'Post',
+      UserComment: 'Comment',
+    },
+  })
+  likeable!: Post | Comment;
+}
+
+describe('GH issue 7722', () => {
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      dbName: ':memory:',
+      entities: [Post, Comment, UserLike, User, Author],
+      metadataProvider: ReflectMetadataProvider,
+    });
+    await orm.schema.refresh();
+  });
+
+  afterAll(async () => {
+    await orm.close(true);
+  });
+
+  test('populating polymorphic relation does not crash when only one target has an actively-filtered relation', async () => {
+    const author = orm.em.create(Author, { name: 'John Doe' });
+    const post = orm.em.create(Post, { title: 'Hello World', author });
+    const comment = orm.em.create(Comment, { text: 'Great post!' });
+    const user = orm.em.create(User, { name: 'Alice' });
+    orm.em.create(UserLike, { user, likeable: post });
+    orm.em.create(UserLike, { user, likeable: comment });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const userLoaded = await orm.em.findOneOrFail(User, user.id, { populate: ['likes', 'likes.likeable'] });
+
+    expect(userLoaded.likes.length).toBe(2);
+    expect(userLoaded.likes[0].likeable).toBeInstanceOf(Post);
+    expect(userLoaded.likes[1].likeable).toBeInstanceOf(Comment);
+  });
+});


### PR DESCRIPTION
## Summary

`autoJoinRefsForFilters` recursed only into `prop.targetMeta` (the first polymorphic target), so a `:ref` hint auto-added for a filtered relation on that target was pushed into the shared `hint.children` and then applied to every polymorph target during populate — crashing in `EntityLoader.populateField` with `TypeError: Cannot read properties of undefined (reading 'kind')` when another target lacked the property.

The fix iterates over every `polymorphTarget` and drops newly-added child hints whose field is not present on every target.

Closes #7722