### PR TITLE
fix(core): support same-named nested embeddables with different props in polymorphic embeddables

### DIFF
--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -1424,10 +1424,24 @@ export class MetadataDiscovery {
           delete prop.default;
 
           if (properties[prop.name] && properties[prop.name].type !== prop.type) {
-            properties[prop.name].type = `${properties[prop.name].type} | ${prop.type}`;
-            properties[prop.name].runtimeType = 'any';
-            properties[prop.name].stiMerged = true;
-            return properties[prop.name];
+            const merged = properties[prop.name];
+            const prevEntity = merged.entity;
+            const nextEntity = prop.entity;
+
+            // merge the `entity`/`target` references too, so the union type survives re-normalization (GH #7983)
+            if (prevEntity && nextEntity) {
+              merged.entity = (() =>
+                Utils.unique([...Utils.asArray(prevEntity()), ...Utils.asArray(nextEntity())])) as never;
+            }
+
+            if (merged.target && prop.target) {
+              merged.target = Utils.unique([...Utils.asArray(merged.target), ...Utils.asArray(prop.target)]) as never;
+            }
+
+            merged.type = `${merged.type} | ${prop.type}`;
+            merged.runtimeType = 'any';
+            merged.stiMerged = true;
+            return merged;
           }
 
           // Deep copy to prevent mutating the original entity's property —
@@ -1740,6 +1754,13 @@ export class MetadataDiscovery {
     Object.values(meta.properties).forEach(prop => {
       const newProp = { ...prop };
       const rootProp = meta.root.properties[prop.name];
+
+      // Same-named embedded props merged from polymorphic embeddable variants keep the merged
+      // union-typed declaration, so nested paths of every variant stay resolvable (GH #7983).
+      if (rootProp?.stiMerged && prop.kind === ReferenceKind.EMBEDDED) {
+        rootProp.nullable = true; // each variant fills only its own columns
+        return;
+      }
 
       // A child that narrows a relation to a subclass of the root's declared
       // target (same STI hierarchy) shares the FK column with the root; treat

--- a/tests/features/embeddables/GH2987.test.ts
+++ b/tests/features/embeddables/GH2987.test.ts
@@ -170,13 +170,13 @@ test('2987', async () => {
   await orm.em.flush();
   expect(mock.mock.calls[0][0]).toMatch('begin');
   expect(mock.mock.calls[1][0]).toMatch(
-    `insert into \`user\` (\`id\`, \`email1\`, \`email2_type\`, \`email2_sent_emails_due_date\`, \`email2_sent_emails_sender_email\`, \`email2_sent_emails_sent_date\`) values (1, '{"type":"DUE_DATE","sent_emails":{"dueDate":"2024-07-01T20:20:00.000Z","sender_email":"foo1"}}', 'DUE_DATE', 1719865200000, 'foo2', null), (2, '{"type":"EMAIL","sent_emails":{"sent_date":"2024-07-02T20:20:00.000Z","sender_email":"foo3"}}', 'EMAIL', null, 'foo4', 1719951600000)`,
+    `insert into \`user\` (\`id\`, \`email1\`, \`email2_sent_emails_due_date\`, \`email2_sent_emails_sender_email\`, \`email2_type\`, \`email2_sent_emails_sent_date\`) values (1, '{"type":"DUE_DATE","sent_emails":{"due_date":"2024-07-01T20:20:00.000Z","sender_email":"foo1"}}', 1719865200000, 'foo2', 'DUE_DATE', null), (2, '{"type":"EMAIL","sent_emails":{"sender_email":"foo3","sent_date":"2024-07-02T20:20:00.000Z"}}', null, 'foo4', 'EMAIL', 1719951600000)`,
   );
   expect(mock.mock.calls[2][0]).toMatch('commit');
   expect(mock.mock.calls[3][0]).toMatch('select `u0`.* from `user` as `u0` order by `u0`.`id` asc');
   expect(mock.mock.calls[4][0]).toMatch('begin');
   expect(mock.mock.calls[5][0]).toMatch(
-    'update `user` set `email1` = case when (`id` = 1) then \'{"type":"DUE_DATE","sent_emails":{"dueDate":"2024-07-03T20:20:00.000Z","sender_email":"foo1"}}\' when (`id` = 2) then \'{"type":"EMAIL","sent_emails":{"sent_date":"2024-07-04T20:20:00.000Z","sender_email":"foo3"}}\' else `email1` end, `email2_sent_emails_due_date` = case when (`id` = 1) then 1720038000000 else `email2_sent_emails_due_date` end, `email2_sent_emails_sent_date` = case when (`id` = 2) then 1720124400000 else `email2_sent_emails_sent_date` end where `id` in (1, 2)',
+    'update `user` set `email1` = case when (`id` = 1) then \'{"type":"DUE_DATE","sent_emails":{"due_date":"2024-07-03T20:20:00.000Z","sender_email":"foo1"}}\' when (`id` = 2) then \'{"type":"EMAIL","sent_emails":{"sender_email":"foo3","sent_date":"2024-07-04T20:20:00.000Z"}}\' else `email1` end, `email2_sent_emails_due_date` = case when (`id` = 1) then 1720038000000 else `email2_sent_emails_due_date` end, `email2_sent_emails_sent_date` = case when (`id` = 2) then 1720124400000 else `email2_sent_emails_sent_date` end where `id` in (1, 2)',
   );
   expect(mock.mock.calls[6][0]).toMatch('commit');
 });

--- a/tests/features/embeddables/__snapshots__/polymorphic-embedded-entities.sqlite.test.ts.snap
+++ b/tests/features/embeddables/__snapshots__/polymorphic-embedded-entities.sqlite.test.ts.snap
@@ -12,7 +12,7 @@ exports[`polymorphic embeddables in sqlite > diffing 1`] = `
   } else if (typeof data.name !== 'undefined') {
     entity.name = data.name;
   }
-  if (data.pet_canBark !== undefined || data.pet_type !== undefined || data.pet_name !== undefined || data.pet_canMeow !== undefined || data.pet_food_cats != null || data.pet_food_mice != null) {
+  if (data.pet_canBark !== undefined || data.pet_food_cats != null || data.pet_food_mice != null || data.pet_type !== undefined || data.pet_name !== undefined || data.pet_canMeow !== undefined) {
     const embeddedData = {
       canBark: data.pet_canBark,
       food: data.pet_food,
@@ -29,27 +29,13 @@ exports[`polymorphic embeddables in sqlite > diffing 1`] = `
       } else if (typeof data.pet_canBark !== 'undefined') {
         entity.pet.canBark = !!data.pet_canBark;
       }
-      if (data.pet_type === null) {
-        entity.pet.type = null;
-      } else if (typeof data.pet_type !== 'undefined') {
-        entity.pet.type = data.pet_type;
-      }
-      if (data.pet_name === null) {
-        entity.pet.name = null;
-      } else if (typeof data.pet_name !== 'undefined') {
-        entity.pet.name = data.pet_name;
-      }
-      if (data.pet_canMeow === null) {
-        entity.pet.canMeow = null;
-      } else if (typeof data.pet_canMeow !== 'undefined') {
-        entity.pet.canMeow = data.pet_canMeow;
-      }
       if (data.pet_food_cats != null || data.pet_food_mice != null) {
         const embeddedData = {
+          cats: data.pet_food_cats,
           mice: data.pet_food_mice,
         };
         if (entity.pet.food == null) {
-          entity.pet.food = factory.createEmbeddable(dog_food_6, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+          entity.pet.food = factory.createEmbeddable(dog_food_3, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
         }
         if (data.pet_food_cats === null) {
           entity.pet.food.cats = null;
@@ -70,7 +56,7 @@ exports[`polymorphic embeddables in sqlite > diffing 1`] = `
       if (data.pet_food != null) {
         const embeddedData = data.pet_food;
         if (entity.pet.food == null) {
-          entity.pet.food = factory.createEmbeddable(dog_food_9, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+          entity.pet.food = factory.createEmbeddable(dog_food_6, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
         }
         if (data.pet_food.cats === null) {
           entity.pet.food.cats = null;
@@ -85,6 +71,21 @@ exports[`polymorphic embeddables in sqlite > diffing 1`] = `
       } else if (data.pet_food === null) {
         entity.pet.food = null;
       }
+      if (data.pet_type === null) {
+        entity.pet.type = null;
+      } else if (typeof data.pet_type !== 'undefined') {
+        entity.pet.type = data.pet_type;
+      }
+      if (data.pet_name === null) {
+        entity.pet.name = null;
+      } else if (typeof data.pet_name !== 'undefined') {
+        entity.pet.name = data.pet_name;
+      }
+      if (data.pet_canMeow === null) {
+        entity.pet.canMeow = null;
+      } else if (typeof data.pet_canMeow !== 'undefined') {
+        entity.pet.canMeow = data.pet_canMeow;
+      }
     }
     if (data.pet_type == '0') {
       if (entity.pet == null) {
@@ -94,6 +95,48 @@ exports[`polymorphic embeddables in sqlite > diffing 1`] = `
         entity.pet.canBark = null;
       } else if (typeof data.pet_canBark !== 'undefined') {
         entity.pet.canBark = data.pet_canBark;
+      }
+      if (data.pet_food_cats != null || data.pet_food_mice != null) {
+        const embeddedData = {
+          cats: data.pet_food_cats,
+          mice: data.pet_food_mice,
+        };
+        if (entity.pet.food == null) {
+          entity.pet.food = factory.createEmbeddable(cat_food_13, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+        }
+        if (data.pet_food_cats === null) {
+          entity.pet.food.cats = null;
+        } else if (typeof data.pet_food_cats !== 'undefined') {
+          entity.pet.food.cats = data.pet_food_cats;
+        }
+        if (data.pet_food_mice === null) {
+          entity.pet.food.mice = null;
+        } else if (typeof data.pet_food_mice !== 'undefined') {
+          entity.pet.food.mice = data.pet_food_mice;
+        }
+      } else if (data.pet_food_cats === null && data.pet_food_mice === null) {
+        entity.pet.food = null;
+      }
+      if (typeof data.pet_food === 'string') {
+        data.pet_food = parseJsonSafe(data.pet_food);
+      }
+      if (data.pet_food != null) {
+        const embeddedData = data.pet_food;
+        if (entity.pet.food == null) {
+          entity.pet.food = factory.createEmbeddable(cat_food_16, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+        }
+        if (data.pet_food.cats === null) {
+          entity.pet.food.cats = null;
+        } else if (typeof data.pet_food.cats !== 'undefined') {
+          entity.pet.food.cats = data.pet_food.cats;
+        }
+        if (data.pet_food.mice === null) {
+          entity.pet.food.mice = null;
+        } else if (typeof data.pet_food.mice !== 'undefined') {
+          entity.pet.food.mice = data.pet_food.mice;
+        }
+      } else if (data.pet_food === null) {
+        entity.pet.food = null;
       }
       if (data.pet_type === null) {
         entity.pet.type = null;
@@ -110,49 +153,8 @@ exports[`polymorphic embeddables in sqlite > diffing 1`] = `
       } else if (typeof data.pet_canMeow !== 'undefined') {
         entity.pet.canMeow = !!data.pet_canMeow;
       }
-      if (data.pet_food_cats != null || data.pet_food_mice != null) {
-        const embeddedData = {
-          mice: data.pet_food_mice,
-        };
-        if (entity.pet.food == null) {
-          entity.pet.food = factory.createEmbeddable(cat_food_16, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
-        }
-        if (data.pet_food_cats === null) {
-          entity.pet.food.cats = null;
-        } else if (typeof data.pet_food_cats !== 'undefined') {
-          entity.pet.food.cats = data.pet_food_cats;
-        }
-        if (data.pet_food_mice === null) {
-          entity.pet.food.mice = null;
-        } else if (typeof data.pet_food_mice !== 'undefined') {
-          entity.pet.food.mice = data.pet_food_mice;
-        }
-      } else if (data.pet_food_cats === null && data.pet_food_mice === null) {
-        entity.pet.food = null;
-      }
-      if (typeof data.pet_food === 'string') {
-        data.pet_food = parseJsonSafe(data.pet_food);
-      }
-      if (data.pet_food != null) {
-        const embeddedData = data.pet_food;
-        if (entity.pet.food == null) {
-          entity.pet.food = factory.createEmbeddable(cat_food_19, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
-        }
-        if (data.pet_food.cats === null) {
-          entity.pet.food.cats = null;
-        } else if (typeof data.pet_food.cats !== 'undefined') {
-          entity.pet.food.cats = data.pet_food.cats;
-        }
-        if (data.pet_food.mice === null) {
-          entity.pet.food.mice = null;
-        } else if (typeof data.pet_food.mice !== 'undefined') {
-          entity.pet.food.mice = data.pet_food.mice;
-        }
-      } else if (data.pet_food === null) {
-        entity.pet.food = null;
-      }
     }
-  } else if (data.pet_canBark === null && data.pet_type === null && data.pet_name === null && data.pet_canMeow === null && data.pet_food_cats === null && data.pet_food_mice === null) {
+  } else if (data.pet_canBark === null && data.pet_food_cats === null && data.pet_food_mice === null && data.pet_type === null && data.pet_name === null && data.pet_canMeow === null) {
     entity.pet = null;
   }
   if (typeof data.pet === 'string') {
@@ -169,6 +171,48 @@ exports[`polymorphic embeddables in sqlite > diffing 1`] = `
       } else if (typeof data.pet.canBark !== 'undefined') {
         entity.pet.canBark = !!data.pet.canBark;
       }
+      if (data.pet_food_cats != null || data.pet_food_mice != null) {
+        const embeddedData = {
+          cats: data.pet_food_cats,
+          mice: data.pet_food_mice,
+        };
+        if (entity.pet.food == null) {
+          entity.pet.food = factory.createEmbeddable(dog_food_23, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+        }
+        if (data.pet_food_cats === null) {
+          entity.pet.food.cats = null;
+        } else if (typeof data.pet_food_cats !== 'undefined') {
+          entity.pet.food.cats = data.pet_food_cats;
+        }
+        if (data.pet_food_mice === null) {
+          entity.pet.food.mice = null;
+        } else if (typeof data.pet_food_mice !== 'undefined') {
+          entity.pet.food.mice = data.pet_food_mice;
+        }
+      } else if (data.pet_food_cats === null && data.pet_food_mice === null) {
+        entity.pet.food = null;
+      }
+      if (typeof data.pet.food === 'string') {
+        data.pet.food = parseJsonSafe(data.pet.food);
+      }
+      if (data.pet.food != null) {
+        const embeddedData = data.pet.food;
+        if (entity.pet.food == null) {
+          entity.pet.food = factory.createEmbeddable(dog_food_26, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+        }
+        if (data.pet.food.cats === null) {
+          entity.pet.food.cats = null;
+        } else if (typeof data.pet.food.cats !== 'undefined') {
+          entity.pet.food.cats = data.pet.food.cats;
+        }
+        if (data.pet.food.mice === null) {
+          entity.pet.food.mice = null;
+        } else if (typeof data.pet.food.mice !== 'undefined') {
+          entity.pet.food.mice = data.pet.food.mice;
+        }
+      } else if (data.pet.food === null) {
+        entity.pet.food = null;
+      }
       if (data.pet.type === null) {
         entity.pet.type = null;
       } else if (typeof data.pet.type !== 'undefined') {
@@ -184,12 +228,23 @@ exports[`polymorphic embeddables in sqlite > diffing 1`] = `
       } else if (typeof data.pet.canMeow !== 'undefined') {
         entity.pet.canMeow = data.pet.canMeow;
       }
+    }
+    if (data.pet.type == '0') {
+      if (entity.pet == null) {
+        entity.pet = factory.createEmbeddable(Cat, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+      }
+      if (data.pet.canBark === null) {
+        entity.pet.canBark = null;
+      } else if (typeof data.pet.canBark !== 'undefined') {
+        entity.pet.canBark = data.pet.canBark;
+      }
       if (data.pet_food_cats != null || data.pet_food_mice != null) {
         const embeddedData = {
+          cats: data.pet_food_cats,
           mice: data.pet_food_mice,
         };
         if (entity.pet.food == null) {
-          entity.pet.food = factory.createEmbeddable(dog_food_26, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+          entity.pet.food = factory.createEmbeddable(cat_food_33, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
         }
         if (data.pet_food_cats === null) {
           entity.pet.food.cats = null;
@@ -210,7 +265,7 @@ exports[`polymorphic embeddables in sqlite > diffing 1`] = `
       if (data.pet.food != null) {
         const embeddedData = data.pet.food;
         if (entity.pet.food == null) {
-          entity.pet.food = factory.createEmbeddable(dog_food_29, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+          entity.pet.food = factory.createEmbeddable(cat_food_36, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
         }
         if (data.pet.food.cats === null) {
           entity.pet.food.cats = null;
@@ -224,16 +279,6 @@ exports[`polymorphic embeddables in sqlite > diffing 1`] = `
         }
       } else if (data.pet.food === null) {
         entity.pet.food = null;
-      }
-    }
-    if (data.pet.type == '0') {
-      if (entity.pet == null) {
-        entity.pet = factory.createEmbeddable(Cat, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
-      }
-      if (data.pet.canBark === null) {
-        entity.pet.canBark = null;
-      } else if (typeof data.pet.canBark !== 'undefined') {
-        entity.pet.canBark = data.pet.canBark;
       }
       if (data.pet.type === null) {
         entity.pet.type = null;
@@ -249,47 +294,6 @@ exports[`polymorphic embeddables in sqlite > diffing 1`] = `
         entity.pet.canMeow = null;
       } else if (typeof data.pet.canMeow !== 'undefined') {
         entity.pet.canMeow = !!data.pet.canMeow;
-      }
-      if (data.pet_food_cats != null || data.pet_food_mice != null) {
-        const embeddedData = {
-          mice: data.pet_food_mice,
-        };
-        if (entity.pet.food == null) {
-          entity.pet.food = factory.createEmbeddable(cat_food_36, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
-        }
-        if (data.pet_food_cats === null) {
-          entity.pet.food.cats = null;
-        } else if (typeof data.pet_food_cats !== 'undefined') {
-          entity.pet.food.cats = data.pet_food_cats;
-        }
-        if (data.pet_food_mice === null) {
-          entity.pet.food.mice = null;
-        } else if (typeof data.pet_food_mice !== 'undefined') {
-          entity.pet.food.mice = data.pet_food_mice;
-        }
-      } else if (data.pet_food_cats === null && data.pet_food_mice === null) {
-        entity.pet.food = null;
-      }
-      if (typeof data.pet.food === 'string') {
-        data.pet.food = parseJsonSafe(data.pet.food);
-      }
-      if (data.pet.food != null) {
-        const embeddedData = data.pet.food;
-        if (entity.pet.food == null) {
-          entity.pet.food = factory.createEmbeddable(cat_food_39, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
-        }
-        if (data.pet.food.cats === null) {
-          entity.pet.food.cats = null;
-        } else if (typeof data.pet.food.cats !== 'undefined') {
-          entity.pet.food.cats = data.pet.food.cats;
-        }
-        if (data.pet.food.mice === null) {
-          entity.pet.food.mice = null;
-        } else if (typeof data.pet.food.mice !== 'undefined') {
-          entity.pet.food.mice = data.pet.food.mice;
-        }
-      } else if (data.pet.food === null) {
-        entity.pet.food = null;
       }
     }
   } else if (data.pet === null) {
@@ -309,6 +313,48 @@ exports[`polymorphic embeddables in sqlite > diffing 1`] = `
       } else if (typeof data.pet2.canBark !== 'undefined') {
         entity.pet2.canBark = !!data.pet2.canBark;
       }
+      if (data['pet2~foodcats'] != null || data['pet2~foodmice'] != null) {
+        const embeddedData = {
+          cats: data['pet2~foodcats'],
+          mice: data['pet2~foodmice'],
+        };
+        if (entity.pet2.food == null) {
+          entity.pet2.food = factory.createEmbeddable(dog_food_43, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+        }
+        if (data['pet2~foodcats'] === null) {
+          entity.pet2.food.cats = null;
+        } else if (typeof data['pet2~foodcats'] !== 'undefined') {
+          entity.pet2.food.cats = data['pet2~foodcats'];
+        }
+        if (data['pet2~foodmice'] === null) {
+          entity.pet2.food.mice = null;
+        } else if (typeof data['pet2~foodmice'] !== 'undefined') {
+          entity.pet2.food.mice = data['pet2~foodmice'];
+        }
+      } else if (data['pet2~foodcats'] === null && data['pet2~foodmice'] === null) {
+        entity.pet2.food = null;
+      }
+      if (typeof data.pet2.food === 'string') {
+        data.pet2.food = parseJsonSafe(data.pet2.food);
+      }
+      if (data.pet2.food != null) {
+        const embeddedData = data.pet2.food;
+        if (entity.pet2.food == null) {
+          entity.pet2.food = factory.createEmbeddable(dog_food_46, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+        }
+        if (data.pet2.food.cats === null) {
+          entity.pet2.food.cats = null;
+        } else if (typeof data.pet2.food.cats !== 'undefined') {
+          entity.pet2.food.cats = data.pet2.food.cats;
+        }
+        if (data.pet2.food.mice === null) {
+          entity.pet2.food.mice = null;
+        } else if (typeof data.pet2.food.mice !== 'undefined') {
+          entity.pet2.food.mice = data.pet2.food.mice;
+        }
+      } else if (data.pet2.food === null) {
+        entity.pet2.food = null;
+      }
       if (data.pet2.type === null) {
         entity.pet2.type = null;
       } else if (typeof data.pet2.type !== 'undefined') {
@@ -324,12 +370,23 @@ exports[`polymorphic embeddables in sqlite > diffing 1`] = `
       } else if (typeof data.pet2.canMeow !== 'undefined') {
         entity.pet2.canMeow = data.pet2.canMeow;
       }
+    }
+    if (data.pet2.type == '0') {
+      if (entity.pet2 == null) {
+        entity.pet2 = factory.createEmbeddable(Cat, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+      }
+      if (data.pet2.canBark === null) {
+        entity.pet2.canBark = null;
+      } else if (typeof data.pet2.canBark !== 'undefined') {
+        entity.pet2.canBark = data.pet2.canBark;
+      }
       if (data['pet2~foodcats'] != null || data['pet2~foodmice'] != null) {
         const embeddedData = {
+          cats: data['pet2~foodcats'],
           mice: data['pet2~foodmice'],
         };
         if (entity.pet2.food == null) {
-          entity.pet2.food = factory.createEmbeddable(dog_food_46, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+          entity.pet2.food = factory.createEmbeddable(cat_food_53, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
         }
         if (data['pet2~foodcats'] === null) {
           entity.pet2.food.cats = null;
@@ -350,7 +407,7 @@ exports[`polymorphic embeddables in sqlite > diffing 1`] = `
       if (data.pet2.food != null) {
         const embeddedData = data.pet2.food;
         if (entity.pet2.food == null) {
-          entity.pet2.food = factory.createEmbeddable(dog_food_49, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+          entity.pet2.food = factory.createEmbeddable(cat_food_56, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
         }
         if (data.pet2.food.cats === null) {
           entity.pet2.food.cats = null;
@@ -364,16 +421,6 @@ exports[`polymorphic embeddables in sqlite > diffing 1`] = `
         }
       } else if (data.pet2.food === null) {
         entity.pet2.food = null;
-      }
-    }
-    if (data.pet2.type == '0') {
-      if (entity.pet2 == null) {
-        entity.pet2 = factory.createEmbeddable(Cat, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
-      }
-      if (data.pet2.canBark === null) {
-        entity.pet2.canBark = null;
-      } else if (typeof data.pet2.canBark !== 'undefined') {
-        entity.pet2.canBark = data.pet2.canBark;
       }
       if (data.pet2.type === null) {
         entity.pet2.type = null;
@@ -389,47 +436,6 @@ exports[`polymorphic embeddables in sqlite > diffing 1`] = `
         entity.pet2.canMeow = null;
       } else if (typeof data.pet2.canMeow !== 'undefined') {
         entity.pet2.canMeow = !!data.pet2.canMeow;
-      }
-      if (data['pet2~foodcats'] != null || data['pet2~foodmice'] != null) {
-        const embeddedData = {
-          mice: data['pet2~foodmice'],
-        };
-        if (entity.pet2.food == null) {
-          entity.pet2.food = factory.createEmbeddable(cat_food_56, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
-        }
-        if (data['pet2~foodcats'] === null) {
-          entity.pet2.food.cats = null;
-        } else if (typeof data['pet2~foodcats'] !== 'undefined') {
-          entity.pet2.food.cats = data['pet2~foodcats'];
-        }
-        if (data['pet2~foodmice'] === null) {
-          entity.pet2.food.mice = null;
-        } else if (typeof data['pet2~foodmice'] !== 'undefined') {
-          entity.pet2.food.mice = data['pet2~foodmice'];
-        }
-      } else if (data['pet2~foodcats'] === null && data['pet2~foodmice'] === null) {
-        entity.pet2.food = null;
-      }
-      if (typeof data.pet2.food === 'string') {
-        data.pet2.food = parseJsonSafe(data.pet2.food);
-      }
-      if (data.pet2.food != null) {
-        const embeddedData = data.pet2.food;
-        if (entity.pet2.food == null) {
-          entity.pet2.food = factory.createEmbeddable(cat_food_59, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
-        }
-        if (data.pet2.food.cats === null) {
-          entity.pet2.food.cats = null;
-        } else if (typeof data.pet2.food.cats !== 'undefined') {
-          entity.pet2.food.cats = data.pet2.food.cats;
-        }
-        if (data.pet2.food.mice === null) {
-          entity.pet2.food.mice = null;
-        } else if (typeof data.pet2.food.mice !== 'undefined') {
-          entity.pet2.food.mice = data.pet2.food.mice;
-        }
-      } else if (data.pet2.food === null) {
-        entity.pet2.food = null;
       }
     }
   } else if (data.pet2 === null) {
@@ -455,6 +461,48 @@ exports[`polymorphic embeddables in sqlite > diffing 1`] = `
           } else if (typeof data.pets[idx_62].canBark !== 'undefined') {
             entity.pets[idx_62].canBark = !!data.pets[idx_62].canBark;
           }
+          if (data['pets~foodcats'] != null || data['pets~foodmice'] != null) {
+            const embeddedData = {
+              cats: data['pets~foodcats'],
+              mice: data['pets~foodmice'],
+            };
+            if (entity.pets[idx_62].food == null) {
+              entity.pets[idx_62].food = factory.createEmbeddable(dog_food_64, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+            }
+            if (data['pets~foodcats'] === null) {
+              entity.pets[idx_62].food.cats = null;
+            } else if (typeof data['pets~foodcats'] !== 'undefined') {
+              entity.pets[idx_62].food.cats = data['pets~foodcats'];
+            }
+            if (data['pets~foodmice'] === null) {
+              entity.pets[idx_62].food.mice = null;
+            } else if (typeof data['pets~foodmice'] !== 'undefined') {
+              entity.pets[idx_62].food.mice = data['pets~foodmice'];
+            }
+          } else if (data['pets~foodcats'] === null && data['pets~foodmice'] === null) {
+            entity.pets[idx_62].food = null;
+          }
+          if (typeof data.pets[idx_62].food === 'string') {
+            data.pets[idx_62].food = parseJsonSafe(data.pets[idx_62].food);
+          }
+          if (data.pets[idx_62].food != null) {
+            const embeddedData = data.pets[idx_62].food;
+            if (entity.pets[idx_62].food == null) {
+              entity.pets[idx_62].food = factory.createEmbeddable(dog_food_67, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+            }
+            if (data.pets[idx_62].food.cats === null) {
+              entity.pets[idx_62].food.cats = null;
+            } else if (typeof data.pets[idx_62].food.cats !== 'undefined') {
+              entity.pets[idx_62].food.cats = data.pets[idx_62].food.cats;
+            }
+            if (data.pets[idx_62].food.mice === null) {
+              entity.pets[idx_62].food.mice = null;
+            } else if (typeof data.pets[idx_62].food.mice !== 'undefined') {
+              entity.pets[idx_62].food.mice = data.pets[idx_62].food.mice;
+            }
+          } else if (data.pets[idx_62].food === null) {
+            entity.pets[idx_62].food = null;
+          }
           if (data.pets[idx_62].type === null) {
             entity.pets[idx_62].type = null;
           } else if (typeof data.pets[idx_62].type !== 'undefined') {
@@ -470,12 +518,23 @@ exports[`polymorphic embeddables in sqlite > diffing 1`] = `
           } else if (typeof data.pets[idx_62].canMeow !== 'undefined') {
             entity.pets[idx_62].canMeow = data.pets[idx_62].canMeow;
           }
+        }
+        if (data.pets[idx_62].type == '0') {
+          if (entity.pets[idx_62] == null) {
+            entity.pets[idx_62] = factory.createEmbeddable(Cat, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+          }
+          if (data.pets[idx_62].canBark === null) {
+            entity.pets[idx_62].canBark = null;
+          } else if (typeof data.pets[idx_62].canBark !== 'undefined') {
+            entity.pets[idx_62].canBark = data.pets[idx_62].canBark;
+          }
           if (data['pets~foodcats'] != null || data['pets~foodmice'] != null) {
             const embeddedData = {
+              cats: data['pets~foodcats'],
               mice: data['pets~foodmice'],
             };
             if (entity.pets[idx_62].food == null) {
-              entity.pets[idx_62].food = factory.createEmbeddable(dog_food_67, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+              entity.pets[idx_62].food = factory.createEmbeddable(cat_food_74, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
             }
             if (data['pets~foodcats'] === null) {
               entity.pets[idx_62].food.cats = null;
@@ -496,7 +555,7 @@ exports[`polymorphic embeddables in sqlite > diffing 1`] = `
           if (data.pets[idx_62].food != null) {
             const embeddedData = data.pets[idx_62].food;
             if (entity.pets[idx_62].food == null) {
-              entity.pets[idx_62].food = factory.createEmbeddable(dog_food_70, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
+              entity.pets[idx_62].food = factory.createEmbeddable(cat_food_77, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
             }
             if (data.pets[idx_62].food.cats === null) {
               entity.pets[idx_62].food.cats = null;
@@ -510,16 +569,6 @@ exports[`polymorphic embeddables in sqlite > diffing 1`] = `
             }
           } else if (data.pets[idx_62].food === null) {
             entity.pets[idx_62].food = null;
-          }
-        }
-        if (data.pets[idx_62].type == '0') {
-          if (entity.pets[idx_62] == null) {
-            entity.pets[idx_62] = factory.createEmbeddable(Cat, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
-          }
-          if (data.pets[idx_62].canBark === null) {
-            entity.pets[idx_62].canBark = null;
-          } else if (typeof data.pets[idx_62].canBark !== 'undefined') {
-            entity.pets[idx_62].canBark = data.pets[idx_62].canBark;
           }
           if (data.pets[idx_62].type === null) {
             entity.pets[idx_62].type = null;
@@ -535,47 +584,6 @@ exports[`polymorphic embeddables in sqlite > diffing 1`] = `
             entity.pets[idx_62].canMeow = null;
           } else if (typeof data.pets[idx_62].canMeow !== 'undefined') {
             entity.pets[idx_62].canMeow = !!data.pets[idx_62].canMeow;
-          }
-          if (data['pets~foodcats'] != null || data['pets~foodmice'] != null) {
-            const embeddedData = {
-              mice: data['pets~foodmice'],
-            };
-            if (entity.pets[idx_62].food == null) {
-              entity.pets[idx_62].food = factory.createEmbeddable(cat_food_77, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
-            }
-            if (data['pets~foodcats'] === null) {
-              entity.pets[idx_62].food.cats = null;
-            } else if (typeof data['pets~foodcats'] !== 'undefined') {
-              entity.pets[idx_62].food.cats = data['pets~foodcats'];
-            }
-            if (data['pets~foodmice'] === null) {
-              entity.pets[idx_62].food.mice = null;
-            } else if (typeof data['pets~foodmice'] !== 'undefined') {
-              entity.pets[idx_62].food.mice = data['pets~foodmice'];
-            }
-          } else if (data['pets~foodcats'] === null && data['pets~foodmice'] === null) {
-            entity.pets[idx_62].food = null;
-          }
-          if (typeof data.pets[idx_62].food === 'string') {
-            data.pets[idx_62].food = parseJsonSafe(data.pets[idx_62].food);
-          }
-          if (data.pets[idx_62].food != null) {
-            const embeddedData = data.pets[idx_62].food;
-            if (entity.pets[idx_62].food == null) {
-              entity.pets[idx_62].food = factory.createEmbeddable(cat_food_80, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
-            }
-            if (data.pets[idx_62].food.cats === null) {
-              entity.pets[idx_62].food.cats = null;
-            } else if (typeof data.pets[idx_62].food.cats !== 'undefined') {
-              entity.pets[idx_62].food.cats = data.pets[idx_62].food.cats;
-            }
-            if (data.pets[idx_62].food.mice === null) {
-              entity.pets[idx_62].food.mice = null;
-            } else if (typeof data.pets[idx_62].food.mice !== 'undefined') {
-              entity.pets[idx_62].food.mice = data.pets[idx_62].food.mice;
-            }
-          } else if (data.pets[idx_62].food === null) {
-            entity.pets[idx_62].food = null;
           }
         }
       } else if (data.pets[idx_62] === null) {
@@ -599,17 +607,14 @@ exports[`polymorphic embeddables in sqlite > diffing 2`] = `
 
   if (entity.pet === null) {
     ret.pet_canBark = null;
+    ret.pet_food_cats = null;
+    ret.pet_food_mice = null;
     ret.pet_type = null;
     ret.pet_name = null;
     ret.pet_canMeow = null;
-    ret.pet_food_cats = null;
-    ret.pet_food_mice = null;
   }
   if (entity.pet != null) {
     if (typeof entity.pet.canBark !== 'undefined') ret.pet_canBark = clone(entity.pet.canBark);
-    if (typeof entity.pet.type !== 'undefined') ret.pet_type = clone(entity.pet.type);
-    if (typeof entity.pet.name !== 'undefined') ret.pet_name = clone(entity.pet.name);
-    if (typeof entity.pet.canMeow !== 'undefined') ret.pet_canMeow = clone(entity.pet.canMeow);
 
     if (entity.pet.food === null) {
       ret.pet_food_cats = null;
@@ -620,15 +625,15 @@ exports[`polymorphic embeddables in sqlite > diffing 2`] = `
       if (typeof entity.pet.food.mice !== 'undefined') ret.pet_food_mice = clone(entity.pet.food.mice);
     }
 
+    if (typeof entity.pet.type !== 'undefined') ret.pet_type = clone(entity.pet.type);
+    if (typeof entity.pet.name !== 'undefined') ret.pet_name = clone(entity.pet.name);
+    if (typeof entity.pet.canMeow !== 'undefined') ret.pet_canMeow = clone(entity.pet.canMeow);
   }
 
   if (entity.pet2 === null) ret.pet2 = null;
   if (entity.pet2 != null) {
     ret.pet2 = {};
     if (typeof entity.pet2.canBark !== 'undefined') ret.pet2.canBark = clone(entity.pet2.canBark);
-    if (typeof entity.pet2.type !== 'undefined') ret.pet2.type = clone(entity.pet2.type);
-    if (typeof entity.pet2.name !== 'undefined') ret.pet2.name = clone(entity.pet2.name);
-    if (typeof entity.pet2.canMeow !== 'undefined') ret.pet2.canMeow = clone(entity.pet2.canMeow);
 
     if (entity.pet2.food === null) ret.pet2.food = null;
     if (entity.pet2.food != null) {
@@ -637,6 +642,9 @@ exports[`polymorphic embeddables in sqlite > diffing 2`] = `
       if (typeof entity.pet2.food.mice !== 'undefined') ret.pet2.food.mice = clone(entity.pet2.food.mice);
     }
 
+    if (typeof entity.pet2.type !== 'undefined') ret.pet2.type = clone(entity.pet2.type);
+    if (typeof entity.pet2.name !== 'undefined') ret.pet2.name = clone(entity.pet2.name);
+    if (typeof entity.pet2.canMeow !== 'undefined') ret.pet2.canMeow = clone(entity.pet2.canMeow);
     ret.pet2 = cloneEmbeddable(ret.pet2);
   }
 
@@ -648,9 +656,6 @@ exports[`polymorphic embeddables in sqlite > diffing 2`] = `
       if (entity.pets[idx_0] != null) {
         ret.pets[idx_0] = {};
         if (typeof entity.pets[idx_0].canBark !== 'undefined') ret.pets[idx_0].canBark = clone(entity.pets[idx_0].canBark);
-        if (typeof entity.pets[idx_0].type !== 'undefined') ret.pets[idx_0].type = clone(entity.pets[idx_0].type);
-        if (typeof entity.pets[idx_0].name !== 'undefined') ret.pets[idx_0].name = clone(entity.pets[idx_0].name);
-        if (typeof entity.pets[idx_0].canMeow !== 'undefined') ret.pets[idx_0].canMeow = clone(entity.pets[idx_0].canMeow);
 
         if (entity.pets[idx_0].food === null) ret.pets[idx_0].food = null;
         if (entity.pets[idx_0].food != null) {
@@ -659,6 +664,9 @@ exports[`polymorphic embeddables in sqlite > diffing 2`] = `
           if (typeof entity.pets[idx_0].food.mice !== 'undefined') ret.pets[idx_0].food.mice = clone(entity.pets[idx_0].food.mice);
         }
 
+        if (typeof entity.pets[idx_0].type !== 'undefined') ret.pets[idx_0].type = clone(entity.pets[idx_0].type);
+        if (typeof entity.pets[idx_0].name !== 'undefined') ret.pets[idx_0].name = clone(entity.pets[idx_0].name);
+        if (typeof entity.pets[idx_0].canMeow !== 'undefined') ret.pets[idx_0].canMeow = clone(entity.pets[idx_0].canMeow);
       }
     });
     ret.pets = cloneEmbeddable(ret.pets);
@@ -669,7 +677,7 @@ exports[`polymorphic embeddables in sqlite > diffing 2`] = `
 `;
 
 exports[`polymorphic embeddables in sqlite > schema 1`] = `
-"create table \`owner\` (\`id\` integer not null primary key autoincrement, \`name\` text not null, \`pet_can_bark\` integer null, \`pet_food_cats\` integer null, \`pet_type\` integer not null, \`pet_name\` text not null, \`pet_can_meow\` integer null, \`pet_food_mice\` integer null, \`pet2\` json not null, \`pets\` json not null);
+"create table \`owner\` (\`id\` integer not null primary key autoincrement, \`name\` text not null, \`pet_can_bark\` integer null, \`pet_food_cats\` integer null, \`pet_type\` integer not null, \`pet_food_mice\` integer null, \`pet_name\` text not null, \`pet_can_meow\` integer null, \`pet2\` json not null, \`pets\` json not null);
 create index \`owner_pet_type_index\` on \`owner\` (\`pet_type\`);
 "
 `;

--- a/tests/features/embeddables/polymorphic-embedded-entities.mongo.test.ts
+++ b/tests/features/embeddables/polymorphic-embedded-entities.mongo.test.ts
@@ -142,7 +142,7 @@ describe('polymorphic embeddables in mongo', () => {
     const mock = mockLogger(orm, ['query']);
     await orm.em.persist([ent1, ent2, ent3]).flush();
     expect(mock.mock.calls[0][0]).toMatch(
-      `db.getCollection('owner').insertMany([ { _id: ObjectId('600000000000000000000002'), name: 'o2', pet_type: 0, pet_name: 'c1', pet_canMeow: true, pet_food_mice: 2, pet2: { canBark: true, type: 1, name: 'd4', food: { cats: 10 } } }, { _id: ObjectId('600000000000000000000003'), name: 'o3', pet_canBark: true, pet_type: 1, pet_name: 'd2', pet_food_cats: 10, pet2: { type: 0, name: 'c4', canMeow: true, food: { mice: 2 } } }, { _id: ObjectId('600000000000000000000001'), name: 'o1', pet_canBark: true, pet_type: 1, pet_name: 'd1', pet_food_cats: 10, pet2: { type: 0, name: 'c3', canMeow: true, food: { mice: 2 } } } ], {});`,
+      `db.getCollection('owner').insertMany([ { _id: ObjectId('600000000000000000000002'), name: 'o2', pet_food_mice: 2, pet_type: 0, pet_name: 'c1', pet_canMeow: true, pet2: { canBark: true, food: { cats: 10 }, type: 1, name: 'd4' } }, { _id: ObjectId('600000000000000000000003'), name: 'o3', pet_canBark: true, pet_food_cats: 10, pet_type: 1, pet_name: 'd2', pet2: { food: { mice: 2 }, type: 0, name: 'c4', canMeow: true } }, { _id: ObjectId('600000000000000000000001'), name: 'o1', pet_canBark: true, pet_food_cats: 10, pet_type: 1, pet_name: 'd1', pet2: { food: { mice: 2 }, type: 0, name: 'c3', canMeow: true } } ], {});`,
     );
     orm.em.clear();
 
@@ -174,7 +174,7 @@ describe('polymorphic embeddables in mongo', () => {
     await orm.em.flush();
     expect(mock.mock.calls).toHaveLength(1);
     expect(mock.mock.calls[0][0]).toMatch(
-      `bulk = db.getCollection('owner').initializeUnorderedBulkOp({});bulk.find({ _id: ObjectId('600000000000000000000001') }).update({ '$set': { pet_type: 0, pet_name: 'c2', pet_canMeow: true, pet_food_mice: 2 }, '$unset': { pet_canBark: '', pet_food_cats: '' } });bulk.find({ _id: ObjectId('600000000000000000000002') }).update({ '$set': { pet_canBark: true, pet_food_cats: 10, pet_type: 1, pet_name: 'd3' }, '$unset': { pet_canMeow: '', pet_food_mice: '' } });bulk.find({ _id: ObjectId('600000000000000000000003') }).update({ '$set': { pet_name: 'old dog' } });bulk.execute()`,
+      `bulk = db.getCollection('owner').initializeUnorderedBulkOp({});bulk.find({ _id: ObjectId('600000000000000000000001') }).update({ '$set': { pet_type: 0, pet_food_mice: 2, pet_name: 'c2', pet_canMeow: true }, '$unset': { pet_canBark: '', pet_food_cats: '' } });bulk.find({ _id: ObjectId('600000000000000000000002') }).update({ '$set': { pet_canBark: true, pet_food_cats: 10, pet_type: 1, pet_name: 'd3' }, '$unset': { pet_food_mice: '', pet_canMeow: '' } });bulk.find({ _id: ObjectId('600000000000000000000003') }).update({ '$set': { pet_name: 'old dog' } });bulk.execute()`,
     );
     orm.em.clear();
 
@@ -252,7 +252,7 @@ describe('polymorphic embeddables in mongo', () => {
     const mock = mockLogger(orm, ['query']);
     await orm.em.persist(owner).flush();
     expect(mock.mock.calls[0][0]).toMatch(
-      `db.getCollection('owner').insertMany([ { _id: ObjectId('600000000000000000000004'), name: 'o1', pet_type: 0, pet_name: 'cat', pet_canMeow: true, pet_food_mice: 2, pet2: { canBark: true, type: 1, name: 'dog', food: { cats: 10 } } } ], {});`,
+      `db.getCollection('owner').insertMany([ { _id: ObjectId('600000000000000000000004'), name: 'o1', pet_food_mice: 2, pet_type: 0, pet_name: 'cat', pet_canMeow: true, pet2: { canBark: true, food: { cats: 10 }, type: 1, name: 'dog' } } ], {});`,
     );
 
     orm.em.assign(owner, {
@@ -261,7 +261,7 @@ describe('polymorphic embeddables in mongo', () => {
     });
     await orm.em.persist(owner).flush();
     expect(mock.mock.calls[1][0]).toMatch(
-      `db.getCollection('owner').updateMany({ _id: ObjectId('600000000000000000000004') }, { '$set': { pet_name: 'cat name', pet2: { canBark: true, type: 1, name: 'dog name', food: { cats: 10 } } } }, {});`,
+      `db.getCollection('owner').updateMany({ _id: ObjectId('600000000000000000000004') }, { '$set': { pet_name: 'cat name', pet2: { canBark: true, food: { cats: 10 }, type: 1, name: 'dog name' } } }, {});`,
     );
 
     expect(wrap(owner).toObject()).toEqual({

--- a/tests/features/embeddables/polymorphic-embedded-entities.sqlite.test.ts
+++ b/tests/features/embeddables/polymorphic-embedded-entities.sqlite.test.ts
@@ -160,7 +160,7 @@ describe('polymorphic embeddables in sqlite', () => {
     await orm.em.persist([ent1, ent2, ent3]).flush();
     expect(mock.mock.calls[0][0]).toMatch('begin');
     expect(mock.mock.calls[1][0]).toMatch(
-      'insert into `owner` (`name`, `pet_type`, `pet_name`, `pet_can_meow`, `pet_food_mice`, `pet2`, `pets`, `pet_can_bark`, `pet_food_cats`) values (?, ?, ?, ?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?, ?, ?, ?) returning `id`',
+      'insert into `owner` (`name`, `pet_food_mice`, `pet_type`, `pet_name`, `pet_can_meow`, `pet2`, `pets`, `pet_can_bark`, `pet_food_cats`) values (?, ?, ?, ?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?, ?, ?, ?) returning `id`',
     );
     expect(mock.mock.calls[2][0]).toMatch('commit');
     orm.em.clear();
@@ -213,7 +213,7 @@ describe('polymorphic embeddables in sqlite', () => {
     expect(mock.mock.calls).toHaveLength(3);
     expect(mock.mock.calls[0][0]).toMatch('begin');
     expect(mock.mock.calls[1][0]).toMatch(
-      'update `owner` set `pet_can_bark` = case when (`id` = ?) then ? when (`id` = ?) then ? else `pet_can_bark` end, `pet_food_cats` = case when (`id` = ?) then ? when (`id` = ?) then ? else `pet_food_cats` end, `pet_type` = case when (`id` = ?) then ? when (`id` = ?) then ? else `pet_type` end, `pet_name` = case when (`id` = ?) then ? when (`id` = ?) then ? when (`id` = ?) then ? else `pet_name` end, `pet_can_meow` = case when (`id` = ?) then ? when (`id` = ?) then ? else `pet_can_meow` end, `pet_food_mice` = case when (`id` = ?) then ? when (`id` = ?) then ? else `pet_food_mice` end, `pets` = case when (`id` = ?) then ? else `pets` end where `id` in (?, ?, ?)',
+      'update `owner` set `pet_can_bark` = case when (`id` = ?) then ? when (`id` = ?) then ? else `pet_can_bark` end, `pet_food_cats` = case when (`id` = ?) then ? when (`id` = ?) then ? else `pet_food_cats` end, `pet_type` = case when (`id` = ?) then ? when (`id` = ?) then ? else `pet_type` end, `pet_food_mice` = case when (`id` = ?) then ? when (`id` = ?) then ? else `pet_food_mice` end, `pet_name` = case when (`id` = ?) then ? when (`id` = ?) then ? when (`id` = ?) then ? else `pet_name` end, `pet_can_meow` = case when (`id` = ?) then ? when (`id` = ?) then ? else `pet_can_meow` end, `pets` = case when (`id` = ?) then ? else `pets` end where `id` in (?, ?, ?)',
     );
     expect(mock.mock.calls[2][0]).toMatch('commit');
     orm.em.clear();
@@ -305,7 +305,7 @@ describe('polymorphic embeddables in sqlite', () => {
     await orm.em.persist(owner).flush();
     expect(mock.mock.calls[0][0]).toMatch('begin');
     expect(mock.mock.calls[1][0]).toMatch(
-      'insert into `owner` (`name`, `pet_type`, `pet_name`, `pet_can_meow`, `pet_food_mice`, `pet2`, `pets`) values (?, ?, ?, ?, ?, ?, ?) returning `id`',
+      'insert into `owner` (`name`, `pet_food_mice`, `pet_type`, `pet_name`, `pet_can_meow`, `pet2`, `pets`) values (?, ?, ?, ?, ?, ?, ?) returning `id`',
     );
     expect(mock.mock.calls[2][0]).toMatch('commit');
 

--- a/tests/issues/GH7983.test.ts
+++ b/tests/issues/GH7983.test.ts
@@ -1,0 +1,116 @@
+import { EntitySchema, type Ref } from '@mikro-orm/core';
+import { MikroORM, type ObjectId } from '@mikro-orm/mongodb';
+
+class Airport {
+  _id!: ObjectId;
+  id!: string;
+  code!: string;
+}
+
+const airportEntity = new EntitySchema({
+  class: Airport,
+  properties: {
+    _id: { primary: true, type: 'ObjectId' },
+    id: { serializedPrimaryKey: true, type: 'string' },
+    code: { type: 'string' },
+  },
+});
+
+const dataEntity = new EntitySchema({
+  abstract: true,
+  discriminatorColumn: 'type',
+  embeddable: true,
+  name: 'Data',
+  properties: {
+    type: { type: 'string' },
+  },
+});
+
+// child A: `in.departureAirport`
+const aInEntity = new EntitySchema({
+  embeddable: true,
+  name: 'AIn',
+  properties: {
+    departureAirport: { entity: () => airportEntity, kind: 'm:1', ref: true },
+  },
+});
+
+const dataAEntity = new EntitySchema({
+  discriminatorValue: 'a',
+  embeddable: true,
+  extends: dataEntity,
+  name: 'DataA',
+  properties: {
+    in: { entity: () => aInEntity, kind: 'embedded', object: true },
+  },
+});
+
+// child B: same child name `in`, different relation name `originAirport`
+const bInEntity = new EntitySchema({
+  embeddable: true,
+  name: 'BIn',
+  properties: {
+    originAirport: { entity: () => airportEntity, kind: 'm:1', ref: true },
+  },
+});
+
+const dataBEntity = new EntitySchema({
+  discriminatorValue: 'b',
+  embeddable: true,
+  extends: dataEntity,
+  name: 'DataB',
+  properties: {
+    in: { entity: () => bInEntity, kind: 'embedded', object: true },
+  },
+});
+
+class Doc {
+  _id!: ObjectId;
+  id!: string;
+  data!: { type: string; in?: { departureAirport?: Ref<Airport>; originAirport?: Ref<Airport> } };
+}
+
+const docEntity = new EntitySchema({
+  class: Doc,
+  properties: {
+    _id: { primary: true, type: 'ObjectId' },
+    id: { serializedPrimaryKey: true, type: 'string' },
+    data: {
+      entity: () => [dataAEntity, dataBEntity],
+      kind: 'embedded',
+      object: true,
+    },
+  },
+});
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    clientUrl: 'mongodb://localhost:27017/mikro-orm-7983',
+    entities: [airportEntity, dataEntity, aInEntity, dataAEntity, bInEntity, dataBEntity, docEntity],
+  });
+  await orm.schema.clear();
+});
+
+afterAll(() => orm.close(true));
+
+test('populate * with polymorphic embeddables having same-named nested embeddable with different relations (GH #7983)', async () => {
+  const em = orm.em.fork();
+  const hav = em.create(Airport, { code: 'HAV' });
+  const mad = em.create(Airport, { code: 'MAD' });
+  em.create(Doc, { data: { type: 'a', in: { departureAirport: hav } } });
+  em.create(Doc, { data: { type: 'b', in: { originAirport: mad } } });
+  await em.flush();
+  em.clear();
+
+  const docs = await em.find(Doc, {}, { populate: ['*'] });
+  expect(docs).toHaveLength(2);
+
+  const docA = docs.find(d => d.data.type === 'a')!;
+  const docB = docs.find(d => d.data.type === 'b')!;
+  expect(docA.data.in!.departureAirport!.isInitialized()).toBe(true);
+  expect(docA.data.in!.departureAirport!.getProperty('code')).toBe('HAV');
+  expect(docB.data.in!.originAirport!.isInitialized()).toBe(true);
+  expect(docB.data.in!.originAirport!.getProperty('code')).toBe('MAD');
+});


### PR DESCRIPTION
When two children of a polymorphic embeddable declare a same-named nested embeddable with different property sets (e.g. `DataA.in.departureAirport` vs `DataB.in.originAirport`), the merged union metadata kept only one branch's shape, so `populate: ['*']` crashed in `expandDotPaths` (`Cannot read properties of undefined (reading 'name')`) and the other branch's relations could not be populated.

Two things collapsed the union:

- the merged prop's `entity`/`target` references still pointed at a single branch, so `EntitySchema.init()` re-derived the union type (`AIn | BIn`) back to the first branch during discovery
- `initSingleTableInheritance` let the first child claim the merged root prop and renamed the others (`in_5000`), orphaning the nested union metadata that `initPolyEmbeddables` had already built

The fix merges the `entity`/`target` references alongside the type union and keeps the merged declaration during STI processing (marked nullable, since each variant fills only its own columns), so nested paths of every variant resolve against the nested union metadata and both branches load correctly.

Behavior notes (visible in the updated test expectations):

- insert/update statements order the merged embeddable's columns/keys slightly differently (the merged prop is no longer re-registered late during STI processing) — cosmetic, schema diffing is name-based
- the persisted JSON keys of such merged nested embeddables are now consistently derived via the naming strategy; previously the first variant's keys kept the raw property name (GH2987 stored `dueDate` next to `sender_email`), and the merged `embeddedData` now includes all variants' keys instead of only the last one's

Closes #7983