### PR TITLE
docs: clarify type-level inheritance of base class methods with defineEntity

### DIFF
--- a/docs/docs/define-entity.md
+++ b/docs/docs/define-entity.md
@@ -171,6 +171,42 @@ console.log(user.createdAt); // current Date
 
 > This approach is useful when you want constructor-level defaults that work without an `EntityManager` context (i.e., with plain `new`). If you only need defaults during persistence, you can use `onCreate` hooks instead — see [Mapped Superclasses](./inheritance-mapping.md#mapped-superclasses) for more details.
 
+#### Inheriting base class methods {#extends-methods}
+
+Methods declared on the base class are always inherited **at runtime** — the auto-generated child class extends the base class, so a child instance is `instanceof` the base and can call its methods. At the **type level**, however, `extends: BaseSchema` only carries the mapped properties; TypeScript cannot see methods you attach to the schema later via `setClass`. To make those methods visible on the child entity type, point `extends` at the base **class** instead of the schema:
+
+```ts
+export class Base extends BaseSchema.class {
+  id = v4();
+  createdAt = new Date();
+  updatedAt = new Date();
+
+  wasUpdated(): boolean {
+    return this.updatedAt > this.createdAt;
+  }
+}
+
+BaseSchema.setClass(Base);
+
+const UserSchema = defineEntity({
+  name: 'User',
+  extends: Base, // the class, not BaseSchema — exposes `wasUpdated()` on the child type
+  properties: {
+    email: p.string().unique(),
+  },
+});
+
+export class User extends UserSchema.class {
+  describe() {
+    return this.wasUpdated() ? `${this.email} (edited)` : this.email;
+  }
+}
+
+UserSchema.setClass(User);
+```
+
+Both forms behave identically at runtime; passing the class simply lets TypeScript propagate the inherited method signatures. Extending the schema (`extends: BaseSchema`) still inherits all mapped properties and is the right choice when the base only contributes columns.
+
 ### Property types
 
 `defineEntity.properties` (aliased as `p`) provides all [MikroORM built-in types](./custom-types#types-provided-by-mikroorm). To use [custom types](./custom-types), use `p.type()`:

--- a/docs/versioned_docs/version-7.1/define-entity.md
+++ b/docs/versioned_docs/version-7.1/define-entity.md
@@ -171,6 +171,42 @@ console.log(user.createdAt); // current Date
 
 > This approach is useful when you want constructor-level defaults that work without an `EntityManager` context (i.e., with plain `new`). If you only need defaults during persistence, you can use `onCreate` hooks instead — see [Mapped Superclasses](./inheritance-mapping.md#mapped-superclasses) for more details.
 
+#### Inheriting base class methods {#extends-methods}
+
+Methods declared on the base class are always inherited **at runtime** — the auto-generated child class extends the base class, so a child instance is `instanceof` the base and can call its methods. At the **type level**, however, `extends: BaseSchema` only carries the mapped properties; TypeScript cannot see methods you attach to the schema later via `setClass`. To make those methods visible on the child entity type, point `extends` at the base **class** instead of the schema:
+
+```ts
+export class Base extends BaseSchema.class {
+  id = v4();
+  createdAt = new Date();
+  updatedAt = new Date();
+
+  wasUpdated(): boolean {
+    return this.updatedAt > this.createdAt;
+  }
+}
+
+BaseSchema.setClass(Base);
+
+const UserSchema = defineEntity({
+  name: 'User',
+  extends: Base, // the class, not BaseSchema — exposes `wasUpdated()` on the child type
+  properties: {
+    email: p.string().unique(),
+  },
+});
+
+export class User extends UserSchema.class {
+  describe() {
+    return this.wasUpdated() ? `${this.email} (edited)` : this.email;
+  }
+}
+
+UserSchema.setClass(User);
+```
+
+Both forms behave identically at runtime; passing the class simply lets TypeScript propagate the inherited method signatures. Extending the schema (`extends: BaseSchema`) still inherits all mapped properties and is the right choice when the base only contributes columns.
+
 ### Property types
 
 `defineEntity.properties` (aliased as `p`) provides all [MikroORM built-in types](./custom-types#types-provided-by-mikroorm). To use [custom types](./custom-types), use `p.type()`:


### PR DESCRIPTION
Addresses #7819, where `defineEntity + class` inheritance via `extends` didn't expose base-class methods on the child entity type.

This is a type-only gap, not a runtime bug. At runtime the child class always extends the base class (because `setClass` runs before the child `defineEntity`), so methods like `isDeleted()` work and the instance is `instanceof` the base. At the type level, `extends: BaseSchema` infers the base from the schema's data-only `~entity` marker, which can't see methods attached later via `setClass`. Pointing `extends` at the base **class** (`extends: Base`) propagates the method signatures, with identical runtime behavior.

The docs claimed `extends` inherits from the parent class but only illustrated property initializers, so users reasonably expected methods to flow through too. This adds an "Inheriting base class methods" subsection explaining the runtime-vs-type distinction and when to extend the class vs the schema, in both the current docs and the v7.1 snapshot. The v7.0 snapshot has no `extends`-based inheritance section (it documents composition only), so it's left unchanged.

Closes #7819