### PR TITLE
feat(pglite): support named databases inside a cluster

### DIFF
--- a/docs/docs/usage-with-pglite.md
+++ b/docs/docs/usage-with-pglite.md
@@ -74,7 +74,7 @@ export default defineConfig({
 });
 ```
 
-In this mode the database lifecycle behaves like a regular PostgreSQL server: `orm.schema.ensureDatabase()` and the `database:create`/`database:drop` CLI commands connect to the cluster's `postgres` management database, run a real `CREATE DATABASE`/`DROP DATABASE`, and reconnect to the target. The `CREATE DATABASE` is never part of a migration — migration files only contain schema DDL; it is the one-off bootstrap step `ensureDatabase()` performs (the same call the migrator runs on startup, so `migration:up` against a not-yet-existing database creates it first). This requires a persistent `dataDir` (file or `idb://`); it is not available for in-memory clusters, where a single instance is kept alive across reconnects.
+The database lifecycle then behaves like a regular PostgreSQL server — `orm.schema.ensureDatabase()` and the `database:create`/`database:drop` commands run real `CREATE DATABASE`/`DROP DATABASE` statements against the cluster. This requires a persistent `dataDir` (file or `idb://`) and is not available for in-memory clusters.
 
 ### Reusing an existing PGlite instance
 

--- a/docs/docs/usage-with-pglite.md
+++ b/docs/docs/usage-with-pglite.md
@@ -58,6 +58,24 @@ export default defineConfig({
 });
 ```
 
+### Named databases inside a cluster
+
+By default `dbName` *is* the PGlite cluster location (the `dataDir`), so each database lives in its own directory. If you point `driverOptions.dataDir` at the cluster explicitly, `dbName` instead selects a named database *within* that cluster (PGlite's [`database`](https://pglite.dev/docs/api) option), just like a regular PostgreSQL server:
+
+```ts
+import { defineConfig } from '@mikro-orm/pglite';
+
+export default defineConfig({
+  entities: [...],
+  dbName: 'app', // a database inside the cluster
+  driverOptions: {
+    dataDir: './cluster', // the cluster location
+  },
+});
+```
+
+In this mode the full database lifecycle works against the cluster's `postgres` management database — `orm.schema.ensureDatabase()`, the `database:create`/`database:drop` CLI commands, and `migration:up` will create the named database with a real `CREATE DATABASE` and reconnect to it. This requires a persistent `dataDir` (file or `idb://`); it is not available for in-memory clusters, where a single instance is kept alive across reconnects.
+
 ### Reusing an existing PGlite instance
 
 Pass an existing `PGlite` instance (or async factory) under `driverOptions.pglite` if you need to share it with non-ORM code, run multiple ORMs against the same database, or pre-load the WASM module yourself. MikroORM will not own the lifecycle — closing the ORM leaves your instance untouched, and the default type parsers are not applied (configure them on your own instance).

--- a/docs/docs/usage-with-pglite.md
+++ b/docs/docs/usage-with-pglite.md
@@ -74,7 +74,7 @@ export default defineConfig({
 });
 ```
 
-In this mode the full database lifecycle works against the cluster's `postgres` management database — `orm.schema.ensureDatabase()`, the `database:create`/`database:drop` CLI commands, and `migration:up` will create the named database with a real `CREATE DATABASE` and reconnect to it. This requires a persistent `dataDir` (file or `idb://`); it is not available for in-memory clusters, where a single instance is kept alive across reconnects.
+In this mode the database lifecycle behaves like a regular PostgreSQL server: `orm.schema.ensureDatabase()` and the `database:create`/`database:drop` CLI commands connect to the cluster's `postgres` management database, run a real `CREATE DATABASE`/`DROP DATABASE`, and reconnect to the target. The `CREATE DATABASE` is never part of a migration — migration files only contain schema DDL; it is the one-off bootstrap step `ensureDatabase()` performs (the same call the migrator runs on startup, so `migration:up` against a not-yet-existing database creates it first). This requires a persistent `dataDir` (file or `idb://`); it is not available for in-memory clusters, where a single instance is kept alive across reconnects.
 
 ### Reusing an existing PGlite instance
 

--- a/packages/pglite/src/PgliteConnection.ts
+++ b/packages/pglite/src/PgliteConnection.ts
@@ -23,6 +23,26 @@ type PgliteDriverOptions = Partial<PGliteOptions> & {
 const isInMemoryDataDir = (dataDir: string | undefined): boolean =>
   !dataDir || dataDir === 'memory://' || dataDir.startsWith('memory:');
 
+/**
+ * Named-database mode is active when `driverOptions.dataDir` points at a real
+ * (persistent) cluster. In that case `dbName` selects a database *within* the
+ * cluster (PGlite's `database` option) instead of acting as the cluster
+ * location, which unlocks the real `CREATE DATABASE` lifecycle (`database:create`,
+ * migrations) handled by `PgliteSchemaHelper`. It stays off for in-memory
+ * clusters (we keep a single instance alive across reconnects, so the database
+ * can't be switched without losing data) and when a user-owned instance is passed.
+ *
+ * @internal — shared between the connection and `PgliteSchemaHelper`.
+ */
+export const pgliteUsesNamedDatabase = (driverOptions: unknown): boolean => {
+  if (!driverOptions || typeof driverOptions !== 'object') {
+    return false;
+  }
+
+  const { pglite, dataDir } = driverOptions as PgliteDriverOptions;
+  return !pglite && !isInMemoryDataDir(dataDir);
+};
+
 /** PostgreSQL-in-WASM database connection using `@electric-sql/pglite`. */
 export class PgliteConnection extends AbstractSqlConnection {
   // Stored as a Promise so `createKyselyDialect` can stay synchronous (else
@@ -36,7 +56,11 @@ export class PgliteConnection extends AbstractSqlConnection {
     const onCreateConnection = this.options.onCreateConnection ?? this.config.get('onCreateConnection');
     const options = (overrides ?? {}) as PgliteDriverOptions;
     const { pglite: userPglite, ...pgliteOptions } = options;
-    const dataDir = options.dataDir ?? (this.config.get('dbName') as string | undefined);
+    const namedDatabase = pgliteUsesNamedDatabase(options);
+    const dbName = this.config.get('dbName') as string | undefined;
+    // In named-database mode the cluster lives at `driverOptions.dataDir` and
+    // `dbName` selects a database inside it; otherwise `dbName` *is* the cluster.
+    const dataDir = options.dataDir ?? dbName;
     const parsers = { ...createPostgreSqlTypeParsers(s => array.parse(s)), ...options.parsers };
 
     this.#ownsPglite = !userPglite;
@@ -53,7 +77,12 @@ export class PgliteConnection extends AbstractSqlConnection {
       if (userPglite) {
         this.#pglite = typeof userPglite === 'function' ? Promise.resolve(userPglite()) : Promise.resolve(userPglite);
       } else {
-        this.#pglite = PGlite.create({ ...pgliteOptions, dataDir, parsers });
+        this.#pglite = PGlite.create({
+          ...pgliteOptions,
+          dataDir,
+          parsers,
+          ...(namedDatabase ? { database: dbName } : {}),
+        });
       }
     }
 

--- a/packages/pglite/src/PgliteSchemaHelper.ts
+++ b/packages/pglite/src/PgliteSchemaHelper.ts
@@ -1,24 +1,48 @@
 import type { Connection } from '@mikro-orm/core';
 import { PostgreSqlSchemaHelper } from '@mikro-orm/sql';
+import { pgliteUsesNamedDatabase } from './PgliteConnection.js';
 
 /**
- * PGlite is a single-database engine — there is no management catalog and no
- * `CREATE DATABASE`. Override the relevant lifecycle hooks to no-ops.
+ * In the default (single-database) setup a PGlite instance maps 1:1 to a
+ * `dataDir`, so there is no management catalog to connect to and the
+ * `CREATE DATABASE` lifecycle is a no-op. When `driverOptions.dataDir` is set,
+ * `dbName` instead selects a database inside that cluster, and we defer to the
+ * PostgreSQL behaviour: connect to the `postgres` management database to run a
+ * real `CREATE DATABASE`/`DROP DATABASE`, then reconnect to the target.
  */
 export class PgliteSchemaHelper extends PostgreSqlSchemaHelper {
+  #usesNamedDatabase(): boolean {
+    // `driverOptions` may be a factory (resolved per-connect in `createKysely`),
+    // so resolve it the same way to stay in sync with the connection.
+    let driverOptions = this.platform.getConfig().get('driverOptions');
+
+    if (typeof driverOptions === 'function') {
+      driverOptions = driverOptions();
+    }
+
+    return pgliteUsesNamedDatabase(driverOptions);
+  }
+
   override getManagementDbName(): string {
-    return '';
+    return this.#usesNamedDatabase() ? super.getManagementDbName() : '';
   }
 
-  override getCreateDatabaseSQL(): string {
-    return '';
+  override getCreateDatabaseSQL(name: string): string {
+    return this.#usesNamedDatabase() ? super.getCreateDatabaseSQL(name) : '';
   }
 
-  override getDropDatabaseSQL(): string {
-    return '';
+  override getDropDatabaseSQL(name: string): string {
+    return this.#usesNamedDatabase() ? super.getDropDatabaseSQL(name) : '';
   }
 
-  override async databaseExists(_connection: Connection, _name: string): Promise<boolean> {
-    return true;
+  override getDatabaseNotExistsError(dbName: string): string {
+    // PGlite throws a generic init error (rather than Postgres' "database ...
+    // does not exist") when the `database` option points at a missing database,
+    // which is how `databaseExists()` detects absence before creating it.
+    return this.#usesNamedDatabase() ? 'PGlite failed to initialize properly' : super.getDatabaseNotExistsError(dbName);
+  }
+
+  override async databaseExists(connection: Connection, name: string): Promise<boolean> {
+    return this.#usesNamedDatabase() ? super.databaseExists(connection, name) : true;
   }
 }

--- a/tests/issues/GH7852.test.ts
+++ b/tests/issues/GH7852.test.ts
@@ -1,0 +1,83 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { MikroORM } from '@mikro-orm/pglite';
+import { Entity, PrimaryKey, Property } from '@mikro-orm/decorators/legacy';
+
+@Entity()
+class User {
+  @PrimaryKey({ type: 'number' })
+  id!: number;
+
+  @Property({ type: 'string' })
+  name!: string;
+}
+
+describe('GH #7852 — named databases inside a pglite cluster', () => {
+  let dataDir: string;
+
+  beforeEach(() => {
+    dataDir = mkdtempSync(join(tmpdir(), 'pglite-cluster-'));
+  });
+
+  afterEach(() => {
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  test('dbName selects a named database in the cluster (driverOptions.dataDir set), creates and persists it', async () => {
+    const init = () =>
+      MikroORM.init({
+        entities: [User],
+        dbName: 'app',
+        driverOptions: { dataDir },
+      });
+
+    const orm = await init();
+    await orm.schema.refresh();
+
+    // the named database is the active one
+    const [{ db }] = await orm.em.getConnection().execute<{ db: string }[]>('select current_database() as db');
+    expect(db).toBe('app');
+
+    orm.em.create(User, { name: 'Foo' });
+    await orm.em.flush();
+    await orm.close();
+
+    // reopen the same cluster + database, data persisted
+    const orm2 = await init();
+    const user = await orm2.em.findOneOrFail(User, { name: 'Foo' });
+    expect(user.name).toBe('Foo');
+    await orm2.close();
+
+    // the default `postgres` database in the same cluster is untouched (isolation)
+    const ormDefault = await MikroORM.init({
+      entities: [User],
+      dbName: 'postgres',
+      driverOptions: { dataDir },
+    });
+    const hasUser = await ormDefault.em
+      .getConnection()
+      .execute<{ t: string | null }[]>(`select to_regclass('public."user"') as t`);
+    expect(hasUser[0].t).toBeNull();
+    await ormDefault.close();
+  });
+
+  test('ensureDatabase creates the named database and is idempotent, dropDatabase removes it', async () => {
+    const orm = await MikroORM.init({
+      entities: [User],
+      dbName: 'mydb',
+      driverOptions: { dataDir },
+    });
+
+    expect(await orm.schema.ensureDatabase()).toBe(true);
+    expect(await orm.schema.ensureDatabase({ forceCheck: true })).toBe(false);
+
+    await orm.schema.dropDatabase('mydb');
+    const dbs = await orm.em
+      .getConnection()
+      .execute<{ datname: string }[]>(`select datname from pg_database where datname = 'mydb'`);
+    expect(dbs).toHaveLength(0);
+
+    await orm.close();
+  });
+});

--- a/tests/issues/GH7852.test.ts
+++ b/tests/issues/GH7852.test.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { MikroORM } from '@mikro-orm/pglite';
+import { MikroORM, pgliteUsesNamedDatabase } from '@mikro-orm/pglite';
 import { Entity, PrimaryKey, Property } from '@mikro-orm/decorators/legacy';
 
 @Entity()
@@ -77,6 +77,42 @@ describe('GH #7852 — named databases inside a pglite cluster', () => {
       .getConnection()
       .execute<{ datname: string }[]>(`select datname from pg_database where datname = 'mydb'`);
     expect(dbs).toHaveLength(0);
+
+    await orm.close();
+  });
+
+  test('driverOptions can be a factory (resolved consistently by the schema helper)', async () => {
+    const orm = await MikroORM.init({
+      entities: [User],
+      dbName: 'factory_db',
+      driverOptions: () => ({ dataDir }),
+    });
+
+    expect(await orm.schema.ensureDatabase()).toBe(true);
+    const [{ db }] = await orm.em.getConnection().execute<{ db: string }[]>('select current_database() as db');
+    expect(db).toBe('factory_db');
+
+    await orm.close();
+  });
+
+  test('pgliteUsesNamedDatabase only activates for a persistent, ORM-owned cluster', () => {
+    expect(pgliteUsesNamedDatabase(undefined)).toBe(false);
+    expect(pgliteUsesNamedDatabase('not-an-object')).toBe(false);
+    expect(pgliteUsesNamedDatabase({})).toBe(false); // no dataDir
+    expect(pgliteUsesNamedDatabase({ dataDir: 'memory://' })).toBe(false); // in-memory cluster
+    expect(pgliteUsesNamedDatabase({ dataDir })).toBe(true);
+    expect(pgliteUsesNamedDatabase({ dataDir, pglite: {} })).toBe(false); // user-owned instance
+  });
+
+  test('schema helper is a no-op in single-database mode (no driverOptions.dataDir)', async () => {
+    const orm = await MikroORM.init({ entities: [User], dbName: 'memory://' });
+    const helper = orm.em.getPlatform().getSchemaHelper()!;
+
+    expect(helper.getManagementDbName()).toBe('');
+    expect(helper.getCreateDatabaseSQL('foo')).toBe('');
+    expect(helper.getDropDatabaseSQL('foo')).toBe('');
+    expect(helper.getDatabaseNotExistsError('foo')).toContain('does not exist');
+    expect(await helper.databaseExists(orm.em.getConnection(), 'foo')).toBe(true);
 
     await orm.close();
   });


### PR DESCRIPTION
Adds support for named databases within a single PGlite cluster.

## Behaviour

By default `dbName` *is* the PGlite cluster location (`dataDir`), so the `CREATE DATABASE` lifecycle is a no-op (a PGlite instance maps 1:1 to a directory). When `driverOptions.dataDir` points at a persistent cluster explicitly, `dbName` instead selects a named database *within* that cluster (PGlite's `database` option):

```ts
defineConfig({
  entities: [...],
  dbName: 'app',                           // a database inside the cluster
  driverOptions: { dataDir: './cluster' }, // the cluster location
});
```

In this mode the database lifecycle behaves like a regular PostgreSQL server — `ensureDatabase()` and the `database:create`/`database:drop` commands run real `CREATE`/`DROP DATABASE` statements against the cluster's `postgres` management database and reconnect to the target, reusing the existing management-DB reconnect mechanism in `SqlSchemaGenerator`. The schema helper defers to the PostgreSQL parent in this mode and stays a no-op otherwise. Named mode is disabled for in-memory clusters (a single instance is kept alive across reconnects) and when a user-owned instance is passed via `driverOptions.pglite`.

Default single-database behaviour is unchanged.

Closes #7852