### PR TITLE
feat(core): add `discriminator` option and column-name override

### DIFF
--- a/docs/docs/decorators.md
+++ b/docs/docs/decorators.md
@@ -37,7 +37,8 @@ For detailed information about decorator types, metadata providers, and configur
 | `comment`             | `string`                   | yes      | Specify comment to table. **(SQL only)**                                           |
 | `repository`          | `() => EntityRepository`   | yes      | Set [custom repository class](./repositories.md#custom-repository).                |
 | `inheritance`         | `'tpt'`                    | yes      | For [Table-Per-Type Inheritance](./inheritance-mapping.md#table-per-type-inheritance-tpt). |
-| `discriminatorColumn` | `string`                   | yes      | For [Single Table Inheritance](./inheritance-mapping.md#single-table-inheritance). |
+| `discriminator`       | `string`                   | yes      | For [Single Table Inheritance](./inheritance-mapping.md#single-table-inheritance). Property name on the entity that stores the discriminator value. |
+| `discriminatorColumn` | `string`                   | yes      | Optional override for the discriminator column name. When `discriminator` is omitted, this is also used as the property name (legacy behavior). |
 | `discriminatorMap`    | `Dictionary<string>`       | yes      | For [Single Table Inheritance](./inheritance-mapping.md#single-table-inheritance). |
 | `discriminatorValue`  | `number` &#124; `string`   | yes      | For [Single Table Inheritance](./inheritance-mapping.md#single-table-inheritance). |
 | `forceConstructor`    | `boolean`                  | yes      | Enforce use of constructor when creating managed entity instances                  |
@@ -58,7 +59,8 @@ See [Embeddables](./embeddables.md) for more details.
 
 | Parameter             | Type                     | Optional | Description                                                                        |
 |-----------------------|--------------------------|----------|------------------------------------------------------------------------------------|
-| `discriminatorColumn` | `string`                 | yes      | For polymorphic embeddables.                                                       |
+| `discriminator`       | `string`                 | yes      | For polymorphic embeddables. Property name on the embeddable that stores the discriminator value. |
+| `discriminatorColumn` | `string`                 | yes      | Optional override for the discriminator column name. When `discriminator` is omitted, this is also used as the property name (legacy behavior). |
 | `discriminatorMap`    | `Dictionary<string>`     | yes      | For polymorphic embeddables.                                                       |
 | `discriminatorValue`  | `number` &#124; `string` | yes      | For polymorphic embeddables.                                                       |
 | `abstract`            | `boolean`                | yes      | Marks embeddable as abstract.                                                      |

--- a/docs/docs/embeddables.md
+++ b/docs/docs/embeddables.md
@@ -902,7 +902,7 @@ const AnimalSchema = defineEntity({
   name: 'Animal',
   embeddable: true,
   abstract: true,
-  discriminatorColumn: 'type',
+  discriminator: 'type',
   properties: {
     type: p.enum(() => AnimalType),
     name: p.string(),
@@ -967,7 +967,7 @@ export const Animal = defineEntity({
   name: 'Animal',
   embeddable: true,
   abstract: true,
-  discriminatorColumn: 'type',
+  discriminator: 'type',
   properties: {
     type: p.enum(() => AnimalType),
     name: p.string(),
@@ -1019,7 +1019,7 @@ export enum AnimalType {
   DOG,
 }
 
-@Embeddable({ abstract: true, discriminatorColumn: 'type' })
+@Embeddable({ abstract: true, discriminator: 'type' })
 export abstract class Animal {
 
   @Enum(() => AnimalType)
@@ -1084,7 +1084,7 @@ export enum AnimalType {
   DOG,
 }
 
-@Embeddable({ abstract: true, discriminatorColumn: 'type' })
+@Embeddable({ abstract: true, discriminator: 'type' })
 export abstract class Animal {
 
   @Enum()

--- a/docs/docs/inheritance-mapping.md
+++ b/docs/docs/inheritance-mapping.md
@@ -346,10 +346,12 @@ export class Employee extends Person {
 
 The `discriminatorColumn` specifies the name of a special column that will be used to define what type of class a given row should be represented with. It will be defined automatically for us, and it will stay hidden (it won't be hydrated as a regular property).
 
-On the other hand, it is perfectly fine to define the column explicitly. Doing so, you will be able to:
+On the other hand, it is perfectly fine to define the column explicitly. When you do so, use the `discriminator` option (which refers to the property name on the entity) instead — the column name is derived from the property via the naming strategy. Defining it explicitly lets you:
 
-- querying by the type, e.g. `em.find(Person, { type: { $ne: 'employee' } }`
-- the column will be part of the serialized response
+- query by the type, e.g. `em.find(Person, { type: { $ne: 'employee' } }`
+- include the column in the serialized response
+
+> `discriminator` is the property name on the entity; `discriminatorColumn` is an optional override for the underlying column name. When `discriminator` is omitted, `discriminatorColumn` is used as the property name too (legacy behavior). The same applies to `@Embeddable`.
 
 Following example shows how you can define the discriminator explicitly, as well as a version where root entity is abstract class.
 
@@ -369,7 +371,7 @@ Following example shows how you can define the discriminator explicitly, as well
 const BasePersonSchema = defineEntity({
   name: 'BasePerson',
   abstract: true,
-  discriminatorColumn: 'type',
+  discriminator: 'type',
   discriminatorMap: { person: 'Person', employee: 'Employee' },
   properties: {
     type: p.enum(['person', 'employee'] as const),
@@ -404,7 +406,7 @@ BasePersonSchema.setClass(BasePerson);
 export const BasePerson = defineEntity({
   name: 'BasePerson',
   abstract: true,
-  discriminatorColumn: 'type',
+  discriminator: 'type',
   discriminatorMap: { person: 'Person', employee: 'Employee' },
   properties: {
     type: p.enum(['person', 'employee'] as const),
@@ -433,7 +435,7 @@ export const Employee = defineEntity({
 
 ```ts
 @Entity({
-  discriminatorColumn: 'type',
+  discriminator: 'type',
   discriminatorMap: { person: 'Person', employee: 'Employee' },
 })
 export abstract class BasePerson {
@@ -475,7 +477,7 @@ If you want to use `discriminatorValue` with abstract entities, you need to mark
 const BasePersonSchema = defineEntity({
   name: 'BasePerson',
   abstract: true,
-  discriminatorColumn: 'type',
+  discriminator: 'type',
   properties: {
     type: p.enum(['person', 'employee'] as const),
   },
@@ -511,7 +513,7 @@ BasePersonSchema.setClass(BasePerson);
 export const BasePerson = defineEntity({
   name: 'BasePerson',
   abstract: true,
-  discriminatorColumn: 'type',
+  discriminator: 'type',
   properties: {
     type: p.enum(['person', 'employee'] as const),
   },
@@ -541,7 +543,7 @@ export const Employee = defineEntity({
 
 ```ts
 @Entity({
-  discriminatorColumn: 'type',
+  discriminator: 'type',
   abstract: true,
 })
 export abstract class BasePerson {

--- a/packages/core/src/entity/EntityLoader.ts
+++ b/packages/core/src/entity/EntityLoader.ts
@@ -614,17 +614,12 @@ export class EntityLoader {
     const fields = this.buildFields(options.fields, prop, ref) as any;
 
     /* eslint-disable prefer-const */
-    let {
-      refresh,
-      filters,
-      convertCustomTypes,
-      lockMode,
-      strategy,
-      populateWhere = 'infer',
-      connectionType,
-      logging,
-    } = options;
+    let { refresh, filters, convertCustomTypes, lockMode, strategy, populateWhere, connectionType, logging } = options;
     /* eslint-enable prefer-const */
+
+    // `populateWhere` is typed as required via `Required<EntityLoaderOptions>`, but `em.populate(...)`
+    // forwards user-supplied options without filling it in — keep the runtime default.
+    populateWhere ??= 'infer';
 
     if (typeof populateWhere === 'object') {
       populateWhere = await this.extractChildCondition({ where: populateWhere } as any, prop);

--- a/packages/core/src/entity/defineEntity.ts
+++ b/packages/core/src/entity/defineEntity.ts
@@ -1285,6 +1285,7 @@ export interface EntityMetadataWithProperties<
   | 'extends'
   | 'primaryKeys'
   | 'hooks'
+  | 'discriminator'
   | 'discriminatorColumn'
   | 'discriminatorValue'
   | 'versionProperty'
@@ -1338,6 +1339,8 @@ export interface EntityMetadataWithProperties<
     | { [K in Extract<AllKeys<TProperties, TBase>, string>]?: QueryOrderKeysFlat }[];
   // Captured as const literals (overriding `EntityMetadata`'s broad types) so children form a
   // proper discriminated union narrowed to their `discriminatorValue` (GH #7677).
+  discriminator?: TDiscriminatorColumn;
+  /** Alias for `discriminator`. */
   discriminatorColumn?: TDiscriminatorColumn;
   discriminatorValue?: TDiscriminatorValue;
   versionProperty?: AllKeys<TProperties, TBase>;

--- a/packages/core/src/metadata/EntitySchema.ts
+++ b/packages/core/src/metadata/EntitySchema.ts
@@ -414,6 +414,23 @@ export class EntitySchema<Entity = any, Base = never, Class extends EntityCtor =
 
     this.setClass(this._meta.class);
 
+    // `discriminator` is the property name on the entity / embeddable; `discriminatorColumn` is an
+    // optional column-name override on that property. For backward compat, when only
+    // `discriminatorColumn` is given (legacy), it is treated as the property name. Once normalized,
+    // `meta.discriminatorColumn` always holds the property name (so existing readers keep working),
+    // and `meta.discriminatorFieldName` carries the explicit column override (if any).
+    if (
+      this._meta.discriminator &&
+      this._meta.discriminatorColumn &&
+      this._meta.discriminator !== this._meta.discriminatorColumn
+    ) {
+      this._meta.discriminatorFieldName = this._meta.discriminatorColumn;
+      this._meta.discriminatorColumn = this._meta.discriminator;
+    } else {
+      this._meta.discriminatorColumn ??= this._meta.discriminator;
+      this._meta.discriminator ??= this._meta.discriminatorColumn;
+    }
+
     // Abstract TPT entities keep their name because they have their own table
     const isTPT = (this._meta as any).inheritance === 'tpt' || this.isPartOfTPTHierarchy();
 

--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -2057,13 +2057,20 @@ export class MetadataDiscovery {
   }
 
   private createDiscriminatorProperty(meta: EntityMetadata): void {
-    meta.addProperty({
-      name: meta.discriminatorColumn!,
+    const prop: Dictionary = {
+      name: meta.discriminatorColumn,
       type: 'string',
       enum: true,
       kind: ReferenceKind.SCALAR,
       userDefined: false,
-    } as EntityProperty);
+    };
+
+    // honor the column-name override set via `discriminatorColumn` when `discriminator` is also given
+    if (meta.discriminatorFieldName) {
+      prop.fieldName = meta.discriminatorFieldName;
+    }
+
+    meta.addProperty(prop as EntityProperty);
   }
 
   private initAutoincrement(meta: EntityMetadata): void {

--- a/packages/core/src/metadata/types.ts
+++ b/packages/core/src/metadata/types.ts
@@ -93,8 +93,10 @@ export type EntityOptions<T, E = T extends EntityClass<infer P> ? P : T> = {
    * 3. Entity-level `@Entity({ orderBy })`
    */
   orderBy?: QueryOrderMap<E> | QueryOrderMap<E>[];
-  /** For {@doclink inheritance-mapping#single-table-inheritance | Single Table Inheritance}. */
-  discriminatorColumn?: (T extends EntityClass<infer P> ? keyof P : string) | AnyString;
+  /** For {@doclink inheritance-mapping#single-table-inheritance | Single Table Inheritance}. Property name on the entity that stores the discriminator value. */
+  discriminator?: (T extends EntityClass<infer P> ? keyof P : string) | AnyString;
+  /** For {@doclink inheritance-mapping#single-table-inheritance | Single Table Inheritance}. Override the discriminator column name (the property is named via `discriminator`; defaults to the naming-strategy-derived column). */
+  discriminatorColumn?: string;
   /** For {@doclink inheritance-mapping#single-table-inheritance | Single Table Inheritance}. */
   discriminatorMap?: Dictionary<string>;
   /** For {@doclink inheritance-mapping#single-table-inheritance | Single Table Inheritance}. */
@@ -714,10 +716,10 @@ export interface EmbeddedOptions<Owner, Target> extends PropertyOptions<Owner> {
 export interface EmbeddableOptions<Owner> {
   /** Specify constructor parameters to be used in `em.create` or when `forceConstructor` is enabled. Those should be names of declared entity properties in the same order as your constructor uses them. The ORM tries to infer those automatically, use this option in case the inference fails. */
   constructorParams?: (Owner extends EntityClass<infer P> ? keyof P : string)[];
-  /** For polymorphic embeddables. Specify the property name that stores the discriminator value. Alias for `discriminatorColumn`. */
+  /** For polymorphic embeddables. Property name on the embeddable class that stores the discriminator value. */
   discriminator?: (Owner extends EntityClass<infer P> ? keyof P : string) | AnyString;
-  /** For polymorphic embeddables. @deprecated Use `discriminator` instead. */
-  discriminatorColumn?: (Owner extends EntityClass<infer P> ? keyof P : string) | AnyString;
+  /** For polymorphic embeddables. Override the discriminator column name (the property is named via `discriminator`; defaults to the naming-strategy-derived column). */
+  discriminatorColumn?: string;
   discriminatorMap?: Dictionary<string>;
   discriminatorValue?: number | string;
   abstract?: boolean;

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -1931,7 +1931,12 @@ export interface EntityMetadata<Entity = any, Class extends EntityCtor<Entity> =
         options: FindOptions<Entity, any, any, any>,
         stream?: boolean,
       ) => MaybePromise<Raw | object | string>);
+  /** Property name on the entity that stores the discriminator value. */
+  discriminator?: EntityKey<Entity> | AnyString;
+  /** Internally holds the discriminator property name (legacy) or a column-name override (when different from `discriminator`); normalized in `EntitySchema.init()`. */
   discriminatorColumn?: EntityKey<Entity> | AnyString;
+  /** Explicit column-name override for the auto-managed discriminator property. Set when both `discriminator` and `discriminatorColumn` are provided and differ. */
+  discriminatorFieldName?: string;
   discriminatorValue?: number | string;
   discriminatorMap?: Dictionary<EntityClass>;
   embeddable: boolean;

--- a/packages/decorators/src/es/Entity.ts
+++ b/packages/decorators/src/es/Entity.ts
@@ -11,7 +11,7 @@ export function Entity<Owner extends EntityClass<unknown> & EntityCtor>(
     Utils.mergeConfig(meta, metadata, options);
     meta.class = target as unknown as Constructor<Owner>;
 
-    if (!options.abstract || meta.discriminatorColumn) {
+    if (!options.abstract || meta.discriminatorColumn || meta.discriminator) {
       meta.name = context.name;
     }
   };

--- a/packages/decorators/src/legacy/Entity.ts
+++ b/packages/decorators/src/legacy/Entity.ts
@@ -8,7 +8,7 @@ export function Entity<T extends EntityClass<unknown>>(options: EntityOptions<T>
     Utils.mergeConfig(meta, options);
     meta.class = target as any;
 
-    if (!options.abstract || meta.discriminatorColumn) {
+    if (!options.abstract || meta.discriminatorColumn || meta.discriminator) {
       meta.name = target.name;
     }
   };

--- a/packages/entity-generator/src/SourceFile.ts
+++ b/packages/entity-generator/src/SourceFile.ts
@@ -642,7 +642,16 @@ export class SourceFile {
       options.virtual = this.meta.virtual;
     }
 
-    return this.getCollectionDecl(options);
+    // when the discriminator references an explicitly defined property, emit the property-oriented
+    // `discriminator` name; fall back to `discriminatorColumn` when the discriminator property is
+    // auto-managed by the ORM and not part of the entity definition.
+    const key = this.isDiscriminatorPropertyUserDefined() ? 'discriminator' : 'discriminatorColumn';
+    return this.getCollectionDecl(options, key);
+  }
+
+  private isDiscriminatorPropertyUserDefined(): boolean {
+    const name = this.meta.discriminatorColumn;
+    return !!name && this.meta.properties[name as never]?.userDefined !== false;
   }
 
   protected getPartitionByDecl(partitionBy: EntityPartitionBy): Dictionary {
@@ -686,17 +695,13 @@ export class SourceFile {
 
   protected getEmbeddableDeclOptions() {
     const options: EmbeddableOptions<unknown> = {};
-    const result = this.getCollectionDecl(options);
-
-    if (result.discriminatorColumn) {
-      result.discriminator = result.discriminatorColumn;
-      delete result.discriminatorColumn;
-    }
-
-    return result;
+    return this.getCollectionDecl(options, 'discriminator');
   }
 
-  private getCollectionDecl<T extends EntityOptions<unknown> | EmbeddableOptions<unknown>>(options: T) {
+  private getCollectionDecl<T extends EntityOptions<unknown> | EmbeddableOptions<unknown>>(
+    options: T,
+    discriminatorKey: 'discriminator' | 'discriminatorColumn',
+  ) {
     if (this.meta.abstract) {
       options.abstract = true;
     }
@@ -709,7 +714,7 @@ export class SourceFile {
     }
 
     if (this.meta.discriminatorColumn) {
-      options.discriminatorColumn = this.quote(this.meta.discriminatorColumn);
+      (options as Dictionary)[discriminatorKey] = this.quote(this.meta.discriminatorColumn);
     }
 
     if (this.meta.discriminatorMap) {

--- a/tests/features/entity-generator/__snapshots__/MetadataHooks.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/MetadataHooks.mysql.test.ts.snap
@@ -129,7 +129,7 @@ export type TBaseUser2Type = (typeof BaseUser2Type)[keyof typeof BaseUser2Type];
 export const BaseUser2Schema = defineEntity({
   class: BaseUser2,
   abstract: true,
-  discriminatorColumn: 'type',
+  discriminator: 'type',
   discriminatorMap: { employee: 'Employee2', manager: 'Manager2' },
   properties: {
     id: p.integer().primary(),
@@ -894,7 +894,7 @@ export type TBaseUser2Type = (typeof BaseUser2Type)[keyof typeof BaseUser2Type];
 export const BaseUser2Schema = new EntitySchema({
   class: BaseUser2,
   abstract: true,
-  discriminatorColumn: 'type',
+  discriminator: 'type',
   discriminatorMap: { employee: 'Employee2', manager: 'Manager2' },
   properties: {
     id: { primary: true, type: 'integer' },
@@ -1762,7 +1762,7 @@ export const BaseUser2Type = {
 
 export type TBaseUser2Type = (typeof BaseUser2Type)[keyof typeof BaseUser2Type];
 
-@Entity({ abstract: true, discriminatorColumn: 'type', discriminatorMap: { employee: 'Employee2', manager: 'Manager2' } })
+@Entity({ abstract: true, discriminator: 'type', discriminatorMap: { employee: 'Employee2', manager: 'Manager2' } })
 export abstract class BaseUser2 extends CustomBase2 {
 
   @PrimaryKey()
@@ -2504,7 +2504,7 @@ export type TBaseUser2Type = (typeof BaseUser2Type)[keyof typeof BaseUser2Type];
 export const BaseUser2Schema = defineEntity({
   class: BaseUser2,
   abstract: true,
-  discriminatorColumn: 'type',
+  discriminator: 'type',
   discriminatorMap: { employee: 'Employee2', manager: 'Manager2' },
   properties: {
     id: p.integer().primary(),
@@ -3277,7 +3277,7 @@ export type TBaseUser2Type = (typeof BaseUser2Type)[keyof typeof BaseUser2Type];
 export const BaseUser2Schema = new EntitySchema({
   class: BaseUser2,
   abstract: true,
-  discriminatorColumn: 'type',
+  discriminator: 'type',
   discriminatorMap: { employee: 'Employee2', manager: 'Manager2' },
   properties: {
     id: { primary: true, type: 'integer' },
@@ -4164,7 +4164,7 @@ export const BaseUser2Type = {
 
 export type TBaseUser2Type = (typeof BaseUser2Type)[keyof typeof BaseUser2Type];
 
-@Entity({ abstract: true, discriminatorColumn: 'type', discriminatorMap: { employee: 'Employee2', manager: 'Manager2' } })
+@Entity({ abstract: true, discriminator: 'type', discriminatorMap: { employee: 'Employee2', manager: 'Manager2' } })
 export abstract class BaseUser2 extends CustomBase2 {
 
   @PrimaryKey()
@@ -4908,7 +4908,7 @@ export type TBaseUser2Type = (typeof BaseUser2Type)[keyof typeof BaseUser2Type];
 export const BaseUser2Schema = defineEntity({
   class: BaseUser2,
   abstract: true,
-  discriminatorColumn: 'type',
+  discriminator: 'type',
   discriminatorMap: { employee: 'Employee2', manager: 'Manager2' },
   properties: {
     id: p.integer().primary(),
@@ -5673,7 +5673,7 @@ export type TBaseUser2Type = (typeof BaseUser2Type)[keyof typeof BaseUser2Type];
 export const BaseUser2Schema = new EntitySchema({
   class: BaseUser2,
   abstract: true,
-  discriminatorColumn: 'type',
+  discriminator: 'type',
   discriminatorMap: { employee: 'Employee2', manager: 'Manager2' },
   properties: {
     id: { primary: true, type: 'integer' },
@@ -6541,7 +6541,7 @@ export const BaseUser2Type = {
 
 export type TBaseUser2Type = (typeof BaseUser2Type)[keyof typeof BaseUser2Type];
 
-@Entity({ abstract: true, discriminatorColumn: 'type', discriminatorMap: { employee: 'Employee2', manager: 'Manager2' } })
+@Entity({ abstract: true, discriminator: 'type', discriminatorMap: { employee: 'Employee2', manager: 'Manager2' } })
 export abstract class BaseUser2 extends CustomBase2 {
 
   @PrimaryKey()
@@ -7283,7 +7283,7 @@ export type TBaseUser2Type = (typeof BaseUser2Type)[keyof typeof BaseUser2Type];
 export const BaseUser2Schema = defineEntity({
   class: BaseUser2,
   abstract: true,
-  discriminatorColumn: 'type',
+  discriminator: 'type',
   discriminatorMap: { employee: 'Employee2', manager: 'Manager2' },
   properties: {
     id: p.integer().primary(),
@@ -8056,7 +8056,7 @@ export type TBaseUser2Type = (typeof BaseUser2Type)[keyof typeof BaseUser2Type];
 export const BaseUser2Schema = new EntitySchema({
   class: BaseUser2,
   abstract: true,
-  discriminatorColumn: 'type',
+  discriminator: 'type',
   discriminatorMap: { employee: 'Employee2', manager: 'Manager2' },
   properties: {
     id: { primary: true, type: 'integer' },
@@ -8943,7 +8943,7 @@ export const BaseUser2Type = {
 
 export type TBaseUser2Type = (typeof BaseUser2Type)[keyof typeof BaseUser2Type];
 
-@Entity({ abstract: true, discriminatorColumn: 'type', discriminatorMap: { employee: 'Employee2', manager: 'Manager2' } })
+@Entity({ abstract: true, discriminator: 'type', discriminatorMap: { employee: 'Employee2', manager: 'Manager2' } })
 export abstract class BaseUser2 extends CustomBase2 {
 
   @PrimaryKey()

--- a/tests/features/inheritance/discriminator-alias.test.ts
+++ b/tests/features/inheritance/discriminator-alias.test.ts
@@ -1,0 +1,151 @@
+import { Embeddable, Embedded, Entity, PrimaryKey, Property } from '@mikro-orm/decorators/legacy';
+import { defineEntity, MikroORM, p } from '@mikro-orm/sqlite';
+import { SqliteDriver } from '@mikro-orm/sqlite';
+
+// the `discriminator` option is an alias for `discriminatorColumn` (deprecated on `@Embeddable`,
+// non-deprecated on `@Entity`). `discriminator` is a property name on the class; the underlying
+// column name is derived via the naming strategy (camelCase -> snake_case by default).
+
+@Embeddable({ abstract: true, discriminator: 'animalType' })
+abstract class Animal {
+  @Property({ type: 'string' })
+  animalType!: string;
+
+  @Property({ type: 'string' })
+  name!: string;
+}
+
+@Embeddable({ discriminatorValue: 'cat' })
+class Cat extends Animal {}
+
+@Embeddable({ discriminatorValue: 'dog' })
+class Dog extends Animal {}
+
+@Entity({ abstract: true, discriminator: 'vehicleType' })
+abstract class Vehicle {
+  @PrimaryKey({ type: 'integer' })
+  id!: number;
+
+  @Property({ type: 'string' })
+  vehicleType!: string;
+
+  @Property({ type: 'string' })
+  brand!: string;
+}
+
+@Entity({ discriminatorValue: 'car' })
+class Car extends Vehicle {}
+
+@Entity({ discriminatorValue: 'bike' })
+class Bike extends Vehicle {}
+
+@Entity()
+class Owner {
+  @PrimaryKey({ type: 'integer' })
+  id!: number;
+
+  @Property({ type: 'string' })
+  name!: string;
+
+  @Embedded(() => [Cat, Dog])
+  pet!: Cat | Dog;
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    entities: [Cat, Dog, Animal, Owner, Vehicle, Car, Bike],
+    dbName: ':memory:',
+    driver: SqliteDriver,
+    metadataCache: { enabled: false },
+  });
+});
+
+afterAll(async () => orm.close());
+
+test('`discriminator` is honored as an alias for `discriminatorColumn` on @Embeddable', () => {
+  const root = orm.getMetadata().get(Cat).root;
+  expect(root.discriminatorColumn).toBe('animalType');
+  // the discriminator property gets a snake_case column name via the naming strategy
+  expect(root.properties.animalType.fieldNames).toEqual(['animal_type']);
+});
+
+test('`discriminator` is honored as an alias for `discriminatorColumn` on @Entity (STI)', () => {
+  const root = orm.getMetadata().get(Car).root;
+  expect(root.discriminatorColumn).toBe('vehicleType');
+  expect(root.properties.vehicleType.fieldNames).toEqual(['vehicle_type']);
+});
+
+test('`discriminatorColumn` overrides the column name when `discriminator` is also set', async () => {
+  @Entity({ abstract: true, discriminator: 'kind', discriminatorColumn: 'kind_col' })
+  abstract class Pet {
+    @PrimaryKey({ type: 'integer' })
+    id!: number;
+  }
+
+  @Entity({ discriminatorValue: 'cat' })
+  class PetCat extends Pet {}
+
+  @Entity({ discriminatorValue: 'fish' })
+  class PetFish extends Pet {}
+
+  const localOrm = await MikroORM.init({
+    entities: [Pet, PetCat, PetFish],
+    dbName: ':memory:',
+    driver: SqliteDriver,
+    metadataCache: { enabled: false },
+  });
+
+  // property is `kind`, column is the explicit override `kind_col`
+  const root = localOrm.getMetadata().get(PetCat).root;
+  expect(root.discriminatorColumn).toBe('kind');
+  expect((root.properties as Record<string, { fieldNames: string[] }>).kind.fieldNames).toEqual(['kind_col']);
+
+  await localOrm.close();
+});
+
+test('`discriminator` narrows STI variants in `defineEntity` like `discriminatorColumn` does', async () => {
+  const BaseSchema = defineEntity({
+    name: 'BasePerson',
+    abstract: true,
+    // captured as a literal type so children form a discriminated union narrowed
+    // to their `discriminatorValue` (GH #7677) — same as `discriminatorColumn`.
+    discriminator: 'type',
+    properties: {
+      id: p.integer().primary(),
+      type: p.enum(['person', 'employee'] as const),
+    },
+  });
+  class BasePerson extends BaseSchema.class {}
+  BaseSchema.setClass(BasePerson);
+
+  const PersonSchema = defineEntity({
+    name: 'Person',
+    extends: BasePerson,
+    discriminatorValue: 'person',
+    properties: {},
+  });
+  class Person extends PersonSchema.class {}
+  PersonSchema.setClass(Person);
+
+  const EmployeeSchema = defineEntity({
+    name: 'Employee',
+    extends: BasePerson,
+    discriminatorValue: 'employee',
+    properties: {
+      salary: p.integer(),
+    },
+  });
+  class Employee extends EmployeeSchema.class {}
+  EmployeeSchema.setClass(Employee);
+
+  const localOrm = await MikroORM.init({
+    entities: [BasePerson, Person, Employee],
+    dbName: ':memory:',
+  });
+
+  expect(localOrm.getMetadata().get(Person).root.discriminatorColumn).toBe('type');
+
+  await localOrm.close();
+});


### PR DESCRIPTION
`discriminator` is a new public option on `@Entity` (STI) and `@Embeddable` (polymorphic embeddables) — the property name on the class that stores the discriminator value. The existing `discriminatorColumn` becomes an optional override for the underlying column name (for both decorators).

```ts
// new — `discriminator` is the property name; column derived via naming strategy
@Entity({ discriminator: 'animalType' /* column: 'animal_type' */ })
abstract class Animal { @Property() animalType!: string; }

// override the column name explicitly
@Entity({ discriminator: 'kind', discriminatorColumn: 'kind_col' })
abstract class Pet { ... }
```

**Backward compatibility:** when only `discriminatorColumn` is given (legacy), it continues to behave as the property name — `EntitySchema.init()` copies it onto `discriminator`. All existing reads of `meta.discriminatorColumn` keep working.

**Why this matters:** `EmbeddableOptions.discriminator` had been declared as an alias since #7121 but was never wired at runtime — `@Embeddable({ discriminator })` silently no-op'd. That's fixed now, for both surfaces. The earlier (unannounced) `@deprecated` marker on `EmbeddableOptions.discriminatorColumn` is dropped — it's a real column-name override now.

**Entity generator:** emits `discriminator` when the discriminator references a user-defined property, falling back to `discriminatorColumn` for auto-managed discriminators. Docs and snapshots updated.

Also bundled: kept the `populateWhere = 'infer'` fallback in `EntityLoader.findChildren` (the `Required<EntityLoaderOptions>` type lies — `em.populate(...)` forwards user options without filling it in, GH6658 regressed when I trusted the type), moved it out of destructuring so it doesn't trip `no-useless-default-assignment`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)