### PR TITLE
fix(migrations): stop migrator.up() from churning a snapshot that matches the DB

### DIFF
--- a/packages/migrations/src/Migrator.ts
+++ b/packages/migrations/src/Migrator.ts
@@ -17,6 +17,7 @@ import {
   DatabaseSchema,
   DatabaseTable,
   type EntityManager,
+  SchemaComparator,
   type SqlSchemaGenerator,
 } from '@mikro-orm/sql';
 import { MigrationRunner } from './MigrationRunner.js';
@@ -214,6 +215,15 @@ export class Migrator extends AbstractMigrator<AbstractSqlDriver> {
         ctx,
       );
 
+      // keep the snapshot authored by `migration:create` when the migrated DB still matches it
+      // semantically — rewriting it from introspection only churns cosmetic serialization noise
+      // (expression casing/reformatting, native-enum mapped type, index method, ...) into the diff
+      const existing = await this.getSchemaFromSnapshot();
+
+      if (existing && !this.snapshotDiffers(existing, schema)) {
+        return result;
+      }
+
       try {
         await this.storeCurrentSchema(schema);
       } catch {
@@ -222,6 +232,13 @@ export class Migrator extends AbstractMigrator<AbstractSqlDriver> {
     }
 
     return result;
+  }
+
+  /** Whether the introspected schema differs from the snapshot in any way the comparator turns into SQL. */
+  private snapshotDiffers(snapshot: DatabaseSchema, schema: DatabaseSchema): boolean {
+    const comparator = new SchemaComparator(this.driver.getPlatform());
+    const diff = comparator.compare(snapshot, schema);
+    return this.#schemaGenerator.diffToSQL(diff, { wrap: false, safe: false, dropTables: true }).trim().length > 0;
   }
 
   override getStorage(): MigrationStorage {

--- a/tests/features/migrations/Migrator.sqlite.test.ts
+++ b/tests/features/migrations/Migrator.sqlite.test.ts
@@ -100,7 +100,7 @@ describe('Migrator (sqlite)', () => {
     migrations.snapshot = false;
   });
 
-  test('migration up and down both write the snapshot', async () => {
+  test('migration up and down do not churn a snapshot that still matches the DB', async () => {
     const migrations = orm.config.get('migrations');
     migrations.snapshot = true;
 
@@ -121,29 +121,21 @@ describe('Migrator (sqlite)', () => {
     const migration2 = await migrator.create();
     expect(migration2.diff).toEqual({ down: [], up: [] });
 
-    // spy on storeCurrentSchema to verify both up and down call it
-    const storeSchemaSpy = vi.spyOn(migrator as any, 'storeCurrentSchema');
-
     // mock the down method so we don't need real SQL
     const migratorMock = vi.spyOn(Migration.prototype, 'down');
     migratorMock.mockImplementation(async () => void 0);
 
     try {
-      // run the migration up — snapshot SHOULD be written
+      // a blank migration leaves the DB unchanged, so up/down must keep the snapshot
+      // authored by `migration:create` byte-for-byte instead of rewriting it from introspection
       await migrator.up(migration1.fileName);
-      expect(storeSchemaSpy).toHaveBeenCalledTimes(1);
-      const snapshotAfterUp = readFileSync(snapshotPath, 'utf8');
-      expect(snapshotAfterUp).toBeDefined();
+      expect(readFileSync(snapshotPath, 'utf8')).toBe(snapshotAfterCreate);
 
-      // run the migration down — snapshot SHOULD also be updated
       await migrator.down(migration1.fileName);
-      expect(storeSchemaSpy).toHaveBeenCalledTimes(2);
-      const snapshotAfterDown = readFileSync(snapshotPath, 'utf8');
-      expect(snapshotAfterDown).toBeDefined();
+      expect(readFileSync(snapshotPath, 'utf8')).toBe(snapshotAfterCreate);
     } finally {
       await rm(path + '/' + migration1.fileName);
       await rm(snapshotPath, { force: true });
-      storeSchemaSpy.mockRestore();
       migratorMock.mockRestore();
       migrations.snapshot = false;
     }

--- a/tests/issues/GH7798b.test.ts
+++ b/tests/issues/GH7798b.test.ts
@@ -1,0 +1,119 @@
+import { readFileSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
+import { MikroORM } from '@mikro-orm/postgresql';
+import {
+  Check,
+  Entity,
+  Enum,
+  Index,
+  PrimaryKey,
+  Property,
+  ReflectMetadataProvider,
+  Unique,
+} from '@mikro-orm/decorators/legacy';
+import { Migrator } from '@mikro-orm/migrations';
+import { BASE_DIR } from '../bootstrap.js';
+
+enum AccountStatus7798 {
+  ACTIVE = 'ACTIVE',
+  ARCHIVED = 'ARCHIVED',
+}
+
+@Entity({ tableName: 'account7798b' })
+@Check({
+  name: 'this_is_an_absurdly_long_check_constraint_name_to_trigger_postgres_truncation_7798',
+  expression: 'balance >= 0',
+})
+@Index({
+  name: 'account_data_gin_7798',
+  properties: ['data'],
+  type: 'gin',
+})
+class Account7798b {
+  @PrimaryKey({ type: 'number' })
+  id!: number;
+
+  @Property({ type: 'number' })
+  balance!: number;
+
+  @Enum({ items: () => AccountStatus7798, nativeEnumName: 'account_status_7798' })
+  status!: AccountStatus7798;
+
+  @Property({ columnType: 'geometry(point, 4326)', type: 'string' })
+  location!: string;
+
+  @Property({ type: 'json' })
+  data!: unknown;
+
+  @Property({ type: 'Date', defaultRaw: 'current_timestamp' })
+  createdAt!: Date;
+
+  @Property({ type: 'number', columnType: 'integer', generated: '(coalesce(balance, 0) * 2) STORED' })
+  doubled!: number;
+}
+
+@Entity({ tableName: 'order7798b' })
+@Unique({
+  name: 'order_pending_unique_ref_7798',
+  properties: ['accountId', 'ref'],
+  where: "status = 'PENDING'",
+})
+class Order7798b {
+  @PrimaryKey({ type: 'number' })
+  id!: number;
+
+  @Property({ type: 'number' })
+  accountId!: number;
+
+  @Property({ type: 'string' })
+  ref!: string;
+
+  @Property({ type: 'string' })
+  status!: string;
+}
+
+const PATH = BASE_DIR + '/../temp/migrations-gh7798b';
+const DB = 'mikro_orm_test_gh7798b';
+
+describe('GH #7798 — snapshot flip-flop between migration:create and migration:up on Postgres', () => {
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      entities: [Account7798b, Order7798b],
+      dbName: DB,
+      port: 5433,
+      migrations: { path: PATH, snapshot: true },
+      extensions: [Migrator],
+    });
+    await rm(PATH, { recursive: true, force: true });
+    await orm.schema.dropDatabase();
+    await orm.schema.createDatabase(DB);
+    await orm.schema.execute('create extension if not exists postgis');
+  });
+
+  afterAll(async () => {
+    await rm(PATH, { recursive: true, force: true });
+    await orm.schema.dropDatabase();
+    await orm.close(true);
+  });
+
+  test('migrator.up() does not rewrite a snapshot that matches the DB', async () => {
+    const initial = await orm.migrator.createInitial();
+    expect(initial.diff.up.length).toBeGreaterThan(0);
+    const createSnapshot = JSON.parse(readFileSync(PATH + '/.snapshot-' + DB + '.json', 'utf8'));
+
+    await orm.migrator.up();
+    const upSnapshot = JSON.parse(readFileSync(PATH + '/.snapshot-' + DB + '.json', 'utf8'));
+
+    // running migrations must not churn the snapshot when the DB still matches it
+    expect(upSnapshot).toEqual(createSnapshot);
+
+    const second = await orm.migrator.create();
+    if (second.fileName) {
+      await rm(PATH + '/' + second.fileName, { force: true });
+    }
+    expect(second.diff).toEqual({ up: [], down: [] });
+  });
+});


### PR DESCRIPTION
Follow-up to #7803 (now merged) for the Postgres side of #7798.

`migration:create` writes `.snapshot-<db>.json` from entity metadata, while `migration:up`/`migration:down` rewrite it from DB introspection. Even when the migrated database still matches the snapshot, the two serializations diverge in cosmetic-only ways the `SchemaComparator` already treats as equal:

- `current_timestamp` → `CURRENT_TIMESTAMP` (default casing)
- `(coalesce(...) ...) STORED` → `(COALESCE(...) ...) stored` (generated-expr reformatting)
- partial-`where` clauses rewrapped with explicit casts (`status = 'PENDING'` → `(status)::text = 'PENDING'::text`)
- native-enum `mappedType`, index `gin` method, check `definition` format

So every `migrator.up()` produced a noisy `git diff` on the snapshot even with no real schema change (the reported symptom). These can't all be normalized byte-for-byte in `toJSON()` — Postgres rewrites the stored expressions unpredictably.

Instead, skip the rewrite when the introspected schema doesn't differ from the on-disk snapshot in any way the comparator turns into SQL. The file then stays exactly as authored by `migration:create`. A real schema change (or a stale snapshot) still rewrites it as before — the existing sqlite up/down snapshot test is updated to assert this no-churn guarantee.

Closes #7798