### PR TITLE
fix(core): infer `string` for `time` type properties instead of `any`

### DIFF
--- a/packages/core/src/types/TimeType.ts
+++ b/packages/core/src/types/TimeType.ts
@@ -4,9 +4,9 @@ import type { EntityProperty } from '../typings.js';
 import { ValidationError } from '../errors.js';
 
 /** Maps a database TIME column to a JS `string` in HH:MM:SS format. */
-export class TimeType extends Type {
-  override convertToDatabaseValue(value: any, platform: Platform): string {
-    if (value && !value.toString().match(/^\d{2,}:(?:[0-5]\d):(?:[0-5]\d)$/)) {
+export class TimeType extends Type<string | null | undefined, string | null | undefined> {
+  override convertToDatabaseValue(value: string | null | undefined, platform: Platform): string | null | undefined {
+    if (value && !/^\d{2,}:(?:[0-5]\d):(?:[0-5]\d)$/.test(value)) {
       throw ValidationError.invalidType(TimeType, value, 'JS');
     }
 

--- a/tests/defineEntity.test.ts
+++ b/tests/defineEntity.test.ts
@@ -350,6 +350,32 @@ describe('defineEntity', () => {
     >(true);
   });
 
+  it('should infer `string` for time type properties', () => {
+    const p = defineEntity.properties;
+
+    const Foo = defineEntity({
+      name: 'Foo',
+      properties: {
+        id: p.integer().primary(),
+        viaBuilder: p.time(),
+        viaTypeString: p.type('time'),
+      },
+    });
+
+    type IFoo = InferEntity<typeof Foo>;
+    assert<
+      IsExact<
+        Omit<IFoo, typeof IndexHints>,
+        {
+          id: number;
+          viaBuilder: string;
+          viaTypeString: string;
+          [PrimaryKeyProp]?: 'id';
+        }
+      >
+    >(true);
+  });
+
   it('should define entity with class constructor as extends', () => {
     class BaseEntity {
       id!: number;

--- a/tests/features/custom-types/TimeType.test.ts
+++ b/tests/features/custom-types/TimeType.test.ts
@@ -9,13 +9,13 @@ describe('TimeType', () => {
     expect(type.convertToDatabaseValue('00:00:01', platform)).toBe('00:00:01');
     expect(type.convertToDatabaseValue(null, platform)).toBe(null);
     expect(type.convertToDatabaseValue(undefined, platform)).toBe(undefined);
-    expect(() => type.convertToDatabaseValue(1, platform)).toThrow(
+    expect(() => type.convertToDatabaseValue(1 as any, platform)).toThrow(
       `Could not convert JS value '1' of type 'number' to type TimeType`,
     );
     expect(() => type.convertToDatabaseValue('2000-01-01', platform)).toThrow(
       `Could not convert JS value '2000-01-01' of type 'string' to type TimeType`,
     );
-    expect(() => type.convertToDatabaseValue(new Date('2000-01-01'), platform)).toThrow(
+    expect(() => type.convertToDatabaseValue(new Date('2000-01-01') as any, platform)).toThrow(
       `Could not convert JS value '2000-01-01T00:00:00.000Z' of type 'date' to type TimeType`,
     );
   });


### PR DESCRIPTION
`time`-typed properties defined via `defineEntity` currently infer as `any`:

```ts
const Foo = defineEntity({
  name: 'Foo',
  properties: p => ({
    t1: p.time(),        // any
    t2: p.type('time'),  // any
  }),
});
```

TimeType extended Type without type arguments (relying on the JSType = string default) and overrode convertToDatabaseValue(value: any, …). The defineEntity inference helper InferJSType derives the runtime type from every position where Type's first type parameter appears — including that value: any parameter — so the any poisoned the inference and collapsed the result to any. DateType avoids this because its value: any sits in convertToJSValue (the DBType slot, already erased in the matcher).

Fix: declare the type parameters explicitly (Type<string | null | undefined, …>, mirroring DateType) and type the override's parameter/return so the inference resolves to string. Runtime behavior is unchanged.