### PR TITLE
fix(core): scope STI subclass discriminator when extends is a schema

### DIFF
--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -500,14 +500,14 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
 
     const types = Object.values(meta.root.discriminatorMap!).map(cls => this.metadata.get(cls));
     const children: EntityMetadata[] = [];
-    const lookUpChildren = (ret: EntityMetadata[], type: EntityName) => {
-      const children = types.filter(meta2 => meta2.extends === type);
-      children.forEach(m => lookUpChildren(ret, m.class));
+    const lookUpChildren = (ret: EntityMetadata[], parent: EntityMetadata) => {
+      const children = types.filter(meta2 => meta2.extends && this.metadata.find(meta2.extends) === parent);
+      children.forEach(m => lookUpChildren(ret, m));
       ret.push(...children.filter(c => c.discriminatorValue));
 
       return children;
     };
-    lookUpChildren(children, meta.class);
+    lookUpChildren(children, meta);
     /* v8 ignore next */
     (where as Dictionary)[meta.root.discriminatorColumn!] =
       children.length > 0

--- a/packages/sql/src/query/QueryBuilder.ts
+++ b/packages/sql/src/query/QueryBuilder.ts
@@ -3367,14 +3367,14 @@ export class QueryBuilder<
 
     const types = Object.values(meta.root.discriminatorMap!).map(cls => this.metadata.get(cls));
     const children: EntityMetadata[] = [];
-    const lookUpChildren = (ret: EntityMetadata[], type: EntityName) => {
-      const children = types.filter(meta2 => meta2.extends === type);
-      children.forEach(m => lookUpChildren(ret, m.class));
+    const lookUpChildren = (ret: EntityMetadata[], parent: EntityMetadata) => {
+      const children = types.filter(meta2 => meta2.extends && this.metadata.find(meta2.extends) === parent);
+      children.forEach(m => lookUpChildren(ret, m));
       ret.push(...children.filter(c => c.discriminatorValue));
 
       return children;
     };
-    lookUpChildren(children, meta.class);
+    lookUpChildren(children, meta);
     this.andWhere({
       [meta.root.discriminatorColumn!]:
         children.length > 0

--- a/tests/issues/GH7726.test.ts
+++ b/tests/issues/GH7726.test.ts
@@ -1,0 +1,78 @@
+import { MikroORM, defineEntity, p } from '@mikro-orm/sqlite';
+
+const UserTypes = ['user', 'casual', 'heavy'] as const;
+
+const UserSchema = defineEntity({
+  discriminatorColumn: 'type',
+  discriminatorValue: 'user',
+  name: 'User',
+  properties: {
+    id: p.integer().primary(),
+    type: p.enum(UserTypes).hidden(),
+  },
+});
+
+class User extends UserSchema.class {}
+UserSchema.setClass(User);
+
+const CasualUserSchema = defineEntity({
+  discriminatorValue: 'casual',
+  extends: UserSchema,
+  name: 'CasualUser',
+  properties: {},
+});
+
+class CasualUser extends CasualUserSchema.class {}
+CasualUserSchema.setClass(CasualUser);
+
+const HeavyUserSchema = defineEntity({
+  discriminatorValue: 'heavy',
+  extends: UserSchema,
+  name: 'HeavyUser',
+  properties: {},
+});
+
+class HeavyUser extends HeavyUserSchema.class {}
+HeavyUserSchema.setClass(HeavyUser);
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    dbName: ':memory:',
+    entities: [UserSchema, CasualUserSchema, HeavyUserSchema],
+  });
+});
+
+beforeEach(async () => {
+  await orm.schema.refresh();
+  const em = orm.em.fork();
+  em.create(User, { id: 1, type: 'user' });
+  em.create(CasualUser, { id: 2, type: 'casual' });
+  em.create(HeavyUser, { id: 3, type: 'heavy' });
+  await em.flush();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+test('STI subclass discriminator applies on SELECT and DELETE (defineEntity extends)', async () => {
+  // SELECT path: querying a subclass must filter by the subclass discriminator,
+  // not the root's — used to wrongly return zero rows / wrong-type rows.
+  const casualOnly = await orm.em.fork().find(CasualUser, {});
+  expect(casualOnly.map(u => u.id)).toEqual([2]);
+
+  // DELETE path: removing a subclass must scope the delete to subtype rows,
+  // not the root discriminator value — used to delete 0 rows.
+  const em = orm.em.fork();
+  const casual = await em.findOneOrFail(CasualUser, { id: 2 });
+  em.remove(casual);
+  await em.flush();
+
+  const stillAlive = await em.fork().find(User, {});
+  expect(stillAlive.map(u => u.id).sort()).toEqual([1, 3]);
+
+  const deadBody = await em.fork().findOne(CasualUser, { id: 2 });
+  expect(deadBody).toBeNull();
+});


### PR DESCRIPTION
## Summary

`applyDiscriminatorCondition` (both the SQL `QueryBuilder` and the base `EntityManager` for Mongo) used a raw `meta2.extends === type` identity check to walk an STI hierarchy. That comparison succeeds for decorator-defined entities (`extends` is the parent class) but fails for `defineEntity({ extends: ParentSchema })`, where `extends` is an `EntitySchema` instance.

When the comparison fails the child list collapses to empty and the query falls back to the root's own discriminator value. The user-visible effects:

- `em.find(SubClass, ...)` returns rows of the root type instead of the subtype.
- `em.remove(subclassEntity)` + `flush` deletes zero rows (the root delete is batched on `meta.root.class` and ends up filtering by the root's discriminator value, e.g. `where id in (?) and type = 'user'`).

Both call sites are normalised through `Utils.className`, the same helper already used in `MetadataDiscovery.ts:1342` for the equivalent check.

Closes #7726