### PR TITLE
fix(core): resolve TPT parent alias for custom-typed inherited columns

### DIFF
--- a/packages/sql/src/AbstractSqlDriver.ts
+++ b/packages/sql/src/AbstractSqlDriver.ts
@@ -2473,6 +2473,7 @@ export abstract class AbstractSqlDriver<
     }
 
     const aliased = this.platform.quoteIdentifier(`${tableAlias}__${prop.fieldNames[0]}`);
+    const sourceAlias = qb.helper.getTPTAliasForProperty(prop.name, tableAlias);
 
     if (prop.customTypes?.some(type => !!type?.convertToJSValueSQL)) {
       return prop.fieldNames.map((col, idx) => {
@@ -2480,7 +2481,7 @@ export abstract class AbstractSqlDriver<
           return col;
         }
 
-        const prefixed = this.platform.quoteIdentifier(`${tableAlias}.${col}`);
+        const prefixed = this.platform.quoteIdentifier(`${sourceAlias}.${col}`);
         const aliased = this.platform.quoteIdentifier(`${tableAlias}__${col}`);
 
         return raw(`${prop.customTypes[idx].convertToJSValueSQL(prefixed, this.platform)} as ${aliased}`);
@@ -2488,7 +2489,7 @@ export abstract class AbstractSqlDriver<
     }
 
     if (prop.customType?.convertToJSValueSQL) {
-      const prefixed = this.platform.quoteIdentifier(`${tableAlias}.${prop.fieldNames[0]}`);
+      const prefixed = this.platform.quoteIdentifier(`${sourceAlias}.${prop.fieldNames[0]}`);
       return [raw(`${prop.customType.convertToJSValueSQL(prefixed, this.platform)} as ${aliased}`)];
     }
 
@@ -2499,7 +2500,6 @@ export abstract class AbstractSqlDriver<
       return [raw(`${this.evaluateFormula(prop.formula, columns, table)} as ${aliased}`)];
     }
 
-    const sourceAlias = qb.helper.getTPTAliasForProperty(prop.name, tableAlias);
     return prop.fieldNames.map(fieldName => {
       return raw('?? as ??', [`${sourceAlias}.${fieldName}`, `${tableAlias}__${fieldName}`]);
     });

--- a/tests/issues/GHx50.test.ts
+++ b/tests/issues/GHx50.test.ts
@@ -1,0 +1,113 @@
+// When populating a relation to a TPT child entity, scalar properties that use
+// a custom type with `convertToJSValueSQL` (e.g. JSON columns inherited from a
+// TPT parent) were being selected from the child sub-table alias instead of
+// the parent table alias, producing "no such column" errors.
+import {
+  Entity,
+  ManyToOne,
+  OneToMany,
+  OneToOne,
+  PrimaryKey,
+  Property,
+  ReflectMetadataProvider,
+} from '@mikro-orm/decorators/legacy';
+import { Collection, MikroORM, type Rel } from '@mikro-orm/sqlite';
+
+@Entity({ inheritance: 'tpt' })
+abstract class ProjectSnapshot {
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ type: 'json' })
+  metadata: Record<string, any>;
+
+  constructor(metadata: Record<string, any>) {
+    this.metadata = metadata;
+  }
+}
+
+@Entity()
+class Offer extends ProjectSnapshot {
+  @Property({ type: 'json' })
+  offerProp: Record<string, any>;
+
+  constructor(metadata: Record<string, any>, offerProp: Record<string, any>) {
+    super(metadata);
+    this.offerProp = offerProp;
+  }
+}
+
+@Entity()
+class Addendum extends ProjectSnapshot {
+  @ManyToOne(() => Contract)
+  contract!: Rel<Contract>;
+
+  @Property({ type: 'json' })
+  addendumProp: Record<string, any>;
+
+  constructor(metadata: Record<string, any>, addendumProp: Record<string, any>) {
+    super(metadata);
+    this.addendumProp = addendumProp;
+  }
+}
+
+@Entity()
+class Contract {
+  @PrimaryKey()
+  id!: number;
+
+  @OneToOne(() => Offer)
+  offer!: Rel<Offer>;
+
+  @OneToMany(() => Addendum, a => a.contract)
+  addendums = new Collection<Addendum>(this);
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    dbName: ':memory:',
+    entities: [ProjectSnapshot, Offer, Addendum, Contract],
+    metadataProvider: ReflectMetadataProvider,
+    allowGlobalContext: true,
+  });
+  await orm.schema.refresh();
+});
+
+afterAll(async () => orm.close(true));
+
+test('populating contract.offer from a TPT child does not collide with own TPT parent join', async () => {
+  const offer = orm.em.create(Offer, { metadata: { foo: 'bar' }, offerProp: { x: 1 } });
+  await orm.em.flush();
+
+  const contract = orm.em.create(Contract, { offer });
+  const addendum = orm.em.create(Addendum, { metadata: { baz: 'qux' }, addendumProp: { y: 2 }, contract });
+  await orm.em.flush();
+  orm.em.clear();
+
+  const result = await orm.em.findOneOrFail(Addendum, addendum.id, {
+    populate: ['contract.offer'],
+  });
+
+  expect(result.metadata).toEqual({ baz: 'qux' });
+  expect(result.contract.offer.metadata).toEqual({ foo: 'bar' });
+});
+
+test('populating contract.offer from a TPT child with select-in does not collide', async () => {
+  const offer = orm.em.create(Offer, { metadata: { foo: 'bar' }, offerProp: { x: 1 } });
+  await orm.em.flush();
+
+  const contract = orm.em.create(Contract, { offer });
+  const addendum = orm.em.create(Addendum, { metadata: { baz: 'qux' }, addendumProp: { y: 2 }, contract });
+  await orm.em.flush();
+  orm.em.clear();
+
+  const result = await orm.em.findOneOrFail(Addendum, addendum.id, {
+    populate: ['contract.offer'],
+    strategy: 'select-in',
+  });
+
+  expect(result.metadata).toEqual({ baz: 'qux' });
+  expect(result.contract.offer.metadata).toEqual({ foo: 'bar' });
+});


### PR DESCRIPTION
## Summary

When populating a relation to a TPT child entity, `mapPropToFieldNames` only resolved the TPT-aware source alias on its fallthrough branch. Scalar properties using a custom type with `convertToJSValueSQL` — most notably JSON columns inherited from a TPT parent — still selected from the child sub-table alias, e.g.

```sql
select `p4`.`id` as `o3__id`,
       `o3`.`metadata` as `o3__metadata`,   -- ← wrong, metadata lives on project_snapshot (p4)
       `o3`.`offer_prop` as `o3__offer_prop`
from `addendum` as `a0`
  inner join `project_snapshot` as `p1` on `a0`.`id` = `p1`.`id`
  inner join `contract` as `c2` on `a0`.`contract_id` = `c2`.`id`
  inner join `offer` as `o3` on `c2`.`offer_id` = `o3`.`id`
  inner join `project_snapshot` as `p4` on `o3`.`id` = `p4`.`id`
```

Hoisting the existing `getTPTAliasForProperty` lookup so it covers the `customType`/`customTypes` branches fixes it.