### PR TITLE
fix(core): preserve sibling conditions next to $and/$or on relation filters

### DIFF
--- a/packages/core/src/utils/QueryHelper.ts
+++ b/packages/core/src/utils/QueryHelper.ts
@@ -113,6 +113,8 @@ export class QueryHelper {
     const keys = Object.keys(where);
     const groupOperator = keys.find(k => {
       return (
+        // sole-key only: caller drops the parent, so siblings would be silently lost
+        keys.length === 1 &&
         k in GroupOperator &&
         Array.isArray(where[k]) &&
         where[k].every(cond => {

--- a/tests/issues/GHx57.test.ts
+++ b/tests/issues/GHx57.test.ts
@@ -1,0 +1,109 @@
+// Sibling scalar conditions on a relation are silently dropped from the WHERE
+// clause when the same relation filter also contains a $and clause.
+//
+// em.find(Periodicity, {
+//   entity: {
+//     $and: [{ id: { $in: [...] } }],
+//     taxManagedByGroup: true,  // ← was silently dropped
+//   },
+//   organization: { id: orgId },
+// })
+
+import { type Ref } from '@mikro-orm/core';
+import { Entity, ManyToOne, PrimaryKey, Property } from '@mikro-orm/decorators/legacy';
+import { MikroORM } from '@mikro-orm/sqlite';
+
+@Entity()
+class Organization {
+  @PrimaryKey({ type: 'number' })
+  id!: number;
+
+  @Property({ type: 'string' })
+  name!: string;
+}
+
+@Entity()
+class LegalEntity {
+  @PrimaryKey({ type: 'number' })
+  id!: number;
+
+  @Property({ type: 'string' })
+  name!: string;
+
+  @Property({ type: 'boolean' })
+  taxManagedByGroup!: boolean;
+
+  @ManyToOne({ entity: () => Organization, ref: true })
+  organization!: Ref<Organization>;
+}
+
+@Entity()
+class Periodicity {
+  @PrimaryKey({ type: 'number' })
+  id!: number;
+
+  @Property({ type: 'string' })
+  title!: string;
+
+  @ManyToOne({ entity: () => LegalEntity, ref: true })
+  entity!: Ref<LegalEntity>;
+
+  @ManyToOne({ entity: () => Organization, ref: true })
+  organization!: Ref<Organization>;
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    dbName: ':memory:',
+    entities: [Organization, LegalEntity, Periodicity],
+  });
+  await orm.schema.refresh();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+test('scalar sibling conditions next to $and in a nested relation filter must reach the SQL', async () => {
+  const seedEm = orm.em.fork();
+
+  const org = seedEm.create(Organization, { name: 'Test Org' });
+  const otherOrg = seedEm.create(Organization, { name: 'Other Org' });
+  await seedEm.flush();
+
+  const included = seedEm.create(LegalEntity, {
+    name: 'Included',
+    taxManagedByGroup: true,
+    organization: org,
+  });
+  const excluded = seedEm.create(LegalEntity, {
+    name: 'Excluded — wrong flag',
+    taxManagedByGroup: false,
+    organization: org,
+  });
+  const wrongOrg = seedEm.create(LegalEntity, {
+    name: 'Excluded — wrong org',
+    taxManagedByGroup: true,
+    organization: otherOrg,
+  });
+  await seedEm.flush();
+
+  seedEm.create(Periodicity, { title: 'should-appear', entity: included, organization: org });
+  seedEm.create(Periodicity, { title: 'should-not-appear (wrong flag)', entity: excluded, organization: org });
+  seedEm.create(Periodicity, { title: 'should-not-appear (wrong org)', entity: wrongOrg, organization: otherOrg });
+  await seedEm.flush();
+
+  const queryEm = orm.em.fork();
+  const results = await queryEm.find(Periodicity, {
+    entity: {
+      $and: [{ id: { $in: [included.id, excluded.id] } }],
+      taxManagedByGroup: true,
+    },
+    organization: { id: org.id },
+  });
+
+  expect(results).toHaveLength(1);
+  expect(results[0].title).toBe('should-appear');
+});


### PR DESCRIPTION
`liftGroupOperators` would rewrite `{ rel: { $and: [pk], scalar: x } }` into `{ $and: [{ rel: pk }] }`, silently dropping the sibling `scalar` because the caller does `delete where[rel]` and re-emits only `value[op]`. The lift now only fires when the group operator is the sole key on the relation filter — otherwise the criteria-node layer auto-joins and emits the full WHERE.

The resulting buggy SQL skipped the join entirely:

```sql
-- before
select * from periodicity where organization_id = ? and entity_id in (...)
-- after
select * from periodicity inner join legal_entity ...
  where legal_entity.id in (...) and legal_entity.tax_managed_by_group = true
  and organization_id = ?
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)