### PR TITLE
fix(mongo): create collections before ensuring indexes in `create()`

### DIFF
--- a/packages/mongodb/src/MongoSchemaGenerator.ts
+++ b/packages/mongodb/src/MongoSchemaGenerator.ts
@@ -42,11 +42,14 @@ export class MongoSchemaGenerator extends AbstractSchemaGenerator<MongoDriver> {
         }),
       );
 
+    // Collections must exist before we touch indexes. `createIndex` on a missing collection
+    // races with the explicit `createCollection` above, and on retries the recovery path can
+    // see partial state and drop indexes that were already created successfully.
+    await Promise.all(promises);
+
     if (options.ensureIndexes) {
       await this.ensureIndexes({ ensureCollections: false });
     }
-
-    await Promise.all(promises);
   }
 
   override async drop(options: { dropMigrationsTable?: boolean } = {}): Promise<void> {


### PR DESCRIPTION
`MongoSchemaGenerator.create()` was awaiting `ensureIndexes()` before the explicit `createCollection` promises it had just kicked off, relying on MongoDB's implicit collection creation via `createIndex` to paper over the race. When the implicit and explicit creates collided badly enough to fail an index, the retry path in `ensureIndexes` would route the collection through `dropIndexes` while only some of its named indexes existed, and depending on which ones were already tracked in `skipIndexes` the recovery could leave the collection without indexes the test expected. Awaiting the collection-creation promises first eliminates the race entirely.

Surfaced as a flake on `tests/features/using-index-hints.test.ts > using passes index name as hint to MongoDB` failing with `hint provided does not correspond to an existing index` in https://github.com/mikro-orm/mikro-orm/actions/runs/25999598660/job/76420220606.