### PR TITLE
chore(tests): isolate stored-routines Oracle test from SchemaGenerator suite

### DIFF
--- a/tests/features/stored-routines/oracle.test.ts
+++ b/tests/features/stored-routines/oracle.test.ts
@@ -168,7 +168,7 @@ describe('stored routines — Oracle', () => {
       });
 
       const orm2 = await MikroORM.init({
-        dbName: 'mikro_orm_test_sg',
+        dbName: 'mikro_orm_test_routines',
         password: 'oracle123',
         schemaGenerator: { managementDbName: 'system', tableSpace: 'mikro_orm' },
         entities: [RecordEntity],


### PR DESCRIPTION
The `read-only functions inside em.transactional` parametrised test was spawning a second ORM bound to `mikro_orm_test_sg`, which is the database used by `SchemaGenerator.oracle.test.ts`. When the two files ran in parallel under vitest, the schema generator suite occasionally diffed against a `PURE_HASH` function left mid-test by the routines suite, producing spurious `drop function if exists "PURE_HASH"` lines in the `update schema enums` / `update schema` snapshots.

Reusing the outer describe's own `mikro_orm_test_routines` database keeps the function contained to the routines test file. Seen as a flake in https://github.com/mikro-orm/mikro-orm/actions/runs/25999407390/job/76419703883.