### PR TITLE
fix(mssql): return result sets from callRoutine without OUT params

### DIFF
--- a/packages/mssql/src/MsSqlConnection.ts
+++ b/packages/mssql/src/MsSqlConnection.ts
@@ -168,7 +168,7 @@ export class MsSqlConnection extends AbstractSqlConnection {
     const result = await this.execute(batch.join('; '), allValues, 'all', ctx);
 
     if (outVars.length === 0) {
-      return undefined as T;
+      return result as T;
     }
 
     const rows = result as Dictionary[];
@@ -178,7 +178,7 @@ export class MsSqlConnection extends AbstractSqlConnection {
       args,
     );
 
-    return undefined as T;
+    return result as T;
   }
 
   override async commit(

--- a/tests/features/stored-routines/mssql.test.ts
+++ b/tests/features/stored-routines/mssql.test.ts
@@ -112,4 +112,35 @@ describe('stored routines — MSSQL', () => {
 
     await orm2.close(true);
   });
+
+  it('em.callRoutine returns result sets from procedures without OUT/INOUT params', async () => {
+    const GetRecords = Routine.create<{ p_name: string }, RecordEntity[]>({
+      name: 'get_records',
+      type: 'procedure',
+      params: {
+        p_name: { type: 'nvarchar(255)' },
+      },
+      body: 'select hash, name, age from record_entity where name = @p_name;',
+    });
+
+    const orm2 = await MikroORM.init({
+      dbName,
+      password: 'Root.Root',
+      entities: [RecordEntity],
+      routines: [GetRecords],
+    });
+    await orm2.schema.update();
+
+    // First insert a record to query
+    await orm2.em.insert(RecordEntity, { hash: 'test-hash-123', name: 'Alice', age: 30 });
+
+    // Now call the procedure that returns result sets
+    const result = await orm2.em.callRoutine(GetRecords, { p_name: 'Alice' });
+    expect(result).toBeDefined();
+    expect(Array.isArray(result)).toBe(true);
+    expect(result.length).toBeGreaterThan(0);
+    expect(result[0]).toEqual({ hash: 'test-hash-123', name: 'Alice', age: 30 });
+
+    await orm2.close(true);
+  });
 });


### PR DESCRIPTION
## Summary
- Fix `callRoutine` in MSSQL driver to return result sets from stored procedures without OUT/INOUT parameters
- Previously, routines without output variables always returned `undefined` despite the query returning results
- Now returns the actual result from the execute call, whether there are output variables or not

## Changes
- `packages/mssql/src/MsSqlConnection.ts`: Return `result` instead of `undefined` in both branches (with and without output variables)
- `tests/features/stored-routines/mssql.test.ts`: Added test case to verify result sets are returned from procedures without OUT/INOUT params

## Verification
- Added test case that creates a procedure with SELECT statement and verifies the result is returned
- Test covers the scenario described in issue #7872

Fixes #7872
