### PR TITLE
fix(sql): expose columns inherited via `extends` in `getKysely()` table type

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -55,6 +55,7 @@ export type {
   FilterObject,
   IndexFilterQuery,
   ExtractIndexHints,
+  ExtractDefineEntityProperties,
   IndexName,
   IndexColumns,
   WithUsingOptions,

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -246,6 +246,15 @@ export type InferPropertyIndexMap<Properties extends Record<string, any>> = {
       : never]: K & string;
 };
 
+/**
+ * Extracts the raw `defineEntity` property builders that `[IndexHints]` carries as a `[Properties]`
+ * tuple. Used to recover a base entity's own builders so that columns inherited via `extends` can be
+ * mapped (e.g. for the Kysely table type). Returns `never` for decorator entities (object-shaped hints).
+ */
+export type ExtractDefineEntityProperties<T> = T extends { [IndexHints]?: [infer P extends Record<string, any>] }
+  ? P
+  : never;
+
 /** Union of declared index names on an entity. Falls back to `string` when no `[IndexHints]` are declared. */
 export type IndexName<T> = [ExtractIndexHints<T>] extends [never]
   ? string

--- a/packages/sql/src/typings.ts
+++ b/packages/sql/src/typings.ts
@@ -6,6 +6,7 @@ import type {
   EntityName,
   EntityProperty,
   EntitySchemaWithMeta,
+  ExtractDefineEntityProperties,
   FilterQuery,
   GroupOperator,
   IndexColumnOptions,
@@ -330,7 +331,21 @@ export interface ICriteriaNode<T extends object> {
 export type MaybeReturnType<T> = T extends (...args: any[]) => infer R ? R : T;
 
 export type InferEntityProperties<Schema> =
-  Schema extends EntitySchemaWithMeta<any, any, any, any, infer Properties> ? Properties : never;
+  Schema extends EntitySchemaWithMeta<any, any, any, infer Base, infer Properties>
+    ? MergeInheritedProperties<Base, Properties>
+    : never;
+
+// Columns inherited via `extends` live in the base entity's own builders, recoverable from its
+// `[IndexHints]` marker; merge them under the child's own properties so the Kysely table type
+// exposes inherited columns too (GH #7937). Child properties win on name conflicts; bases without
+// recoverable builders (no base, or a decorator class) fall back to the child's own properties.
+type MergeInheritedProperties<Base, Properties extends Record<string, any>> = [
+  ExtractDefineEntityProperties<Base>,
+] extends [infer BaseProps extends Record<string, any>]
+  ? [BaseProps] extends [never]
+    ? Properties
+    : Omit<BaseProps, keyof Properties> & Properties
+  : Properties;
 
 export type InferKyselyDB<
   TEntities extends { name: string },

--- a/tests/features/get-kysely.test.ts
+++ b/tests/features/get-kysely.test.ts
@@ -440,6 +440,42 @@ describe('InferKyselyDB', () => {
     }>();
   });
 
+  test('infer columns inherited via extends (GH #7937)', async () => {
+    const BaseEntity = defineEntity({
+      abstract: true,
+      name: 'BaseEntity7937',
+      properties: {
+        id: p.integer().autoincrement().primary(),
+        createdAt: p.datetime().fieldName('created_at'),
+      },
+    });
+
+    const Book = defineEntity({
+      name: 'Book7937',
+      tableName: 'books7937',
+      extends: BaseEntity,
+      properties: p => ({
+        title: p.string(),
+      }),
+    });
+
+    const orm = new MikroORM({
+      entities: [Book],
+      dbName: ':memory:',
+    });
+
+    type KyselyDB = InferKyselyDB<typeof Book, {}>;
+    type BookTable = KyselyDB['books7937'];
+    expectTypeOf<BookTable>().toEqualTypeOf<{
+      id: Generated<number>;
+      created_at: Date;
+      title: string;
+    }>();
+
+    const kysely = orm.em.getKysely();
+    kysely.selectFrom('books7937').select(['id', 'created_at', 'title']);
+  });
+
   test('use InferKyselyTable manually', async () => {
     const User = defineEntity({
       name: 'User',


### PR DESCRIPTION
`getKysely()`'s table type derived columns from each entity's *own* property builders only, so columns inherited through `defineEntity`'s `extends` were absent from the Kysely type — selecting or filtering on them was a compile error even though the column exists at runtime.

`InferKyselyTable` reads `InferEntityProperties<Schema>`, which extracted the schema's own `TProperties`. The base's builders aren't a child schema type-param; they only survive inside the resolved base entity type via the `[IndexHints]?: [Properties]` marker that `defineEntity` already attaches to every inferred entity (today consumed for index-name autocomplete). The fix recovers them from there and merges them under the child's own properties — child wins on name conflicts. No change is required from users.

Known limitation: this recovers the *immediate* base's builders, so a multi-level `extends` chain still drops grandparent columns (that case was fully broken before too). A follow-up will address arbitrary depth, which needs reworking core `InferEntityFromProperties`.

Closes #7937