### PR TITLE
fix(core): keep async-clonable resources by reference in config clone

### DIFF
--- a/packages/core/src/utils/clone.ts
+++ b/packages/core/src/utils/clone.ts
@@ -42,6 +42,13 @@ export function clone<T>(parent: T, respectCustomCloneMethod = true): T {
     }
 
     if (respectCustomCloneMethod && 'clone' in parent && typeof parent.clone === 'function') {
+      // an async `clone()` signals a live stateful resource (e.g. a PGlite instance
+      // in `driverOptions`, whose `clone()` boots a second WASM database) — this sync
+      // function cannot await it, so keep the instance by reference instead
+      if (parent.clone.constructor.name === 'AsyncFunction') {
+        return parent;
+      }
+
       return parent.clone();
     }
 

--- a/tests/Utils.win.test.ts
+++ b/tests/Utils.win.test.ts
@@ -157,6 +157,29 @@ describe('Utils', () => {
       expect(c.inner.p).toBeInstanceOf(Promise);
     });
 
+    test('should honor a sync custom clone method but keep async-clonable resources by reference', () => {
+      const sync = {
+        value: 1,
+        clone() {
+          return { value: 2 };
+        },
+      };
+      expect(Utils.copy({ inner: sync }).inner).toEqual({ value: 2 });
+
+      // an async `clone()` signals a live resource (e.g. a PGlite instance) that
+      // the sync copy must keep by reference rather than invoke
+      let cloned = false;
+      const resource = {
+        async clone() {
+          cloned = true;
+          return {};
+        },
+      };
+      const copy = Utils.copy({ inner: resource });
+      expect(copy.inner).toBe(resource);
+      expect(cloned).toBe(false);
+    });
+
     it('should copy child object even though getter property is dynamically injected', () => {
       function NameDecorator<T extends { new (...args: any[]): {} }>(constructor: T) {
         return class extends constructor {

--- a/tests/issues/GH7862.test.ts
+++ b/tests/issues/GH7862.test.ts
@@ -1,3 +1,4 @@
+import { PGlite } from '@electric-sql/pglite';
 import { MikroORM } from '@mikro-orm/pglite';
 import { Entity, PrimaryKey, Property } from '@mikro-orm/decorators/legacy';
 
@@ -29,5 +30,27 @@ describe('GH #7862 — in-memory pglite is fully closed on orm.close()', () => {
     await expect(orm.em.fork().count(User)).resolves.toBe(0);
 
     await orm.close();
+  });
+});
+
+describe('GH #7862 — externally managed pglite instance is used directly, not cloned', () => {
+  test('the user-supplied instance receives the schema/data and is never deep-cloned', async () => {
+    const pglite = await PGlite.create();
+    const orm = await MikroORM.init({ entities: [User], driverOptions: { pglite } });
+
+    // config normalization must keep the exact instance — deep-cloning would
+    // invoke PGlite's async `clone()` and spin up a second, divergent database
+    expect((orm.config.get('driverOptions') as { pglite: PGlite }).pglite).toBe(pglite);
+
+    await orm.schema.create();
+    orm.em.create(User, { id: 1, name: 'Foo' });
+    await orm.em.flush();
+
+    // the write must land in the user's own instance, queried directly
+    const res = await pglite.query<{ count: number }>('select count(*)::int as count from "user"');
+    expect(res.rows[0].count).toBe(1);
+
+    await orm.close(true);
+    await pglite.close();
   });
 });


### PR DESCRIPTION
The sync `clone()` helper (used by `Utils.copy`/`mergeConfig` to deep-clone the config, including `driverOptions`) invoked any custom `clone()` method it encountered. A user-supplied PGlite instance passed via `driverOptions.pglite` exposes an **`async clone()`** that boots a whole second WASM database. So config normalization during `MikroORM.init` silently:

- spun up an orphaned PGlite instance that was never closed — its lingering open handles are what jest's open-handle detector flags (the ~10s hang in #7862), and
- replaced `driverOptions.pglite` with that clone, so the ORM operated on the copy while the caller's own instance never received the schema/data.

This is the remaining half of #7862 — [#7870](https://github.com/mikro-orm/mikro-orm/pull/7870) covered *owned* in-memory instances; this covers *externally managed* ones.

Fix: in `clone()`, when the custom `clone()` is declared `async`, return the instance by reference instead of invoking it — a sync clone can't await an async clone, and an object exposing one is a live resource that shouldn't be duplicated. Verified no internal `clone()` method is async, so the new branch only affects external resources.

Closes #7862