### PR TITLE
fix(core): carry merged ancestor builders so Kysely types span multi-level `extends`

### DIFF
--- a/packages/core/src/entity/defineEntity.ts
+++ b/packages/core/src/entity/defineEntity.ts
@@ -42,6 +42,7 @@ import type {
   MaybePromise,
   IndexHints,
   InferPropertyIndexMap,
+  ExtractDefineEntityProperties,
 } from '../typings.js';
 import type { Raw } from '../utils/RawQueryFragment.js';
 import type { ScalarReference } from './Reference.js';
@@ -1647,8 +1648,18 @@ export type InferEntityFromProperties<
     ? {}
     : NarrowDiscriminator<Omit<Base, typeof PrimaryKeyProp>, BaseDiscriminatorColumn, DiscriminatorValue>) &
   (ForceObject extends true ? { [Config]?: DefineConfig<{ forceObject: true }> } : {}) & {
-    [IndexHints]?: [Properties];
+    [IndexHints]?: [Omit<ExtractBaseProperties<Base>, keyof Properties> & Properties];
   };
+
+// Recovers a base entity's (already-merged) property builders from its `[IndexHints]` marker; `{}`
+// when there is no base or it's a decorator class. Because each base's marker is itself built this way,
+// the merge is transitive across multi-level `extends`, so inferred Kysely columns and index hints span
+// the full ancestor chain (own props win on clash).
+type ExtractBaseProperties<Base> = [ExtractDefineEntityProperties<Base>] extends [infer P extends Record<string, any>]
+  ? [P] extends [never]
+    ? {}
+    : P
+  : {};
 
 // Narrows the inherited discriminator property on `Base` to the literal `DiscValue` so a union
 // of sibling subtypes forms a proper discriminated union (GH #7677). Falls through to `Base`

--- a/tests/features/get-kysely.test.ts
+++ b/tests/features/get-kysely.test.ts
@@ -582,6 +582,63 @@ describe('InferKyselyDB', () => {
 
     expectTypeOf<AutoInferredDB>().toEqualTypeOf<ManualDatabase>();
   });
+
+  test('infer columns inherited via extends, including multi-level chains (GH #7937)', () => {
+    const Base = defineEntity({
+      name: 'Base7937',
+      abstract: true,
+      properties: {
+        id: p.integer().primary().autoincrement(),
+        createdAt: p.datetime().fieldName('created_at_col'),
+      },
+    });
+
+    const Middle = defineEntity({
+      name: 'Middle7937',
+      extends: Base,
+      abstract: true,
+      properties: {
+        mid: p.string(),
+      },
+    });
+
+    // single-level child of Base
+    const Animal = defineEntity({
+      name: 'Animal7937',
+      tableName: 'animal',
+      extends: Base,
+      properties: {
+        species: p.string(),
+      },
+    });
+
+    // multi-level child: Base -> Middle -> Cat
+    const Cat = defineEntity({
+      name: 'Cat7937',
+      tableName: 'cat',
+      extends: Middle,
+      properties: {
+        lives: p.integer(),
+      },
+    });
+
+    type DB = InferKyselyDB<typeof Animal | typeof Cat, {}>;
+
+    // single-level: own + grandparent-less base columns (builder metadata like fieldName propagates)
+    expectTypeOf<DB['animal']>().toEqualTypeOf<{
+      id: Generated<number>;
+      created_at_col: Date;
+      species: string;
+    }>();
+
+    // multi-level: own + parent + grandparent columns
+    expectTypeOf<DB['cat']>().toEqualTypeOf<{
+      id: Generated<number>;
+      created_at_col: Date;
+      mid: string;
+      lives: number;
+    }>();
+  });
 });
 
 describe('InferClassEntityDB', () => {


### PR DESCRIPTION
## What

Follow-up to #7938. That PR exposed columns inherited via `defineEntity`'s `extends` in the `getKysely()` table type, but only for the **immediate** base — a multi-level chain (`Animal -> Mammal -> Cat`) still dropped grandparent columns. #7938 explicitly deferred this, noting it "needs reworking core `InferEntityFromProperties`".

## Fix

The root cause is the `[IndexHints]` marker that `defineEntity` attaches to every inferred entity: it carried only the entity's **own** property builders, so the SQL-layer recovery (`MergeInheritedProperties` / `ExtractDefineEntityProperties`) added from #7938 could only see one level up.

`InferEntityFromProperties` now builds that marker by merging the base's (already-merged) builders under the child's own (`Omit<base, keyof own> & own`). Because every base's marker is constructed the same way, the merge is **transitive** — the marker on any entity carries its full ancestor builder set, without needing a retained `TBase` generic. The existing SQL-layer recovery then spans arbitrary depth with no change.

As a side effect, named index hints (`ExtractIndexHints`) declared on a base are now inherited by children at any depth too.

The marker is a type-level phantom erased at runtime, so there is no runtime behavior change.

Relates to #7937