### PR TITLE
fix(core): stop STI subtype property leaking to siblings when shared by 2+ children

### DIFF
--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -1825,7 +1825,10 @@ export class MetadataDiscovery {
       // The primary key column is shared by every subtype, so it stays NOT NULL —
       // only subtype-specific columns become nullable for the rows of other subtypes.
       newProp.nullable = !newProp.primary;
-      newProp.inherited = !rootProp;
+      // A subtype-specific property is `inherited` on the root so it is not pushed down to
+      // sibling subtypes that don't declare it. When a second child redeclares the same
+      // property, the root prop was already marked inherited by the first child, so keep it.
+      newProp.inherited = !rootProp || !!rootProp.inherited;
 
       // For narrowed relation overrides, keep the root's declaration intact so
       // the full target union (e.g. `Food`) is preserved for populates from the

--- a/tests/issues/GH7922.test.ts
+++ b/tests/issues/GH7922.test.ts
@@ -1,0 +1,82 @@
+import { MikroORM, defineEntity, p } from '@mikro-orm/sqlite';
+
+const UserTypes = ['heavy', 'casual', 'normal'] as const;
+
+const UserSchema = defineEntity({
+  abstract: true,
+  discriminatorColumn: 'type',
+  name: 'Entity',
+  properties: {
+    id: p
+      .uuid()
+      .primary()
+      .onCreate(() => crypto.randomUUID()),
+    name: p.string(),
+    type: p.enum(UserTypes).hidden(),
+  },
+  tableName: 'user',
+});
+
+class User extends UserSchema.class {}
+UserSchema.setClass(User);
+
+const NormalUserSchema = defineEntity({
+  discriminatorValue: 'normal',
+  extends: UserSchema,
+  name: 'NormalUser',
+  properties: {},
+});
+
+class NormalUser extends NormalUserSchema.class {}
+NormalUserSchema.setClass(NormalUser);
+
+const HeavyUserSchema = defineEntity({
+  discriminatorValue: 'heavy',
+  extends: User,
+  name: 'HeavyUser',
+  properties: {
+    age: p.integer(),
+  },
+});
+
+class HeavyUser extends HeavyUserSchema.class {}
+HeavyUserSchema.setClass(HeavyUser);
+
+const CasualUserSchema = defineEntity({
+  discriminatorValue: 'casual',
+  extends: User,
+  name: 'CasualUser',
+  properties: {
+    age: p.integer(),
+  },
+});
+
+class CasualUser extends CasualUserSchema.class {}
+CasualUserSchema.setClass(CasualUser);
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    entities: [User, NormalUser, HeavyUser, CasualUser],
+    dbName: ':memory:',
+  });
+  await orm.schema.refresh();
+  const em = orm.em.fork();
+  em.create(NormalUser, { id: '1', name: 'Normal User', type: 'normal' });
+  await em.flush();
+});
+
+afterAll(() => orm.close(true));
+
+test(`subtype-specific property is not pushed down to siblings that don't declare it`, async () => {
+  const em = orm.em.fork();
+  const user = await em.findOne(NormalUser, { id: '1' });
+  expect(user).not.toBeNull();
+  expect('age' in user!).toBe(false);
+
+  // the subtypes that declare `age` must still keep it
+  expect(orm.getMetadata(HeavyUser).properties.age).toBeDefined();
+  expect(orm.getMetadata(CasualUser).properties.age).toBeDefined();
+  expect('age' in orm.getMetadata(NormalUser).properties).toBe(false);
+});


### PR DESCRIPTION
In an STI hierarchy, a property declared by a subtype is propagated up to the root entity and flagged `inherited` so it is *not* pushed back down to sibling subtypes that don't declare it.

When **two** siblings declared a property of the same name (e.g. `HeavyUser` and `CasualUser` both with `age`), processing the second sibling found the root property already present and reset its `inherited` flag to `false`. The root property was then treated as root-owned and propagated to every subtype — including ones that never declared it (`NormalUser` ended up with an `age` property). With a single declaring child the flag stayed `true`, which is why the bug only surfaced with 2+ siblings.

The fix preserves `inherited` when the existing root property is itself inherited (added by a prior child); only a property the root genuinely declares stays root-owned and propagates down.

Closes #7922