### PR TITLE
fix(core): preserve sibling conditions next to `$and`/`$or` on relation filters

### DIFF
--- a/packages/core/src/utils/QueryHelper.ts
+++ b/packages/core/src/utils/QueryHelper.ts
@@ -70,7 +70,8 @@ export class QueryHelper {
 
     const keys = Object.keys(where);
     const groupOperator = keys.find(k => {
-      return Utils.isGroupOperator(k) && Array.isArray(where[k]) && where[k].every(cond => {
+      // sole-key only: caller drops the parent, so siblings would be silently lost
+      return keys.length === 1 && Utils.isGroupOperator(k) && Array.isArray(where[k]) && where[k].every(cond => {
         return Utils.isPlainObject(cond) && Object.keys(cond).every(k2 => {
           if (Utils.isOperator(k2, false)) {
             if (k2 === '$not') {

--- a/tests/issues/GHx46.test.ts
+++ b/tests/issues/GHx46.test.ts
@@ -1,0 +1,113 @@
+// Sibling scalar conditions on a relation are silently dropped from the WHERE
+// clause when the same relation filter also contains a $and clause.
+//
+// em.find(Periodicity, {
+//   entity: {
+//     $and: [{ id: { $in: [...] } }],
+//     taxManagedByGroup: true,  // ← was silently dropped
+//   },
+//   organization: { id: orgId },
+// })
+
+import { Entity, ManyToOne, MikroORM, PrimaryKey, Property, Ref } from '@mikro-orm/sqlite';
+
+@Entity()
+class Organization {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+}
+
+@Entity()
+class LegalEntity {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @Property()
+  taxManagedByGroup!: boolean;
+
+  @ManyToOne({ entity: () => Organization, ref: true })
+  organization!: Ref<Organization>;
+
+}
+
+@Entity()
+class Periodicity {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  title!: string;
+
+  @ManyToOne({ entity: () => LegalEntity, ref: true })
+  entity!: Ref<LegalEntity>;
+
+  @ManyToOne({ entity: () => Organization, ref: true })
+  organization!: Ref<Organization>;
+
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    dbName: ':memory:',
+    entities: [Organization, LegalEntity, Periodicity],
+  });
+  await orm.schema.refreshDatabase();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+test('scalar sibling conditions next to $and in a nested relation filter must reach the SQL', async () => {
+  const seedEm = orm.em.fork();
+
+  const org = seedEm.create(Organization, { name: 'Test Org' });
+  const otherOrg = seedEm.create(Organization, { name: 'Other Org' });
+  await seedEm.flush();
+
+  const included = seedEm.create(LegalEntity, {
+    name: 'Included',
+    taxManagedByGroup: true,
+    organization: org,
+  });
+  const excluded = seedEm.create(LegalEntity, {
+    name: 'Excluded — wrong flag',
+    taxManagedByGroup: false,
+    organization: org,
+  });
+  const wrongOrg = seedEm.create(LegalEntity, {
+    name: 'Excluded — wrong org',
+    taxManagedByGroup: true,
+    organization: otherOrg,
+  });
+  await seedEm.flush();
+
+  seedEm.create(Periodicity, { title: 'should-appear', entity: included, organization: org });
+  seedEm.create(Periodicity, { title: 'should-not-appear (wrong flag)', entity: excluded, organization: org });
+  seedEm.create(Periodicity, { title: 'should-not-appear (wrong org)', entity: wrongOrg, organization: otherOrg });
+  await seedEm.flush();
+
+  const queryEm = orm.em.fork();
+  const results = await queryEm.find(Periodicity, {
+    entity: {
+      $and: [{ id: { $in: [included.id, excluded.id] } }],
+      taxManagedByGroup: true,
+    },
+    organization: { id: org.id },
+  });
+
+  expect(results).toHaveLength(1);
+  expect(results[0].title).toBe('should-appear');
+});


### PR DESCRIPTION
Backport of [#7790](https://github.com/mikro-orm/mikro-orm/pull/7790) to 6.x.

`liftGroupOperators` would rewrite `{ rel: { $and: [pk], scalar: x } }` into `{ $and: [{ rel: pk }] }`, silently dropping the sibling `scalar` because the caller does `delete where[rel]` and re-emits only `value[op]`. The lift now only fires when the group operator is the sole key on the relation filter — otherwise the criteria-node layer auto-joins and emits the full WHERE.

User-reported, reproducible on 6.6.13 / 6.6.14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)