### PR TITLE
fix(core): propagate pivot entity to STI root for inverse M:N

### DIFF
--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -770,6 +770,11 @@ export class MetadataDiscovery {
 
           if (prop.inversedBy) {
             prop.targetMeta!.properties[prop.inversedBy].pivotEntity = pivotMeta.class;
+            const targetRoot = prop.targetMeta!.root;
+
+            if (targetRoot !== prop.targetMeta && targetRoot.properties[prop.inversedBy]) {
+              targetRoot.properties[prop.inversedBy].pivotEntity = pivotMeta.class;
+            }
           }
 
           return pivotMeta;

--- a/tests/issues/GH7724.test.ts
+++ b/tests/issues/GH7724.test.ts
@@ -37,9 +37,9 @@ describe('GH issue 7724', () => {
 
   test('self-referencing M:N on STI child can be joined via the STI root', async () => {
     await orm.em
-      .qb(Animal, 'e')
-      .leftJoinAndSelect('e.friends' as never, 'a')
-      .leftJoinAndSelect('e.friendOf' as never, 'b')
+      .qb(Animal as typeof Cat, 'e')
+      .leftJoinAndSelect('e.friends', 'a')
+      .leftJoinAndSelect('e.friendOf', 'b')
       .getResultList();
   });
 });

--- a/tests/issues/GH7724.test.ts
+++ b/tests/issues/GH7724.test.ts
@@ -35,11 +35,20 @@ describe('GH issue 7724', () => {
     await orm.close(true);
   });
 
-  test('self-referencing M:N on STI child can be joined via the STI root', async () => {
+  test('qb leftJoinAndSelect of child inverse M:N via the STI root', async () => {
+    // original repro from the issue — joins the inverse M:N through the
+    // STI root, which used to crash because the root's inlined copy of the
+    // inverse property had a stale undefined `pivotEntity`.
     await orm.em
       .qb(Animal as typeof Cat, 'e')
       .leftJoinAndSelect('e.friends', 'a')
       .leftJoinAndSelect('e.friendOf', 'b')
       .getResultList();
+  });
+
+  test('em.find with filter on child inverse M:N via the STI root', async () => {
+    // realistic usage hitting the same underlying bug: filtering by the
+    // inverse M:N auto-joins it through the STI root.
+    await orm.em.find(Animal as typeof Cat, { friendOf: { id: 1 } });
   });
 });

--- a/tests/issues/GH7724.test.ts
+++ b/tests/issues/GH7724.test.ts
@@ -1,0 +1,45 @@
+import { Collection, MikroORM } from '@mikro-orm/sqlite';
+import { Entity, Enum, ManyToMany, PrimaryKey, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+
+@Entity({ discriminatorColumn: 'kind', abstract: true, tableName: 'animal' })
+abstract class Animal {
+  @PrimaryKey()
+  id!: number;
+
+  @Enum()
+  kind!: string;
+}
+
+@Entity({ discriminatorValue: 'cat' })
+class Cat extends Animal {
+  @ManyToMany({ entity: () => Cat, inversedBy: 'friendOf' })
+  friends = new Collection<Cat>(this);
+
+  @ManyToMany({ entity: () => Cat, mappedBy: 'friends' })
+  friendOf = new Collection<Cat>(this);
+}
+
+describe('GH issue 7724', () => {
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      dbName: ':memory:',
+      entities: [Animal, Cat],
+      metadataProvider: ReflectMetadataProvider,
+    });
+    await orm.schema.refresh();
+  });
+
+  afterAll(async () => {
+    await orm.close(true);
+  });
+
+  test('self-referencing M:N on STI child can be joined via the STI root', async () => {
+    await orm.em
+      .qb(Animal, 'e')
+      .leftJoinAndSelect('e.friends' as never, 'a')
+      .leftJoinAndSelect('e.friendOf' as never, 'b')
+      .getResultList();
+  });
+});


### PR DESCRIPTION
The inverse side of a M:N has its `pivotEntity` set in `processEntity` after `definePivotTableEntity` runs, but by then `initSingleTableInheritance` has already inlined the inverse property onto the STI root via a shallow copy with `pivotEntity` still `undefined`. Joining the inverse through the STI root then crashed in `joinManyToManyReference` reading `pivotMeta.tableName`. Owner-side joins worked because `processEntity` also iterates the root entity directly.

Closes #7724