### PR TITLE
fix(core): apply populateOrderBy to select-in relations without leaking into M:N pivots

### DIFF
--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -259,6 +259,7 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
       await em.#entityLoader.populate<Entity>(entityName, cached.data as Entity[], populate, {
         ...(options as Dictionary),
         ...em.getPopulateWhere(where as ObjectQuery<Entity>, options),
+        orderBy: options.populateOrderBy ?? options.orderBy,
         ignoreLazyScalarProperties: true,
         lookup: false,
       });
@@ -298,6 +299,7 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
     await em.#entityLoader.populate<Entity, Fields>(entityName, unique as Entity[], populate, {
       ...(options as Dictionary),
       ...em.getPopulateWhere(where as ObjectQuery<Entity>, options),
+      orderBy: options.populateOrderBy ?? options.orderBy,
       ignoreLazyScalarProperties: true,
       lookup: false,
     });

--- a/packages/sql/src/AbstractSqlDriver.ts
+++ b/packages/sql/src/AbstractSqlDriver.ts
@@ -1835,6 +1835,12 @@ export abstract class AbstractSqlDriver<
       return {};
     }
 
+    // The pivot order is recomputed via `getPivotOrderBy`, so the parent `populateOrderBy` must not leak
+    // into the pivot subquery — its keys reference the parent entity, not the pivot (GH #7910).
+    if (options?.populateOrderBy != null) {
+      options = { ...options, populateOrderBy: undefined };
+    }
+
     const pivotMeta = this.metadata.get(prop.pivotEntity);
 
     if (prop.discriminatorColumn && QueryHelper.isUnionTargetPolymorphic(prop)) {

--- a/tests/issues/GH7910.test.ts
+++ b/tests/issues/GH7910.test.ts
@@ -1,0 +1,81 @@
+import { Collection, MikroORM } from '@mikro-orm/sqlite';
+import {
+  Entity,
+  ManyToMany,
+  ManyToOne,
+  OneToMany,
+  PrimaryKey,
+  Property,
+  ReflectMetadataProvider,
+} from '@mikro-orm/decorators/legacy';
+
+@Entity()
+class Tag {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+}
+
+@Entity()
+class Book {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  title!: string;
+
+  @ManyToMany(() => Tag)
+  tags = new Collection<Tag>(this);
+
+  @OneToMany(() => Label, label => label.book)
+  labels = new Collection<Label>(this);
+}
+
+@Entity()
+class Label {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  position!: number;
+
+  @ManyToOne(() => Book)
+  book!: Book;
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    metadataProvider: ReflectMetadataProvider,
+    entities: [Book, Tag, Label],
+    dbName: ':memory:',
+    loadStrategy: 'select-in',
+  });
+  await orm.schema.refresh();
+});
+
+afterAll(() => orm.close(true));
+
+test('populateOrderBy for a sibling relation does not leak into the M:N pivot load (GH #7910)', async () => {
+  const book = orm.em.create(Book, { title: 'b1' });
+  book.tags.add(orm.em.create(Tag, { name: 't1' }), orm.em.create(Tag, { name: 't2' }));
+  orm.em.create(Label, { position: 2, book });
+  orm.em.create(Label, { position: 1, book });
+  await orm.em.flush();
+  orm.em.clear();
+
+  const [loaded] = await orm.em.find(
+    Book,
+    {},
+    {
+      populate: ['tags', 'labels'],
+      populateOrderBy: { labels: { position: 'asc' } },
+    },
+  );
+
+  expect(loaded.tags.getItems()).toHaveLength(2);
+  expect(loaded.labels.getItems().map(l => l.position)).toEqual([1, 2]);
+});


### PR DESCRIPTION
`em.find` never folded `populateOrderBy` into the order passed to the entity loader, so ordering a relation loaded via the `select-in`/`balanced` strategy was silently ignored — only `findOne` (via `lockAndPopulate`) handled it.

Mapping it through the same way `findOne` does also surfaced a leak: the parent `populateOrderBy` was carried into the M:N pivot subquery, which then threw `Trying to order by not existing property <pivot>.<field>` for a *sibling* relation's key (e.g. ordering `Book.labels` while populating `Book.tags`). Since the pivot order is recomputed independently via `getPivotOrderBy`, the parent `populateOrderBy` is stripped before the pivot load.

Closes #7910