### PR TITLE
test: cover multi-element array operator nested under a relation

### DIFF
--- a/tests/issues/GH7899.test.ts
+++ b/tests/issues/GH7899.test.ts
@@ -1,0 +1,90 @@
+import { Collection, Entity, Enum, ManyToOne, MikroORM, OneToMany, PrimaryKey, Property } from '@mikro-orm/postgresql';
+
+enum SchoolGrade {
+  GradeOne = '1',
+  GradeTwo = '2',
+  GradeThree = '3',
+  GradeFour = '4',
+  GradeFive = '5',
+  GradeSix = '6',
+}
+
+@Entity({ tableName: 'subtests' })
+class SubTestEntity {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  title!: string;
+
+  @Enum({ items: () => SchoolGrade, array: true })
+  grades!: SchoolGrade[];
+
+  @OneToMany(() => ExerciseEntity, exercise => exercise.subtest)
+  exercises = new Collection<ExerciseEntity>(this);
+
+}
+
+@Entity({ tableName: 'exercises' })
+class ExerciseEntity {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Enum({ items: () => SchoolGrade, array: true })
+  grades!: SchoolGrade[];
+
+  @ManyToOne(() => SubTestEntity)
+  subtest!: SubTestEntity;
+
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    dbName: '7899',
+    entities: [SubTestEntity, ExerciseEntity],
+  });
+
+  await orm.schema.refreshDatabase();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+// a multi-element array operator nested under a relation lands in the JOIN-ON
+// condition and must serialize as an array literal, not a record tuple
+test('multi-element $contains on relation property in populateWhere (m:1 side)', async () => {
+  const subtest = new SubTestEntity();
+  subtest.title = 'Subtest One';
+  subtest.grades = [SchoolGrade.GradeFour, SchoolGrade.GradeFive];
+
+  for (let i = 0; i < 5; i++) {
+    const exercise = new ExerciseEntity();
+    exercise.subtest = subtest;
+    exercise.grades = [SchoolGrade.GradeFour, SchoolGrade.GradeFive];
+    subtest.exercises.add(exercise);
+  }
+
+  await orm.em.fork().persistAndFlush(subtest);
+
+  const res = await orm.em.fork().find(
+    ExerciseEntity,
+    {},
+    {
+      populate: ['subtest'],
+      populateWhere: {
+        subtest: {
+          grades: {
+            $contains: [SchoolGrade.GradeFour, SchoolGrade.GradeFive],
+          },
+        },
+      },
+    },
+  );
+
+  expect(res).toHaveLength(5);
+});


### PR DESCRIPTION
Adds a regression test for a multi-element array operator (`$contains`) on an array column nested under a relation via `populateWhere`, which lands in a JOIN-ON condition.

The v7 fix for #7899 ([#7900](https://github.com/mikro-orm/mikro-orm/pull/7900)) addressed a tuple-vs-array serialization bug in that path. v6 already serializes this as a single array literal (the bug was a v7-only regression), so no source change is needed here — this is a regression guard only.

Closes #7899