### PR TITLE
fix(sql): keep nested collection populateOrderBy by a to-one relation field under joined strategy

### DIFF
--- a/packages/sql/src/AbstractSqlDriver.ts
+++ b/packages/sql/src/AbstractSqlDriver.ts
@@ -3261,6 +3261,24 @@ export abstract class AbstractSqlDriver<
         const propAlias = qb.getAliasForJoinPath(join ?? path, { matchPopulateJoins: true }) ?? parentAlias;
 
         if (!join) {
+          // an owner to-one relation that is not joined (e.g. ordering a populated collection by such
+          // a relation's primary key) can be ordered by its local FK columns, matching the `select-in`
+          // and `balanced` strategies instead of silently dropping the clause
+          if (
+            prop.owner &&
+            [ReferenceKind.MANY_TO_ONE, ReferenceKind.ONE_TO_ONE].includes(prop.kind) &&
+            Utils.isPlainObject(childOrder)
+          ) {
+            for (const childField of Utils.getObjectQueryKeys(childOrder as Dictionary)) {
+              const idx = prop.referencedPKs.indexOf(childField as EntityKey);
+              const order = (childOrder as Dictionary)[childField as string];
+
+              if (idx !== -1 && order) {
+                orderBy.push({ [`${parentAlias}.${prop.joinColumns[idx]}` as EntityKey]: order } as QueryOrderMap<T>);
+              }
+            }
+          }
+
           continue;
         }
 

--- a/tests/issues/GH7911.test.ts
+++ b/tests/issues/GH7911.test.ts
@@ -1,0 +1,90 @@
+import { Collection, MikroORM } from '@mikro-orm/sqlite';
+import {
+  Entity,
+  ManyToOne,
+  OneToMany,
+  PrimaryKey,
+  Property,
+  ReflectMetadataProvider,
+} from '@mikro-orm/decorators/legacy';
+import { mockLogger } from '../helpers.js';
+
+@Entity()
+class Workflow {
+  @PrimaryKey()
+  id!: number;
+
+  @OneToMany({ entity: () => Phase, mappedBy: phase => phase.workflow })
+  phases = new Collection<Phase>(this);
+}
+
+@Entity()
+class Phase {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  position!: number;
+
+  @ManyToOne(() => Workflow)
+  workflow!: Workflow;
+
+  @OneToMany({ entity: () => Element, mappedBy: element => element.phase })
+  elements = new Collection<Element>(this);
+}
+
+@Entity()
+class Element {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  position!: number;
+
+  @ManyToOne(() => Phase)
+  phase!: Phase;
+
+  @ManyToOne({ entity: () => Element, nullable: true })
+  parent?: Element | null;
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    metadataProvider: ReflectMetadataProvider,
+    entities: [Workflow, Phase, Element],
+    dbName: ':memory:',
+  });
+  await orm.schema.refresh();
+
+  const workflow = orm.em.create(Workflow, { id: 1 });
+  const phase = orm.em.create(Phase, { id: 1, position: 1, workflow });
+  orm.em.create(Element, { id: 2, position: 1, phase, parent: null });
+  orm.em.create(Element, { id: 1, position: 1, phase, parent: 2 });
+  await orm.em.flush();
+  orm.em.clear();
+});
+
+afterAll(() => orm.close(true));
+
+// ordering a populated collection by a to-one relation's FK was silently dropped under the `joined` strategy
+test('joined strategy keeps nested collection orderBy by a to-one relation field', async () => {
+  const mock = mockLogger(orm);
+  const workflow = await orm.em.findOneOrFail(
+    Workflow,
+    { id: 1 },
+    {
+      populate: ['phases.elements'],
+      strategy: 'joined',
+      populateOrderBy: {
+        phases: { position: 'asc', elements: { parent: { id: 'asc nulls first' }, position: 'asc' } },
+      },
+    },
+  );
+
+  expect(mock.mock.calls[0][0]).toMatch(
+    'order by `p1`.`position` asc, `e2`.`parent_id` asc nulls first, `e2`.`position` asc',
+  );
+  expect(workflow.phases[0].elements.getItems().map(e => e.id)).toEqual([2, 1]);
+});


### PR DESCRIPTION
Under `loadStrategy: 'joined'`, ordering a populated collection by a to-one relation's primary key was silently dropped:

```ts
await em.findOne(Workflow, { id: 1 }, {
  populate: ['phases.elements'],
  populateOrderBy: {
    phases: { position: 'asc', elements: { parent: { id: 'asc nulls first' }, position: 'asc' } },
  },
});
```

The `parent.id` part produced no `ORDER BY` clause (results came back ordered by `position` alone), while `select-in` / `balanced` ordered correctly.

In `buildPopulateOrderBy`, a to-one relation used only for ordering has no join to resolve, so the clause was skipped entirely. For an owner to-one ordered by its referenced PK, the FK lives on the local table, so we now emit the local FK columns on the parent alias (the same `referencedPKs → joinColumns` mapping used by `ObjectCriteriaNode`), matching the non-joined strategies.

Closes #7911