### PR TITLE
fix(core): avoid spurious updates for object embeddables with undeclared keys

### DIFF
--- a/packages/core/src/utils/EntityComparator.ts
+++ b/packages/core/src/utils/EntityComparator.ts
@@ -528,8 +528,31 @@ export class EntityComparator {
       mapEntityProperties(meta);
     }
 
+    // pass through any unmapped columns (e.g. extra selections or virtual props). for embeddables we restrict
+    // this to declared keys, otherwise JSON keys not part of the schema leak into the original data while
+    // hydration drops them from the entity, diverging the snapshot and triggering spurious updates.
+    let knownKeysGuard = '';
+
+    if (meta.embeddable) {
+      const knownKeys = new Set<string>();
+      for (const m of meta.polymorphs?.length ? meta.polymorphs : [meta]) {
+        for (const prop of m.props) {
+          knownKeys.add(prop.name);
+
+          if (prop.embedded) {
+            knownKeys.add(prop.embedded[1]);
+          }
+
+          prop.fieldNames?.forEach(field => knownKeys.add(field));
+        }
+      }
+
+      context.set('knownKeys', knownKeys);
+      knownKeysGuard = ' && knownKeys.has(k)';
+    }
+
     lines.push(
-      `  for (let k in result) { if (Object.hasOwn(result, k) && !mapped[k] && ret[k] === undefined) ret[k] = result[k]; }`,
+      `  for (let k in result) { if (Object.hasOwn(result, k) && !mapped[k] && ret[k] === undefined${knownKeysGuard}) ret[k] = result[k]; }`,
     );
 
     const code =

--- a/tests/features/cli/__snapshots__/CompileCommand.test.ts.snap
+++ b/tests/features/cli/__snapshots__/CompileCommand.test.ts.snap
@@ -181,7 +181,7 @@ module.exports = {
       return ret;
     }
   },
-  'resultMapper-undefined_1000': function(PolymorphicRef) {
+  'resultMapper-undefined_1000': function(PolymorphicRef, knownKeys) {
     // compiled mapper for entity Address
     return function(result) {
       const ret = {};
@@ -190,7 +190,7 @@ module.exports = {
         ret.street = result.street;
         mapped.street = true;
       }
-      for (let k in result) { if (Object.hasOwn(result, k) && !mapped[k] && ret[k] === undefined) ret[k] = result[k]; }
+      for (let k in result) { if (Object.hasOwn(result, k) && !mapped[k] && ret[k] === undefined && knownKeys.has(k)) ret[k] = result[k]; }
       return ret;
     }
   }
@@ -378,7 +378,7 @@ exports[`CompileCommand > handler generates ESM output when project uses type=mo
       return ret;
     }
   },
-  'resultMapper-undefined_3000': function(PolymorphicRef) {
+  'resultMapper-undefined_3000': function(PolymorphicRef, knownKeys) {
     // compiled mapper for entity Address
     return function(result) {
       const ret = {};
@@ -387,7 +387,7 @@ exports[`CompileCommand > handler generates ESM output when project uses type=mo
         ret.street = result.street;
         mapped.street = true;
       }
-      for (let k in result) { if (Object.hasOwn(result, k) && !mapped[k] && ret[k] === undefined) ret[k] = result[k]; }
+      for (let k in result) { if (Object.hasOwn(result, k) && !mapped[k] && ret[k] === undefined && knownKeys.has(k)) ret[k] = result[k]; }
       return ret;
     }
   }

--- a/tests/issues/GH7821.test.ts
+++ b/tests/issues/GH7821.test.ts
@@ -1,0 +1,45 @@
+import { defineEntity, p, MikroORM } from '@mikro-orm/sqlite';
+import { mockLogger } from '../helpers.js';
+
+const EmbeddableSchema = defineEntity({
+  name: 'Embeddable',
+  embeddable: true,
+  properties: {
+    someProperty: p.integer(),
+  },
+});
+class Embeddable extends EmbeddableSchema.class {}
+EmbeddableSchema.setClass(Embeddable);
+
+const EntitySchema = defineEntity({
+  name: 'Entity',
+  properties: {
+    id: p.integer().primary(),
+    embeddable: () => p.embedded(Embeddable).object(),
+  },
+});
+class Entity extends EntitySchema.class {}
+EntitySchema.setClass(Entity);
+
+// loading an entity whose object embeddable column holds a key not declared in the
+// embeddable schema must not be treated as a change and trigger a spurious update on flush
+test('GH #7821: object embeddable with extra JSON key does not trigger update on flush', async () => {
+  const orm = await MikroORM.init({
+    dbName: ':memory:',
+    entities: [Embeddable, Entity],
+  });
+  await orm.schema.refresh();
+
+  await orm.em.insert(Entity, { id: 1, embeddable: { someProperty: 1, unexpected: null } } as any);
+
+  const em = orm.em.fork();
+  await em.findOneOrFail(Entity, { id: 1 });
+
+  const mock = mockLogger(orm, ['query']);
+  await em.flush();
+
+  const updates = mock.mock.calls.flat().filter((q: string) => /update/i.test(q));
+  expect(updates).toHaveLength(0);
+
+  await orm.close();
+});


### PR DESCRIPTION
Loading an entity whose `object` embeddable column holds a JSON key not declared in the embeddable schema triggered an `UPDATE` on every `flush()` — even for purely read-only loads (and a write error on read-only connections), as reported in #7821.

The result mapper's pass-through loop copied any unmapped column from the DB row into the original-data snapshot. For an object embeddable, an undeclared JSON key (e.g. `{ someProperty: 1, unexpected: null }`) leaked into `__originalEntityData`, while hydration dropped it from the entity instance. The change-detection snapshot (built from the entity) then diverged from the original data, so the embeddable was reported as changed and rewritten — silently dropping the extra key.

The fix restricts the embeddable pass-through to declared keys (prop names, nested `embedded` keys, and field names, across all polymorphic variants), so the original data matches the hydrated entity. Nested object embeddables without own field names — which legitimately rely on the pass-through — are unaffected.

Closes #7821