### PR TITLE
fix(sql): strip comments from view definitions in schema generator

### DIFF
--- a/packages/sql/src/schema/DatabaseSchema.ts
+++ b/packages/sql/src/schema/DatabaseSchema.ts
@@ -11,6 +11,7 @@ import {
   isRaw,
 } from '@mikro-orm/core';
 import { DatabaseTable } from './DatabaseTable.js';
+import { normalizeViewDefinition } from './SchemaHelper.js';
 import type { AbstractSqlConnection } from '../AbstractSqlConnection.js';
 import type { DatabaseView, SqlRoutineDef } from '../typings.js';
 import type { AbstractSqlPlatform } from '../AbstractSqlPlatform.js';
@@ -508,7 +509,7 @@ export class DatabaseSchema {
 
   private static getViewDefinition(meta: EntityMetadata, em: any, platform: AbstractSqlPlatform): string | undefined {
     if (typeof meta.expression === 'string') {
-      return meta.expression;
+      return normalizeViewDefinition(meta.expression);
     }
 
     // Expression is a function, need to evaluate it
@@ -528,7 +529,7 @@ export class DatabaseSchema {
 
     /* v8 ignore next */
     if (typeof result === 'string') {
-      return result;
+      return normalizeViewDefinition(result);
     }
 
     /* v8 ignore next */

--- a/packages/sql/src/schema/SchemaHelper.ts
+++ b/packages/sql/src/schema/SchemaHelper.ts
@@ -27,6 +27,24 @@ export function stripStatementNewlines(body: string): string {
   return body.replace(/;[\t ]*\r?\n/g, '; ');
 }
 
+/**
+ * Strips SQL comments and blank lines from a view definition. Comments are dropped by the database
+ * on `create view` anyway, and a `--` comment would otherwise comment out the rest of the definition
+ * once newlines are collapsed; blank lines act as statement separators in the schema-generator's
+ * statement splitter, which would break the view DDL apart.
+ *
+ * The stripping is not string-literal aware, so comment markers inside string literals (or `a--b`
+ * style arithmetic) are treated as comments — an accepted tradeoff to avoid a full SQL tokenizer.
+ * @see https://github.com/mikro-orm/mikro-orm/issues/7875
+ */
+export function normalizeViewDefinition(definition: string): string {
+  return definition
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/--[^\n]*/g, '')
+    .replace(/[\t ]*\r?\n(?:[\t ]*\r?\n)+/g, '\n')
+    .trim();
+}
+
 /** Base class for database-specific schema helpers. Provides SQL generation for DDL operations. */
 export abstract class SchemaHelper {
   constructor(protected readonly platform: AbstractSqlPlatform) {}

--- a/packages/sql/src/schema/SchemaHelper.ts
+++ b/packages/sql/src/schema/SchemaHelper.ts
@@ -28,20 +28,21 @@ export function stripStatementNewlines(body: string): string {
 }
 
 /**
- * Strips SQL comments and blank lines from a view definition. Comments are dropped by the database
- * on `create view` anyway, and a `--` comment would otherwise comment out the rest of the definition
- * once newlines are collapsed; blank lines act as statement separators in the schema-generator's
- * statement splitter, which would break the view DDL apart.
+ * Strips SQL line comments and blank lines from a view definition. Comments are dropped by the
+ * database on `create view` anyway, and a `--` comment would otherwise comment out the rest of the
+ * definition once newlines are collapsed; blank lines act as statement separators in the
+ * schema-generator's statement splitter, which would break the view DDL apart.
  *
- * The stripping is not string-literal aware, so comment markers inside string literals (or `a--b`
- * style arithmetic) are treated as comments — an accepted tradeoff to avoid a full SQL tokenizer.
+ * Comment stripping is not string-literal aware, so a `--` inside a string literal (or `a--b` style
+ * arithmetic) is treated as a comment — an accepted tradeoff to avoid a full SQL tokenizer.
  * @see https://github.com/mikro-orm/mikro-orm/issues/7875
  */
 export function normalizeViewDefinition(definition: string): string {
   return definition
-    .replace(/\/\*[\s\S]*?\*\//g, '')
     .replace(/--[^\n]*/g, '')
-    .replace(/[\t ]*\r?\n(?:[\t ]*\r?\n)+/g, '\n')
+    .split('\n')
+    .filter(line => line.trim() !== '')
+    .join('\n')
     .trim();
 }
 

--- a/tests/features/view-entities/__snapshots__/view-entities.postgres.test.ts.snap
+++ b/tests/features/view-entities/__snapshots__/view-entities.postgres.test.ts.snap
@@ -178,13 +178,11 @@ alter table "configuration2" add constraint "configuration2_test_id_foreign" for
 alter table "test2_bars" add constraint "test2_bars_test2_id_foreign" foreign key ("test2_id") references "test2" ("id") on update cascade on delete cascade;
 alter table "test2_bars" add constraint "test2_bars_foo_bar2_id_foreign" foreign key ("foo_bar2_id") references "foo_bar2" ("id") on update cascade on delete cascade;
 
-create view "select_star_view" as 
-    SELECT
+create view "select_star_view" as SELECT
     *
     FROM author2;
 
-create view "multiline_author_stats_view" as 
-    SELECT
+create view "multiline_author_stats_view" as SELECT
     name, (select count(*)::int from book2 b where b.author_id = a.id) as book_count
     FROM author2 a
     GROUP BY a.id;
@@ -375,8 +373,7 @@ alter table "configuration2" add constraint "configuration2_test_id_foreign" for
 alter table "test2_bars" add constraint "test2_bars_test2_id_foreign" foreign key ("test2_id") references "test2" ("id") on update cascade on delete cascade;
 alter table "test2_bars" add constraint "test2_bars_foo_bar2_id_foreign" foreign key ("foo_bar2_id") references "foo_bar2" ("id") on update cascade on delete cascade;
 
-create view "book_metadata_view" as 
-    select
+create view "book_metadata_view" as select
       b.uuid_pk,
       b.title,
       b.price,

--- a/tests/features/view-entities/__snapshots__/view-entities.sqlite.test.ts.snap
+++ b/tests/features/view-entities/__snapshots__/view-entities.sqlite.test.ts.snap
@@ -33,8 +33,7 @@ create table \`publisher4_tests\` (\`id\` integer not null primary key autoincre
 create index \`publisher4_tests_publisher4_id_index\` on \`publisher4_tests\` (\`publisher4_id\`);
 create index \`publisher4_tests_test4_id_index\` on \`publisher4_tests\` (\`test4_id\`);
 
-create view \`multiline_author_stats_view\` as 
-    SELECT
+create view \`multiline_author_stats_view\` as SELECT
     name, (select count(*) from book4 b where b.author_id = a.id) as book_count
     FROM author4 a;
 

--- a/tests/issues/GH7875.test.ts
+++ b/tests/issues/GH7875.test.ts
@@ -1,0 +1,61 @@
+// Schema create/update must not break when a view definition contains SQL
+// comments. A `-- comment` followed by a blank line used to split the view DDL
+// into two invalid statements (blank lines act as statement separators), and
+// collapsing newlines made the comment swallow the rest of the definition.
+
+import { defineEntity, MikroORM, p } from '@mikro-orm/postgresql';
+
+const User = defineEntity({
+  name: 'User7875',
+  tableName: 'user7875',
+  properties: {
+    id: p.integer().primary().autoincrement(),
+    name: p.string(),
+  },
+});
+
+const UserView = defineEntity({
+  name: 'UserView7875',
+  tableName: 'user7875_view',
+  view: true,
+  expression: `
+    WITH data AS (SELECT id, name FROM user7875)
+    -- comment about the view
+
+    SELECT id, name FROM data
+  `,
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+  },
+});
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    dbName: 'mikro_orm_test_gh7875',
+    entities: [User, UserView],
+  });
+  await orm.schema.drop();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+test('schema create/update works with views containing SQL comments', async () => {
+  const createSql = await orm.schema.getCreateSchemaSQL();
+  expect(createSql).toContain('create view "user7875_view"');
+  expect(createSql).not.toContain('-- comment about the view');
+
+  await expect(orm.schema.create()).resolves.toBeUndefined();
+
+  // a no-op update should detect no changes (comment must not cause churn)
+  const diff = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+  expect(diff).toBe('');
+
+  // executing the generated create SQL directly must also work
+  await orm.schema.drop();
+  await expect(orm.em.execute(createSql)).resolves.toBeDefined();
+});


### PR DESCRIPTION
A view `expression` containing a SQL comment broke `schema.create()`/`update()`. A `--` comment followed by a blank line split the view DDL into two invalid statements (blank lines act as statement separators in the schema-generator's statement splitter), producing `syntax error at end of input`. When newlines were collapsed, the `--` comment also commented out the rest of the definition. Comments are dropped by the database on `create view` regardless, so retaining them additionally caused schema-diff churn.

Fix normalizes view definitions via a shared `normalizeViewDefinition()` helper (sibling to `stripStatementNewlines`) that strips line/block comments and collapses blank lines, applied at the single source where the definition is read from metadata.

Closes #7875