### PR TITLE
fix(sql): avoid phantom changeset for inline embeddable loaded via joined strategy

### DIFF
--- a/packages/sql/src/AbstractSqlDriver.ts
+++ b/packages/sql/src/AbstractSqlDriver.ts
@@ -814,6 +814,12 @@ export abstract class AbstractSqlDriver<
       return;
     }
 
+    // inline embeddables are mapped via their flattened child props; mapping the embedded root prop
+    // here would leak a raw column value into the snapshot and produce a phantom changeset
+    if (prop.kind === ReferenceKind.EMBEDDED && !prop.object && !meta.embeddable) {
+      return;
+    }
+
     if (prop.polymorphic && prop.kind !== ReferenceKind.EMBEDDED) {
       const discriminatorAlias = `${relationAlias}__${prop.fieldNames[0]}` as EntityKey<T>;
       const discriminatorValue = root[discriminatorAlias] as string;

--- a/tests/issues/GH7954.test.ts
+++ b/tests/issues/GH7954.test.ts
@@ -1,0 +1,68 @@
+import { MikroORM } from '@mikro-orm/postgresql';
+import {
+  Embeddable,
+  Embedded,
+  Entity,
+  OneToOne,
+  PrimaryKey,
+  Property,
+  ReflectMetadataProvider,
+} from '@mikro-orm/decorators/legacy';
+
+@Embeddable()
+class CommentTemplate {
+  @Property({ fieldName: 'comment_template', type: 'varchar' })
+  value: string;
+
+  constructor(value: string) {
+    this.value = value;
+  }
+}
+
+@Entity()
+class Child {
+  @PrimaryKey()
+  id!: number;
+
+  @Embedded(() => CommentTemplate, { prefix: false, nullable: true })
+  commentTemplate: CommentTemplate | null = null;
+}
+
+@Entity()
+class Parent {
+  @PrimaryKey()
+  id!: number;
+
+  @OneToOne(() => Child)
+  child!: Child;
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    metadataProvider: ReflectMetadataProvider,
+    entities: [Parent, Child, CommentTemplate],
+    dbName: '7954',
+  });
+  await orm.schema.refresh();
+});
+
+afterAll(() => orm.close(true));
+
+test('no phantom changeset for nullable flattened embedded with underscore fieldName loaded via joined strategy', async () => {
+  const em1 = orm.em.fork();
+  const child = em1.create(Child, { id: 1, commentTemplate: new CommentTemplate('hello') });
+  em1.create(Parent, { id: 1, child });
+  await em1.flush();
+
+  const em2 = orm.em.fork();
+  const found = await em2.findOneOrFail(Parent, { id: 1 }, { populate: ['child'], strategy: 'joined' });
+  expect(found.child.commentTemplate).toEqual({ value: 'hello' });
+
+  const uow = em2.getUnitOfWork();
+  uow.computeChangeSets();
+  expect(uow.getChangeSets()).toHaveLength(0);
+
+  await expect(em2.flush()).resolves.not.toThrow();
+});


### PR DESCRIPTION
When loading an entity with an inline (non-`object`, flattened) `@Embedded` property via the `joined` populate strategy, `flush()` could emit a phantom changeset — resulting in an `UPDATE` with an empty `SET` clause and a `No data provided` error.

## Root cause

In `AbstractSqlDriver.mapJoinedProp`, the inline embeddable **root** prop was mapped as a raw scalar/composite column in addition to its flattened child props. The root prop's field names are derived by the naming strategy (snake-casing its name), so when a child column's explicit `fieldName` happened to match (e.g. a `fieldName` containing an underscore like `comment_template` matching the snake-cased root name `commentTemplate`), the raw column value leaked into the entity snapshot. That snapshot then diverged from the hydrated nested object (`"hello"` vs `{ value: "hello" }`), so the unit of work computed a spurious changeset.

Without the underscore the derived root field name no longer matches the real column, the value is `undefined`, and the existing early-return skips it — which is why the bug only surfaced for underscored field names.

## Fix

Skip inline embeddable root props in `mapJoinedProp`; their flattened child props already carry the column values (mirroring the existing JSON-embeddable branch that only runs for `object`/embeddable metas).

Closes #7954