### PR TITLE
fix(sql): stop sqlite snapshot flip on table/column comments

### DIFF
--- a/packages/core/src/platforms/Platform.ts
+++ b/packages/core/src/platforms/Platform.ts
@@ -841,6 +841,11 @@ export abstract class Platform {
     return false;
   }
 
+  /** Whether the platform persists table/column comments (so they round-trip through introspection). */
+  supportsComments(): boolean {
+    return true;
+  }
+
   /**
    * Maximum length of identifiers (table, column, index, constraint, …) the platform supports.
    * Names produced by {@link getIndexName} above this limit are hash-truncated. Defaults to

--- a/packages/sql/src/dialects/sqlite/SqlitePlatform.ts
+++ b/packages/sql/src/dialects/sqlite/SqlitePlatform.ts
@@ -25,6 +25,11 @@ export class SqlitePlatform extends AbstractSqlPlatform {
     return true;
   }
 
+  // sqlite has no table/column comments, so they cannot round-trip through introspection
+  override supportsComments(): boolean {
+    return false;
+  }
+
   override getCurrentTimestampSQL(length: number): string {
     return `(strftime('%s', 'now') * 1000)`;
   }

--- a/packages/sql/src/schema/DatabaseTable.ts
+++ b/packages/sql/src/schema/DatabaseTable.ts
@@ -1332,6 +1332,7 @@ export class DatabaseTable {
       mappedType instanceof t.double;
 
     const supportsUnsigned = this.#platform.supportsUnsigned();
+    const supportsComments = this.#platform.supportsComments();
 
     const columnsMapped = sortedColumnKeys.reduce((o, col) => {
       const c = columns[col];
@@ -1361,7 +1362,7 @@ export class DatabaseTable {
         precision: fixedPrecision ? null : (c.precision ?? null),
         scale: fixedPrecision ? null : (c.scale ?? null),
         default: defaultValue,
-        comment: c.comment || null,
+        comment: supportsComments ? c.comment || null : null,
         collation: c.collation ?? null,
         enumItems: c.enumItems ?? [],
         mappedType: Utils.keys(t).find(k => t[k] === c.mappedType.constructor),
@@ -1462,8 +1463,9 @@ export class DatabaseTable {
       triggers: sortedTriggers,
       foreignKeys: sortedForeignKeys,
       // emit `comment` even when unset so introspection (which always reads it) matches metadata;
-      // collapse mysql's `""` for unset comments to `null` so both sources agree
-      comment: this.comment || null,
+      // collapse mysql's `""` for unset comments to `null` so both sources agree. drop entirely on
+      // platforms that can't read comments back (sqlite), where keeping it would flip the snapshot
+      comment: supportsComments ? this.comment || null : null,
     };
   }
 }

--- a/packages/sql/src/schema/SchemaComparator.ts
+++ b/packages/sql/src/schema/SchemaComparator.ts
@@ -448,7 +448,7 @@ export class SchemaComparator {
       toTable,
     };
 
-    if (this.diffComment(fromTable.comment, toTable.comment)) {
+    if (this.#platform.supportsComments() && this.diffComment(fromTable.comment, toTable.comment)) {
       tableDifferences.changedComment = toTable.comment;
       this.log(`table comment changed for ${tableDifferences.name}`, {
         fromTableComment: fromTable.comment,
@@ -914,7 +914,7 @@ export class SchemaComparator {
       changedProperties.add('default');
     }
 
-    if (this.diffComment(fromColumn.comment, toColumn.comment)) {
+    if (this.#platform.supportsComments() && this.diffComment(fromColumn.comment, toColumn.comment)) {
       log(`'comment' changed for column ${fromTable.name}.${fromColumn.name}`, { fromColumn, toColumn });
       changedProperties.add('comment');
     }

--- a/tests/issues/GH7798.test.ts
+++ b/tests/issues/GH7798.test.ts
@@ -1,0 +1,58 @@
+import { readFileSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
+import { MikroORM } from '@mikro-orm/sqlite';
+import { Entity, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+import { Migrator } from '@mikro-orm/migrations';
+import { BASE_DIR } from '../bootstrap.js';
+
+@Entity({ tableName: 'account7798', comment: 'accounts table' })
+class Account7798 {
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ type: 'string', comment: 'free-form notes' })
+  notes!: string;
+}
+
+const PATH = BASE_DIR + '/../temp/migrations-gh7798';
+
+describe('GH #7798 — migrator.up() rewrites snapshot, dropping sqlite comments', () => {
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      entities: [Account7798],
+      dbName: ':memory:',
+      migrations: { path: PATH, snapshot: true },
+      extensions: [Migrator],
+    });
+    await rm(PATH, { recursive: true, force: true });
+  });
+
+  afterAll(async () => {
+    await rm(PATH, { recursive: true, force: true });
+    await orm.close(true);
+  });
+
+  test('snapshot from entity metadata matches snapshot from sqlite introspection', async () => {
+    const initial = await orm.migrator.createInitial();
+    expect(initial.diff.up.length).toBeGreaterThan(0);
+    const createSnapshot = JSON.parse(readFileSync(PATH + '/.snapshot-memory.json', 'utf8'));
+
+    await orm.migrator.up();
+    const upSnapshot = JSON.parse(readFileSync(PATH + '/.snapshot-memory.json', 'utf8'));
+
+    // sqlite does not persist table/column comments, so `up()` must not flip the snapshot
+    expect(upSnapshot).toEqual(createSnapshot);
+    const account = upSnapshot.tables.find((t: any) => t.name === 'account7798');
+    expect(account.comment).toBeNull();
+    expect(account.columns.notes.comment).toBeNull();
+
+    const second = await orm.migrator.create();
+    if (second.fileName) {
+      await rm(PATH + '/' + second.fileName, { force: true });
+    }
+    expect(second.diff).toEqual({ up: [], down: [] });
+  });
+});


### PR DESCRIPTION
`migrator.up()` rewrites the migration snapshot from DB introspection, while `migration:create` writes it from entity metadata. SQLite persists neither table nor column comments — a column comment is emitted nowhere in the DDL, a table comment only as a `/* ... */` SQL comment, and introspection reads neither back. So any comment in metadata disappeared on `up()` and the snapshot flip-flopped on every run (the reported `notes` column comment going `"free-form notes"` → `null`, and the same for table comments).

Audited all SQL drivers: mysql/mariadb, postgres, mssql and oracle all read both comment kinds back via introspection, so the divergence is sqlite-only (libsql shares `SqlitePlatform`). Adds a `Platform.supportsComments()` capability (default `true`, overridden to `false` in `SqlitePlatform`). `DatabaseTable.toJSON()` drops table/column comments and `SchemaComparator` skips the comment diff when the platform can't persist them, so both serialization paths agree.

Closes #7798