### PR TITLE
fix(core): keep custom-typed PK snapshots in DB-form to avoid spurious updates

### DIFF
--- a/packages/core/src/entity/EntityFactory.ts
+++ b/packages/core/src/entity/EntityFactory.ts
@@ -194,6 +194,25 @@ export class EntityFactory {
     }
 
     if (options.merge && wrapped.hasPrimaryKey()) {
+      // A reference seeded from a raw scalar PK with `convertCustomTypes: false` (e.g. `em.getReference()` or a to-one
+      // relation assigned a raw scalar in `em.create()`) keeps the PK in JS-form, while `EntityComparator.prepareEntity()`
+      // derives DB-form. For a custom type mapping between different shapes (e.g. ULID <-> UUID) the two always diff,
+      // yielding a spurious PK update on every flush — so normalize the snapshot payload to DB-form here (GH #7966).
+      if (!options.convertCustomTypes && !options.initialized) {
+        for (const prop of meta.getPrimaryProps()) {
+          if (
+            prop.kind === ReferenceKind.SCALAR &&
+            prop.customType?.ensureComparable(meta, prop) &&
+            data[prop.name] != null
+          ) {
+            data[prop.name] = prop.customType.convertToDatabaseValue(data[prop.name], this.#platform, {
+              key: prop.name,
+              mode: 'hydration',
+            }) as EntityDataValue<T>;
+          }
+        }
+      }
+
       this.unitOfWork.register(entity, data, {
         // Always refresh to ensure the payload is in correct shape for joined strategy. When loading nested relations,
         // they will be created early without `Type.ensureComparable` being properly handled, resulting in extra updates.
@@ -293,8 +312,7 @@ export class EntityFactory {
         prop.customType?.ensureComparable(meta, prop) &&
         diff2[key] != null
       ) {
-        const converted = prop.customType.convertToJSValue(diff2[key], this.#platform, { force: true });
-        diff2[key] = prop.customType.convertToDatabaseValue(converted, this.#platform, { fromQuery: true });
+        diff2[key] = prop.customType.convertToDatabaseValue(diff2[key], this.#platform, { fromQuery: true });
       }
 
       originalEntityData[key] = diff2[key] === null ? nullVal : diff2[key];

--- a/packages/core/src/entity/EntityFactory.ts
+++ b/packages/core/src/entity/EntityFactory.ts
@@ -194,25 +194,6 @@ export class EntityFactory {
     }
 
     if (options.merge && wrapped.hasPrimaryKey()) {
-      // A reference seeded from a raw scalar PK with `convertCustomTypes: false` (e.g. `em.getReference()` or a to-one
-      // relation assigned a raw scalar in `em.create()`) keeps the PK in JS-form, while `EntityComparator.prepareEntity()`
-      // derives DB-form. For a custom type mapping between different shapes (e.g. ULID <-> UUID) the two always diff,
-      // yielding a spurious PK update on every flush — so normalize the snapshot payload to DB-form here (GH #7966).
-      if (!options.convertCustomTypes && !options.initialized) {
-        for (const prop of meta.getPrimaryProps()) {
-          if (
-            prop.kind === ReferenceKind.SCALAR &&
-            prop.customType?.ensureComparable(meta, prop) &&
-            data[prop.name] != null
-          ) {
-            data[prop.name] = prop.customType.convertToDatabaseValue(data[prop.name], this.#platform, {
-              key: prop.name,
-              mode: 'hydration',
-            }) as EntityDataValue<T>;
-          }
-        }
-      }
-
       this.unitOfWork.register(entity, data, {
         // Always refresh to ensure the payload is in correct shape for joined strategy. When loading nested relations,
         // they will be created early without `Type.ensureComparable` being properly handled, resulting in extra updates.
@@ -221,7 +202,11 @@ export class EntityFactory {
         loaded: options.initialized,
       });
 
-      if (options.recomputeSnapshot) {
+      // A reference seeded from a raw scalar PK with `convertCustomTypes: false` (e.g. `em.getReference()` or a to-one
+      // relation assigned a raw scalar in `em.create()`) keeps its snapshot in JS-form, while `prepareEntity()` derives
+      // DB-form — so for a custom type mapping between different shapes (e.g. ULID <-> UUID) they always diff, yielding a
+      // spurious PK update on every flush. Recompute the snapshot from the entity to keep it in DB-form (GH #7966).
+      if (options.recomputeSnapshot || (!options.convertCustomTypes && !options.initialized)) {
         wrapped.__originalEntityData = this.#comparator.prepareEntity(entity);
       }
     }

--- a/tests/issues/GH7702.test.ts
+++ b/tests/issues/GH7702.test.ts
@@ -1,6 +1,6 @@
 // GH #7702 - `LockMode.NONE` should behave like `lockMode: undefined`
 import { defineEntity, LockMode, MikroORM, p } from '@mikro-orm/sqlite';
-import { mockLogger } from '../helpers';
+import { mockLogger } from '../helpers.js';
 
 const User = defineEntity({
   name: 'User7702',

--- a/tests/issues/GH7966.test.ts
+++ b/tests/issues/GH7966.test.ts
@@ -2,7 +2,7 @@
 // desyncs `__originalEntityData` when a to-one relation is assigned a raw scalar PK,
 // causing a spurious UPDATE of the referenced entity's PK on every flush.
 import { defineEntity, MikroORM, p, Type } from '@mikro-orm/sqlite';
-import { mockLogger } from '../helpers';
+import { mockLogger } from '../helpers.js';
 
 // JS-form: "js-<n>"   DB-form: "db-<n>" (analogous to ULID <-> UUID)
 class RemappingType extends Type<string | null | undefined> {

--- a/tests/issues/GH7966.test.ts
+++ b/tests/issues/GH7966.test.ts
@@ -1,0 +1,84 @@
+// GH #7966 - custom `Type` whose JS-form and DB-form are different string shapes
+// desyncs `__originalEntityData` when a to-one relation is assigned a raw scalar PK,
+// causing a spurious UPDATE of the referenced entity's PK on every flush.
+import { defineEntity, MikroORM, p, Type } from '@mikro-orm/sqlite';
+import { mockLogger } from '../helpers';
+
+// JS-form: "js-<n>"   DB-form: "db-<n>" (analogous to ULID <-> UUID)
+class RemappingType extends Type<string | null | undefined> {
+  override convertToDatabaseValue(value: string | null | undefined): string | null | undefined {
+    return value == null ? value : value.replace(/^js-/, 'db-');
+  }
+
+  override convertToJSValue(value: string | null | undefined): string | null | undefined {
+    return value == null ? value : value.replace(/^db-/, 'js-');
+  }
+
+  override compareAsType(): string {
+    return 'string';
+  }
+}
+
+const authorSchema = defineEntity({
+  name: 'Author7966',
+  properties: {
+    id: p.type(RemappingType).primary(),
+    name: p.string(),
+  },
+});
+
+class Author extends authorSchema.class {}
+authorSchema.setClass(Author);
+
+const bookSchema = defineEntity({
+  name: 'Book7966',
+  properties: {
+    id: p.integer().primary().autoincrement(),
+    title: p.string(),
+    author: () => p.manyToOne(Author).ref(),
+  },
+});
+
+class Book extends bookSchema.class {}
+bookSchema.setClass(Book);
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    entities: [Author, Book],
+    dbName: ':memory:',
+  });
+  await orm.schema.create();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+test('assigning a to-one relation via raw scalar PK does not emit a spurious PK update', async () => {
+  const em = orm.em.fork();
+
+  // seed an Author directly with a known DB-form id
+  await em.getConnection().execute('insert into "author7966" ("id", "name") values (?, ?)', ['db-1', 'Ada']);
+
+  const book = em.create(Book, {
+    title: 'Structure and Interpretation',
+    author: 'js-1', // JS-form id, as seen on `author.id`
+  });
+  em.persist(book);
+
+  const author = await em.findOneOrFail(Author, 'js-1');
+  expect(author.id).toBe('js-1');
+  expect(author === book.author.unwrap()).toBe(true);
+
+  const mock = mockLogger(orm);
+  await em.flush();
+
+  const updates = mock.mock.calls.filter(([msg]) => /update `author7966`/i.test(String(msg)));
+  expect(updates).toHaveLength(0);
+
+  // sanity: the row is untouched
+  const rows = await em.getConnection().execute('select * from "author7966"');
+  expect(rows).toEqual([{ id: 'db-1', name: 'Ada' }]);
+});


### PR DESCRIPTION
Assigning a to-one relation via a raw scalar PK (`em.getReference(Entity, id)`, or a raw scalar in `em.create()`'s data) uses `convertCustomTypes: false`, so the reference's change-tracking snapshot (`__originalEntityData`) kept the PK in its **JS-form**, while `EntityComparator.prepareEntity()` always derives the **DB-form** on every flush.

For a custom `Type` whose JS-form and DB-form are genuinely different strings (e.g. ULID ↔ UUID), the two never compare equal, so the ORM believed the PK changed and emitted `UPDATE <table> SET id = <db-form> WHERE id = <js-form>` on every flush — silently on loosely-typed columns, or throwing `invalid input syntax for type uuid` on a native `uuid` column. Built-in `UuidType`/`ObjectId` don't surface it because their JS/DB forms are effectively identical.

The fix normalizes a scalar custom-typed PK to DB-form when seeding the reference snapshot, so it matches what `prepareEntity()` produces. This also required correcting the matching `mergeData` normalization to convert the JS-form value directly — the previous `convertToJSValue` → `convertToDatabaseValue` round-trip assumed DB-form input and threw for these types once the snapshot was correct (uncovered by a `UuidBinaryType` regression test).

Closes #7966