### PR TITLE
fix(core): keep STI primary key NOT NULL when a child re-declares it

### DIFF
--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -1822,7 +1822,9 @@ export class MetadataDiscovery {
         }
       }
 
-      newProp.nullable = true;
+      // The primary key column is shared by every subtype, so it stays NOT NULL —
+      // only subtype-specific columns become nullable for the rows of other subtypes.
+      newProp.nullable = !newProp.primary;
       newProp.inherited = !rootProp;
 
       // For narrowed relation overrides, keep the root's declaration intact so

--- a/tests/features/single-table-inheritance/GH7826.test.ts
+++ b/tests/features/single-table-inheritance/GH7826.test.ts
@@ -1,0 +1,37 @@
+import { MikroORM } from '@mikro-orm/postgresql';
+import { Entity, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+
+@Entity({ discriminatorColumn: 'type', abstract: true })
+abstract class Animal {
+  @PrimaryKey()
+  id!: string;
+}
+
+@Entity({ discriminatorValue: 'dog' })
+class Dog extends Animal {
+  @PrimaryKey()
+  declare id: string;
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    metadataProvider: ReflectMetadataProvider,
+    entities: [Animal, Dog],
+    dbName: 'mikro_orm_test_7826',
+  });
+});
+
+afterAll(() => orm.close(true));
+
+test('STI primary key is NOT NULL when a child re-declares it', async () => {
+  expect(orm.getMetadata().get(Animal).properties.id.nullable).toBe(false);
+
+  const sql = await orm.schema.getCreateSchemaSQL();
+  expect(sql).not.toMatch(/"id" varchar\(255\) null/);
+
+  await orm.schema.refresh();
+  const diff = await orm.schema.getUpdateSchemaSQL();
+  expect(diff).toBe('');
+});


### PR DESCRIPTION
When an STI child re-declares the inherited `@PrimaryKey`, the inherited-property merge in `MetadataDiscovery` marked the root PK column nullable just like any subtype-specific column. That produced a contradictory schema: `getCreateSchemaSQL()` emitted the PK as `"id" varchar(255) null`, while `getUpdateSchemaSQL()` against an in-sync database wanted `alter column "id" drop not null` on a primary key.

The PK column is shared by every subtype, so it must stay NOT NULL — only genuinely subtype-specific columns become nullable for the rows of other subtypes. The fix guards the nullable assignment with `!newProp.primary`.

Closes #7826