### PR TITLE
fix(core): avoid crash on STI subclass narrowing an inverse collection

### DIFF
--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -1179,7 +1179,12 @@ export class MetadataDiscovery {
       return false;
     }
 
-    if (prop.kind !== ReferenceKind.MANY_TO_ONE && prop.kind !== ReferenceKind.ONE_TO_ONE) {
+    if (
+      prop.kind !== ReferenceKind.MANY_TO_ONE &&
+      prop.kind !== ReferenceKind.ONE_TO_ONE &&
+      prop.kind !== ReferenceKind.ONE_TO_MANY &&
+      prop.kind !== ReferenceKind.MANY_TO_MANY
+    ) {
       return false;
     }
 
@@ -1232,7 +1237,15 @@ export class MetadataDiscovery {
       const narrowedRelationOverride =
         rootProp != null && rootProp.type !== prop.type && this.sameRelationTargetRoot(rootProp, prop);
 
-      if (rootProp && !narrowedRelationOverride && (rootProp.type !== prop.type || (rootProp.fieldNames && prop.fieldNames && !compareArrays(rootProp.fieldNames, prop.fieldNames)))) {
+      // Inverse-side relations (1:m, inverse m:n) have no FK column on this
+      // entity, so the rename branch — which exists to disambiguate physical
+      // columns shared across STI children — doesn't apply. Skipping it also
+      // avoids crashing on `[...rootProp.fieldNames]` since fieldNames is
+      // never populated for inverse-side properties.
+      const isInverseSideRelation =
+        prop.kind === ReferenceKind.ONE_TO_MANY || (prop.kind === ReferenceKind.MANY_TO_MANY && !prop.owner);
+
+      if (rootProp && !narrowedRelationOverride && !isInverseSideRelation && (rootProp.type !== prop.type || (rootProp.fieldNames && prop.fieldNames && !compareArrays(rootProp.fieldNames, prop.fieldNames)))) {
         const name = newProp.name;
         this.initFieldName(newProp, newProp.object);
         newProp.renamedFrom = name;
@@ -1275,6 +1288,15 @@ export class MetadataDiscovery {
       // the full target union (e.g. `Food`) is preserved for populates from the
       // abstract root — otherwise the last child processed would win.
       if (narrowedRelationOverride) {
+        return;
+      }
+
+      // STI siblings can declare the same property name on inverse-side relations
+      // pointing to disjoint targets (e.g. `Dog.items → DogItem` and
+      // `Cat.items → CatItem` with no shared base). There's no physical column
+      // to manage at root, and propagating would clobber the first child's
+      // declaration; each child keeps its local typed property instead.
+      if (isInverseSideRelation && rootProp && rootProp.type !== prop.type) {
         return;
       }
 

--- a/tests/issues/GH7867.test.ts
+++ b/tests/issues/GH7867.test.ts
@@ -1,0 +1,115 @@
+import {
+  Collection,
+  Entity,
+  Enum,
+  ManyToMany,
+  ManyToOne,
+  MikroORM,
+  OneToMany,
+  PrimaryKey,
+  Property,
+} from '@mikro-orm/sqlite';
+
+// STI hierarchies where subclasses narrow an inverse collection by overriding it with a same-root
+// subclass target. STI discovery wrongly entered the "column rename" branch for these overrides
+// and crashed on `[...prop.fieldNames]` / `prop.fieldNames[0]` because inverse collections
+// (ONE_TO_MANY / inverse MANY_TO_MANY) have no `fieldNames` in this table.
+
+enum DatabaseType {
+  REFERENCE = 'reference',
+  CUSTOM = 'custom',
+}
+
+@Entity({ tableName: 'database', discriminatorColumn: 'type', abstract: true })
+abstract class Database {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Enum(() => DatabaseType)
+  type!: DatabaseType;
+
+  @Property()
+  name!: string;
+
+  // inverse collection — no column in this table
+  @OneToMany(() => DatabaseVersion, v => v.database)
+  readonly versions = new Collection<DatabaseVersion>(this);
+
+  // inverse side of a M:N — also no column in this table
+  @ManyToMany(() => DatabaseVersion, v => v.tags)
+  readonly tagged = new Collection<DatabaseVersion>(this);
+
+}
+
+@Entity({ tableName: 'database_version', discriminatorColumn: 'type', abstract: true })
+abstract class DatabaseVersion {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Enum(() => DatabaseType)
+  type!: DatabaseType;
+
+  @ManyToOne(() => Database)
+  database!: Database;
+
+  // owning side of the M:N narrowed on the inverse (database) side
+  @ManyToMany(() => Database, db => db.tagged, { owner: true })
+  readonly tags = new Collection<Database>(this);
+
+}
+
+@Entity({ discriminatorValue: DatabaseType.REFERENCE })
+class ReferenceDatabaseVersion extends DatabaseVersion {}
+
+@Entity({ discriminatorValue: DatabaseType.CUSTOM })
+class CustomDatabaseVersion extends DatabaseVersion {}
+
+@Entity({ discriminatorValue: DatabaseType.REFERENCE })
+class ReferenceDatabase extends Database {
+
+  // narrow the collection targets to the matching same-root version subclass — no column change needed
+  @OneToMany(() => ReferenceDatabaseVersion, v => v.database)
+  override readonly versions = new Collection<ReferenceDatabaseVersion>(this);
+
+  @ManyToMany(() => ReferenceDatabaseVersion, v => v.tags)
+  override readonly tagged = new Collection<ReferenceDatabaseVersion>(this);
+
+}
+
+@Entity({ discriminatorValue: DatabaseType.CUSTOM })
+class CustomDatabase extends Database {
+
+  @OneToMany(() => CustomDatabaseVersion, v => v.database)
+  override readonly versions = new Collection<CustomDatabaseVersion>(this);
+
+  @ManyToMany(() => CustomDatabaseVersion, v => v.tags)
+  override readonly tagged = new Collection<CustomDatabaseVersion>(this);
+
+}
+
+test('STI subclass narrowing an inverse collection (@OneToMany/@ManyToMany) to a same-root subclass does not crash discovery', async () => {
+  const orm = await MikroORM.init({
+    dbName: ':memory:',
+    entities: [
+      Database,
+      ReferenceDatabase,
+      CustomDatabase,
+      DatabaseVersion,
+      ReferenceDatabaseVersion,
+      CustomDatabaseVersion,
+    ],
+  });
+
+  const meta = orm.getMetadata();
+
+  // root declaration keeps the abstract target so populates from the root resolve all children
+  expect(meta.get(Database).properties.versions.type).toBe('DatabaseVersion');
+  // inverse collections must not be turned into renamed columns
+  expect(meta.get(Database).properties.versions.fieldNames).toBeUndefined();
+  expect(meta.get(Database).properties.tagged.fieldNames).toBeUndefined();
+
+  await orm.schema.refreshDatabase();
+  await orm.close(true);
+});


### PR DESCRIPTION
When an STI child overrides an inverse collection (`@OneToMany`, or the inverse side of a `@ManyToMany`) to narrow its target to a subclass that shares the same STI root, metadata discovery crashed with `TypeError: rootProp.fieldNames is not iterable`. The rename branch in `initSingleTableInheritance` — which disambiguates physical FK columns across STI children — was entered for these inverse-side overrides, but inverse-side properties never populate `fieldNames`, so spreading them blew up.

`sameRelationTargetRoot` now recognizes 1:m and inverse m:n so narrowed overrides flow through the existing `narrowedRelationOverride` path and preserve the root's broad target; the rename branch is skipped for any inverse-side relation, and disjoint inverse overrides keep each child's local typed property instead of clobbering the root's declaration.

This is the v6 port of the equivalent v7 fix (#7636), which already covered the `@OneToMany` paths on master.

Closes #7867