### PR TITLE
fix(core): emit composite unique for OneToOne across 3+ STI variants

### DIFF
--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -1808,17 +1808,18 @@ export class MetadataDiscovery {
 
       // When multiple STI children share the same unique relation (OneToOne/ManyToOne),
       // replace the simple unique with a composite one including the discriminator column
-      // so different subtypes can independently reference the same target row.
-      if (
-        rootProp?.unique &&
-        newProp.unique &&
-        [ReferenceKind.ONE_TO_ONE, ReferenceKind.MANY_TO_ONE].includes(newProp.kind)
-      ) {
+      // so different subtypes can independently reference the same target row. The second
+      // child already cleared `rootProp.unique`, so for 3+ children we key on the shared
+      // root property existing rather than its (now false) flag, and dedupe the composite.
+      if (rootProp && newProp.unique && [ReferenceKind.ONE_TO_ONE, ReferenceKind.MANY_TO_ONE].includes(newProp.kind)) {
         newProp.unique = false;
         rootProp.unique = false;
-        meta.root.uniques.push({
-          properties: [prop.name, meta.root.discriminatorColumn!] as EntityKey[],
-        });
+        const properties = [prop.name, meta.root.discriminatorColumn!] as EntityKey[];
+        const exists = meta.root.uniques.some(u => Utils.equals(Utils.asArray(u.properties), properties));
+
+        if (!exists) {
+          meta.root.uniques.push({ properties });
+        }
       }
 
       newProp.nullable = true;

--- a/tests/issues/GH7805.test.ts
+++ b/tests/issues/GH7805.test.ts
@@ -1,0 +1,79 @@
+import type { Ref } from '@mikro-orm/sqlite';
+import { MikroORM, OptionalProps } from '@mikro-orm/sqlite';
+import { Entity, Enum, OneToOne, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+
+@Entity()
+class Owner {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+}
+
+@Entity({ abstract: true, discriminatorColumn: 'type', discriminatorMap: { dog: 'Dog', cat: 'Cat', bird: 'Bird' } })
+abstract class Animal {
+  [OptionalProps]?: 'type';
+
+  @PrimaryKey()
+  id!: number;
+
+  @Enum()
+  type!: string;
+}
+
+@Entity({ discriminatorValue: 'dog' })
+class Dog extends Animal {
+  @OneToOne(() => Owner, { owner: true, ref: true })
+  owner!: Ref<Owner>;
+}
+
+@Entity({ discriminatorValue: 'cat' })
+class Cat extends Animal {
+  @OneToOne(() => Owner, { owner: true, ref: true })
+  owner!: Ref<Owner>;
+}
+
+@Entity({ discriminatorValue: 'bird' })
+class Bird extends Animal {
+  @OneToOne(() => Owner, { owner: true, ref: true })
+  owner!: Ref<Owner>;
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    dbName: ':memory:',
+    entities: [Owner, Animal, Dog, Cat, Bird],
+    metadataProvider: ReflectMetadataProvider,
+  });
+  await orm.schema.refresh();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+test('GH #7805 - @OneToOne in 3+ STI variants should not produce a simple unique constraint on FK alone', async () => {
+  const sql = await orm.schema.getCreateSchemaSQL();
+
+  // Should NOT have a simple unique index on just owner_id
+  expect(sql).not.toMatch(/unique.*\(`owner_id`\)/i);
+
+  // Should have a composite unique including the discriminator column
+  expect(sql).toMatch(/unique.*\(`owner_id`, `type`\)/i);
+
+  // Functional test: dog, cat and bird can all reference the same Owner
+  const em = orm.em.fork();
+  const owner1 = em.create(Owner, { name: 'Alice' });
+  em.create(Dog, { owner: owner1 });
+  em.create(Cat, { owner: owner1 });
+  em.create(Bird, { owner: owner1 });
+
+  await em.flush();
+
+  expect(await em.count(Dog, {})).toBe(1);
+  expect(await em.count(Cat, {})).toBe(1);
+  expect(await em.count(Bird, {})).toBe(1);
+});


### PR DESCRIPTION
#7480 fixed the spurious simple unique constraint for two STI variants sharing an owning `@OneToOne`/`@ManyToOne`, but the problem returns with 3+ variants.

During STI merge, each child is processed in turn. The second child clears `rootProp.unique` and pushes the composite `(fk, discriminator)` unique. For the third child the old guard required `rootProp.unique`, which was already `false`, so it was skipped — and `addProperty` then reinstated a simple unique on the FK column alone, re-emitting `unique index (owner_id)`.

The guard now keys on the shared root property existing rather than its (now false) `unique` flag, and dedupes the composite so additional children don't push duplicates.

Closes #7805