### PR TITLE
test: fix flaky result cache test (GH7112)

### DIFF
--- a/tests/features/result-cache/GH7112.test.ts
+++ b/tests/features/result-cache/GH7112.test.ts
@@ -54,6 +54,9 @@ beforeAll(async () => {
 
 beforeEach(async () => {
   await orm.schema.clear();
+  // result cache lives on the shared orm instance and survives `em.clear()`,
+  // so reset it between runs to keep retries from reusing a stale entry
+  await orm.config.getResultCacheAdapter().clear();
 });
 
 afterAll(() => orm.close(true));
@@ -68,13 +71,13 @@ describe('result cache with custom types (GH 7112)', () => {
     const mockLog = mockLogger(orm, ['query']);
 
     // First query - from database
-    const res1 = await orm.em.findOneOrFail(EntityWithEncryptedProp, 1, { cache: 50 });
+    const res1 = await orm.em.findOneOrFail(EntityWithEncryptedProp, 1, { cache: 5000 });
     expect(mockLog.mock.calls).toHaveLength(1);
     expect(res1.secret).toBe('my-secret-value'); // decrypted
     orm.em.clear();
 
     // Second query - should hit cache and still return decrypted value
-    const res2 = await orm.em.findOneOrFail(EntityWithEncryptedProp, 1, { cache: 50 });
+    const res2 = await orm.em.findOneOrFail(EntityWithEncryptedProp, 1, { cache: 5000 });
     expect(mockLog.mock.calls).toHaveLength(1); // cache hit, no new query fired
     expect(res2.secret).toBe('my-secret-value'); // should still be decrypted
   });
@@ -90,13 +93,13 @@ describe('result cache with custom types (GH 7112)', () => {
     const mockLog = mockLogger(orm, ['query']);
 
     // First query - from database
-    const res1 = await orm.em.find(EntityWithEncryptedProp, {}, { cache: 50 });
+    const res1 = await orm.em.find(EntityWithEncryptedProp, {}, { cache: 5000 });
     expect(mockLog.mock.calls).toHaveLength(1);
     expect(res1.map(e => e.secret)).toEqual(['secret-1', 'secret-2']);
     orm.em.clear();
 
     // Second query - should hit cache
-    const res2 = await orm.em.find(EntityWithEncryptedProp, {}, { cache: 50 });
+    const res2 = await orm.em.find(EntityWithEncryptedProp, {}, { cache: 5000 });
     expect(mockLog.mock.calls).toHaveLength(1); // cache hit, no new query fired
     expect(res2.map(e => e.secret)).toEqual(['secret-1', 'secret-2']);
   });


### PR DESCRIPTION
Fixes a flaky test in `tests/features/result-cache/GH7112.test.ts` that intermittently failed on CI.

### Cause
- The test used `cache: 50` (50ms TTL). On a slow runner more than 50ms could elapse between the two queries, expiring the cache and firing a second query — breaking the `toHaveLength(1)` "cache hit" assertion (`expected […(2)] to have a length of 1 but got 2`).
- The result cache lives on the shared `orm` instance and is not cleared by `em.clear()`. On the vitest retry the previous run's entry was still cached, so the first query hit the cache and logged no query (`expected [] to have a length of 1 but got +0`).

### Fix
- Bump the TTL to `5000` so it can't expire mid-test.
- Clear the result cache adapter in `beforeEach` so each run (including retries) starts with a clean cache.