### PR TITLE
fix(sql): validate order by direction against known values

### DIFF
--- a/packages/knex/src/AbstractSqlPlatform.ts
+++ b/packages/knex/src/AbstractSqlPlatform.ts
@@ -4,6 +4,15 @@ import { SqlEntityRepository } from './SqlEntityRepository';
 import { SqlSchemaGenerator, type SchemaHelper } from './schema';
 import type { IndexDef } from './typings';
 
+const ORDER_BY_DIRECTIONS = new Set([
+  'asc',
+  'desc',
+  'asc nulls first',
+  'asc nulls last',
+  'desc nulls first',
+  'desc nulls last',
+]);
+
 export abstract class AbstractSqlPlatform extends Platform {
 
   protected readonly schemaHelper?: SchemaHelper;
@@ -133,7 +142,22 @@ export abstract class AbstractSqlPlatform extends Platform {
    * @internal
    */
   getOrderByExpression(column: string, direction: string): string[] {
-    return [ `${column} ${direction.toLowerCase()}` ];
+    return [ `${column} ${this.validateOrderByDirection(direction)}` ];
+  }
+
+  /**
+   * `toLowerCase()` folds every `QueryOrder` enum member (and the normalized `QueryOrderNumeric`
+   * values) onto the six allow-listed directions, so only unknown values are rejected.
+   * @internal
+   */
+  validateOrderByDirection(direction: string): string {
+    const dir = ('' + direction).toLowerCase().trim();
+
+    if (!ORDER_BY_DIRECTIONS.has(dir)) {
+      throw new Error(`Invalid order direction: '${direction}'`);
+    }
+
+    return dir;
   }
 
 }

--- a/packages/knex/src/dialects/mysql/MySqlPlatform.ts
+++ b/packages/knex/src/dialects/mysql/MySqlPlatform.ts
@@ -141,7 +141,7 @@ export class MySqlPlatform extends AbstractSqlPlatform {
 
   override getOrderByExpression(column: string, direction: string): string[] {
     const ret: string[] = [];
-    const dir = direction.toLowerCase() as keyof typeof this.ORDER_BY_NULLS_TRANSLATE;
+    const dir = this.validateOrderByDirection(direction) as keyof typeof this.ORDER_BY_NULLS_TRANSLATE;
 
     if (dir in this.ORDER_BY_NULLS_TRANSLATE) {
       ret.push(`${column} ${this.ORDER_BY_NULLS_TRANSLATE[dir]}`);

--- a/packages/mssql/src/MsSqlPlatform.ts
+++ b/packages/mssql/src/MsSqlPlatform.ts
@@ -261,17 +261,19 @@ export class MsSqlPlatform extends AbstractSqlPlatform {
   }
 
   override getOrderByExpression(column: string, direction: QueryOrder): string[] {
-    switch (direction.toUpperCase()) {
-      case QueryOrder.ASC_NULLS_FIRST:
+    const dir = this.validateOrderByDirection(direction);
+
+    switch (dir) {
+      case QueryOrder.asc_nulls_first:
         return [`case when ${column} is null then 0 else 1 end, ${column} asc`];
-      case QueryOrder.ASC_NULLS_LAST:
+      case QueryOrder.asc_nulls_last:
         return [`case when ${column} is null then 1 else 0 end, ${column} asc`];
-      case QueryOrder.DESC_NULLS_FIRST:
+      case QueryOrder.desc_nulls_first:
         return [`case when ${column} is null then 0 else 1 end, ${column} desc`];
-      case QueryOrder.DESC_NULLS_LAST:
+      case QueryOrder.desc_nulls_last:
         return [`case when ${column} is null then 1 else 0 end, ${column} desc`];
       default:
-        return [`${column} ${direction.toLowerCase()}`];
+        return [`${column} ${dir}`];
     }
   }
 

--- a/tests/issues/GHx47.test.ts
+++ b/tests/issues/GHx47.test.ts
@@ -1,0 +1,51 @@
+// The orderBy key is validated against entity metadata, but the direction value used to be passed
+// through to the ORDER BY clause without any validation. Only the known QueryOrder directions
+// should be accepted; anything else must be rejected instead of reaching the query.
+
+import { Entity, MikroORM, PrimaryKey, Property } from '@mikro-orm/sqlite';
+
+@Entity()
+class User {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    entities: [User],
+    dbName: ':memory:',
+  });
+  await orm.schema.createSchema();
+  const em = orm.em.fork();
+  em.create(User, { id: 1, name: 'a' });
+  em.create(User, { id: 2, name: 'b' });
+  await em.flush();
+});
+
+afterAll(async () => orm.close(true));
+
+const findOrdered = (dir: string) => orm.em.fork().find(User, {}, { orderBy: { id: dir } as any });
+
+test('rejects an unknown order direction', async () => {
+  await expect(findOrdered('upwards')).rejects.toThrow(/Invalid order direction/);
+});
+
+test('rejects an order direction carrying extra tokens', async () => {
+  await expect(findOrdered('asc, name')).rejects.toThrow(/Invalid order direction/);
+});
+
+test('accepts all known order directions', async () => {
+  await expect(findOrdered('asc')).resolves.toHaveLength(2);
+  await expect(findOrdered('DESC')).resolves.toHaveLength(2);
+  await expect(findOrdered('asc nulls last')).resolves.toHaveLength(2);
+  await expect(findOrdered('DESC NULLS FIRST')).resolves.toHaveLength(2);
+  await expect(orm.em.fork().find(User, {}, { orderBy: { id: 1 } })).resolves.toHaveLength(2);
+  await expect(orm.em.fork().find(User, {}, { orderBy: { id: -1 } })).resolves.toHaveLength(2);
+});


### PR DESCRIPTION
Backport of #7996 to the 6.x line.

The `orderBy` key is validated against entity metadata, but the direction value was passed straight into the `ORDER BY` clause with only a `toLowerCase()` applied — unknown or malformed values were never rejected.

Adds a shared `validateOrderByDirection()` helper on `AbstractSqlPlatform` (`@mikro-orm/knex`) that allow-lists the direction against the known `QueryOrder` values, and routes the base implementation plus the `MySqlPlatform` and `MsSqlPlatform` overrides through it — all three previously used the value as-is.

The six canonical directions (`asc`/`desc` and the four `nulls first`/`nulls last` variants) cover every `QueryOrder` enum member as well as the normalized `QueryOrderNumeric` values, so legitimate usage is unaffected; anything else now throws `Invalid order direction: '...'`.