### PR TITLE
fix(sql): derive bulk insert columns from all rows, not just the first

### DIFF
--- a/packages/sql/src/query/NativeQueryBuilder.ts
+++ b/packages/sql/src/query/NativeQueryBuilder.ts
@@ -558,7 +558,8 @@ export class NativeQueryBuilder implements Subquery {
 
   protected processInsertData(): string[] {
     const dataAsArray = Utils.asArray(this.options.data);
-    const keys = Object.keys(dataAsArray[0]);
+    const keys =
+      dataAsArray.length > 1 ? [...new Set(dataAsArray.flatMap(row => Object.keys(row)))] : Object.keys(dataAsArray[0]);
     const values = keys.map(() => '?');
     const parts = [];
     this.parts.push(`(${keys.map(key => this.quote(key)).join(', ')})`);

--- a/tests/features/upsert/GH7871.postgres.test.ts
+++ b/tests/features/upsert/GH7871.postgres.test.ts
@@ -1,0 +1,56 @@
+import { MikroORM } from '@mikro-orm/postgresql';
+import { Entity, PrimaryKey, Property, ReflectMetadataProvider, Unique } from '@mikro-orm/decorators/legacy';
+
+@Entity({ discriminatorColumn: 'type', abstract: true })
+class Base {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  @Unique()
+  key!: string;
+
+  @Property()
+  type!: string;
+}
+
+@Entity({ discriminatorValue: 'a' })
+class A extends Base {
+  @Property({ nullable: true })
+  x?: string;
+}
+
+@Entity({ discriminatorValue: 'b' })
+class B extends Base {
+  @Property({ nullable: true })
+  y?: string;
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    metadataProvider: ReflectMetadataProvider,
+    dbName: '7871',
+    entities: [Base, A, B],
+  });
+  await orm.schema.refresh();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+test('upsertMany with distinct subclass schemas keeps subclass-specific props', async () => {
+  // first row is a B (no `x`), second row is an A (with `x`)
+  await orm.em
+    .fork()
+    .upsertMany(Base, [{ key: 'b1', type: 'b', y: 'yval' } as B, { key: 'a1', type: 'a', x: 'xval' } as A]);
+
+  const em = orm.em.fork();
+  const a = await em.findOneOrFail(A, { key: 'a1' });
+  const b = await em.findOneOrFail(B, { key: 'b1' });
+
+  expect(b.y).toBe('yval');
+  expect(a.x).toBe('xval');
+});


### PR DESCRIPTION
`upsertMany` (and any bulk insert routed through `NativeQueryBuilder`) built the INSERT column list from the first row only (`Object.keys(dataAsArray[0])`). Any column present in later rows but missing from the first row was silently dropped from the statement.

With inherited / STI entities sharing a base schema, this means subclass-specific properties get lost whenever the first item of a batch happens to lack them — so across large `upsertMany` calls (batched by `batchSize`) the same property is persisted for some rows and stored as `null` for others, depending purely on batch ordering.

Fix: union the column keys across all rows in the batch. The value-emission loop already emits `default`/`null` for keys a given row doesn't have, so no other change is needed. This mirrors what `AbstractSqlDriver.nativeInsertMany` already does at the higher level.

Closes #7871