### PR TITLE
fix(postgres): introspect native enums with no members

### DIFF
--- a/packages/sql/src/dialects/postgresql/PostgreSqlSchemaHelper.ts
+++ b/packages/sql/src/dialects/postgresql/PostgreSqlSchemaHelper.ts
@@ -1060,11 +1060,11 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
   ): Promise<Dictionary<{ name: string; schema?: string; items: string[] }>> {
     const uniqueSchemas = Utils.unique(schemas);
     const res = await connection.execute(
-      `select t.typname as enum_name, n.nspname as schema_name, array_agg(e.enumlabel order by e.enumsortorder) as enum_value
+      `select t.typname as enum_name, n.nspname as schema_name, array_remove(array_agg(e.enumlabel order by e.enumsortorder), null) as enum_value
         from pg_type t
-        join pg_enum e on t.oid = e.enumtypid
+        left join pg_enum e on t.oid = e.enumtypid
         join pg_catalog.pg_namespace n on n.oid = t.typnamespace
-        where n.nspname in (${Array(uniqueSchemas.length).fill('?').join(', ')})
+        where t.typtype = 'e' and n.nspname in (${Array(uniqueSchemas.length).fill('?').join(', ')})
         group by t.typname, n.nspname`,
       uniqueSchemas,
       'all',

--- a/tests/features/native-postgres-enums/GH7825.test.ts
+++ b/tests/features/native-postgres-enums/GH7825.test.ts
@@ -1,0 +1,39 @@
+import { MikroORM } from '@mikro-orm/postgresql';
+import { Entity, Enum, PrimaryKey, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+
+// A native enum that currently has no members (e.g. every value was removed
+// over the project's lifetime, leaving `create type "task_kind" as enum ();`).
+const TaskKind = {} as const;
+type TaskKind = (typeof TaskKind)[keyof typeof TaskKind];
+
+@Entity({ tableName: 'task' })
+class Task {
+  @PrimaryKey()
+  id!: number;
+
+  @Enum({ items: () => TaskKind, nativeEnumName: 'task_kind' })
+  kind!: TaskKind;
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    metadataProvider: ReflectMetadataProvider,
+    entities: [Task],
+    dbName: '7825',
+  });
+
+  await orm.schema.ensureDatabase();
+  await orm.schema.execute(`drop type if exists task_kind cascade`);
+  await orm.schema.execute(`drop table if exists task`);
+});
+
+afterAll(() => orm.close());
+
+test('GH #7825 — empty native enum is introspected and does not cause spurious create type', async () => {
+  await orm.schema.execute(await orm.schema.getCreateSchemaSQL());
+
+  const diff = await orm.schema.getUpdateSchemaSQL();
+  expect(diff).toBe('');
+});


### PR DESCRIPTION
A native PostgreSQL enum can legitimately have zero members (e.g. every value was removed over time, leaving `create type "x" as enum ();`). The introspection query in `getNativeEnumDefinitions` used an inner join on `pg_enum`, so member-less enums never surfaced — `getUpdateSchemaSQL()` then re-emitted `create type` against an in-sync database.

Switched to a left join, added an explicit `typtype = 'e'` filter to preserve the enum-only restriction the inner join provided implicitly, and used `array_remove(array_agg(...), null)` to collapse the resulting `{NULL}` to `{}`.

Closes #7825