### PR TITLE
fix(sql): stop spurious Postgres schema diff on geometry typmod and truncated check names

### DIFF
--- a/packages/sql/src/dialects/postgresql/BasePostgreSqlPlatform.ts
+++ b/packages/sql/src/dialects/postgresql/BasePostgreSqlPlatform.ts
@@ -201,6 +201,12 @@ export class BasePostgreSqlPlatform extends AbstractSqlPlatform {
       return this.getIntervalTypeDeclarationSQL(options);
     }
 
+    // postgis reports the typmod without spaces (`geometry(point,4326)`) — collapse any
+    // user-supplied spacing so the metadata and introspection forms compare equal
+    if (['geometry', 'geography'].includes(simpleType)) {
+      return type.toLowerCase().replace(/\s+/g, '');
+    }
+
     // TimeType.getColumnType drops the timezone qualifier, so detect tz aliases from the original column type.
     const originalType = options.columnTypes?.[0]?.toLowerCase() ?? type;
     if (/^timetz\b/.test(originalType) || /^time\s+with\s+time\s+zone\b/.test(originalType)) {

--- a/packages/sql/src/dialects/postgresql/PostgreSqlSchemaHelper.ts
+++ b/packages/sql/src/dialects/postgresql/PostgreSqlSchemaHelper.ts
@@ -541,6 +541,7 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
       is_nullable,
       udt_name,
       udt_schema,
+      pg_catalog.format_type(pga.atttypid, pga.atttypmod) format_type,
       coalesce(datetime_precision, character_maximum_length) length,
       atttypmod custom_length,
       numeric_precision,
@@ -581,6 +582,12 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
 
       if (type === 'bpchar') {
         type = 'char';
+      }
+
+      // postgis stores the geometry/geography typmod (`geometry(point,4326)`) in atttypmod, which
+      // information_schema does not expose — recover the full type via format_type so it round-trips
+      if ((col.udt_name === 'geometry' || col.udt_name === 'geography') && col.format_type) {
+        type = col.format_type;
       }
 
       if (type === 'vector' && col.length == null && col.custom_length != null && col.custom_length !== -1) {

--- a/packages/sql/src/schema/DatabaseSchema.ts
+++ b/packages/sql/src/schema/DatabaseSchema.ts
@@ -348,7 +348,9 @@ export class DatabaseSchema {
           : (check.expression as string);
 
         table.addCheck({
-          name: check.name!,
+          // the engine truncates identifiers past its limit (postgres 63 bytes) on storage, so
+          // mirror that here — otherwise the introspected (truncated) name never matches metadata
+          name: check.name!.substring(0, platform.getMaxIdentifierLength()),
           expression,
           definition: `check (${expression})`,
           columnName,

--- a/tests/issues/GH7798.postgis.test.ts
+++ b/tests/issues/GH7798.postgis.test.ts
@@ -1,0 +1,47 @@
+import { MikroORM } from '@mikro-orm/postgresql';
+import { Check, Entity, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+
+@Entity({ tableName: 'account7798pg' })
+@Check({
+  name: 'this_is_an_absurdly_long_check_constraint_name_to_trigger_postgres_truncation_7798',
+  expression: 'balance >= 0',
+})
+class Account7798pg {
+  @PrimaryKey({ type: 'number' })
+  id!: number;
+
+  @Property({ type: 'number' })
+  balance!: number;
+
+  @Property({ columnType: 'geometry(point, 4326)', type: 'string' })
+  location!: string;
+}
+
+const DB = 'mikro_orm_test_gh7798_postgis';
+
+describe('GH #7798 — spurious schema diff on Postgres geometry typmod and truncated identifiers', () => {
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      entities: [Account7798pg],
+      dbName: DB,
+      port: 5433,
+    });
+    await orm.schema.dropDatabase();
+    await orm.schema.createDatabase(DB);
+    await orm.schema.execute('create extension if not exists postgis');
+    await orm.schema.create();
+  });
+
+  afterAll(async () => {
+    await orm.schema.dropDatabase();
+    await orm.close(true);
+  });
+
+  test('no schema drift is detected right after creating the schema', async () => {
+    const diff = await orm.schema.getUpdateSchemaSQL();
+    expect(diff).toBe('');
+  });
+});


### PR DESCRIPTION
First of two PRs splitting out the Postgres follow-up to #7798. This one covers the two **real** comparator divergences that make `schema:update` (and `migration:create` after `migration:up`) emit no-op statements — independent of the snapshot file itself.

- **PostGIS geometry/geography typmod.** The `geometry(point,4326)` modifier lives in `pg_attribute.atttypmod`, which `information_schema` doesn't expose, so introspection read a bare `geometry` and the comparator saw a spurious type change. Recover the full type via `format_type(atttypid, atttypmod)` and collapse user-supplied spacing in `normalizeColumnType` so the metadata (`geometry(point, 4326)`) and introspected (`geometry(point,4326)`) forms compare equal.
- **Over-length identifiers.** Postgres truncates identifiers to 63 bytes on storage, so an explicit `@Check` name longer than that never matched the introspected (truncated) name and churned a drop+add every run. Truncate explicit check names to the platform identifier limit when building the target schema, mirroring what the engine does and the existing `getIndexName` truncation.

The remaining (purely cosmetic) snapshot-file churn from `migrator.up()` rewriting `.snapshot-<db>.json` from introspection will be addressed in a follow-up PR.

Refs #7798