### PR TITLE
fix(postgres): unwrap single-paren CHECK shell for bare boolean CASE bodies

### DIFF
--- a/packages/sql/src/dialects/postgresql/PostgreSqlSchemaHelper.ts
+++ b/packages/sql/src/dialects/postgresql/PostgreSqlSchemaHelper.ts
@@ -690,10 +690,13 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
       seen.add(dedupeKey);
       ret[key] ??= [];
       // CHECK: unwrap the `CHECK ((<predicate>))` shell and drop pg-added `::type` casts so the
-      // inner predicate matches the user's metadata. EXCLUDE bodies are kept verbatim — the user's
-      // `@Check` expression is the full body (see SchemaHelper.createCheck).
+      // inner predicate matches the user's metadata. Bare boolean bodies (e.g. a top-level CASE)
+      // are emitted as the single-paren `CHECK (<predicate>)` form, which we unwrap too. EXCLUDE
+      // bodies are kept verbatim — the user's `@Check` expression is the full body (see
+      // SchemaHelper.createCheck).
       const m = /^check \(\((.*)\)\)$/is.exec(check.expression);
-      const def = m ? m[1].replace(/\((.*?)\)::\w+/g, '$1') : check.expression;
+      const single = m ? null : /^check \((.*)\)$/is.exec(check.expression);
+      const def = m ? m[1].replace(/\((.*?)\)::\w+/g, '$1') : single ? single[1] : check.expression;
       ret[key].push({
         name: check.name,
         columnName: check.column_name,

--- a/tests/features/schema-generator/check-constraint.postgres.test.ts
+++ b/tests/features/schema-generator/check-constraint.postgres.test.ts
@@ -294,4 +294,41 @@ describe('check constraint [postgres]', () => {
     await orm.schema.dropDatabase();
     await orm.close();
   });
+
+  test('check constraint with bare boolean CASE expression does not cause drift [postgres]', async () => {
+    const orm = await initORMPostgreSql();
+    const meta = orm.getMetadata();
+    await orm.schema.update();
+
+    // A CASE expression that yields a boolean directly (no surrounding comparison) is emitted by
+    // PostgreSQL as a single-paren `CHECK (CASE ... END)` shell, unlike `CHECK ((<predicate>))`.
+    // getAllChecks() must unwrap the single-paren form too, otherwise the `CHECK (` prefix leaks
+    // into the introspected expression and the constraint is dropped+recreated on every diff.
+    const newTableMeta = new EntitySchema({
+      properties: {
+        id: { primary: true, name: 'id', type: 'number', fieldName: 'id', columnType: 'int' },
+        kind: { type: 'string', name: 'kind', fieldName: 'kind', columnType: 'varchar(20)' },
+        value: { type: 'number', name: 'value', fieldName: 'value', columnType: 'int' },
+      },
+      name: 'BareCaseCheckTable',
+      tableName: 'bare_case_check_table',
+      checks: [
+        {
+          name: 'chk_kind_value',
+          expression: "CASE WHEN kind = 'POSITIVE' THEN value > 0 ELSE true END",
+        },
+      ],
+    }).init().meta;
+    meta.set(newTableMeta.class, newTableMeta);
+
+    let diff = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(diff).not.toBe('');
+    await orm.schema.execute(diff);
+
+    diff = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(diff).toBe('');
+
+    await orm.schema.dropDatabase();
+    await orm.close();
+  });
 });


### PR DESCRIPTION
On Postgres, a bare boolean CHECK body — e.g. a top-level `CASE ... END` that yields a boolean directly — is stored as the single-paren `CHECK (<predicate>)` form, not the double-paren `CHECK ((<predicate>))`. Introspection only unwrapped the double-paren form, so the literal `CHECK (` prefix leaked into the constraint's `expression`. It then no longer matched the metadata predicate, and `schema:update` dropped and re-created the constraint on every run against an in-sync database.

The fix adds a single-paren fallback to the unwrap in `getAllChecks`, only used when the double-paren form doesn't match. EXCLUDE bodies (`EXCLUDE USING ...`) match neither regex and remain verbatim as before.

Closes #7824