### PR TITLE
ci: make docker image pull resilient to transient mssql registry blocks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -162,9 +162,22 @@ jobs:
 
       - name: Install & pull docker images
         run: |
-          for i in 1 2 3; do docker compose pull && break || sleep $((i*15)); done &
+          # mcr.microsoft.com (mssql) intermittently returns "the request is blocked";
+          # retry with backoff and surface a real failure instead of masking it (the old
+          # loop ended on `sleep`, so an exhausted pull still exited 0 and the missing
+          # image only blew up later in `docker compose up`).
+          (
+            for i in 1 2 3 4 5; do
+              docker compose pull && exit 0
+              echo "::warning::docker compose pull attempt $i failed, retrying in $((i * 15))s"
+              sleep $((i * 15))
+            done
+            echo "::error::docker compose pull failed after 5 attempts"
+            exit 1
+          ) &
+          pull_pid=$!
           yarn
-          wait
+          wait "$pull_pid"
 
       - name: Init docker
         run: |


### PR DESCRIPTION
Addresses the intermittent CI failure where `mcr.microsoft.com` rejects the mssql image pull with `the request is blocked` / `pull access denied`, killing the test job at the "Init docker" step.

### Cause
The "Install & pull docker images" step retried `docker compose pull` only 3× and ended each iteration on `sleep`, so once the retries were exhausted the loop still exited 0. The step went green even though the mssql image was never pulled, and the missing image then surfaced as a hard failure later in `docker compose up -d`.

### Fix
- Retry up to 5× with backoff (15/30/45/60s) to ride out the transient registry block.
- Propagate the real exit code via `wait "$pull_pid"` so a genuinely failed pull fails the step loudly with a clear `::error::`, instead of being masked.