### PR TITLE
fix(core): use owner targetKey for inverse collection loads

### DIFF
--- a/packages/core/src/entity/Collection.ts
+++ b/packages/core/src/entity/Collection.ts
@@ -454,9 +454,17 @@ export class Collection<T extends object, O extends object = object> {
     return em;
   }
 
+  /** The owning-side property this collection is mapped by (the inverse of `mappedBy`); `undefined` for the owning side of m:n. */
+  private get mappedByProp(): EntityProperty | undefined {
+    return this.property.mappedBy ? this.property.targetMeta!.properties[this.property.mappedBy] : undefined;
+  }
+
   private createCondition<TT extends T>(cond: FilterQuery<TT> = {}): FilterQuery<TT> {
     if (this.property.kind === ReferenceKind.ONE_TO_MANY) {
-      cond[this.property.mappedBy as unknown as FilterKey<TT>] = helper(this.owner).getPrimaryKey() as any;
+      // the owning FK may reference a non-PK column (`targetKey`), so match on that value when set
+      cond[this.property.mappedBy as unknown as FilterKey<TT>] = helper(this.owner).getTargetKeyValue(
+        this.mappedByProp?.targetKey,
+      ) as any;
     } else {
       // MANY_TO_MANY
       this.createManyToManyCondition(cond);
@@ -480,7 +488,12 @@ export class Collection<T extends object, O extends object = object> {
 
   private createLoadCountCondition(cond: FilterQuery<T>) {
     const wrapped = helper(this.owner);
-    const val = wrapped.__meta.compositePK ? { $in: wrapped.__primaryKeys } : wrapped.getPrimaryKey();
+    const ownerProp = this.mappedByProp;
+    const val = ownerProp?.targetKey
+      ? wrapped.getTargetKeyValue(ownerProp.targetKey)
+      : wrapped.__meta.compositePK
+        ? { $in: wrapped.__primaryKeys }
+        : wrapped.getPrimaryKey();
     const dict = cond as Dictionary;
 
     if (this.property.kind === ReferenceKind.ONE_TO_MANY) {

--- a/packages/core/src/entity/EntityLoader.ts
+++ b/packages/core/src/entity/EntityLoader.ts
@@ -504,8 +504,8 @@ export class EntityLoader {
         let key: string;
 
         if (targetKey) {
-          const ref = Reference.isReference(fk) ? fk.unwrap() : fk;
-          key = Utils.isEntity(ref) ? helper(ref).getSerializedTargetKey(targetKey) : '' + fk;
+          // `fk` is the owner reference (resolve its targetKey) unless the relation maps to the raw PK value
+          key = Utils.isEntity(fk, true) ? helper(fk).getSerializedTargetKey(targetKey) : '' + fk;
         } else {
           key = helper(
             ownerProp.mapToPk ? this.#em.getReference(prop.targetMeta!.class, fk) : fk,

--- a/packages/core/src/entity/EntityLoader.ts
+++ b/packages/core/src/entity/EntityLoader.ts
@@ -487,26 +487,37 @@ export class EntityLoader {
     partial: boolean,
     readonly?: boolean,
   ): void {
-    const mapToPk = prop.targetMeta!.properties[prop.mappedBy].mapToPk;
+    const ownerProp = prop.targetMeta!.properties[prop.mappedBy];
+    const targetKey = ownerProp.targetKey;
     const map: Dictionary<Entity[]> = {};
+    // when the owning side targets a non-PK column, group by that value on both sides
+    const parentKey = (entity: AnyEntity) => helper(entity).getSerializedTargetKey(targetKey);
 
     for (const entity of filtered) {
-      const key = helper(entity).getSerializedPrimaryKey();
-      map[key] = [];
+      map[parentKey(entity)] = [];
     }
 
     for (const child of children) {
-      const pk = child.__helper.__data[prop.mappedBy] ?? child[prop.mappedBy];
+      const fk = child.__helper.__data[prop.mappedBy] ?? child[prop.mappedBy];
 
-      if (pk) {
-        const key = helper(mapToPk ? this.#em.getReference(prop.targetMeta!.class, pk) : pk).getSerializedPrimaryKey();
+      if (fk) {
+        let key: string;
+
+        if (targetKey) {
+          const ref = Reference.isReference(fk) ? fk.unwrap() : fk;
+          key = Utils.isEntity(ref) ? helper(ref).getSerializedTargetKey(targetKey) : '' + fk;
+        } else {
+          key = helper(
+            ownerProp.mapToPk ? this.#em.getReference(prop.targetMeta!.class, fk) : fk,
+          ).getSerializedPrimaryKey();
+        }
+
         map[key]?.push(child as Entity);
       }
     }
 
     for (const entity of filtered) {
-      const key = helper(entity).getSerializedPrimaryKey();
-      (entity[field] as unknown as Collection<Entity>).hydrate(map[key], undefined, partial, readonly);
+      (entity[field] as unknown as Collection<Entity>).hydrate(map[parentKey(entity)], undefined, partial, readonly);
     }
   }
 
@@ -555,10 +566,12 @@ export class EntityLoader {
     let schema: string | undefined = options.schema;
     const partial = !Utils.isEmpty(prop.where) || !Utils.isEmpty(options.where);
     let polymorphicOwnerProp: EntityProperty | undefined;
+    const ownerProp =
+      prop.kind === ReferenceKind.ONE_TO_MANY || (prop.kind === ReferenceKind.MANY_TO_MANY && !prop.owner)
+        ? meta.properties[prop.mappedBy]
+        : undefined;
 
-    if (prop.kind === ReferenceKind.ONE_TO_MANY || (prop.kind === ReferenceKind.MANY_TO_MANY && !prop.owner)) {
-      const ownerProp = meta.properties[prop.mappedBy];
-
+    if (ownerProp) {
       if (ownerProp.polymorphic && ownerProp.fieldNames.length >= 2) {
         const idColumns = ownerProp.fieldNames.slice(1);
         fk = idColumns.length === 1 ? idColumns[0] : idColumns;
@@ -582,7 +595,9 @@ export class EntityLoader {
       schema = children.find(e => e.__helper!.__schema)?.__helper!.__schema;
     }
 
-    const ids = Utils.unique(children.map(e => (prop.targetKey ? e[prop.targetKey] : e.__helper.getPrimaryKey())));
+    // for inverse sides the `targetKey` lives on the owning property, otherwise on the prop itself
+    const targetKey = prop.targetKey ?? ownerProp?.targetKey;
+    const ids = Utils.unique(children.map(e => e.__helper.getTargetKeyValue(targetKey)));
     let where: FilterQuery<Entity>;
 
     if (polymorphicOwnerProp && Array.isArray(fk)) {
@@ -670,7 +685,7 @@ export class EntityLoader {
     if (prop.targetKey && [ReferenceKind.ONE_TO_ONE, ReferenceKind.MANY_TO_ONE].includes(prop.kind)) {
       const itemsByKey = new Map<string, AnyEntity>();
       for (const item of items) {
-        itemsByKey.set('' + item[prop.targetKey], item);
+        itemsByKey.set(helper(item).getSerializedTargetKey(prop.targetKey), item);
       }
 
       for (const entity of entities) {
@@ -680,8 +695,7 @@ export class EntityLoader {
           continue;
         }
 
-        // oxfmt-ignore
-        const keyValue = '' + (Reference.isReference(ref) ? (ref.unwrap() as Dictionary)[prop.targetKey] : (ref as Dictionary)[prop.targetKey]);
+        const keyValue = helper(Reference.isReference(ref) ? ref.unwrap() : ref).getSerializedTargetKey(prop.targetKey);
         const loadedItem = itemsByKey.get(keyValue);
 
         if (loadedItem) {
@@ -696,7 +710,8 @@ export class EntityLoader {
       const nullVal = this.#em.config.get('forceUndefined') ? undefined : null;
       const itemsMap = new Set<string>();
       const childrenMap = new Set<string>();
-      // Use targetKey value if set, otherwise use serialized PK
+      // `e` may be an unresolved reference here, so read the targetKey value directly instead of
+      // resolving it through the entity — that keeps orphaned references (missing target row) intact
       const getKey = (e: AnyEntity) => (prop.targetKey ? '' + e[prop.targetKey] : helper(e).getSerializedPrimaryKey());
 
       for (const item of items) {

--- a/packages/core/src/entity/EntityLoader.ts
+++ b/packages/core/src/entity/EntityLoader.ts
@@ -695,7 +695,7 @@ export class EntityLoader {
           continue;
         }
 
-        const keyValue = helper(Reference.isReference(ref) ? ref.unwrap() : ref).getSerializedTargetKey(prop.targetKey);
+        const keyValue = helper(ref).getSerializedTargetKey(prop.targetKey);
         const loadedItem = itemsByKey.get(keyValue);
 
         if (loadedItem) {

--- a/packages/core/src/entity/WrappedEntity.ts
+++ b/packages/core/src/entity/WrappedEntity.ts
@@ -296,6 +296,16 @@ export class WrappedEntity<Entity extends object> {
     return this.pkSerializer!(this.entity);
   }
 
+  /** Returns the value a relation references on this entity — the `targetKey` column when set, otherwise the primary key. */
+  getTargetKeyValue(targetKey?: string): Primary<Entity> | null {
+    return targetKey ? ((this.entity as Dictionary)[targetKey] as Primary<Entity>) : this.getPrimaryKey();
+  }
+
+  /** Serialized counterpart of `getTargetKeyValue`, suitable for identity map / grouping keys. */
+  getSerializedTargetKey(targetKey?: string): string {
+    return targetKey ? '' + (this.entity as Dictionary)[targetKey] : this.getSerializedPrimaryKey();
+  }
+
   get __meta(): EntityMetadata<Entity> {
     return (this.entity as IWrappedEntityInternal<Entity>).__meta;
   }

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -596,6 +596,8 @@ export interface IWrappedEntityInternal<Entity extends object> extends IWrappedE
   getPrimaryKeys(convertCustomTypes?: boolean): Primary<Entity>[] | null;
   setPrimaryKey(val: Primary<Entity>): void;
   getSerializedPrimaryKey(): string & keyof Entity;
+  getTargetKeyValue(targetKey?: string): Primary<Entity> | null;
+  getSerializedTargetKey(targetKey?: string): string;
   __meta: EntityMetadata<Entity>;
   __data: Dictionary;
   __em?: EntityManager;

--- a/tests/features/non-pk-relation-target/non-pk-relation-target.postgres.test.ts
+++ b/tests/features/non-pk-relation-target/non-pk-relation-target.postgres.test.ts
@@ -181,4 +181,14 @@ describe('non-PK relation target with schema (postgres)', () => {
     expect(books).toHaveLength(1);
     expect(books[0].title).toBe('Inverse Book 3');
   });
+
+  test('collection.loadCount uses targetKey on owning side', async () => {
+    const author = orm.em.create(Author, { uuid: 'uuid-inv-4', name: 'Inverse Four' });
+    orm.em.create(Book, { title: 'Inverse Book 4', author });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const loaded = await orm.em.findOneOrFail(Author, { uuid: 'uuid-inv-4' });
+    await expect(loaded.books.loadCount()).resolves.toBe(1);
+  });
 });

--- a/tests/features/non-pk-relation-target/non-pk-relation-target.postgres.test.ts
+++ b/tests/features/non-pk-relation-target/non-pk-relation-target.postgres.test.ts
@@ -143,4 +143,42 @@ describe('non-PK relation target with schema (postgres)', () => {
     expect(books[0].author.unwrap()).toBe(books[1].author.unwrap());
     expect(books[0].author.unwrap().uuid).toBe('uuid-123');
   });
+
+  test('populate inverse oneToMany uses targetKey on owning side', async () => {
+    const author = orm.em.create(Author, { uuid: 'uuid-inv-1', name: 'Inverse One' });
+    orm.em.create(Book, { title: 'Inverse Book 1', author });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const loaded = await orm.em.findOneOrFail(Author, { uuid: 'uuid-inv-1' });
+    expect(loaded.books.isInitialized()).toBe(false);
+
+    await orm.em.populate(loaded, ['books']);
+    expect(loaded.books.isInitialized()).toBe(true);
+    expect(loaded.books.getItems()).toHaveLength(1);
+    expect(loaded.books.getItems()[0].title).toBe('Inverse Book 1');
+  });
+
+  test('find author with populate books uses targetKey', async () => {
+    const author = orm.em.create(Author, { uuid: 'uuid-inv-2', name: 'Inverse Two' });
+    orm.em.create(Book, { title: 'Inverse Book 2', author });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const loaded = await orm.em.findOneOrFail(Author, { uuid: 'uuid-inv-2' }, { populate: ['books'] });
+    expect(loaded.books.getItems()).toHaveLength(1);
+    expect(loaded.books.getItems()[0].title).toBe('Inverse Book 2');
+  });
+
+  test('collection.load uses targetKey on owning side', async () => {
+    const author = orm.em.create(Author, { uuid: 'uuid-inv-3', name: 'Inverse Three' });
+    orm.em.create(Book, { title: 'Inverse Book 3', author });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const loaded = await orm.em.findOneOrFail(Author, { uuid: 'uuid-inv-3' });
+    const books = await loaded.books.loadItems();
+    expect(books).toHaveLength(1);
+    expect(books[0].title).toBe('Inverse Book 3');
+  });
 });

--- a/tests/features/non-pk-relation-target/non-pk-relation-target.sqlite.test.ts
+++ b/tests/features/non-pk-relation-target/non-pk-relation-target.sqlite.test.ts
@@ -169,6 +169,29 @@ describe('non-PK relation target (targetKey)', () => {
     expect(book.author.unwrap().name).toBe('John Doe');
   });
 
+  test('populate inverse oneToMany uses targetKey on owning side', async () => {
+    const author = await orm.em.findOneOrFail(Author, { name: 'John Doe' });
+    expect(author.books.isInitialized()).toBe(false);
+
+    await orm.em.populate(author, ['books']);
+    expect(author.books.isInitialized()).toBe(true);
+    expect(author.books.getItems()).toHaveLength(1);
+    expect(author.books.getItems()[0].title).toBe('My Book');
+  });
+
+  test('find author with populate books uses targetKey', async () => {
+    const author = await orm.em.findOneOrFail(Author, { name: 'John Doe' }, { populate: ['books'] });
+    expect(author.books.getItems()).toHaveLength(1);
+    expect(author.books.getItems()[0].title).toBe('My Book');
+  });
+
+  test('collection.load uses targetKey on owning side', async () => {
+    const author = await orm.em.findOneOrFail(Author, { name: 'John Doe' });
+    const books = await author.books.loadItems();
+    expect(books).toHaveLength(1);
+    expect(books[0].title).toBe('My Book');
+  });
+
   test('multiple books with same author are resolved correctly', async () => {
     // Create another book with the same author
     const author = await orm.em.findOneOrFail(Author, { name: 'John Doe' });
@@ -433,6 +456,18 @@ describe('non-PK relation target with defineEntity', () => {
     );
     expect(loadedBook.author.uuid).toBe('def-uuid-123');
     expect(loadedBook.author.name).toBe('Defined Author');
+  });
+
+  test('defineEntity populate inverse oneToMany with targetKey', async () => {
+    const author = orm.em.create(DefAuthor, { uuid: 'def-uuid-456', name: 'Author For Books' });
+    orm.em.create(DefBook, { title: 'Inverse Book', author });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const loadedAuthor = await orm.em.findOneOrFail(DefAuthor, { uuid: 'def-uuid-456' });
+    await orm.em.populate(loadedAuthor, ['books']);
+    expect(loadedAuthor.books.getItems()).toHaveLength(1);
+    expect(loadedAuthor.books.getItems()[0].title).toBe('Inverse Book');
   });
 });
 

--- a/tests/features/non-pk-relation-target/non-pk-relation-target.sqlite.test.ts
+++ b/tests/features/non-pk-relation-target/non-pk-relation-target.sqlite.test.ts
@@ -192,6 +192,11 @@ describe('non-PK relation target (targetKey)', () => {
     expect(books[0].title).toBe('My Book');
   });
 
+  test('collection.loadCount uses targetKey on owning side', async () => {
+    const author = await orm.em.findOneOrFail(Author, { name: 'John Doe' });
+    await expect(author.books.loadCount()).resolves.toBe(1);
+  });
+
   test('multiple books with same author are resolved correctly', async () => {
     // Create another book with the same author
     const author = await orm.em.findOneOrFail(Author, { name: 'John Doe' });


### PR DESCRIPTION
Inverse `OneToMany` populate/find and `Collection.load`/`count` resolved the owner identity from the parent's primary key, so collections came back empty whenever the owning side referenced a non-PK column via `targetKey`. Both sides now key off the owner's `targetKey` value when set, falling back to the PK.

Adds two siblings on `WrappedEntity` — `getTargetKeyValue` / `getSerializedTargetKey` — for the value/serialized key a relation references on an entity (the `targetKey` column when set, otherwise the PK), plus a `Collection.mappedByProp` accessor for the owning-side property. These replace the ad-hoc `targetKey`-vs-PK ternaries previously scattered across `EntityLoader` and `Collection`.

Reimplemented from #7842 — thanks @jaronpate for the report and original patch.

Closes #7842