### PR TITLE
chore(ci): retry docker compose up --wait to survive mssql restart

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -167,12 +167,25 @@ jobs:
 
       - name: Init docker
         run: |
-          if docker compose up -d --wait; then
-            # mssql 2025-CU3 occasionally crashes shortly after first healthy
-            # probe (SQLPAL/lsass.exe segfault). `restart: always` recovers it,
-            # but `--wait` returns as soon as one probe succeeds. Re-verify it
-            # stays reachable for a short stability window so any crash-restart
-            # cycle settles before tests start.
+          # mssql 2025-CU3 occasionally crashes shortly after first healthy
+          # probe (SQLPAL/lsass.exe segfault). `restart: always` recovers it,
+          # but `docker compose up -d --wait` aborts the moment it sees the
+          # restart cycle and reports the container "unhealthy", before the
+          # restart actually settles. Retry once after a brief delay so the
+          # second `--wait` observes the recovered container.
+          bring_up() {
+            for attempt in 1 2; do
+              if docker compose up -d --wait; then
+                return 0
+              fi
+              echo "::warning::docker compose up --wait failed (attempt $attempt); waiting 30s for any restart cycle to settle"
+              sleep 30
+            done
+            return 1
+          }
+          if bring_up; then
+            # Re-verify mssql stays reachable for a short stability window so
+            # any remaining crash-restart cycle settles before tests start.
             for i in 1 2 3 4 5; do
               sleep 5
               docker compose exec -T mssql /opt/mssql-tools18/bin/sqlcmd -b -C -S tcp:localhost -U sa -P 'Root.Root' -Q 'select 1' >/dev/null 2>&1 && continue
@@ -183,7 +196,7 @@ jobs:
             done
             exit 0
           fi
-          rc=$?
+          rc=1
           set +e
           echo "::group::docker compose ps -a"
           docker compose ps -a


### PR DESCRIPTION
mssql 2025-CU3 occasionally segfaults in SQLPAL (`lsass.exe` / `samsrv.dll`) shortly after the first healthy probe — see [the crash dump in this failing run](https://github.com/mikro-orm/mikro-orm/actions/runs/25990383787/job/76395303576). `restart: always` recovers the container, but `docker compose up -d --wait` aborts the moment it sees the restart cycle and reports the container "unhealthy" before the restart actually settles, so the existing 5-iteration stability probe loop never gets to run.

Wrap the bring-up in a 2-attempt retry: on first failure, sleep 30s for the restart cycle to settle, then retry `--wait`. The second attempt observes the recovered container, and the stability loop continues to guard against any crash that happens after `--wait` succeeds.

No exact upstream issue matches this CU3 + samsrv/lsass signature; closest candidate is [microsoft/mssql-docker#954](https://github.com/microsoft/mssql-docker/issues/954) (processor topology), but that's a different stack trace and our runner reports 4 CPUs which divides cleanly.