### PR TITLE
fix(mssql): retry create database when the model database is locked

### DIFF
--- a/packages/mssql/src/MsSqlExceptionConverter.ts
+++ b/packages/mssql/src/MsSqlExceptionConverter.ts
@@ -18,6 +18,13 @@ export class MsSqlExceptionConverter extends ExceptionConverter {
    * @see https://github.com/doctrine/dbal/blob/master/src/Driver/AbstractPostgreSQLDriver.php
    */
   override convertException(exception: Error & Dictionary): DriverException {
+    // the kysely mssql driver rejects with a plain array when a request produces multiple errors
+    if (Array.isArray(exception) && exception.length > 0) {
+      const [first, ...rest] = exception;
+      first.message += rest.map(e => '\n' + e.message).join('');
+      exception = first;
+    }
+
     let errno = exception.number;
 
     /* v8 ignore next */

--- a/packages/mssql/src/MsSqlSchemaGenerator.ts
+++ b/packages/mssql/src/MsSqlSchemaGenerator.ts
@@ -7,6 +7,22 @@ export class MsSqlSchemaGenerator extends SchemaGenerator {
     orm.config.registerExtension('@mikro-orm/schema-generator', () => new MsSqlSchemaGenerator(orm.em));
   }
 
+  override async createDatabase(name?: string, options?: { skipOnConnect?: boolean }): Promise<void> {
+    // `create database` clones the `model` database under an exclusive lock, so concurrent
+    // calls (e.g. parallel test workers) can fail with error 1807 — retry a few times
+    for (let attempt = 1; ; attempt++) {
+      try {
+        return await super.createDatabase(name, options);
+      } catch (e: any) {
+        if (attempt >= 5 || e?.number !== 1807) {
+          throw e;
+        }
+
+        await new Promise(resolve => setTimeout(resolve, attempt * 200));
+      }
+    }
+  }
+
   override async clear(options?: ClearDatabaseOptions): Promise<void> {
     // truncate by default, so no value is considered as true
     /* v8 ignore next */

--- a/tests/features/schema-generator/create-database-retry.mssql.test.ts
+++ b/tests/features/schema-generator/create-database-retry.mssql.test.ts
@@ -1,0 +1,77 @@
+import { defineEntity } from '@mikro-orm/core';
+import { MikroORM } from '@mikro-orm/mssql';
+import { vi } from 'vitest';
+
+const Foo = defineEntity({
+  name: 'Foo',
+  properties: p => ({ id: p.integer().primary() }),
+});
+
+// `create database` clones the `model` database under an exclusive lock, so concurrent calls
+// (e.g. parallel test workers) can fail with error 1807 and need to be retried.
+describe('createDatabase retry on model database lock [mssql]', () => {
+  let orm: MikroORM;
+
+  // tedious reports the failure as an array of request errors
+  const modelLockError = () => [
+    Object.assign(new Error(`Could not obtain exclusive lock on database 'model'. Retry the operation later.`), {
+      code: 'EREQUEST',
+      number: 1807,
+    }),
+    Object.assign(
+      new Error('CREATE DATABASE failed. Some file names listed could not be created. Check related errors.'),
+      {
+        code: 'EREQUEST',
+        number: 1802,
+      },
+    ),
+  ];
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      dbName: 'mikro_orm_test_create_db_retry',
+      password: 'Root.Root',
+      entities: [Foo],
+    });
+  });
+
+  beforeEach(() => {
+    vi.spyOn(orm.driver, 'reconnect').mockResolvedValue(orm.em.getConnection());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterAll(() => orm.close(true));
+
+  test('retries when the model database is locked', async () => {
+    const execute = vi
+      .spyOn(orm.em.getConnection(), 'execute')
+      .mockRejectedValueOnce(modelLockError())
+      .mockRejectedValueOnce(modelLockError())
+      .mockResolvedValue([]);
+
+    await orm.schema.createDatabase('mikro_orm_test_create_db_retry');
+    // two failed attempts + successful attempt with two statements (`create database` + `use`)
+    expect(execute).toHaveBeenCalledTimes(4);
+  });
+
+  test('rethrows when the model database lock persists', async () => {
+    const execute = vi.spyOn(orm.em.getConnection(), 'execute').mockRejectedValue(modelLockError());
+
+    await expect(orm.schema.createDatabase('mikro_orm_test_create_db_retry')).rejects.toThrow(
+      `Could not obtain exclusive lock on database 'model'`,
+    );
+    expect(execute).toHaveBeenCalledTimes(5);
+  });
+
+  test('does not retry other errors', async () => {
+    const execute = vi
+      .spyOn(orm.em.getConnection(), 'execute')
+      .mockRejectedValue(Object.assign(new Error('some other error'), { code: 'EREQUEST', number: 102 }));
+
+    await expect(orm.schema.createDatabase('mikro_orm_test_create_db_retry')).rejects.toThrow('some other error');
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
MSSQL clones the `model` database when creating a new database, which requires an exclusive lock on it. Concurrent `createDatabase` calls (e.g. parallel test workers in CI) can therefore fail with error 1807 (`Could not obtain exclusive lock on database 'model'. Retry the operation later.`) — this was the source of occasional CI flakes like [this one](https://github.com/mikro-orm/mikro-orm/actions/runs/29312570952/job/87019366126). The schema generator now retries up to 5 times with a backoff before rethrowing.

Also normalizes array-shaped driver errors — the kysely mssql driver rejects with a plain array when a request produces multiple errors, which previously resulted in a `DriverException` with an empty message (and unreadable CI output). The converter now merges them into a single error with a proper message and error `number`.