### PR TITLE
fix(sql): support orderBy on persist(false) virtual fields with pagination

### DIFF
--- a/packages/mariadb/src/MariaDbQueryBuilder.ts
+++ b/packages/mariadb/src/MariaDbQueryBuilder.ts
@@ -1,12 +1,4 @@
-import {
-  type AnyEntity,
-  type EntityKey,
-  type EntityMetadata,
-  isRaw,
-  raw,
-  RawQueryFragment,
-  Utils,
-} from '@mikro-orm/core';
+import { type AnyEntity, type EntityKey, type EntityMetadata, raw, RawQueryFragment, Utils } from '@mikro-orm/core';
 import { QueryBuilder } from '@mikro-orm/mysql';
 
 /**
@@ -32,8 +24,6 @@ export class MariaDbQueryBuilder<
       subQuery.offset(this.state.offset);
     }
 
-    const addToSelect = [];
-
     if (this.state.orderBy.length > 0) {
       const orderBy = [];
 
@@ -51,12 +41,13 @@ export class MariaDbQueryBuilder<
           const type = this.platform.castColumn(prop);
           const fieldName = this.helper.mapper(field, this.type, undefined, null);
 
-          if (!prop?.persist && !prop?.formula && !pks.includes(fieldName)) {
-            addToSelect.push(fieldName);
-          }
-
-          const key = raw(`min(${this.platform.quoteIdentifier(fieldName)}${type})`);
-          orderBy.push({ [key as any]: direction });
+          // virtual fields (e.g. `qb.as(...)`) have no column to reference inside `min()`; inline their expression
+          const virtual =
+            !prop?.persist && !prop?.formula && !pks.includes(fieldName)
+              ? this.resolveVirtualField(f, fieldName)
+              : undefined;
+          const expr = virtual ? virtual.expr : this.platform.quoteIdentifier(fieldName);
+          orderBy.push({ [raw(`min(${expr}${type})`) as any]: direction });
         }
       }
 
@@ -65,30 +56,6 @@ export class MariaDbQueryBuilder<
 
     subQuery.state.finalized = true;
     const innerQuery = subQuery.as(this.mainAlias.aliasName).clear('select').select(pks);
-
-    /* v8 ignore next */
-    if (addToSelect.length > 0) {
-      addToSelect.forEach(prop => {
-        const field = this.state.fields!.find(field => {
-          if (typeof field === 'object' && field && '__as' in field) {
-            return field.__as === prop;
-          }
-
-          if (isRaw(field)) {
-            // not perfect, but should work most of the time, ideally we should check only the alias (`... as alias`)
-            return field.sql.includes(prop);
-          }
-
-          return false;
-        });
-
-        if (isRaw(field)) {
-          innerQuery.select(this.platform.formatQuery(field.sql, field.params));
-        } else if (field) {
-          innerQuery.select(field as string);
-        }
-      });
-    }
 
     // multiple sub-queries are needed to get around mysql limitations with order by + limit + where in + group by (o.O)
     // https://stackoverflow.com/questions/17892762/mysql-this-version-of-mysql-doesnt-yet-support-limit-in-all-any-some-subqu

--- a/packages/sql/src/query/QueryBuilder.ts
+++ b/packages/sql/src/query/QueryBuilder.ts
@@ -64,6 +64,13 @@ import type { AbstractSqlPlatform } from '../AbstractSqlPlatform.js';
 import { type CteOptions, NativeQueryBuilder } from './NativeQueryBuilder.js';
 import type { AbstractSqlConnection } from '../AbstractSqlConnection.js';
 
+/**
+ * Tags a {@link NativeQueryBuilder} produced by `qb.as(alias)` with the alias literal, so it can be
+ * matched back to its `orderBy`/pagination usage. A symbol is used (rather than a string key) so the
+ * tag survives `clone()` — {@link Utils.copy} preserves non-enumerable symbols but drops string keys.
+ */
+const VirtualFieldAlias = Symbol('virtualFieldAlias');
+
 export interface ExecuteOptions {
   mapResults?: boolean;
   mergeResults?: boolean;
@@ -2198,7 +2205,7 @@ export class QueryBuilder<
     Utils.runIfNotEmpty(() => {
       const queryOrder = this.helper.getQueryOrder(
         this.type,
-        this.#state.orderBy as FlatQueryOrderMap[],
+        this.rewriteVirtualFieldOrderBy(this.#state.orderBy as FlatQueryOrderMap[]),
         this.#state.populateMap,
         this.#state.collation,
       );
@@ -2725,8 +2732,8 @@ export class QueryBuilder<
 
     qb.as(finalAlias);
 
-    // tag the instance, so it is possible to detect it easily
-    Object.defineProperty(qb, '__as', { enumerable: false, value: finalAlias });
+    // tag the instance, so it is possible to detect it easily (symbol survives clone, see VirtualFieldAlias)
+    Object.defineProperty(qb, VirtualFieldAlias, { value: finalAlias });
 
     return qb;
   }
@@ -3942,6 +3949,81 @@ export class QueryBuilder<
     });
   }
 
+  /**
+   * Resolves a `persist: false` virtual field referenced in `orderBy` (e.g. `qb.as('reviewCount')` or a
+   * `raw()` fragment aliased in the select) to the alias and SQL expression it was selected under. The
+   * alias is used to order the outer query; the raw expression is inlined into `min(...)` inside the
+   * pagination sub-query, where dialects like PostgreSQL cannot reference a select alias.
+   */
+  protected resolveVirtualField(propName: string, fieldName: string): { alias: string; expr: string } | undefined {
+    const field = this.#state.fields?.find(f => {
+      if (f instanceof NativeQueryBuilder) {
+        const as = (f as any)[VirtualFieldAlias];
+        return as === propName || as === fieldName;
+      }
+
+      // not perfect, but should work most of the time, ideally we should check only the alias (`... as alias`)
+      return isRaw(f) && (f.sql.includes(propName) || f.sql.includes(fieldName));
+    });
+
+    if (field instanceof NativeQueryBuilder) {
+      const alias = (field as any)[VirtualFieldAlias] as string;
+      const rendered = field.toString();
+      // strip the known trailing alias via the platform quoting, so it works on every dialect (mssql uses `[...]`)
+      const suffix = ` as ${this.platform.quoteIdentifier(alias)}`;
+      return { alias, expr: rendered.endsWith(suffix) ? rendered.slice(0, -suffix.length) : rendered };
+    }
+
+    if (isRaw(field)) {
+      const compiled = this.platform.formatQuery(field.sql, field.params);
+      return {
+        alias: / as [`"[]([^`"\]]+)[`"\]]$/.exec(compiled)?.[1] ?? fieldName,
+        expr: compiled.replace(/ as [`"[][^`"\]]+[`"\]]$/, ''),
+      };
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Rewrites `orderBy` keys that reference a `persist: false` virtual field selected via `qb.as(alias)` so
+   * they point at the actual select alias. The mapper would otherwise resolve such a key to the property's
+   * naming-strategy column name, which does not exist when the alias literal differs (e.g. `reviewCount`).
+   */
+  private rewriteVirtualFieldOrderBy(orderBy: FlatQueryOrderMap[]): FlatQueryOrderMap[] {
+    // only aliased sub-queries (`qb.as(...)`) or `raw()` fragments can back a virtual field, skip otherwise
+    if (!this.#state.fields?.some(f => f instanceof NativeQueryBuilder || isRaw(f))) {
+      return orderBy;
+    }
+
+    return orderBy.map(orderMap => {
+      const out: FlatQueryOrderMap = {};
+
+      for (const key of Utils.getObjectQueryKeys(orderMap)) {
+        const direction = (orderMap as Dictionary)[key as any];
+
+        if (!RawQueryFragment.isKnownFragmentSymbol(key)) {
+          const [a, f] = this.helper.splitField<Entity>(key as EntityKey<Entity>);
+          const prop = this.helper.getProperty(f, a);
+
+          if (prop?.persist === false && !prop.formula && !prop.embedded) {
+            const fieldName = this.helper.mapper(key, this.type, undefined, null) as string;
+            const virtual = this.resolveVirtualField(f, fieldName);
+
+            if (virtual) {
+              (out as Dictionary)[raw(this.platform.quoteIdentifier(virtual.alias)) as any] = direction;
+              continue;
+            }
+          }
+        }
+
+        (out as Dictionary)[key as any] = direction;
+      }
+
+      return out;
+    });
+  }
+
   protected wrapPaginateSubQuery(meta: EntityMetadata): void {
     const schema = this.getSchema(this.mainAlias);
     const pks = this.prepareFields(meta.primaryKeys, 'sub-query', schema) as string[];
@@ -3961,8 +4043,6 @@ export class QueryBuilder<
       subQuery.offset(this.#state.offset);
     }
 
-    const addToSelect = [];
-
     if (this.#state.orderBy.length > 0) {
       const orderBy = [];
 
@@ -3980,13 +4060,14 @@ export class QueryBuilder<
           const type = this.platform.castColumn(prop);
           const fieldName = this.helper.mapper(field, this.type, undefined, null);
 
-          if (!prop?.persist && !prop?.formula && !prop?.hasConvertToJSValueSQL && !pks.includes(fieldName)) {
-            addToSelect.push(fieldName);
-          }
-
-          const quoted = this.platform.quoteIdentifier(fieldName);
-          const key = raw(`min(${quoted}${type})`);
-          orderBy.push({ [key]: direction });
+          // virtual fields (e.g. `qb.as(...)`) have no column to reference inside `min()`; inline their
+          // expression instead, as a select alias is not resolvable there on some dialects (e.g. PostgreSQL)
+          const virtual =
+            !prop?.persist && !prop?.formula && !prop?.hasConvertToJSValueSQL && !pks.includes(fieldName)
+              ? this.resolveVirtualField(f, fieldName)
+              : undefined;
+          const expr = virtual ? virtual.expr : this.platform.quoteIdentifier(fieldName);
+          orderBy.push({ [raw(`min(${expr}${type})`)]: direction });
         }
       }
 
@@ -3995,32 +4076,6 @@ export class QueryBuilder<
 
     subQuery.#state.finalized = true;
     const innerQuery = subQuery.as(this.mainAlias.aliasName).clear('select').select(pks);
-
-    if (addToSelect.length > 0) {
-      addToSelect.forEach(prop => {
-        const field = this.#state.fields!.find(field => {
-          if (typeof field === 'object' && field && '__as' in field) {
-            return field.__as === prop;
-          }
-
-          if (isRaw(field)) {
-            // not perfect, but should work most of the time, ideally we should check only the alias (`... as alias`)
-            return field.sql.includes(prop);
-          }
-
-          return false;
-        });
-
-        /* v8 ignore next */
-        if (isRaw(field)) {
-          innerQuery.select(field);
-        } else if (field instanceof NativeQueryBuilder) {
-          innerQuery.select(field.toRaw());
-        } else if (field) {
-          innerQuery.select(field as string);
-        }
-      });
-    }
 
     // multiple sub-queries are needed to get around mysql limitations with order by + limit + where in + group by (o.O)
     // https://stackoverflow.com/questions/17892762/mysql-this-version-of-mysql-doesnt-yet-support-limit-in-all-any-some-subqu

--- a/packages/sql/src/query/QueryBuilder.ts
+++ b/packages/sql/src/query/QueryBuilder.ts
@@ -3976,10 +3976,16 @@ export class QueryBuilder<
 
     if (isRaw(field)) {
       const compiled = this.platform.formatQuery(field.sql, field.params);
-      return {
-        alias: / as [`"[]([^`"\]]+)[`"\]]$/.exec(compiled)?.[1] ?? fieldName,
-        expr: compiled.replace(/ as [`"[][^`"\]]+[`"\]]$/, ''),
-      };
+      const close = compiled[compiled.length - 1];
+      const open = close === ']' ? '[' : close === '"' ? '"' : close === '`' ? '`' : undefined;
+      // scan back for the trailing `as <quoted alias>` (linear, avoids regex backtracking on user SQL)
+      const start = open ? compiled.lastIndexOf(open, compiled.length - 2) : -1;
+
+      if (start >= 4 && compiled.slice(start - 4, start) === ' as ') {
+        return { alias: compiled.slice(start + 1, -1), expr: compiled.slice(0, start - 4) };
+      }
+
+      return { alias: fieldName, expr: compiled };
     }
 
     return undefined;

--- a/tests/features/query-builder/query-builder-advanced.test.ts
+++ b/tests/features/query-builder/query-builder-advanced.test.ts
@@ -555,7 +555,7 @@ describe('QueryBuilder - Advanced', () => {
 
     await qb.getResult();
     expect(qb.getQuery()).toEqual(
-      'select `a`.*, (select count(distinct `b`.`uuid_pk`) as `count` from `book2` as `b` where `b`.`author_id` = `a`.`id`) as `books_total` from `author2` as `a` where `a`.`id` in (select `a`.`id` from (select `a`.`id`, (select count(distinct `b`.`uuid_pk`) as `count` from `book2` as `b` where `b`.`author_id` = `a`.`id`) as `books_total` from `author2` as `a` left join `book2` as `e1` on `a`.`id` = `e1`.`author_id` where `e1`.`title` = ? group by `a`.`id` order by min(`books_total`) asc limit ?) as `a`) order by `books_total` asc',
+      'select `a`.*, (select count(distinct `b`.`uuid_pk`) as `count` from `book2` as `b` where `b`.`author_id` = `a`.`id`) as `books_total` from `author2` as `a` where `a`.`id` in (select `a`.`id` from (select `a`.`id` from `author2` as `a` left join `book2` as `e1` on `a`.`id` = `e1`.`author_id` where `e1`.`title` = ? group by `a`.`id` order by min((select count(distinct `b`.`uuid_pk`) as `count` from `book2` as `b` where `b`.`author_id` = `a`.`id`)) asc limit ?) as `a`) order by `books_total` asc',
     );
     expect(qb.getParams()).toEqual(['foo', 1]);
   });

--- a/tests/issues/persist-false-orderby-pagination.test.ts
+++ b/tests/issues/persist-false-orderby-pagination.test.ts
@@ -1,0 +1,134 @@
+import { defineEntity, MikroORM, p, raw, sql } from '@mikro-orm/sqlite';
+
+const Tag = defineEntity({
+  name: 'Tag',
+  tableName: 'tags',
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+  },
+});
+
+const Review = defineEntity({
+  name: 'Review',
+  tableName: 'reviews',
+  properties: {
+    id: p.integer().primary(),
+    body: p.string(),
+    product: () => p.manyToOne(Product).deleteRule('cascade'),
+  },
+});
+
+const Product = defineEntity({
+  name: 'Product',
+  tableName: 'products',
+  properties: {
+    id: p.integer().primary(),
+    title: p.string(),
+    reviewCount: p.integer().persist(false),
+    tags: () =>
+      p.manyToMany(Tag).owner().pivotTable('_join_products_tags').joinColumn('product_id').inverseJoinColumn('tag_id'),
+    reviews: () => p.oneToMany(Review).mappedBy(r => r.product),
+  },
+});
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    entities: [Product, Tag, Review],
+    dbName: ':memory:',
+  });
+  await orm.schema.refresh();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+beforeEach(async () => {
+  await orm.schema.clear();
+  orm.em.clear();
+});
+
+async function seedData() {
+  const tag1 = orm.em.create(Tag, { name: 'electronics' });
+  const tag2 = orm.em.create(Tag, { name: 'sale' });
+  const p1 = orm.em.create(Product, { title: 'Product A', tags: [tag1, tag2] });
+  const p2 = orm.em.create(Product, { title: 'Product B', tags: [tag1] });
+  orm.em.create(Review, { body: 'great', product: p1 });
+  orm.em.create(Review, { body: 'good', product: p1 });
+  orm.em.create(Review, { body: 'ok', product: p2 });
+  await orm.em.flush();
+  orm.em.clear();
+}
+
+test('orderBy a persist(false) qb.as() virtual field with plain getResultList', async () => {
+  await seedData();
+
+  const reviewCountQB = orm.em
+    .createQueryBuilder(Review, 'r')
+    .select(raw('count(*)'))
+    .where({ product: { id: sql.ref('p.id') } });
+
+  const results = await orm.em
+    .createQueryBuilder(Product, 'p')
+    .select(['id', 'title'])
+    .addSelect(reviewCountQB.as('reviewCount'))
+    .orderBy({ reviewCount: 'desc' })
+    .getResultList();
+
+  expect(results.map(r => [r.title, (r as any).reviewCount])).toEqual([
+    ['Product A', 2],
+    ['Product B', 1],
+  ]);
+});
+
+test('qb.as() virtual field survives clone and orderBy works with M:N join', async () => {
+  await seedData();
+
+  const reviewCountQB = orm.em
+    .createQueryBuilder(Review, 'r')
+    .select(raw('count(*)'))
+    .where({ product: { id: sql.ref('p.id') } });
+
+  const qb = orm.em
+    .createQueryBuilder(Product, 'p')
+    .select(['id', 'title'])
+    .joinAndSelect('p.tags', 't')
+    .addSelect(reviewCountQB.as('reviewCount'))
+    .orderBy({ reviewCount: 'desc' })
+    .limit(10);
+
+  const [results, count] = await qb.getResultAndCount();
+
+  expect(count).toBe(2);
+  expect(results[0].title).toBe('Product A');
+  expect((results[0] as any).reviewCount).toBe(2);
+  expect(results[1].title).toBe('Product B');
+  expect((results[1] as any).reviewCount).toBe(1);
+});
+
+test('raw() virtual field works with orderBy and M:N pagination', async () => {
+  await seedData();
+
+  const reviewCountQB = orm.em
+    .createQueryBuilder(Review, 'r')
+    .select(raw('count(*)'))
+    .where({ product: { id: sql.ref('p.id') } });
+
+  const qb = orm.em
+    .createQueryBuilder(Product, 'p')
+    .select(['id', 'title', raw(`(${reviewCountQB.getFormattedQuery()}) as "review_count"`)])
+    .joinAndSelect('p.tags', 't')
+    .orderBy({ reviewCount: 'desc' })
+    .limit(10);
+
+  const [results, count] = await qb.getResultAndCount();
+
+  expect(count).toBe(2);
+  expect(results[0].title).toBe('Product A');
+  expect((results[0] as any).reviewCount).toBe(2);
+  expect(results[1].title).toBe('Product B');
+  expect((results[1] as any).reviewCount).toBe(1);
+});


### PR DESCRIPTION
Ordering by a `persist(false)` virtual field populated via `qb.as('alias')` failed with `no such column`. The root cause is a mismatch: `qb.as('camelCase')` emits the alias literal, but `orderBy({ camelCase })` resolves the property through the naming strategy to its snake_case column name, which doesn't exist. It fails even without pagination; the M:N + `getResultAndCount()` path fails further because the `__as` tag is dropped on `clone()` and `min("alias")` can't reference a select alias inside an aggregate on PostgreSQL.

This is an alternative to #7932. Rather than change the public `as()` semantics — the single-arg `as(alias)` is documented to preserve the alias literal, and its type (`RawQueryFragment<Alias>`) surfaces that key on `execute()` results — the fix stays in the orderBy layer:

- tag the aliased builder with a `Symbol` so it survives `clone()` (`Utils.copy` preserves non-enumerable symbols but drops string keys, which is why the old non-enumerable `__as` string key was lost)
- rewrite the outer orderBy key to the field's actual select alias, so `qb.as()` behaviour (and the `execute()` result shape) is unchanged
- inline the sub-query expression into `min(...)` in the pagination sub-query (valid on every dialect, incl. PostgreSQL) and drop the now-redundant re-select of the virtual column

The virtual-field lookup, previously duplicated across the sql and mariadb builders, is consolidated into a shared `resolveVirtualField` helper. Verified on sqlite, postgres, mysql and mariadb.