### PR TITLE
docs: document em.clone(), qb.insertFrom() and the using index-hint option

### DIFF
--- a/docs/blog/2026-05-20-mikro-orm-7-1-released.md
+++ b/docs/blog/2026-05-20-mikro-orm-7-1-released.md
@@ -90,7 +90,7 @@ em.find(User, { name: 'foo' }, { using: ['idx_user_name', 'uniq_user_email'] });
 
 The type system narrows `where` to only allow properties covered by the named index(es), and the index name itself is checked against your entity's declared indexes. For `defineEntity`, index names are inferred automatically from `.index('name')` / `.unique('name')` calls; for decorator entities you declare them via the `[IndexHints]` symbol (same pattern as `[PrimaryKeyProp]`).
 
-Driver support includes MySQL/MariaDB (`USE INDEX`), MSSQL (`WITH (INDEX(...))`), MongoDB (passed as the `hint` option), and validation-only on PostgreSQL/SQLite/libSQL. The existing `indexHint` option still works and takes precedence when explicitly set. See [indexes](/docs/indexes) for the full reference.
+Driver support includes MySQL/MariaDB (`USE INDEX`), MSSQL (`WITH (INDEX(...))`), MongoDB (passed as the `hint` option), and validation-only on PostgreSQL/SQLite/libSQL. The existing `indexHint` option still works and takes precedence when explicitly set. See [query-time index hints](/docs/indexes#query-time-index-hints-using) for the full reference.
 
 ## Partial indexes via `where`
 
@@ -404,7 +404,7 @@ const qb = em.qb(Book).insertFrom(
 
 `em.clone()` returns a hydrated entity (registered in the identity map) and delegates to a new `driver.nativeClone()` method. It handles TPT inheritance (multi-table inserts), embedded properties, M:1 FK preservation, and version property reset automatically. `qb.insertFrom()` is the lower-level building block, with 3-tier column derivation: metadata-driven, select-field-driven, or explicit.
 
-Works across all SQL drivers; MongoDB uses a find+insert fallback.
+Works across all SQL drivers; MongoDB uses a find+insert fallback. See [cloning entities](/docs/entity-manager#cloning-entities) and [insert from select](/docs/query-builder#insert-from-select-insertfrom) for the full reference.
 
 ## `fields` whitelist in `serialize()`
 

--- a/docs/docs/entity-manager.md
+++ b/docs/docs/entity-manager.md
@@ -529,6 +529,43 @@ const users = await em.find(User, {}, {
 });
 ```
 
+#### Named Index Hints via `using`
+
+The `using` option is a higher-level alternative to `indexHint`. You pass the **name** of a declared index and MikroORM does three things:
+
+1. Validates that the index exists on the entity.
+2. Validates that every property used in `where` / `orderBy` is covered by that index — typos and accidentally-unindexed queries become compile-time and runtime errors instead of silent table scans.
+3. Emits the driver-specific SQL hint for you (`USE INDEX (...)` on MySQL/MariaDB, `WITH (INDEX(...))` on MSSQL, `hint` option on MongoDB, validation-only on PostgreSQL / SQLite / libSQL).
+
+```ts
+// single index
+const users = await em.find(User, { name: 'foo' }, {
+  using: 'idx_user_name',
+});
+
+// multiple indexes — where/orderBy may use the union of their covered properties
+const users = await em.find(User, { name: 'foo', email: 'bar@x' }, {
+  using: ['idx_user_name', 'uniq_user_email'],
+});
+```
+
+The option works on every read method: `find`, `findOne`, `findOneOrFail`, `findAndCount`, `findAll`, `findByCursor`, `stream`, and the matching `EntityRepository` methods.
+
+For type-safe `using`, declare the available indexes on the entity — see [Query-time index hints](./indexes.md#query-time-index-hints-using) on the indexes page.
+
+`using` and `indexHint` can be used together: when both are set, `indexHint` wins and emits its raw string verbatim. `using` still validates `where` / `orderBy` against the named index, which is useful if you want the runtime check but need to spell out a non-standard hint manually:
+
+```ts
+await em.find(User, { name: 'foo' }, {
+  using: 'idx_user_name',                        // validation only
+  indexHint: 'force index for join (idx_user_name)', // emitted as-is
+});
+```
+
+If the named index does not exist, or `where` / `orderBy` references a property the index doesn't cover, MikroORM throws a clear error listing the available indexes and the offending property.
+
+MongoDB accepts only a single index per query — passing an array throws. For SQLite / libSQL the option is validation-only (the engines don't expose a public way to force an index from a `SELECT` statement).
+
 #### MongoDB-only Options
 
 ```ts
@@ -729,6 +766,49 @@ await em.upsert(Document, {
   onConflictWhere: { version: { $lt: 2 } },
 });
 ```
+
+## Cloning entities
+
+`em.clone()` copies rows at the database level via `INSERT ... SELECT`, without round-tripping the data through Node.js. It returns a hydrated entity that is already registered in the identity map.
+
+```ts
+// clone(EntityClass, where, overrides?, options?)
+const cloned = await em.clone(Author, { id: 1 }, { email: 'new@email.com' });
+
+// clone(entity, overrides?, options?)
+const author = await em.findOneOrFail(Author, 1);
+const cloned = await em.clone(author, { email: 'new@email.com' });
+
+// pure clone (no overrides) — all non-PK fields are copied
+const cloned = await em.clone(Author, { id: 1 });
+```
+
+The `where` argument is a regular `FilterQuery<T>` — the same shape `em.find()` accepts. When you pass an entity instance instead of an entity class, the entity's primary key is used as the where clause automatically.
+
+The `overrides` argument is an `EntityData<T>` partial used to replace selected columns in the cloned row. It is typically used to satisfy unique constraints (e.g. a unique `email`) or to mark the clone with a new value:
+
+```ts
+const cloned = await em.clone(
+  Author,
+  { id: 1 },
+  { email: 'cloned@example.com', age: 99 },
+);
+```
+
+What gets cloned:
+
+- Auto-increment primary keys are excluded — the database assigns a new PK to the cloned row.
+- Embedded properties are copied (they live on the same row).
+- M:1 foreign keys are preserved (both rows point at the same parent).
+- Version properties are reset to their initial value.
+- Generated / `persist: false` / formula columns are excluded.
+- M:N and 1:M relations are **not** cloned — pivot rows and inverse side rows stay attached to the original entity. If you need them, follow up with explicit `em.persist()` calls.
+
+Cloning works across single-table-inheritance and table-per-type (TPT) inheritance — for TPT, MikroORM emits one `INSERT ... SELECT` per ancestor table so the full row is reconstructed in every table.
+
+All SQL drivers (SQLite, libSQL, PostgreSQL, MySQL, MariaDB, MSSQL) execute a server-side `INSERT ... SELECT`. MongoDB falls back to a `find` + `insertOne` round-trip with the same end shape.
+
+> For the lower-level building block, see [`qb.insertFrom()`](./query-builder.md#insert-from-select-insertfrom) in the Query Builder — it generates the raw `INSERT ... SELECT` statement that `em.clone()` builds on top of.
 
 ## Refreshing entity state
 

--- a/docs/docs/indexes.md
+++ b/docs/docs/indexes.md
@@ -696,6 +696,130 @@ export class User {
 | Clustered indexes | - | ✅ | - | - | - | ✅ | - | - | - | - |
 | Deferrable constraints | - | - | ✅ | ✅ | - | - | ✅ | - | - | - |
 
+## Query-time index hints (`using`)
+
+The `using` option on `FindOptions` lets you tell the database which named index to use for a given query, with validation built in. It is the higher-level companion to the raw [`indexHint`](./entity-manager.md#index-hints) option — instead of writing dialect-specific hint syntax by hand, you pass the **name** of an index declared on the entity, and MikroORM:
+
+1. Validates that the index exists on the entity.
+2. Validates that every property used in `where` / `orderBy` is covered by that index.
+3. Emits the appropriate SQL hint for the underlying driver.
+
+```ts
+const users = await em.find(User, { name: 'foo' }, {
+  using: 'idx_user_name',
+});
+
+// also accepts an array — where/orderBy may use the union of their properties
+em.find(User, { name: 'foo', email: 'bar@x' }, {
+  using: ['idx_user_name', 'uniq_user_email'],
+});
+```
+
+Per-driver behavior:
+
+| Driver           | Emitted hint                          |
+|------------------|---------------------------------------|
+| MySQL / MariaDB  | `USE INDEX (idx_name[, ...])`         |
+| MSSQL            | `WITH (INDEX(idx_name[, ...]))`       |
+| MongoDB          | passed as the `hint` option (single index only) |
+| PostgreSQL       | validation only — no native hint syntax |
+| SQLite / libSQL  | validation only                       |
+
+When both `using` and `indexHint` are set, the raw `indexHint` wins and is emitted verbatim; `using` still validates `where` / `orderBy`.
+
+### Type-safe `using`
+
+To make `using` autocomplete index names and narrow `where` to only the properties covered by the chosen index, the entity has to declare an index map. The mechanism differs between definition styles:
+
+#### `defineEntity` — automatic inference
+
+Named indexes declared via property-level `.index('name')` / `.unique('name')` and the entity-level `indexes` / `uniques` arrays are picked up automatically. No extra declaration is needed:
+
+```ts
+import { defineEntity, p } from '@mikro-orm/core';
+
+const Article = defineEntity({
+  name: 'Article',
+  properties: {
+    id: p.integer().primary(),
+    title: p.string().index('idx_article_title'),
+    slug: p.string().unique('uniq_article_slug'),
+    status: p.string(),
+    views: p.integer(),
+  },
+  indexes: [{ name: 'idx_article_status_views', properties: ['status', 'views'] }],
+});
+
+em.find(Article, { title: 'foo' }, { using: 'idx_article_title' });
+em.find(Article, { slug: 'foo' }, { using: 'uniq_article_slug' });
+em.find(Article, { status: 'draft', views: 100 }, { using: 'idx_article_status_views' });
+
+// @ts-expect-error 'views' is not covered by 'idx_article_title'
+em.find(Article, { views: 100 }, { using: 'idx_article_title' });
+```
+
+#### Decorator entities — `[IndexHints]` symbol
+
+Decorator metadata doesn't carry the index names into the entity type, so you spell the index map out as a phantom property using the `IndexHints` symbol (same pattern as `[PrimaryKeyProp]` or `[OptionalProps]`):
+
+```ts
+import { Entity, Index, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+import { IndexHints, PrimaryKeyProp } from '@mikro-orm/core';
+
+@Entity()
+@Index({ name: 'idx_user_name', properties: ['name'] })
+@Index({ name: 'idx_user_name_email', properties: ['name', 'email'] })
+@Unique({ name: 'uniq_user_email', properties: ['email'] })
+class User {
+
+  [PrimaryKeyProp]?: 'id';
+  [IndexHints]?: {
+    idx_user_name: 'name';
+    idx_user_name_email: 'name' | 'email';
+    uniq_user_email: 'email';
+  };
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @Property()
+  email!: string;
+
+  @Property({ nullable: true })
+  age?: number;
+
+}
+
+em.find(User, { name: 'foo' }, { using: 'idx_user_name' });
+
+// @ts-expect-error 'age' is not in idx_user_name
+em.find(User, { age: 30 }, { using: 'idx_user_name' });
+```
+
+The phantom `[IndexHints]?` declaration is type-only — it does not exist at runtime and is never serialized. Each key is an index name; each value is the union of property names covered by that index. When `[IndexHints]` is not declared, `using` falls back to `string` and accepts any name (runtime validation still applies).
+
+### Runtime validation
+
+Validation runs even when the type system doesn't catch the mistake (e.g. for entities without `[IndexHints]`, or when `where` is cast to `any`):
+
+```ts
+// throws: Index 'nonexistent_idx' not found on entity 'User'. Available indexes: ...
+em.find(User, { name: 'foo' }, { using: 'nonexistent_idx' });
+
+// throws: Property 'age' in where clause is not covered by index 'idx_user_name'
+em.find(User, { age: 30 } as any, { using: 'idx_user_name' });
+
+// throws: Property 'age' in orderBy is not covered by index 'idx_user_name'
+em.find(User, { name: 'foo' }, { using: 'idx_user_name', orderBy: { age: 'asc' } });
+```
+
+The validator walks `$and` / `$or` / `$not` recursively, so nested conditions are checked too. Non-property operators inside a property value (e.g. `{ name: { $eq: 'foo' } }`) are accepted as long as the surrounding property is covered.
+
+See [Index Hints](./entity-manager.md#index-hints) and [Named Index Hints via `using`](./entity-manager.md#named-index-hints-via-using) on the Entity Manager page for the matching FindOptions reference.
+
 ## See Also
 
 - [Defining Entities](./defining-entities.md) - General entity definition guide

--- a/docs/docs/query-builder.md
+++ b/docs/docs/query-builder.md
@@ -776,6 +776,58 @@ const qb3 = em.createQueryBuilder(Author)
 ```
 
 
+## Insert from select (`insertFrom()`)
+
+`qb.insertFrom(source, options?)` generates an `INSERT INTO ... SELECT` statement that copies rows produced by a source `QueryBuilder` into the target table — without round-tripping the rows through Node.js.
+
+It is the lower-level building block that powers [`em.clone()`](./entity-manager.md#cloning-entities), but you can use it directly to bulk-clone, archive, or seed rows from another query.
+
+```ts
+// Copy a single row, all columns auto-derived from entity metadata
+const source = em.createQueryBuilder(Book).where({ id: 1 });
+await em.createQueryBuilder(Book).insertFrom(source).execute();
+
+// Copy with overrides via raw() aliases on the SELECT side
+const source = em.createQueryBuilder(Author)
+  .select(['name', raw("'cloned@test.com'").as('email'), 'age', 'createdAt'])
+  .where({ id: 1 });
+await em.createQueryBuilder(Author).insertFrom(source).execute();
+
+// Explicit column list — useful when raw() expressions in the SELECT have no `.as()` alias
+await em.createQueryBuilder(Author)
+  .insertFrom(source, { columns: ['name', 'email', 'age', 'createdAt'] })
+  .execute();
+```
+
+### Column resolution
+
+`insertFrom()` derives the `INSERT (col, col, ...)` column list in three tiers, in order of precedence:
+
+1. **Explicit `columns` option** — the user-supplied array wins over everything else.
+2. **Explicit `select()` on the source** — when the source query has its own `select(...)`, the selected field names (or `.as()` aliases) become the column list.
+3. **No `select()` on the source** — MikroORM derives the column list from the entity metadata, excluding auto-increment primary keys, generated columns, formula properties, `persist: false`, and 1:M / M:N (inverse-side) relations. Embedded properties and M:1 foreign-key columns are included.
+
+### Composable with `onConflict()` and `returning()`
+
+The returned `InsertQueryBuilder` exposes the same methods as a regular `qb.insert()`, so you can chain conflict handlers or RETURNING clauses:
+
+```ts
+// Skip duplicates by unique constraint
+const source = em.createQueryBuilder(Author).where({ id: 1 });
+await em.createQueryBuilder(Author)
+  .insertFrom(source)
+  .onConflict('email').ignore()
+  .execute();
+
+// Return the inserted rows (PostgreSQL / MSSQL / SQLite / libSQL)
+const inserted = await em.createQueryBuilder(Author)
+  .insertFrom(source)
+  .returning('*')
+  .execute();
+```
+
+The statement runs on all SQL drivers (SQLite, libSQL, PostgreSQL, MySQL, MariaDB, MSSQL). MySQL / MariaDB don't support `RETURNING`, so prefer `onConflict()` or a follow-up SELECT there.
+
 ## Referring to column in update queries
 
 You can use static `raw()` helper to insert raw SQL snippets like this:

--- a/docs/versioned_docs/version-7.1/entity-manager.md
+++ b/docs/versioned_docs/version-7.1/entity-manager.md
@@ -529,6 +529,43 @@ const users = await em.find(User, {}, {
 });
 ```
 
+#### Named Index Hints via `using`
+
+The `using` option is a higher-level alternative to `indexHint`. You pass the **name** of a declared index and MikroORM does three things:
+
+1. Validates that the index exists on the entity.
+2. Validates that every property used in `where` / `orderBy` is covered by that index — typos and accidentally-unindexed queries become compile-time and runtime errors instead of silent table scans.
+3. Emits the driver-specific SQL hint for you (`USE INDEX (...)` on MySQL/MariaDB, `WITH (INDEX(...))` on MSSQL, `hint` option on MongoDB, validation-only on PostgreSQL / SQLite / libSQL).
+
+```ts
+// single index
+const users = await em.find(User, { name: 'foo' }, {
+  using: 'idx_user_name',
+});
+
+// multiple indexes — where/orderBy may use the union of their covered properties
+const users = await em.find(User, { name: 'foo', email: 'bar@x' }, {
+  using: ['idx_user_name', 'uniq_user_email'],
+});
+```
+
+The option works on every read method: `find`, `findOne`, `findOneOrFail`, `findAndCount`, `findAll`, `findByCursor`, `stream`, and the matching `EntityRepository` methods.
+
+For type-safe `using`, declare the available indexes on the entity — see [Query-time index hints](./indexes.md#query-time-index-hints-using) on the indexes page.
+
+`using` and `indexHint` can be used together: when both are set, `indexHint` wins and emits its raw string verbatim. `using` still validates `where` / `orderBy` against the named index, which is useful if you want the runtime check but need to spell out a non-standard hint manually:
+
+```ts
+await em.find(User, { name: 'foo' }, {
+  using: 'idx_user_name',                        // validation only
+  indexHint: 'force index for join (idx_user_name)', // emitted as-is
+});
+```
+
+If the named index does not exist, or `where` / `orderBy` references a property the index doesn't cover, MikroORM throws a clear error listing the available indexes and the offending property.
+
+MongoDB accepts only a single index per query — passing an array throws. For SQLite / libSQL the option is validation-only (the engines don't expose a public way to force an index from a `SELECT` statement).
+
 #### MongoDB-only Options
 
 ```ts
@@ -729,6 +766,49 @@ await em.upsert(Document, {
   onConflictWhere: { version: { $lt: 2 } },
 });
 ```
+
+## Cloning entities
+
+`em.clone()` copies rows at the database level via `INSERT ... SELECT`, without round-tripping the data through Node.js. It returns a hydrated entity that is already registered in the identity map.
+
+```ts
+// clone(EntityClass, where, overrides?, options?)
+const cloned = await em.clone(Author, { id: 1 }, { email: 'new@email.com' });
+
+// clone(entity, overrides?, options?)
+const author = await em.findOneOrFail(Author, 1);
+const cloned = await em.clone(author, { email: 'new@email.com' });
+
+// pure clone (no overrides) — all non-PK fields are copied
+const cloned = await em.clone(Author, { id: 1 });
+```
+
+The `where` argument is a regular `FilterQuery<T>` — the same shape `em.find()` accepts. When you pass an entity instance instead of an entity class, the entity's primary key is used as the where clause automatically.
+
+The `overrides` argument is an `EntityData<T>` partial used to replace selected columns in the cloned row. It is typically used to satisfy unique constraints (e.g. a unique `email`) or to mark the clone with a new value:
+
+```ts
+const cloned = await em.clone(
+  Author,
+  { id: 1 },
+  { email: 'cloned@example.com', age: 99 },
+);
+```
+
+What gets cloned:
+
+- Auto-increment primary keys are excluded — the database assigns a new PK to the cloned row.
+- Embedded properties are copied (they live on the same row).
+- M:1 foreign keys are preserved (both rows point at the same parent).
+- Version properties are reset to their initial value.
+- Generated / `persist: false` / formula columns are excluded.
+- M:N and 1:M relations are **not** cloned — pivot rows and inverse side rows stay attached to the original entity. If you need them, follow up with explicit `em.persist()` calls.
+
+Cloning works across single-table-inheritance and table-per-type (TPT) inheritance — for TPT, MikroORM emits one `INSERT ... SELECT` per ancestor table so the full row is reconstructed in every table.
+
+All SQL drivers (SQLite, libSQL, PostgreSQL, MySQL, MariaDB, MSSQL) execute a server-side `INSERT ... SELECT`. MongoDB falls back to a `find` + `insertOne` round-trip with the same end shape.
+
+> For the lower-level building block, see [`qb.insertFrom()`](./query-builder.md#insert-from-select-insertfrom) in the Query Builder — it generates the raw `INSERT ... SELECT` statement that `em.clone()` builds on top of.
 
 ## Refreshing entity state
 

--- a/docs/versioned_docs/version-7.1/indexes.md
+++ b/docs/versioned_docs/version-7.1/indexes.md
@@ -696,6 +696,130 @@ export class User {
 | Clustered indexes | - | ✅ | - | - | - | ✅ | - | - | - | - |
 | Deferrable constraints | - | - | ✅ | ✅ | - | - | ✅ | - | - | - |
 
+## Query-time index hints (`using`)
+
+The `using` option on `FindOptions` lets you tell the database which named index to use for a given query, with validation built in. It is the higher-level companion to the raw [`indexHint`](./entity-manager.md#index-hints) option — instead of writing dialect-specific hint syntax by hand, you pass the **name** of an index declared on the entity, and MikroORM:
+
+1. Validates that the index exists on the entity.
+2. Validates that every property used in `where` / `orderBy` is covered by that index.
+3. Emits the appropriate SQL hint for the underlying driver.
+
+```ts
+const users = await em.find(User, { name: 'foo' }, {
+  using: 'idx_user_name',
+});
+
+// also accepts an array — where/orderBy may use the union of their properties
+em.find(User, { name: 'foo', email: 'bar@x' }, {
+  using: ['idx_user_name', 'uniq_user_email'],
+});
+```
+
+Per-driver behavior:
+
+| Driver           | Emitted hint                          |
+|------------------|---------------------------------------|
+| MySQL / MariaDB  | `USE INDEX (idx_name[, ...])`         |
+| MSSQL            | `WITH (INDEX(idx_name[, ...]))`       |
+| MongoDB          | passed as the `hint` option (single index only) |
+| PostgreSQL       | validation only — no native hint syntax |
+| SQLite / libSQL  | validation only                       |
+
+When both `using` and `indexHint` are set, the raw `indexHint` wins and is emitted verbatim; `using` still validates `where` / `orderBy`.
+
+### Type-safe `using`
+
+To make `using` autocomplete index names and narrow `where` to only the properties covered by the chosen index, the entity has to declare an index map. The mechanism differs between definition styles:
+
+#### `defineEntity` — automatic inference
+
+Named indexes declared via property-level `.index('name')` / `.unique('name')` and the entity-level `indexes` / `uniques` arrays are picked up automatically. No extra declaration is needed:
+
+```ts
+import { defineEntity, p } from '@mikro-orm/core';
+
+const Article = defineEntity({
+  name: 'Article',
+  properties: {
+    id: p.integer().primary(),
+    title: p.string().index('idx_article_title'),
+    slug: p.string().unique('uniq_article_slug'),
+    status: p.string(),
+    views: p.integer(),
+  },
+  indexes: [{ name: 'idx_article_status_views', properties: ['status', 'views'] }],
+});
+
+em.find(Article, { title: 'foo' }, { using: 'idx_article_title' });
+em.find(Article, { slug: 'foo' }, { using: 'uniq_article_slug' });
+em.find(Article, { status: 'draft', views: 100 }, { using: 'idx_article_status_views' });
+
+// @ts-expect-error 'views' is not covered by 'idx_article_title'
+em.find(Article, { views: 100 }, { using: 'idx_article_title' });
+```
+
+#### Decorator entities — `[IndexHints]` symbol
+
+Decorator metadata doesn't carry the index names into the entity type, so you spell the index map out as a phantom property using the `IndexHints` symbol (same pattern as `[PrimaryKeyProp]` or `[OptionalProps]`):
+
+```ts
+import { Entity, Index, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+import { IndexHints, PrimaryKeyProp } from '@mikro-orm/core';
+
+@Entity()
+@Index({ name: 'idx_user_name', properties: ['name'] })
+@Index({ name: 'idx_user_name_email', properties: ['name', 'email'] })
+@Unique({ name: 'uniq_user_email', properties: ['email'] })
+class User {
+
+  [PrimaryKeyProp]?: 'id';
+  [IndexHints]?: {
+    idx_user_name: 'name';
+    idx_user_name_email: 'name' | 'email';
+    uniq_user_email: 'email';
+  };
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @Property()
+  email!: string;
+
+  @Property({ nullable: true })
+  age?: number;
+
+}
+
+em.find(User, { name: 'foo' }, { using: 'idx_user_name' });
+
+// @ts-expect-error 'age' is not in idx_user_name
+em.find(User, { age: 30 }, { using: 'idx_user_name' });
+```
+
+The phantom `[IndexHints]?` declaration is type-only — it does not exist at runtime and is never serialized. Each key is an index name; each value is the union of property names covered by that index. When `[IndexHints]` is not declared, `using` falls back to `string` and accepts any name (runtime validation still applies).
+
+### Runtime validation
+
+Validation runs even when the type system doesn't catch the mistake (e.g. for entities without `[IndexHints]`, or when `where` is cast to `any`):
+
+```ts
+// throws: Index 'nonexistent_idx' not found on entity 'User'. Available indexes: ...
+em.find(User, { name: 'foo' }, { using: 'nonexistent_idx' });
+
+// throws: Property 'age' in where clause is not covered by index 'idx_user_name'
+em.find(User, { age: 30 } as any, { using: 'idx_user_name' });
+
+// throws: Property 'age' in orderBy is not covered by index 'idx_user_name'
+em.find(User, { name: 'foo' }, { using: 'idx_user_name', orderBy: { age: 'asc' } });
+```
+
+The validator walks `$and` / `$or` / `$not` recursively, so nested conditions are checked too. Non-property operators inside a property value (e.g. `{ name: { $eq: 'foo' } }`) are accepted as long as the surrounding property is covered.
+
+See [Index Hints](./entity-manager.md#index-hints) and [Named Index Hints via `using`](./entity-manager.md#named-index-hints-via-using) on the Entity Manager page for the matching FindOptions reference.
+
 ## See Also
 
 - [Defining Entities](./defining-entities.md) - General entity definition guide

--- a/docs/versioned_docs/version-7.1/query-builder.md
+++ b/docs/versioned_docs/version-7.1/query-builder.md
@@ -776,6 +776,58 @@ const qb3 = em.createQueryBuilder(Author)
 ```
 
 
+## Insert from select (`insertFrom()`)
+
+`qb.insertFrom(source, options?)` generates an `INSERT INTO ... SELECT` statement that copies rows produced by a source `QueryBuilder` into the target table — without round-tripping the rows through Node.js.
+
+It is the lower-level building block that powers [`em.clone()`](./entity-manager.md#cloning-entities), but you can use it directly to bulk-clone, archive, or seed rows from another query.
+
+```ts
+// Copy a single row, all columns auto-derived from entity metadata
+const source = em.createQueryBuilder(Book).where({ id: 1 });
+await em.createQueryBuilder(Book).insertFrom(source).execute();
+
+// Copy with overrides via raw() aliases on the SELECT side
+const source = em.createQueryBuilder(Author)
+  .select(['name', raw("'cloned@test.com'").as('email'), 'age', 'createdAt'])
+  .where({ id: 1 });
+await em.createQueryBuilder(Author).insertFrom(source).execute();
+
+// Explicit column list — useful when raw() expressions in the SELECT have no `.as()` alias
+await em.createQueryBuilder(Author)
+  .insertFrom(source, { columns: ['name', 'email', 'age', 'createdAt'] })
+  .execute();
+```
+
+### Column resolution
+
+`insertFrom()` derives the `INSERT (col, col, ...)` column list in three tiers, in order of precedence:
+
+1. **Explicit `columns` option** — the user-supplied array wins over everything else.
+2. **Explicit `select()` on the source** — when the source query has its own `select(...)`, the selected field names (or `.as()` aliases) become the column list.
+3. **No `select()` on the source** — MikroORM derives the column list from the entity metadata, excluding auto-increment primary keys, generated columns, formula properties, `persist: false`, and 1:M / M:N (inverse-side) relations. Embedded properties and M:1 foreign-key columns are included.
+
+### Composable with `onConflict()` and `returning()`
+
+The returned `InsertQueryBuilder` exposes the same methods as a regular `qb.insert()`, so you can chain conflict handlers or RETURNING clauses:
+
+```ts
+// Skip duplicates by unique constraint
+const source = em.createQueryBuilder(Author).where({ id: 1 });
+await em.createQueryBuilder(Author)
+  .insertFrom(source)
+  .onConflict('email').ignore()
+  .execute();
+
+// Return the inserted rows (PostgreSQL / MSSQL / SQLite / libSQL)
+const inserted = await em.createQueryBuilder(Author)
+  .insertFrom(source)
+  .returning('*')
+  .execute();
+```
+
+The statement runs on all SQL drivers (SQLite, libSQL, PostgreSQL, MySQL, MariaDB, MSSQL). MySQL / MariaDB don't support `RETURNING`, so prefer `onConflict()` or a follow-up SELECT there.
+
 ## Referring to column in update queries
 
 You can use static `raw()` helper to insert raw SQL snippets like this:


### PR DESCRIPTION
## Summary

- Documents `em.clone()` (PR #7365) under a new **Cloning entities** section in [entity-manager.md](docs/docs/entity-manager.md)
- Documents `qb.insertFrom()` (PR #7365) under a new **Insert from select** section in [query-builder.md](docs/docs/query-builder.md)
- Documents the `using` option (PR #7375) in both [entity-manager.md](docs/docs/entity-manager.md) (next to existing `indexHint`) and [indexes.md](docs/docs/indexes.md) (with the `defineEntity` auto-inference and decorator `[IndexHints]` patterns, runtime validation, and a per-driver hint table)
- Mirrors the changes into the v7.1 docs snapshot
- Links the new sections from the v7.1 release blog post