### PR TITLE
refactor: export the Postgres-flavoured EntityManager

### DIFF
--- a/packages/pglite/src/index.ts
+++ b/packages/pglite/src/index.ts
@@ -10,8 +10,8 @@ export {
 } from './PgliteMikroORM.js';
 export { raw } from './raw.js';
 
-import { type AbstractSqlDriver, SqlEntityManager } from '@mikro-orm/sql';
+import { type AbstractSqlDriver, BasePostgreSqlEntityManager } from '@mikro-orm/sql';
 import type { PgliteDriver } from './PgliteDriver.js';
 
-export type EntityManager<Driver extends AbstractSqlDriver = PgliteDriver> = SqlEntityManager<Driver>;
-export const EntityManager = SqlEntityManager;
+export type EntityManager<Driver extends AbstractSqlDriver = PgliteDriver> = BasePostgreSqlEntityManager<Driver>;
+export const EntityManager = BasePostgreSqlEntityManager;


### PR DESCRIPTION
## Summary

pglite's driver and ORM both already use `BasePostgreSqlEntityManager` (see `PgliteDriver.ts` and `PgliteMikroORM.ts`), but the top-level `EntityManager` re-export added in #7756 — the one consumed via NestJS DI and the `discovery:export` barrel — pointed at the plain `SqlEntityManager` instead. That hid Postgres-only helpers like `refreshMaterializedView()` from anything resolving the EM through the driver package.

Swapping the `index.ts` re-export to `BasePostgreSqlEntityManager` makes the public surface line up with what the driver actually instantiates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)