### PR TITLE
chore: resolve postgres-interval Temporal types via the ESNext.Temporal lib

### DIFF
--- a/packages/cli/tsconfig.build.json
+++ b/packages/cli/tsconfig.build.json
@@ -2,8 +2,7 @@
   "extends": "../../tsconfig.build.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src",
-    "skipLibCheck": true
+    "rootDir": "./src"
   },
   "include": ["src/**/*"]
 }

--- a/packages/postgresql/tsconfig.build.json
+++ b/packages/postgresql/tsconfig.build.json
@@ -2,8 +2,7 @@
   "extends": "../../tsconfig.build.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src",
-    "skipLibCheck": true
+    "rootDir": "./src"
   },
   "include": ["src/**/*"]
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "module": "Node20",
     "target": "ES2023",
-    "lib": ["ES2023"],
+    "lib": ["ES2023", "ESNext.Temporal"],
     "incremental": true,
     "declaration": true,
     "sourceMap": false,


### PR DESCRIPTION
Follow-up to #7912, which pulled in `postgres-interval@4.1.0`. That version's `.d.ts` declares `toTemporalDuration(): Temporal.Duration`, referencing the `Temporal` global that isn't in the `ES2023` lib, so any package that resolves the type fails to build — `postgresql` (direct import) and `cli` (transitive, via its dynamic `import('@mikro-orm/postgresql')`). Neither a value-only nor a type-only import avoids it; resolving the module pulls its `.d.ts` either way.

#7912 worked around this with `skipLibCheck: true` in two build tsconfigs, which disables **all** library type-checking, not just this declaration.

Instead, add the `ESNext.Temporal` lib to the shared build config so the `Temporal` type resolves for real:

```jsonc
// tsconfig.build.json
"lib": ["ES2023", "ESNext.Temporal"],
```

- shipped by both `tsc` and `tsgo`, so `yarn build` and `yarn lint` both pass with **no** `skipLibCheck`;
- lives in one shared config and propagates to every package build and the lint program via `extends`;
- keeps `postgres-interval@4.1.0` and full library type-checking.

Both `skipLibCheck` flags added in #7912 are removed. `pglite`'s own `skipLibCheck` is left untouched — it predates this (added with the driver in #7622 for `@electric-sql/pglite`).

Note: `ESNext.Temporal` is an unstable lib name; when Temporal stabilizes it may be renamed to a versioned `ES20XX.Temporal`, a trivial one-line follow-up.
