### PR TITLE
fix(mssql): map FK, CHECK, PK/unique, deadlock and lock-timeout errors to driver exceptions

### DIFF
--- a/packages/mssql/src/MsSqlExceptionConverter.ts
+++ b/packages/mssql/src/MsSqlExceptionConverter.ts
@@ -1,6 +1,10 @@
 import {
+  CheckConstraintViolationException,
+  DeadlockException,
   ExceptionConverter,
+  ForeignKeyConstraintViolationException,
   InvalidFieldNameException,
+  LockWaitTimeoutException,
   NonUniqueFieldNameException,
   NotNullConstraintViolationException,
   SyntaxErrorException,
@@ -14,8 +18,8 @@ import {
 /** Converts MSSQL native errors into typed MikroORM driver exceptions. */
 export class MsSqlExceptionConverter extends ExceptionConverter {
   /**
-   * @see https://docs.microsoft.com/en-us/sql/relational-databases/errors-events/mssqlserver-511-database-engine-error?view=sql-server-ver15
-   * @see https://github.com/doctrine/dbal/blob/master/src/Driver/AbstractPostgreSQLDriver.php
+   * @see https://learn.microsoft.com/en-us/sql/relational-databases/errors-events/database-engine-events-and-errors
+   * @see https://github.com/doctrine/dbal/blob/4.4.x/src/Driver/API/SQLSrv/ExceptionConverter.php
    */
   override convertException(exception: Error & Dictionary): DriverException {
     let errno = exception.number;
@@ -43,7 +47,26 @@ export class MsSqlExceptionConverter extends ExceptionConverter {
         return new TableNotFoundException(exception);
       case 209:
         return new NonUniqueFieldNameException(exception);
+      case 547:
+        // 547 covers both referential (FOREIGN KEY/REFERENCE) and CHECK constraint
+        // violations; only the message distinguishes them. The surrounding text is
+        // localized (e.g. "CHECK-Einschränkung" on a German server), but the
+        // constraint-type keyword itself is an untranslated SQL keyword, so match on
+        // the bare `CHECK` token.
+        if (exception.message.includes('CHECK')) {
+          return new CheckConstraintViolationException(exception);
+        }
+
+        return new ForeignKeyConstraintViolationException(exception);
+      case 4712:
+        // TRUNCATE blocked because the table is referenced by a FOREIGN KEY.
+        return new ForeignKeyConstraintViolationException(exception);
+      case 1205:
+        return new DeadlockException(exception);
+      case 1222:
+        return new LockWaitTimeoutException(exception);
       case 2601:
+      case 2627:
         return new UniqueConstraintViolationException(exception);
       case 2714:
         return new TableExistsException(exception);

--- a/tests/features/entity-manager/EntityManager.mssql.test.ts
+++ b/tests/features/entity-manager/EntityManager.mssql.test.ts
@@ -1,9 +1,13 @@
 import { performance } from 'node:perf_hooks';
 import { v4 } from 'uuid';
 import {
+  CheckConstraintViolationException,
   Collection,
+  DeadlockException,
   EntityManager,
+  ForeignKeyConstraintViolationException,
   InvalidFieldNameException,
+  LockWaitTimeoutException,
   IsolationLevel,
   LockMode,
   MikroORM,
@@ -1482,11 +1486,30 @@ describe('EntityManagerMsSql', () => {
 
   test('exceptions', async () => {
     const driver = orm.em.getDriver();
-    await driver.nativeInsert(Author2, { name: 'author', email: 'email' });
+    const { insertId: authorId } = await driver.nativeInsert(Author2, { name: 'author', email: 'email' });
     await expect(driver.nativeInsert(Author2, { name: 'author', email: 'email' })).rejects.toThrow(
       UniqueConstraintViolationException,
     );
     await expect(driver.nativeInsert(Author2, {})).rejects.toThrow(NotNullConstraintViolationException);
+
+    // 547 with a referential constraint -> ForeignKeyConstraintViolationException
+    await expect(driver.nativeInsert(Book2, { uuid: v4(), author: 999999 })).rejects.toThrow(
+      ForeignKeyConstraintViolationException,
+    );
+
+    // 2627 (violation of PRIMARY KEY constraint) -> UniqueConstraintViolationException
+    const uuid = v4();
+    await driver.nativeInsert(Book2, { uuid, author: authorId });
+    await expect(driver.nativeInsert(Book2, { uuid, author: authorId })).rejects.toThrow(
+      UniqueConstraintViolationException,
+    );
+
+    // 547 with a CHECK constraint -> CheckConstraintViolationException (same error number as FK)
+    await driver.execute('create table check_test (id int check (id > 0))');
+    await expect(driver.execute('insert into check_test (id) values (-1)')).rejects.toThrow(
+      CheckConstraintViolationException,
+    );
+
     orm.getMetadata(Author2).tableName = 'test';
     await expect(driver.nativeInsert(Author2, { foo: 'bar' } as any)).rejects.toThrow(TableNotFoundException);
     orm.getMetadata(Author2).tableName = 'author2';
@@ -1494,6 +1517,44 @@ describe('EntityManagerMsSql', () => {
     await expect(driver.execute('foo bar 123')).rejects.toThrow(SyntaxErrorException);
     await expect(driver.execute('select id from author2, foo_bar2')).rejects.toThrow(NonUniqueFieldNameException);
     await expect(driver.execute('select uuid from author2')).rejects.toThrow(InvalidFieldNameException);
+  });
+
+  test('MsSqlExceptionConverter distinguishes 547 (FK vs CHECK) independently of message locale', () => {
+    const converter = orm.em.getPlatform().getExceptionConverter();
+    const convert = (number: number, message: string) =>
+      converter.convertException(Object.assign(new Error(message), { number }));
+
+    // 547 is shared by referential and CHECK constraints and only the message tells them
+    // apart. The surrounding text is localized, but the FOREIGN KEY/REFERENCE/CHECK keyword
+    // is not, so the mapping must not rely on the English wording. The messages below are
+    // verbatim en-US and de-DE server output; the DB-backed `exceptions` test above can only
+    // exercise the locale the CI server runs in.
+    expect(convert(547, 'The INSERT statement conflicted with the FOREIGN KEY constraint "FK_c_p".')).toBeInstanceOf(
+      ForeignKeyConstraintViolationException,
+    );
+    expect(convert(547, 'The DELETE statement conflicted with the REFERENCE constraint "FK_c_p".')).toBeInstanceOf(
+      ForeignKeyConstraintViolationException,
+    );
+    expect(convert(547, 'The INSERT statement conflicted with the CHECK constraint "CK_x".')).toBeInstanceOf(
+      CheckConstraintViolationException,
+    );
+    expect(
+      convert(547, 'Die INSERT-Anweisung steht in Konflikt mit der FOREIGN KEY-Einschränkung "FK_c_p".'),
+    ).toBeInstanceOf(ForeignKeyConstraintViolationException);
+    expect(
+      convert(547, 'Die INSERT-Anweisung steht in Konflikt mit der CHECK-Einschränkung "CK__ck_t".'),
+    ).toBeInstanceOf(CheckConstraintViolationException);
+
+    // 4712: TRUNCATE blocked by an FK reference is also a foreign-key violation.
+    expect(
+      convert(4712, 'Cannot truncate table "t" because it is being referenced by a FOREIGN KEY constraint.'),
+    ).toBeInstanceOf(ForeignKeyConstraintViolationException);
+
+    // 1205/1222 have no dedicated integration coverage, so assert the number mapping here.
+    expect(convert(1205, 'Transaction was deadlocked ... and has been chosen as the deadlock victim.')).toBeInstanceOf(
+      DeadlockException,
+    );
+    expect(convert(1222, 'Lock request time out period exceeded.')).toBeInstanceOf(LockWaitTimeoutException);
   });
 
   // this should run in ~300ms (when running single test locally)


### PR DESCRIPTION
The MSSQL exception converter only recognised 7 error numbers; several common constraint violations fell through to the generic DriverException. Map them to the appropriate typed exceptions, matching the other dialects and Doctrine DBAL:

- 547 -> ForeignKeyConstraintViolationException, or CheckConstraintViolationException when the message names a CHECK constraint (547 is shared by both; the FOREIGN KEY/REFERENCE/CHECK keyword stays English even on localized servers, so it is matched on the bare token)
- 4712 (TRUNCATE blocked by an FK reference) -> ForeignKeyConstraintViolationException
- 2627 (PK/unique constraint) -> UniqueConstraintViolationException, alongside the existing 2601 (unique index)
- 1205 -> DeadlockException, 1222 -> LockWaitTimeoutException