### PR TITLE
fix(mongo): clean up inlined pivot on em.remove when owning side is populated

### DIFF
--- a/packages/core/src/unit-of-work/UnitOfWork.ts
+++ b/packages/core/src/unit-of-work/UnitOfWork.ts
@@ -540,15 +540,27 @@ export class UnitOfWork {
         continue;
       }
 
-      // inlined pivot M:N (mongo): we can't scrub references from owning-side documents we haven't loaded
+      // inlined pivot M:N: scrub the deleted entity from each owning-side document's array;
+      // the owner's collection update rides along inside its UPDATE changeset in the same flush
       if (
         prop.kind === ReferenceKind.MANY_TO_MANY &&
         prop.mappedBy &&
         !this.#platform.usesPivotTable() &&
-        Utils.isCollection<AnyEntity>(relation) &&
-        !relation.isInitialized()
+        Utils.isCollection<AnyEntity>(relation)
       ) {
-        throw ValidationError.cannotModifyInverseCollection(entity as AnyEntity, prop);
+        if (!relation.isInitialized(true)) {
+          throw ValidationError.cannotModifyInverseCollection(entity as AnyEntity, prop);
+        }
+
+        for (const owner of relation.getItems(false)) {
+          const ownerColl = (owner as Dictionary)[inverseProp];
+
+          if (Utils.isCollection(ownerColl)) {
+            ownerColl.removeWithoutPropagation(entity);
+          }
+        }
+
+        continue;
       }
 
       const target = relation?.[inverseProp as keyof typeof relation] as unknown;

--- a/tests/issues/GH7750.test.ts
+++ b/tests/issues/GH7750.test.ts
@@ -1,5 +1,6 @@
 import { Collection, MikroORM, ObjectId, ValidationError } from '@mikro-orm/mongodb';
 import { Entity, ManyToMany, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+import { mockLogger } from '../helpers.js';
 
 @Entity()
 class User {
@@ -49,6 +50,35 @@ test('throws when removing target of inlined-pivot M:N without owning side initi
 
   expect(() => em.remove(user)).toThrow(ValidationError);
   expect(() => em.remove(user)).toThrow(/devices.*owning side is not initialized/);
+});
+
+test('throws when owning side is populated as `:ref` only (items not fully loaded)', async () => {
+  const em = orm.em.fork();
+  const user = await em.findOneOrFail(User, { _id: { $exists: true } }, { populate: ['devices:ref'] });
+
+  expect(() => em.remove(user)).toThrow(ValidationError);
+  expect(() => em.remove(user)).toThrow(/devices.*owning side is not initialized/);
+});
+
+test('inlined pivot cleanup works when owning side is populated', async () => {
+  const em = orm.em.fork();
+  const user = await em.findOneOrFail(User, { _id: { $exists: true } }, { populate: ['devices'] });
+
+  const [loadedDevice] = user.devices.getItems();
+  expect(loadedDevice.users).toHaveLength(1);
+
+  const mock = mockLogger(orm);
+  em.remove(user);
+  await em.flush();
+
+  const queries = mock.mock.calls.map(c => c[0]);
+  expect(queries.some(q => /db\.getCollection\('device'\)\.updateMany/.test(q))).toBe(true);
+  expect(queries.some(q => /db\.getCollection\('user'\)\.deleteMany/.test(q))).toBe(true);
+
+  expect(loadedDevice.users).toHaveLength(0);
+
+  const device = await em.fork().findOneOrFail(Device, { name: 'Monitor' });
+  expect(device.users).toHaveLength(0);
 });
 
 test('inlined pivot cleanup works when owning side is removed first', async () => {


### PR DESCRIPTION
## Summary

Follow-up to #7752. With the owning side fully populated, `em.remove(user)` now scrubs the user from each owner's inlined pivot array as part of the same flush — the owner's UPDATE rides along inside its entity changeset, so no stale ObjectIds are left behind.

The previous PR added a guard that throws `ValidationError.cannotModifyInverseCollection` when the inverse collection isn't initialized, but did not write anything back to the owners. As a result, even users who *did* populate could still end up with stale references unless they manually called `device.users.remove(user)`. This PR closes that gap: when the inverse is fully initialized, we now mirror the in-memory removal on each owner's collection inside `UnitOfWork.remove`, so the standard change-set computation picks it up and writes the inlined array.

Two related changes:
- Guard now uses `isInitialized(true)`, so populating with `:ref` (items are unloaded `Reference` proxies, `device.users` not hydrated) still throws the validation. Otherwise we would let the user through but silently fail to clean up.
- New tests in `tests/issues/GH7750.test.ts` cover the `:ref`-throws case and the full-populate cleanup case (asserting the mongo `updateMany` actually fires alongside the delete).