### PR TITLE
fix(core): allow local `forceObject: false` to override global setting

### DIFF
--- a/packages/core/src/serialization/EntitySerializer.ts
+++ b/packages/core/src/serialization/EntitySerializer.ts
@@ -302,7 +302,7 @@ export class EntitySerializer {
 
     const pk = this.processCustomType(wrapped.getPrimaryKey()!, prop, wrapped.__platform, options.convertCustomTypes);
 
-    if (options.forceObject || wrapped.__config.get('serialization').forceObject) {
+    if (options.forceObject ?? wrapped.__config.get('serialization').forceObject) {
       return Utils.primaryKeyToObject(meta, pk, visible) as EntityValue<T>;
     }
 
@@ -340,7 +340,7 @@ export class EntitySerializer {
 
       const pk = this.processCustomType(wrapped.getPrimaryKey()!, prop, wrapped.__platform, options.convertCustomTypes);
 
-      if (options.forceObject || wrapped.__config.get('serialization').forceObject) {
+      if (options.forceObject ?? wrapped.__config.get('serialization').forceObject) {
         return Utils.primaryKeyToObject(wrapped.__meta, pk) as EntityValue<T>;
       }
 

--- a/tests/issues/GH7738.test.ts
+++ b/tests/issues/GH7738.test.ts
@@ -1,0 +1,42 @@
+import { MikroORM, Ref, ref, serialize, wrap } from '@mikro-orm/sqlite';
+import { Entity, OneToOne, PrimaryKey, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+
+@Entity()
+class Parent {
+  @PrimaryKey()
+  id!: string;
+}
+
+@Entity()
+class Child {
+  @PrimaryKey()
+  id!: string;
+
+  @OneToOne(() => Parent, { ref: true, nullable: true })
+  parent!: Ref<Parent>;
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    metadataProvider: ReflectMetadataProvider,
+    entities: [Parent, Child],
+    dbName: ':memory:',
+    serialization: { forceObject: true },
+  });
+  await orm.schema.create();
+});
+
+afterAll(() => orm.close());
+
+test('local `forceObject: false` overrides global `serialization.forceObject: true`', async () => {
+  const child = orm.em.create(Child, {
+    id: 'child_id',
+    parent: ref(Parent, { id: 'parent_id' }),
+  });
+
+  expect(serialize(child)).toEqual({ id: 'child_id', parent: { id: 'parent_id' } });
+  expect(serialize(child, { forceObject: false })).toEqual({ id: 'child_id', parent: 'parent_id' });
+  expect(wrap(child).serialize({ forceObject: false })).toEqual({ id: 'child_id', parent: 'parent_id' });
+});


### PR DESCRIPTION
## Summary

`serialize(entity, { forceObject: false })` and `wrap(entity).serialize({ forceObject: false })` had no effect when `serialization.forceObject: true` was set globally on the ORM config — the local option was OR-ed with the global value, so a local `false` could never override a global `true`.

Switched the two call sites in `EntitySerializer` to use `??` so an explicitly provided local option wins over the global fallback. When `options.forceObject` is `undefined`, behavior is unchanged.

Closes #7738