### PR TITLE
fix(mongo): throw on em.remove of inlined-pivot M:N target with uninitialized owning side

### DIFF
--- a/packages/core/src/unit-of-work/UnitOfWork.ts
+++ b/packages/core/src/unit-of-work/UnitOfWork.ts
@@ -540,6 +540,17 @@ export class UnitOfWork {
         continue;
       }
 
+      // inlined pivot M:N (mongo): we can't scrub references from owning-side documents we haven't loaded
+      if (
+        prop.kind === ReferenceKind.MANY_TO_MANY &&
+        prop.mappedBy &&
+        !this.#platform.usesPivotTable() &&
+        Utils.isCollection<AnyEntity>(relation) &&
+        !relation.isInitialized()
+      ) {
+        throw ValidationError.cannotModifyInverseCollection(entity as AnyEntity, prop);
+      }
+
       const target = relation?.[inverseProp as keyof typeof relation] as unknown;
 
       if (relation && Utils.isCollection(target)) {

--- a/tests/issues/GH7750.test.ts
+++ b/tests/issues/GH7750.test.ts
@@ -1,0 +1,66 @@
+import { Collection, MikroORM, ObjectId, ValidationError } from '@mikro-orm/mongodb';
+import { Entity, ManyToMany, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+
+@Entity()
+class User {
+  @PrimaryKey()
+  _id!: ObjectId;
+
+  @ManyToMany({ entity: () => Device, mappedBy: 'users' })
+  devices = new Collection<Device>(this);
+}
+
+@Entity()
+class Device {
+  @PrimaryKey()
+  _id!: ObjectId;
+
+  @Property()
+  name!: string;
+
+  @ManyToMany({ entity: () => User, inversedBy: 'devices' })
+  users = new Collection<User>(this);
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    metadataProvider: ReflectMetadataProvider,
+    entities: [User, Device],
+    clientUrl: 'mongodb://localhost:27017/mikro-orm-7750',
+  });
+  await orm.schema.create();
+});
+
+afterAll(() => orm.close(true));
+
+beforeEach(async () => {
+  await orm.schema.refresh();
+  const em = orm.em.fork();
+  const user = em.create(User, {});
+  em.create(Device, { name: 'Monitor', users: [user] });
+  await em.flush();
+});
+
+test('throws when removing target of inlined-pivot M:N without owning side initialized', async () => {
+  const em = orm.em.fork();
+  const user = await em.findOneOrFail(User, { _id: { $exists: true } });
+
+  expect(() => em.remove(user)).toThrow(ValidationError);
+  expect(() => em.remove(user)).toThrow(/devices.*owning side is not initialized/);
+});
+
+test('inlined pivot cleanup works when owning side is removed first', async () => {
+  const em = orm.em.fork();
+  const user = await em.findOneOrFail(User, { _id: { $exists: true } }, { populate: ['devices'] });
+
+  for (const device of user.devices) {
+    device.users.remove(user);
+  }
+  em.remove(user);
+  await em.flush();
+
+  const device = await em.fork().findOneOrFail(Device, { name: 'Monitor' });
+  expect(device.users).toHaveLength(0);
+});


### PR DESCRIPTION
## Summary

On platforms without a pivot table (MongoDB), an M:N relation is stored as an inlined array of ids on the owning side. When the target entity is removed, MikroORM can only scrub those references from owning-side documents that are loaded into the identity map — there is no equivalent of SQL's FK `ON DELETE CASCADE` to do it at the DB layer, and a full collection scan on every delete is not viable.

So far this case fell through silently and left stale ids in the inlined pivot array. This change makes `UnitOfWork.remove` throw `ValidationError.cannotModifyInverseCollection` when:

- the entity has an M:N inverse-side relation,
- the platform doesn't use a pivot table,
- and that inverse collection is not initialized.

The user is then nudged to either initialize the owning side or remove the entity from each owner's collection explicitly before flush.

Closes #7750