### PR TITLE
fix(sql): coerce to.default to string in SchemaComparator.hasSameDefaultValue

### DIFF
--- a/packages/sql/src/schema/SchemaComparator.ts
+++ b/packages/sql/src/schema/SchemaComparator.ts
@@ -1247,10 +1247,10 @@ export class SchemaComparator {
       from.default.toString().toLowerCase() === 'null' ||
       from.default.toString().startsWith('nextval(')
     ) {
-      return to.default == null || to.default.toLowerCase() === 'null';
+      return to.default == null || to.default.toString().toLowerCase() === 'null';
     }
 
-    if (to.default == null || to.default.toLowerCase() === 'null') {
+    if (to.default == null || to.default.toString().toLowerCase() === 'null') {
       return false;
     }
 

--- a/tests/features/schema-generator/GH7976.test.ts
+++ b/tests/features/schema-generator/GH7976.test.ts
@@ -1,0 +1,39 @@
+import { MikroORM, SchemaComparator } from '@mikro-orm/sqlite';
+import type { Column } from '@mikro-orm/sql';
+
+// GH #7976 — SchemaComparator.hasSameDefaultValue threw `to.default.toLowerCase is not a function`
+// when `to.default` was a non-string (a number or boolean — e.g. a column whose entity default is
+// `@Property({ default: 0 })` or `@Property({ default: true })`). The `from` side was already coerced
+// with `.toString()`; the `to` side was not.
+describe('GH 7976', () => {
+  let orm: MikroORM;
+  let comparator: SchemaComparator;
+
+  const col = (def: unknown): Column => ({ default: def } as unknown as Column);
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({ dbName: ':memory:', entities: [], discovery: { warnWhenNoEntities: false } });
+    comparator = new SchemaComparator(orm.em.getPlatform());
+  });
+
+  afterAll(() => orm.close(true));
+
+  it('does not throw on a numeric `to.default` (from.default null)', () => {
+    expect(() => comparator.hasSameDefaultValue(col(null), col(0))).not.toThrow();
+    expect(comparator.hasSameDefaultValue(col(null), col(0))).toBe(false);
+  });
+
+  it('does not throw on a boolean `to.default` (from.default null)', () => {
+    expect(() => comparator.hasSameDefaultValue(col(null), col(false))).not.toThrow();
+    expect(() => comparator.hasSameDefaultValue(col(null), col(true))).not.toThrow();
+    expect(comparator.hasSameDefaultValue(col(null), col(false))).toBe(false);
+  });
+
+  it('does not throw on a numeric `to.default` (from.default a real value)', () => {
+    expect(() => comparator.hasSameDefaultValue(col('1'), col(0))).not.toThrow();
+  });
+
+  it('still treats two null defaults as equal', () => {
+    expect(comparator.hasSameDefaultValue(col(null), col(null))).toBe(true);
+  });
+});


### PR DESCRIPTION
## What's this PR do?

Fixes a crash in `SchemaComparator.hasSameDefaultValue` when a column's `to.default` is a non-string value.

The method coerces `from.default` defensively (`from.default.toString().toLowerCase()`) but calls `.toLowerCase()` **directly** on `to.default` at the two `=== 'null'` guards. When `to.default` is a **number** or **boolean** (a column whose entity default is `@Property({ default: 0 })` or `@Property({ default: true })`), it throws:

```
TypeError: to.default.toLowerCase is not a function
```

…which aborts schema diffing / migration generation. This PR mirrors the `from` side and coerces `to.default` with `.toString()` on both guards.

Closes #7976.

## The change

```diff
-      return to.default == null || to.default.toLowerCase() === 'null';
+      return to.default == null || to.default.toString().toLowerCase() === 'null';
     }

-    if (to.default == null || to.default.toLowerCase() === 'null') {
+    if (to.default == null || to.default.toString().toLowerCase() === 'null') {
```

## Tests

Added a DB-free unit test (`tests/features/schema-generator/GH7976.test.ts`) that constructs a `SchemaComparator` from an in-memory ORM and asserts `hasSameDefaultValue` no longer throws on numeric/boolean `to.default`, and still returns the correct result:

- `hasSameDefaultValue({ default: null }, { default: 0 })` → `false` (was: `TypeError`)
- `hasSameDefaultValue({ default: null }, { default: false })` → `false` (was: `TypeError`)
- `hasSameDefaultValue({ default: null }, { default: null })` → `true` (unchanged)

Verified downstream against the published `@mikro-orm/sql@7.1.4`: before the change `migrator.create()` over entities with numeric/boolean column defaults crashed with the above `TypeError`; after the change it completes. The bug is present on `master` and in the published `7.1.5`.

## Checklist

- [x] `fix` conventional-commit message
- [x] DCO `Signed-off-by`
- [x] Added a regression test
- [x] No public API change (behaviour-only fix)
