### PR TITLE
fix(core): skip PK collapse when composite FK doesn't align with target PK

### DIFF
--- a/packages/core/src/utils/QueryHelper.ts
+++ b/packages/core/src/utils/QueryHelper.ts
@@ -221,12 +221,16 @@ export class QueryHelper {
       const meta2 = metadata.find(prop?.targetMeta?.class as any) || meta;
 
       if (this.inlinePrimaryKeyObjects(where[k], meta2, metadata, k)) {
-        // Skip the PK collapse when the relation's FK column count does not match the target's
-        // PK column count (e.g. FK references target PK + an extra unique column). Otherwise the
-        // criteria layer would emit a malformed tuple predicate such as `(joinCol1, joinCol2) =
-        // scalar` (single-PK target) or `(joinCol1, joinCol2, joinCol3) = [v1, v2]` (composite
-        // target + extra FK column).
-        if (prop?.joinColumns && prop.joinColumns.length !== meta2.primaryKeys.length) {
+        // Skip the PK collapse when an owning M:1/1:1 relation's FK column count does not match
+        // the target's PK column count (e.g. FK references target PK + an extra unique column).
+        // The criteria layer would otherwise emit a malformed predicate such as
+        // `(joinCol1, joinCol2) = scalar`. Limited to owning relations — `joinColumns` on the
+        // inverse side (1:m) describes the owning entity's FK columns, not the LHS tuple.
+        if (
+          prop?.owner &&
+          [ReferenceKind.MANY_TO_ONE, ReferenceKind.ONE_TO_ONE].includes(prop.kind) &&
+          prop.joinColumns.length !== meta2.primaryKeys.length
+        ) {
           return;
         }
 

--- a/packages/core/src/utils/QueryHelper.ts
+++ b/packages/core/src/utils/QueryHelper.ts
@@ -217,9 +217,19 @@ export class QueryHelper {
     }
 
     Object.keys(where).forEach(k => {
-      const meta2 = metadata.find(meta.properties[k as EntityKey<T>]?.targetMeta?.class as any) || meta;
+      const prop = meta.properties[k as EntityKey<T>];
+      const meta2 = metadata.find(prop?.targetMeta?.class as any) || meta;
 
       if (this.inlinePrimaryKeyObjects(where[k], meta2, metadata, k)) {
+        // Skip the PK collapse when the relation's FK column count does not match the target's
+        // PK column count (e.g. FK references target PK + an extra unique column). Otherwise the
+        // criteria layer would emit a malformed tuple predicate such as `(joinCol1, joinCol2) =
+        // scalar` (single-PK target) or `(joinCol1, joinCol2, joinCol3) = [v1, v2]` (composite
+        // target + extra FK column).
+        if (prop?.joinColumns && prop.joinColumns.length !== meta2.primaryKeys.length) {
+          return;
+        }
+
         where[k] = Utils.getPrimaryKeyValues(where[k], meta2, true);
       }
     });

--- a/tests/issues/GH7764.test.ts
+++ b/tests/issues/GH7764.test.ts
@@ -1,0 +1,60 @@
+import { MikroORM } from '@mikro-orm/sqlite';
+import { Entity, ManyToOne, PrimaryKey, ReflectMetadataProvider, Unique } from '@mikro-orm/decorators/legacy';
+
+@Entity()
+class Carrier {
+  @PrimaryKey()
+  id!: string;
+}
+
+@Entity()
+@Unique({ properties: ['id', 'carrier'] })
+class TimeTrackingSystem {
+  @PrimaryKey()
+  id!: string;
+
+  @ManyToOne(() => Carrier)
+  carrier!: Carrier;
+}
+
+@Entity()
+class Location {
+  @PrimaryKey()
+  id!: string;
+
+  // composite FK references target's PK plus an extra column scoped via the
+  // composite UNIQUE constraint on TimeTrackingSystem; target PK itself is scalar.
+  @ManyToOne(() => TimeTrackingSystem, {
+    joinColumns: ['time_tracking_system_id', 'carrier_id'],
+    referencedColumnNames: ['id', 'carrier_id'],
+  })
+  timeTrackingSystem!: TimeTrackingSystem;
+
+  @ManyToOne(() => Carrier)
+  carrier!: Carrier;
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    dbName: ':memory:',
+    entities: [Carrier, TimeTrackingSystem, Location],
+    metadataProvider: ReflectMetadataProvider,
+  });
+  await orm.schema.refresh();
+});
+
+afterAll(() => orm.close(true));
+
+test('filter by FK target PK only does not produce `(col1,col2) = scalar`', async () => {
+  const qb = orm.em
+    .fork()
+    .qb(Location)
+    .where({ timeTrackingSystem: { id: 'abc' } });
+  expect(qb.getFormattedQuery()).toBe(
+    "select `l0`.* from `location` as `l0` where `l0`.`time_tracking_system_id` = 'abc'",
+  );
+  // executes against the database without raising "row value misused"
+  await orm.em.fork().find(Location, { timeTrackingSystem: { id: 'abc' } });
+});


### PR DESCRIPTION
Filtering by a relation's PK (e.g. `em.find(Location, { timeTrackingSystem: { id: 'x' } })`) produced malformed SQL whenever the relation declared a composite FK that referenced more columns than the target's PK — for example a FK to PK + an extra column scoped via a composite UNIQUE constraint.

`QueryHelper.inlinePrimaryKeyObjects` would collapse the where to a scalar PK value (because the target's PK matched), then `CriteriaNode.renameFieldToPK` expanded the LHS to the full join-column tuple (because the FK was composite). The two passes disagreed about composite-ness and the resulting predicate was rejected by the database:

- Postgres: `input of anonymous composite types is not implemented`
- SQLite: `row value misused`

Guard the collapse so it only runs when the FK column count equals the target PK count. Worked correctly in 7.0.13; regression surfaced once the composite-FK path was exercised more broadly.

Closes #7764