### PR TITLE
fix(schema): detect removed default on boolean columns

### DIFF
--- a/packages/sql/src/schema/SchemaComparator.ts
+++ b/packages/sql/src/schema/SchemaComparator.ts
@@ -1241,6 +1241,10 @@ export class SchemaComparator {
       return to.default == null || to.default.toLowerCase() === 'null';
     }
 
+    if (to.default == null || to.default.toLowerCase() === 'null') {
+      return false;
+    }
+
     if (to.mappedType instanceof BooleanType) {
       const defaultValueFrom = !['0', 'false', 'f', 'n', 'no', 'off'].includes('' + from.default);
       const defaultValueTo = !['0', 'false', 'f', 'n', 'no', 'off'].includes('' + to.default!);

--- a/tests/issues/GH7774.test.ts
+++ b/tests/issues/GH7774.test.ts
@@ -1,0 +1,48 @@
+import { defineEntity, MikroORM, p } from '@mikro-orm/postgresql';
+
+const UserV1Schema = defineEntity({
+  name: 'User',
+  tableName: 'gh_7774_user',
+  properties: {
+    id: p.integer().primary().autoincrement(),
+    flag: p.boolean().default(true),
+  },
+});
+
+class UserV1 extends UserV1Schema.class {}
+UserV1Schema.setClass(UserV1);
+
+const UserV2Schema = defineEntity({
+  name: 'User',
+  tableName: 'gh_7774_user',
+  properties: {
+    id: p.integer().primary().autoincrement(),
+    flag: p.boolean(),
+  },
+});
+
+class UserV2 extends UserV2Schema.class {}
+UserV2Schema.setClass(UserV2);
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    dbName: 'mikro_orm_test_gh_7774',
+    entities: [UserV1],
+  });
+  await orm.schema.refresh();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+test('removing boolean default is detected by schema diff (GH #7774)', async () => {
+  orm.discoverEntity(UserV2, UserV1);
+
+  const diff = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+  expect(diff).toContain('alter table "gh_7774_user" alter column "flag" drop default');
+
+  await expect(orm.schema.execute(diff)).resolves.toBeUndefined();
+});


### PR DESCRIPTION
`SchemaComparator.hasSameDefaultValue` failed to detect a dropped `default: true` on a boolean column. With `from.default = 'true'` (introspected) and `to.default = undefined` (metadata), the boolean-normalization branch coerced `undefined` to the string `'undefined'`, which is not in the falsy list, so both sides evaluated to `true` and the diff omitted the `alter column ... drop default` statement.

Bail out symmetrically when `to.default` is null/'null' before reaching the type-specific branches — the existing early return only covered the from side.

Closes #7774