### PR TITLE
fix(pglite): make createDatabase/dropDatabase true no-ops in single-database mode

### DIFF
--- a/packages/pglite/src/PglitePlatform.ts
+++ b/packages/pglite/src/PglitePlatform.ts
@@ -1,8 +1,10 @@
 import array from 'postgres-array';
 import parseDate from 'postgres-date';
 import PostgresInterval, { type IPostgresInterval } from 'postgres-interval';
-import { BasePostgreSqlPlatform, Utils } from '@mikro-orm/sql';
+import { BasePostgreSqlPlatform, type EntityManager, type IDatabaseDriver, type MikroORM, Utils } from '@mikro-orm/sql';
 import { PgliteSchemaHelper } from './PgliteSchemaHelper.js';
+import { PgliteSchemaGenerator } from './PgliteSchemaGenerator.js';
+import type { PgliteDriver } from './PgliteDriver.js';
 
 /** Platform implementation for PGlite (PostgreSQL in WASM, single-database). */
 export class PglitePlatform extends BasePostgreSqlPlatform {
@@ -11,6 +13,15 @@ export class PglitePlatform extends BasePostgreSqlPlatform {
   /** PGlite uses the extended query protocol — one statement per `query()` call. */
   override supportsMultipleStatements(): boolean {
     return false;
+  }
+
+  override lookupExtensions(orm: MikroORM<PgliteDriver>): void {
+    PgliteSchemaGenerator.register(orm);
+  }
+
+  /* v8 ignore next: kept for type inference only */
+  override getSchemaGenerator(driver: IDatabaseDriver, em?: EntityManager): PgliteSchemaGenerator {
+    return new PgliteSchemaGenerator(em ?? (driver as any));
   }
 
   override convertIntervalToJSValue(value: string): unknown {

--- a/packages/pglite/src/PgliteSchemaGenerator.ts
+++ b/packages/pglite/src/PgliteSchemaGenerator.ts
@@ -1,0 +1,35 @@
+import { type MikroORM, type SqlEntityManager, SchemaGenerator } from '@mikro-orm/sql';
+import type { PgliteDriver } from './PgliteDriver.js';
+
+/**
+ * In the default (single-database) setup a PGlite instance maps 1:1 to its
+ * `dataDir`, so there are no separate databases to create or drop and both
+ * operations are no-ops. The inherited implementation would otherwise switch
+ * `dbName` and reconnect, rebuilding the instance with the new name as its
+ * `dataDir` — materializing a stray on-disk data directory. Named-database mode
+ * (`driverOptions.dataDir` set) keeps the real `CREATE DATABASE` lifecycle.
+ */
+export class PgliteSchemaGenerator extends SchemaGenerator {
+  static override register(orm: MikroORM<PgliteDriver>): void {
+    orm.config.registerExtension(
+      '@mikro-orm/schema-generator',
+      () => new PgliteSchemaGenerator(orm.em as SqlEntityManager),
+    );
+  }
+
+  override async createDatabase(name?: string, options?: { skipOnConnect?: boolean }): Promise<void> {
+    if (!this.helper.getManagementDbName()) {
+      return;
+    }
+
+    return super.createDatabase(name, options);
+  }
+
+  override async dropDatabase(name?: string): Promise<void> {
+    if (!this.helper.getManagementDbName()) {
+      return;
+    }
+
+    return super.dropDatabase(name);
+  }
+}

--- a/packages/pglite/src/index.ts
+++ b/packages/pglite/src/index.ts
@@ -3,6 +3,7 @@ export * from './PgliteConnection.js';
 export * from './PgliteDriver.js';
 export * from './PglitePlatform.js';
 export * from './PgliteSchemaHelper.js';
+export * from './PgliteSchemaGenerator.js';
 export {
   PgliteMikroORM as MikroORM,
   type PgliteOptions as Options,

--- a/tests/features/entity-manager/EntityManager.pglite.test.ts
+++ b/tests/features/entity-manager/EntityManager.pglite.test.ts
@@ -3109,6 +3109,10 @@ describe('EntityManagerPglite', () => {
   test('createDatabase / dropDatabase are no-ops on pglite', async () => {
     await orm.schema.createDatabase('whatever');
     await orm.schema.dropDatabase('whatever');
+
+    // single-database PGlite must not materialize an on-disk data directory for the name
+    const { existsSync } = await import('node:fs');
+    expect(existsSync('whatever')).toBe(false);
   });
 
   test('MikroORM.init resolves with PgliteDriver and accepts a PGlite instance', async () => {


### PR DESCRIPTION
In single-database mode a PGlite instance maps 1:1 to its `dataDir`, so there are no separate databases to create or drop. The schema helper already made the SQL a no-op, but the inherited `SqlSchemaGenerator.createDatabase`/`dropDatabase` still switched `dbName` and reconnected — which rebuilds the PGlite instance with the given name as its `dataDir`, materializing a stray on-disk data directory.

This surfaced as tests leaving a `whatever/` folder behind (from the existing "createDatabase / dropDatabase are no-ops on pglite" test calling `createDatabase('whatever')`).

Fix: a dedicated `PgliteSchemaGenerator` short-circuits both operations in single-database mode (`getManagementDbName()` empty). Named-database mode (`driverOptions.dataDir` set) keeps the real `CREATE DATABASE` lifecycle, still covered by the existing GH7852 test. The no-op test now also asserts no directory is created.