### PR TITLE
fix(sql): infer scalar array properties as columns in Kysely types

### DIFF
--- a/packages/sql/src/typings.ts
+++ b/packages/sql/src/typings.ts
@@ -489,7 +489,7 @@ type ClassEntityColumnName<K, V, TOptions extends MikroKyselyPluginOptions = {}>
       ? never
       : TOptions['columnNamingStrategy'] extends 'property'
         ? K
-        : NV extends Scalar
+        : NV extends Scalar | readonly any[]
           ? K extends string
             ? SnakeCase<K>
             : never
@@ -501,4 +501,4 @@ type ClassEntityColumnName<K, V, TOptions extends MikroKyselyPluginOptions = {}>
 type ClassEntityJoinColumnName<TName extends string, V> =
   PrimaryProperty<V> extends string ? `${TName}_${SnakeCase<PrimaryProperty<V>>}` : never;
 
-type ClassEntityColumnValue<V> = NonNullable<V> extends Scalar ? V : Primary<NonNullable<V>>;
+type ClassEntityColumnValue<V> = NonNullable<V> extends Scalar | readonly any[] ? V : Primary<NonNullable<V>>;

--- a/tests/features/get-kysely.test.ts
+++ b/tests/features/get-kysely.test.ts
@@ -804,6 +804,46 @@ describe('InferClassEntityDB', () => {
     type DBEntity = InferClassEntityDB<typeof Foo7423, { tableNamingStrategy: 'entity' }>;
     expectTypeOf<DBEntity>().toHaveProperty('Foo7423');
   });
+
+  test('scalar array properties are inferred as columns (GH #7751)', () => {
+    interface Stop {
+      offset: number;
+      color: string;
+    }
+
+    @Entity()
+    class ColorTemplateFlat {
+      [EntityName]?: 'ColorTemplateFlat';
+
+      @PrimaryKey({ type: 'uuid' })
+      id!: string;
+
+      @Property({ nullable: true })
+      name!: null | string;
+
+      @Property({ default: true })
+      visible: boolean = true;
+
+      @Property()
+      hexColors!: string[];
+
+      @Property({ defaultRaw: `'[]'::jsonb`, nullable: false, type: 'jsonb' })
+      stops!: Stop[];
+    }
+
+    type DB = InferClassEntityDB<typeof ColorTemplateFlat>;
+    type ColumnKeys = keyof DB['color_template_flat'];
+    expectTypeOf<'hex_colors'>().toExtend<ColumnKeys>();
+    expectTypeOf<'stops'>().toExtend<ColumnKeys>();
+    expectTypeOf<DB['color_template_flat']['hex_colors']>().toEqualTypeOf<string[]>();
+    expectTypeOf<DB['color_template_flat']['stops']>().toEqualTypeOf<Stop[]>();
+
+    type DBProp = InferClassEntityDB<typeof ColorTemplateFlat, { columnNamingStrategy: 'property' }>;
+    type ColumnKeysProp = keyof DBProp['color_template_flat'];
+    expectTypeOf<'hexColors'>().toExtend<ColumnKeysProp>();
+    expectTypeOf<'stops'>().toExtend<ColumnKeysProp>();
+    expectTypeOf<DBProp['color_template_flat']['hexColors']>().toEqualTypeOf<string[]>();
+  });
 });
 
 interface Generated<T> {


### PR DESCRIPTION
`InferClassEntityDB` filtered out class-entity properties whose type was `T[]` (e.g. `string[]`, JSON arrays like `Stop[]`) because they matched neither `Scalar` nor a relation with a primary key, so the snake-cased column key resolved to `never` and was dropped.

The fix widens the scalar check in `ClassEntityColumnName` / `ClassEntityColumnValue` to also accept `readonly any[]`, so array-typed columns are exposed with their original value type preserved. `Collection<T>` is still excluded by the prior owner-shape guard.

Closes #7751