### PR TITLE
fix(sql): infer array columns as arrays in Kysely table types

### DIFF
--- a/packages/sql/src/typings.ts
+++ b/packages/sql/src/typings.ts
@@ -443,8 +443,14 @@ type InferColumnValue<TBuilder, TProcessOnCreate extends boolean> = TBuilder ext
   '~type'?: { value: infer Value };
   '~options': infer TOptions;
 }
-  ? MaybeNever<MaybeGenerated<MaybeJoinKey<Value, TOptions>, TOptions, TProcessOnCreate>, TOptions>
+  ? MaybeNever<
+      MaybeGenerated<MaybeJoinKey<MaybeArray<Value, TOptions>, TOptions>, TOptions, TProcessOnCreate>,
+      TOptions
+    >
   : never;
+
+// `.array()` marks a native array column (e.g. postgres text[]); mirror the em.create inference.
+type MaybeArray<TValue, TOptions> = TOptions extends { array: true } ? TValue[] : TValue;
 
 type MaybeGenerated<TValue, TOptions, TProcessOnCreate extends boolean> = TOptions extends { nullable: true }
   ? TValue | null

--- a/tests/issues/GH7967.test.ts
+++ b/tests/issues/GH7967.test.ts
@@ -1,0 +1,26 @@
+import { defineEntity, InferEntity, InferKyselyTable, p } from '@mikro-orm/postgresql';
+import { expectTypeOf } from 'vitest';
+
+// https://github.com/mikro-orm/mikro-orm/issues/7967
+// `.array()` marks a column as a native array (e.g. postgres text[]). The em.create
+// inference already treats such a column as `Value[]`, but the Kysely inference used to
+// ignore the `array` flag, so plain `.array()` columns surfaced as the element type there.
+const User = defineEntity({
+  name: 'User',
+  properties: {
+    id: p.integer().primary(),
+    emails: p.text().array(),
+    emailsOverrideAsString: p.text().array().$type<string>(),
+  },
+});
+
+type IUser = InferEntity<typeof User>;
+interface UserTable extends InferKyselyTable<typeof User> {}
+
+test('array columns infer as arrays for both em.create and kysely', () => {
+  expectTypeOf<IUser['emails']>().toEqualTypeOf<string[]>();
+  expectTypeOf<IUser['emailsOverrideAsString']>().toEqualTypeOf<string[]>();
+
+  expectTypeOf<UserTable['emails']>().toEqualTypeOf<string[]>();
+  expectTypeOf<UserTable['emails_override_as_string']>().toEqualTypeOf<string[]>();
+});


### PR DESCRIPTION
`.array()` marks a native array column (e.g. postgres `text[]`). The `em.create` inference already treated such columns as `Value[]`, but the Kysely inference (`InferColumnValue`) ignored the `array` flag, so a plain `.array()` column surfaced as its element type in the Kysely table type and rejected array inserts.

The fix applies the same `MaybeArray` wrapping used by the core `em.create` inference, placed innermost to mirror `defineEntity.ts`. Both inference paths now agree: `p.text().array()` is `string[]` everywhere, so the type override workarounds from the issue are no longer needed.

Closes #7967