### PR TITLE
fix(sql): emit column name for kysely on-create/on-update hook injection

### DIFF
--- a/packages/sql/src/plugin/transformer.ts
+++ b/packages/sql/src/plugin/transformer.ts
@@ -413,7 +413,7 @@ export class MikroTransformer extends OperationNodeTransformer {
 
     const newColumns = [...node.columns];
     for (const prop of missingProps) {
-      newColumns.push(ColumnNode.create(prop.name));
+      newColumns.push(ColumnNode.create(prop.fieldNames[0]));
     }
 
     const newRows = node.values.values.map(row => {
@@ -466,7 +466,7 @@ export class MikroTransformer extends OperationNodeTransformer {
     const newUpdates = [...node.updates];
     for (const prop of missingProps) {
       const val = prop.onUpdate!(undefined, this.#em);
-      newUpdates.push(ColumnUpdateNode.create(ColumnNode.create(prop.name), ValueNode.create(val)));
+      newUpdates.push(ColumnUpdateNode.create(ColumnNode.create(prop.fieldNames[0]), ValueNode.create(val)));
     }
 
     return {

--- a/tests/features/mikro-kysely-plugin.test.ts
+++ b/tests/features/mikro-kysely-plugin.test.ts
@@ -1896,6 +1896,75 @@ describe('MikroKyselyPlugin', () => {
     });
   });
 
+  describe('hooks with default (column) naming strategy', () => {
+    interface PersonTable extends InferKyselyTable<
+      typeof Person,
+      { processOnCreateHooks: true; processOnUpdateHooks: true }
+    > {}
+    interface DB {
+      person: PersonTable;
+    }
+
+    let orm: MikroORM;
+    let kysely: Kysely<DB>;
+
+    beforeAll(async () => {
+      orm = new MikroORM({
+        entities: [Person, Pet, Toy],
+        dbName: ':memory:',
+      });
+      await orm.schema.refresh();
+      kysely = orm.em.getKysely({
+        processOnCreateHooks: true,
+        processOnUpdateHooks: true,
+        convertValues: true,
+      });
+    });
+
+    afterAll(async () => {
+      await orm.close(true);
+    });
+
+    test('ON CONFLICT with onUpdate hook emits column name, not property name', async () => {
+      const now = new Date(Date.now() - 1000);
+      await kysely
+        .insertInto('person')
+        .values({
+          id: 1234,
+          first_name: 'Conflict',
+          last_name: 'Test',
+          gender: 'male',
+          children: 0,
+          created_at: now,
+          updated_at: now,
+        })
+        .execute();
+
+      await kysely
+        .insertInto('person')
+        .values({
+          id: 1234,
+          first_name: 'NewName',
+          last_name: 'NewLast',
+          gender: 'female',
+          children: 1,
+          created_at: now,
+        })
+        .onConflict(oc =>
+          oc.column('id').doUpdateSet({
+            first_name: 'NewName',
+            // updated_at omitted: added by the onUpdate hook
+          }),
+        )
+        .execute();
+
+      const result = await kysely.selectFrom('person').selectAll().where('id', '=', 1234).executeTakeFirstOrThrow();
+
+      expect(result.first_name).toBe('NewName');
+      expect(new Date(result.updated_at!).getTime()).toBeGreaterThan(now.getTime());
+    });
+  });
+
   describe('type conversions and timezone handling', () => {
     interface TypeTable extends InferKyselyTable<
       typeof TypeEntity,


### PR DESCRIPTION
The kysely plugin injected hook-driven columns using the property name instead of the database column name. Under the default `columnNamingStrategy: 'column'`, no identifier rewrite follows, so an `onConflict().doUpdateSet()` upsert emitted e.g. `updatedAt` and the driver rejected it with "no such column".

Use `prop.fieldNames[0]`, which is the real DB column name and correct under both naming strategies (under `'property'` the field name passes through the identifier rewrite unchanged).

Closes #7836