### PR TITLE
feat(postgresql): support `EXCLUDE` constraints via `@Check`

### DIFF
--- a/docs/docs/defining-entities.md
+++ b/docs/docs/defining-entities.md
@@ -1511,6 +1511,32 @@ export class Book {
   </TabItem>
 </Tabs>
 
+### Exclusion constraints (PostgreSQL)
+
+PostgreSQL's [`EXCLUDE`](https://www.postgresql.org/docs/current/ddl-constraints.html#DDL-CONSTRAINTS-EXCLUSION) constraints share the same lifecycle as `CHECK` (table-level constraint, dropped via `ALTER TABLE … DROP CONSTRAINT`), so `@Check()` accepts a full constraint body as the `expression` and emits it verbatim when it starts with `EXCLUDE`:
+
+```ts
+@Entity()
+@Check({
+  name: 'room_booking_no_overlap',
+  expression: 'exclude using gist (room_id with =, during with &&)',
+})
+export class RoomBooking {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  room_id!: number;
+
+  @Property({ columnType: 'tstzrange' })
+  during!: string;
+
+}
+```
+
+This requires the `btree_gist` extension when the constraint uses `=` on a non-range type. The schema generator round-trips EXCLUDE constraints through introspection just like check constraints — no extra diffing churn.
+
 ## Database Triggers
 
 You can define database triggers via the `@Trigger()` decorator or the `triggers` option in `defineEntity`/`EntitySchema`. Triggers are managed by the schema generator and migration system — they are created, updated, and removed automatically.

--- a/packages/sql/src/dialects/postgresql/PostgreSqlSchemaHelper.ts
+++ b/packages/sql/src/dialects/postgresql/PostgreSqlSchemaHelper.ts
@@ -682,8 +682,12 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
 
       seen.add(dedupeKey);
       ret[key] ??= [];
+      // CHECK constraints come back as `CHECK ((<predicate>))`; strip the double-paren wrap and
+      // postgres-added type casts so the inner predicate matches what the user wrote in metadata.
+      // EXCLUDE constraints come back as `EXCLUDE USING <method> (<cols WITH ops>)` and are stored as-is
+      // (the user's @Check expression is itself the full body, see SchemaHelper.createCheck).
       const m = /^check \(\((.*)\)\)$/is.exec(check.expression);
-      const def = m?.[1].replace(/\((.*?)\)::\w+/g, '$1');
+      const def = m ? m[1].replace(/\((.*?)\)::\w+/g, '$1') : check.expression;
       ret[key].push({
         name: check.name,
         columnName: check.column_name,
@@ -1480,17 +1484,39 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
       join pg_am as am on am.oid = i.relam
       left join pg_constraint as c on c.conname = i.relname
       where indrelid in (${tables.map(t => `${this.platform.quoteValue(`${this.quote(t.schema_name)}.${this.quote(t.table_name)}`)}::regclass`).join(', ')})
+        and (c.contype is null or c.contype <> 'x')
       order by relname`;
   }
 
   private getChecksSQL(tablesBySchemas: Map<string | undefined, Table[]>): string {
+    const checkFilter = [...tablesBySchemas.entries()]
+      .map(
+        ([schema, tables]) =>
+          `ccu.table_name in (${tables.map(t => this.platform.quoteValue(t.table_name)).join(',')}) and ccu.table_schema = ${this.platform.quoteValue(schema)}`,
+      )
+      .join(' or ');
+    // EXCLUDE constraints (contype='x') don't appear in information_schema.constraint_column_usage,
+    // so the EXCLUDE branch resolves table/schema directly from pg_class/pg_namespace. CHECK keeps the
+    // ccu join to surface column_name, which the comparator needs to diff enum changes on the column.
+    const excludeFilter = [...tablesBySchemas.entries()]
+      .map(
+        ([schema, tables]) =>
+          `cls.relname in (${tables.map(t => this.platform.quoteValue(t.table_name)).join(',')}) and nsp.nspname = ${this.platform.quoteValue(schema)}`,
+      )
+      .join(' or ');
     return `select ccu.table_name as table_name, ccu.table_schema as schema_name, pgc.conname as name, conrelid::regclass as table_from, ccu.column_name as column_name, pg_get_constraintdef(pgc.oid) as expression
       from pg_constraint pgc
       join pg_namespace nsp on nsp.oid = pgc.connamespace
       join pg_class cls on pgc.conrelid = cls.oid
       join information_schema.constraint_column_usage ccu on pgc.conname = ccu.constraint_name and nsp.nspname = ccu.constraint_schema and cls.relname = ccu.table_name
-      where contype = 'c' and (${[...tablesBySchemas.entries()].map(([schema, tables]) => `ccu.table_name in (${tables.map(t => this.platform.quoteValue(t.table_name)).join(',')}) and ccu.table_schema = ${this.platform.quoteValue(schema)}`).join(' or ')})
-      order by pgc.conname`;
+      where pgc.contype = 'c' and (${checkFilter})
+      union all
+      select cls.relname as table_name, nsp.nspname as schema_name, pgc.conname as name, conrelid::regclass as table_from, null as column_name, pg_get_constraintdef(pgc.oid) as expression
+      from pg_constraint pgc
+      join pg_namespace nsp on nsp.oid = pgc.connamespace
+      join pg_class cls on pgc.conrelid = cls.oid
+      where pgc.contype = 'x' and (${excludeFilter})
+      order by name`;
   }
 
   override inferLengthFromColumnType(type: string): number | undefined {

--- a/packages/sql/src/dialects/postgresql/PostgreSqlSchemaHelper.ts
+++ b/packages/sql/src/dialects/postgresql/PostgreSqlSchemaHelper.ts
@@ -682,10 +682,9 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
 
       seen.add(dedupeKey);
       ret[key] ??= [];
-      // CHECK constraints come back as `CHECK ((<predicate>))`; strip the double-paren wrap and
-      // postgres-added type casts so the inner predicate matches what the user wrote in metadata.
-      // EXCLUDE constraints come back as `EXCLUDE USING <method> (<cols WITH ops>)` and are stored as-is
-      // (the user's @Check expression is itself the full body, see SchemaHelper.createCheck).
+      // CHECK: unwrap the `CHECK ((<predicate>))` shell and drop pg-added `::type` casts so the
+      // inner predicate matches the user's metadata. EXCLUDE bodies are kept verbatim — the user's
+      // `@Check` expression is the full body (see SchemaHelper.createCheck).
       const m = /^check \(\((.*)\)\)$/is.exec(check.expression);
       const def = m ? m[1].replace(/\((.*?)\)::\w+/g, '$1') : check.expression;
       ret[key].push({
@@ -1495,9 +1494,8 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
           `ccu.table_name in (${tables.map(t => this.platform.quoteValue(t.table_name)).join(',')}) and ccu.table_schema = ${this.platform.quoteValue(schema)}`,
       )
       .join(' or ');
-    // EXCLUDE constraints (contype='x') don't appear in information_schema.constraint_column_usage,
-    // so the EXCLUDE branch resolves table/schema directly from pg_class/pg_namespace. CHECK keeps the
-    // ccu join to surface column_name, which the comparator needs to diff enum changes on the column.
+    // EXCLUDE constraints don't appear in information_schema.constraint_column_usage, so the second
+    // branch resolves the table from pg_class/pg_namespace directly.
     const excludeFilter = [...tablesBySchemas.entries()]
       .map(
         ([schema, tables]) =>

--- a/packages/sql/src/schema/SchemaHelper.ts
+++ b/packages/sql/src/schema/SchemaHelper.ts
@@ -27,6 +27,16 @@ export function stripStatementNewlines(body: string): string {
   return body.replace(/;[\t ]*\r?\n/g, '; ');
 }
 
+/**
+ * Detects `@Check` expressions that are full table-constraint bodies (e.g. `exclude using gist (...)`),
+ * so the emitter can skip the `check (...)` wrap. Used as an escape hatch for dialect-specific
+ * constraint kinds (currently PostgreSQL `EXCLUDE`) that share the lifecycle of a CHECK constraint
+ * but a different DDL keyword.
+ */
+export function isRawConstraintBody(expression: string): boolean {
+  return /^\s*exclude\b/i.test(expression);
+}
+
 /** Base class for database-specific schema helpers. Provides SQL generation for DDL operations. */
 export abstract class SchemaHelper {
   constructor(protected readonly platform: AbstractSqlPlatform) {}
@@ -1080,7 +1090,10 @@ export abstract class SchemaHelper {
   }
 
   createCheck(table: DatabaseTable, check: CheckDef): string {
-    return `alter table ${table.getQuotedName()} add constraint ${this.quote(check.name)} check (${check.expression})`;
+    const body = isRawConstraintBody(check.expression as string)
+      ? (check.expression as string)
+      : `check (${check.expression})`;
+    return `alter table ${table.getQuotedName()} add constraint ${this.quote(check.name)} ${body}`;
   }
 
   /**

--- a/packages/sql/src/schema/SchemaHelper.ts
+++ b/packages/sql/src/schema/SchemaHelper.ts
@@ -27,16 +27,6 @@ export function stripStatementNewlines(body: string): string {
   return body.replace(/;[\t ]*\r?\n/g, '; ');
 }
 
-/**
- * Detects `@Check` expressions that are full table-constraint bodies (e.g. `exclude using gist (...)`),
- * so the emitter can skip the `check (...)` wrap. Used as an escape hatch for dialect-specific
- * constraint kinds (currently PostgreSQL `EXCLUDE`) that share the lifecycle of a CHECK constraint
- * but a different DDL keyword.
- */
-export function isRawConstraintBody(expression: string): boolean {
-  return /^\s*exclude\b/i.test(expression);
-}
-
 /** Base class for database-specific schema helpers. Provides SQL generation for DDL operations. */
 export abstract class SchemaHelper {
   constructor(protected readonly platform: AbstractSqlPlatform) {}
@@ -1090,10 +1080,14 @@ export abstract class SchemaHelper {
   }
 
   createCheck(table: DatabaseTable, check: CheckDef): string {
-    const body = isRawConstraintBody(check.expression as string)
-      ? (check.expression as string)
-      : `check (${check.expression})`;
+    const expression = check.expression as string;
+    const body = this.isRawConstraintBody(expression) ? expression : `check (${expression})`;
     return `alter table ${table.getQuotedName()} add constraint ${this.quote(check.name)} ${body}`;
+  }
+
+  /** True for `@Check` expressions that are a full table-constraint body (e.g. PostgreSQL `exclude using gist (...)`) and must be emitted verbatim instead of wrapped in `check (...)`. */
+  private isRawConstraintBody(expression: string): boolean {
+    return /^\s*exclude\b/i.test(expression);
   }
 
   /**

--- a/tests/features/schema-generator/exclude-constraint.postgres.test.ts
+++ b/tests/features/schema-generator/exclude-constraint.postgres.test.ts
@@ -1,0 +1,120 @@
+import { EntitySchema, MikroORM } from '@mikro-orm/postgresql';
+import { Check, Entity, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+
+@Entity()
+@Check({ name: 'room_booking_no_overlap', expression: `exclude using gist (room_id with =, during with &&)` })
+class RoomBooking {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  room_id!: number;
+
+  @Property({ columnType: 'tstzrange' })
+  during!: string;
+}
+
+describe('exclude constraint [postgres]', () => {
+  test('exclude constraint roundtrip — create, then no diff on stable schema [postgres]', async () => {
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      entities: [RoomBooking],
+      dbName: `mikro_orm_test_exclude_1`,
+    });
+
+    // btree_gist is required for the `=` operator on a regular type in a gist index
+    await orm.schema.ensureDatabase();
+    await orm.em.getConnection().execute('create extension if not exists btree_gist');
+
+    const createSql = await orm.schema.getCreateSchemaSQL({ wrap: false });
+    expect(createSql).toContain(
+      `alter table "room_booking" add constraint "room_booking_no_overlap" exclude using gist (room_id with =, during with &&)`,
+    );
+    expect(createSql).not.toContain('check (exclude using');
+
+    await orm.schema.execute(createSql);
+
+    // After creation the diff must be empty — pg stores EXCLUDE as contype='x',
+    // and introspection has to round-trip it back to the same expression for diffing
+    // to see no change.
+    let diff = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(diff).toBe('');
+
+    // Sanity: the constraint actually fires — overlapping inserts must be rejected
+    await orm.em
+      .getConnection()
+      .execute(`insert into "room_booking" ("id", "room_id", "during") values (1, 1, '[2026-01-01, 2026-01-05)')`);
+    await expect(
+      orm.em
+        .getConnection()
+        .execute(`insert into "room_booking" ("id", "room_id", "during") values (2, 1, '[2026-01-03, 2026-01-10)')`),
+    ).rejects.toThrow(/conflicting key value violates exclusion constraint/);
+
+    diff = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(diff).toBe('');
+
+    await orm.schema.dropDatabase();
+    await orm.close();
+  });
+
+  test('exclude constraint diff — add, change, remove [postgres]', async () => {
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      entities: [RoomBooking],
+      dbName: `mikro_orm_test_exclude_2`,
+    });
+
+    await orm.schema.ensureDatabase();
+    await orm.em.getConnection().execute('create extension if not exists btree_gist');
+    const meta = orm.getMetadata();
+
+    const tableMeta = new EntitySchema({
+      properties: {
+        id: { primary: true, name: 'id', type: 'number', fieldName: 'id', columnType: 'int' },
+        room_id: { type: 'number', name: 'room_id', fieldName: 'room_id', columnType: 'int' },
+        during: { type: 'string', name: 'during', fieldName: 'during', columnType: 'tstzrange' },
+      },
+      name: 'BookingDiff',
+      tableName: 'booking_diff',
+      checks: [],
+    }).init().meta;
+    meta.set(tableMeta.class, tableMeta);
+
+    // Initial create — no exclude constraint yet
+    let diff = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    await orm.schema.execute(diff);
+    diff = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(diff).toBe('');
+
+    // Add the EXCLUDE constraint
+    tableMeta.checks = [
+      { name: 'booking_diff_no_overlap', expression: 'exclude using gist (room_id with =, during with &&)' },
+    ];
+    diff = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(diff).toContain(`add constraint "booking_diff_no_overlap" exclude using gist`);
+    await orm.schema.execute(diff);
+    diff = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(diff).toBe('');
+
+    // Change the expression (drop the room_id predicate)
+    tableMeta.checks = [{ name: 'booking_diff_no_overlap', expression: 'exclude using gist (during with &&)' }];
+    diff = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(diff).toContain(`drop constraint "booking_diff_no_overlap"`);
+    expect(diff).toContain(`add constraint "booking_diff_no_overlap" exclude using gist (during with &&)`);
+    await orm.schema.execute(diff);
+    diff = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(diff).toBe('');
+
+    // Remove the constraint
+    tableMeta.checks = [];
+    diff = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(diff).toContain(`drop constraint "booking_diff_no_overlap"`);
+    expect(diff).not.toContain(`add constraint`);
+    await orm.schema.execute(diff);
+    diff = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(diff).toBe('');
+
+    await orm.schema.dropDatabase();
+    await orm.close();
+  });
+});


### PR DESCRIPTION
The `@Check` decorator already covers the lifecycle EXCLUDE constraints need (ALTER/DROP CONSTRAINT, name-based matching, opaque expression diff), so this teaches the existing pipeline to pass the body through verbatim when the expression itself is a full table-constraint body — no new decorator, no new option.

- `SchemaHelper.createCheck` skips the `check (…)` wrap when the expression starts with `EXCLUDE`.
- `PostgreSqlSchemaHelper.getChecksSQL` UNIONs in `contype = 'x'` rows; since EXCLUDE doesn't appear in `information_schema.constraint_column_usage`, that branch resolves table/schema directly from `pg_class` / `pg_namespace`.
- `getAllChecks` keeps the raw `pg_get_constraintdef()` text when it isn't a `CHECK ((…))` wrap, so round-trip comparison through `diffExpression` is symmetric.
- The index introspection query filters out `contype = 'x'` rows so the index pg auto-creates to back the constraint doesn't leak through as a stray index needing a `drop index`.

```ts
@Entity()
@Check({
  name: 'room_booking_no_overlap',
  expression: 'exclude using gist (room_id with =, during with &&)',
})
class RoomBooking { /* … */ }
```

Closes #7787

🤖 Generated with [Claude Code](https://claude.com/claude-code)