### PR TITLE
chore(ci): pin windows runner to `windows-2025-vs2026`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -313,7 +313,7 @@ jobs:
   test-windows:
     name: Tests (windows, node ${{ matrix.node-version }})
     if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
-    runs-on: 'windows-latest'
+    runs-on: 'windows-2025-vs2026'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
GitHub will redirect `windows-latest` to `windows-2025-vs2026` by June 15, 2026. Pinning explicitly now to avoid surprise image changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)