### PR TITLE
fix(sql): keep nullable relation FK columns nullable in class-based Kysely inference

### DIFF
--- a/packages/sql/src/typings.ts
+++ b/packages/sql/src/typings.ts
@@ -516,4 +516,9 @@ type ClassEntityColumnName<K, V, TOptions extends MikroKyselyPluginOptions = {}>
 type ClassEntityJoinColumnName<TName extends string, V> =
   PrimaryProperty<V> extends string ? `${TName}_${SnakeCase<PrimaryProperty<V>>}` : never;
 
-type ClassEntityColumnValue<V> = NonNullable<V> extends Scalar | readonly any[] ? V : Primary<NonNullable<V>>;
+type ClassEntityColumnValue<V> =
+  NonNullable<V> extends Scalar | readonly any[]
+    ? V
+    : V extends NonNullable<V>
+      ? Primary<NonNullable<V>>
+      : Primary<NonNullable<V>> | null;

--- a/tests/features/get-kysely.test.ts
+++ b/tests/features/get-kysely.test.ts
@@ -898,6 +898,51 @@ describe('InferClassEntityDB', () => {
     expectTypeOf<DBEntity>().toHaveProperty('Foo7423');
   });
 
+  test('nullable m:1 FK columns keep null in class inference (GH #7962)', async () => {
+    const Address = defineEntity({
+      name: 'Address7962',
+      properties: {
+        id: p.uuid().primary(),
+      },
+    });
+
+    const UserSchema = defineEntity({
+      name: 'User7962',
+      properties: {
+        id: p.integer().primary(),
+        address: () => p.manyToOne(Address).nullable(),
+      },
+    });
+
+    class User7962 extends UserSchema.class {}
+    UserSchema.setClass(User7962);
+
+    // nullable FK column must stay nullable on the class-based inference path,
+    // matching the schema-based path
+    type DB = InferClassEntityDB<typeof User7962>;
+    expectTypeOf<DB['user7962']['address_id']>().toEqualTypeOf<string | null>();
+
+    type DBProp = InferClassEntityDB<typeof User7962, { columnNamingStrategy: 'property' }>;
+    expectTypeOf<DBProp['user7962']['address']>().toEqualTypeOf<string | null>();
+
+    // the type surfaces through getKysely() the same as a class-less schema, so `null` is accepted
+    const orm = await MikroORM.init({
+      entities: [User7962, Address],
+      dbName: ':memory:',
+    });
+    await orm.schema.create();
+
+    const kysely = orm.em.getKysely();
+    type KyselyDB = InferDBFromKysely<typeof kysely>;
+    expectTypeOf<KyselyDB['user7962']['address_id']>().toEqualTypeOf<string | null>();
+
+    await kysely.insertInto('user7962').values({ id: 1, address_id: null }).execute();
+    const rows = await kysely.selectFrom('user7962').select(['id', 'address_id']).execute();
+    expect(rows).toEqual([{ id: 1, address_id: null }]);
+
+    await orm.close();
+  });
+
   test('scalar array properties are inferred as columns (GH #7751)', () => {
     interface Stop {
       offset: number;


### PR DESCRIPTION
The class-based `getKysely()` inference path (`ClassEntityColumnValue`) collapsed any non-scalar (relation) value to `Primary<NonNullable<V>>`, stripping nullability. A nullable `@ManyToOne`/`@OneToOne` therefore produced a non-nullable FK column type, so `null` could not be assigned to it — diverging from the class-less schema path, which correctly yields `Primary | null` via `MaybeGenerated`.

This surfaced when a `defineEntity` schema was bound to a class via `setClass`: the class-less schema worked, but the class variant rejected `address_id: null`.

The fix distributes over `V` and re-adds `| null` when `V` is nullable, bringing the two inference paths into agreement.

Closes #7962