### PR TITLE
fix(cli): skip local-dependency check under Deno

### DIFF
--- a/packages/cli/src/CLIHelper.ts
+++ b/packages/cli/src/CLIHelper.ts
@@ -35,7 +35,7 @@ export class CLIHelper {
     paths ??= await this.getConfigPaths();
     const deps = fs.getORMPackages();
 
-    if (!deps.has('@mikro-orm/cli') && !process.env.MIKRO_ORM_ALLOW_GLOBAL_CLI) {
+    if (!deps.has('@mikro-orm/cli') && !process.env.MIKRO_ORM_ALLOW_GLOBAL_CLI && !process.versions.deno) {
       throw new Error('@mikro-orm/cli needs to be installed as a local dependency!');
     }
 

--- a/tests/features/cli/CLIHelper.test.ts
+++ b/tests/features/cli/CLIHelper.test.ts
@@ -218,6 +218,24 @@ describe('CLIHelper', () => {
     );
   });
 
+  test('skips local-dependency check under Deno', async () => {
+    delete process.env.MIKRO_ORM_ALLOW_GLOBAL_CLI;
+    const originalDeno = process.versions.deno;
+    Object.defineProperty(process.versions, 'deno', { value: '2.7.14', configurable: true });
+
+    try {
+      await expect(CLIHelper.getConfiguration()).rejects.not.toThrow(
+        '@mikro-orm/cli needs to be installed as a local dependency!',
+      );
+    } finally {
+      if (originalDeno === undefined) {
+        delete (process.versions as any).deno;
+      } else {
+        Object.defineProperty(process.versions, 'deno', { value: originalDeno, configurable: true });
+      }
+    }
+  });
+
   test('gets ORM configuration [no mikro-orm.config]', async () => {
     delete process.env.MIKRO_ORM_ALLOW_GLOBAL_CONTEXT;
     await expect(CLIHelper.getConfiguration()).rejects.toThrow(


### PR DESCRIPTION
The `@mikro-orm/cli needs to be installed as a local dependency!` check reads `dependencies`/`devDependencies` from `package.json`. Under Deno, npm packages are typically declared in `deno.json` under `imports`, so the check fires even when the CLI is properly declared (e.g. via `deno add npm:@mikro-orm/cli`).

Detect Deno via `process.versions.deno` and skip the heuristic — same pattern already used for `process.versions.bun` elsewhere in the file.

Closes #7766