### PR TITLE
fix(postgres): make check introspection columnName deterministic

### DIFF
--- a/packages/sql/src/dialects/postgresql/PostgreSqlSchemaHelper.ts
+++ b/packages/sql/src/dialects/postgresql/PostgreSqlSchemaHelper.ts
@@ -1604,7 +1604,7 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
       join pg_namespace nsp on nsp.oid = pgc.connamespace
       join pg_class cls on pgc.conrelid = cls.oid
       where pgc.contype = 'x' and (${excludeFilter})
-      order by name`;
+      order by schema_name, table_name, name, column_name`;
   }
 
   override inferLengthFromColumnType(type: string): number | undefined {

--- a/tests/features/schema-generator/check-constraint.postgres.test.ts
+++ b/tests/features/schema-generator/check-constraint.postgres.test.ts
@@ -24,6 +24,28 @@ class FooEntity extends Base {
   email!: string;
 }
 
+@Entity()
+@Check({ name: 'bounds_sample_bounds_check', expression: 'col_a + col_b + col_c + col_d + col_e > 0' })
+class BoundsSample {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  colA!: number;
+
+  @Property()
+  colB!: number;
+
+  @Property()
+  colC!: number;
+
+  @Property()
+  colD!: number;
+
+  @Property()
+  colE!: number;
+}
+
 describe('check constraint [postgres]', () => {
   test('check constraint is generated for decorator [postgres]', async () => {
     const orm = await MikroORM.init({
@@ -329,6 +351,29 @@ describe('check constraint [postgres]', () => {
     // CASE expression must be parsed correctly and not appear as changed
     diff = await orm.schema.getUpdateSchemaSQL({ wrap: false });
     expect(diff).toBe('');
+
+    await orm.schema.dropDatabase();
+    await orm.close();
+  });
+
+  test('multi-column check introspection has deterministic columnName [postgres]', async () => {
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      entities: [BoundsSample],
+      dbName: 'mikro_orm_test_check_7991',
+      pool: { min: 1, max: 1 },
+    });
+    await orm.schema.refresh();
+
+    // `constraint_column_usage` yields one row per referenced column and only the first one is kept —
+    // `enable_sort = off` makes the view's DISTINCT hash-based, so ties stop being alphabetical by accident.
+    await orm.em.getConnection().execute('set enable_sort = off');
+    const schema = await DatabaseSchema.create(orm.em.getConnection(), orm.em.getPlatform(), orm.config);
+    const check = schema
+      .getTable('bounds_sample')!
+      .getChecks()
+      .find(c => c.name === 'bounds_sample_bounds_check');
+    expect(check?.columnName).toBe('col_a');
 
     await orm.schema.dropDatabase();
     await orm.close();


### PR DESCRIPTION
The check introspection query in `PostgreSqlSchemaHelper.getChecksSQL()` joins `information_schema.constraint_column_usage`, which returns one row per referenced column, but ordered only by constraint name. `getAllChecks()` keeps the first row per constraint, so a multi-column check could be attached to a different arbitrary `columnName` between introspection runs — rewriting an otherwise equivalent migration snapshot after a `migration:down`/`migration:up` round trip while the generated DDL stayed empty.

Ordering by the complete key (`schema_name, table_name, name, column_name`) resolves ties deterministically, so the kept row is always the alphabetically-first referenced column.

The regression test disables sort-based plans on its connection (`set enable_sort = off`) so the view's internal `DISTINCT` becomes hash-based — without that, the tie order happens to come back alphabetically sorted by accident on most instances and the bug doesn't reproduce.

Closes #7991