### PR TITLE
fix(sql): stop MySQL schema diff churning on generated columns and date defaults

### DIFF
--- a/packages/sql/src/schema/SchemaComparator.ts
+++ b/packages/sql/src/schema/SchemaComparator.ts
@@ -2,6 +2,7 @@ import {
   ArrayType,
   BooleanType,
   DateTimeType,
+  DateType,
   DecimalType,
   type Dictionary,
   type EntityProperty,
@@ -1142,7 +1143,11 @@ export class SchemaComparator {
     const simplify = (str?: string) => {
       return (
         str
-          ?.replace(/_\w+'(.*?)'/g, '$1')
+          // Strip MySQL charset introducers (`_utf8mb4'foo'` -> `foo`). The negative lookbehind
+          // ensures we only match a real introducer (always preceded by a delimiter or the start of
+          // the expression), never an underscore inside a string literal such as `'a_b'` — which has
+          // no introducer on the entity side and would otherwise be corrupted (`'a_b'` -> `'a`).
+          ?.replace(/(?<![\w'])_\w+'(.*?)'/g, '$1')
           .replace(/!=/g, '<>')
           .replace(/in\s*\((.*?)\)/gi, '= any (array[$1])')
           // MySQL normalizes count(*) to count(0)
@@ -1273,6 +1278,15 @@ export class SchemaComparator {
       const defaultValueTo = to.default.toLowerCase().replace('current_timestamp', 'now').replace(/\(\)$/, '');
 
       return defaultValueFrom === defaultValueTo;
+    }
+
+    if (to.mappedType instanceof DateType && from.default && to.default) {
+      // MySQL stores/reports a `current_date` default as `curdate()`, while the entity keeps the raw
+      // (parenthesized) expression. Normalize the synonym and drop all parentheses so the introspected
+      // `curdate()` and the entity's `(current_date)`/`(curdate())` don't churn a no-op migration.
+      const norm = (d: string) => d.toLowerCase().replace('current_date', 'curdate').replace(/[()]/g, '');
+
+      return norm(from.default) === norm(to.default);
     }
 
     // mysql stores decimal defaults padded to scale (`0` → `0.00`); compare numerically so the

--- a/tests/features/schema-generator/date-default-diffing.mysql.test.ts
+++ b/tests/features/schema-generator/date-default-diffing.mysql.test.ts
@@ -1,0 +1,36 @@
+import { MikroORM } from '@mikro-orm/mysql';
+import { Entity, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+
+@Entity()
+class User {
+  @PrimaryKey()
+  id!: number;
+
+  // MySQL reports a `(current_date)` expression default back as `curdate()`; the comparator must treat
+  // the two as equal (like it already does for `current_timestamp` on datetime columns), otherwise the
+  // column churns a no-op migration on every diff.
+  @Property({ type: 'date', defaultRaw: `(current_date)` })
+  day!: string;
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    metadataProvider: ReflectMetadataProvider,
+    entities: [User],
+    dbName: `date-default-diffing`,
+    port: 3308,
+  });
+  await orm.schema.refresh();
+});
+
+afterAll(() => orm.close(true));
+
+test('date column with a (current_date) default is not churned', async () => {
+  const diff = await orm.schema.getUpdateSchemaMigrationSQL({ wrap: false });
+  expect(diff).toEqual({
+    up: '',
+    down: '',
+  });
+});

--- a/tests/features/schema-generator/generated-column-diffing.mysql.test.ts
+++ b/tests/features/schema-generator/generated-column-diffing.mysql.test.ts
@@ -1,0 +1,43 @@
+import { MikroORM } from '@mikro-orm/mysql';
+import { Entity, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+
+@Entity()
+class User {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  // The generation expression contains a string literal with an underscore (`'a_b'`). MySQL reports
+  // it back with a charset introducer (`_utf8mb4'a_b'`); when the comparator strips introducers it
+  // must not corrupt the un-introduced entity-side literal, otherwise this column churns on every diff.
+  @Property({
+    type: 'string',
+    nullable: true,
+    generated: `(case when \`name\` = 'a_b' then 'x' else null end) virtual`,
+  })
+  label?: string;
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    metadataProvider: ReflectMetadataProvider,
+    entities: [User],
+    dbName: `generated-column-diffing`,
+    port: 3308,
+  });
+  await orm.schema.refresh();
+});
+
+afterAll(() => orm.close(true));
+
+test('generated column with an underscore string literal is not churned', async () => {
+  const diff = await orm.schema.getUpdateSchemaMigrationSQL({ wrap: false });
+  expect(diff).toEqual({
+    up: '',
+    down: '',
+  });
+});


### PR DESCRIPTION
## What's the problem?

On MySQL/MariaDB, two kinds of columns made the schema diff non-idempotent: right after
creating the schema, `getUpdateSchemaSQL()` was never empty, so `migration:create` kept
producing a migration and applying it never converged.

### 1. Generated columns whose expression contains a string literal with an underscore

`SchemaComparator.diffExpression()` normalizes both sides through `simplify()`, whose first
step strips MySQL charset introducers (`_utf8mb4'foo'` → `foo`) with `/_\w+'(.*?)'/g`.

That pattern also matches an underscore **inside a string literal**. On the database side the
real `_utf8mb4` introducer absorbs the `_`, so the literal survives; on the entity side there is
no introducer, so e.g. `'a_b'` gets mangled (the `_b'…'` is swallowed up to the next quote). The
two normalized strings then never match, and the column is dropped + re-added on every diff.

A negative lookbehind makes the regex match only a real introducer — one that is always preceded
by a delimiter (or the start of the expression), never by a word char or a quote.

### 2. `date` columns with a `(current_date)` / `curdate()` default

`hasSameDefaultValue()` already special-cases `DateTimeType` (it treats `current_timestamp` and
`now()` as equal), but `date` columns are `DateType` and fell through to a plain string compare.
MySQL stores/reports a `(current_date)` default as `curdate()`, so the entity value and the
introspected value never matched. Added a `DateType` branch that normalizes the synonym and drops
parentheses, mirroring the existing `DateTimeType` handling.

## Reproduction (minimal)

```ts
@Entity()
class A {
  @PrimaryKey() id!: number;
  @Property() name!: string;

  // (1) underscore in a literal -> churns before the fix
  @Property({ type: 'string', nullable: true, generated: `(case when \`name\` = 'a_b' then 'x' else null end) virtual` })
  label?: string;

  // (2) date expression default -> churns before the fix
  @Property({ type: 'date', defaultRaw: `(current_date)` })
  day!: string;
}

// after orm.schema.refresh(), this should be '' but wasn't:
await orm.schema.getUpdateSchemaSQL();
```

## Changes

- `packages/sql/src/schema/SchemaComparator.ts` — anchor the introducer regex; add a `DateType`
  branch to `hasSameDefaultValue()`.
- Two regression tests under `tests/features/schema-generator/` (`generated-column-diffing.mysql`,
  `date-default-diffing.mysql`) asserting an empty up/down diff after `refresh()`. Both fail
  without the fix.

Verified no regressions across MySQL, MariaDB, PostgreSQL, PostGIS and SQLite schema-generator,
generated-column and check-constraint suites.
