### PR TITLE
chore(tests): skip MongoMemoryReplSet startup for `test:sqlite`

### DIFF
--- a/tests/globalSetup.ts
+++ b/tests/globalSetup.ts
@@ -237,7 +237,13 @@ async function cleanupMssqlOrphanFiles(t: SqlTarget): Promise<number> {
 }
 
 export async function setup() {
-  if (!(globalThis as any).__MONGOINSTANCE) {
+  // Narrow-scope test scripts (currently only `test:sqlite`, used by the Windows CI matrix) don't
+  // touch MongoDB, so skip the ~781MB binary download and 3-process replica-set spawn entirely.
+  // It's wasted work on every run and a flake source on Windows where worker startup occasionally
+  // emits unhandled errors that kill the vitest process before its try/catch can absorb them.
+  const skipMongo = process.env.npm_lifecycle_event === 'test:sqlite';
+
+  if (!skipMongo && !(globalThis as any).__MONGOINSTANCE) {
     try {
       const instance = await MongoMemoryReplSet.create({
         replSet: { name: 'rs', count: 3 },


### PR DESCRIPTION
The Windows CI matrix runs only `yarn test:sqlite`, which contains no MongoDB tests, yet `tests/globalSetup.ts` unconditionally downloads ~781MB of mongod binaries and spawns a 3-node replica set on every run.

The spawn step is a flake source on Windows — mongodb-memory-server has historically emitted unhandled rejections during worker startup that kill the vitest process before the existing try/catch can absorb them, producing exit code 1 with no captured test output (see https://github.com/mikro-orm/mikro-orm/actions/runs/25999407390/job/76419703844 — the log truncates 7 seconds after the download completes with no vitest output).

Gating on `npm_lifecycle_event === 'test:sqlite'` is the narrowest applicable check — only that one script is affected, and the teardown branch is already a no-op when no instance was created.