### PR TITLE
fix(core): make entity type inference robust under TS 7 stable type ordering

### DIFF
--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -913,7 +913,11 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
     Using extends string = never,
   >(
     entityName: EntityName<Entity>,
-    options: WithUsingOptions<FindByCursorOptions<Entity, Hint, Fields, Excludes, IncludeCount>, Entity, Using>,
+    options: WithUsingOptions<
+      FindByCursorOptions<NoInfer<Entity>, Hint, Fields, Excludes, IncludeCount>,
+      NoInfer<Entity>,
+      Using
+    >,
   ): Promise<Cursor<Entity, Hint, Fields, Excludes, IncludeCount>> {
     const em = this.getContext(false);
     options.overfetch ??= true;
@@ -1763,7 +1767,7 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
    */
   async insert<Entity extends object>(
     entityNameOrEntity: EntityName<Entity> | Entity,
-    data?: RequiredEntityData<Entity> | Entity,
+    data?: NoInfer<RequiredEntityData<Entity> | Entity>,
     options: NativeInsertUpdateOptions<Entity> = {},
   ): Promise<Primary<Entity>> {
     const em = this.getContext(false);
@@ -1868,7 +1872,7 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
    */
   async insertMany<Entity extends object>(
     entityNameOrEntities: EntityName<Entity> | Entity[],
-    data?: RequiredEntityData<Entity>[] | Entity[],
+    data?: NoInfer<RequiredEntityData<Entity>[] | Entity[]>,
     options: NativeInsertUpdateOptions<Entity> = {},
   ): Promise<Primary<Entity>[]> {
     const em = this.getContext(false);

--- a/tests/features/serialization/GH4263.test.ts
+++ b/tests/features/serialization/GH4263.test.ts
@@ -1,4 +1,4 @@
-import { serialize } from '@mikro-orm/core';
+import { Opt, serialize } from '@mikro-orm/core';
 import {
   Embeddable,
   Embedded,
@@ -24,7 +24,7 @@ export class ListEntity2Test {
   id!: string;
 
   @Property({ nullable: true })
-  title!: string;
+  title!: string & Opt;
 
   @Embedded(() => DetailsEntity)
   details!: DetailsEntity;


### PR DESCRIPTION
`insert`, `insertMany` and `findByCursor` inferred the `Entity` type parameter from the trailing data/options argument. Under TS 7 (`tsgo`), which defaults to stable type ordering, calling them with the entity class **and** an object/array literal narrows `Entity` to the literal's shape and then rejects the class:

```ts
em.insertMany(Book, [{ title, author, isFavorite: false }]);
// Argument of type 'typeof Book' is not assignable to parameter of type
//   '{ ... }[] | EntityName<{ title: string; author: number; isFavorite: false }>'
```

The fix wraps the data/options parameters in `NoInfer` so `Entity` comes only from the entity-name argument — the same approach `find` and `upsert`/`upsertMany` already use.

Verified with `@typescript/native-preview` (TS 7.0 RC line) directly on the test suite: the affected call sites drop from 8 type errors to 0, `bench:types` shows a 0.00% instantiation delta, and the current `tsc`/tsgolint checks and build stay green.

`GH4263`'s `title` (a `nullable` property, so omittable on insert) is marked `Opt` — the previous lenient inference was hiding that it was required in `RequiredEntityData`.

Upstream tracking issue for the stable-type-ordering inference change: microsoft/typescript-go#4464.

Note: this does not bump `oxlint-tsgolint` to 0.24 yet — 0.24 bundles an older `tsgo` that also emits `FilterQuery` false-positives which are already fixed upstream but not in any released tsgolint. Once tsgolint ships a newer `tsgo`, the bump will be clean and these fixes are already in place.
