### PR TITLE
fix(core): reload non-merged columns after upsert with a raw conflict target

### DIFF
--- a/packages/core/src/utils/upsert-utils.ts
+++ b/packages/core/src/utils/upsert-utils.ts
@@ -121,7 +121,10 @@ export function getOnConflictReturningFields<T, P extends string>(
         return true;
       }
 
-      return Array.isArray(uniqueFields) && !uniqueFields.includes(p.name);
+      // for a raw `onConflictFields` fragment we can't introspect which columns form the conflict
+      // target, so we keep every comparable prop (returning the unique key columns is harmless) –
+      // otherwise the non-merged columns would never be reloaded and the entity would diverge from db
+      return !Array.isArray(uniqueFields) || !uniqueFields.includes(p.name);
     })
     .map(p => p.name) as (keyof T)[];
 

--- a/tests/issues/GHx58.test.ts
+++ b/tests/issues/GHx58.test.ts
@@ -1,0 +1,79 @@
+import { defineEntity, MikroORM, p, quote, sql } from '@mikro-orm/sqlite';
+
+// upsertMany with a raw `onConflictFields` fragment (a partial unique index) plus `onConflictMergeFields`
+// used to leave the returned managed entity holding the *input* values for the non-merged columns, even
+// though the conflict update never wrote them. the in-memory state thus diverged from the db, so a later
+// `assign()` of that same value was a no-op and never got flushed.
+const Product = defineEntity({
+  name: 'Product',
+  tableName: 'products',
+  properties: {
+    id: p.integer().primary(),
+    title: p.string(),
+    localizedTitle: p.string().nullable(),
+    externalId: p.string().length(12).nullable(),
+    category: p.string().default('default'),
+  },
+  indexes: [
+    {
+      name: 'products_external_id_unique',
+      expression: (columns, table, indexName) =>
+        quote`CREATE UNIQUE INDEX IF NOT EXISTS ${indexName} ON ${table} (${columns.externalId}) WHERE ${columns.externalId} IS NOT NULL`,
+    },
+  ],
+});
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    entities: [Product],
+    dbName: ':memory:',
+  });
+  await orm.schema.refresh();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+test('non-merged columns reflect db state after upsertMany with a raw conflict target', async () => {
+  orm.em.create(Product, {
+    title: 'Localized Product',
+    localizedTitle: 'Old Localized Title',
+    externalId: 'EXT000000008',
+    category: 'Localized Category',
+  });
+  await orm.em.flush();
+  orm.em.clear();
+
+  const [upserted] = await orm.em.upsertMany(
+    Product,
+    [
+      orm.em.create(Product, {
+        title: 'Localized Product Updated',
+        localizedTitle: 'New Localized Title',
+        externalId: 'EXT000000008',
+        category: 'Localized Category Updated',
+      }),
+    ],
+    {
+      onConflictFields: sql`(external_id) where external_id is not null`,
+      onConflictAction: 'merge',
+      onConflictMergeFields: ['title', 'category'],
+    },
+  );
+
+  // localizedTitle was not part of the merge fields, so the db keeps the old value and the
+  // managed entity must reflect that, not the value we passed in
+  expect(upserted.localizedTitle).toBe('Old Localized Title');
+
+  orm.em.assign(upserted, { localizedTitle: 'New Localized Title' });
+  await orm.em.flush();
+  orm.em.clear();
+
+  const reloaded = await orm.em.findOneOrFail(Product, { externalId: 'EXT000000008' });
+  expect(reloaded.title).toBe('Localized Product Updated');
+  expect(reloaded.category).toBe('Localized Category Updated');
+  expect(reloaded.localizedTitle).toBe('New Localized Title');
+});


### PR DESCRIPTION
`em.upsertMany` (and `upsert`) with a **raw** `onConflictFields` fragment plus `onConflictMergeFields` left the returned managed entity holding the *input* values for the non-merged columns, even though the conflict update never wrote them. The in-memory state thus diverged from the database, so a later `em.assign()` of that same value was detected as a no-op and never flushed.

The cause is in `getOnConflictReturningFields`: when `onConflictFields` is a `Raw`, `Array.isArray(uniqueFields)` is `false`, so every non-autoincrement comparable prop was dropped from the RETURNING / reload set and the excluded columns were never refreshed from the db. The array path (`onConflictFields: ['externalId']`) already worked correctly.

A raw conflict target can't be introspected, so we keep all comparable props (returning the unique-key columns is harmless); only known array unique fields are still skipped, leaving the array path's generated SQL unchanged.