### PR TITLE
fix(postgresql): handle stored routines with unnamed parameters

### DIFF
--- a/packages/sql/src/dialects/postgresql/PostgreSqlSchemaHelper.ts
+++ b/packages/sql/src/dialects/postgresql/PostgreSqlSchemaHelper.ts
@@ -838,7 +838,8 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
       .map(p => {
         const dir = p.direction === 'in' ? '' : `${p.direction.toUpperCase()} `;
         const def = p.defaultRaw ? ` default ${p.defaultRaw}` : '';
-        return `${dir}${this.platform.quoteIdentifier(p.name)} ${p.type}${def}`;
+        const name = p.name ? `${this.platform.quoteIdentifier(p.name)} ` : '';
+        return `${dir}${name}${p.type}${def}`;
       })
       .join(', ');
   }
@@ -851,10 +852,12 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
     return signature.split(/,(?![^()]*\))/).map(part => {
       const trimmed = part.trim();
       // INOUT before IN/OUT, with required trailing space so identifiers like `input` aren't
-      // mis-parsed as a direction keyword.
-      const match = /^(?:(INOUT|VARIADIC|IN|OUT)\s+)?(?:"((?:[^"]|"")+)"|([\w$]+))\s+(.+?)(?:\s+default\s+.+)?$/i.exec(
-        trimmed,
-      );
+      // mis-parsed as a direction keyword. The name is optional — `pg_get_function_arguments`
+      // omits it for unnamed parameters (e.g. `text`), leaving just the type.
+      const match =
+        /^(?:(INOUT|VARIADIC|IN|OUT)\s+)?(?:(?:"((?:[^"]|"")+)"|([\w$]+))\s+)?(.+?)(?:\s+default\s+.+)?$/i.exec(
+          trimmed,
+        );
 
       /* v8 ignore next 3: defensive guard for unexpected `pg_get_function_arguments` output shapes */
       if (!match) {
@@ -863,7 +866,7 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
 
       const dirRaw = (match[1] ?? 'in').toLowerCase();
       const direction = dirRaw === 'inout' ? 'inout' : dirRaw === 'out' ? 'out' : 'in';
-      const name = match[2] != null ? match[2].replaceAll('""', '"') : match[3];
+      const name = match[2] != null ? match[2].replaceAll('""', '"') : (match[3] ?? '');
 
       return {
         name,

--- a/tests/features/stored-routines/helpers.test.ts
+++ b/tests/features/stored-routines/helpers.test.ts
@@ -235,6 +235,14 @@ SELECT y`;
       });
       expect(sql).toContain('default 42');
     });
+
+    it('createRoutine omits the identifier for unnamed params (introspected as `text`)', () => {
+      const sql = helper.createRoutine({
+        ...baseRoutine,
+        params: [{ name: '', type: 'text', direction: 'in' }],
+      });
+      expect(sql).toMatch(/\(text\)/);
+    });
   });
 
   describe('MSSQL', () => {

--- a/tests/issues/GH7905.test.ts
+++ b/tests/issues/GH7905.test.ts
@@ -11,14 +11,12 @@ class User {
 }
 
 describe('GH issue 7905', () => {
-  let orm: MikroORM;
-
-  beforeAll(async () => {
-    orm = await MikroORM.init({
+  async function createOrm(ignoreRoutines: boolean) {
+    const orm = await MikroORM.init({
       metadataProvider: ReflectMetadataProvider,
       entities: [User],
       dbName: `mikro_orm_test_gh_7905`,
-      schemaGenerator: { ignoreRoutines: true },
+      schemaGenerator: { ignoreRoutines },
     });
 
     await orm.schema.ensureDatabase();
@@ -33,15 +31,25 @@ describe('GH issue 7905', () => {
       end;
       $$ language plpgsql;
     `);
-  });
 
-  afterAll(async () => {
+    return orm;
+  }
+
+  it('introspects routines with unnamed parameters without throwing (ignoreRoutines enabled)', async () => {
+    const orm = await createOrm(true);
+    const sql = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    // routines are left unmanaged — no churn for the externally created function
+    expect(sql).toBe('');
     await orm.schema.execute(`drop function if exists echo_message(text)`);
     await orm.close(true);
   });
 
-  it('introspects routines with unnamed parameters without throwing', async () => {
+  it('diffs the unmanaged routine for removal without throwing (ignoreRoutines disabled)', async () => {
+    const orm = await createOrm(false);
     const sql = await orm.schema.getUpdateSchemaSQL({ wrap: false });
-    expect(sql).toBe('');
+    // unmanaged routine gets dropped, with the unnamed parameter rendered as a bare type
+    expect(sql).toMatch(/drop function if exists "echo_message"\(text\)/i);
+    await orm.schema.execute(`drop function if exists echo_message(text)`);
+    await orm.close(true);
   });
 });

--- a/tests/issues/GH7905.test.ts
+++ b/tests/issues/GH7905.test.ts
@@ -1,0 +1,47 @@
+import { MikroORM } from '@mikro-orm/postgresql';
+import { Entity, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+
+@Entity()
+class User {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+}
+
+describe('GH issue 7905', () => {
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      entities: [User],
+      dbName: `mikro_orm_test_gh_7905`,
+      schemaGenerator: { ignoreRoutines: true },
+    });
+
+    await orm.schema.ensureDatabase();
+    await orm.schema.refresh();
+
+    // a function with an unnamed parameter, created outside of MikroORM
+    await orm.schema.execute(`
+      create or replace function echo_message(text)
+      returns text as $$
+      begin
+        return $1;
+      end;
+      $$ language plpgsql;
+    `);
+  });
+
+  afterAll(async () => {
+    await orm.schema.execute(`drop function if exists echo_message(text)`);
+    await orm.close(true);
+  });
+
+  it('introspects routines with unnamed parameters without throwing', async () => {
+    const sql = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(sql).toBe('');
+  });
+});

--- a/tests/issues/GH7905.test.ts
+++ b/tests/issues/GH7905.test.ts
@@ -74,4 +74,29 @@ describe('GH issue 7905', () => {
 
     await orm2.close(true);
   });
+
+  test('detects a type change on the unnamed parameter (recreates the routine)', async () => {
+    // The DB function takes an unnamed `text`; declaring the (still unnamed) parameter as a
+    // different type must be picked up by the comparator rather than silently treated as equal.
+    const EchoMessage = new Routine({
+      name: 'echo_message',
+      type: 'function',
+      language: 'plpgsql',
+      params: { '': { type: 'integer', runtimeType: 'number' } },
+      returns: { runtimeType: 'string', columnType: 'text' },
+      expression: echoMessageDdl,
+    });
+
+    const orm2 = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      entities: [User],
+      dbName: `mikro_orm_test_gh_7905`,
+      routines: [EchoMessage],
+    });
+
+    const diff = await orm2.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(diff).toMatch(/create or replace function echo_message/i);
+
+    await orm2.close(true);
+  });
 });

--- a/tests/issues/GH7905.test.ts
+++ b/tests/issues/GH7905.test.ts
@@ -1,4 +1,4 @@
-import { MikroORM } from '@mikro-orm/postgresql';
+import { MikroORM, Routine } from '@mikro-orm/postgresql';
 import { Entity, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
 
 @Entity()
@@ -10,46 +10,68 @@ class User {
   name!: string;
 }
 
+// A function with an unnamed parameter — `pg_get_function_arguments` reports its signature as just
+// the bare type (`text`), which used to crash routine introspection.
+const echoMessageDdl = `create or replace function echo_message(text) returns text as $$ begin return $1; end; $$ language plpgsql`;
+
 describe('GH issue 7905', () => {
-  async function createOrm(ignoreRoutines: boolean) {
-    const orm = await MikroORM.init({
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
       metadataProvider: ReflectMetadataProvider,
       entities: [User],
       dbName: `mikro_orm_test_gh_7905`,
-      schemaGenerator: { ignoreRoutines },
+      schemaGenerator: { ignoreRoutines: true },
     });
 
     await orm.schema.ensureDatabase();
     await orm.schema.refresh();
+    await orm.schema.execute(echoMessageDdl);
+  });
 
-    // a function with an unnamed parameter, created outside of MikroORM
-    await orm.schema.execute(`
-      create or replace function echo_message(text)
-      returns text as $$
-      begin
-        return $1;
-      end;
-      $$ language plpgsql;
-    `);
-
-    return orm;
-  }
-
-  it('introspects routines with unnamed parameters without throwing (ignoreRoutines enabled)', async () => {
-    const orm = await createOrm(true);
-    const sql = await orm.schema.getUpdateSchemaSQL({ wrap: false });
-    // routines are left unmanaged — no churn for the externally created function
-    expect(sql).toBe('');
+  afterAll(async () => {
     await orm.schema.execute(`drop function if exists echo_message(text)`);
     await orm.close(true);
   });
 
-  it('diffs the unmanaged routine for removal without throwing (ignoreRoutines disabled)', async () => {
-    const orm = await createOrm(false);
-    const sql = await orm.schema.getUpdateSchemaSQL({ wrap: false });
-    // unmanaged routine gets dropped, with the unnamed parameter rendered as a bare type
-    expect(sql).toMatch(/drop function if exists "echo_message"\(text\)/i);
-    await orm.schema.execute(`drop function if exists echo_message(text)`);
-    await orm.close(true);
+  test('introspects the unnamed parameter into a nameless param def', async () => {
+    const helper = orm.em.getPlatform().getSchemaHelper()!;
+    const routines = await helper.getAllRoutines(orm.em.getConnection(), ['public']);
+    const echo = routines.find(r => r.name === 'echo_message');
+
+    expect(echo).toBeDefined();
+    expect(echo!.params).toEqual([{ name: '', type: 'text', direction: 'in' }]);
+    expect(echo!.returns?.type).toBe('text');
+  });
+
+  test('leaves the unmanaged routine alone (ignoreRoutines enabled, no churn)', async () => {
+    const diff = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(diff).toBe('');
+  });
+
+  test('diffs cleanly against a managed declaration with an unnamed parameter', async () => {
+    // An unnamed parameter cannot be keyed by name, so it is declared under an empty key; the
+    // routine is created via raw DDL (`expression`) to match the externally created function.
+    const EchoMessage = new Routine({
+      name: 'echo_message',
+      type: 'function',
+      language: 'plpgsql',
+      params: { '': { type: 'text', runtimeType: 'string' } },
+      returns: { runtimeType: 'string', columnType: 'text' },
+      expression: echoMessageDdl,
+    });
+
+    const orm2 = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      entities: [User],
+      dbName: `mikro_orm_test_gh_7905`,
+      routines: [EchoMessage],
+    });
+
+    const diff = await orm2.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(diff).toBe('');
+
+    await orm2.close(true);
   });
 });


### PR DESCRIPTION
`pg_get_function_arguments` omits the parameter name for unnamed arguments — e.g. a function created as `echo_message(text)` introspects as just `text`. `parseRoutineParams` required a `name type` shape, so schema introspection threw `Could not parse PostgreSQL routine parameter signature: "text"`. Because routines are always introspected, this happened even with `ignoreRoutines: true`.

Make the parameter name optional in the parser, and skip emitting the identifier in `formatRoutineParams` when it's absent.

Closes #7905