### PR TITLE
fix(sql): serialize array operators as a single literal in JOIN-ON conditions

### DIFF
--- a/packages/sql/src/query/QueryBuilderHelper.ts
+++ b/packages/sql/src/query/QueryBuilderHelper.ts
@@ -871,6 +871,8 @@ export class QueryBuilderHelper {
         return `(${tmp.join(', ')})`;
       }
 
+      // array custom types (e.g. `$contains`/`$overlap` on `string[]` columns) are converted to a single
+      // array literal, so we emit a single bound parameter — not one per element wrapped in a tuple
       if (prop?.customType instanceof ArrayType) {
         const item = prop.customType.convertToDatabaseValue(value, this.#platform, {
           fromQuery: true,
@@ -878,9 +880,10 @@ export class QueryBuilderHelper {
           mode: 'query',
         });
         params.push(item);
-      } else {
-        value.forEach(p => params.push(p));
+        return '?';
       }
+
+      value.forEach(p => params.push(p));
 
       return `(${value.map(() => '?').join(', ')})`;
     }

--- a/tests/issues/GH7899.test.ts
+++ b/tests/issues/GH7899.test.ts
@@ -1,0 +1,97 @@
+import { Collection, MikroORM } from '@mikro-orm/postgresql';
+
+import {
+  Entity,
+  Enum,
+  ManyToOne,
+  OneToMany,
+  PrimaryKey,
+  Property,
+  ReflectMetadataProvider,
+} from '@mikro-orm/decorators/legacy';
+
+enum SchoolGrade {
+  GradeOne = '1',
+  GradeTwo = '2',
+  GradeThree = '3',
+  GradeFour = '4',
+  GradeFive = '5',
+  GradeSix = '6',
+}
+
+@Entity({ tableName: 'subtests' })
+class SubTestEntity {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  title!: string;
+
+  @Enum({ items: () => SchoolGrade, array: true })
+  grades!: SchoolGrade[];
+
+  @OneToMany(() => ExerciseEntity, exercise => exercise.subtest)
+  exercises = new Collection<ExerciseEntity>(this);
+}
+
+@Entity({ tableName: 'exercises' })
+class ExerciseEntity {
+  @PrimaryKey()
+  id!: number;
+
+  @Enum({ items: () => SchoolGrade, array: true })
+  grades!: SchoolGrade[];
+
+  @ManyToOne(() => SubTestEntity)
+  subtest!: SubTestEntity;
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    metadataProvider: ReflectMetadataProvider,
+    dbName: '7899',
+    entities: [SubTestEntity, ExerciseEntity],
+  });
+
+  await orm.schema.refresh();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+// a multi-element array operator nested under a relation lands in the JOIN-ON
+// condition and must serialize as an array literal, not a record tuple
+test('multi-element $contains on relation property in populateWhere (m:1 side)', async () => {
+  const subtest = new SubTestEntity();
+  subtest.title = 'Subtest One';
+  subtest.grades = [SchoolGrade.GradeFour, SchoolGrade.GradeFive];
+
+  for (let i = 0; i < 5; i++) {
+    const exercise = new ExerciseEntity();
+    exercise.subtest = subtest;
+    exercise.grades = [SchoolGrade.GradeFour, SchoolGrade.GradeFive];
+    subtest.exercises.add(exercise);
+  }
+
+  await orm.em.fork().persist(subtest).flush();
+
+  const res = await orm.em.fork().find(
+    ExerciseEntity,
+    {},
+    {
+      populate: ['subtest'],
+      populateWhere: {
+        subtest: {
+          grades: {
+            $contains: [SchoolGrade.GradeFour, SchoolGrade.GradeFive],
+          },
+        },
+      },
+    },
+  );
+
+  expect(res).toHaveLength(5);
+});


### PR DESCRIPTION
An array operator (`$contains`/`$overlap`/`$contained`) on an array custom-type column (e.g. `@Enum({ array: true })` or `@Property({ type: 'string[]' })`) serialized incorrectly when the predicate landed in a JOIN-ON condition — i.e. when nested under a relation via `populateWhere` (or a relation filter in `where`).

In `getValueReplacement`, such a value arrives as an unconverted array. It was marshalled into a single array literal (one bound param) but rendered with one placeholder per element, so a multi-element array produced a record tuple:

```sql
... on ... and "t1"."scope" @> ('{DEAL,PROJECT}', undefined)
```

instead of the array literal the flat WHERE path already produces:

```sql
... where "t0"."scope" @> '{DEAL,PROJECT}'
```

Postgres then failed with `column "undefined" does not exist` (or `operator does not exist: text[] @> record`). Single-element arrays masked the bug because `(?)` is equivalent to `?`. This was a regression from v6.

The fix emits a single bound parameter for the array-literal case, matching the flat WHERE serialization.

Closes #7899