### PR TITLE
fix(postgresql): recast column default when changing array element type

### DIFF
--- a/packages/sql/src/schema/SchemaHelper.ts
+++ b/packages/sql/src/schema/SchemaHelper.ts
@@ -658,12 +658,24 @@ export abstract class SchemaHelper {
 
   alterTableColumn(column: Column, table: DatabaseTable, changedProperties: Set<string>): string[] {
     const sql: string[] = [];
+    const typeChanged = changedProperties.has('type') || changedProperties.has('collation');
+    const defaultChanged = changedProperties.has('default');
+    // Postgres can't implicitly cast a stored DEFAULT across array element types
+    // (e.g. `'{}'::text[]` -> `numeric(3,2)[]`), so drop+re-set it around ALTER TYPE.
+    const fromColumn = typeChanged ? table.getColumn(column.name) : undefined;
+    const needsArrayDefaultRecast =
+      typeChanged &&
+      fromColumn?.default != null &&
+      fromColumn.type.endsWith(']') &&
+      column.type.endsWith(']') &&
+      fromColumn.type !== column.type;
+    const recastDefault = needsArrayDefaultRecast && !defaultChanged;
 
-    if (changedProperties.has('default') && column.default == null) {
+    if ((defaultChanged && column.default == null) || needsArrayDefaultRecast) {
       sql.push(`alter table ${table.getQuotedName()} alter column ${this.quote(column.name)} drop default`);
     }
 
-    if (changedProperties.has('type') || changedProperties.has('collation')) {
+    if (typeChanged) {
       let type = column.type + (column.generated ? ` generated always as ${column.generated}` : '');
 
       if (column.nativeEnumName) {
@@ -685,7 +697,7 @@ export abstract class SchemaHelper {
       );
     }
 
-    if (changedProperties.has('default') && column.default != null) {
+    if ((defaultChanged && column.default != null) || recastDefault) {
       sql.push(
         `alter table ${table.getQuotedName()} alter column ${this.quote(column.name)} set default ${column.default}`,
       );

--- a/tests/issues/GHx56.test.ts
+++ b/tests/issues/GHx56.test.ts
@@ -1,0 +1,55 @@
+// Schema diff for a scalar-array column whose type is changing (e.g. text[] ->
+// numeric(3,2)[]) must drop the existing default and re-set it around the
+// `alter column ... type` statement — Postgres cannot auto-cast the stored
+// default expression to the new array type.
+
+import { defineEntity, MikroORM, p } from '@mikro-orm/postgresql';
+
+const ClientSettingsV1Schema = defineEntity({
+  name: 'ClientSettings',
+  tableName: 'client_settings',
+  properties: {
+    id: p.integer().primary().autoincrement(),
+    vatRates: p.array(Number).default([]),
+  },
+});
+
+class ClientSettingsV1 extends ClientSettingsV1Schema.class {}
+ClientSettingsV1Schema.setClass(ClientSettingsV1);
+
+const ClientSettingsV2Schema = defineEntity({
+  name: 'ClientSettings',
+  tableName: 'client_settings',
+  properties: {
+    id: p.integer().primary().autoincrement(),
+    vatRates: p.decimal('number').array().precision(3).scale(2).default([]),
+  },
+});
+
+class ClientSettingsV2 extends ClientSettingsV2Schema.class {}
+ClientSettingsV2Schema.setClass(ClientSettingsV2);
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    dbName: 'mikro_orm_test_ghx56',
+    entities: [ClientSettingsV1],
+  });
+  await orm.schema.refresh();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+test('schema update handles scalar array type change with default empty array', async () => {
+  orm.discoverEntity(ClientSettingsV2, ClientSettingsV1);
+
+  const diff = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+  expect(diff).toContain('alter table "client_settings" alter column "vat_rates" drop default');
+  expect(diff).toContain('alter table "client_settings" alter column "vat_rates" type numeric(3,2)[]');
+  expect(diff).toContain('alter table "client_settings" alter column "vat_rates" set default');
+
+  await expect(orm.schema.execute(diff)).resolves.toBeUndefined();
+});


### PR DESCRIPTION
Postgres can't implicitly cast a stored `DEFAULT` expression across array element types (e.g. `'{}'::text[]` → `numeric(3,2)[]`), so the `ALTER COLUMN ... TYPE ... USING ...` emitted by the schema diff fails for otherwise valid schema updates — the `USING` clause only handles row data, not the stored default expression.

`alterTableColumn` now drops the default before the type change and re-emits it afterwards, but only when both the old and new types are arrays with different element types and the old column had a non-null default. All other type changes (varchar widths, numeric precision, enum transitions handled by `getPreAlterTable`/`getPostAlterTable`, etc.) are unaffected — no extra SQL emitted for cases Postgres can already auto-cast.

Repro: `tests/issues/GHx56.test.ts`.