### PR TITLE
fix(sql): resolve target entity schema in nested collection operators

### DIFF
--- a/packages/sql/src/query/ObjectCriteriaNode.ts
+++ b/packages/sql/src/query/ObjectCriteriaNode.ts
@@ -63,7 +63,11 @@ export class ObjectCriteriaNode<T extends object> extends CriteriaNode<T> {
           }
 
           const payload = (this.payload[key] as CriteriaNode<T>).unwrap();
-          const qb2 = qb.clone(true, ['schema']);
+          // entities with a fixed schema must resolve the `from` table's own schema in the subquery,
+          // otherwise a nested operator inherits the root entity's schema (GH #7894); for wildcard or
+          // schema-less entities the schema is resolved dynamically and needs to be carried over
+          const fixedSchema = parentMeta.schema && parentMeta.schema !== '*';
+          const qb2 = qb.clone(true, fixedSchema ? undefined : ['schema']);
           const joinAlias = qb2.getNextAlias(this.prop!.targetMeta!.class);
           const sub = qb2
             .from(parentMeta.class)

--- a/tests/features/multiple-schemas/GH7894.test.ts
+++ b/tests/features/multiple-schemas/GH7894.test.ts
@@ -1,0 +1,68 @@
+import { Collection, MikroORM } from '@mikro-orm/postgresql';
+import {
+  Entity,
+  ManyToMany,
+  ManyToOne,
+  OneToMany,
+  PrimaryKey,
+  Property,
+  ReflectMetadataProvider,
+} from '@mikro-orm/decorators/legacy';
+import { mockLogger } from '../../helpers.js';
+
+@Entity({ schema: 'a' })
+class Author {
+  @PrimaryKey()
+  id!: number;
+
+  @ManyToMany({ entity: () => Book, owner: true })
+  books = new Collection<Book>(this);
+}
+
+@Entity({ schema: 'b' })
+class Book {
+  @PrimaryKey()
+  id!: number;
+
+  @OneToMany(() => Review, r => r.book)
+  reviews = new Collection<Review>(this);
+}
+
+@Entity({ schema: 'b' })
+class Review {
+  @PrimaryKey()
+  id!: number;
+
+  @ManyToOne(() => Book)
+  book!: Book;
+
+  @Property()
+  rating!: number;
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    dbName: 'mikro_orm_test_7894',
+    entities: [Author, Book, Review],
+    metadataProvider: ReflectMetadataProvider,
+  });
+  await orm.schema.refresh();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+test('nested $some across schemas uses target entity schema (GH #7894)', async () => {
+  const mock = mockLogger(orm);
+
+  await orm.em.findOne(Author, {
+    books: { $some: { reviews: { $some: { rating: 5 } } } },
+  });
+
+  const sql = mock.mock.calls.map(c => c[0]).join('\n');
+  expect(sql).toContain('"b"."book"');
+  expect(sql).not.toContain('"a"."book"');
+});


### PR DESCRIPTION
A nested collection operator (`$some` inside another `$some`, etc.) that crosses from an entity in one fixed schema into entities in a different schema generated a subquery that qualified the inner `from` table with the **root** entity's schema instead of the target entity's own `@Entity({ schema })`. The first-level join was correct; only the nested subquery inherited the wrong schema, so Postgres threw `relation "<wrong_schema>.<table>" does not exist`.

The collection-operator subquery cloned the query builder while preserving the root `schema` state unconditionally (`qb.clone(true, ['schema'])`), leaking the root entity's resolved schema into the nested `from`. The schema is now carried over only for wildcard (`'*'`) or schema-less entities (where it is resolved dynamically); entities with a fixed schema let the subquery resolve the `from` table's own schema.

Closes #7894