### PR TITLE
fix(sql): wrap raw subqueries with parens inside INSERT VALUES

### DIFF
--- a/packages/sql/src/AbstractSqlDriver.ts
+++ b/packages/sql/src/AbstractSqlDriver.ts
@@ -1289,14 +1289,19 @@ export abstract class AbstractSqlDriver<
               const field = prop.fieldNames[0];
 
               if (!duplicates.includes(field) || !usedDups.includes(field)) {
+                const rowValue = row[prop.name];
+                const rowValueIsRaw = isRaw(rowValue);
                 if (
                   prop.customType &&
                   !prop.object &&
                   'convertToDatabaseValueSQL' in prop.customType &&
-                  row[prop.name] != null &&
-                  !isRaw(row[prop.name])
+                  rowValue != null &&
+                  !rowValueIsRaw
                 ) {
                   keys.push(prop.customType.convertToDatabaseValueSQL!('?', this.platform));
+                } else if (rowValueIsRaw && /^\s*(?:with|select)\b/i.test(rowValue.sql)) {
+                  // raw subqueries must be parenthesized when inlined as a VALUES position
+                  keys.push('(?)');
                 } else {
                   keys.push('?');
                 }

--- a/tests/issues/GH7749.test.ts
+++ b/tests/issues/GH7749.test.ts
@@ -1,0 +1,62 @@
+import { MikroORM, raw } from '@mikro-orm/postgresql';
+import { Entity, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+import { mockLogger } from '../helpers.js';
+
+@Entity()
+class Item {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  order!: number;
+
+  @Property()
+  pk!: string;
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    metadataProvider: ReflectMetadataProvider,
+    entities: [Item],
+    dbName: 'gh-7749',
+  });
+  await orm.schema.refresh();
+});
+
+afterAll(async () => {
+  await orm.schema.drop();
+  await orm.close(true);
+});
+
+// Reproduces: when raw(qb) wraps a Kysely query that contains a CTE (WITH ...),
+// using it as a value in INSERT produces invalid SQL because the WITH clause is
+// not parenthesized inside VALUES (...).
+test('raw(qb) with kysely CTE wraps WITH in parens inside INSERT VALUES', async () => {
+  const kysely = orm.em.getKysely<{ item: { id: number; order: number; pk: string } }>();
+
+  const $order = kysely
+    .with('qb', q => q.selectFrom('item').select('item.order'))
+    .selectFrom('qb')
+    .select(({ fn, eb }) => eb(fn.coalesce(fn.max('qb.order'), eb.lit(0)), '+', 1).as('order'));
+
+  const mock = mockLogger(orm, ['query', 'query-params']);
+
+  const item = orm.em.create(Item, {
+    order: raw($order) as unknown as number,
+    pk: 'e809c1d7-02a0-4993-b4b1-ea813bdbdfb0',
+  });
+  orm.em.persist(item);
+  await orm.em.flush();
+
+  const insertCall = mock.mock.calls.find(c => /insert into /i.test(c[0]));
+  expect(insertCall).toBeDefined();
+  const sql: string = insertCall![0];
+
+  // The CTE must be wrapped in parens within the VALUES list, otherwise the
+  // generated SQL is invalid (`values (with "qb" as ...)` collides with the
+  // outer VALUES tuple delimiters and Postgres throws "syntax error at or
+  // near 'with'").
+  expect(sql).toMatch(/values\s*\(\s*\(with /i);
+});

--- a/tests/issues/GH7749.test.ts
+++ b/tests/issues/GH7749.test.ts
@@ -44,7 +44,7 @@ test('raw(qb) with kysely CTE wraps WITH in parens inside INSERT VALUES', async 
   const mock = mockLogger(orm, ['query', 'query-params']);
 
   const item = orm.em.create(Item, {
-    order: raw($order) as unknown as number,
+    order: raw<number>($order),
     pk: 'e809c1d7-02a0-4993-b4b1-ea813bdbdfb0',
   });
   orm.em.persist(item);


### PR DESCRIPTION
## Summary

A `raw()` fragment whose SQL starts with `SELECT` or `WITH` (e.g. `raw(kyselyQbWithCte)`) was inlined verbatim into the `VALUES (...)` tuple, producing invalid SQL such as:

```
insert into "x" (...) values (with "qb" as (...) select ..., ?, ?)
```

Postgres rejects this with `syntax error at or near "with"`. A bare subquery without CTE has the same problem when the row has more than one column.

The INSERT placeholder generator now wraps the `?` as `(?)` when the matching value is a raw fragment whose SQL begins with `with`/`select`, so the inlined subquery becomes a valid scalar subquery: `values ((with "qb" as (...) select ...), ?, ?)`.

Closes #7749