### PR TITLE
fix(postgres): only diff partitioning for entities that declare `partitionBy`

### DIFF
--- a/docs/docs/schema-generator.md
+++ b/docs/docs/schema-generator.md
@@ -240,7 +240,8 @@ Notes:
 - Property-name expressions are mapped to physical column names automatically.
 - For `list` and `range`, each `values` entry can be either the full `for values ...` clause or just its trailing part, such as `in (...)`, `from ... to ...`, or `default`.
 - Existing partitioned tables are introspected back from PostgreSQL, so `schema:update` will not keep recreating them.
-- Changing the partition definition of an existing table is not auto-migrated. Generate a manual migration for repartitioning work.
+- Mapping an already-partitioned table with an entity that does not declare `partitionBy` leaves the partitioning untouched — partitioning is only managed for entities that opt into it, so adopting MikroORM on a database with existing partitioned tables won't try to drop their partitioning.
+- Changing the partition definition of an existing table is not auto-migrated; on a normal `schema:update` this throws so the change isn't silently lost, while `--safe` runs (e.g. `migration:create`) skip it. Generate a manual migration for repartitioning work.
 
 ## Ignoring specific column changes
 

--- a/docs/docs/schema-generator.md
+++ b/docs/docs/schema-generator.md
@@ -241,7 +241,7 @@ Notes:
 - For `list` and `range`, each `values` entry can be either the full `for values ...` clause or just its trailing part, such as `in (...)`, `from ... to ...`, or `default`.
 - Existing partitioned tables are introspected back from PostgreSQL, so `schema:update` will not keep recreating them.
 - Mapping an already-partitioned table with an entity that does not declare `partitionBy` leaves the partitioning untouched — partitioning is only managed for entities that opt into it, so adopting MikroORM on a database with existing partitioned tables won't try to drop their partitioning.
-- Changing the partition definition of an existing table is not auto-migrated; on a normal `schema:update` this throws so the change isn't silently lost, while `--safe` runs (e.g. `migration:create`) skip it. Generate a manual migration for repartitioning work.
+- Adding partitioning to an existing table, or changing an already-partitioned table's definition, cannot be applied in place, so `schema:update` and `migration:create` throw to avoid silently losing the change. Enabling safe mode (`schema:update --safe`, or `migrations: { safe: true }`) skips it instead. Generate a manual migration for repartitioning work.
 
 ## Ignoring specific column changes
 

--- a/packages/sql/src/dialects/postgresql/PostgreSqlSchemaHelper.ts
+++ b/packages/sql/src/dialects/postgresql/PostgreSqlSchemaHelper.ts
@@ -1222,7 +1222,9 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
   }
 
   override getPreAlterTable(tableDiff: TableDifference, safe: boolean): string[] {
-    if (tableDiff.changedPartitioning) {
+    // In-place partition changes aren't supported; surface a helpful error on a normal run, but in safe
+    // mode skip it so `migration:create` isn't blocked (the user can author the change manually).
+    if (tableDiff.changedPartitioning && !safe) {
       const from = tableDiff.changedPartitioning.from?.definition;
       const to = tableDiff.changedPartitioning.to?.definition;
       const action = !from ? 'Adding' : !to ? 'Removing' : 'Changing';

--- a/packages/sql/src/schema/partitioning.ts
+++ b/packages/sql/src/schema/partitioning.ts
@@ -378,11 +378,14 @@ export const diffPartitioning = (
   to: TablePartitioning | undefined,
   defaultSchema: string | undefined,
 ): boolean => {
-  if (!from && !to) {
+  // Metadata does not declare `partitionBy`, so partitioning is left unmanaged — never drop or alter an
+  // existing table's partitioning just because the entity omits it (in-place removal isn't supported anyway).
+  if (!to) {
     return false;
   }
 
-  if (!from || !to) {
+  // Metadata declares partitioning the table does not have yet (adding it in place isn't supported).
+  if (!from) {
     return true;
   }
 

--- a/tests/SchemaHelper.test.ts
+++ b/tests/SchemaHelper.test.ts
@@ -325,21 +325,21 @@ describe('SchemaHelper', () => {
       ]);
     });
 
-    test('getPreAlterTable tailors message for add/remove/change partitioning transitions', () => {
+    test('getPreAlterTable tailors message for add/remove/change partitioning transitions (non-safe only)', () => {
       const helper = new PostgreSqlPlatform().getSchemaHelper()!;
       const partitioning = { definition: 'hash (type)', partitions: [] } as any;
 
       expect(() =>
         helper.getPreAlterTable(
           { name: 'evt', changedPartitioning: { from: undefined, to: partitioning } } as TableDifference,
-          true,
+          false,
         ),
       ).toThrow(/Adding partition definitions.*'<none>' -> 'hash \(type\)'/);
 
       expect(() =>
         helper.getPreAlterTable(
           { name: 'evt', changedPartitioning: { from: partitioning, to: undefined } } as TableDifference,
-          true,
+          false,
         ),
       ).toThrow(/Removing partition definitions.*'hash \(type\)' -> '<none>'/);
 
@@ -352,9 +352,25 @@ describe('SchemaHelper', () => {
               to: { definition: 'hash (type, id)', partitions: [] } as any,
             },
           } as TableDifference,
-          true,
+          false,
         ),
       ).toThrow(/Changing partition definitions.*'hash \(type\)' -> 'hash \(type, id\)'/);
+    });
+
+    test('getPreAlterTable skips the partitioning change in safe mode instead of throwing', () => {
+      const helper = new PostgreSqlPlatform().getSchemaHelper()!;
+      const partitioning = { definition: 'hash (type)', partitions: [] } as any;
+
+      expect(
+        helper.getPreAlterTable(
+          {
+            name: 'evt',
+            changedColumns: {},
+            changedPartitioning: { from: partitioning, to: { definition: 'hash (type, id)', partitions: [] } as any },
+          } as TableDifference,
+          true,
+        ),
+      ).toEqual([]);
     });
 
     test('splices partition definitions containing regex-replacement tokens verbatim', () => {

--- a/tests/features/schema-generator/partitioning.test.ts
+++ b/tests/features/schema-generator/partitioning.test.ts
@@ -169,7 +169,10 @@ describe('partitioning helpers', () => {
     };
 
     expect(diffPartitioning(undefined, undefined, 'public')).toBe(false);
-    expect(diffPartitioning(from, undefined, 'public')).toBe(true);
+    // metadata declares partitioning the table does not have yet (adding) — still a change
+    expect(diffPartitioning(undefined, equivalent, 'public')).toBe(true);
+    // DB is partitioned but metadata omits partitionBy — partitioning is left unmanaged (no-op)
+    expect(diffPartitioning(from, undefined, 'public')).toBe(false);
     expect(diffPartitioning(from, equivalent, 'public')).toBe(false);
     expect(diffPartitioning(from, { ...equivalent, definition: 'list (tenant_id, type)' }, 'public')).toBe(true);
     expect(diffPartitioning(from, { ...equivalent, partitions: equivalent.partitions.slice(0, 1) }, 'public')).toBe(
@@ -788,5 +791,26 @@ describe('partitioning helpers', () => {
       from: fromSchema.getTable('partitioned_event')!.getPartitioning(),
       to: toSchema.getTable('partitioned_event')!.getPartitioning(),
     });
+  });
+
+  test('does not flag partitioning when metadata omits partitionBy (adoption no-op)', () => {
+    const config = new Configuration({ driver: PostgreSqlDriver }, false);
+    const platform = config.getPlatform() as PostgreSqlPlatform;
+    // `from` mimics an existing partitioned table in the DB
+    const fromSchema = DatabaseSchema.fromMetadata(
+      [createPartitionedMeta({ type: 'hash', expression: ['type'], partitions: 4 })],
+      platform as any,
+      config,
+    );
+    // `to` is an entity that maps the same table without declaring partitionBy
+    const toSchema = DatabaseSchema.fromMetadata([createPartitionedMeta()], platform as any, config);
+    const comparator = new SchemaComparator(platform);
+    const diff = comparator.diffTable(
+      fromSchema.getTable('partitioned_event')!,
+      toSchema.getTable('partitioned_event')!,
+    );
+
+    // partitioning must be left untouched — no diff, hence no destructive throw downstream
+    expect(diff === false ? undefined : diff.changedPartitioning).toBeUndefined();
   });
 });


### PR DESCRIPTION
The schema generator introspects partitioning for every table, so any mismatch between the introspected definition and the metadata made `schema:update`/`migration:create` throw `partition definitions … not supported automatically`. A table partitioned in the database but mapped by an entity without `partitionBy` failed schema diffing as a result.

Partitioning is now diffed only when the entity declares `partitionBy`; otherwise the existing partitioning is left untouched (no diff, no throw). Adding partitioning to an existing table or changing an existing definition still can't be applied in place, so it throws on a normal run to avoid silently losing the change — unless safe mode is enabled (`schema:update --safe` or `migrations: { safe: true }`), in which case it is skipped. Note `migrations.safe` defaults to `false`, so `migration:create` throws unless safe mode is turned on.