### PR TITLE
feat(core): allow specifying a callback for the RequestContext options

### DIFF
--- a/docs/docs/identity-map.md
+++ b/docs/docs/identity-map.md
@@ -112,6 +112,53 @@ app.use((req, res, next) => {
 });
 ```
 
+### Adding additional options to the fork
+
+Additional options can be specified at the last argument. This is useful for example if you'd like to change the schema based on the request.
+
+```ts
+// `orm.em` is the global EntityManager instance
+
+app.use((req, res, next) => {
+    // calls `orm.em.fork()` and attaches it to the async context
+    RequestContext.create(orm.em, next, { schema: req.query?.tenant ?? 'public' });
+});
+```
+
+### Using multiple database configurations per request
+
+The `RequestContext.create()` method can also accept an array of entity managers, which may be from two different database configurations.
+
+```ts
+// `orm` and `adminOrm` are entity manager instances of different ORM instances.
+// `adminOrm` has `{ contextName: 'admin' }` set as part of its configuration.
+
+app.use((req, res, next) => {
+    // calls `orm.em.fork()` and attaches it to the async context
+    RequestContext.create(
+        [orm.em, adminOrm.em],
+        next
+    );
+});
+```
+
+If different options for each instance are needed, a function that takes the `contextName` and returns the options for that `contextName` can be specified.
+
+```ts
+// `orm` and `adminOrm` are entity manager instances of different ORM instances.
+// `adminOrm` has `{ contextName: 'admin' }` set as part of its configuration.
+
+app.use((req, res, next) => {
+    // calls `orm.em.fork()` and attaches it to the async context
+    RequestContext.create(
+        [orm.em, adminOrm.em],
+        next,
+        // "default" instance uses a different schema based on request, while the "admin" always uses its own default
+        (contextName) => contextName === 'default' ? { schema: req.query?.tenant ?? 'public' } : {}
+    );
+});
+```
+
 ## `@CreateRequestContext()` decorator
 
 > Before v6, `@CreateRequestContext()` was called `@UseRequestContext()`.

--- a/packages/core/src/utils/RequestContext.ts
+++ b/packages/core/src/utils/RequestContext.ts
@@ -26,7 +26,7 @@ export class RequestContext {
   static create<T>(
     em: EntityManager | EntityManager[],
     next: (...args: any[]) => T,
-    options: CreateContextOptions = {},
+    options: ((name: string) => CreateContextOptions) | CreateContextOptions = {},
   ): T {
     const ctx = this.createContext(em, options);
     return this.storage.run(ctx, next);
@@ -37,7 +37,10 @@ export class RequestContext {
    * If the handler is async, the return value needs to be awaited.
    * Uses `AsyncLocalStorage.enterWith()`, suitable for elysia style middlewares without a `next` callback.
    */
-  static enter(em: EntityManager | EntityManager[], options: CreateContextOptions = {}): void {
+  static enter(
+    em: EntityManager | EntityManager[],
+    options: ((name: string) => CreateContextOptions) | CreateContextOptions = {},
+  ): void {
     const ctx = this.createContext(em, options);
     this.storage.enterWith(ctx);
   }
@@ -59,14 +62,25 @@ export class RequestContext {
 
   private static createContext(
     em: EntityManager | EntityManager[],
-    options: CreateContextOptions = {},
+    options: ((name: string) => CreateContextOptions) | CreateContextOptions = {},
   ): RequestContext {
     const forks = new Map<string, EntityManager>();
 
     if (Array.isArray(em)) {
-      em.forEach(em => forks.set(em.name, em.fork({ useContext: true, ...options })));
+      if (typeof options === 'function') {
+        for (const emInstance of em) {
+          forks.set(emInstance.name, emInstance.fork({ useContext: true, ...options(emInstance.name) }));
+        }
+      } else {
+        for (const emInstance of em) {
+          forks.set(emInstance.name, emInstance.fork({ useContext: true, ...options }));
+        }
+      }
     } else {
-      forks.set(em.name, em.fork({ useContext: true, ...options }));
+      forks.set(
+        em.name,
+        em.fork({ useContext: true, ...(typeof options === 'function' ? options(em.name) : options) }),
+      );
     }
 
     return new RequestContext(forks);

--- a/tests/RequestContext.test.ts
+++ b/tests/RequestContext.test.ts
@@ -144,6 +144,32 @@ describe('MultiRequestContext', () => {
     expect(RequestContext.currentRequestContext()).toBeUndefined();
   });
 
+  test('create new context with variable options', async () => {
+    expect(RequestContext.getEntityManager(orm1.em.name)).toBeUndefined();
+    expect(RequestContext.getEntityManager(orm2.em.name)).toBeUndefined();
+    RequestContext.create(
+      [orm1.em, orm2.em],
+      () => {
+        const em1 = orm1.em.getContext();
+        expect(em1).not.toBe(orm1.em);
+        expect(em1.name).toBe(orm1.em.name);
+        expect(em1.getLoggerContext()).toEqual({ name: em1.name });
+        expect(em1.getUnitOfWork(false).getIdentityMap()).not.toBe(orm1.em.getUnitOfWork(false).getIdentityMap());
+
+        const em2 = orm2.em.getContext();
+        expect(em2).not.toBe(orm2.em);
+        expect(em2.name).toBe(orm2.em.name);
+        expect(em1).not.toBe(em2);
+        expect(em2.getLoggerContext()).toEqual({ name: em2.name });
+        expect(em2.getUnitOfWork(false).getIdentityMap()).not.toBe(orm2.em.getUnitOfWork(false).getIdentityMap());
+
+        expect(RequestContext.currentRequestContext()).not.toBeUndefined();
+      },
+      (name: string) => ({ loggerContext: { name } }),
+    );
+    expect(RequestContext.currentRequestContext()).toBeUndefined();
+  });
+
   afterAll(async () => {
     await orm1.close(true);
     await orm2.close(true);


### PR DESCRIPTION
This enables setting different options per instance, which is particularly useful with multiple instances present.