### PR TITLE
fix(core): merge index `columns` overrides with the full property list

### DIFF
--- a/packages/mssql/src/MsSqlSchemaHelper.ts
+++ b/packages/mssql/src/MsSqlSchemaHelper.ts
@@ -687,22 +687,19 @@ export class MsSqlSchemaHelper extends SchemaHelper {
    * Build the column list for a MSSQL index.
    */
   protected override getIndexColumns(index: IndexDef): string {
-    if (index.columns?.length) {
-      return index.columns
-        .map(col => {
-          let colDef = this.quote(col.name);
+    return index.columnNames
+      .map(name => {
+        const col = index.columns?.find(c => c.name === name);
+        let colDef = this.quote(name);
 
-          // MSSQL supports sort order
-          if (col.sort) {
-            colDef += ` ${col.sort}`;
-          }
+        // MSSQL supports sort order
+        if (col?.sort) {
+          colDef += ` ${col.sort}`;
+        }
 
-          return colDef;
-        })
-        .join(', ');
-    }
-
-    return index.columnNames.map(c => this.quote(c)).join(', ');
+        return colDef;
+      })
+      .join(', ');
   }
 
   /**

--- a/packages/sql/src/dialects/mysql/MySqlSchemaHelper.ts
+++ b/packages/sql/src/dialects/mysql/MySqlSchemaHelper.ts
@@ -211,42 +211,39 @@ export class MySqlSchemaHelper extends SchemaHelper {
    * MySQL requires collation to be specified as an expression: (column_name COLLATE collation_name)
    */
   protected override getIndexColumns(index: IndexDef): string {
-    if (index.columns?.length) {
-      return index.columns
-        .map(col => {
-          const quotedName = this.quote(col.name);
+    return index.columnNames
+      .map(name => {
+        const col = index.columns?.find(c => c.name === name);
+        const quotedName = this.quote(name);
 
-          // MySQL supports collation via expression: (column_name COLLATE collation_name)
-          // When collation is specified, wrap in parentheses as an expression
-          if (col.collation) {
-            let expr = col.length ? `${quotedName}(${col.length})` : quotedName;
-            expr = `(${expr} collate ${col.collation})`;
-            // Sort order comes after the expression
-            if (col.sort) {
-              expr += ` ${col.sort}`;
-            }
-            return expr;
-          }
-
-          // Standard column definition without collation
-          let colDef = quotedName;
-
-          // MySQL supports prefix length
-          if (col.length) {
-            colDef += `(${col.length})`;
-          }
-
-          // MySQL supports sort order
+        // MySQL supports collation via expression: (column_name COLLATE collation_name)
+        // When collation is specified, wrap in parentheses as an expression
+        if (col?.collation) {
+          let expr = col.length ? `${quotedName}(${col.length})` : quotedName;
+          expr = `(${expr} collate ${col.collation})`;
+          // Sort order comes after the expression
           if (col.sort) {
-            colDef += ` ${col.sort}`;
+            expr += ` ${col.sort}`;
           }
+          return expr;
+        }
 
-          return colDef;
-        })
-        .join(', ');
-    }
+        // Standard column definition without collation
+        let colDef = quotedName;
 
-    return index.columnNames.map(c => this.quote(c)).join(', ');
+        // MySQL supports prefix length
+        if (col?.length) {
+          colDef += `(${col.length})`;
+        }
+
+        // MySQL supports sort order
+        if (col?.sort) {
+          colDef += ` ${col.sort}`;
+        }
+
+        return colDef;
+      })
+      .join(', ');
   }
 
   /**

--- a/packages/sql/src/dialects/postgresql/PostgreSqlSchemaHelper.ts
+++ b/packages/sql/src/dialects/postgresql/PostgreSqlSchemaHelper.ts
@@ -968,32 +968,29 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
    * Build the column list for a PostgreSQL index.
    */
   protected override getIndexColumns(index: IndexDef): string {
-    if (index.columns?.length) {
-      return index.columns
-        .map(col => {
-          let colDef = this.quote(col.name);
+    return index.columnNames
+      .map(name => {
+        const col = index.columns?.find(c => c.name === name);
+        let colDef = this.quote(name);
 
-          // PostgreSQL supports collation with double quotes
-          if (col.collation) {
-            colDef += ` collate ${this.quote(col.collation)}`;
-          }
+        // PostgreSQL supports collation with double quotes
+        if (col?.collation) {
+          colDef += ` collate ${this.quote(col.collation)}`;
+        }
 
-          // PostgreSQL supports sort order
-          if (col.sort) {
-            colDef += ` ${col.sort}`;
-          }
+        // PostgreSQL supports sort order
+        if (col?.sort) {
+          colDef += ` ${col.sort}`;
+        }
 
-          // PostgreSQL supports NULLS FIRST/LAST
-          if (col.nulls) {
-            colDef += ` nulls ${col.nulls}`;
-          }
+        // PostgreSQL supports NULLS FIRST/LAST
+        if (col?.nulls) {
+          colDef += ` nulls ${col.nulls}`;
+        }
 
-          return colDef;
-        })
-        .join(', ');
-    }
-
-    return index.columnNames.map(c => this.quote(c)).join(', ');
+        return colDef;
+      })
+      .join(', ');
   }
 
   /**

--- a/packages/sql/src/schema/SchemaHelper.ts
+++ b/packages/sql/src/schema/SchemaHelper.ts
@@ -198,32 +198,29 @@ export abstract class SchemaHelper {
    * Note: Prefix length is only supported by MySQL/MariaDB which override this method.
    */
   protected getIndexColumns(index: IndexDef): string {
-    if (index.columns?.length) {
-      return index.columns
-        .map(col => {
-          let colDef = this.quote(col.name);
+    return index.columnNames
+      .map(name => {
+        const col = index.columns?.find(c => c.name === name);
+        let colDef = this.quote(name);
 
-          // Collation comes after column name (SQLite syntax: column COLLATE name)
-          if (col.collation) {
-            colDef += ` collate ${col.collation}`;
-          }
+        // Collation comes after column name (SQLite syntax: column COLLATE name)
+        if (col?.collation) {
+          colDef += ` collate ${col.collation}`;
+        }
 
-          // Sort order
-          if (col.sort) {
-            colDef += ` ${col.sort}`;
-          }
+        // Sort order
+        if (col?.sort) {
+          colDef += ` ${col.sort}`;
+        }
 
-          // NULLS ordering (PostgreSQL)
-          if (col.nulls) {
-            colDef += ` nulls ${col.nulls}`;
-          }
+        // NULLS ordering (PostgreSQL)
+        if (col?.nulls) {
+          colDef += ` nulls ${col.nulls}`;
+        }
 
-          return colDef;
-        })
-        .join(', ');
-    }
-
-    return index.columnNames.map(c => this.quote(c)).join(', ');
+        return colDef;
+      })
+      .join(', ');
   }
 
   /** Returns SQL to drop an index. */

--- a/tests/issues/GHx51.test.ts
+++ b/tests/issues/GHx51.test.ts
@@ -1,0 +1,52 @@
+// When a composite index has `columns` overriding a subset of the columns
+// listed in `properties`, the schema generator dropped the property columns
+// that were not mentioned in `columns` instead of merging the overrides into
+// the full property column list.
+import { defineEntity, MikroORM, p } from '@mikro-orm/sqlite';
+
+const Client = defineEntity({
+  name: 'ClientGHx51',
+  tableName: 'client_ghx51',
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+  },
+});
+
+const Job = defineEntity({
+  name: 'JobGHx51',
+  tableName: 'job_ghx51',
+  indexes: [
+    {
+      name: 'job_ghx51_client_closed_at_idx',
+      properties: ['client', 'closedAt'],
+      columns: [{ name: 'closedAt', sort: 'DESC' }],
+    },
+  ],
+  properties: {
+    id: p.integer().primary(),
+    client: () => p.manyToOne(Client),
+    closedAt: p.datetime().nullable(),
+  },
+});
+
+describe('GHx51', () => {
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      dbName: ':memory:',
+      entities: [Client, Job],
+    });
+  });
+
+  afterAll(() => orm.close(true));
+
+  test('schema generator keeps property columns when index columns customize another column', async () => {
+    const sql = await orm.schema.getCreateSchemaSQL({ wrap: false });
+
+    expect(sql).toContain(
+      'create index `job_ghx51_client_closed_at_idx` on `job_ghx51` (`client_id`, `closed_at` DESC);',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

When an index declared both `properties` and `columns` with the latter only overriding a subset (e.g. to set `sort: 'DESC'` on a single column), the schema generator emitted **only** the overridden columns and silently dropped the rest.

Example: `properties: ['client', 'closedAt']` + `columns: [{ name: 'closedAt', sort: 'DESC' }]` produced `(\`closed_at\` DESC)` instead of `(\`client_id\`, \`closed_at\` DESC)`.

`getIndexColumns` now iterates the full `columnNames` list and uses `index.columns` purely as a per-column override lookup. The change is applied consistently in the four dialect helpers (base SQL/SQLite/MariaDB, MySQL, PostgreSQL, MSSQL).