### PR TITLE
fix(seeder): widen `Factory.model` type to `EntityName<T>`

### DIFF
--- a/packages/seeder/src/Factory.ts
+++ b/packages/seeder/src/Factory.ts
@@ -1,8 +1,8 @@
-import type { RequiredEntityData, EntityData, EntityManager, Constructor } from '@mikro-orm/core';
+import type { RequiredEntityData, EntityData, EntityManager, EntityName } from '@mikro-orm/core';
 
 /** Base class for entity factories used in seeding. Provides methods to create and persist test entities. */
 export abstract class Factory<TEntity extends object, TInput = EntityData<TEntity>> {
-  abstract readonly model: Constructor<TEntity>;
+  abstract readonly model: EntityName<TEntity>;
   private eachFunction?: (entity: TEntity, index: number) => void;
 
   constructor(protected readonly em: EntityManager) {}

--- a/tests/features/seeder/factory-define-entity.test.ts
+++ b/tests/features/seeder/factory-define-entity.test.ts
@@ -1,0 +1,42 @@
+import { defineEntity, type EntityData, type InferEntity } from '@mikro-orm/core';
+import { MikroORM } from '@mikro-orm/sqlite';
+import { Factory } from '@mikro-orm/seeder';
+
+const BookSchema = defineEntity({
+  name: 'Book',
+  tableName: 'books',
+  properties: p => ({
+    id: p.integer().autoincrement().primary(),
+    title: p.string(),
+  }),
+});
+
+type Book = InferEntity<typeof BookSchema>;
+
+class BookFactory extends Factory<Book> {
+  model = BookSchema;
+
+  definition(): EntityData<Book> {
+    return { title: 'book' };
+  }
+}
+
+describe('Factory with defineEntity (GH discussion #7768)', () => {
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      entities: [BookSchema],
+      dbName: ':memory:',
+    });
+    await orm.schema.create();
+  });
+
+  afterAll(() => orm.close(true));
+
+  test('factory accepts a defineEntity schema as model', async () => {
+    const book = await new BookFactory(orm.em).createOne();
+    expect(book.id).toBeDefined();
+    expect(book.title).toBe('book');
+  });
+});


### PR DESCRIPTION
## Summary

`Factory.model` was typed as `Constructor<TEntity>` (non-abstract `new (...args: any[]) => T`), which rejects:

- the auto-generated class exposed on a `defineEntity()` schema (`Book.class` has an abstract constructor signature via `EntityCtor<T>`)
- passing the `EntitySchema` instance directly

Both work at runtime — `em.create()` already accepts `EntityName<T>`. Widening the field type to `EntityName<T>` makes the type system agree.

Reported in #7768.