### PR TITLE
fix(core): avoid evaluating getters when snapshotting unhydrated references

### DIFF
--- a/packages/core/src/utils/EntityComparator.ts
+++ b/packages/core/src/utils/EntityComparator.ts
@@ -612,7 +612,15 @@ export class EntityComparator {
 
   private getPropertySnapshot<T>(meta: EntityMetadata<T>, prop: EntityProperty<T>, context: Map<string, any>, dataKey: string, entityKey: string, path: string[], level = 1, object?: boolean): string {
     const unwrap = prop.ref ? '?.unwrap()' : '';
-    let ret = `  if (${this.getPropertyCondition(path)}) {\n`;
+    let condition = this.getPropertyCondition(path);
+
+    // a getter may dereference state that only exists once hydrated, so when snapshotting an
+    // unhydrated reference we short-circuit the read behind the initialized check
+    if (prop.getter && !prop.setter && path.length === 1) {
+      condition = `entity.__helper.__initialized && ${condition}`;
+    }
+
+    let ret = `  if (${condition}) {\n`;
 
     if (['number', 'string', 'boolean'].includes(prop.type.toLowerCase())) {
       return ret + `    ret${dataKey} = entity${entityKey}${unwrap};\n  }\n`;

--- a/tests/issues/GH7918.test.ts
+++ b/tests/issues/GH7918.test.ts
@@ -1,0 +1,41 @@
+import { Entity, PrimaryKey, Property, type Opt } from '@mikro-orm/core';
+import { MikroORM } from '@mikro-orm/sqlite';
+
+@Entity()
+class MyEntity {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name: Opt<string> = '';
+
+  @Property({ hydrate: false })
+  get nameLength(): Opt<number> {
+    return this.name.length;
+  }
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    entities: [MyEntity],
+    dbName: ':memory:',
+  });
+  await orm.schema.createSchema();
+});
+
+afterAll(() => orm.close(true));
+
+test('getter does not fail on find when an unhydrated reference exists', async () => {
+  const em1 = orm.em.fork();
+  const entity = em1.create(MyEntity, {});
+  await em1.flush();
+
+  const em2 = orm.em.fork();
+  // the unhydrated reference sits in the identity map, so loading the row triggers `mergeData`,
+  // which snapshots the entity and would invoke the getter against not-yet-hydrated state
+  em2.getReference(MyEntity, entity.id);
+  const found = await em2.findOneOrFail(MyEntity, { id: entity.id });
+  expect(found.name).toBe('');
+});

--- a/tests/issues/GH7918.test.ts
+++ b/tests/issues/GH7918.test.ts
@@ -3,6 +3,7 @@ import { MikroORM } from '@mikro-orm/sqlite';
 
 @Entity()
 class MyEntity {
+
   @PrimaryKey()
   id!: number;
 
@@ -13,6 +14,7 @@ class MyEntity {
   get nameLength(): Opt<number> {
     return this.name.length;
   }
+
 }
 
 let orm: MikroORM;


### PR DESCRIPTION
Backport of #7919 to the 6.x line.

A persisted getter (`@Property({ hydrate: false })`) that derives from another property throws `Cannot read properties of undefined` on `find` when an unhydrated reference for the same entity is already in the identity map.

The reference loads into `factory.mergeData`, which snapshots the existing entity via `EntityComparator.prepareEntity` to compute a diff. The compiled snapshot reads every comparable property — including the getter — but on a bare reference the backing state isn't hydrated yet, so the getter dereferences `undefined`.

The fix guards read-only getter properties behind the `entity.__helper.__initialized` check (placed first so it short-circuits before the getter runs). Initialized entities are unchanged; unhydrated references skip the getter, whose snapshot value would be meaningless anyway.

Closes #7918