### PR TITLE
fix(core): populate polymorphic embedded arrays loaded via a relation

### DIFF
--- a/packages/sql/src/AbstractSqlDriver.ts
+++ b/packages/sql/src/AbstractSqlDriver.ts
@@ -814,7 +814,7 @@ export abstract class AbstractSqlDriver<
       return;
     }
 
-    if (prop.polymorphic) {
+    if (prop.polymorphic && prop.kind !== ReferenceKind.EMBEDDED) {
       const discriminatorAlias = `${relationAlias}__${prop.fieldNames[0]}` as EntityKey<T>;
       const discriminatorValue = root[discriminatorAlias] as string;
       const pkFieldNames = prop.fieldNames.slice(1);

--- a/tests/features/embeddables/GH7845.test.ts
+++ b/tests/features/embeddables/GH7845.test.ts
@@ -1,0 +1,114 @@
+import { Collection, MikroORM } from '@mikro-orm/sqlite';
+import {
+  Embeddable,
+  Embedded,
+  Entity,
+  Enum,
+  ManyToOne,
+  OneToMany,
+  PrimaryKey,
+  Property,
+} from '@mikro-orm/decorators/legacy';
+
+enum TagType {
+  CATEGORY,
+  KEYWORD,
+}
+
+@Embeddable({ abstract: true, discriminatorColumn: 'type' })
+abstract class BaseTag {
+  @Enum(() => TagType)
+  type!: TagType;
+
+  @Property({ type: 'string' })
+  name!: string;
+}
+
+@Embeddable({ discriminatorValue: TagType.CATEGORY })
+class CategoryTag extends BaseTag {
+  @Property({ type: 'number' })
+  category: number;
+
+  constructor(name: string, category: number) {
+    super();
+    this.type = TagType.CATEGORY;
+    this.name = name;
+    this.category = category;
+  }
+}
+
+@Embeddable({ discriminatorValue: TagType.KEYWORD })
+class KeywordTag extends BaseTag {
+  @Property({ type: 'string' })
+  keyword: string;
+
+  constructor(name: string, keyword: string) {
+    super();
+    this.type = TagType.KEYWORD;
+    this.name = name;
+    this.keyword = keyword;
+  }
+}
+
+@Entity()
+class Group {
+  @PrimaryKey({ type: 'number' })
+  id!: number;
+
+  @Property({ type: 'string' })
+  name: string;
+
+  @OneToMany(() => User, user => user.group)
+  users = new Collection<User>(this);
+
+  @Embedded(() => [KeywordTag, CategoryTag], { array: true })
+  tags: (KeywordTag | CategoryTag)[] = [];
+
+  constructor(name: string, tags: (KeywordTag | CategoryTag)[]) {
+    this.name = name;
+    this.tags = tags;
+  }
+}
+
+@Entity()
+class User {
+  @PrimaryKey({ type: 'number' })
+  id!: number;
+
+  @Property({ type: 'string' })
+  name: string;
+
+  @ManyToOne(() => Group, { nullable: true })
+  group?: Group;
+
+  constructor(name: string, group?: Group) {
+    this.name = name;
+    this.group = group;
+  }
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    entities: [Group, User, BaseTag, CategoryTag, KeywordTag],
+    dbName: ':memory:',
+  });
+  await orm.schema.create();
+});
+
+afterAll(() => orm.close());
+
+test('polymorphic embedded array is populated when loaded through a relation', async () => {
+  const group = new Group('g1', [new CategoryTag('c1', 1), new KeywordTag('k1', 'kw')]);
+  orm.em.create(User, new User('u1', group));
+  await orm.em.flush();
+  orm.em.clear();
+
+  const users = await orm.em.findAll(User, { populate: ['group'] });
+  expect(users[0].group!.tags).toHaveLength(2);
+  expect(users[0].group!.tags[0]).toBeInstanceOf(CategoryTag);
+  expect(users[0].group!.tags[0]).toMatchObject({ type: TagType.CATEGORY, name: 'c1', category: 1 });
+  expect(users[0].group!.tags[1]).toBeInstanceOf(KeywordTag);
+  expect(users[0].group!.tags[1]).toMatchObject({ type: TagType.KEYWORD, name: 'k1', keyword: 'kw' });
+});


### PR DESCRIPTION
Polymorphic embeddables (`@Embedded(() => [A, B], { array: true })` with an abstract base + discriminator) were not populated when their owning entity was loaded through a joined relation (e.g. `em.findAll(User, { populate: ['group'] })`), even though querying the owner directly worked fine.

A polymorphic embeddable carries `prop.polymorphic === true`, so in `mapJoinedProp` the embedded column was routed into the polymorphic-*relation* branch (which builds a `PolymorphicRef` from a discriminator + FK), instead of the embedded branch that JSON-parses the column and maps each row. The array/object therefore stayed unpopulated.

The fix excludes `EMBEDDED` props from that branch so they fall through to the existing embedded handler.

Closes #7845