### PR TITLE
fix(sql): do not propagate TPT parent check constraints to child tables

### DIFF
--- a/packages/sql/src/schema/DatabaseSchema.ts
+++ b/packages/sql/src/schema/DatabaseSchema.ts
@@ -344,6 +344,14 @@ export class DatabaseSchema {
 
       for (const check of meta.checks) {
         const columnName = check.property ? meta.properties[check.property].fieldNames[0] : undefined;
+
+        // In TPT, inherited columns live on the parent table only, so a check
+        // that references such a column must not be emitted onto the child
+        // table, where that column does not exist.
+        if (meta.inheritanceType === 'tpt' && meta.tptParent && columnName && !table.hasColumn(columnName)) {
+          continue;
+        }
+
         const expression = isRaw(check.expression)
           ? platform.formatQuery(check.expression.sql, check.expression.params)
           : (check.expression as string);

--- a/tests/issues/GH7935.test.ts
+++ b/tests/issues/GH7935.test.ts
@@ -1,0 +1,44 @@
+import { Entity, Enum, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+import { MikroORM } from '@mikro-orm/sqlite';
+
+// GH #7935 - An enum CHECK constraint defined on an abstract TPT parent must not
+// be propagated to child TPT tables. In TPT the enum column lives only on the
+// parent table, so a copy of the check on the child references a column that
+// does not exist there and produces invalid DDL (e.g. sqlite `no such column`).
+
+@Entity({ inheritance: 'tpt' })
+abstract class Account7935 {
+  @PrimaryKey()
+  id!: number;
+
+  @Enum({ items: ['active', 'suspended', 'closed'] })
+  status!: string;
+}
+
+@Entity()
+class SavingsAccount7935 extends Account7935 {
+  @Property()
+  interestRate!: number;
+}
+
+test('GH #7935 - parent TPT enum check is not propagated to child tables', async () => {
+  const orm = await MikroORM.init({
+    metadataProvider: ReflectMetadataProvider,
+    dbName: ':memory:',
+    entities: [Account7935, SavingsAccount7935],
+  });
+
+  const sql = await orm.schema.getCreateSchemaSQL();
+
+  // Parent table owns the enum column and its check constraint.
+  expect(sql).toContain("`status` text check (`status` in ('active', 'suspended', 'closed'))");
+
+  // Child table has no `status` column, so it must not get a copy of the check.
+  expect(sql).not.toContain('savings_account7935_status_check');
+  expect(sql).not.toMatch(/create table `savings_account7935`[^;]*`status`/);
+
+  // The generated schema must be valid (this throws before the fix).
+  await orm.schema.create();
+
+  await orm.close();
+});


### PR DESCRIPTION
In table-per-type inheritance an inherited column lives only on the parent table, but its check constraint (for example the one generated for an enum) was still emitted onto each child table. The child-table check then references a column that does not exist there, so the generated DDL is invalid and `schema.create()` fails.

Checks whose column is not present on the child table are now skipped, the same way parent indexes are handled (#7714).

Closes #7935
