### PR TITLE
fix(sql): keep non-lazy `@Formula` out of partial-index predicate rendering

### DIFF
--- a/packages/sql/src/AbstractSqlDriver.ts
+++ b/packages/sql/src/AbstractSqlDriver.ts
@@ -2980,6 +2980,10 @@ export abstract class AbstractSqlDriver<
 
     const alias = '__p';
     const qb = this.createQueryBuilder(entityName, undefined, undefined, undefined, undefined, alias);
+    // Select a constant instead of the default `*` — otherwise non-lazy `@Formula` properties
+    // (and their embedded subqueries, which may contain their own `where`/cross-table refs)
+    // leak into the SQL and corrupt the predicate extracted below. Only `from ... where` matters here.
+    qb.select(raw('1'));
     qb.where(where as any);
     const sql = qb.getFormattedQuery();
 

--- a/tests/features/schema-generator/partial-index.sqlite.test.ts
+++ b/tests/features/schema-generator/partial-index.sqlite.test.ts
@@ -1,6 +1,13 @@
 import { defineEntity, EntitySchema, MikroORM, p, raw } from '@mikro-orm/sqlite';
 import { EntityGenerator } from '@mikro-orm/entity-generator';
-import { Entity, ManyToOne, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+import {
+  Entity,
+  Formula,
+  ManyToOne,
+  PrimaryKey,
+  Property,
+  ReflectMetadataProvider,
+} from '@mikro-orm/decorators/legacy';
 
 interface PartialUser {
   id: number;
@@ -27,6 +34,23 @@ class PostRel {
 
   @ManyToOne(() => TagRel)
   tag!: TagRel;
+}
+
+@Entity({ tableName: 'formula_user' })
+class FormulaUser {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  email!: string;
+
+  @Property()
+  status: string = 'active';
+
+  // non-lazy formula, selected by default — its subquery has an inner `where`
+  // referencing another table, which must NOT leak into the partial-index predicate
+  @Formula(alias => `(select count(*) from post_rel p where p.tag_id = ${alias}.id)`)
+  postCount!: number;
 }
 
 function makeMeta(opts: { where?: string }) {
@@ -150,7 +174,7 @@ describe('partial index [sqlite]', () => {
     // Decorator-based entities wire up relation metadata (EntitySchema's string `entity`
     // reference isn't enough for the QB to resolve join targets).
     const rtOrm = await MikroORM.init({
-      entities: [TagRel, PostRel],
+      entities: [TagRel, PostRel, FormulaUser],
       dbName: ':memory:',
       metadataProvider: ReflectMetadataProvider,
       discovery: { warnWhenNoEntities: false },
@@ -186,6 +210,12 @@ describe('partial index [sqlite]', () => {
       // lookahead distinguishes `pg_catalog.lower(name)` (OK) from `other_table.col` (rejected).
       expect(driver.renderPartialIndexWhere(TagRel, { name: raw(`pg_catalog.lower('x')`) })).toMatch(
         /`name` = pg_catalog\.lower\('x'\)/,
+      );
+
+      // a clean predicate on an entity with a non-lazy @Formula (whose subquery has its own
+      // inner `where` referencing another table) must not false-positive as a cross-table ref
+      expect(driver.renderPartialIndexWhere(FormulaUser, { status: { $ne: 'deleted' } })).toMatch(
+        /`status` != 'deleted'/,
       );
     } finally {
       await rtOrm.close(true);


### PR DESCRIPTION
`renderPartialIndexWhere` builds a synthetic query with `createQueryBuilder(...)` and no explicit `.select()`, so it falls back to `select "__p".*`. That default select pulls in any non-lazy `@Formula` property, including its embedded subquery. The predicate is then extracted from the formatted SQL via `/\bwhere\s+([\s\S]+)$/i`, which matches the **first** `where` keyword — so a formula whose subquery contains its own `where` (e.g. `(select count(*) from book b where b.author_id = __p.id)`) hijacks the match. The captured text then includes the formula's legitimate cross-table refs, and the cross-table guard rejects a predicate that is actually clean.

Fix: select a constant (`raw('1')`) on the synthetic QB so formulas never enter the generated SQL — only the `from ... where` clause matters for this purpose. This also incidentally hardens the relation-traversal guard, which splits on the same first-`where`.

Closes #7946