### PR TITLE
feat(schema): add `ignoreTriggers` option and skip trigger drops in safe mode

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -548,6 +548,7 @@ MikroORM.init({
     disableForeignKeys: true, // try to disable foreign_key_checks (or equivalent)
     createForeignKeyConstraints: true, // do not generate FK constraints
     ignoreSchema: [], // allows ignoring some schemas when diffing
+    ignoreTriggers: false, // leave triggers unmanaged (never drop or alter existing ones)
     skipTables: [], // ignore some database tables during schema generation
     skipColumns: {}, // ignore some database table columns during schema generation
   },
@@ -763,6 +764,7 @@ Full list of supported options:
 | `MIKRO_ORM_MIGRATIONS_EMIT`                                 | `migrations.emit`                              |
 | `MIKRO_ORM_SCHEMA_GENERATOR_DISABLE_FOREIGN_KEYS`           | `migrations.disableForeignKeys`                |
 | `MIKRO_ORM_SCHEMA_GENERATOR_CREATE_FOREIGN_KEY_CONSTRAINTS` | `migrations.createForeignKeyConstraints`       |
+| `MIKRO_ORM_SCHEMA_GENERATOR_IGNORE_TRIGGERS`               | `schemaGenerator.ignoreTriggers`               |
 | `MIKRO_ORM_SEEDER_PATH`                                     | `seeder.path`                                  |
 | `MIKRO_ORM_SEEDER_PATH_TS`                                  | `seeder.pathTs`                                |
 | `MIKRO_ORM_SEEDER_GLOB`                                     | `seeder.glob`                                  |

--- a/docs/docs/schema-generator.md
+++ b/docs/docs/schema-generator.md
@@ -22,7 +22,7 @@ npx mikro-orm schema:drop --dump     # Dumps drop schema SQL
 
 `schema:create` will automatically create the database if it does not exist.
 
-`schema:update` drops all unknown tables by default, you can use `--no-drop-tables` to get around it. There is also `--safe` flag that will disable both table dropping and column dropping.
+`schema:update` drops all unknown tables by default, you can use `--no-drop-tables` to get around it. There is also `--safe` flag that will disable destructive changes such as table dropping, column dropping and trigger dropping.
 
 `schema:drop` will by default drop all database tables. You can use `--drop-db` flag to drop the whole database instead.
 
@@ -50,6 +50,7 @@ const orm = await MikroORM.init({
     disableForeignKeys: true,
     createForeignKeyConstraints: true,
     ignoreSchema: [],
+    ignoreTriggers: false,
     skipTables: [],
     skipColumns: {},
   },
@@ -63,6 +64,7 @@ const orm = await MikroORM.init({
 | `disableForeignKeys: boolean`                             | Whether to wrap schema statements with `set foreign_key_checks = 0` or equivalent. Defaults to `true`. This disables foreign key checks during schema operations to avoid constraint violations during table creation/modification.                                                                                                                                    |
 | `createForeignKeyConstraints: boolean`                    | Whether to generate foreign key constraints. Defaults to `true`. When set to `false`, foreign key relationships will not create database-level constraints.                                                                                                                                                                                                           |
 | `ignoreSchema: string[]`                                  | Array of schema names to ignore during schema diffing. Useful when working with databases that have multiple schemas and you want to exclude certain schemas from being managed by MikroORM.                                                                                                                                                                          |
+| `ignoreTriggers: boolean`                                 | Leave database triggers unmanaged. Defaults to `false`. When set to `true`, declared triggers are still created, but existing triggers are never dropped or altered based on the entity metadata — use this to protect hand-written triggers that are not mirrored in your entity definitions (e.g. after upgrading to a version with trigger support).                |
 | `skipTables: (string \| RegExp)[]`                        | Array of table names and patterns to exclude from schema generation. Accepts exact table names (case-insensitive) and RegExp patterns. Can include schema-qualified names like `'schema.table'`. Tables matching these names or patterns will be completely ignored during schema operations.                                                                      |
 | `skipColumns: Dictionary<(string \| RegExp)[]>`           | Object mapping table names to arrays of column names and patterns to exclude from schema generation. Keys can be table names or schema-qualified table names (e.g., `'auth.users'`). Values are arrays of exact column names (case-insensitive) or RegExp patterns. Columns matching these names or patterns will be ignored during schema operations for the specified tables. |
 | `managementDbName: string`                                | Name of the management database to use for operations that require administrative privileges (like creating databases). Platform-specific option mainly used by SQL Server.                                                                                                                                                                                           |

--- a/packages/core/src/utils/Configuration.ts
+++ b/packages/core/src/utils/Configuration.ts
@@ -127,6 +127,7 @@ const DEFAULTS = {
   schemaGenerator: {
     createForeignKeyConstraints: true,
     ignoreSchema: [],
+    ignoreTriggers: false,
     skipTables: [],
     skipViews: [],
     skipColumns: {},
@@ -1286,6 +1287,13 @@ export interface Options<
      * @default []
      */
     ignoreSchema?: string[];
+    /**
+     * Leave database triggers unmanaged. Declared triggers are still created, but existing triggers are never
+     * dropped or altered based on the entity metadata — use this to protect hand-written triggers from being
+     * removed when they are not mirrored in the entity definitions.
+     * @default false
+     */
+    ignoreTriggers?: boolean;
     /**
      * Table names or patterns to skip during schema generation.
      * @default []

--- a/packages/core/src/utils/env-vars.ts
+++ b/packages/core/src/utils/env-vars.ts
@@ -98,6 +98,7 @@ export function loadEnvironmentVars(): Partial<Options> {
   const read3 = read.bind(null, ret.schemaGenerator, 'MIKRO_ORM_SCHEMA_GENERATOR_');
   read3('disableForeignKeys', bool);
   read3('createForeignKeyConstraints', bool);
+  read3('ignoreTriggers', bool);
   cleanup(ret, 'schemaGenerator');
 
   ret.seeder = {};

--- a/packages/sql/src/dialects/sqlite/SqliteSchemaHelper.ts
+++ b/packages/sql/src/dialects/sqlite/SqliteSchemaHelper.ts
@@ -755,8 +755,10 @@ export class SqliteSchemaHelper extends SchemaHelper {
       }
     }
 
-    for (const trigger of Object.values(diff.removedTriggers)) {
-      this.append(ret, this.dropTrigger(diff.toTable, trigger));
+    if (!safe) {
+      for (const trigger of Object.values(diff.removedTriggers)) {
+        this.append(ret, this.dropTrigger(diff.toTable, trigger));
+      }
     }
 
     for (const trigger of Object.values(diff.changedTriggers)) {

--- a/packages/sql/src/schema/SchemaComparator.ts
+++ b/packages/sql/src/schema/SchemaComparator.ts
@@ -636,23 +636,26 @@ export class SchemaComparator {
       changes++;
     }
 
-    for (const trigger of fromTableTriggers) {
-      if (!toTable.hasTrigger(trigger.name)) {
-        tableDifferences.removedTriggers[trigger.name] = trigger;
-        this.log(`trigger ${trigger.name} removed from table ${tableDifferences.name}`);
-        changes++;
-        continue;
-      }
+    // `ignoreTriggers` makes triggers create-only: declared ones are still added above, but existing triggers are never diffed for drop/alter.
+    if (!this.#platform.getConfig().get('schemaGenerator').ignoreTriggers) {
+      for (const trigger of fromTableTriggers) {
+        if (!toTable.hasTrigger(trigger.name)) {
+          tableDifferences.removedTriggers[trigger.name] = trigger;
+          this.log(`trigger ${trigger.name} removed from table ${tableDifferences.name}`);
+          changes++;
+          continue;
+        }
 
-      const toTableTrigger = toTable.getTrigger(trigger.name)!;
+        const toTableTrigger = toTable.getTrigger(trigger.name)!;
 
-      if (this.diffTrigger(trigger, toTableTrigger)) {
-        this.log(`trigger ${trigger.name} changed in table ${tableDifferences.name}`, {
-          fromTableTrigger: trigger,
-          toTableTrigger,
-        });
-        tableDifferences.changedTriggers[trigger.name] = toTableTrigger;
-        changes++;
+        if (this.diffTrigger(trigger, toTableTrigger)) {
+          this.log(`trigger ${trigger.name} changed in table ${tableDifferences.name}`, {
+            fromTableTrigger: trigger,
+            toTableTrigger,
+          });
+          tableDifferences.changedTriggers[trigger.name] = toTableTrigger;
+          changes++;
+        }
       }
     }
 

--- a/packages/sql/src/schema/SchemaHelper.ts
+++ b/packages/sql/src/schema/SchemaHelper.ts
@@ -515,8 +515,10 @@ export abstract class SchemaHelper {
       ret.push(this.dropConstraint(diff.name, check.name));
     }
 
-    for (const trigger of Object.values(diff.removedTriggers)) {
-      ret.push(this.dropTrigger(diff.toTable, trigger));
+    if (!safe) {
+      for (const trigger of Object.values(diff.removedTriggers)) {
+        ret.push(this.dropTrigger(diff.toTable, trigger));
+      }
     }
 
     for (const trigger of Object.values(diff.changedTriggers)) {

--- a/tests/features/trigger.test.ts
+++ b/tests/features/trigger.test.ts
@@ -435,4 +435,104 @@ describe('trigger (defineEntity)', () => {
 
     await orm2.close();
   });
+
+  it('should not drop unmanaged DB triggers with ignoreTriggers', async () => {
+    const schema1 = new EntitySchema({
+      name: 'IgnoreTrgTable',
+      tableName: 'ignore_trg_table',
+      properties: {
+        id: { type: 'number', primary: true, fieldName: 'id', columnType: 'integer' },
+        val: { type: 'number', name: 'val', fieldName: 'val', columnType: 'integer' },
+      },
+    });
+    const orm2 = await MikroORM.init({
+      dbName: ':memory:',
+      entities: [schema1],
+      schemaGenerator: { ignoreTriggers: true },
+    });
+    await orm2.schema.refresh();
+
+    // Simulate a hand-written trigger the ORM never declared (e.g. left over after upgrade)
+    await orm2.em
+      .getConnection()
+      .execute(
+        `create trigger trg_external after insert on ignore_trg_table for each row begin update ignore_trg_table set val = val + 1 where id = NEW.id; end`,
+      );
+
+    const diff = await orm2.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(diff).not.toContain('drop trigger');
+
+    await orm2.close();
+  });
+
+  it('should still create declared triggers with ignoreTriggers (create-only)', async () => {
+    const withoutTrigger = new EntitySchema({
+      name: 'CreateOnlyTable',
+      tableName: 'create_only_table',
+      properties: {
+        id: { type: 'number', primary: true, fieldName: 'id', columnType: 'integer' },
+        val: { type: 'number', name: 'val', fieldName: 'val', columnType: 'integer' },
+      },
+    });
+    const orm2 = await MikroORM.init({
+      dbName: ':memory:',
+      entities: [withoutTrigger],
+      schemaGenerator: { ignoreTriggers: true },
+    });
+    await orm2.schema.refresh();
+
+    // Declaring a new trigger should still produce a create (only drops/diffs are suppressed)
+    const meta = orm2.getMetadata(withoutTrigger);
+    meta.triggers = [
+      {
+        name: 'trg_create_only',
+        timing: 'after',
+        events: ['insert'],
+        forEach: 'row',
+        body: 'UPDATE create_only_table SET val = val + 1 WHERE id = NEW.id',
+      },
+    ];
+
+    const diff = await orm2.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(diff).toContain('create trigger');
+
+    await orm2.close();
+  });
+
+  it('should not drop removed triggers in safe mode', async () => {
+    const schema1 = new EntitySchema({
+      name: 'SafeTrgTable',
+      tableName: 'safe_trg_table',
+      properties: {
+        id: { type: 'number', primary: true, fieldName: 'id', columnType: 'integer' },
+        val: { type: 'number', name: 'val', fieldName: 'val', columnType: 'integer' },
+      },
+      triggers: [
+        {
+          name: 'trg_safe',
+          timing: 'after',
+          events: ['insert'],
+          body: 'UPDATE safe_trg_table SET val = val + 1 WHERE id = NEW.id',
+        },
+      ],
+    });
+    const orm2 = await MikroORM.init({
+      dbName: ':memory:',
+      entities: [schema1],
+    });
+    await orm2.schema.refresh();
+
+    // Remove the trigger from metadata — its drop is destructive, so safe mode must skip it
+    const meta = orm2.getMetadata(schema1);
+    meta.triggers = [];
+
+    const safeDiff = await orm2.schema.getUpdateSchemaSQL({ wrap: false, safe: true });
+    expect(safeDiff).not.toContain('drop trigger');
+
+    // Without safe mode the drop is still emitted
+    const diff = await orm2.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(diff).toContain('drop trigger');
+
+    await orm2.close();
+  });
 });


### PR DESCRIPTION
Since v7.1 the schema generator manages triggers as first-class schema objects: introspection reads every trigger from the database and the comparator drops any that are not mirrored in entity metadata. Upgrading an existing app therefore generated `DROP TRIGGER` statements for hand-written triggers the ORM never knew about, and the drop was not guarded by `safe` mode.

This makes trigger management non-destructive in two ways:

- **New `schemaGenerator.ignoreTriggers` option** (default `false`, also via `MIKRO_ORM_SCHEMA_GENERATOR_IGNORE_TRIGGERS`). When enabled, triggers are create-only — declared triggers are still created, but existing ones are never dropped or altered from the diff, protecting hand-written triggers (e.g. after upgrading to a version with trigger support).
- **`safe` mode now skips `removedTriggers` drops**, matching the existing `removedColumns` and `removedRoutines` behavior. `changedTriggers` still drop+recreate, consistent with changed indexes/routines.