### PR TITLE
fix(core): skip view entities in schema.clear()

### DIFF
--- a/packages/core/src/utils/AbstractSchemaGenerator.ts
+++ b/packages/core/src/utils/AbstractSchemaGenerator.ts
@@ -59,6 +59,11 @@ export abstract class AbstractSchemaGenerator<D extends IDatabaseDriver> impleme
 
   async clear(options?: ClearDatabaseOptions): Promise<void> {
     for (const meta of this.getOrderedMetadata(options?.schema).reverse()) {
+      // view entities are not backed by a real table, so there is nothing to delete
+      if (meta.view) {
+        continue;
+      }
+
       await this.driver.nativeDelete(meta.class, {}, options);
     }
 

--- a/packages/core/src/utils/AbstractSchemaGenerator.ts
+++ b/packages/core/src/utils/AbstractSchemaGenerator.ts
@@ -58,12 +58,7 @@ export abstract class AbstractSchemaGenerator<D extends IDatabaseDriver> impleme
   }
 
   async clear(options?: ClearDatabaseOptions): Promise<void> {
-    for (const meta of this.getOrderedMetadata(options?.schema).reverse()) {
-      // view entities are not backed by a real table, so there is nothing to delete
-      if (meta.view) {
-        continue;
-      }
-
+    for (const meta of this.getOrderedMetadataForClear(options?.schema).reverse()) {
       await this.driver.nativeDelete(meta.class, {}, options);
     }
 
@@ -168,6 +163,11 @@ export abstract class AbstractSchemaGenerator<D extends IDatabaseDriver> impleme
         const targetSchema = meta.schema ?? this.config.get('schema', this.platform.getDefaultSchemaName());
         return schema ? [schema, '*'].includes(targetSchema) : meta.schema !== '*';
       });
+  }
+
+  /** View entities are not backed by real tables, so they must be skipped when truncating/deleting during `clear()`. */
+  protected getOrderedMetadataForClear(schema?: string): EntityMetadata[] {
+    return this.getOrderedMetadata(schema).filter(meta => !meta.view);
   }
 
   protected notImplemented(): never {

--- a/packages/mssql/src/MsSqlSchemaGenerator.ts
+++ b/packages/mssql/src/MsSqlSchemaGenerator.ts
@@ -16,6 +16,11 @@ export class MsSqlSchemaGenerator extends SchemaGenerator {
 
     // https://stackoverflow.com/questions/253849/cannot-truncate-table-because-it-is-being-referenced-by-a-foreign-key-constraint
     for (const meta of this.getOrderedMetadata(options?.schema).reverse()) {
+      // view entities are not backed by a real table, so there is nothing to delete
+      if (meta.view) {
+        continue;
+      }
+
       const res = await this.driver.nativeDelete(meta.class, {}, options);
 
       if (meta.getPrimaryProps().some(pk => pk.autoincrement)) {

--- a/packages/mssql/src/MsSqlSchemaGenerator.ts
+++ b/packages/mssql/src/MsSqlSchemaGenerator.ts
@@ -15,12 +15,7 @@ export class MsSqlSchemaGenerator extends SchemaGenerator {
     }
 
     // https://stackoverflow.com/questions/253849/cannot-truncate-table-because-it-is-being-referenced-by-a-foreign-key-constraint
-    for (const meta of this.getOrderedMetadata(options?.schema).reverse()) {
-      // view entities are not backed by a real table, so there is nothing to delete
-      if (meta.view) {
-        continue;
-      }
-
+    for (const meta of this.getOrderedMetadataForClear(options?.schema).reverse()) {
       const res = await this.driver.nativeDelete(meta.class, {}, options);
 
       if (meta.getPrimaryProps().some(pk => pk.autoincrement)) {

--- a/packages/oracledb/src/OracleSchemaGenerator.ts
+++ b/packages/oracledb/src/OracleSchemaGenerator.ts
@@ -452,6 +452,11 @@ export class OracleSchemaGenerator extends SchemaGenerator {
     const stmts: string[] = [];
 
     for (const meta of this.getOrderedMetadata(options?.schema).reverse()) {
+      // view entities are not backed by a real table, so there is nothing to delete
+      if (meta.view) {
+        continue;
+      }
+
       const schema =
         meta.schema && meta.schema !== '*'
           ? meta.schema

--- a/packages/oracledb/src/OracleSchemaGenerator.ts
+++ b/packages/oracledb/src/OracleSchemaGenerator.ts
@@ -451,12 +451,7 @@ export class OracleSchemaGenerator extends SchemaGenerator {
 
     const stmts: string[] = [];
 
-    for (const meta of this.getOrderedMetadata(options?.schema).reverse()) {
-      // view entities are not backed by a real table, so there is nothing to delete
-      if (meta.view) {
-        continue;
-      }
-
+    for (const meta of this.getOrderedMetadataForClear(options?.schema).reverse()) {
       const schema =
         meta.schema && meta.schema !== '*'
           ? meta.schema

--- a/packages/sql/src/schema/SqlSchemaGenerator.ts
+++ b/packages/sql/src/schema/SqlSchemaGenerator.ts
@@ -195,6 +195,11 @@ export class SqlSchemaGenerator extends AbstractSchemaGenerator<AbstractSqlDrive
     const schema = options?.schema ?? this.config.get('schema', this.platform.getDefaultSchemaName());
 
     for (const meta of this.getOrderedMetadata(schema).reverse()) {
+      // view entities are not backed by a real table, so there is nothing to truncate
+      if (meta.view) {
+        continue;
+      }
+
       try {
         await this.driver
           .createQueryBuilder(meta.class, this.em?.getTransactionContext(), 'write', false)

--- a/packages/sql/src/schema/SqlSchemaGenerator.ts
+++ b/packages/sql/src/schema/SqlSchemaGenerator.ts
@@ -194,12 +194,7 @@ export class SqlSchemaGenerator extends AbstractSchemaGenerator<AbstractSqlDrive
 
     const schema = options?.schema ?? this.config.get('schema', this.platform.getDefaultSchemaName());
 
-    for (const meta of this.getOrderedMetadata(schema).reverse()) {
-      // view entities are not backed by a real table, so there is nothing to truncate
-      if (meta.view) {
-        continue;
-      }
-
+    for (const meta of this.getOrderedMetadataForClear(schema).reverse()) {
       try {
         await this.driver
           .createQueryBuilder(meta.class, this.em?.getTransactionContext(), 'write', false)

--- a/tests/features/view-entities/view-entities.sqlite.test.ts
+++ b/tests/features/view-entities/view-entities.sqlite.test.ts
@@ -202,4 +202,30 @@ describe('View entities (sqlite)', () => {
     expect(prolificAuthors[0].name).toBe('Jon Snow');
     expect(prolificAuthors[0].bookCount).toBe(2);
   });
+
+  // GH #7874 - schema.clear() must not try to truncate/delete view entities
+  test('schema.clear() does not fail when views exist', async () => {
+    const orm2 = await MikroORM.init({
+      entities: [
+        Author4,
+        Book4,
+        BookTag4,
+        Publisher4,
+        Test4,
+        FooBar4,
+        FooBaz4,
+        BaseEntity4,
+        BaseEntity5,
+        IdentitySchema,
+        AuthorStatsSchema,
+      ],
+      dbName: ':memory:',
+      metadataProvider: ReflectMetadataProvider,
+    });
+    await orm2.schema.create();
+
+    await expect(orm2.schema.clear()).resolves.not.toThrow();
+
+    await orm2.close(true);
+  });
 });

--- a/tests/features/view-entities/view-entities.sqlite.test.ts
+++ b/tests/features/view-entities/view-entities.sqlite.test.ts
@@ -225,6 +225,7 @@ describe('View entities (sqlite)', () => {
     await orm2.schema.create();
 
     await expect(orm2.schema.clear()).resolves.not.toThrow();
+    await expect(orm2.schema.clear({ truncate: false })).resolves.not.toThrow();
 
     await orm2.close(true);
   });


### PR DESCRIPTION
`orm.schema.clear()` iterated over all entity metadata and issued a TRUNCATE (or DELETE for the `truncate: false` / MSSQL / Oracle paths) for each one, including view entities. Since views aren't backed by real tables, this failed with errors like `cannot modify <view> because it is a view`.

The fix skips any metadata flagged as a view (`meta.view`) in all four schema generators.

Closes #7874