### PR TITLE
fix(migrations): restore triggers when reading the migration snapshot

### DIFF
--- a/packages/migrations/src/Migrator.ts
+++ b/packages/migrations/src/Migrator.ts
@@ -329,6 +329,10 @@ export class Migrator extends AbstractMigrator<AbstractSqlDriver> {
         table.setForeignKeys(tbl.foreignKeys);
       }
 
+      if (tbl.triggers) {
+        table.setTriggers(tbl.triggers);
+      }
+
       const cols = tbl.columns;
       Object.keys(cols).forEach(col => {
         const column = { ...cols[col] };

--- a/tests/issues/GH7878.test.ts
+++ b/tests/issues/GH7878.test.ts
@@ -1,0 +1,65 @@
+import { rm } from 'node:fs/promises';
+import { EntitySchema, MikroORM } from '@mikro-orm/postgresql';
+import { Migrator } from '@mikro-orm/migrations';
+import { BASE_DIR } from '../bootstrap.js';
+
+interface AuditLog {
+  id: number;
+  updatedAt: Date;
+}
+
+const AuditLog = new EntitySchema<AuditLog>({
+  name: 'AuditLog',
+  tableName: 'audit_log_gh7878',
+  properties: {
+    id: { primary: true, type: 'number', fieldName: 'id', columnType: 'serial' },
+    updatedAt: { type: 'Date', fieldName: 'updated_at', columnType: 'timestamptz' },
+  },
+  triggers: [
+    {
+      name: 'update_timestamp_gh7878',
+      timing: 'before',
+      events: ['insert', 'update'],
+      body: 'NEW.updated_at = NOW(); RETURN NEW',
+    },
+  ],
+});
+
+const PATH = BASE_DIR + '/../temp/migrations-gh7878';
+const DB = 'mikro_orm_test_gh7878';
+
+describe('GH #7878 — triggers dropped from migration snapshot in getSchemaFromSnapshot()', () => {
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      entities: [AuditLog],
+      dbName: DB,
+      migrations: { path: PATH, snapshot: true },
+      extensions: [Migrator],
+    });
+    await rm(PATH, { recursive: true, force: true });
+    await orm.schema.dropDatabase();
+    await orm.schema.createDatabase(DB);
+  });
+
+  afterAll(async () => {
+    await rm(PATH, { recursive: true, force: true });
+    await orm.schema.dropDatabase();
+    await orm.close(true);
+  });
+
+  test('the trigger survives the snapshot round-trip and a second create has no churn', async () => {
+    // first create against an empty DB: produces a real CREATE TRIGGER diff and writes the snapshot
+    const first = await orm.migrator.create();
+    expect(first.diff.up.join('\n')).toMatch(/create trigger/i);
+    await rm(PATH + '/' + first.fileName, { force: true });
+
+    // a second create against the untouched entity must be empty — the trigger must survive the round-trip
+    const second = await orm.migrator.create();
+    if (second.fileName) {
+      await rm(PATH + '/' + second.fileName, { force: true });
+    }
+    expect(second.diff).toEqual({ up: [], down: [] });
+  });
+});


### PR DESCRIPTION
`getSchemaFromSnapshot()` reconstructs the snapshot-side `DatabaseTable` with its indexes, checks and foreign keys, but never called `setTriggers`. Triggers serialized by `DatabaseTable.toJSON()` (under the `triggers` key) were therefore discarded on read-back, so the comparator always saw zero triggers on the snapshot side. Every `migrator.create()` after the first re-emitted a spurious `create trigger` diff, and `migration:check` reported changes on an up-to-date schema.

The fix adds the symmetric `setTriggers(tbl.triggers)` call, mirroring the adjacent index/check/FK blocks (and guarded the same way, so it degrades gracefully on older snapshots predating trigger serialization).

Closes #7878