### PR TITLE
fix(sql): persist(false) virtual fields with orderBy + M:N pagination

### DIFF
--- a/packages/mariadb/src/MariaDbQueryBuilder.ts
+++ b/packages/mariadb/src/MariaDbQueryBuilder.ts
@@ -7,7 +7,7 @@ import {
   RawQueryFragment,
   Utils,
 } from '@mikro-orm/core';
-import { QueryBuilder } from '@mikro-orm/mysql';
+import { NativeQueryBuilder, QueryBuilder } from '@mikro-orm/mysql';
 
 /**
  * @inheritDoc
@@ -32,7 +32,21 @@ export class MariaDbQueryBuilder<
       subQuery.offset(this.state.offset);
     }
 
-    const addToSelect = [];
+    const addToSelect: { fieldName: string; propName: string }[] = [];
+
+    const findVirtualField = (fieldName: string, propName: string) => {
+      return this.state.fields?.find(field => {
+        if (typeof field === 'object' && field && '__as' in field) {
+          return field.__as === fieldName || field.__as === propName;
+        }
+
+        if (isRaw(field)) {
+          return field.sql.includes(fieldName);
+        }
+
+        return false;
+      });
+    };
 
     if (this.state.orderBy.length > 0) {
       const orderBy = [];
@@ -52,11 +66,27 @@ export class MariaDbQueryBuilder<
           const fieldName = this.helper.mapper(field, this.type, undefined, null);
 
           if (!prop?.persist && !prop?.formula && !pks.includes(fieldName)) {
-            addToSelect.push(fieldName);
-          }
+            addToSelect.push({ fieldName, propName: f });
 
-          const key = raw(`min(${this.platform.quoteIdentifier(fieldName)}${type})`);
-          orderBy.push({ [key as any]: direction });
+            const matchedField = findVirtualField(fieldName, f);
+
+            if (matchedField instanceof NativeQueryBuilder) {
+              const expr = matchedField.toString().replace(/\s+as\s+[`"][^`"]+[`"]\s*$/i, '');
+              const key = raw(`min(${expr}${type})`);
+              orderBy.push({ [key as any]: direction });
+            } else if (isRaw(matchedField)) {
+              const compiled = this.platform.formatQuery(matchedField.sql, matchedField.params);
+              const expr = compiled.replace(/\s+as\s+[`"][^`"]+[`"]\s*$/i, '');
+              const key = raw(`min(${expr}${type})`);
+              orderBy.push({ [key as any]: direction });
+            } else {
+              const key = raw(`min(${this.platform.quoteIdentifier(fieldName)}${type})`);
+              orderBy.push({ [key as any]: direction });
+            }
+          } else {
+            const key = raw(`min(${this.platform.quoteIdentifier(fieldName)}${type})`);
+            orderBy.push({ [key as any]: direction });
+          }
         }
       }
 
@@ -68,22 +98,13 @@ export class MariaDbQueryBuilder<
 
     /* v8 ignore next */
     if (addToSelect.length > 0) {
-      addToSelect.forEach(prop => {
-        const field = this.state.fields!.find(field => {
-          if (typeof field === 'object' && field && '__as' in field) {
-            return field.__as === prop;
-          }
-
-          if (isRaw(field)) {
-            // not perfect, but should work most of the time, ideally we should check only the alias (`... as alias`)
-            return field.sql.includes(prop);
-          }
-
-          return false;
-        });
+      addToSelect.forEach(({ fieldName, propName }) => {
+        const field = findVirtualField(fieldName, propName);
 
         if (isRaw(field)) {
           innerQuery.select(this.platform.formatQuery(field.sql, field.params));
+        } else if (field instanceof NativeQueryBuilder) {
+          innerQuery.select(field.toRaw());
         } else if (field) {
           innerQuery.select(field as string);
         }

--- a/packages/mariadb/src/MariaDbQueryBuilder.ts
+++ b/packages/mariadb/src/MariaDbQueryBuilder.ts
@@ -71,12 +71,12 @@ export class MariaDbQueryBuilder<
             const matchedField = findVirtualField(fieldName, f);
 
             if (matchedField instanceof NativeQueryBuilder) {
-              const expr = matchedField.toString().replace(/\s+as\s+[`"][^`"]+[`"]\s*$/i, '');
+              const expr = matchedField.toString().replace(/ as [`"][^`"]+[`"]$/, '');
               const key = raw(`min(${expr}${type})`);
               orderBy.push({ [key as any]: direction });
             } else if (isRaw(matchedField)) {
               const compiled = this.platform.formatQuery(matchedField.sql, matchedField.params);
-              const expr = compiled.replace(/\s+as\s+[`"][^`"]+[`"]\s*$/i, '');
+              const expr = compiled.replace(/ as [`"][^`"]+[`"]$/, '');
               const key = raw(`min(${expr}${type})`);
               orderBy.push({ [key as any]: direction });
             } else {

--- a/packages/sql/src/query/QueryBuilder.ts
+++ b/packages/sql/src/query/QueryBuilder.ts
@@ -3944,7 +3944,7 @@ export class QueryBuilder<
     });
   }
 
-  #findVirtualField(fieldName: string, propName: string) {
+  private findVirtualField(fieldName: string, propName: string) {
     return this.#state.fields?.find(field => {
       if (typeof field === 'object' && field && '__as' in field) {
         return field.__as === fieldName || field.__as === propName;
@@ -3999,7 +3999,7 @@ export class QueryBuilder<
           if (!prop?.persist && !prop?.formula && !prop?.hasConvertToJSValueSQL && !pks.includes(fieldName)) {
             addToSelect.push({ fieldName, propName: f });
 
-            const matchedField = this.#findVirtualField(fieldName, f);
+            const matchedField = this.findVirtualField(fieldName, f);
 
             if (matchedField instanceof NativeQueryBuilder) {
               const expr = matchedField.toString().replace(/ as [`"][^`"]+[`"]$/, '');
@@ -4031,7 +4031,7 @@ export class QueryBuilder<
 
     if (addToSelect.length > 0) {
       addToSelect.forEach(({ fieldName, propName }) => {
-        const field = this.#findVirtualField(fieldName, propName);
+        const field = this.findVirtualField(fieldName, propName);
 
         /* v8 ignore next */
         if (isRaw(field)) {

--- a/packages/sql/src/query/QueryBuilder.ts
+++ b/packages/sql/src/query/QueryBuilder.ts
@@ -2721,12 +2721,14 @@ export class QueryBuilder<
       const meta = this.metadata.get(aliasOrTargetEntity as EntityName<T>);
       /* v8 ignore next */
       finalAlias = meta.properties[alias]?.fieldNames[0] ?? alias;
+    } else {
+      finalAlias = this.driver.config.getNamingStrategy().propertyToColumnName(finalAlias);
     }
 
     qb.as(finalAlias);
 
     // tag the instance, so it is possible to detect it easily
-    Object.defineProperty(qb, '__as', { enumerable: false, value: finalAlias });
+    Object.defineProperty(qb, '__as', { enumerable: true, value: finalAlias });
 
     return qb;
   }
@@ -3942,6 +3944,20 @@ export class QueryBuilder<
     });
   }
 
+  #findVirtualField(fieldName: string, propName: string) {
+    return this.#state.fields?.find(field => {
+      if (typeof field === 'object' && field && '__as' in field) {
+        return field.__as === fieldName || field.__as === propName;
+      }
+
+      if (isRaw(field)) {
+        return field.sql.includes(fieldName);
+      }
+
+      return false;
+    });
+  }
+
   protected wrapPaginateSubQuery(meta: EntityMetadata): void {
     const schema = this.getSchema(this.mainAlias);
     const pks = this.prepareFields(meta.primaryKeys, 'sub-query', schema) as string[];
@@ -3961,7 +3977,7 @@ export class QueryBuilder<
       subQuery.offset(this.#state.offset);
     }
 
-    const addToSelect = [];
+    const addToSelect: { fieldName: string; propName: string }[] = [];
 
     if (this.#state.orderBy.length > 0) {
       const orderBy = [];
@@ -3981,12 +3997,29 @@ export class QueryBuilder<
           const fieldName = this.helper.mapper(field, this.type, undefined, null);
 
           if (!prop?.persist && !prop?.formula && !prop?.hasConvertToJSValueSQL && !pks.includes(fieldName)) {
-            addToSelect.push(fieldName);
-          }
+            addToSelect.push({ fieldName, propName: f });
 
-          const quoted = this.platform.quoteIdentifier(fieldName);
-          const key = raw(`min(${quoted}${type})`);
-          orderBy.push({ [key]: direction });
+            const matchedField = this.#findVirtualField(fieldName, f);
+
+            if (matchedField instanceof NativeQueryBuilder) {
+              const expr = matchedField.toString().replace(/\s+as\s+[`"][^`"]+[`"]\s*$/i, '');
+              const key = raw(`min(${expr}${type})`);
+              orderBy.push({ [key]: direction });
+            } else if (isRaw(matchedField)) {
+              const compiled = this.platform.formatQuery(matchedField.sql, matchedField.params);
+              const expr = compiled.replace(/\s+as\s+[`"][^`"]+[`"]\s*$/i, '');
+              const key = raw(`min(${expr}${type})`);
+              orderBy.push({ [key]: direction });
+            } else {
+              const quoted = this.platform.quoteIdentifier(fieldName);
+              const key = raw(`min(${quoted}${type})`);
+              orderBy.push({ [key]: direction });
+            }
+          } else {
+            const quoted = this.platform.quoteIdentifier(fieldName);
+            const key = raw(`min(${quoted}${type})`);
+            orderBy.push({ [key]: direction });
+          }
         }
       }
 
@@ -3997,19 +4030,8 @@ export class QueryBuilder<
     const innerQuery = subQuery.as(this.mainAlias.aliasName).clear('select').select(pks);
 
     if (addToSelect.length > 0) {
-      addToSelect.forEach(prop => {
-        const field = this.#state.fields!.find(field => {
-          if (typeof field === 'object' && field && '__as' in field) {
-            return field.__as === prop;
-          }
-
-          if (isRaw(field)) {
-            // not perfect, but should work most of the time, ideally we should check only the alias (`... as alias`)
-            return field.sql.includes(prop);
-          }
-
-          return false;
-        });
+      addToSelect.forEach(({ fieldName, propName }) => {
+        const field = this.#findVirtualField(fieldName, propName);
 
         /* v8 ignore next */
         if (isRaw(field)) {

--- a/packages/sql/src/query/QueryBuilder.ts
+++ b/packages/sql/src/query/QueryBuilder.ts
@@ -4002,12 +4002,12 @@ export class QueryBuilder<
             const matchedField = this.#findVirtualField(fieldName, f);
 
             if (matchedField instanceof NativeQueryBuilder) {
-              const expr = matchedField.toString().replace(/\s+as\s+[`"][^`"]+[`"]\s*$/i, '');
+              const expr = matchedField.toString().replace(/ as [`"][^`"]+[`"]$/, '');
               const key = raw(`min(${expr}${type})`);
               orderBy.push({ [key]: direction });
             } else if (isRaw(matchedField)) {
               const compiled = this.platform.formatQuery(matchedField.sql, matchedField.params);
-              const expr = compiled.replace(/\s+as\s+[`"][^`"]+[`"]\s*$/i, '');
+              const expr = compiled.replace(/ as [`"][^`"]+[`"]$/, '');
               const key = raw(`min(${expr}${type})`);
               orderBy.push({ [key]: direction });
             } else {

--- a/tests/features/query-builder/query-builder-advanced.test.ts
+++ b/tests/features/query-builder/query-builder-advanced.test.ts
@@ -555,7 +555,7 @@ describe('QueryBuilder - Advanced', () => {
 
     await qb.getResult();
     expect(qb.getQuery()).toEqual(
-      'select `a`.*, (select count(distinct `b`.`uuid_pk`) as `count` from `book2` as `b` where `b`.`author_id` = `a`.`id`) as `books_total` from `author2` as `a` where `a`.`id` in (select `a`.`id` from (select `a`.`id`, (select count(distinct `b`.`uuid_pk`) as `count` from `book2` as `b` where `b`.`author_id` = `a`.`id`) as `books_total` from `author2` as `a` left join `book2` as `e1` on `a`.`id` = `e1`.`author_id` where `e1`.`title` = ? group by `a`.`id` order by min(`books_total`) asc limit ?) as `a`) order by `books_total` asc',
+      'select `a`.*, (select count(distinct `b`.`uuid_pk`) as `count` from `book2` as `b` where `b`.`author_id` = `a`.`id`) as `books_total` from `author2` as `a` where `a`.`id` in (select `a`.`id` from (select `a`.`id`, (select count(distinct `b`.`uuid_pk`) as `count` from `book2` as `b` where `b`.`author_id` = `a`.`id`) as `books_total` from `author2` as `a` left join `book2` as `e1` on `a`.`id` = `e1`.`author_id` where `e1`.`title` = ? group by `a`.`id` order by min((select count(distinct `b`.`uuid_pk`) as `count` from `book2` as `b` where `b`.`author_id` = `a`.`id`)) asc limit ?) as `a`) order by `books_total` asc',
     );
     expect(qb.getParams()).toEqual(['foo', 1]);
   });

--- a/tests/issues/persist-false-orderby-bug.test.ts
+++ b/tests/issues/persist-false-orderby-bug.test.ts
@@ -1,8 +1,8 @@
-import { defineEntity, MikroORM, p, raw, sql } from "@mikro-orm/sqlite";
+import { defineEntity, MikroORM, p, raw, sql } from '@mikro-orm/sqlite';
 
 const Tag = defineEntity({
-  name: "Tag",
-  tableName: "tags",
+  name: 'Tag',
+  tableName: 'tags',
   properties: {
     id: p.integer().primary(),
     name: p.string(),
@@ -10,30 +10,25 @@ const Tag = defineEntity({
 });
 
 const Review = defineEntity({
-  name: "Review",
-  tableName: "reviews",
+  name: 'Review',
+  tableName: 'reviews',
   properties: {
     id: p.integer().primary(),
     body: p.string(),
-    product: () => p.manyToOne(Product).deleteRule("cascade"),
+    product: () => p.manyToOne(Product).deleteRule('cascade'),
   },
 });
 
 const Product = defineEntity({
-  name: "Product",
-  tableName: "products",
+  name: 'Product',
+  tableName: 'products',
   properties: {
     id: p.integer().primary(),
     title: p.string(),
     reviewCount: p.integer().persist(false),
     tags: () =>
-      p
-        .manyToMany(Tag)
-        .owner()
-        .pivotTable("_join_products_tags")
-        .joinColumn("product_id")
-        .inverseJoinColumn("tag_id"),
-    reviews: () => p.oneToMany(Review).mappedBy((r) => r.product),
+      p.manyToMany(Tag).owner().pivotTable('_join_products_tags').joinColumn('product_id').inverseJoinColumn('tag_id'),
+    reviews: () => p.oneToMany(Review).mappedBy(r => r.product),
   },
 });
 
@@ -42,7 +37,7 @@ let orm: MikroORM;
 beforeAll(async () => {
   orm = await MikroORM.init({
     entities: [Product, Tag, Review],
-    dbName: ":memory:",
+    dbName: ':memory:',
   });
   await orm.schema.refresh();
 });
@@ -57,66 +52,62 @@ beforeEach(async () => {
 });
 
 async function seedData() {
-  const tag1 = orm.em.create(Tag, { name: "electronics" });
-  const tag2 = orm.em.create(Tag, { name: "sale" });
-  const p1 = orm.em.create(Product, { title: "Product A", tags: [tag1, tag2] });
-  const p2 = orm.em.create(Product, { title: "Product B", tags: [tag1] });
-  orm.em.create(Review, { body: "great", product: p1 });
-  orm.em.create(Review, { body: "good", product: p1 });
-  orm.em.create(Review, { body: "ok", product: p2 });
+  const tag1 = orm.em.create(Tag, { name: 'electronics' });
+  const tag2 = orm.em.create(Tag, { name: 'sale' });
+  const p1 = orm.em.create(Product, { title: 'Product A', tags: [tag1, tag2] });
+  const p2 = orm.em.create(Product, { title: 'Product B', tags: [tag1] });
+  orm.em.create(Review, { body: 'great', product: p1 });
+  orm.em.create(Review, { body: 'good', product: p1 });
+  orm.em.create(Review, { body: 'ok', product: p2 });
   await orm.em.flush();
   orm.em.clear();
 }
 
-test("qb.as() virtual field survives clone and orderBy works with M:N join", async () => {
+test('qb.as() virtual field survives clone and orderBy works with M:N join', async () => {
   await seedData();
 
   const reviewCountQB = orm.em
-    .createQueryBuilder(Review, "r")
-    .select(raw("count(*)"))
-    .where({ product: { id: sql.ref("p.id") } });
+    .createQueryBuilder(Review, 'r')
+    .select(raw('count(*)'))
+    .where({ product: { id: sql.ref('p.id') } });
 
   const qb = orm.em
-    .createQueryBuilder(Product, "p")
-    .select(["id", "title"])
-    .joinAndSelect("p.tags", "t")
-    .addSelect(reviewCountQB.as("reviewCount"))
-    .orderBy({ reviewCount: "desc" })
+    .createQueryBuilder(Product, 'p')
+    .select(['id', 'title'])
+    .joinAndSelect('p.tags', 't')
+    .addSelect(reviewCountQB.as('reviewCount'))
+    .orderBy({ reviewCount: 'desc' })
     .limit(10);
 
   const [results, count] = await qb.getResultAndCount();
 
   expect(count).toBe(2);
-  expect(results[0].title).toBe("Product A");
+  expect(results[0].title).toBe('Product A');
   expect(results[0].reviewCount).toBe(2);
-  expect(results[1].title).toBe("Product B");
+  expect(results[1].title).toBe('Product B');
   expect(results[1].reviewCount).toBe(1);
 });
 
-test("raw() getFormattedQuery virtual field works with orderBy and M:N join", async () => {
+test('raw() getFormattedQuery virtual field works with orderBy and M:N join', async () => {
   await seedData();
 
   const reviewCountQB = orm.em
-    .createQueryBuilder(Review, "r")
-    .select(raw("count(*)"))
-    .where({ product: { id: sql.ref("p.id") } });
+    .createQueryBuilder(Review, 'r')
+    .select(raw('count(*)'))
+    .where({ product: { id: sql.ref('p.id') } });
 
   const qb = orm.em
-    .createQueryBuilder(Product, "p")
-    .select([
-      "id",
-      "title",
-      raw(`(${reviewCountQB.getFormattedQuery()}) as "review_count"`),
-    ])
-    .joinAndSelect("p.tags", "t")
-    .orderBy({ reviewCount: "desc" })
+    .createQueryBuilder(Product, 'p')
+    .select(['id', 'title', raw(`(${reviewCountQB.getFormattedQuery()}) as "review_count"`)])
+    .joinAndSelect('p.tags', 't')
+    .orderBy({ reviewCount: 'desc' })
     .limit(10);
 
   const [results, count] = await qb.getResultAndCount();
 
   expect(count).toBe(2);
-  expect(results[0].title).toBe("Product A");
+  expect(results[0].title).toBe('Product A');
   expect(results[0].reviewCount).toBe(2);
-  expect(results[1].title).toBe("Product B");
+  expect(results[1].title).toBe('Product B');
   expect(results[1].reviewCount).toBe(1);
 });

--- a/tests/issues/persist-false-orderby-bug.test.ts
+++ b/tests/issues/persist-false-orderby-bug.test.ts
@@ -83,9 +83,9 @@ test('qb.as() virtual field survives clone and orderBy works with M:N join', asy
 
   expect(count).toBe(2);
   expect(results[0].title).toBe('Product A');
-  expect(results[0].reviewCount).toBe(2);
+  expect((results[0] as any).reviewCount).toBe(2);
   expect(results[1].title).toBe('Product B');
-  expect(results[1].reviewCount).toBe(1);
+  expect((results[1] as any).reviewCount).toBe(1);
 });
 
 test('raw() getFormattedQuery virtual field works with orderBy and M:N join', async () => {
@@ -107,7 +107,7 @@ test('raw() getFormattedQuery virtual field works with orderBy and M:N join', as
 
   expect(count).toBe(2);
   expect(results[0].title).toBe('Product A');
-  expect(results[0].reviewCount).toBe(2);
+  expect((results[0] as any).reviewCount).toBe(2);
   expect(results[1].title).toBe('Product B');
-  expect(results[1].reviewCount).toBe(1);
+  expect((results[1] as any).reviewCount).toBe(1);
 });

--- a/tests/issues/persist-false-orderby-bug.test.ts
+++ b/tests/issues/persist-false-orderby-bug.test.ts
@@ -1,0 +1,122 @@
+import { defineEntity, MikroORM, p, raw, sql } from "@mikro-orm/sqlite";
+
+const Tag = defineEntity({
+  name: "Tag",
+  tableName: "tags",
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+  },
+});
+
+const Review = defineEntity({
+  name: "Review",
+  tableName: "reviews",
+  properties: {
+    id: p.integer().primary(),
+    body: p.string(),
+    product: () => p.manyToOne(Product).deleteRule("cascade"),
+  },
+});
+
+const Product = defineEntity({
+  name: "Product",
+  tableName: "products",
+  properties: {
+    id: p.integer().primary(),
+    title: p.string(),
+    reviewCount: p.integer().persist(false),
+    tags: () =>
+      p
+        .manyToMany(Tag)
+        .owner()
+        .pivotTable("_join_products_tags")
+        .joinColumn("product_id")
+        .inverseJoinColumn("tag_id"),
+    reviews: () => p.oneToMany(Review).mappedBy((r) => r.product),
+  },
+});
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    entities: [Product, Tag, Review],
+    dbName: ":memory:",
+  });
+  await orm.schema.refresh();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+beforeEach(async () => {
+  await orm.schema.clear();
+  orm.em.clear();
+});
+
+async function seedData() {
+  const tag1 = orm.em.create(Tag, { name: "electronics" });
+  const tag2 = orm.em.create(Tag, { name: "sale" });
+  const p1 = orm.em.create(Product, { title: "Product A", tags: [tag1, tag2] });
+  const p2 = orm.em.create(Product, { title: "Product B", tags: [tag1] });
+  orm.em.create(Review, { body: "great", product: p1 });
+  orm.em.create(Review, { body: "good", product: p1 });
+  orm.em.create(Review, { body: "ok", product: p2 });
+  await orm.em.flush();
+  orm.em.clear();
+}
+
+test("qb.as() virtual field survives clone and orderBy works with M:N join", async () => {
+  await seedData();
+
+  const reviewCountQB = orm.em
+    .createQueryBuilder(Review, "r")
+    .select(raw("count(*)"))
+    .where({ product: { id: sql.ref("p.id") } });
+
+  const qb = orm.em
+    .createQueryBuilder(Product, "p")
+    .select(["id", "title"])
+    .joinAndSelect("p.tags", "t")
+    .addSelect(reviewCountQB.as("reviewCount"))
+    .orderBy({ reviewCount: "desc" })
+    .limit(10);
+
+  const [results, count] = await qb.getResultAndCount();
+
+  expect(count).toBe(2);
+  expect(results[0].title).toBe("Product A");
+  expect(results[0].reviewCount).toBe(2);
+  expect(results[1].title).toBe("Product B");
+  expect(results[1].reviewCount).toBe(1);
+});
+
+test("raw() getFormattedQuery virtual field works with orderBy and M:N join", async () => {
+  await seedData();
+
+  const reviewCountQB = orm.em
+    .createQueryBuilder(Review, "r")
+    .select(raw("count(*)"))
+    .where({ product: { id: sql.ref("p.id") } });
+
+  const qb = orm.em
+    .createQueryBuilder(Product, "p")
+    .select([
+      "id",
+      "title",
+      raw(`(${reviewCountQB.getFormattedQuery()}) as "review_count"`),
+    ])
+    .joinAndSelect("p.tags", "t")
+    .orderBy({ reviewCount: "desc" })
+    .limit(10);
+
+  const [results, count] = await qb.getResultAndCount();
+
+  expect(count).toBe(2);
+  expect(results[0].title).toBe("Product A");
+  expect(results[0].reviewCount).toBe(2);
+  expect(results[1].title).toBe("Product B");
+  expect(results[1].reviewCount).toBe(1);
+});


### PR DESCRIPTION
Three bugs caused persist(false) virtual fields (populated by scalar subqueries via qb.as()) to fail when used with orderBy and getResultAndCount() on queries with many-to-many joins:

1. qb.as() set __as as non-enumerable — lost during clone in getResultAndCount(), so wrapPaginateSubQuery couldn't match the virtual field to its subquery expression.

2. wrapPaginateSubQuery wrapped ORDER BY in min("column_alias"), but PostgreSQL cannot resolve SELECT aliases inside aggregate functions. Now uses the actual subquery expression inside min() instead.

3. qb.as("camelCase") didn't apply the naming strategy, producing a SELECT alias that didn't match the mapper's ORDER BY reference. Now applies propertyToColumnName() for consistency.