### PR TITLE
fix(core): ignore process-local metadata `_id` when loading from cache

### DIFF
--- a/packages/core/src/metadata/MetadataProvider.ts
+++ b/packages/core/src/metadata/MetadataProvider.ts
@@ -58,6 +58,10 @@ export class MetadataProvider {
 
   /** Merges cached metadata into the given entity metadata, preserving function expressions. */
   loadFromCache(meta: EntityMetadata, cache: EntityMetadata): void {
+    // `_id` is a process-local runtime counter; a cached value comes from a different discovery
+    // run and can collide with ids assigned in the current process, collapsing distinct entities.
+    Reflect.deleteProperty(cache, '_id');
+
     Object.values(cache.properties).forEach(prop => {
       const metaProp = meta.properties[prop.name];
 

--- a/tests/issues/GH7975.test.ts
+++ b/tests/issues/GH7975.test.ts
@@ -1,0 +1,21 @@
+// GH #7975 - `EntityMetadata._id` is a process-local runtime counter that leaks into
+// serialized metadata cache files. When independent discovery processes populate different
+// cache entries, their local counters can assign the same `_id`; loading both cache entries
+// then collapses distinct entities under one id in `MetadataStorage`/`CommitOrderCalculator`.
+// `loadFromCache()` must keep the fresh runtime `_id` and never restore the cached one.
+import { EntityMetadata, MetadataProvider } from '@mikro-orm/core';
+
+test('loadFromCache keeps the runtime _id and merges other cached fields', () => {
+  const provider = new MetadataProvider({} as any);
+
+  const meta = new EntityMetadata({ className: 'Alpha', tableName: 'alpha' });
+  const runtimeId = meta._id;
+
+  // simulate a cache file written by another process with a colliding/stale _id
+  const cache = { _id: runtimeId + 1000, collection: 'alpha_cached', properties: {} } as unknown as EntityMetadata;
+
+  provider.loadFromCache(meta, cache);
+
+  expect(meta._id).toBe(runtimeId);
+  expect((meta as any).collection).toBe('alpha_cached');
+});


### PR DESCRIPTION
`EntityMetadata._id` is a process-local runtime counter (`1000 * counter++`) that leaks into serialized metadata cache files. When independent discovery processes populate different per-entity cache entries in a shared cache directory, their local counters can assign the same `_id`. A later process loading both entries then merges the stale cached `_id` over the fresh runtime one, collapsing distinct entities under a single id in `MetadataStorage` and in the commit-order grouping — so schema generation can omit a physical table.

Fix strips the cached `_id` in `loadFromCache()` before merging, so the freshly assigned runtime id is always preserved. Placing the guard at the merge point also keeps existing cache files (and combined caches) usable, regardless of provider.

Closes #7975