### PR TITLE
fix(core): carry user-declared STI discriminator through mergeData

### DIFF
--- a/packages/core/src/entity/EntityFactory.ts
+++ b/packages/core/src/entity/EntityFactory.ts
@@ -254,15 +254,17 @@ export class EntityFactory {
       })
       .forEach(key => delete diff2[key]);
 
-    // but always add collection properties, formulas, generated columns, and version properties if they
-    // are part of the `data`, as these are excluded from `comparableProps` and won't appear in the diff
+    // but always add collection properties, formulas, generated columns, version properties, and the
+    // user-declared STI discriminator if they are part of the `data`, as these are excluded from
+    // `comparableProps` and won't appear in the diff
     Utils.keys(data)
       .filter(
         key =>
           meta.properties[key]?.formula ||
           meta.properties[key]?.version ||
           (meta.properties[key]?.generated && !meta.properties[key]?.primary) ||
-          [ReferenceKind.ONE_TO_MANY, ReferenceKind.MANY_TO_MANY].includes(meta.properties[key]?.kind),
+          [ReferenceKind.ONE_TO_MANY, ReferenceKind.MANY_TO_MANY].includes(meta.properties[key]?.kind) ||
+          (key === meta.root.discriminatorColumn && meta.properties[key]?.userDefined !== false),
       )
       .forEach(key => (diff2[key] = data[key]));
 

--- a/tests/issues/GH7735.test.ts
+++ b/tests/issues/GH7735.test.ts
@@ -1,0 +1,81 @@
+import { MikroORM } from '@mikro-orm/sqlite';
+import { Entity, Enum, ManyToOne, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+
+enum VehicleType {
+  Car = 'car',
+  Truck = 'truck',
+}
+
+@Entity({
+  abstract: true,
+  discriminatorColumn: 'type',
+  tableName: 'vehicle',
+})
+abstract class Vehicle {
+  @PrimaryKey()
+  id!: string;
+
+  @Enum(() => VehicleType)
+  type!: VehicleType;
+
+  @ManyToOne(() => Vehicle, { nullable: true })
+  predecessor?: Vehicle;
+
+  @Property()
+  label!: string;
+}
+
+@Entity({ discriminatorValue: VehicleType.Car })
+class Car extends Vehicle {
+  @Property()
+  doors!: number;
+}
+
+@Entity({ discriminatorValue: VehicleType.Truck })
+class Truck extends Vehicle {
+  @Property()
+  loadCapacity!: number;
+}
+
+describe('GH issue 7735', () => {
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      dbName: ':memory:',
+      entities: [Vehicle, Car, Truck],
+      metadataProvider: ReflectMetadataProvider,
+    });
+    await orm.schema.refresh();
+
+    const oldCar = orm.em.create(Car, { id: '1', type: VehicleType.Car, label: 'old', doors: 2 });
+    orm.em.create(Car, { id: '2', type: VehicleType.Car, label: 'new', doors: 4, predecessor: oldCar });
+    await orm.em.flush();
+    orm.em.clear();
+  });
+
+  afterAll(async () => {
+    await orm.close(true);
+  });
+
+  test('user-declared discriminator is hydrated on direct find', async () => {
+    const loaded = await orm.em.findOneOrFail(Car, { id: '2' });
+    expect(loaded.type).toBe(VehicleType.Car);
+  });
+
+  test('user-declared discriminator is hydrated on populated reference', async () => {
+    const loaded = await orm.em.findOneOrFail(Car, { id: '2' }, { populate: ['predecessor'] });
+    expect(loaded.type).toBe(VehicleType.Car);
+    expect(loaded.predecessor!.type).toBe(VehicleType.Car);
+  });
+
+  test('user-declared discriminator is hydrated when entity already exists as a reference (mergeData path)', async () => {
+    orm.em.clear();
+    // pre-populate the identity map with an uninitialized reference so the
+    // subsequent find path goes through EntityFactory.mergeData
+    orm.em.getReference(Car, '2');
+    const loaded = await orm.em.findOneOrFail(Car, { id: '2' }, { populate: ['predecessor'] });
+    expect(loaded.type).toBe(VehicleType.Car);
+    expect(loaded.predecessor!.type).toBe(VehicleType.Car);
+  });
+});


### PR DESCRIPTION
`EntityComparator.isComparable` excludes the discriminator column from `comparableProps`, so the diff computed in `EntityFactory.mergeData` never contained it. When an entity already existed in the identity map as a reference and was then populated, the subsequent hydrate skipped the discriminator and left `entity[discriminatorColumn]` undefined even though the row carried the correct value.

Always carry the discriminator through `mergeData` alongside the other properties already exempted from the diff (formulas, generated columns, versions, collections), but only when it is user-declared — the auto-generated discriminator is still excluded from hydration by the `hydrateProps` filter.

Closes #7735