### PR TITLE
fix(postgres): don't mis-detect JSON operator checks as enums

### DIFF
--- a/packages/sql/src/dialects/postgresql/PostgreSqlSchemaHelper.ts
+++ b/packages/sql/src/dialects/postgresql/PostgreSqlSchemaHelper.ts
@@ -1146,7 +1146,10 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
         // `CHECK ((type = 'a'::text))`
         const m1 =
           item.definition?.match(/check \(\(\("?(\w+)"?\)::/i) || item.definition?.match(/check \(\("?(\w+)"? = /i);
-        const m2 = item.definition?.match(/\(array\[(.*)]\)/i) || item.definition?.match(/ = (.*)\)/i);
+        // the single-value form must compare against a quoted literal (`= 'a'::text`); anything else
+        // (e.g. a JSON `->>` extraction like `name = data->>'name'`) is not an enum constraint
+        const m2 =
+          item.definition?.match(/\(array\[(.*)]\)/i) || item.definition?.match(/ = ('(?:[^']|'')*'::[\w ]+)\)/i);
 
         if (item.columnName && m1 && m2) {
           /* v8 ignore next */

--- a/tests/features/schema-generator/check-constraint.postgres.test.ts
+++ b/tests/features/schema-generator/check-constraint.postgres.test.ts
@@ -258,6 +258,45 @@ describe('check constraint [postgres]', () => {
     await orm.close();
   });
 
+  test('check constraint using a JSON operator is not mis-detected as enum [postgres]', async () => {
+    const orm = await initORMPostgreSql();
+    const meta = orm.getMetadata();
+    await orm.schema.update();
+
+    // A check that compares a column against a JSON `->>` extraction (`name = data->>'name'`)
+    // was incorrectly parsed as an enum constraint by getEnumDefinitions(), corrupting the
+    // referenced `data` column into a native enum and producing phantom diffs on every run.
+    const newTableMeta = new EntitySchema({
+      properties: {
+        id: { primary: true, name: 'id', type: 'number', fieldName: 'id', columnType: 'int' },
+        name: { type: 'string', name: 'name', fieldName: 'name', columnType: 'varchar(255)' },
+        data: { type: 'json', name: 'data', fieldName: 'data', columnType: 'jsonb' },
+      },
+      name: 'JsonOperatorCheckTable',
+      tableName: 'json_operator_check_table',
+      checks: [{ name: 'chk_name', expression: `name = data->>'name'` }],
+    }).init().meta;
+    meta.set(newTableMeta.class, newTableMeta);
+
+    let diff = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(diff).not.toBe('');
+    await orm.schema.execute(diff);
+
+    // The `data` column must remain a JSON column, not be corrupted into a native enum.
+    const schema = await DatabaseSchema.create(orm.em.getConnection(), orm.em.getPlatform(), orm.config);
+    const table = schema.getTable('json_operator_check_table')!;
+    const dataColumn = table.getColumn('data')!;
+    expect(dataColumn.enumItems ?? []).toEqual([]);
+    expect(dataColumn.nativeEnumName).toBeUndefined();
+
+    // After creation the diff must be empty — no phantom enum constraint changes
+    diff = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(diff).toBe('');
+
+    await orm.schema.dropDatabase();
+    await orm.close();
+  });
+
   test('check constraint with multiline expression does not cause drift [postgres]', async () => {
     const orm = await initORMPostgreSql();
     const meta = orm.getMetadata();


### PR DESCRIPTION
A single-value CHECK constraint that compares a column against an arbitrary expression — e.g. `@Check({ expression: "name = data->>'name'" })` — was parsed by `getEnumDefinitions` as if it were an enum constraint. The fallback regex `/ = (.*)\)/i` greedily matched anything after `=`, so postgres' stored `CHECK ((name = (data ->> 'name'::text)))` was read back as an enum on the `data` column: the JSON column got corrupted into a native enum (`mappedType=EnumType`, `enumItems: ["name"]`) and the check was rewritten to `"data" in ('name')`, producing phantom diffs on every `schema.update()`.

The single-value enum form postgres stores is always a quoted-literal cast (`column = 'a'::text`), so the branch is tightened to `/ = ('(?:[^']|'')*'::[\w ]+)\)/i`. Multi-value enums go through the separate `ARRAY[...]` branch and are unaffected.

Closes #7822