### PR TITLE
fix(core): avoid circular type in defineEntity index/unique `where` with self-referencing relations

### DIFF
--- a/packages/core/src/entity/defineEntity.ts
+++ b/packages/core/src/entity/defineEntity.ts
@@ -1267,6 +1267,14 @@ function getBuilderOptions(builder: any) {
 /** Own keys + base entity keys (when TBase is not `never`). Guards against `keyof never = string | number | symbol`. */
 type AllKeys<TProperties, TBase> = keyof TProperties | (IsNever<TBase> extends true ? never : keyof TBase);
 
+// Loose `where` filter for index/unique definitions. Using the fully inferred entity
+// (`InferEntityFromProperties`) here forces eager evaluation while contextually typing the
+// `defineEntity` argument, which is circular for self-referencing relations (e.g. `() => m:1(Self)`).
+// A shallow key-only shape breaks that cycle, at the cost of per-property value typing and
+// unknown-key rejection in the filter (the `unknown` values make `FilterQuery` accept any key).
+// GH #7440 dodged the same trap for `filters.cond` by falling back to a loose `Dictionary` there.
+type PartialWhere<TProperties, TBase> = string | FilterQuery<{ [K in AllKeys<TProperties, TBase> & string]?: unknown }>;
+
 /** Metadata descriptor for `defineEntity()`, combining entity options with property definitions. */
 export interface EntityMetadataWithProperties<
   TName extends string,
@@ -1352,7 +1360,7 @@ export interface EntityMetadataWithProperties<
     type?: string;
     options?: Dictionary;
     expression?: string | IndexCallback<InferEntityFromProperties<TProperties, TPK, TBase>>;
-    where?: string | FilterQuery<InferEntityFromProperties<TProperties, TPK, TBase>>;
+    where?: PartialWhere<TProperties, TBase>;
     columns?: IndexColumnOptions[];
     include?: NoInfer<AllKeys<TProperties, TBase>> | NoInfer<AllKeys<TProperties, TBase>>[];
     fillFactor?: number;
@@ -1365,7 +1373,7 @@ export interface EntityMetadataWithProperties<
     name?: string;
     options?: Dictionary;
     expression?: string | IndexCallback<InferEntityFromProperties<TProperties, TPK, TBase>>;
-    where?: string | FilterQuery<InferEntityFromProperties<TProperties, TPK, TBase>>;
+    where?: PartialWhere<TProperties, TBase>;
     deferMode?: DeferMode | `${DeferMode}`;
     columns?: IndexColumnOptions[];
     include?: NoInfer<AllKeys<TProperties, TBase>> | NoInfer<AllKeys<TProperties, TBase>>[];

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -1420,6 +1420,32 @@ describe('check typings', () => {
     });
   });
 
+  test('defineEntity self-referencing relation with index/unique `where` does not circularly reference itself', () => {
+    // A self-referencing m:1 combined with a typed `where` on an index/unique used to force eager
+    // evaluation of the inferred entity while contextually typing the argument, which is circular.
+    const ClientSchema = defineEntity({
+      name: 'Client',
+      tableName: 'Clients',
+      properties: {
+        id: p.integer().primary(),
+        email: p.text(),
+        username: p.string().length(120),
+        chainAdmin: () => p.manyToOne(Client).nullable(),
+      },
+      uniques: [{ properties: ['username'] }],
+      // the cycle-breaking `where` type intentionally relaxes value typing and unknown-key
+      // rejection, so a typo'd key like `{ foo: null }` would type-check here.
+      indexes: [{ properties: ['chainAdmin'], where: { chainAdmin: { $ne: null } } }],
+    });
+
+    class Client extends ClientSchema.class {}
+    ClientSchema.setClass(Client);
+
+    const client = new Client();
+    assert<IsExact<typeof client.id, number>>(true);
+    assert<IsExact<typeof client.chainAdmin, Client | null | undefined>>(true);
+  });
+
   test('GH #7470 - entity with relation named "owner" should not break populate types', async () => {
     const UserSchema = defineEntity({
       name: 'User7470',


### PR DESCRIPTION
A self-referencing relation (e.g. `chainAdmin: () => p.manyToOne(Self)`) combined with a typed `where` on an index or unique broke type-checking with `TS2615` (`[PrimaryKeyProp] circularly references itself`):

```ts
const ClientSchema = defineEntity({
  name: 'Client',
  properties: {
    id: p.integer().primary(),
    chainAdmin: () => p.manyToOne(Client).nullable(),
  },
  indexes: [{ properties: ['chainAdmin'], where: { chainAdmin: { $ne: null } } }],
});
export class Client extends ClientSchema.class {}
```

`index.where`/`uniques.where` were typed as `FilterQuery<InferEntityFromProperties<...>>`. Sitting in argument position, this forces eager evaluation of the fully inferred entity while TS is still contextually typing the `defineEntity` argument — circular once a relation points back at the entity's own class. The same type in return position is lazy and works, which is why a self-ref relation without such an index compiles fine.

Loosen both `where` filters to a shallow key-only shape (`PartialWhere`), which breaks the cycle. The tradeoff is losing per-property value typing inside the index filter — the two goals are inherently in tension. This mirrors the existing workaround for `filters.cond` (GH #7440).

🤖 Generated with [Claude Code](https://claude.com/claude-code)