### PR TITLE
fix(mariadb): keep JSON columns as strings on mysql2 3.23+

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,12 +93,6 @@
         "groupSlug": "all-non-major",
         "automerge": true,
         "automergeType": "branch"
-      },
-      {
-        "matchPackageNames": [
-          "mysql2"
-        ],
-        "allowedVersions": "<3.23.0"
       }
     ],
     "schedule": [

--- a/packages/mysql/package.json
+++ b/packages/mysql/package.json
@@ -49,7 +49,7 @@
   "dependencies": {
     "@mikro-orm/sql": "7.1.6",
     "kysely": "0.29.3",
-    "mysql2": "3.22.6",
+    "mysql2": "3.23.0",
     "sqlstring": "2.3.3"
   },
   "devDependencies": {

--- a/packages/mysql/src/MySqlConnection.ts
+++ b/packages/mysql/src/MySqlConnection.ts
@@ -88,6 +88,9 @@ export class MySqlConnection extends AbstractSqlConnection {
 
     ret.supportBigNumbers = true;
     ret.dateStrings = true;
+    // mysql2 3.23+ parses mariadb JSON columns via extended metadata, but the mariadb
+    // platform converts them on its own, so keep them as strings there.
+    ret.jsonStrings = !this.platform.convertsJsonAutomatically();
 
     return Utils.mergeConfig(ret, overrides);
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1380,7 +1380,7 @@ __metadata:
     "@mikro-orm/core": "npm:^7.1.6"
     "@mikro-orm/sql": "npm:7.1.6"
     kysely: "npm:0.29.3"
-    mysql2: "npm:3.22.6"
+    mysql2: "npm:3.23.0"
     sqlstring: "npm:2.3.3"
   peerDependencies:
     "@mikro-orm/core": 7.1.6
@@ -7837,9 +7837,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mysql2@npm:3.22.6":
-  version: 3.22.6
-  resolution: "mysql2@npm:3.22.6"
+"mysql2@npm:3.23.0":
+  version: 3.23.0
+  resolution: "mysql2@npm:3.23.0"
   dependencies:
     aws-ssl-profiles: "npm:^1.1.2"
     denque: "npm:^2.1.0"
@@ -7848,10 +7848,10 @@ __metadata:
     long: "npm:^5.3.2"
     lru.min: "npm:^1.1.4"
     named-placeholders: "npm:^1.1.6"
-    sql-escaper: "npm:^1.4.0"
+    sql-escaper: "npm:^1.5.1"
   peerDependencies:
     "@types/node": ">= 8"
-  checksum: 10/4a2196c6ea7d4cdf38849807eb6278fd5a9aace84af15a764d7a0bacd14cdeafd60dce38e4a0c6779c705452e153ef96ffb0c9ebc2f1c45105a5582495357d87
+  checksum: 10/173a7fb9bf9d0ddc2f4acd578e38418a1398eb7e0d074f177de952b0969ffa1b1e3cb8ceb3fee2a972612177714d78f915606f2c8e644ba19e9d2c93d0cc1b34
   languageName: node
   linkType: hard
 
@@ -9976,7 +9976,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sql-escaper@npm:^1.4.0":
+"sql-escaper@npm:^1.5.1":
   version: 1.5.1
   resolution: "sql-escaper@npm:1.5.1"
   checksum: 10/787ff7b829152380ac996bdba29a631f2005b772c302426d4676b24246ee47787cbdf9b0e565060851e078e2d15f7a014d6c48e637ec9a0127f0cbb436743ef4


### PR DESCRIPTION
[mysql2 3.23.0](https://github.com/sidorares/node-mysql2/pull/4373) negotiates MariaDB's `MARIADB_CLIENT_EXTENDED_METADATA`, so MariaDB JSON columns (a `LONGTEXT` alias the driver previously could not identify) now parse to objects by default.

`MariaDbPlatform` converts JSON itself and declares `convertsJsonAutomatically(): false`, so with 3.23 the values got handled twice: they hydrated with the wrong type, and change detection then saw a phantom diff and emitted an update on every load of a JSON property — the exact regression `GH5499` guards against.

mysql2 exposes `jsonStrings` to keep the old behaviour, so this ties that option to the platform contract: drivers whose platform converts JSON itself opt out, and mysql keeps the native parsing it relies on. Preferred over dropping our conversion and adopting the driver's, because the extended metadata needs MariaDB 10.5+ — on older servers JSON would still arrive as a string and silently break.

Also lifts the `mysql2` hold-back added in #7981.

Covered by the existing `GH5499` and `json-properties` suites, which fail on 3.23.0 without this.