### PR TITLE
fix(core): allow array return in onCreate/onUpdate on embedded/scalar arrays

### DIFF
--- a/packages/core/src/entity/defineEntity.ts
+++ b/packages/core/src/entity/defineEntity.ts
@@ -130,14 +130,14 @@ export interface PropertyChain<Value, Options> {
   name<T extends string>(name: T): PropertyChain<Value, Omit<Options, 'fieldName'> & { fieldName: T }>;
   fieldName<T extends string>(fieldName: T): PropertyChain<Value, Omit<Options, 'fieldName'> & { fieldName: T }>;
   onCreate(
-    onCreate: (entity: any, em: EntityManager) => Value,
+    onCreate: (entity: any, em: EntityManager) => MaybeArray<Value, Options>,
   ): PropertyChain<Value, Options & { onCreate: (...args: any[]) => any }>;
   default(
     defaultValue: string | string[] | number | number[] | boolean | null | Date | Raw,
   ): PropertyChain<Value, Omit<Options, 'default'> & { default: any }>;
   defaultRaw(defaultRaw: string): PropertyChain<Value, Options & { defaultRaw: string }>;
   formula(formula: string | FormulaCallback<any>): PropertyChain<Value, Omit<Options, 'formula'> & { formula: any }>;
-  onUpdate(onUpdate: (entity: any, em: EntityManager) => Value): PropertyChain<Value, Options>;
+  onUpdate(onUpdate: (entity: any, em: EntityManager) => MaybeArray<Value, Options>): PropertyChain<Value, Options>;
   fieldNames(...fieldNames: string[]): PropertyChain<Value, Options>;
   type(type: PropertyValueType): PropertyChain<Value, Options>;
   runtimeType(runtimeType: string): PropertyChain<Value, Options>;
@@ -468,7 +468,7 @@ export class UniversalPropertyOptionsBuilder<Value, Options, IncludeKeys extends
    * Automatically set the property value when entity gets created, executed during flush operation.
    */
   onCreate(
-    onCreate: (entity: any, em: EntityManager) => Value,
+    onCreate: (entity: any, em: EntityManager) => MaybeArray<Value, Options>,
   ): Pick<
     UniversalPropertyOptionsBuilder<Value, Options & { onCreate: (...args: any[]) => any }, IncludeKeys>,
     IncludeKeys
@@ -480,7 +480,7 @@ export class UniversalPropertyOptionsBuilder<Value, Options, IncludeKeys extends
    * Automatically update the property value every time entity gets updated, executed during flush operation.
    */
   onUpdate(
-    onUpdate: (entity: any, em: EntityManager) => Value,
+    onUpdate: (entity: any, em: EntityManager) => MaybeArray<Value, Options>,
   ): Pick<UniversalPropertyOptionsBuilder<Value, Options, IncludeKeys>, IncludeKeys> {
     return this.assignOptions({ onUpdate });
   }

--- a/tests/defineEntity.test.ts
+++ b/tests/defineEntity.test.ts
@@ -1776,6 +1776,33 @@ describe('EmbeddedOptionsBuilder', () => {
     expect(User.meta).toEqual(asSnapshot(UserSchema.meta));
     User.init();
   });
+
+  it('should allow .onCreate() returning an array on embedded arrays', () => {
+    const Address = defineEntity({
+      name: 'Address',
+      embeddable: true,
+      properties: p => ({
+        street: p.string(),
+      }),
+    });
+
+    const User = defineEntity({
+      name: 'User',
+      properties: p => ({
+        id: p.integer().primary().autoincrement(),
+        addresses: () =>
+          p
+            .embedded(Address)
+            .array()
+            .onCreate(() => []),
+      }),
+    });
+
+    type IUser = InferEntity<typeof User>;
+    assert<IsExact<IUser['addresses'], Opt<InferEntity<typeof Address>[]>>>(true);
+
+    expect(User.meta.properties.addresses.array).toBe(true);
+  });
 });
 
 describe('ManyToManyRelationOptionsBuilder', () => {


### PR DESCRIPTION
The fluent `defineEntity` builder typed `onCreate`/`onUpdate` callbacks to return the singular `Value`, so chaining `.array().onCreate(() => [])` (as shown in the [embeddables docs](https://mikro-orm.io/docs/embeddables#array-of-embeddables)) failed type checking with `Type 'never[]' is not assignable to type '...'`.

Fix wraps the callback return type in the existing `MaybeArray<Value, Options>` helper so it follows the `array` option — the same helper already used in the property value-inference path. Applies to both `onCreate` and `onUpdate`, on the `PropertyChain` interface and the `UniversalPropertyOptionsBuilder` class.

Closes #7847