### PR TITLE
fix(sql): skip inline embedded prop in mapJoinedProp to prevent phantom changeset (#7954)

### DIFF
--- a/packages/sql/src/AbstractSqlDriver.ts
+++ b/packages/sql/src/AbstractSqlDriver.ts
@@ -853,6 +853,16 @@ export abstract class AbstractSqlDriver<
         relationPojo[prop.name] = value as EntityDataValue<T>;
       }
     } else {
+      // Inline (prefix:false, non-JSON) embedded props have no dedicated column of their
+      // own — the individual child SCALAR props carry each flattened column value and will
+      // be processed separately in this same loop.  Writing the raw DB column value here
+      // would corrupt __originalEntityData with a key in the wrong shape and produce a
+      // phantom changeset on the next flush whenever the embedded property's camelCase→
+      // snake_case column name coincidentally equals one of the child fieldNames.
+      if (prop.kind === ReferenceKind.EMBEDDED && !prop.object && !meta.embeddable) {
+        return;
+      }
+
       const alias = `${relationAlias}__${prop.fieldNames[0]}` as EntityKey<T>;
       relationPojo[prop.name] = root[alias];
 

--- a/tests/features/embeddables/embedded-entities.postgres.test.ts
+++ b/tests/features/embeddables/embedded-entities.postgres.test.ts
@@ -4,6 +4,7 @@ import {
   Embedded,
   Entity,
   ManyToOne,
+  OneToOne,
   PrimaryKey,
   Property,
   ReflectMetadataProvider,
@@ -740,5 +741,108 @@ describe('embedded entities in postgresql', () => {
     expect(mock.mock.calls[0][0]).toMatch(
       `select "u0".* from "user" as "u0" where exists (select 1 from jsonb_array_elements("u0"."addresses") as "__je0" where "__je0"->>'postal_code' is not null)`,
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regression test for https://github.com/mikro-orm/mikro-orm/issues/7954
+// A nullable prefix:false @Embedded whose child property has an explicit
+// fieldName containing an underscore (e.g. "comment_template") caused a
+// phantom changeset on flush when the parent entity was loaded via the
+// default joined populate strategy through a OneToOne relation.
+// ---------------------------------------------------------------------------
+
+@Embeddable()
+class CommentTemplate7954 {
+  // The explicit fieldName with an underscore is what triggers the bug:
+  // propertyToColumnName('commentTemplate') also yields 'comment_template',
+  // so the EMBEDDED prop's fieldNames[0] coincidentally equals the child's
+  // fieldNames[0].  mapJoinedProp was then writing the raw DB string to
+  // relationPojo['commentTemplate'], corrupting __originalEntityData.
+  @Property({ fieldName: 'comment_template', type: 'varchar' })
+  value!: string;
+}
+
+@Entity()
+class IssueChild7954 {
+  @PrimaryKey()
+  id!: number;
+
+  @Embedded(() => CommentTemplate7954, { prefix: false, nullable: true })
+  commentTemplate: CommentTemplate7954 | null = null;
+}
+
+@Entity()
+class IssueParent7954 {
+  @PrimaryKey()
+  id!: number;
+
+  @OneToOne(() => IssueChild7954, { fieldName: 'child_id', nullable: true })
+  child: Rel<IssueChild7954> | null = null;
+}
+
+describe('issue #7954 – phantom changeset for prefix:false nullable embedded with underscore fieldName loaded via joined populate', () => {
+  let orm: MikroORM<PostgreSqlDriver>;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      entities: [IssueParent7954, IssueChild7954],
+      dbName: 'mikro_orm_test_embeddables',
+      driver: PostgreSqlDriver,
+    });
+
+    const conn = orm.em.getConnection();
+    await conn.execute('drop table if exists "issue_parent7954" cascade');
+    await conn.execute('drop table if exists "issue_child7954" cascade');
+    await conn.execute(`
+      create table "issue_child7954" (
+        "id" int not null primary key,
+        "comment_template" varchar null
+      )
+    `);
+    await conn.execute(`
+      create table "issue_parent7954" (
+        "id" int not null primary key,
+        "child_id" int references "issue_child7954" ("id")
+      )
+    `);
+
+    // Seed
+    await conn.execute(`insert into "issue_child7954" values (1, 'hello')`);
+    await conn.execute(`insert into "issue_parent7954" values (1, 1)`);
+  });
+
+  afterAll(async () => {
+    const conn = orm.em.getConnection();
+    await conn.execute('drop table if exists "issue_parent7954" cascade');
+    await conn.execute('drop table if exists "issue_child7954" cascade');
+    await orm.close(true);
+  });
+
+  test('no phantom changeset after joined populate of child with prefix:false nullable embedded whose fieldName contains an underscore', async () => {
+    // Loading Parent with { populate: ['child'], strategy: 'joined' } triggers
+    // mapJoinedProp for every prop of Child, including the EMBEDDED
+    // commentTemplate.  Before the fix, mapJoinedProp was writing the raw DB
+    // string ('hello') to relationPojo['commentTemplate'] because
+    // propertyToColumnName('commentTemplate') → 'comment_template' happened to
+    // equal the child property's explicit fieldName.  That stray key then
+    // polluted __originalEntityData, causing a phantom { commentTemplate:
+    // undefined } changeset and an empty-SET-clause UPDATE on flush.
+    const em = orm.em.fork();
+    const found = await em.findOne(
+      IssueParent7954,
+      { id: 1 },
+      { populate: ['child'], strategy: LoadStrategy.JOINED },
+    );
+
+    expect(found).not.toBeNull();
+    expect(found!.child).not.toBeNull();
+    expect(found!.child!.commentTemplate).not.toBeNull();
+    expect(found!.child!.commentTemplate!.value).toBe('hello');
+
+    // Before the fix, flush() threw:
+    //   DriverException: No data provided (empty SET clause on Postgres)
+    await expect(em.flush()).resolves.toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

Fixes #7954.

When a `prefix: false` nullable `@Embedded` property's camelCase→snake_case column name happens to equal the explicit `fieldName` of one of its child properties (e.g. property `commentTemplate` → column `comment_template`, and child `@Property({ fieldName: 'comment_template' })`), `mapJoinedProp` was reading that shared column alias and writing the raw DB string to `relationPojo['commentTemplate']`.

Because `normalizeEntityData` only expands embedded POJOs (plain objects), not raw strings, the stray value leaked into `__originalEntityData['commentTemplate']`. The snapshot generator (`prepareEntity`) never sets that key — it only tracks the flattened scalar `comment_template_value` — so `getEntityComparator` saw `last['commentTemplate'] = 'hello'` vs `current['commentTemplate'] = undefined` and produced a phantom `{ commentTemplate: undefined }` changeset. Postgres then rejected the resulting empty-SET-clause `UPDATE`.

**Root cause in `mapJoinedProp`:** The `else` branch unconditionally read the alias column and assigned it to `relationPojo[prop.name]` for *any* property, including inline (non-object) `EMBEDDED` props. These props have no dedicated DB column of their own — the individual child SCALAR props (e.g. `comment_template_value`) are also present in `targetProps` and already carry the correct flattened values.

**Fix:** Return early in `mapJoinedProp` for inline embedded props (`kind === EMBEDDED && !prop.object && !meta.embeddable`). Their child SCALAR props handle the actual column values, so no data is lost.

## Changes

- `packages/sql/src/AbstractSqlDriver.ts` — add early-return guard in `mapJoinedProp` for inline embedded props
- `tests/features/embeddables/embedded-entities.postgres.test.ts` — regression test: loads a `Parent` with a `OneToOne` to `Child` (joined strategy) where `Child` has a `prefix:false` nullable embedded whose child `fieldName` contains an underscore, then asserts `flush()` produces no phantom changeset