### PR TITLE
docs: include pglite in driver listings and index support matrix

### DIFF
--- a/docs/docs/architecture.md
+++ b/docs/docs/architecture.md
@@ -284,7 +284,7 @@ See [Serializing](./serializing.md) for all options including serialization grou
 
 MikroORM uses a driver abstraction to support multiple databases. The `@mikro-orm/core` package contains database-agnostic logic (EntityManager, UnitOfWork, IdentityMap), while driver packages provide database-specific implementations.
 
-**SQL drivers**: `@mikro-orm/postgresql`, `@mikro-orm/mysql`, `@mikro-orm/mariadb`, `@mikro-orm/sqlite`, `@mikro-orm/libsql`, `@mikro-orm/mssql` - all with full QueryBuilder support.
+**SQL drivers**: `@mikro-orm/postgresql`, `@mikro-orm/pglite`, `@mikro-orm/mysql`, `@mikro-orm/mariadb`, `@mikro-orm/sqlite`, `@mikro-orm/libsql`, `@mikro-orm/mssql`, `@mikro-orm/oracledb` - all with full QueryBuilder support.
 
 **MongoDB driver**: `@mikro-orm/mongodb` - uses the native MongoDB driver. No QueryBuilder (use `em.find()` with filter objects instead).
 

--- a/docs/docs/deployment.md
+++ b/docs/docs/deployment.md
@@ -312,6 +312,8 @@ external: [
   '@mikro-orm/mongodb',
   '@mikro-orm/mysql',
   '@mikro-orm/mssql',
+  '@mikro-orm/oracledb',
+  '@mikro-orm/pglite',
   '@mikro-orm/seeder',
   '@mikro-orm/sqlite',
   '@mikro-orm/libsql',

--- a/docs/docs/guide/00-introduction.md
+++ b/docs/docs/guide/00-introduction.md
@@ -52,6 +52,7 @@ Full list of currently available drivers:
 - `@mikro-orm/mysql`
 - `@mikro-orm/mariadb`
 - `@mikro-orm/postgresql`
+- `@mikro-orm/pglite`
 - `@mikro-orm/sqlite`
 - `@mikro-orm/libsql`
 - `@mikro-orm/mssql`

--- a/docs/docs/indexes.md
+++ b/docs/docs/indexes.md
@@ -677,24 +677,24 @@ export class User {
 
 ## Database Support Summary
 
-| Feature | MySQL | MariaDB | PostgreSQL | MSSQL | SQLite | MongoDB |
-|---------|-------|---------|------------|-------|--------|---------|
-| Basic indexes | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Unique constraints | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Composite indexes | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Index expressions | ✅ | ✅ | ✅ | ✅ | ✅ | - |
-| Partial indexes (`where`) | ✅ (CASE WHEN) | - | ✅ | ✅ | ✅ | ✅ (object form → `partialFilterExpression`) |
-| Fulltext indexes | ✅ | ✅ | ✅ | ✅ | - | ✅ |
-| Sort order (ASC/DESC) | ✅ | ✅ | ✅ | ✅ | ✅ | - |
-| NULLS FIRST/LAST | - | - | ✅ | - | - | - |
-| Column prefix length | ✅ | ✅ | - | - | - | - |
-| Collation | ✅ | ✅ | ✅ | - | ✅ | - |
-| INCLUDE columns | - | - | ✅ | ✅ | - | - |
-| Fill factor | - | - | ✅ | ✅ | - | - |
-| Invisible indexes | ✅ | ✅ | - | - | - | ✅ |
-| Disabled indexes | - | - | - | ✅ | - | - |
-| Clustered indexes | - | ✅ | - | ✅ | - | - |
-| Deferrable constraints | - | - | ✅ | - | - | - |
+| Feature | MySQL | MariaDB | PostgreSQL | PGlite | CockroachDB | MSSQL | Oracle | SQLite | libSQL | MongoDB |
+|---------|-------|---------|------------|--------|-------------|-------|--------|--------|--------|---------|
+| Basic indexes | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Unique constraints | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Composite indexes | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Index expressions | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | - |
+| Partial indexes (`where`) | ✅ (CASE WHEN) | - | ✅ | ✅ | ✅ | ✅ | ✅ (CASE WHEN) | ✅ | ✅ | ✅ (object form → `partialFilterExpression`) |
+| Fulltext indexes | ✅ | ✅ | ✅ | ✅ | - | ✅ | - | - | - | ✅ |
+| Sort order (ASC/DESC) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | - |
+| NULLS FIRST/LAST | - | - | ✅ | ✅ | ✅ | - | ✅ | - | - | - |
+| Column prefix length | ✅ | ✅ | - | - | - | - | - | - | - | - |
+| Collation | ✅ | ✅ | ✅ | ✅ | ✅ | - | ✅ | ✅ | ✅ | - |
+| INCLUDE columns | - | - | ✅ | ✅ | ✅ | ✅ | - | - | - | - |
+| Fill factor | - | - | ✅ | ✅ | - | ✅ | - | - | - | - |
+| Invisible indexes | ✅ | ✅ | - | - | - | - | - | - | - | ✅ |
+| Disabled indexes | - | - | - | - | - | ✅ | - | - | - | - |
+| Clustered indexes | - | ✅ | - | - | - | ✅ | - | - | - | - |
+| Deferrable constraints | - | - | ✅ | ✅ | - | - | ✅ | - | - | - |
 
 ## See Also
 

--- a/docs/docs/usage-with-sql.md
+++ b/docs/docs/usage-with-sql.md
@@ -8,6 +8,8 @@ MikroORM supports several SQL databases out of the box. Install the driver packa
 # for postgresql (works with cockroachdb too)
 npm install @mikro-orm/postgresql
 
+# for pglite (embedded PostgreSQL in WASM)
+npm install @mikro-orm/pglite
 
 # for mysql (works with mariadb too)
 npm install @mikro-orm/mysql

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -198,6 +198,7 @@ function FeatureScroll() {
 
 const driverPackages = [
   '@mikro-orm/postgresql',
+  '@mikro-orm/pglite',
   '@mikro-orm/mysql',
   '@mikro-orm/mariadb',
   '@mikro-orm/sqlite',


### PR DESCRIPTION
PGlite was missing from several places that list the available drivers. Filling those in and expanding the index support matrix to cover the rest of the supported engines while at it.

- homepage install snippet rotation (`docs/src/pages/index.js`)
- `usage-with-sql.md` install commands
- `architecture.md` SQL drivers sentence
- guide intro driver list
- `deployment.md` esbuild externals example
- `indexes.md` "Database Support Summary" — added PGlite, CockroachDB, Oracle, libSQL columns