### PR TITLE
fix(sql): stabilize MySQL snapshot serialization for decimal/text/extra/comment

### DIFF
--- a/packages/core/src/platforms/Platform.ts
+++ b/packages/core/src/platforms/Platform.ts
@@ -344,6 +344,21 @@ export abstract class Platform {
     return `numeric(${precision},${scale})`;
   }
 
+  /**
+   * Rounds a decimal value to the column's scale and returns it as a number. Used to compare
+   * decimal values across representations — `EntityComparator` for `compareValues`, and the
+   * schema layer for collapsing snapshot defaults like `0` / `0.00` to the same canonical form
+   * so databases that pad to scale (mysql) don't churn no-op migrations.
+   */
+  formatDecimal(value: string | number, scale?: number): number {
+    if (scale == null) {
+      return +value;
+    }
+
+    const base = Math.pow(10, scale);
+    return Math.round((+value + Number.EPSILON) * base) / base;
+  }
+
   getUuidTypeDeclarationSQL(column: { length?: number }): string {
     column.length ??= 36;
     return this.getVarcharTypeDeclarationSQL(column);

--- a/packages/core/src/types/DecimalType.ts
+++ b/packages/core/src/types/DecimalType.ts
@@ -20,17 +20,7 @@ export class DecimalType<Mode extends 'number' | 'string' = 'string'> extends Ty
   }
 
   override compareValues(a: string, b: string): boolean {
-    return this.format(a) === this.format(b);
-  }
-
-  private format(val: string | number) {
-    /* v8 ignore next */
-    if (this.prop?.scale == null) {
-      return +val;
-    }
-
-    const base = Math.pow(10, this.prop.scale);
-    return Math.round((+val + Number.EPSILON) * base) / base;
+    return this.platform!.formatDecimal(a, this.prop?.scale) === this.platform!.formatDecimal(b, this.prop?.scale);
   }
 
   override getColumnType(prop: EntityProperty, platform: Platform): string {

--- a/packages/sql/src/schema/DatabaseTable.ts
+++ b/packages/sql/src/schema/DatabaseTable.ts
@@ -1340,6 +1340,15 @@ export class DatabaseTable {
       const normOptions = { length: c.length, precision: c.precision, scale: c.scale };
       const type = this.#platform.normalizeColumnType(c.type ?? '', normOptions)?.toLowerCase() || rawType;
       const fixedPrecision = isFixedPrecisionFamily(c.mappedType);
+      // only emit `length` for types that actually use one — text/enum/json/etc. don't, but mysql
+      // information_schema still reports `character_maximum_length` for them (65535 for text, etc.)
+      const hasMeaningfulLength = typeof c.mappedType.getDefaultLength !== 'undefined';
+      // mysql stores decimal defaults padded to scale (`0` → `0.00`); collapse to canonical numeric form
+      // so the metadata-side (`0`) and introspection-side (`0.00`) snapshots agree
+      let defaultValue: string | null = c.default ?? null;
+      if (defaultValue != null && c.mappedType instanceof DecimalType && Number.isFinite(+defaultValue)) {
+        defaultValue = this.#platform.formatDecimal(defaultValue, c.scale).toString();
+      }
       const normalized: Dictionary = {
         name: c.name,
         type,
@@ -1348,26 +1357,27 @@ export class DatabaseTable {
         primary: primaryColumns.has(c.name) || !!c.primary,
         nullable: !!c.nullable,
         unique: uniqueColumns.has(c.name) || !!c.unique,
-        length: c.length || null,
+        length: hasMeaningfulLength ? c.length || null : null,
         precision: fixedPrecision ? null : (c.precision ?? null),
         scale: fixedPrecision ? null : (c.scale ?? null),
-        default: c.default ?? null,
-        comment: c.comment ?? null,
+        default: defaultValue,
+        comment: c.comment || null,
         collation: c.collation ?? null,
         enumItems: c.enumItems ?? [],
         mappedType: Utils.keys(t).find(k => t[k] === c.mappedType.constructor),
       };
 
-      for (const field of [
-        'generated',
-        'nativeEnumName',
-        'extra',
-        'ignoreSchemaChanges',
-        'defaultConstraint',
-      ] as const) {
+      for (const field of ['generated', 'nativeEnumName', 'ignoreSchemaChanges', 'defaultConstraint'] as const) {
         if (c[field]) {
           normalized[field] = c[field];
         }
+      }
+
+      // `extra` casing varies between metadata (user-supplied, typically uppercase like
+      // `ON UPDATE CURRENT_TIMESTAMP`) and mysql introspection (returns it lowercased) — the
+      // comparator already lowercases both sides when diffing, mirror that in the snapshot
+      if (c.extra) {
+        normalized.extra = c.extra.toLowerCase();
       }
 
       o[col] = normalized;
@@ -1451,8 +1461,9 @@ export class DatabaseTable {
       checks: sortedChecks,
       triggers: sortedTriggers,
       foreignKeys: sortedForeignKeys,
-      // emit `comment` even when unset so introspection (which always reads it) matches metadata
-      comment: this.comment ?? null,
+      // emit `comment` even when unset so introspection (which always reads it) matches metadata;
+      // collapse mysql's `""` for unset comments to `null` so both sources agree
+      comment: this.comment || null,
     };
   }
 }

--- a/packages/sql/src/schema/SchemaComparator.ts
+++ b/packages/sql/src/schema/SchemaComparator.ts
@@ -2,6 +2,7 @@ import {
   ArrayType,
   BooleanType,
   DateTimeType,
+  DecimalType,
   type Dictionary,
   type EntityProperty,
   inspect,
@@ -1265,6 +1266,14 @@ export class SchemaComparator {
       const defaultValueTo = to.default.toLowerCase().replace('current_timestamp', 'now').replace(/\(\)$/, '');
 
       return defaultValueFrom === defaultValueTo;
+    }
+
+    // mysql stores decimal defaults padded to scale (`0` → `0.00`); compare numerically so the
+    // entity-side raw literal and the introspected padded form don't churn the no-op migration
+    if (to.mappedType instanceof DecimalType && Number.isFinite(+from.default) && Number.isFinite(+to.default)) {
+      return (
+        this.#platform.formatDecimal(from.default, to.scale) === this.#platform.formatDecimal(to.default, to.scale)
+      );
     }
 
     if (from.default && to.default) {

--- a/tests/issues/GH7796.test.ts
+++ b/tests/issues/GH7796.test.ts
@@ -1,0 +1,92 @@
+import { readFileSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
+import { MikroORM } from '@mikro-orm/mysql';
+import { Entity, Enum, ManyToOne, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+import { Migrator } from '@mikro-orm/migrations';
+import { BASE_DIR } from '../bootstrap.js';
+
+@Entity()
+class Category7796 {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+}
+
+@Entity()
+class Widget7796 {
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ columnType: 'timestamp', defaultRaw: 'CURRENT_TIMESTAMP' })
+  createdAt!: Date;
+
+  @Property({
+    columnType: 'timestamp',
+    defaultRaw: 'CURRENT_TIMESTAMP',
+    extra: 'ON UPDATE CURRENT_TIMESTAMP',
+  })
+  updatedAt!: Date;
+
+  @Property({ columnType: 'text' })
+  description!: string;
+
+  @Enum({ items: () => ['small', 'medium', 'large'] })
+  size!: 'small' | 'medium' | 'large';
+
+  @Property({ columnType: 'decimal(10,2)', default: 0 })
+  price: number = 0;
+
+  @ManyToOne(() => Category7796, { deleteRule: 'cascade', updateRule: 'cascade' })
+  category!: Category7796;
+}
+
+const PATH = BASE_DIR + '/../temp/migrations-gh7796';
+const DB = 'mikro_orm_test_gh7796';
+
+describe('GH #7796 — snapshot flip-flop between migration:create and migration:up on MySQL', () => {
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      entities: [Category7796, Widget7796],
+      dbName: DB,
+      port: 3308,
+      user: 'root',
+      migrations: { path: PATH, snapshot: true },
+      extensions: [Migrator],
+    });
+    await rm(PATH, { recursive: true, force: true });
+    await orm.schema.dropDatabase();
+    await orm.schema.createDatabase(DB);
+  });
+
+  afterAll(async () => {
+    await rm(PATH, { recursive: true, force: true });
+    await orm.schema.dropDatabase();
+    await orm.close(true);
+  });
+
+  test('snapshot from entity metadata matches snapshot from MySQL introspection', async () => {
+    // initial create from entity metadata: writes .snapshot-<db>.json
+    const initial = await orm.migrator.createInitial();
+    expect(initial.diff.up.length).toBeGreaterThan(0);
+    const createSnapshot = JSON.parse(readFileSync(PATH + '/.snapshot-' + DB + '.json', 'utf8'));
+
+    // apply via the migrator (rewrites .snapshot-<db>.json from MySQL information_schema)
+    await orm.migrator.up();
+    const upSnapshot = JSON.parse(readFileSync(PATH + '/.snapshot-' + DB + '.json', 'utf8'));
+
+    // both sources must produce the same snapshot — otherwise the file flip-flops
+    expect(upSnapshot).toEqual(createSnapshot);
+
+    // and the user-visible symptom: a second create against an untouched entity must be empty
+    const second = await orm.migrator.create();
+    if (second.fileName) {
+      await rm(PATH + '/' + second.fileName, { force: true });
+    }
+    expect(second.diff).toEqual({ up: [], down: [] });
+  });
+});


### PR DESCRIPTION
`migration:create` writes `.snapshot-<db>.json` from entity metadata while `migration:up` rewrites it from MySQL `information_schema`. The two serializations still diverge on a few fields after #7235/#7608, and a decimal default mismatch (`0` vs `0.00`) actively churns a no-op migration every time `migration:create` runs.

| Field | metadata-side | introspection-side |
|---|---|---|
| `extra` on `ON UPDATE` timestamp | `ON UPDATE CURRENT_TIMESTAMP` | `on update CURRENT_TIMESTAMP` |
| `length` on `text` | `null` | `65535` |
| `length` on `enum` | `null` | max value length |
| `default` on `decimal(10,2)` with `default: 0` | `"0"` | `"0.00"` |
| table `comment` (unset) | `null` | `""` |

Only the decimal default propagates to an actual no-op migration (`SchemaComparator.hasSameDefaultValue` falls through to a lowercase string compare with no numeric handling). The rest pass the comparator but still leave the snapshot file in a flip-flop state.

### Fix

- `DatabaseTable.toJSON`:
  - Emit `length` only for types that declare `getDefaultLength` (mirrors `addColumnFromProperty`), so text/enum/json drop the spurious MySQL-side length.
  - Canonicalize decimal defaults through `Number(x).toString()`, collapsing `"0"`/`"0.00"` to the same form.
  - Lowercase `extra` to match what the comparator already does at diff time.
  - Collapse table-level `""` comment to `null`.
- `SchemaComparator.hasSameDefaultValue`: numeric compare for `DecimalType` so legacy snapshots and snapshot-less diffs stop generating no-op `ALTER TABLE … MODIFY` statements.

Closes #7796