### PR TITLE
fix(sql): validate order by direction against known values

### DIFF
--- a/packages/mssql/src/MsSqlPlatform.ts
+++ b/packages/mssql/src/MsSqlPlatform.ts
@@ -320,19 +320,20 @@ export class MsSqlPlatform extends AbstractSqlPlatform {
   }
 
   override getOrderByExpression(column: string, direction: QueryOrder, collation?: string): string[] {
+    const dir = this.validateOrderByDirection(direction);
     const col = collation ? `${column} collate ${this.quoteCollation(collation)}` : column;
 
-    switch (direction.toUpperCase()) {
-      case QueryOrder.ASC_NULLS_FIRST:
+    switch (dir) {
+      case QueryOrder.asc_nulls_first:
         return [`case when ${column} is null then 0 else 1 end, ${col} asc`];
-      case QueryOrder.ASC_NULLS_LAST:
+      case QueryOrder.asc_nulls_last:
         return [`case when ${column} is null then 1 else 0 end, ${col} asc`];
-      case QueryOrder.DESC_NULLS_FIRST:
+      case QueryOrder.desc_nulls_first:
         return [`case when ${column} is null then 0 else 1 end, ${col} desc`];
-      case QueryOrder.DESC_NULLS_LAST:
+      case QueryOrder.desc_nulls_last:
         return [`case when ${column} is null then 1 else 0 end, ${col} desc`];
       default:
-        return [`${col} ${direction.toLowerCase()}`];
+        return [`${col} ${dir}`];
     }
   }
 

--- a/packages/sql/src/AbstractSqlPlatform.ts
+++ b/packages/sql/src/AbstractSqlPlatform.ts
@@ -21,6 +21,14 @@ import { NativeQueryBuilder } from './query/NativeQueryBuilder.js';
 /** Base class for SQL database platforms, providing SQL generation and quoting utilities. */
 export abstract class AbstractSqlPlatform extends Platform {
   static readonly #JSON_PROPERTY_NAME_RE = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+  private static readonly ORDER_BY_DIRECTIONS = new Set([
+    'asc',
+    'desc',
+    'asc nulls first',
+    'asc nulls last',
+    'desc nulls first',
+    'desc nulls last',
+  ]);
 
   protected readonly schemaHelper?: SchemaHelper;
 
@@ -167,11 +175,28 @@ export abstract class AbstractSqlPlatform extends Platform {
    * @internal
    */
   getOrderByExpression(column: string, direction: string, collation?: string): string[] {
+    const dir = this.validateOrderByDirection(direction);
+
     if (collation) {
-      return [`${column} collate ${this.quoteCollation(collation)} ${direction.toLowerCase()}`];
+      return [`${column} collate ${this.quoteCollation(collation)} ${dir}`];
     }
 
-    return [`${column} ${direction.toLowerCase()}`];
+    return [`${column} ${dir}`];
+  }
+
+  /**
+   * `toLowerCase()` folds every `QueryOrder` enum member (and the normalized `QueryOrderNumeric`
+   * values) onto the six allow-listed directions, so only unknown values are rejected.
+   * @internal
+   */
+  validateOrderByDirection(direction: string): string {
+    const dir = ('' + direction).toLowerCase().trim();
+
+    if (!AbstractSqlPlatform.ORDER_BY_DIRECTIONS.has(dir)) {
+      throw new Error(`Invalid order direction: '${direction}'`);
+    }
+
+    return dir;
   }
 
   /**

--- a/packages/sql/src/dialects/mysql/BaseMySqlPlatform.ts
+++ b/packages/sql/src/dialects/mysql/BaseMySqlPlatform.ts
@@ -167,7 +167,7 @@ export class BaseMySqlPlatform extends AbstractSqlPlatform {
 
   override getOrderByExpression(column: string, direction: string, collation?: string): string[] {
     const ret: string[] = [];
-    const dir = direction.toLowerCase() as keyof typeof this.ORDER_BY_NULLS_TRANSLATE;
+    const dir = this.validateOrderByDirection(direction) as keyof typeof this.ORDER_BY_NULLS_TRANSLATE;
     const col = collation ? `${column} collate ${this.quoteCollation(collation)}` : column;
 
     if (dir in this.ORDER_BY_NULLS_TRANSLATE) {

--- a/tests/issues/GHx59.test.ts
+++ b/tests/issues/GHx59.test.ts
@@ -1,0 +1,47 @@
+import { defineEntity, MikroORM, p } from '@mikro-orm/sqlite';
+
+// the orderBy key is validated against entity metadata, but the direction value used to be passed
+// through to the ORDER BY clause without any validation. only the known QueryOrder directions
+// should be accepted; anything else must be rejected instead of reaching the query.
+const User = defineEntity({
+  name: 'User',
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+  },
+});
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    entities: [User],
+    dbName: ':memory:',
+  });
+  await orm.schema.create();
+  const em = orm.em.fork();
+  em.create(User, { id: 1, name: 'a' });
+  em.create(User, { id: 2, name: 'b' });
+  await em.flush();
+});
+
+afterAll(async () => orm.close(true));
+
+const findOrdered = (dir: string) => orm.em.fork().find(User, {}, { orderBy: { id: dir } as any });
+
+test('rejects an unknown order direction', async () => {
+  await expect(findOrdered('upwards')).rejects.toThrow(/Invalid order direction/);
+});
+
+test('rejects an order direction carrying extra tokens', async () => {
+  await expect(findOrdered('asc, name')).rejects.toThrow(/Invalid order direction/);
+});
+
+test('accepts all known order directions', async () => {
+  await expect(findOrdered('asc')).resolves.toHaveLength(2);
+  await expect(findOrdered('DESC')).resolves.toHaveLength(2);
+  await expect(findOrdered('asc nulls last')).resolves.toHaveLength(2);
+  await expect(findOrdered('DESC NULLS FIRST')).resolves.toHaveLength(2);
+  await expect(orm.em.fork().find(User, {}, { orderBy: { id: 1 } })).resolves.toHaveLength(2);
+  await expect(orm.em.fork().find(User, {}, { orderBy: { id: -1 } })).resolves.toHaveLength(2);
+});


### PR DESCRIPTION
The `orderBy` key is validated against entity metadata, but the direction value was passed straight into the `ORDER BY` clause with only a `toLowerCase()` applied — unknown or malformed values were never rejected.

Adds a shared `validateOrderByDirection()` helper on `AbstractSqlPlatform` that allow-lists the direction against the known `QueryOrder` values, and routes the base implementation plus the `BaseMySqlPlatform` (MySQL/MariaDB) and `MsSqlPlatform` overrides through it — all three previously used the value as-is.

The six canonical directions (`asc`/`desc` and the four `nulls first`/`nulls last` variants) cover every `QueryOrder` enum member as well as the normalized `QueryOrderNumeric` values, so legitimate usage is unaffected; anything else now throws `Invalid order direction: '...'`. This mirrors the existing collation name and orderBy field validation.