### PR TITLE
fix(core): ignore special object keys in `assign()`

### DIFF
--- a/packages/core/src/entity/EntityAssigner.ts
+++ b/packages/core/src/entity/EntityAssigner.ts
@@ -25,6 +25,9 @@ import { EntityHelper } from './EntityHelper';
 
 const validator = new EntityValidator(false);
 
+/** Keys that are never valid entity properties, as they resolve to inherited object accessors. */
+const UNSAFE_PROPERTY_NAMES: string[] = ['__proto__', 'constructor', 'prototype'];
+
 export class EntityAssigner {
 
   static assign<
@@ -63,6 +66,11 @@ export class EntityAssigner {
   }
 
   private static assignProperty<T extends object, C extends boolean>(entity: T, propName: string, props: Dictionary<EntityProperty<T>>, data: Dictionary, options: InternalAssignOptions<C>) {
+    // needs to happen before the `props` lookup, as those keys resolve to inherited accessors
+    if (UNSAFE_PROPERTY_NAMES.includes(propName)) {
+      return;
+    }
+
     let value = data[propName];
 
     const onlyProperties = options.onlyProperties && !(propName in props);

--- a/packages/core/src/entity/EntityAssigner.ts
+++ b/packages/core/src/entity/EntityAssigner.ts
@@ -16,7 +16,7 @@ import type {
   Primary,
   RequiredEntityData,
 } from '../typings';
-import { Utils } from '../utils/Utils';
+import { DANGEROUS_PROPERTY_NAMES, Utils } from '../utils/Utils';
 import { Reference } from './Reference';
 import { ReferenceKind, SCALAR_TYPES } from '../enums';
 import { EntityValidator } from './EntityValidator';
@@ -24,9 +24,6 @@ import { helper, wrap } from './wrap';
 import { EntityHelper } from './EntityHelper';
 
 const validator = new EntityValidator(false);
-
-/** Keys that are never valid entity properties, as they resolve to inherited object accessors. */
-const UNSAFE_PROPERTY_NAMES: string[] = ['__proto__', 'constructor', 'prototype'];
 
 export class EntityAssigner {
 
@@ -67,7 +64,7 @@ export class EntityAssigner {
 
   private static assignProperty<T extends object, C extends boolean>(entity: T, propName: string, props: Dictionary<EntityProperty<T>>, data: Dictionary, options: InternalAssignOptions<C>) {
     // needs to happen before the `props` lookup, as those keys resolve to inherited accessors
-    if (UNSAFE_PROPERTY_NAMES.includes(propName)) {
+    if (DANGEROUS_PROPERTY_NAMES.includes(propName)) {
       return;
     }
 

--- a/packages/core/src/utils/Utils.ts
+++ b/packages/core/src/utils/Utils.ts
@@ -29,6 +29,19 @@ import { EntityHelper } from '../entity/EntityHelper';
 
 export const ObjectBindingPattern = Symbol('ObjectBindingPattern');
 
+/**
+ * List of property names that could lead to prototype pollution vulnerabilities.
+ * These names should never be used as entity property names because they could
+ * allow malicious code to modify object prototypes when property values are assigned.
+ *
+ * - `__proto__`: Could modify the prototype chain
+ * - `constructor`: Could modify the constructor property
+ * - `prototype`: Could modify the prototype object
+ *
+ * @internal
+ */
+export const DANGEROUS_PROPERTY_NAMES: readonly string[] = ['__proto__', 'constructor', 'prototype'];
+
 function compareConstructors(a: any, b: any) {
   if (a.constructor === b.constructor) {
     return true;
@@ -362,7 +375,7 @@ export class Utils {
 
     if (Utils.isObject(target) && Utils.isPlainObject(source)) {
       for (const [key, value] of Object.entries(source)) {
-        if (['__proto__', 'constructor', 'prototype'].includes(key)) {
+        if (DANGEROUS_PROPERTY_NAMES.includes(key)) {
           continue;
         }
 

--- a/tests/EntityAssigner.test.ts
+++ b/tests/EntityAssigner.test.ts
@@ -1,0 +1,69 @@
+import { defineEntity, wrap } from '@mikro-orm/core';
+import { MikroORM } from '@mikro-orm/sqlite';
+
+const Address = defineEntity({
+  name: 'Address',
+  embeddable: true,
+  properties: p => ({
+    city: p.string(),
+  }),
+});
+
+const User = defineEntity({
+  name: 'User',
+  properties: p => ({
+    id: p.integer().primary().autoincrement(),
+    name: p.string(),
+    address: p.embedded(Address).object(),
+  }),
+});
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    entities: [User, Address],
+    dbName: ':memory:',
+  });
+  await orm.schema.refreshDatabase();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+describe('EntityAssigner', () => {
+  // keys inherited from `Object.prototype` are never valid entity properties, so they have to be
+  // ignored rather than written through to the accessor they resolve to
+  test('assign() ignores special object keys', async () => {
+    const user = orm.em.create(User, { name: 'alice', address: { city: 'prague' } });
+    const proto = Object.getPrototypeOf(user);
+
+    wrap(user).assign(JSON.parse('{"name":"alice2","__proto__":{"city":"nope"}}'));
+
+    expect(user.name).toBe('alice2');
+    expect(Object.getPrototypeOf(user)).toBe(proto);
+  });
+
+  test('assign() ignores special object keys in embeddables', async () => {
+    const user = orm.em.create(User, { name: 'alice', address: { city: 'prague' } });
+    const proto = Object.getPrototypeOf(user.address);
+
+    orm.em.assign(user, { address: JSON.parse('{"city":"brno","__proto__":{"city":"nope"}}') });
+
+    expect(user.address.city).toBe('brno');
+    expect(Object.getPrototypeOf(user.address)).toBe(proto);
+  });
+
+  test('assign() ignores constructor and prototype keys', async () => {
+    const user = orm.em.create(User, { name: 'alice', address: { city: 'prague' } });
+    const ctor = user.constructor;
+
+    wrap(user).assign(JSON.parse('{"name":"alice2","constructor":{"city":"nope"},"prototype":{"city":"nope"}}'));
+
+    expect(user.name).toBe('alice2');
+    expect(Object.hasOwn(user, 'constructor')).toBe(false);
+    expect(Object.hasOwn(user, 'prototype')).toBe(false);
+    expect(user.constructor).toBe(ctor);
+  });
+});


### PR DESCRIPTION
`__proto__`, `constructor` and `prototype` are never valid entity property names, but they resolve to inherited object accessors rather than to real properties, so they were not filtered out as unknown keys and were assigned to the entity.

Ignore them in `assignProperty()`, which is shared by the top level `assign()` loop and by embeddable payloads, so both are covered by a single check. This matches what `Utils.merge()` and the entity property name validation during metadata discovery already do.

v6 backport of #7998.