### PR TITLE
fix(core): ignore special object keys in `assign()`

### DIFF
--- a/packages/core/src/entity/EntityAssigner.ts
+++ b/packages/core/src/entity/EntityAssigner.ts
@@ -15,16 +15,13 @@ import type {
   Primary,
   RequiredEntityData,
 } from '../typings.js';
-import { Utils } from '../utils/Utils.js';
+import { DANGEROUS_PROPERTY_NAMES, Utils } from '../utils/Utils.js';
 import { Reference } from './Reference.js';
 import { ReferenceKind, SCALAR_TYPES } from '../enums.js';
 import { validateProperty } from './validators.js';
 import { helper, wrap } from './wrap.js';
 import { EntityHelper } from './EntityHelper.js';
 import { ValidationError } from '../errors.js';
-
-/** Keys that are never valid entity properties, as they resolve to inherited object accessors. */
-const UNSAFE_PROPERTY_NAMES: string[] = ['__proto__', 'constructor', 'prototype'];
 
 /** Handles assigning data to entities, resolving relations, and propagating changes. */
 export class EntityAssigner {
@@ -78,7 +75,7 @@ export class EntityAssigner {
     options: InternalAssignOptions<C>,
   ) {
     // needs to happen before the `props` lookup, as those keys resolve to inherited accessors
-    if (UNSAFE_PROPERTY_NAMES.includes(propName)) {
+    if (DANGEROUS_PROPERTY_NAMES.includes(propName)) {
       return;
     }
 

--- a/packages/core/src/entity/EntityAssigner.ts
+++ b/packages/core/src/entity/EntityAssigner.ts
@@ -23,6 +23,9 @@ import { helper, wrap } from './wrap.js';
 import { EntityHelper } from './EntityHelper.js';
 import { ValidationError } from '../errors.js';
 
+/** Keys that are never valid entity properties, as they resolve to inherited object accessors. */
+const UNSAFE_PROPERTY_NAMES: string[] = ['__proto__', 'constructor', 'prototype'];
+
 /** Handles assigning data to entities, resolving relations, and propagating changes. */
 export class EntityAssigner {
   /** Assigns the given data to the entity, resolving relations and handling custom types. */
@@ -74,6 +77,11 @@ export class EntityAssigner {
     data: Dictionary,
     options: InternalAssignOptions<C>,
   ) {
+    // needs to happen before the `props` lookup, as those keys resolve to inherited accessors
+    if (UNSAFE_PROPERTY_NAMES.includes(propName)) {
+      return;
+    }
+
     let value = data[propName];
 
     const onlyProperties = options.onlyProperties && !(propName in props);

--- a/packages/core/src/metadata/MetadataValidator.ts
+++ b/packages/core/src/metadata/MetadataValidator.ts
@@ -1,6 +1,6 @@
 import type { EntityMetadata, EntityName, EntityProperty } from '../typings.js';
 import type { Routine } from './Routine.js';
-import { Utils } from '../utils/Utils.js';
+import { DANGEROUS_PROPERTY_NAMES, Utils } from '../utils/Utils.js';
 import { type MetadataDiscoveryOptions } from '../utils/Configuration.js';
 import { normalizePartitionNameForComparison, splitCommaSeparatedIdentifiers } from '../utils/partition-utils.js';
 import { MetadataError } from '../errors.js';
@@ -8,19 +8,6 @@ import { ReferenceKind } from '../enums.js';
 import type { MetadataStorage } from './MetadataStorage.js';
 
 type PartitionExpression = NonNullable<EntityMetadata['partitionBy']>['expression'];
-
-/**
- * List of property names that could lead to prototype pollution vulnerabilities.
- * These names should never be used as entity property names because they could
- * allow malicious code to modify object prototypes when property values are assigned.
- *
- * - `__proto__`: Could modify the prototype chain
- * - `constructor`: Could modify the constructor property
- * - `prototype`: Could modify the prototype object
- *
- * @internal
- */
-const DANGEROUS_PROPERTY_NAMES = ['__proto__', 'constructor', 'prototype'] as const;
 
 /**
  * @internal
@@ -824,7 +811,7 @@ export class MetadataValidator {
    */
   private validatePropertyNames(meta: EntityMetadata): void {
     for (const prop of Utils.values(meta.properties)) {
-      if (DANGEROUS_PROPERTY_NAMES.includes(prop.name as any)) {
+      if (DANGEROUS_PROPERTY_NAMES.includes(prop.name)) {
         throw MetadataError.dangerousPropertyName(meta, prop);
       }
     }

--- a/packages/core/src/utils/Utils.ts
+++ b/packages/core/src/utils/Utils.ts
@@ -18,6 +18,19 @@ import { Collection } from '../entity/Collection.js';
 import { EntityHelper } from '../entity/EntityHelper.js';
 import { Raw, isRaw, type RawQueryFragmentSymbol } from './RawQueryFragment.js';
 
+/**
+ * List of property names that could lead to prototype pollution vulnerabilities.
+ * These names should never be used as entity property names because they could
+ * allow malicious code to modify object prototypes when property values are assigned.
+ *
+ * - `__proto__`: Could modify the prototype chain
+ * - `constructor`: Could modify the constructor property
+ * - `prototype`: Could modify the prototype object
+ *
+ * @internal
+ */
+export const DANGEROUS_PROPERTY_NAMES: readonly string[] = ['__proto__', 'constructor', 'prototype'];
+
 function compareConstructors(a: any, b: any) {
   if (a.constructor === b.constructor) {
     return true;
@@ -300,7 +313,7 @@ export class Utils {
 
     if (Utils.isObject(target) && Utils.isPlainObject(source)) {
       for (const [key, value] of Object.entries(source)) {
-        if (['__proto__', 'constructor', 'prototype'].includes(key)) {
+        if (DANGEROUS_PROPERTY_NAMES.includes(key)) {
           continue;
         }
 

--- a/tests/EntityAssigner.test.ts
+++ b/tests/EntityAssigner.test.ts
@@ -1,0 +1,67 @@
+import { defineEntity, MikroORM, wrap } from '@mikro-orm/sqlite';
+
+const Address = defineEntity({
+  name: 'Address',
+  embeddable: true,
+  properties: p => ({
+    city: p.string(),
+  }),
+});
+
+const User = defineEntity({
+  name: 'User',
+  properties: p => ({
+    id: p.integer().primary().autoincrement(),
+    name: p.string(),
+    address: p.embedded(Address).object(),
+  }),
+});
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    entities: [User, Address],
+    dbName: ':memory:',
+  });
+  await orm.schema.refresh();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+describe('EntityAssigner', () => {
+  // keys inherited from `Object.prototype` are never valid entity properties, so they have to be
+  // ignored rather than written through to the accessor they resolve to
+  test('assign() ignores special object keys', async () => {
+    const user = orm.em.create(User, { name: 'alice', address: { city: 'prague' } });
+    const proto = Object.getPrototypeOf(user);
+
+    wrap(user).assign(JSON.parse('{"name":"alice2","__proto__":{"city":"nope"}}'));
+
+    expect(user.name).toBe('alice2');
+    expect(Object.getPrototypeOf(user)).toBe(proto);
+  });
+
+  test('assign() ignores special object keys in embeddables', async () => {
+    const user = orm.em.create(User, { name: 'alice', address: { city: 'prague' } });
+    const proto = Object.getPrototypeOf(user.address);
+
+    orm.em.assign(user, { address: JSON.parse('{"city":"brno","__proto__":{"city":"nope"}}') });
+
+    expect(user.address.city).toBe('brno');
+    expect(Object.getPrototypeOf(user.address)).toBe(proto);
+  });
+
+  test('assign() ignores constructor and prototype keys', async () => {
+    const user = orm.em.create(User, { name: 'alice', address: { city: 'prague' } });
+
+    wrap(user).assign(JSON.parse('{"name":"alice2","constructor":{"city":"nope"},"prototype":{"city":"nope"}}'));
+
+    expect(user.name).toBe('alice2');
+    expect(Object.hasOwn(user, 'constructor')).toBe(false);
+    expect(Object.hasOwn(user, 'prototype')).toBe(false);
+    expect(user.constructor).toBe(User.meta.class);
+  });
+});


### PR DESCRIPTION
`__proto__`, `constructor` and `prototype` are never valid entity property names, but they resolve to inherited object accessors rather than to real properties, so they were not filtered out as unknown keys and were assigned to the entity.

Ignore them in `assignProperty()`, which is shared by the top level `assign()` loop and by embeddable payloads, so both are covered by a single check. This matches what `Utils.merge()` and the entity property name validation during metadata discovery already do.