### PR TITLE
fix(core): skip M:N inverse scrub for STI siblings that can't reference the entity

### DIFF
--- a/packages/core/src/unit-of-work/UnitOfWork.ts
+++ b/packages/core/src/unit-of-work/UnitOfWork.ts
@@ -527,10 +527,23 @@ export class UnitOfWork {
     }
 
     // remove from referencing relations that are nullable
-    for (const prop of helper(entity).__meta.bidirectionalRelations) {
+    const entityMeta = helper(entity).__meta;
+    for (const prop of entityMeta.bidirectionalRelations) {
       const inverseProp = prop.mappedBy || prop.inversedBy;
       const relation = Reference.unwrapReference(entity[prop.name] as T);
       const prop2 = prop.targetMeta!.properties[inverseProp];
+
+      // skip relations that this entity's class can't actually participate in.
+      // happens with STI: a child meta picks up a sibling's inverse-side relation via the root,
+      // but the owning side targets the sibling — no collection can reference this entity.
+      const inverseTarget = prop2.targetMeta!;
+      if (
+        inverseTarget.abstract
+          ? inverseTarget.root.class !== entityMeta.root.class
+          : inverseTarget.class !== entityMeta.class
+      ) {
+        continue;
+      }
 
       if (prop.kind === ReferenceKind.ONE_TO_MANY && prop2.nullable && Utils.isCollection<AnyEntity>(relation)) {
         for (const item of relation.getItems(false)) {

--- a/tests/issues/GHx55.test.ts
+++ b/tests/issues/GHx55.test.ts
@@ -1,0 +1,92 @@
+import { defineEntity, MikroORM, ObjectId, p } from '@mikro-orm/mongodb';
+
+const UserTypes = ['heavy', 'casual', 'normal'] as const;
+
+const UserSchema = defineEntity({
+  abstract: true,
+  discriminatorColumn: 'type',
+  name: 'Entity',
+  properties: {
+    _id: p.type(ObjectId).primary(),
+    name: p.string(),
+    type: p.enum(UserTypes).hidden(),
+  },
+  tableName: 'entities',
+});
+
+class Entity extends UserSchema.class {}
+UserSchema.setClass(Entity);
+
+const HeavyUserSchema = defineEntity({
+  discriminatorValue: 'heavy',
+  extends: UserSchema,
+  name: 'HeavyUser',
+  properties: {
+    devices: () => p.manyToMany(Device).mappedBy('heavyUsers'),
+  },
+});
+
+class HeavyUser extends HeavyUserSchema.class {}
+HeavyUserSchema.setClass(HeavyUser);
+
+const CasualUserSchema = defineEntity({
+  discriminatorValue: 'casual',
+  extends: UserSchema,
+  name: 'CasualUser',
+  properties: {},
+});
+
+class CasualUser extends CasualUserSchema.class {}
+CasualUserSchema.setClass(CasualUser);
+
+const NormalUserSchema = defineEntity({
+  discriminatorValue: 'normal',
+  extends: UserSchema,
+  name: 'NormalUser',
+  properties: {
+    devices: () => p.manyToMany(Device).mappedBy('normalUsers'),
+  },
+});
+
+class NormalUser extends NormalUserSchema.class {}
+NormalUserSchema.setClass(NormalUser);
+
+const DeviceSchema = defineEntity({
+  name: 'Device',
+  properties: {
+    _id: p.type(ObjectId).primary(),
+    heavyUsers: () => p.manyToMany(HeavyUser),
+    normalUsers: () => p.manyToMany(NormalUser).inversedBy('devices'),
+  },
+});
+
+class Device extends DeviceSchema.class {}
+DeviceSchema.setClass(Device);
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    entities: [UserSchema, HeavyUserSchema, CasualUserSchema, NormalUserSchema, DeviceSchema],
+    clientUrl: 'mongodb://localhost:27017/mikro-orm-ghx55',
+  });
+  await orm.schema.refresh();
+});
+
+afterAll(() => orm.close(true));
+
+test('STI sibling without M:N relation can be removed across forked EMs', async () => {
+  const em1 = orm.em.fork();
+  const created = em1.create(CasualUser, { name: 'Casual User', type: 'casual' });
+  await em1.flush();
+  const id = created._id;
+
+  const em2 = orm.em.fork();
+  const user = await em2.findOne(CasualUser, { _id: id });
+  expect(user).not.toBeNull();
+  em2.remove(user!);
+  await em2.flush();
+
+  const gone = await orm.em.fork().findOne(CasualUser, { _id: id });
+  expect(gone).toBeNull();
+});


### PR DESCRIPTION
## Summary

For STI hierarchies, child metadata picks up a sibling's inverse-side M:N relation via the root. When such a child entity is removed (Mongo / inlined pivot path) the UoW iterated `bidirectionalRelations` and threw `cannot modify inverse side of M:N collection ...` even though the owning side targets a different sibling and no collection could reference the entity.

Skip the scrub when the inverse-side target class isn't the removed entity's class (or, for abstract targets, isn't in the same STI root) — mirroring the guard already present in `EntityHelper.propagate`.

Reported via reproduction: https://github.com/ameinhardt/reproduction/blob/e7faf2d4863c2a71c847277973a84bc8333da50b/src/example.test.ts#L45-L51

🤖 Generated with [Claude Code](https://claude.com/claude-code)