### PR TITLE
fix(core): key change set groups by metadata id to avoid dropped writes

### DIFF
--- a/packages/core/src/unit-of-work/UnitOfWork.ts
+++ b/packages/core/src/unit-of-work/UnitOfWork.ts
@@ -1320,7 +1320,7 @@ export class UnitOfWork {
   }
 
   private async persistToDatabase(
-    groups: { [K in ChangeSetType]: Map<EntityMetadata, ChangeSet<any>[]> },
+    groups: { [K in ChangeSetType]: Map<number, ChangeSet<any>[]> },
     ctx?: Transaction,
   ): Promise<void> {
     if (ctx) {
@@ -1332,12 +1332,12 @@ export class UnitOfWork {
 
     // early delete - when we recreate entity in the same UoW, we need to issue those delete queries before inserts
     for (const meta of commitOrderReversed) {
-      await this.commitDeleteChangeSets(groups[ChangeSetType.DELETE_EARLY].get(meta) ?? [], ctx);
+      await this.commitDeleteChangeSets(groups[ChangeSetType.DELETE_EARLY].get(meta._id) ?? [], ctx);
     }
 
     // early update - when we recreate entity in the same UoW, we need to issue those delete queries before inserts
     for (const meta of commitOrder) {
-      await this.commitUpdateChangeSets(groups[ChangeSetType.UPDATE_EARLY].get(meta) ?? [], ctx);
+      await this.commitUpdateChangeSets(groups[ChangeSetType.UPDATE_EARLY].get(meta._id) ?? [], ctx);
     }
 
     // extra updates
@@ -1345,12 +1345,12 @@ export class UnitOfWork {
 
     // create
     for (const meta of commitOrder) {
-      await this.commitCreateChangeSets(groups[ChangeSetType.CREATE].get(meta) ?? [], ctx);
+      await this.commitCreateChangeSets(groups[ChangeSetType.CREATE].get(meta._id) ?? [], ctx);
     }
 
     // update
     for (const meta of commitOrder) {
-      await this.commitUpdateChangeSets(groups[ChangeSetType.UPDATE].get(meta) ?? [], ctx);
+      await this.commitUpdateChangeSets(groups[ChangeSetType.UPDATE].get(meta._id) ?? [], ctx);
     }
 
     // extra updates
@@ -1361,7 +1361,7 @@ export class UnitOfWork {
 
     // delete - entity deletions need to be in reverse commit order
     for (const meta of commitOrderReversed) {
-      await this.commitDeleteChangeSets(groups[ChangeSetType.DELETE].get(meta) ?? [], ctx);
+      await this.commitDeleteChangeSets(groups[ChangeSetType.DELETE].get(meta._id) ?? [], ctx);
     }
 
     // take snapshots of all persisted collections
@@ -1608,13 +1608,13 @@ export class UnitOfWork {
   /**
    * Orders change sets so FK constrains are maintained, ensures stable order (needed for node < 11)
    */
-  private getChangeSetGroups(): { [K in ChangeSetType]: Map<EntityMetadata, ChangeSet<any>[]> } {
+  private getChangeSetGroups(): { [K in ChangeSetType]: Map<number, ChangeSet<any>[]> } {
     const groups = {
-      [ChangeSetType.CREATE]: new Map<EntityMetadata, ChangeSet<any>[]>(),
-      [ChangeSetType.UPDATE]: new Map<EntityMetadata, ChangeSet<any>[]>(),
-      [ChangeSetType.DELETE]: new Map<EntityMetadata, ChangeSet<any>[]>(),
-      [ChangeSetType.UPDATE_EARLY]: new Map<EntityMetadata, ChangeSet<any>[]>(),
-      [ChangeSetType.DELETE_EARLY]: new Map<EntityMetadata, ChangeSet<any>[]>(),
+      [ChangeSetType.CREATE]: new Map<number, ChangeSet<any>[]>(),
+      [ChangeSetType.UPDATE]: new Map<number, ChangeSet<any>[]>(),
+      [ChangeSetType.DELETE]: new Map<number, ChangeSet<any>[]>(),
+      [ChangeSetType.UPDATE_EARLY]: new Map<number, ChangeSet<any>[]>(),
+      [ChangeSetType.DELETE_EARLY]: new Map<number, ChangeSet<any>[]>(),
     };
 
     const addToGroup = (cs: ChangeSet<any>) => {
@@ -1627,7 +1627,10 @@ export class UnitOfWork {
       }
 
       const group = groups[cs.type];
-      const groupKey = cs.meta.inheritanceType === 'tpt' ? cs.meta : cs.rootMeta;
+      // keyed by `_id` so the groups share keys with `getCommitOrder()`, which dedupes by `_id`;
+      // two `EntityMetadata` instances with the same `_id` (shared metadata cache) must not split
+      // a group between them, or the lookup in `persistToDatabase()` misses and drops it (GH #7903)
+      const groupKey = cs.meta.inheritanceType === 'tpt' ? cs.meta._id : cs.rootMeta._id;
       const classGroup = group.get(groupKey) ?? [];
       classGroup.push(cs);
 

--- a/tests/issues/GH7903.test.ts
+++ b/tests/issues/GH7903.test.ts
@@ -1,0 +1,98 @@
+import { rmSync } from 'node:fs';
+import { Cascade, Collection } from '@mikro-orm/core';
+import {
+  Entity,
+  ManyToOne,
+  OneToMany,
+  PrimaryKey,
+  Property,
+  ReflectMetadataProvider,
+} from '@mikro-orm/decorators/legacy';
+import { MikroORM } from '@mikro-orm/sqlite';
+import { TEMP_DIR } from '../helpers.js';
+
+@Entity()
+class Parent {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  title!: string;
+
+  @OneToMany(() => Child, c => c.parent, { orphanRemoval: true, cascade: [Cascade.PERSIST] })
+  children = new Collection<Child>(this);
+}
+
+@Entity()
+class Child {
+  @PrimaryKey()
+  id!: number;
+
+  @ManyToOne(() => Parent)
+  parent!: Parent;
+
+  @Property()
+  body!: string;
+}
+
+// File-based metadata cache so the two ORM instances below share the persisted `_id`.
+const CACHE_DIR = TEMP_DIR + '/.metadata-cache-7903';
+
+const baseConfig = {
+  dbName: ':memory:',
+  entities: [Parent, Child],
+  metadataProvider: ReflectMetadataProvider,
+  // Persist EntityMetadata._id to disk (TsMorphMetadataProvider enables this implicitly).
+  metadataCache: { enabled: true, options: { cacheDir: CACHE_DIR } },
+};
+
+// Replacing a re-fetched parent's 1:m collection (with orphanRemoval) by a new child via
+// `em.assign()` and flushing must not silently skip the INSERT for the new child.
+//
+// Two `MikroORM` instances share a file-based metadata cache, so the second init reads back the
+// persisted `_id` and ends up with a second `EntityMetadata` instance carrying the same `_id`.
+// `getChangeSetGroups()` keyed groups by the meta instance while `getCommitOrder()` dedupes by
+// `_id`, so the CREATE group stored under instance A was looked up by instance B and dropped.
+test('GH 7903: INSERT of a new collection item is not skipped with duplicate metadata sharing an _id', async () => {
+  rmSync(CACHE_DIR, { recursive: true, force: true });
+
+  // We operate on `orm`; `orm2` is initialized last so it overwrites the entity class's attached
+  // metadata, making hydrated entities resolve to a different instance than freshly created ones.
+  const orm = await MikroORM.init({ ...baseConfig, contextName: 'ctx1' });
+  const orm2 = await MikroORM.init({ ...baseConfig, contextName: 'ctx2' });
+  await orm.schema.refresh();
+
+  // seed: a parent with one child
+  let parentId: number;
+  {
+    const em = orm.em.fork();
+    const parent = new Parent();
+    parent.title = 'seed';
+    const child = new Child();
+    child.body = 'old-child';
+    child.parent = parent;
+    parent.children.add(child);
+    em.persist(parent);
+    await em.flush();
+    parentId = parent.id;
+  }
+
+  // re-fetch the parent and replace its collection with a new child
+  const em = orm.em.fork();
+  const [parent] = await em.populate([em.getReference(Parent, parentId)], ['children']);
+  const newChild = new Child();
+  newChild.parent = parent;
+  newChild.body = 'new-child';
+  em.assign(parent, { children: [newChild] });
+  await em.flush();
+
+  const newChildId = newChild.id;
+  const count = await orm.em.fork().count(Child);
+
+  await orm.close(true);
+  await orm2.close(true);
+  rmSync(CACHE_DIR, { recursive: true, force: true });
+
+  expect(newChildId).toBeDefined();
+  expect(count).toBe(1);
+});


### PR DESCRIPTION
## Summary

Completes the #7511 fix. `getCommitOrder()` already dedupes by `EntityMetadata._id`, but `getChangeSetGroups()` still keyed its maps by the metadata *instance*.

When two `MikroORM` instances share a file-based metadata cache, the second init reads back the persisted `_id` and ends up with a second `EntityMetadata` instance carrying the same `_id`. Hydrated entities resolve to one instance while freshly created ones resolve to the other. The change-set group stored under instance A was then looked up by instance B in `persistToDatabase()`, `Map.get` missed, fell back to `?? []`, and the whole group was silently dropped — no SQL emitted, no error, PK left `undefined`.

In the reported case, replacing a re-fetched parent's `1:m` collection (with `orphanRemoval`) by a new child via `em.assign()` ran the `orphanRemoval` DELETE but skipped the INSERT for the new child.

The fix keys the groups by `_id` so they share the same key space as `getCommitOrder()` (which, along with `CommitOrderCalculator`, already operates entirely on `_id`).

Regression since v7.0.10 (#7513), which fixed the DELETE path the same way for the commit order but left the group map keyed by instance.

Closes #7903