### PR TITLE
fix(core): treat inlined embeddables as loaded when their leaves are

### DIFF
--- a/packages/core/src/entity/EntityLoader.ts
+++ b/packages/core/src/entity/EntityLoader.ts
@@ -1118,7 +1118,18 @@ export class EntityLoader {
     const wrapped = helper(entity);
 
     if (!field.includes('.')) {
-      return wrapped.__loadedProperties.has(field);
+      if (wrapped.__loadedProperties.has(field)) {
+        return true;
+      }
+
+      // Inlined embeddables track each leaf child separately, not the parent property,
+      // so we need to recurse for nested inline embeddables.
+      const prop = wrapped.__meta.properties[field];
+      if (prop?.kind === ReferenceKind.EMBEDDED && !prop.object) {
+        return Object.values(prop.embeddedProps).every(child => this.isPropertyLoaded(entity, child.name));
+      }
+
+      return false;
     }
 
     const [f, ...r] = field.split('.');

--- a/tests/issues/GHx54.test.ts
+++ b/tests/issues/GHx54.test.ts
@@ -1,0 +1,134 @@
+import { Opt, SimpleLogger } from '@mikro-orm/core';
+import {
+  Embeddable,
+  Embedded,
+  Entity,
+  Formula,
+  ManyToOne,
+  OneToOne,
+  PrimaryKey,
+  Property,
+  ReflectMetadataProvider,
+} from '@mikro-orm/decorators/legacy';
+import { MikroORM } from '@mikro-orm/sqlite';
+import { mockLogger } from '../helpers.js';
+
+@Embeddable()
+class ProductPackageLocalizedTitle {
+  @Property({ nullable: true })
+  en?: string;
+
+  @Property({ nullable: true })
+  el?: string;
+}
+
+@Entity()
+class Product {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  title!: string;
+
+  @OneToOne({ entity: () => ProductPackage, mappedBy: 'product', nullable: true })
+  package?: ProductPackage | null;
+}
+
+@Entity()
+class ProductPackage {
+  @PrimaryKey()
+  id!: number;
+
+  @Formula(cols => `${cols.quantity} || ' x ' || ${cols.multiplier}`)
+  title!: Opt<string>;
+
+  @Embedded(() => ProductPackageLocalizedTitle)
+  localizedTitle!: ProductPackageLocalizedTitle;
+
+  @Property()
+  quantity!: number;
+
+  @Property()
+  multiplier!: number;
+
+  @OneToOne({ entity: () => Product, inversedBy: 'package' })
+  product!: Product;
+}
+
+@Entity()
+class ClientProduct {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  title!: string;
+
+  @ManyToOne(() => Product)
+  product!: Product;
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    metadataProvider: ReflectMetadataProvider,
+    dbName: ':memory:',
+    entities: [ClientProduct, Product, ProductPackage],
+    loggerFactory: SimpleLogger.create,
+  });
+  await orm.schema.refresh();
+});
+
+beforeEach(async () => {
+  await orm.schema.clear();
+  orm.em.clear();
+
+  const product1 = orm.em.create(Product, { title: 'Product 1' });
+  const product2 = orm.em.create(Product, { title: 'Product 2' });
+  orm.em.create(ProductPackage, {
+    quantity: 2,
+    multiplier: 3,
+    localizedTitle: { en: 'Package 1' },
+    product: product1,
+  });
+  orm.em.create(ProductPackage, {
+    quantity: 4,
+    multiplier: 5,
+    localizedTitle: { en: 'Package 2' },
+    product: product2,
+  });
+  orm.em.create(ClientProduct, { title: 'Client Product 1', product: product1 });
+  orm.em.create(ClientProduct, { title: 'Client Product 2', product: product2 });
+  await orm.em.flush();
+  orm.em.clear();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+// The JOIN strategy should already cover `product.package` in the main query.
+// A second populate phase that re-fetches the same rows is a bug.
+test('em.find with nested populate + projected fields runs a single query', async () => {
+  const em = orm.em.fork();
+  const mock = mockLogger(orm, ['query']);
+
+  await em.find(
+    ClientProduct,
+    {},
+    {
+      fields: [
+        'product.package.title',
+        'product.package.quantity',
+        'product.package.multiplier',
+        'product.package.localizedTitle',
+      ],
+      populate: ['product.package'],
+    },
+  );
+
+  const queries = mock.mock.calls.map(call => String(call[0]));
+  expect(queries).toHaveLength(1);
+  expect(queries[0]).toContain('inner join `product`');
+  expect(queries[0]).toContain('left join `product_package`');
+});

--- a/tests/issues/GHx54.test.ts
+++ b/tests/issues/GHx54.test.ts
@@ -22,6 +22,24 @@ class ProductPackageLocalizedTitle {
   el?: string;
 }
 
+@Embeddable()
+class FontStyle {
+  @Property({ nullable: true })
+  fontFamily?: string;
+
+  @Property({ nullable: true })
+  fontWeight?: string;
+}
+
+@Embeddable()
+class DisplayInfo {
+  @Property({ nullable: true })
+  badgeLabel?: string;
+
+  @Embedded(() => FontStyle, { nullable: true })
+  font?: FontStyle;
+}
+
 @Entity()
 class Product {
   @PrimaryKey()
@@ -44,6 +62,9 @@ class ProductPackage {
 
   @Embedded(() => ProductPackageLocalizedTitle)
   localizedTitle!: ProductPackageLocalizedTitle;
+
+  @Embedded(() => DisplayInfo, { nullable: true })
+  display?: DisplayInfo;
 
   @Property()
   quantity!: number;
@@ -89,12 +110,14 @@ beforeEach(async () => {
     quantity: 2,
     multiplier: 3,
     localizedTitle: { en: 'Package 1' },
+    display: { badgeLabel: 'Hot', font: { fontFamily: 'Inter', fontWeight: '700' } },
     product: product1,
   });
   orm.em.create(ProductPackage, {
     quantity: 4,
     multiplier: 5,
     localizedTitle: { en: 'Package 2' },
+    display: { badgeLabel: 'New', font: { fontFamily: 'Arial', fontWeight: '400' } },
     product: product2,
   });
   orm.em.create(ClientProduct, { title: 'Client Product 1', product: product1 });
@@ -131,4 +154,25 @@ test('em.find with nested populate + projected fields runs a single query', asyn
   expect(queries).toHaveLength(1);
   expect(queries[0]).toContain('inner join `product`');
   expect(queries[0]).toContain('left join `product_package`');
+});
+
+// Same scenario, but the populated relation contains an inline embeddable that itself
+// contains another inline embeddable — exercises the recursive embedded-leaf check.
+test('em.find with nested populate + projected fields handles nested inline embeddables', async () => {
+  const em = orm.em.fork();
+  const mock = mockLogger(orm, ['query']);
+
+  const results = await em.find(
+    ClientProduct,
+    {},
+    {
+      fields: ['product.package.title', 'product.package.display'],
+      populate: ['product.package'],
+    },
+  );
+
+  const queries = mock.mock.calls.map(call => String(call[0]));
+  expect(queries).toHaveLength(1);
+  expect(results[0].product.package?.display?.font?.fontFamily).toBe('Inter');
+  expect(results[0].product.package?.display?.font?.fontWeight).toBe('700');
 });


### PR DESCRIPTION
`em.find` with `populate` and projected `fields` was firing duplicate populate queries when the populated relation contained an inlined embeddable. The main JOIN already loaded all the data, but the populate phase re-queried because `EntityLoader.isPropertyLoaded` returned `false` for the parent embedded name — hydration only tracks each leaf column (`localized_title_en`, …) in `__loadedProperties`, never the parent (`localizedTitle`).

The fix recognises inlined embeddables in `isPropertyLoaded` and recurses into `prop.embeddedProps`, so nested inline-in-inline cases also resolve correctly. Regression test in `tests/issues/GHx54.test.ts` covers both the single-level case (original repro) and a nested embed-in-embed case.