### PR TITLE
fix(core): support `mapToPk` scalar typing with ES decorators

### DIFF
--- a/packages/decorators/src/es/ManyToOne.ts
+++ b/packages/decorators/src/es/ManyToOne.ts
@@ -4,6 +4,7 @@ import {
   type EntityKey,
   type EntityName,
   type EntityProperty,
+  type Primary,
   Utils,
   type Ref,
 } from '@mikro-orm/core';
@@ -13,10 +14,13 @@ import { prepareMetadataContext, processDecoratorParameters } from '../utils.js'
 export function ManyToOne<Target extends object, Owner extends object>(
   entity: ManyToOneOptions<Owner, Target> | ((e?: Owner) => EntityName<Target> | EntityName[]) = {},
   options: Partial<ManyToOneOptions<Owner, Target>> = {},
-): (_: unknown, context: ClassFieldDecoratorContext<Owner, Target | undefined | null | Ref<Target>>) => void {
+): (
+  _: unknown,
+  context: ClassFieldDecoratorContext<Owner, Target | Primary<Target> | undefined | null | Ref<Target>>,
+) => void {
   return function (
     _: unknown,
-    context: ClassFieldDecoratorContext<Owner, Target | undefined | null | Ref<Target>>,
+    context: ClassFieldDecoratorContext<Owner, Target | Primary<Target> | undefined | null | Ref<Target>>,
   ): void {
     const meta = prepareMetadataContext(context, ReferenceKind.MANY_TO_ONE);
     options = processDecoratorParameters<ManyToOneOptions<Owner, Target>>({ entity, options });

--- a/packages/decorators/src/es/OneToOne.ts
+++ b/packages/decorators/src/es/OneToOne.ts
@@ -4,6 +4,7 @@ import {
   type EntityProperty,
   type OneToManyOptions,
   type OneToOneOptions,
+  type Primary,
   type Ref,
   ReferenceKind,
 } from '@mikro-orm/core';
@@ -14,10 +15,16 @@ export function OneToOne<Target extends object, Owner extends object>(
   entity?: OneToOneOptions<Owner, Target> | string | ((e: Owner) => EntityName<Target> | EntityName[]),
   mappedByOrOptions?: (string & keyof Target) | ((e: Target) => any) | Partial<OneToOneOptions<Owner, Target>>,
   options: Partial<OneToOneOptions<Owner, Target>> = {},
-): (_: unknown, context: ClassFieldDecoratorContext<Owner, Target | Ref<Target> | null | undefined>) => void {
+): (
+  _: unknown,
+  context: ClassFieldDecoratorContext<Owner, Target | Primary<Target> | Ref<Target> | null | undefined>,
+) => void {
   const mappedBy = typeof mappedByOrOptions === 'object' ? mappedByOrOptions.mappedBy : mappedByOrOptions;
   options = typeof mappedByOrOptions === 'object' ? { ...mappedByOrOptions, ...options } : options;
-  return function (_: unknown, context: ClassFieldDecoratorContext<Owner, Target | Ref<Target> | null | undefined>) {
+  return function (
+    _: unknown,
+    context: ClassFieldDecoratorContext<Owner, Target | Primary<Target> | Ref<Target> | null | undefined>,
+  ) {
     const meta = prepareMetadataContext(context, ReferenceKind.ONE_TO_ONE);
     options = processDecoratorParameters<OneToManyOptions<Owner, Target>>({ entity, mappedBy, options });
     const property = { name: context.name, kind: ReferenceKind.ONE_TO_ONE } as EntityProperty<Owner>;

--- a/tests/features/decorators/es/GH7817.test.ts
+++ b/tests/features/decorators/es/GH7817.test.ts
@@ -1,0 +1,36 @@
+import { MikroORM } from '@mikro-orm/sqlite';
+import { Entity, ManyToOne, PrimaryKey, Property } from '@mikro-orm/decorators/es';
+
+@Entity()
+class User {
+  @PrimaryKey({ type: 'integer' })
+  id!: number;
+
+  @Property({ type: 'string' })
+  name: string;
+
+  @ManyToOne(() => User, { mapToPk: true })
+  manager: number;
+
+  @ManyToOne(() => User)
+  friend: User;
+
+  constructor(name: string, manager: number, friend: User) {
+    this.name = name;
+    this.manager = manager;
+    this.friend = friend;
+  }
+}
+
+test('mapToPk maps to scalar type with new decorators (GH 7817)', async () => {
+  const orm = await MikroORM.init({
+    entities: [User],
+    dbName: ':memory:',
+  });
+  await orm.schema.create();
+
+  const meta = orm.getMetadata().get(User);
+  expect(meta.properties.manager.mapToPk).toBe(true);
+
+  await orm.close(true);
+});


### PR DESCRIPTION
The TC39 `@ManyToOne`/`@OneToOne` decorators from `@mikro-orm/decorators/es` typed the class field context as `Target | Ref<Target> | null | undefined`. A property declared with `mapToPk: true` maps to the target's primary key scalar (e.g. `number`), which is not assignable to that union, so it failed to type check with TS1240.

Widen the field value type to also allow `Primary<Target>`.

Closes #7817