### PR TITLE
fix(sql): stop schema diff churning on generated columns with underscore literals

### DIFF
--- a/packages/sql/src/schema/SchemaComparator.ts
+++ b/packages/sql/src/schema/SchemaComparator.ts
@@ -1142,7 +1142,8 @@ export class SchemaComparator {
     const simplify = (str?: string) => {
       return (
         str
-          ?.replace(/_\w+'(.*?)'/g, '$1')
+          // lookbehind: only strip a real charset introducer, never an underscore inside a literal like 'a_b'
+          ?.replace(/(?<![\w'])_\w+'(.*?)'/g, '$1')
           .replace(/!=/g, '<>')
           .replace(/in\s*\((.*?)\)/gi, '= any (array[$1])')
           // MySQL normalizes count(*) to count(0)

--- a/tests/features/schema-generator/generated-column-diffing.mysql.test.ts
+++ b/tests/features/schema-generator/generated-column-diffing.mysql.test.ts
@@ -1,0 +1,38 @@
+import { MikroORM } from '@mikro-orm/mysql';
+import { Entity, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+
+@Entity()
+class User {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  // entity-side 'a_b' has no _utf8mb4 introducer, so the introducer-stripping regex must not corrupt it
+  @Property({
+    type: 'string',
+    nullable: true,
+    generated: `(case when \`name\` = 'a_b' then 'x' else null end) virtual`,
+  })
+  label?: string;
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    metadataProvider: ReflectMetadataProvider,
+    entities: [User],
+    dbName: `generated-column-diffing`,
+    port: 3308,
+  });
+  await orm.schema.refresh();
+});
+
+afterAll(() => orm.close(true));
+
+test('generated column with an underscore string literal is not churned', async () => {
+  const diff = await orm.schema.getUpdateSchemaMigrationSQL({ wrap: false });
+  expect(diff).toEqual({ up: '', down: '' });
+});


### PR DESCRIPTION
SchemaComparator.simplify() strips MySQL charset introducers (_utf8mb4'foo' → foo) so both sides of an expression diff compare equal. The pattern /_\w+'(.*?)'/g also matched an underscore inside a string literal (e.g. 'a_b'): the DB side's real introducer absorbs the _, but the entity side has none, so 'a_b' gets mangled and the two sides never match — a generated column with such a literal is dropped + re-added on every diff.

Anchoring the pattern with a negative lookbehind makes it match only a real introducer (always preceded by a delimiter or the start of the expression).

Test covers MySQL. MariaDB isn't covered: this generated-column form fails at CREATE TABLE on MariaDB for an unrelated, pre-existing reason, so the churn can't be exercised there.