### PR TITLE
fix(pglite): really close in-memory instances on orm.close()

### DIFF
--- a/packages/pglite/src/PgliteConnection.ts
+++ b/packages/pglite/src/PgliteConnection.ts
@@ -64,14 +64,16 @@ export class PgliteConnection extends AbstractSqlConnection {
     const parsers = { ...createPostgreSqlTypeParsers(s => array.parse(s)), ...options.parsers };
 
     this.#ownsPglite = !userPglite;
-    // Skip `pglite.close()` (called by kysely's `PGliteDriver.destroy()`) when:
-    //   - the user owns the instance (closing it is their responsibility), or
-    //   - we hold an in-memory DB whose data would otherwise be lost on
-    //     reconnect (e.g. test harnesses that drive `orm.close()` + `orm.connect()`).
-    // For file/IDB-backed instances we let kysely close so file handles / IDB
-    // connections are released; we drop our cached promise in `close()` below
-    // so the next dialect-construction rebuilds the PGlite instance.
-    this.#neuterClose = !this.#ownsPglite || isInMemoryDataDir(dataDir);
+    // Skip `pglite.close()` (called by kysely's `PGliteDriver.destroy()`) only
+    // when the user owns the instance — closing it is their responsibility, and
+    // patching `close` on it directly would orphan it (its real `close` would
+    // stay neutered after `orm.close()`). Instances we own (in-memory or
+    // file/IDB-backed) get really closed so the underlying WASM / file handle /
+    // IDB resources are released; we drop our cached promise in `close()` below
+    // so the next dialect-construction rebuilds the PGlite instance. In-memory
+    // data does not survive `orm.close()`, consistent with other in-memory
+    // drivers (e.g. SQLite `:memory:`).
+    this.#neuterClose = !this.#ownsPglite;
 
     if (!this.#pglite) {
       if (userPglite) {
@@ -118,9 +120,9 @@ export class PgliteConnection extends AbstractSqlConnection {
 
   override async close(force?: boolean): Promise<void> {
     await super.close(force);
-    // Persistent backings (file/IDB) we own get really closed by kysely — drop
-    // the cached promise so a subsequent reconnect rebuilds a fresh instance
-    // (which then re-reads the persisted data from disk / IDB).
+    // Instances we own get really closed by kysely — drop the cached promise so a
+    // subsequent reconnect rebuilds a fresh instance (file/IDB backings re-read the
+    // persisted data; in-memory starts empty, matching other in-memory drivers).
     if (this.#ownsPglite && !this.#neuterClose) {
       this.#pglite = undefined;
     }

--- a/tests/features/entity-manager/EntityManager.pglite.test.ts
+++ b/tests/features/entity-manager/EntityManager.pglite.test.ts
@@ -82,23 +82,27 @@ describe('EntityManagerPglite', () => {
   afterAll(async () => orm.close(true));
 
   test('isConnected()', async () => {
-    expect(orm.driver.getORMClass()).toBe(MikroORM);
-    expect(await orm.isConnected()).toBe(true);
-    expect(await orm.checkConnection()).toEqual({
+    // own throwaway ORM — closing an in-memory pglite really tears it down now,
+    // so we must not close the shared `orm` other tests rely on
+    const orm2 = await initORMPglite();
+    expect(orm2.driver.getORMClass()).toBe(MikroORM);
+    expect(await orm2.isConnected()).toBe(true);
+    expect(await orm2.checkConnection()).toEqual({
       ok: true,
     });
-    await orm.close(true);
-    expect(await orm.isConnected()).toBe(false);
-    const check = await orm.checkConnection();
+    await orm2.close(true);
+    expect(await orm2.isConnected()).toBe(false);
+    const check = await orm2.checkConnection();
     expect(check).toMatchObject({
       ok: false,
       reason: 'Connection not established',
     });
-    await orm.connect();
-    expect(await orm.isConnected()).toBe(true);
-    expect(await orm.checkConnection()).toEqual({
+    await orm2.connect();
+    expect(await orm2.isConnected()).toBe(true);
+    expect(await orm2.checkConnection()).toEqual({
       ok: true,
     });
+    await orm2.close(true);
   });
 
   test('raw query with array param', async () => {

--- a/tests/issues/GH7862.test.ts
+++ b/tests/issues/GH7862.test.ts
@@ -1,0 +1,33 @@
+import { MikroORM } from '@mikro-orm/pglite';
+import { Entity, PrimaryKey, Property } from '@mikro-orm/decorators/legacy';
+
+@Entity()
+class User {
+  @PrimaryKey({ type: 'number' })
+  id!: number;
+
+  @Property({ type: 'string' })
+  name!: string;
+}
+
+describe('GH #7862 — in-memory pglite is fully closed on orm.close()', () => {
+  test('close tears the instance down; reconnect yields a fresh empty database', async () => {
+    const init = () => MikroORM.init({ entities: [User], dbName: 'memory://' });
+
+    const orm = await init();
+    await orm.schema.create();
+    orm.em.create(User, { id: 1, name: 'Foo' });
+    await orm.em.flush();
+    await expect(orm.em.fork().count(User)).resolves.toBe(1);
+
+    // close really closes the underlying PGlite (no lingering async handles
+    // for jest's open-handle detector); reconnecting therefore rebuilds a
+    // fresh, empty in-memory instance instead of resurrecting the old data
+    await orm.close();
+    await orm.connect();
+    await orm.schema.create();
+    await expect(orm.em.fork().count(User)).resolves.toBe(0);
+
+    await orm.close();
+  });
+});


### PR DESCRIPTION
In-memory databases skipped `pglite.close()` (kysely's `PGliteDriver.destroy()`) to keep their data alive across `orm.close()` + `orm.connect()`. The side effect: the underlying PGlite (WASM) instance was never actually closed for the entire process lifetime, which jest's open-handle detector correctly flags as "asynchronous operations that weren't stopped".

The skip is now limited to **user-supplied** instances — those we hold as an opaque handle (can't rebuild) and whose lifecycle the user owns. Instances we own (in-memory and file/IDB-backed) are really closed, and the cached promise is dropped so a reconnect rebuilds a fresh instance.

As a result, in-memory data no longer survives `orm.close()`, which makes pglite consistent with every other in-memory driver (e.g. SQLite `:memory:`). No internal flow relied on the old behavior — for in-memory the schema generator short-circuits and never reconnects.

Closes #7862