### PR TITLE
fix(sql): expose raw aliases in QueryBuilder execute() result type

### DIFF
--- a/packages/sql/src/query/QueryBuilder.ts
+++ b/packages/sql/src/query/QueryBuilder.ts
@@ -2696,8 +2696,9 @@ export class QueryBuilder<
 
   /**
    * Returns native query builder instance with sub-query aliased with given alias.
+   * The alias literal is preserved in the type so `addSelect()` exposes it on `execute()` results.
    */
-  as(alias: string): NativeQueryBuilder;
+  as<Alias extends string>(alias: Alias): NativeQueryBuilder & RawQueryFragment<Alias>;
 
   /**
    * Returns native query builder instance with sub-query aliased with given alias.
@@ -4461,7 +4462,18 @@ type JoinDTO<T, K extends keyof T, F extends string> =
             >
           | Extract<T[K], null | undefined>;
 
-type ExecuteDTO<T, H extends string, F extends string> = [H] extends [never]
+/**
+ * Raw aliases (`sql`...`.as('x')`, `'col as x'`, or aliased sub-queries) are not entity keys,
+ * so they never appear in the selected-fields DTO. They are tracked in the `RawAliases` generic
+ * (preserved across joins), so expose them on the result as `unknown` — their value type is not
+ * known at the type level. Only intersected when raw aliases are present, to keep the plain DTO
+ * untouched when there are none.
+ */
+type WithRawAliases<DTO, RawAliases extends string> = [RawAliases] extends [never]
+  ? DTO
+  : DTO & { [K in RawAliases]: unknown };
+
+type ExecuteDTOInner<T, H extends string, F extends string> = [H] extends [never]
   ? [F] extends ['*']
     ? EntityDTOFlat<T>
     : DirectDTO<T, F & keyof T>
@@ -4475,6 +4487,11 @@ type ExecuteDTO<T, H extends string, F extends string> = [H] extends [never]
       ? EntityDTOFlat<Loaded<T, H, F>>
       : DirectDTO<T, (RootFields<F, H> | PrimaryProperty<T>) & keyof T> & { [K in H & keyof T]: JoinDTO<T, K, F> };
 
+type ExecuteDTO<T, H extends string, F extends string, RawAliases extends string = never> = WithRawAliases<
+  ExecuteDTOInner<T, H, F>,
+  RawAliases
+>;
+
 /** Shorthand for `QueryBuilder` with all generic parameters set to `any`. */
 export type AnyQueryBuilder<T extends object = AnyEntity> = QueryBuilder<T, any, any, any, any, any, any>;
 
@@ -4487,12 +4504,15 @@ export interface SelectQueryBuilder<
   Fields extends string = '*',
   CTEs extends Record<string, object> = {},
 > extends QueryBuilder<Entity, RootAlias, Hint, Context, RawAliases, Fields, CTEs> {
-  execute<Result = ExecuteDTO<Entity, Hint, Fields>[]>(
+  execute<Result = ExecuteDTO<Entity, Hint, Fields, RawAliases>[]>(
     method?: 'all' | 'get' | 'run',
     mapResults?: boolean,
   ): Promise<Result>;
-  execute<Result = ExecuteDTO<Entity, Hint, Fields>[]>(method: 'all', mapResults?: boolean): Promise<Result>;
-  execute<Result = ExecuteDTO<Entity, Hint, Fields>>(method: 'get', mapResults?: boolean): Promise<Result>;
+  execute<Result = ExecuteDTO<Entity, Hint, Fields, RawAliases>[]>(
+    method: 'all',
+    mapResults?: boolean,
+  ): Promise<Result>;
+  execute<Result = ExecuteDTO<Entity, Hint, Fields, RawAliases>>(method: 'get', mapResults?: boolean): Promise<Result>;
   execute<Result = QueryResult<Entity>>(method: 'run', mapResults?: boolean): Promise<Result>;
 }
 

--- a/tests/features/query-builder/query-builder-fields-type.test.ts
+++ b/tests/features/query-builder/query-builder-fields-type.test.ts
@@ -1,6 +1,7 @@
 import {
   MikroORM,
   Loaded,
+  sql,
   type EntityDTO,
   type EntityDTOFlat,
   type SerializeDTO,
@@ -388,6 +389,41 @@ describe('QueryBuilder Fields type tracking', () => {
 
       const result = await qb.execute<Dictionary[]>();
       expectTypeOf(result).toEqualTypeOf<Dictionary[]>();
+    });
+
+    test('execute() should surface a raw fragment alias as a result property', async () => {
+      const qb = orm.em.createQueryBuilder(Author2, 'a').select(['a.id']).addSelect(sql.ref('a.name').as('authorName'));
+
+      const result = await qb.execute('all');
+      type Element = (typeof result)[number];
+      expectTypeOf<Element['id']>().toEqualTypeOf<number>();
+      expectTypeOf<Element['authorName']>().toEqualTypeOf<unknown>();
+    });
+
+    test('execute() should surface an aliased sub-query as a result property', async () => {
+      const bookCount = orm.em
+        .createQueryBuilder(Book2)
+        .count()
+        .where({ author: sql.ref('a.id') })
+        .as('bookCount');
+      const qb = orm.em.createQueryBuilder(Author2, 'a').select(['a.id']).addSelect([bookCount]);
+
+      const result = await qb.execute('all');
+      type Element = (typeof result)[number];
+      expectTypeOf<Element['id']>().toEqualTypeOf<number>();
+      expectTypeOf<Element['bookCount']>().toEqualTypeOf<unknown>();
+    });
+
+    test('execute() should surface aliases alongside a join', async () => {
+      const qb = orm.em
+        .createQueryBuilder(Author2, 'a')
+        .select(['a.id'])
+        .addSelect(sql.ref('b.title').as('bookTitle'))
+        .join('a.books', 'b');
+
+      const result = await qb.execute('all');
+      type Element = (typeof result)[number];
+      expectTypeOf<Element['bookTitle']>().toEqualTypeOf<unknown>();
     });
   });
 });


### PR DESCRIPTION
## Problem

`QueryBuilder.execute()` typed its result through `DirectDTO<T, F & keyof T>`. The `F & keyof T` intersection silently discards any selected column that is not an entity key — so raw aliases and aliased sub-queries never appeared on the result type:

```ts
const rows = await em.createQueryBuilder(Author, 'a')
  .select(['a.id'])
  .addSelect(sql.ref('u.name').as('authorName'))
  .execute('all');

rows[0].id;          // ✅
rows[0].authorName;  // ❌ TS2339: Property 'authorName' does not exist
```

This reproduces in plain `tsc` (both 5.9 and 6.0), regardless of the editor.

## Fix

- `ExecuteDTO` now threads the `RawAliases` generic (which accumulates across `select`/`addSelect` and is preserved across joins) and surfaces those aliases on the result as `unknown`, intersected only when aliases are present so plain selected-field DTOs are unchanged.
- `qb.as(alias)` now returns `NativeQueryBuilder & RawQueryFragment<Alias>` so aliased sub-queries carry their alias literal into `RawAliases` (still assignable everywhere `NativeQueryBuilder` was).

Raw alias values are typed `unknown` (the SQL value type is not knowable at the type level); inferring them where possible (e.g. `count()` → `number`) can follow up.

## Tests

Added `execute()` result-type assertions in `query-builder-fields-type.test.ts` for a raw fragment alias, an aliased sub-query, and an alias alongside a join. Full `tests/tsconfig.json` type-check passes with no regressions.