### PR TITLE
docs: document custom EntityManager with discovery:export

### DIFF
--- a/docs/docs/kysely.md
+++ b/docs/docs/kysely.md
@@ -319,6 +319,21 @@ export class ArticleService {
 }
 ```
 
+#### Using a custom `EntityManager` subclass
+
+The generated `EntityManager` re-exports the driver's stock EM. If you extend it (see [Extending `EntityManager`](./entity-manager.md#extending-entitymanager)) and want the same entity-aware typing for your subclass, leave the generated file alone and write a tiny adjacent wrapper that grafts the generated `Database` tuple onto your own class:
+
+```ts title="custom-em.ts"
+import { entities, type Database } from './entities.generated.js';
+import { MyEntityManager } from './MyEntityManager.js';
+
+export { entities };
+export type EntityManager = MyEntityManager & { '~entities': Database };
+export const EntityManager = MyEntityManager;
+```
+
+Then import `EntityManager` from `./custom-em` instead of `./entities.generated` in your DI bindings and services. The generated barrel stays purely mechanical (so re-running `discovery:export` never clobbers your custom-EM glue), and `em.getKysely(opts)` keeps full type inference through the subclass.
+
 #### Command Options
 
 | Flag | Type | Description |

--- a/docs/versioned_docs/version-7.1/kysely.md
+++ b/docs/versioned_docs/version-7.1/kysely.md
@@ -319,6 +319,21 @@ export class ArticleService {
 }
 ```
 
+#### Using a custom `EntityManager` subclass
+
+The generated `EntityManager` re-exports the driver's stock EM. If you extend it (see [Extending `EntityManager`](./entity-manager.md#extending-entitymanager)) and want the same entity-aware typing for your subclass, leave the generated file alone and write a tiny adjacent wrapper that grafts the generated `Database` tuple onto your own class:
+
+```ts title="custom-em.ts"
+import { entities, type Database } from './entities.generated.js';
+import { MyEntityManager } from './MyEntityManager.js';
+
+export { entities };
+export type EntityManager = MyEntityManager & { '~entities': Database };
+export const EntityManager = MyEntityManager;
+```
+
+Then import `EntityManager` from `./custom-em` instead of `./entities.generated` in your DI bindings and services. The generated barrel stays purely mechanical (so re-running `discovery:export` never clobbers your custom-EM glue), and `em.getKysely(opts)` keeps full type inference through the subclass.
+
 #### Command Options
 
 | Flag | Type | Description |


### PR DESCRIPTION
The generated `EntityManager` from `discovery:export` re-exports the driver's stock EM, which doesn't help users who extend it via the `entityManager` config option. Documents the small adjacent wrapper file pattern that grafts the generated `Database` tuple onto the user's subclass — keeps the generated barrel mechanical (re-running the CLI never clobbers custom-EM glue) while still giving entity-aware typing through `em.getKysely(opts)`. Mirrored into the v7.1 versioned snapshot.

The NestJS adapter already registers the custom EM class as a DI provider alongside the core `EntityManager` token (`mikro-orm/nestjs#mikro-orm-core.module.ts`), so the wrapper-file pattern works end-to-end with `@Injectable()` services.