### PR TITLE
fix(core): reload suppressed entities from partially-suppressed upsertMany

### DIFF
--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -1023,7 +1023,7 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
       }
 
       const data2 = await this.driver.findOne(meta.className, where, {
-        fields: returning as any[],
+        fields: returning.concat(...(options.onConflictMergeFields ?? []) as string[]) as any[],
         ctx: em.transactionContext,
         convertCustomTypes: true,
         connectionType: 'write',
@@ -1197,10 +1197,11 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
       entitiesByData.set(row, entity);
     });
 
-    // skip if we got the PKs via returning statement (`rows`)
+    // skip the reload only when RETURNING brought back a row for every input
+    // (onConflictWhere can suppress writes, leaving some rows out)
     const uniqueFields = options.onConflictFields ?? (Utils.isPlainObject(allWhere![0]) ? Object.keys(allWhere![0]).flatMap(key => Utils.splitPrimaryKeys(key)) : meta!.primaryKeys) as (keyof Entity)[];
     const returning = getOnConflictReturningFields(meta, data[0], uniqueFields, options) as string[];
-    const reloadFields = returning.length > 0 && !(this.getPlatform().usesReturningStatement() && res.rows?.length);
+    const reloadFields = returning.length > 0 && !(this.getPlatform().usesReturningStatement() && res.rows?.length === data.length);
 
     if (options.onConflictAction === 'ignore' || (!res.rows?.length && loadPK.size > 0) || reloadFields) {
       const unique = meta.hydrateProps.filter(p => !p.lazy).map(p => p.name);
@@ -1222,7 +1223,7 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
       }
 
       const data2 = await this.driver.find(meta.className, where, {
-        fields: returning.concat(...add).concat(...(Array.isArray(uniqueFields) ? uniqueFields : []) as string[]) as any,
+        fields: returning.concat(...add).concat(...(Array.isArray(uniqueFields) ? uniqueFields : []) as string[]).concat(...(options.onConflictMergeFields ?? []) as string[]) as any,
         ctx: em.transactionContext,
         convertCustomTypes: true,
         connectionType: 'write',

--- a/tests/features/upsert/__snapshots__/upsert.mssql.test.ts.snap
+++ b/tests/features/upsert/__snapshots__/upsert.mssql.test.ts.snap
@@ -59,7 +59,7 @@ exports[`em.upsert(Type, data, options) with advanced options 1`] = `
     "[query] merge into [author] using (values (42, N'a2', 1)) as tsource([current_age], [email], [foo]) on [author].[email] = tsource.[email] when not matched then insert ([current_age], [email], [foo]) values (tsource.[current_age], tsource.[email], tsource.[foo]) when matched then update set [current_age]=tsource.[current_age] output inserted.[_id], inserted.[foo], inserted.[bar];",
   ],
   [
-    "[query] select top (1) [a0].[_id], [a0].[foo], [a0].[bar] from [author] as [a0] where [a0].[email] = 'a2'",
+    "[query] select top (1) [a0].[_id], [a0].[foo], [a0].[bar], [a0].[current_age] from [author] as [a0] where [a0].[email] = 'a2'",
   ],
   [
     "[query] merge into [author] using (values (43, N'a3', 1)) as tsource([current_age], [email], [foo]) on [author].[email] = tsource.[email] when not matched then insert ([current_age], [email], [foo]) values (tsource.[current_age], tsource.[email], tsource.[foo]) when matched then update set [current_age]=tsource.[current_age], [foo]=tsource.[foo] output inserted.[_id], inserted.[current_age], inserted.[foo], inserted.[bar];",
@@ -82,7 +82,7 @@ exports[`em.upsert(Type, entity, options) with advanced options 1`] = `
     "[query] merge into [author] using (values (123, 42, N'a2', 1)) as tsource([bar], [current_age], [email], [foo]) on [author].[email] = tsource.[email] when not matched then insert ([bar], [current_age], [email], [foo]) values (tsource.[bar], tsource.[current_age], tsource.[email], tsource.[foo]) when matched then update set [current_age]=tsource.[current_age] output inserted.[_id], inserted.[foo], inserted.[bar];",
   ],
   [
-    "[query] select top (1) [a0].[_id], [a0].[foo], [a0].[bar] from [author] as [a0] where [a0].[email] = N'a2'",
+    "[query] select top (1) [a0].[_id], [a0].[foo], [a0].[bar], [a0].[current_age] from [author] as [a0] where [a0].[email] = N'a2'",
   ],
   [
     "[query] merge into [author] using (values (123, 43, N'a3', 1)) as tsource([bar], [current_age], [email], [foo]) on [author].[email] = tsource.[email] when not matched then insert ([bar], [current_age], [email], [foo]) values (tsource.[bar], tsource.[current_age], tsource.[email], tsource.[foo]) when matched then update set [current_age]=tsource.[current_age], [foo]=tsource.[foo], [bar]=tsource.[bar] output inserted.[_id], inserted.[current_age], inserted.[foo], inserted.[bar];",

--- a/tests/features/upsert/__snapshots__/upsert.test.ts.snap
+++ b/tests/features/upsert/__snapshots__/upsert.test.ts.snap
@@ -311,7 +311,7 @@ exports[`em.upsert [mariadb] em.upsert(Type, data, options) with advanced option
     "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`, \`foo\`) values (2, 42, 'a2', true) on duplicate key update \`current_age\` = values(\`current_age\`)",
   ],
   [
-    "[query] select \`a0\`.\`_id\`, \`a0\`.\`foo\`, \`a0\`.\`bar\` from \`author\` as \`a0\` where \`a0\`.\`email\` = 'a2' limit 1",
+    "[query] select \`a0\`.\`_id\`, \`a0\`.\`foo\`, \`a0\`.\`bar\`, \`a0\`.\`current_age\` from \`author\` as \`a0\` where \`a0\`.\`email\` = 'a2' limit 1",
   ],
   [
     "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`, \`foo\`) values (5, 43, 'a3', true) on duplicate key update \`current_age\` = values(\`current_age\`), \`foo\` = values(\`foo\`)",
@@ -334,7 +334,7 @@ exports[`em.upsert [mariadb] em.upsert(Type, entity, options) with advanced opti
     "[query] insert into \`author\` (\`_id\`, \`bar\`, \`current_age\`, \`email\`, \`foo\`) values (2, 123, 42, 'a2', true) on duplicate key update \`current_age\` = values(\`current_age\`)",
   ],
   [
-    "[query] select \`a0\`.\`_id\`, \`a0\`.\`foo\`, \`a0\`.\`bar\` from \`author\` as \`a0\` where \`a0\`.\`email\` = 'a2' limit 1",
+    "[query] select \`a0\`.\`_id\`, \`a0\`.\`foo\`, \`a0\`.\`bar\`, \`a0\`.\`current_age\` from \`author\` as \`a0\` where \`a0\`.\`email\` = 'a2' limit 1",
   ],
   [
     "[query] insert into \`author\` (\`_id\`, \`bar\`, \`current_age\`, \`email\`, \`foo\`) values (5, 123, 43, 'a3', true) on duplicate key update \`current_age\` = values(\`current_age\`), \`foo\` = values(\`foo\`), \`bar\` = values(\`bar\`)",
@@ -420,7 +420,7 @@ exports[`em.upsert [mariadb] em.upsertMany(Type, [data], options) with advanced 
     "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`, \`foo\`) values (1, 41, 'a1', true), (2, 42, 'a2', true), (5, 43, 'a3', true) on duplicate key update \`current_age\` = values(\`current_age\`)",
   ],
   [
-    "[query] select \`a0\`.\`_id\`, \`a0\`.\`foo\`, \`a0\`.\`bar\`, \`a0\`.\`email\` from \`author\` as \`a0\` where (\`a0\`.\`email\` = 'a1' or \`a0\`.\`email\` = 'a2' or \`a0\`.\`email\` = 'a3')",
+    "[query] select \`a0\`.\`_id\`, \`a0\`.\`foo\`, \`a0\`.\`bar\`, \`a0\`.\`email\`, \`a0\`.\`current_age\` from \`author\` as \`a0\` where (\`a0\`.\`email\` = 'a1' or \`a0\`.\`email\` = 'a2' or \`a0\`.\`email\` = 'a3')",
   ],
 ]
 `;
@@ -475,7 +475,7 @@ exports[`em.upsert [mariadb] em.upsertMany(Type, [entity], options) with advance
     "[query] insert into \`author\` (\`_id\`, \`bar\`, \`current_age\`, \`email\`, \`foo\`) values (1, 123, 41, 'a1', true), (2, 123, 42, 'a2', true), (5, 123, 43, 'a3', true) on duplicate key update \`current_age\` = values(\`current_age\`)",
   ],
   [
-    "[query] select \`a0\`.\`_id\`, \`a0\`.\`foo\`, \`a0\`.\`bar\`, \`a0\`.\`email\` from \`author\` as \`a0\` where (\`a0\`.\`email\` = 'a1' or \`a0\`.\`email\` = 'a2' or \`a0\`.\`email\` = 'a3')",
+    "[query] select \`a0\`.\`_id\`, \`a0\`.\`foo\`, \`a0\`.\`bar\`, \`a0\`.\`email\`, \`a0\`.\`current_age\` from \`author\` as \`a0\` where (\`a0\`.\`email\` = 'a1' or \`a0\`.\`email\` = 'a2' or \`a0\`.\`email\` = 'a3')",
   ],
 ]
 `;
@@ -584,7 +584,7 @@ exports[`em.upsert [mongo] em.upsert(Type, data, options) with advanced options 
     "[query] db.getCollection('author').updateMany({ email: 'a2' }, { '$set': { current_age: 42 }, '$setOnInsert': { _id: 2, email: 'a2', foo: true } }, { upsert: true });",
   ],
   [
-    "[query] db.getCollection('author').find({ email: 'a2' }, { projection: { _id: 1, foo: 1, bar: 1 } }).limit(1).toArray();",
+    "[query] db.getCollection('author').find({ email: 'a2' }, { projection: { _id: 1, foo: 1, bar: 1, current_age: 1 } }).limit(1).toArray();",
   ],
   [
     "[query] db.getCollection('author').updateMany({ email: 'a3' }, { '$set': { email: 'a3', current_age: 43, foo: true }, '$setOnInsert': { _id: 5 } }, { upsert: true });",
@@ -607,7 +607,7 @@ exports[`em.upsert [mongo] em.upsert(Type, entity, options) with advanced option
     "[query] db.getCollection('author').updateMany({ email: 'a2' }, { '$set': { current_age: 42 }, '$setOnInsert': { _id: 2, email: 'a2', foo: true, bar: 123 } }, { upsert: true });",
   ],
   [
-    "[query] db.getCollection('author').find({ email: 'a2' }, { projection: { _id: 1, foo: 1, bar: 1 } }).limit(1).toArray();",
+    "[query] db.getCollection('author').find({ email: 'a2' }, { projection: { _id: 1, foo: 1, bar: 1, current_age: 1 } }).limit(1).toArray();",
   ],
   [
     "[query] db.getCollection('author').updateMany({ email: 'a3' }, { '$set': { email: 'a3', current_age: 43, foo: true, bar: 123 }, '$setOnInsert': { _id: 5 } }, { upsert: true });",
@@ -693,7 +693,7 @@ exports[`em.upsert [mongo] em.upsertMany(Type, [data], options) with advanced op
     "[query] bulk = db.getCollection('author').initializeUnorderedBulkOp({ upsert: true });bulk.find({ email: 'a1' }).upsert().update({ '$set': { current_age: 41 }, '$setOnInsert': { _id: 1, email: 'a1', foo: true } });bulk.find({ email: 'a2' }).upsert().update({ '$set': { current_age: 42 }, '$setOnInsert': { _id: 2, email: 'a2', foo: true } });bulk.find({ email: 'a3' }).upsert().update({ '$set': { current_age: 43 }, '$setOnInsert': { _id: 5, email: 'a3', foo: true } });bulk.execute()",
   ],
   [
-    "[query] db.getCollection('author').find({ '$or': [ { email: 'a1' }, { email: 'a2' }, { email: 'a3' } ] }, { projection: { _id: 1, foo: 1, bar: 1, email: 1 } }).toArray();",
+    "[query] db.getCollection('author').find({ '$or': [ { email: 'a1' }, { email: 'a2' }, { email: 'a3' } ] }, { projection: { _id: 1, foo: 1, bar: 1, email: 1, current_age: 1 } }).toArray();",
   ],
 ]
 `;
@@ -748,7 +748,7 @@ exports[`em.upsert [mongo] em.upsertMany(Type, [entity], options) with advanced 
     "[query] bulk = db.getCollection('author').initializeUnorderedBulkOp({ upsert: true });bulk.find({ email: 'a1' }).upsert().update({ '$set': { current_age: 41 }, '$setOnInsert': { _id: 1, email: 'a1', foo: true, bar: 123 } });bulk.find({ email: 'a2' }).upsert().update({ '$set': { current_age: 42 }, '$setOnInsert': { _id: 2, email: 'a2', foo: true, bar: 123 } });bulk.find({ email: 'a3' }).upsert().update({ '$set': { current_age: 43 }, '$setOnInsert': { _id: 5, email: 'a3', foo: true, bar: 123 } });bulk.execute()",
   ],
   [
-    "[query] db.getCollection('author').find({ '$or': [ { email: 'a1' }, { email: 'a2' }, { email: 'a3' } ] }, { projection: { _id: 1, foo: 1, bar: 1, email: 1 } }).toArray();",
+    "[query] db.getCollection('author').find({ '$or': [ { email: 'a1' }, { email: 'a2' }, { email: 'a3' } ] }, { projection: { _id: 1, foo: 1, bar: 1, email: 1, current_age: 1 } }).toArray();",
   ],
 ]
 `;
@@ -857,7 +857,7 @@ exports[`em.upsert [mysql] em.upsert(Type, data, options) with advanced options 
     "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`, \`foo\`) values (2, 42, 'a2', true) on duplicate key update \`current_age\` = values(\`current_age\`)",
   ],
   [
-    "[query] select \`a0\`.\`_id\`, \`a0\`.\`foo\`, \`a0\`.\`bar\` from \`author\` as \`a0\` where \`a0\`.\`email\` = 'a2' limit 1",
+    "[query] select \`a0\`.\`_id\`, \`a0\`.\`foo\`, \`a0\`.\`bar\`, \`a0\`.\`current_age\` from \`author\` as \`a0\` where \`a0\`.\`email\` = 'a2' limit 1",
   ],
   [
     "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`, \`foo\`) values (5, 43, 'a3', true) on duplicate key update \`current_age\` = values(\`current_age\`), \`foo\` = values(\`foo\`)",
@@ -880,7 +880,7 @@ exports[`em.upsert [mysql] em.upsert(Type, entity, options) with advanced option
     "[query] insert into \`author\` (\`_id\`, \`bar\`, \`current_age\`, \`email\`, \`foo\`) values (2, 123, 42, 'a2', true) on duplicate key update \`current_age\` = values(\`current_age\`)",
   ],
   [
-    "[query] select \`a0\`.\`_id\`, \`a0\`.\`foo\`, \`a0\`.\`bar\` from \`author\` as \`a0\` where \`a0\`.\`email\` = 'a2' limit 1",
+    "[query] select \`a0\`.\`_id\`, \`a0\`.\`foo\`, \`a0\`.\`bar\`, \`a0\`.\`current_age\` from \`author\` as \`a0\` where \`a0\`.\`email\` = 'a2' limit 1",
   ],
   [
     "[query] insert into \`author\` (\`_id\`, \`bar\`, \`current_age\`, \`email\`, \`foo\`) values (5, 123, 43, 'a3', true) on duplicate key update \`current_age\` = values(\`current_age\`), \`foo\` = values(\`foo\`), \`bar\` = values(\`bar\`)",
@@ -966,7 +966,7 @@ exports[`em.upsert [mysql] em.upsertMany(Type, [data], options) with advanced op
     "[query] insert into \`author\` (\`_id\`, \`current_age\`, \`email\`, \`foo\`) values (1, 41, 'a1', true), (2, 42, 'a2', true), (5, 43, 'a3', true) on duplicate key update \`current_age\` = values(\`current_age\`)",
   ],
   [
-    "[query] select \`a0\`.\`_id\`, \`a0\`.\`foo\`, \`a0\`.\`bar\`, \`a0\`.\`email\` from \`author\` as \`a0\` where (\`a0\`.\`email\` = 'a1' or \`a0\`.\`email\` = 'a2' or \`a0\`.\`email\` = 'a3')",
+    "[query] select \`a0\`.\`_id\`, \`a0\`.\`foo\`, \`a0\`.\`bar\`, \`a0\`.\`email\`, \`a0\`.\`current_age\` from \`author\` as \`a0\` where (\`a0\`.\`email\` = 'a1' or \`a0\`.\`email\` = 'a2' or \`a0\`.\`email\` = 'a3')",
   ],
 ]
 `;
@@ -1021,7 +1021,7 @@ exports[`em.upsert [mysql] em.upsertMany(Type, [entity], options) with advanced 
     "[query] insert into \`author\` (\`_id\`, \`bar\`, \`current_age\`, \`email\`, \`foo\`) values (1, 123, 41, 'a1', true), (2, 123, 42, 'a2', true), (5, 123, 43, 'a3', true) on duplicate key update \`current_age\` = values(\`current_age\`)",
   ],
   [
-    "[query] select \`a0\`.\`_id\`, \`a0\`.\`foo\`, \`a0\`.\`bar\`, \`a0\`.\`email\` from \`author\` as \`a0\` where (\`a0\`.\`email\` = 'a1' or \`a0\`.\`email\` = 'a2' or \`a0\`.\`email\` = 'a3')",
+    "[query] select \`a0\`.\`_id\`, \`a0\`.\`foo\`, \`a0\`.\`bar\`, \`a0\`.\`email\`, \`a0\`.\`current_age\` from \`author\` as \`a0\` where (\`a0\`.\`email\` = 'a1' or \`a0\`.\`email\` = 'a2' or \`a0\`.\`email\` = 'a3')",
   ],
 ]
 `;

--- a/tests/features/upsert/upsert-where-condition.postgres.test.ts
+++ b/tests/features/upsert/upsert-where-condition.postgres.test.ts
@@ -136,4 +136,56 @@ describe('upsert with where condition', () => {
     expect(doc5.version).toBe(1);
     expect(doc5.content).toBe('new 5');
   });
+
+  test('upsert should reload a suppressed entity with onConflictMergeFields (GH #7775)', async () => {
+    // DB row has version 10 so the onConflictWhere predicate (version < 5) is false → suppressed
+    await orm.em.insert(Document, { name: 'doc-single', version: 10, content: 'original' });
+
+    const result = await orm.em.fork().upsert(Document, {
+      name: 'doc-single',
+      version: 3,
+      content: 'stale-loser',
+    }, {
+      onConflictFields: ['name'],
+      onConflictWhere: { version: { $lt: 5 } },
+      onConflictMergeFields: ['version', 'content'],
+    });
+
+    expect(result.version).toBe(10);
+    expect(result.content).toBe('original');
+
+    const doc = await orm.em.fork().findOneOrFail(Document, { name: 'doc-single' });
+    expect(doc.version).toBe(10);
+    expect(doc.content).toBe('original');
+  });
+
+  test('upsertMany should reload suppressed entities in a partially-suppressed batch (GH #7775)', async () => {
+    // doc-a's DB version (10) fails the onConflictWhere predicate (version < 5) → suppressed
+    // doc-b's DB version (2) passes → applied
+    await orm.em.insertMany(Document, [
+      { name: 'doc-a', version: 10, content: 'original a' },
+      { name: 'doc-b', version: 2, content: 'original b' },
+    ]);
+
+    const results = await orm.em.fork().upsertMany(Document, [
+      { name: 'doc-a', version: 3, content: 'stale-loser' },
+      { name: 'doc-b', version: 7, content: 'fresh-winner' },
+    ], {
+      onConflictFields: ['name'],
+      onConflictWhere: { version: { $lt: 5 } },
+      onConflictMergeFields: ['version', 'content'],
+    });
+
+    expect(results[0].version).toBe(10);
+    expect(results[0].content).toBe('original a');
+    expect(results[1].version).toBe(7);
+    expect(results[1].content).toBe('fresh-winner');
+
+    const docA = await orm.em.fork().findOneOrFail(Document, { name: 'doc-a' });
+    expect(docA.version).toBe(10);
+    expect(docA.content).toBe('original a');
+    const docB = await orm.em.fork().findOneOrFail(Document, { name: 'doc-b' });
+    expect(docB.version).toBe(7);
+    expect(docB.content).toBe('fresh-winner');
+  });
 });


### PR DESCRIPTION
6.x backport of #7779.

When `em.upsertMany` (or `em.upsert`) was called with `onConflictWhere` and the predicate suppressed some — or in the singular case, the only — row, the entities returned for suppressed rows carried their (rejected) input values instead of the actual DB state. The DB rows themselves were correct — only the returned in-memory entities were wrong.

Two issues combined:

1. The `reloadFields` guard in `upsertMany` treated any non-zero `res.rows.length` as "RETURNING covered everything". For a partial-suppression batch on Postgres, RETURNING only emits a row per applied insert/update, so `res.rows.length > 0` was truthy even though some rows were missing — the fallback reload never ran. Tightened to `res.rows.length === data.length`.
2. Both `upsert` and `upsertMany` reload paths built their `fields` projection from `returning`, which excludes `onConflictMergeFields` (those columns are normally trusted from the input). For suppressed rows the input is exactly what we cannot trust, so the merge-field columns must come from DB. They're now added to the projection.

Closes #7775