### PR TITLE
fix(mysql): treat (current_date) and curdate() date defaults as equal

### DIFF
--- a/packages/sql/src/dialects/mysql/MySqlSchemaHelper.ts
+++ b/packages/sql/src/dialects/mysql/MySqlSchemaHelper.ts
@@ -20,6 +20,7 @@ export class MySqlSchemaHelper extends SchemaHelper {
   static readonly DEFAULT_VALUES = {
     'now()': ['now()', 'current_timestamp'],
     'current_timestamp(?)': ['current_timestamp(?)'],
+    'curdate()': ['(current_date)'],
     '0': ['0', 'false'],
   };
 

--- a/packages/sql/src/dialects/mysql/MySqlSchemaHelper.ts
+++ b/packages/sql/src/dialects/mysql/MySqlSchemaHelper.ts
@@ -20,7 +20,7 @@ export class MySqlSchemaHelper extends SchemaHelper {
   static readonly DEFAULT_VALUES = {
     'now()': ['now()', 'current_timestamp'],
     'current_timestamp(?)': ['current_timestamp(?)'],
-    'curdate()': ['curdate()', '(current_date)'],
+    'curdate()': ['(current_date)', 'curdate()'],
     '0': ['0', 'false'],
   };
 

--- a/packages/sql/src/dialects/mysql/MySqlSchemaHelper.ts
+++ b/packages/sql/src/dialects/mysql/MySqlSchemaHelper.ts
@@ -20,7 +20,7 @@ export class MySqlSchemaHelper extends SchemaHelper {
   static readonly DEFAULT_VALUES = {
     'now()': ['now()', 'current_timestamp'],
     'current_timestamp(?)': ['current_timestamp(?)'],
-    'curdate()': ['(current_date)'],
+    'curdate()': ['curdate()', '(current_date)'],
     '0': ['0', 'false'],
   };
 

--- a/tests/features/schema-generator/date-default-diffing.mariadb.test.ts
+++ b/tests/features/schema-generator/date-default-diffing.mariadb.test.ts
@@ -1,0 +1,31 @@
+import { MikroORM } from '@mikro-orm/mariadb';
+import { Entity, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+
+@Entity()
+class User {
+  @PrimaryKey()
+  id!: number;
+
+  // MariaDB reports a (current_date) default back as curdate()
+  @Property({ type: 'date', defaultRaw: `(current_date)` })
+  day!: string;
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    metadataProvider: ReflectMetadataProvider,
+    entities: [User],
+    dbName: `date-default-diffing`,
+    port: 3309,
+  });
+  await orm.schema.refresh();
+});
+
+afterAll(() => orm.close(true));
+
+test('date column with a (current_date) default is not churned', async () => {
+  const diff = await orm.schema.getUpdateSchemaMigrationSQL({ wrap: false });
+  expect(diff).toEqual({ up: '', down: '' });
+});

--- a/tests/features/schema-generator/date-default-diffing.mysql.test.ts
+++ b/tests/features/schema-generator/date-default-diffing.mysql.test.ts
@@ -1,0 +1,31 @@
+import { MikroORM } from '@mikro-orm/mysql';
+import { Entity, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+
+@Entity()
+class User {
+  @PrimaryKey()
+  id!: number;
+
+  // MySQL reports a (current_date) default back as curdate()
+  @Property({ type: 'date', defaultRaw: `(current_date)` })
+  day!: string;
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    metadataProvider: ReflectMetadataProvider,
+    entities: [User],
+    dbName: `date-default-diffing`,
+    port: 3308,
+  });
+  await orm.schema.refresh();
+});
+
+afterAll(() => orm.close(true));
+
+test('date column with a (current_date) default is not churned', async () => {
+  const diff = await orm.schema.getUpdateSchemaMigrationSQL({ wrap: false });
+  expect(diff).toEqual({ up: '', down: '' });
+});


### PR DESCRIPTION
A date column with a (current_date) default churned a no-op migration on every diff: MySQL/MariaDB report the default back as curdate(), while the entity keeps (current_date), so hasSameDefaultValue() never saw them as equal.

Instead of special-casing DateType in the cross-dialect SchemaComparator, this normalizes the introspected curdate() back to (current_date) via a single MySqlSchemaHelper.DEFAULT_VALUES entry. Direction matters: norm[0] is also the value emitted into the entity's CREATE TABLE DDL, and a bare curdate() there is invalid (a date expression default must be parenthesized) — so the entity side is left untouched and only the introspected side is normalized.

Both dialects report curdate() identically, so the one entry (shared via MariaDbSchemaHelper extends MySqlSchemaHelper) fixes both. Tests cover both.