### PR TITLE
fix(core): support `@Check()` on class level with TC39 decorators

### DIFF
--- a/packages/decorators/src/es/Check.ts
+++ b/packages/decorators/src/es/Check.ts
@@ -1,13 +1,20 @@
-import { type CheckConstraint, type EntityMetadata } from '@mikro-orm/core';
+import { type CheckConstraint, type EntityMetadata, type EntityCtor } from '@mikro-orm/core';
 
-/** Defines a database check constraint on a property (TC39 decorator). */
+/** Defines a database check constraint on a property or entity class (TC39 decorator). */
 export function Check<T>(
   options: CheckConstraint<T>,
-): (value: unknown, context: ClassFieldDecoratorContext<T>) => void {
-  return function (value: unknown, context: ClassFieldDecoratorContext<T>): void {
+): (value: unknown, context: ClassDecoratorContext<T & EntityCtor> | ClassFieldDecoratorContext<T>) => void {
+  return function (
+    value: unknown,
+    context: ClassDecoratorContext<T & EntityCtor> | ClassFieldDecoratorContext<T>,
+  ): void {
     const meta = context.metadata as Partial<EntityMetadata<T>>;
     meta.checks ??= [];
-    options.property ??= context.name as string;
+
+    if (context.kind === 'field') {
+      options.property ??= context.name as string;
+    }
+
     meta.checks.push(options);
   };
 }

--- a/tests/features/decorators/es/GHx59.test.ts
+++ b/tests/features/decorators/es/GHx59.test.ts
@@ -1,0 +1,39 @@
+import { MikroORM } from '@mikro-orm/sqlite';
+import { Check, Entity, PrimaryKey, Property } from '@mikro-orm/decorators/es';
+
+@Entity()
+@Check({ expression: 'id is not null' })
+class Person {
+  @PrimaryKey({ type: 'string' })
+  id!: string;
+
+  @Property({ type: 'string' })
+  @Check({ expression: c => `${c.name} <> ''` })
+  name!: string;
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    entities: [Person],
+    dbName: ':memory:',
+  });
+});
+
+afterAll(() => orm.close(true));
+
+test('@Check() works on both class and property level (TC39 decorators)', async () => {
+  const meta = orm.getMetadata().get(Person);
+  expect(meta.checks).toHaveLength(2);
+
+  const classCheck = meta.checks.find(c => c.expression === 'id is not null');
+  expect(classCheck).toBeDefined();
+  expect(classCheck!.property).toBeUndefined();
+
+  const propCheck = meta.checks.find(c => c.property === 'name');
+  expect(propCheck).toBeDefined();
+
+  const sql = await orm.schema.getCreateSchemaSQL();
+  expect(sql).toContain('id is not null');
+});


### PR DESCRIPTION
The TC39 `@Check()` decorator only handled `ClassFieldDecoratorContext`, so applying it to an entity class (e.g. `@Check({ expression: 'id is not null' })` above a class) set `options.property` to the class name and then crashed in metadata discovery (`Cannot read properties of undefined (reading 'fieldNames')`).

Widened the context type and guarded `property` derivation behind `context.kind === 'field'`, mirroring how `@Index()`/`@Unique()` already support both class- and property-level usage.