### PR TITLE
fix(sql): handle scalar PK in joined mapping of composite-FK relations

### DIFF
--- a/packages/sql/src/AbstractSqlDriver.ts
+++ b/packages/sql/src/AbstractSqlDriver.ts
@@ -829,8 +829,11 @@ export abstract class AbstractSqlDriver<
     } else if (prop.fieldNames.length > 1) {
       // composite keys
       const fk = prop.fieldNames.map(name => root[`${relationAlias}__${name}` as EntityKey<T>]) as Primary<T>[];
-      const pk = Utils.mapFlatCompositePrimaryKey(fk, prop) as unknown[];
-      relationPojo[prop.name] = pk.every(val => val != null) ? (pk as EntityDataValue<T>) : null;
+      // `mapFlatCompositePrimaryKey` collapses to a scalar when the target PK is a single prop
+      // (e.g. a relation referencing a composite unique key on a single-PK target).
+      const pk = Utils.mapFlatCompositePrimaryKey(fk, prop);
+      const valid = Array.isArray(pk) ? pk.every(val => val != null) : pk != null;
+      relationPojo[prop.name] = valid ? (pk as EntityDataValue<T>) : null;
     } else if (prop.runtimeType === 'Date') {
       const alias = `${relationAlias}__${prop.fieldNames[0]}` as EntityKey<T>;
       const value = root[alias] as unknown;

--- a/tests/issues/GH7801.test.ts
+++ b/tests/issues/GH7801.test.ts
@@ -1,0 +1,64 @@
+import { Ref, MikroORM } from '@mikro-orm/sqlite';
+import { Entity, PrimaryKey, Property, ManyToOne, Unique } from '@mikro-orm/decorators/legacy';
+
+// `A` has a single (scalar) primary key, plus a composite unique key (x, y).
+@Entity()
+@Unique({ properties: ['x', 'y'] })
+class A {
+  @PrimaryKey({ type: 'number' })
+  id!: number;
+
+  @Property({ type: 'number' })
+  x!: number;
+
+  @Property({ type: 'number' })
+  y!: number;
+}
+
+// `B` references `A` through its composite unique key, so `a` has two field names
+// even though the resolved target primary key of `A` is a single scalar.
+@Entity()
+class B {
+  @PrimaryKey({ type: 'number' })
+  id!: number;
+
+  @ManyToOne(() => A, { ref: true, joinColumns: ['a_x', 'a_y'], referencedColumnNames: ['x', 'y'] })
+  a!: Ref<A>;
+
+  @Property({ type: 'string' })
+  name!: string;
+}
+
+@Entity()
+class C {
+  @PrimaryKey({ type: 'number' })
+  id!: number;
+
+  @ManyToOne(() => B, { ref: true })
+  b!: Ref<B>;
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    entities: [A, B, C],
+    dbName: ':memory:',
+  });
+  await orm.schema.create();
+
+  const conn = orm.em.getConnection();
+  await conn.execute(`insert into a (id, x, y) values (1, 10, 20)`);
+  await conn.execute(`insert into b (id, a_x, a_y, name) values (1, 10, 20, 'b')`);
+  await conn.execute(`insert into c (id, b_id) values (1, 1)`);
+});
+
+afterAll(() => orm.close(true));
+
+// `mapJoinedProp` takes the composite-key branch for `B.a` (two field names) but
+// `mapFlatCompositePrimaryKey` collapses to a scalar (A's PK is single), so `pk.every` blew up.
+test('joined load of a composite-FK relation whose target PK collapses to a scalar', async () => {
+  const res = await orm.em.find(C, {}, { populate: ['b'], strategy: 'joined' });
+  expect(res).toHaveLength(1);
+  expect(res[0].b.unwrap().name).toBe('b');
+});


### PR DESCRIPTION
`AbstractSqlDriver.mapJoinedProp` entered the composite-key branch whenever a relation had `fieldNames.length > 1` and blindly cast the result of `Utils.mapFlatCompositePrimaryKey` to an array before calling `.every`. That helper, however, collapses to a **scalar** when the target's primary key resolves to a single prop — e.g. a relation that references a composite *unique* key on a target whose own PK is a single scalar column. In that case `pk.every` threw `TypeError: pk.every is not a function` during a joined `find()`.

Normalize both return shapes (scalar vs array) before the null check.

Repro added as `tests/issues/GH7801.test.ts`: `A` has a scalar PK plus a composite unique `(x, y)`, `B` references it through that unique key (so `B.a` has two field names while `A`'s PK is scalar), and a joined load of `C → b` mapped `B.a` as a PK and crashed.

Closes #7801