### PR TITLE
fix(core): fix infinite recursion when flushing a `mapToPk` FK with value `0`

### DIFF
--- a/packages/core/src/unit-of-work/ChangeSetComputer.ts
+++ b/packages/core/src/unit-of-work/ChangeSetComputer.ts
@@ -185,7 +185,8 @@ export class ChangeSetComputer {
   }
 
   private processProperty<T extends object>(changeSet: ChangeSet<T>, prop: EntityProperty<T>, target?: unknown): void {
-    if (!target) {
+    // check for `null`/`undefined` explicitly, the target can be a falsy raw PK value like `0` (e.g. with `mapToPk`)
+    if (target == null) {
       const targets = Utils.unwrapProperty(changeSet.entity, changeSet.meta, prop);
       targets.forEach(([t]) => this.processProperty(changeSet, prop, t));
 

--- a/tests/issues/GH8003.test.ts
+++ b/tests/issues/GH8003.test.ts
@@ -1,0 +1,53 @@
+import { Collection } from '@mikro-orm/core';
+import {
+  Entity,
+  ManyToOne,
+  OneToMany,
+  PrimaryKey,
+  Property,
+  ReflectMetadataProvider,
+} from '@mikro-orm/decorators/legacy';
+import { MikroORM } from '@mikro-orm/sqlite';
+
+@Entity()
+class Author {
+  @PrimaryKey({ autoincrement: false })
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @OneToMany(() => Book, b => b.author)
+  books = new Collection<Book>(this);
+}
+
+@Entity()
+class Book {
+  @PrimaryKey()
+  id!: number;
+
+  @ManyToOne(() => Author, { mapToPk: true })
+  author!: number;
+}
+
+// `ChangeSetComputer.processProperty()` used a truthiness check on the unwrapped property
+// value, so a `mapToPk` FK holding a falsy but valid raw PK value (`0`) recursed forever.
+test('flushing an entity with a mapToPk FK of 0 does not recurse infinitely', async () => {
+  const orm = await MikroORM.init({
+    dbName: ':memory:',
+    entities: [Author, Book],
+    metadataProvider: ReflectMetadataProvider,
+  });
+  await orm.schema.refresh();
+
+  await orm.em.insert(Author, { id: 0, name: 'a0' });
+  orm.em.create(Book, { id: 1, author: 0 });
+  await orm.em.flush();
+  orm.em.clear();
+
+  const books = await orm.em.find(Book, {});
+  expect(books).toHaveLength(1);
+  expect(books[0].author).toBe(0);
+
+  await orm.close(true);
+});


### PR DESCRIPTION
Closes #8003

`ChangeSetComputer.processProperty` guarded the unwrap branch with `if (!target)`, so a raw `mapToPk` FK of `0` was treated as "no target" and the branch re-entered itself until the stack overflowed — `em.flush()` on such an entity crashed with `RangeError: Maximum call stack size exceeded`, deterministically.

Fix relaxes the guard to `target == null`. This is behavior-safe for the other falsy values too: `Utils.unwrapProperty` only yields non-null values, and `processToOne` early-returns for `mapToPk`, so `0`/`''`/`false` FKs flow through the same path a truthy PK does.

Companion to #8002 — that PR fixes the read side of the falsy-FK class (1:m population), this one fixes the write side (flush crash).

Verified: `GH8003.test.ts` red on master (stack overflow) → green after; unit-of-work sqlite suites pass; `yarn build` / format / lint clean.
