### PR TITLE
fix(core): use owner targetKey for inverse collection loads

### DIFF
--- a/packages/core/src/entity/Collection.ts
+++ b/packages/core/src/entity/Collection.ts
@@ -15,6 +15,7 @@ import {
   type Primary,
   CollectionBrand,
 } from '../typings.js';
+import { getInverseCollectionOwnerValue } from '../utils/RelationIdentity.js';
 import { Utils } from '../utils/Utils.js';
 import { MetadataError, ValidationError } from '../errors.js';
 import { DataloaderType, ReferenceKind } from '../enums.js';
@@ -454,9 +455,20 @@ export class Collection<T extends object, O extends object = object> {
     return em;
   }
 
+  private getInverseOwnerProp(): EntityProperty | undefined {
+    if (this.property.kind !== ReferenceKind.ONE_TO_MANY) {
+      return undefined;
+    }
+
+    return this.property.targetMeta!.properties[this.property.mappedBy];
+  }
+
   private createCondition<TT extends T>(cond: FilterQuery<TT> = {}): FilterQuery<TT> {
     if (this.property.kind === ReferenceKind.ONE_TO_MANY) {
-      cond[this.property.mappedBy as unknown as FilterKey<TT>] = helper(this.owner).getPrimaryKey() as any;
+      cond[this.property.mappedBy as unknown as FilterKey<TT>] = getInverseCollectionOwnerValue(
+        this.owner,
+        this.getInverseOwnerProp(),
+      ) as any;
     } else {
       // MANY_TO_MANY
       this.createManyToManyCondition(cond);
@@ -479,8 +491,7 @@ export class Collection<T extends object, O extends object = object> {
   }
 
   private createLoadCountCondition(cond: FilterQuery<T>) {
-    const wrapped = helper(this.owner);
-    const val = wrapped.__meta.compositePK ? { $in: wrapped.__primaryKeys } : wrapped.getPrimaryKey();
+    const val = getInverseCollectionOwnerValue(this.owner, this.getInverseOwnerProp(), true);
     const dict = cond as Dictionary;
 
     if (this.property.kind === ReferenceKind.ONE_TO_MANY) {

--- a/packages/core/src/entity/EntityLoader.ts
+++ b/packages/core/src/entity/EntityLoader.ts
@@ -16,6 +16,10 @@ import type {
 } from '../typings.js';
 import type { EntityManager } from '../EntityManager.js';
 import { QueryHelper } from '../utils/QueryHelper.js';
+import {
+  getEntityIdentityKey,
+  getOneToManyChildOwnerKey,
+} from '../utils/RelationIdentity.js';
 import { Utils } from '../utils/Utils.js';
 import { ValidationError } from '../errors.js';
 import type { Collection } from './Collection.js';
@@ -487,25 +491,25 @@ export class EntityLoader {
     partial: boolean,
     readonly?: boolean,
   ): void {
-    const mapToPk = prop.targetMeta!.properties[prop.mappedBy].mapToPk;
+    const ownerProp = prop.targetMeta!.properties[prop.mappedBy];
+    const ownerKey = ownerProp.targetKey;
     const map: Dictionary<Entity[]> = {};
 
     for (const entity of filtered) {
-      const key = helper(entity).getSerializedPrimaryKey();
+      const key = getEntityIdentityKey(entity, ownerKey);
       map[key] = [];
     }
 
     for (const child of children) {
-      const pk = child.__helper.__data[prop.mappedBy] ?? child[prop.mappedBy];
+      const key = getOneToManyChildOwnerKey(child, prop, ownerProp, prop.targetMeta!.class, this.#em);
 
-      if (pk) {
-        const key = helper(mapToPk ? this.#em.getReference(prop.targetMeta!.class, pk) : pk).getSerializedPrimaryKey();
+      if (key) {
         map[key]?.push(child as Entity);
       }
     }
 
     for (const entity of filtered) {
-      const key = helper(entity).getSerializedPrimaryKey();
+      const key = getEntityIdentityKey(entity, ownerKey);
       (entity[field] as unknown as Collection<Entity>).hydrate(map[key], undefined, partial, readonly);
     }
   }
@@ -550,15 +554,17 @@ export class EntityLoader {
   ): Promise<{ items: AnyEntity[]; partial: boolean }> {
     const children = Utils.unique(this.getChildReferences<Entity>(entities, prop, options, ref, populate));
     const meta = prop.targetMeta!;
+    const ownerProp =
+      prop.kind === ReferenceKind.ONE_TO_MANY || (prop.kind === ReferenceKind.MANY_TO_MANY && !prop.owner)
+        ? meta.properties[prop.mappedBy]
+        : undefined;
     // When targetKey is set, use it for FK lookup instead of the PK
     let fk: string | string[] = prop.targetKey ?? Utils.getPrimaryKeyHash(meta.primaryKeys);
     let schema: string | undefined = options.schema;
     const partial = !Utils.isEmpty(prop.where) || !Utils.isEmpty(options.where);
     let polymorphicOwnerProp: EntityProperty | undefined;
 
-    if (prop.kind === ReferenceKind.ONE_TO_MANY || (prop.kind === ReferenceKind.MANY_TO_MANY && !prop.owner)) {
-      const ownerProp = meta.properties[prop.mappedBy];
-
+    if (ownerProp) {
       if (ownerProp.polymorphic && ownerProp.fieldNames.length >= 2) {
         const idColumns = ownerProp.fieldNames.slice(1);
         fk = idColumns.length === 1 ? idColumns[0] : idColumns;
@@ -582,7 +588,8 @@ export class EntityLoader {
       schema = children.find(e => e.__helper!.__schema)?.__helper!.__schema;
     }
 
-    const ids = Utils.unique(children.map(e => (prop.targetKey ? e[prop.targetKey] : e.__helper.getPrimaryKey())));
+    const targetKey = prop?.targetKey ?? ownerProp?.targetKey;
+    const ids = Utils.unique(children.map(e => (targetKey ? e[targetKey] : e.__helper.getPrimaryKey())));
     let where: FilterQuery<Entity>;
 
     if (polymorphicOwnerProp && Array.isArray(fk)) {
@@ -670,7 +677,7 @@ export class EntityLoader {
     if (prop.targetKey && [ReferenceKind.ONE_TO_ONE, ReferenceKind.MANY_TO_ONE].includes(prop.kind)) {
       const itemsByKey = new Map<string, AnyEntity>();
       for (const item of items) {
-        itemsByKey.set('' + item[prop.targetKey], item);
+        itemsByKey.set(getEntityIdentityKey(item, prop.targetKey), item);
       }
 
       for (const entity of entities) {
@@ -680,8 +687,10 @@ export class EntityLoader {
           continue;
         }
 
-        // oxfmt-ignore
-        const keyValue = '' + (Reference.isReference(ref) ? (ref.unwrap() as Dictionary)[prop.targetKey] : (ref as Dictionary)[prop.targetKey]);
+        const keyValue = getEntityIdentityKey(
+          Reference.isReference(ref) ? ref.unwrap() : (ref as AnyEntity),
+          prop.targetKey,
+        );
         const loadedItem = itemsByKey.get(keyValue);
 
         if (loadedItem) {
@@ -696,8 +705,7 @@ export class EntityLoader {
       const nullVal = this.#em.config.get('forceUndefined') ? undefined : null;
       const itemsMap = new Set<string>();
       const childrenMap = new Set<string>();
-      // Use targetKey value if set, otherwise use serialized PK
-      const getKey = (e: AnyEntity) => (prop.targetKey ? '' + e[prop.targetKey] : helper(e).getSerializedPrimaryKey());
+      const getKey = (e: AnyEntity) => getEntityIdentityKey(e, prop.targetKey);
 
       for (const item of items) {
         /* v8 ignore next */

--- a/packages/core/src/utils/RelationIdentity.ts
+++ b/packages/core/src/utils/RelationIdentity.ts
@@ -1,0 +1,82 @@
+import type { AnyEntity, Dictionary, EntityClass, EntityProperty, Primary } from '../typings.js';
+import type { EntityManager } from '../EntityManager.js';
+import { Reference } from '../entity/Reference.js';
+import { helper } from '../entity/wrap.js';
+import { Utils } from './Utils.js';
+
+/** Serialized map key for an entity, using `targetKey` when set instead of the primary key. */
+export function getEntityIdentityKey(entity: AnyEntity, targetKey?: string): string {
+  if (targetKey) {
+    return '' + (entity as Dictionary)[targetKey];
+  }
+
+  return helper(entity).getSerializedPrimaryKey();
+}
+
+/**
+ * FK / filter value for the owner side of an inverse collection (`OneToMany` / non-owning `ManyToMany`).
+ * When `composite` is true, composite PK owners use `{ $in: primaryKeys }` (e.g. count queries).
+ */
+export function getInverseCollectionOwnerValue(
+  owner: AnyEntity,
+  ownerProp?: Pick<EntityProperty, 'targetKey'>,
+  composite = false,
+): unknown {
+  if (ownerProp?.targetKey) {
+    return (owner as Dictionary)[ownerProp.targetKey];
+  }
+
+  const wrapped = helper(owner);
+
+  if (composite && wrapped.__meta.compositePK) {
+    return { $in: wrapped.__primaryKeys };
+  }
+
+  return wrapped.getPrimaryKey();
+}
+
+/**
+ * Map key for wiring loaded `OneToMany` children to their parent, from the child's owning FK (`mappedBy`).
+ */
+export function getOneToManyChildOwnerKey(
+  child: AnyEntity,
+  prop: Pick<EntityProperty, 'mappedBy'>,
+  ownerProp: EntityProperty,
+  targetClass: EntityClass<AnyEntity>,
+  em: EntityManager,
+): string | undefined {
+  const fk = child.__helper.__data[prop.mappedBy] ?? child[prop.mappedBy];
+
+  if (!fk) {
+    return undefined;
+  }
+
+  return getRelationFkIdentityKey(fk, ownerProp, targetClass, em);
+}
+
+function getRelationFkIdentityKey(
+  fk: unknown,
+  ownerProp: EntityProperty,
+  targetClass: EntityClass<AnyEntity>,
+  em: EntityManager,
+): string {
+  const targetKey = ownerProp.targetKey;
+
+  if (targetKey) {
+    if (ownerProp.mapToPk) {
+      return helper(em.getReference(targetClass, fk as Primary)).getSerializedPrimaryKey();
+    }
+
+    const ref = Reference.isReference(fk) ? fk.unwrap() : fk;
+
+    if (Utils.isEntity(ref)) {
+      return getEntityIdentityKey(ref, targetKey);
+    }
+
+    return '' + fk;
+  }
+
+  const entity = ownerProp.mapToPk ? em.getReference(targetClass, fk as Primary) : (fk as AnyEntity);
+
+  return helper(entity).getSerializedPrimaryKey();
+}

--- a/tests/features/non-pk-relation-target/non-pk-relation-target.postgres.test.ts
+++ b/tests/features/non-pk-relation-target/non-pk-relation-target.postgres.test.ts
@@ -9,8 +9,7 @@ import {
   ReflectMetadataProvider,
 } from '@mikro-orm/decorators/legacy';
 
-// Entity in custom schema
-@Entity({ schema: 'custom_schema' })
+@Entity()
 class Author {
   @PrimaryKey()
   id!: number;
@@ -22,11 +21,11 @@ class Author {
   @Property()
   name!: string;
 
-  @OneToMany(() => Book, b => b.author)
+  @OneToMany(() => Book, book => book.author)
   books = new Collection<Book>(this);
 }
 
-@Entity({ schema: 'custom_schema' })
+@Entity()
 class Book {
   @PrimaryKey()
   id!: number;
@@ -38,7 +37,7 @@ class Book {
   author!: Ref<Author>;
 }
 
-describe('non-PK relation target with schema (postgres)', () => {
+describe('non-PK relation target (targetKey)', () => {
   let orm: MikroORM;
 
   beforeAll(async () => {
@@ -48,99 +47,52 @@ describe('non-PK relation target with schema (postgres)', () => {
       dbName: 'mikro_orm_test_non_pk_target',
     });
     await orm.schema.ensureDatabase();
+    await orm.schema.refresh();
 
-    // Drop and recreate schema using schema generator
-    await orm.schema.execute('drop schema if exists custom_schema cascade');
-    await orm.schema.update({ schema: 'custom_schema' });
+    const author = orm.em.create(Author, { uuid: 'uuid-123', name: 'John Doe' });
+    orm.em.create(Book, { title: 'My Book', author });
+    await orm.em.flush();
   });
 
   beforeEach(() => orm.em.clear());
 
   afterAll(() => orm.close(true));
 
-  test('relation with targetKey in custom schema', async () => {
-    // Create an author
-    const author = orm.em.create(Author, { uuid: 'uuid-123', name: 'John Doe' });
-    await orm.em.flush();
-    orm.em.clear();
-
-    // Load the author
-    const loadedAuthor = await orm.em.findOneOrFail(Author, { name: 'John Doe' });
-    expect(loadedAuthor.uuid).toBe('uuid-123');
-
-    // Create a book with the author
-    const book = orm.em.create(Book, {
-      title: 'Test Book',
-      author: loadedAuthor,
-    });
-    await orm.em.flush();
-    orm.em.clear();
-
-    // Load the book and verify the author reference works
-    const loadedBook = await orm.em.findOneOrFail(
-      Book,
-      { title: 'Test Book' },
-      {
-        populate: ['author'],
-      },
-    );
+  test('creating book with author reference by uuid', async () => {
+    const loadedBook = await orm.em.findOneOrFail(Book, { title: 'My Book' });
     expect(loadedBook.author.unwrap().uuid).toBe('uuid-123');
-    expect(loadedBook.author.unwrap().name).toBe('John Doe');
   });
 
-  test('identity map key includes schema for alternate key', async () => {
-    // Get a reference to author by uuid
-    const authorRef = orm.em.getReference(Author, 'uuid-123', { key: 'uuid' });
-
-    // Verify it's stored in identity map with the correct schema
-    const identityMap = orm.em.getUnitOfWork().getIdentityMap();
-    const keys = identityMap.keys();
-
-    // Check that the key includes schema information
-    const authorKey = keys.find(k => k.includes('Author') && k.includes('[uuid]'));
-    expect(authorKey).toBeDefined();
-    expect(authorKey).toContain('custom_schema'); // Should include schema in the key
-  });
-
-  test('getReference finds entity by alternate key with schema', async () => {
-    // Load the book without populating author
-    const book = await orm.em.findOneOrFail(Book, { title: 'Test Book' });
+  test('populate author with select-in strategy', async () => {
+    const book = await orm.em.findOneOrFail(Book, { title: 'My Book' });
     expect(book.author.isInitialized()).toBe(false);
 
-    // The author reference should have the uuid property set
-    const authorRef = book.author.unwrap();
-    expect(authorRef.uuid).toBe('uuid-123');
-
-    // Populate and verify
-    await orm.em.populate(book, ['author']);
+    await orm.em.populate(book, ['author'], { strategy: 'select-in' });
     expect(book.author.isInitialized()).toBe(true);
+    expect(book.author.unwrap().uuid).toBe('uuid-123');
     expect(book.author.unwrap().name).toBe('John Doe');
   });
 
-  test('select-in strategy works with targetKey in custom schema', async () => {
-    // Create another book
+  test('populate inverse oneToMany uses targetKey on owning side', async () => {
     const author = await orm.em.findOneOrFail(Author, { name: 'John Doe' });
-    const book2 = orm.em.create(Book, {
-      title: 'Second Book',
-      author,
-    });
-    await orm.em.flush();
-    orm.em.clear();
+    expect(author.books.isInitialized()).toBe(false);
 
-    // Load books with select-in strategy
-    const books = await orm.em.find(
-      Book,
-      {},
-      {
-        populate: ['author'],
-        strategy: 'select-in',
-        orderBy: { title: 'asc' },
-      },
-    );
+    await orm.em.populate(author, ['books']);
+    expect(author.books.isInitialized()).toBe(true);
+    expect(author.books.getItems()).toHaveLength(1);
+    expect(author.books.getItems()[0].title).toBe('My Book');
+  });
 
-    expect(books).toHaveLength(2);
-    // Both books should reference the same author instance
-    expect(books[0].author.unwrap()).toBe(books[1].author.unwrap());
-    expect(books[0].author.unwrap().uuid).toBe('uuid-123');
+  test('find author with populate books uses targetKey', async () => {
+    const author = await orm.em.findOneOrFail(Author, { name: 'John Doe' }, { populate: ['books'] });
+    expect(author.books.getItems()).toHaveLength(1);
+    expect(author.books.getItems()[0].title).toBe('My Book');
+  });
+
+  test('collection.load uses targetKey on owning side', async () => {
+    const author = await orm.em.findOneOrFail(Author, { name: 'John Doe' });
+    const books = await author.books.loadItems();
+    expect(books).toHaveLength(1);
+    expect(books[0].title).toBe('My Book');
   });
 });

--- a/tests/features/non-pk-relation-target/non-pk-relation-target.sqlite.test.ts
+++ b/tests/features/non-pk-relation-target/non-pk-relation-target.sqlite.test.ts
@@ -169,6 +169,29 @@ describe('non-PK relation target (targetKey)', () => {
     expect(book.author.unwrap().name).toBe('John Doe');
   });
 
+  test('populate inverse oneToMany uses targetKey on owning side', async () => {
+    const author = await orm.em.findOneOrFail(Author, { name: 'John Doe' });
+    expect(author.books.isInitialized()).toBe(false);
+
+    await orm.em.populate(author, ['books']);
+    expect(author.books.isInitialized()).toBe(true);
+    expect(author.books.getItems()).toHaveLength(1);
+    expect(author.books.getItems()[0].title).toBe('My Book');
+  });
+
+  test('find author with populate books uses targetKey', async () => {
+    const author = await orm.em.findOneOrFail(Author, { name: 'John Doe' }, { populate: ['books'] });
+    expect(author.books.getItems()).toHaveLength(1);
+    expect(author.books.getItems()[0].title).toBe('My Book');
+  });
+
+  test('collection.load uses targetKey on owning side', async () => {
+    const author = await orm.em.findOneOrFail(Author, { name: 'John Doe' });
+    const books = await author.books.loadItems();
+    expect(books).toHaveLength(1);
+    expect(books[0].title).toBe('My Book');
+  });
+
   test('multiple books with same author are resolved correctly', async () => {
     // Create another book with the same author
     const author = await orm.em.findOneOrFail(Author, { name: 'John Doe' });
@@ -433,6 +456,18 @@ describe('non-PK relation target with defineEntity', () => {
     );
     expect(loadedBook.author.uuid).toBe('def-uuid-123');
     expect(loadedBook.author.name).toBe('Defined Author');
+  });
+
+  test('defineEntity populate inverse oneToMany with targetKey', async () => {
+    const author = orm.em.create(DefAuthor, { uuid: 'def-uuid-456', name: 'Author For Books' });
+    orm.em.create(DefBook, { title: 'Inverse Book', author });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const loadedAuthor = await orm.em.findOneOrFail(DefAuthor, { uuid: 'def-uuid-456' });
+    await orm.em.populate(loadedAuthor, ['books']);
+    expect(loadedAuthor.books.getItems()).toHaveLength(1);
+    expect(loadedAuthor.books.getItems()[0].title).toBe('Inverse Book');
   });
 });
 


### PR DESCRIPTION
Populate, find, and Collection.load/count for inverse OneToMany relations now resolve identity from the owning side's targetKey (e.g. uuid) instead of the parent's primary key. Child hydration and FK id collection in EntityLoader follow the same rule.

Extract RelationIdentity helpers for entity/collection keys and OneToMany child wiring. Collection reuses getInverseCollectionOwnerValue for load and count conditions.

Add non-pk-relation-target tests for inverse populate, find+populate, and collection.loadItems.

Full disclosure AI helped me write this. There is no way I could absorb enough info about the codebase to make this change. Please review with a close eye.