### PR TITLE
fix(mssql): return result sets from callRoutine without OUT params

### DIFF
--- a/packages/mssql/src/MsSqlConnection.ts
+++ b/packages/mssql/src/MsSqlConnection.ts
@@ -165,13 +165,14 @@ export class MsSqlConnection extends AbstractSqlConnection {
       batch.push(`select ${selectClause}`);
     }
 
-    const result = await this.execute(batch.join('; '), allValues, 'all', ctx);
+    const rows = (await this.execute(batch.join('; '), allValues, 'all', ctx)) as Dictionary[];
 
     if (outVars.length === 0) {
-      return undefined as T;
+      // A procedure can still return result sets via SELECT without declaring OUT params —
+      // surface those rows instead of discarding them. Pure-DML procedures yield no rows.
+      return (rows.length > 0 ? rows : undefined) as T;
     }
 
-    const rows = result as Dictionary[];
     this.applyRoutineOutParams(
       rows[0] ?? {},
       outVars.map(o => o.param),

--- a/tests/features/stored-routines/mssql.test.ts
+++ b/tests/features/stored-routines/mssql.test.ts
@@ -85,6 +85,37 @@ describe('stored routines — MSSQL', () => {
     expect(found!.name).toBe('Jon Snow');
   });
 
+  it('em.callRoutine returns result set rows for a procedure without OUT params (#7872)', async () => {
+    const ListRecords = new Routine({
+      name: 'list_records',
+      type: 'procedure',
+      params: {
+        p_name: { type: 'nvarchar(255)' },
+      },
+      returns: () => RecordEntity,
+      body: 'select id, hash, name, age from record_entity where name = @p_name;',
+    });
+
+    const orm2 = await MikroORM.init({
+      dbName,
+      password: 'Root.Root',
+      entities: [RecordEntity],
+      routines: [ListRecords],
+    });
+    await orm2.schema.update();
+
+    await orm2.em.insertMany(RecordEntity, [
+      { hash: 'list-1', name: 'Arya', age: 18 },
+      { hash: 'list-2', name: 'Arya', age: 20 },
+    ]);
+
+    const rows = await orm2.em.callRoutine(ListRecords, { p_name: 'Arya' });
+    expect(rows).toBeDefined();
+    expect(rows!.map(r => r.hash).sort()).toEqual(['list-1', 'list-2']);
+
+    await orm2.close(true);
+  });
+
   it('em.callRoutine invokes an IN-only procedure (no OUT/INOUT params)', async () => {
     const InsertRecord = new Routine({
       name: 'insert_record',


### PR DESCRIPTION
T-SQL procedures can return result sets implicitly via a bare `SELECT`, but `callRoutine` discarded them whenever the routine declared no OUT/INOUT params — it always short-circuited to `undefined` even though the rows were sitting right there in the `execute()` result.

This surfaces those rows when present, while keeping pure-DML procedures resolving to `undefined`, matching how the MySQL driver already handles implicit result sets (`resultSets.length > 0 ? resultSets : undefined`).

Scoped to MSSQL only: MySQL already handles this, while PostgreSQL/Oracle don't surface implicit result sets (data comes back via refcursors/OUT params, already handled) and SQLite/libSQL don't support procedures.

The OUT/INOUT path is intentionally left untouched — those values come back through `ScalarReference` and the call still resolves to `undefined`, consistent with the other drivers.

Closes #7872