### PR TITLE
fix(core): respect custom type conversion in identity map lookups

### DIFF
--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -2091,7 +2091,13 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
     options.cascade ??= true;
     validatePrimaryKey(data as EntityData<Entity>, em.metadata.get(entityName));
 
-    let entity = em.#unitOfWork.tryGetById<Entity>(entityName, data as FilterQuery<Entity>, options.schema, false);
+    let entity = em.#unitOfWork.tryGetById<Entity>(
+      entityName,
+      data as FilterQuery<Entity>,
+      options.schema,
+      false,
+      options.convertCustomTypes,
+    );
 
     if (entity && helper(entity).__managed && helper(entity).__initialized && !options.refresh) {
       return entity;

--- a/packages/core/src/entity/EntityAssigner.ts
+++ b/packages/core/src/entity/EntityAssigner.ts
@@ -300,7 +300,9 @@ export class EntityAssigner {
         const pk = Utils.extractPK(item, prop.targetMeta);
 
         if (pk && EntityAssigner.validateEM(em)) {
-          const ref = em.getUnitOfWork().getById(prop.targetMeta!.class, pk as Primary<U>, options.schema);
+          const ref = em
+            .getUnitOfWork()
+            .getById(prop.targetMeta!.class, pk as Primary<U>, options.schema, options.convertCustomTypes);
 
           if (ref) {
             return EntityAssigner.assign(ref, item as any, options);

--- a/packages/core/src/entity/EntityFactory.ts
+++ b/packages/core/src/entity/EntityFactory.ts
@@ -645,7 +645,12 @@ export class EntityFactory {
 
       if (prop && [ReferenceKind.MANY_TO_ONE, ReferenceKind.ONE_TO_ONE].includes(prop.kind) && value) {
         const pk = Reference.unwrapReference<any>(value);
-        const entity = this.unitOfWork.getById(prop.targetMeta!.class, pk, options.schema, true) as T[keyof T];
+        const entity = this.unitOfWork.getById(
+          prop.targetMeta!.class,
+          pk,
+          options.schema,
+          options.convertCustomTypes,
+        ) as T[keyof T];
 
         if (entity) {
           return entity;

--- a/packages/core/src/unit-of-work/UnitOfWork.ts
+++ b/packages/core/src/unit-of-work/UnitOfWork.ts
@@ -326,6 +326,7 @@ export class UnitOfWork {
     where: FilterQuery<T>,
     schema?: string,
     strict = true,
+    convertCustomTypes?: boolean,
   ): T | null {
     const pk = Utils.extractPK(where, this.#metadata.find<T>(entityName), strict);
 
@@ -333,7 +334,7 @@ export class UnitOfWork {
       return null;
     }
 
-    return this.getById<T>(entityName, pk as Primary<T>, schema)!;
+    return this.getById<T>(entityName, pk as Primary<T>, schema, convertCustomTypes)!;
   }
 
   /**

--- a/packages/core/src/utils/TransactionManager.ts
+++ b/packages/core/src/utils/TransactionManager.ts
@@ -212,7 +212,8 @@ export class TransactionManager {
     for (const entity of fork.getUnitOfWork(false).getIdentityMap()) {
       const wrapped = helper(entity);
       const meta = wrapped.__meta;
-      const parentEntity = parentUoW.getById(meta.class, wrapped.getPrimaryKey(), parent.schema, true);
+      // the identity map is keyed by the database form, so the lookup has to use it too
+      const parentEntity = parentUoW.getById(meta.class, wrapped.getPrimaryKey(true), parent.schema, true);
 
       if (parentEntity && parentEntity !== entity) {
         const parentWrapped = helper(parentEntity);

--- a/tests/issues/GH8020.test.ts
+++ b/tests/issues/GH8020.test.ts
@@ -1,0 +1,64 @@
+import { defineEntity, MikroORM, p, Type } from '@mikro-orm/sqlite';
+
+class RemappingType extends Type<string | null | undefined> {
+  override convertToDatabaseValue(value: string | null | undefined): string | null | undefined {
+    if (typeof value !== 'string') {
+      return value;
+    }
+
+    if (!value.startsWith('js-')) {
+      throw new Error(`Unexpected value for RemappingType.convertToDatabaseValue: ${value}.`);
+    }
+
+    return value.replace(/^js-/, 'db-');
+  }
+
+  override convertToJSValue(value: string | null | undefined): string | null | undefined {
+    if (typeof value !== 'string') {
+      return value;
+    }
+
+    if (!value.startsWith('db-')) {
+      throw new Error(`Unexpected value for RemappingType.convertToJSValue: ${value}.`);
+    }
+
+    return value.replace(/^db-/, 'js-');
+  }
+
+  override compareAsType(): string {
+    return 'string';
+  }
+}
+
+const AuthorSchema = defineEntity({
+  name: 'Author',
+  properties: {
+    id: p.type(RemappingType).primary(),
+  },
+});
+
+class Author extends AuthorSchema.class {}
+AuthorSchema.setClass(Author);
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    entities: [Author],
+    dbName: ':memory:',
+  });
+  await orm.schema.create();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+test('GH #8020: em.map does not convert database-form custom primary key again', () => {
+  const em = orm.em.fork();
+  const author = em.map(Author, { id: 'db-1' });
+  const authorAgain = em.map(Author, { id: 'db-1' });
+
+  expect(author.id).toBe('js-1');
+  expect(authorAgain).toBe(author);
+});

--- a/tests/issues/GH8020.test.ts
+++ b/tests/issues/GH8020.test.ts
@@ -30,10 +30,21 @@ class RemappingType extends Type<string | null | undefined> {
   }
 }
 
+const TagSchema = defineEntity({
+  name: 'Tag',
+  properties: {
+    id: p.type(RemappingType).primary(),
+  },
+});
+
+class Tag extends TagSchema.class {}
+TagSchema.setClass(Tag);
+
 const AuthorSchema = defineEntity({
   name: 'Author',
   properties: {
     id: p.type(RemappingType).primary(),
+    tags: () => p.manyToMany(Tag),
   },
 });
 
@@ -44,7 +55,7 @@ let orm: MikroORM;
 
 beforeAll(async () => {
   orm = await MikroORM.init({
-    entities: [Author],
+    entities: [Author, Tag],
     dbName: ':memory:',
   });
   await orm.schema.create();
@@ -61,4 +72,13 @@ test('GH #8020: em.map does not convert database-form custom primary key again',
 
   expect(author.id).toBe('js-1');
   expect(authorAgain).toBe(author);
+});
+
+test('GH #8020: em.assign does not convert database-form custom primary key again', () => {
+  const em = orm.em.fork();
+  const tag = em.map(Tag, { id: 'db-1' });
+  const author = em.create(Author, { id: 'js-1' });
+  em.assign(author, { tags: [{ id: 'db-1' }] }, { convertCustomTypes: true });
+
+  expect(author.tags[0]).toBe(tag);
 });

--- a/tests/issues/GH8020.test.ts
+++ b/tests/issues/GH8020.test.ts
@@ -51,11 +51,28 @@ const AuthorSchema = defineEntity({
 class Author extends AuthorSchema.class {}
 AuthorSchema.setClass(Author);
 
+const ItemSchema = defineEntity({
+  name: 'Item',
+  properties: {
+    id: p.integer().primary(),
+    tag: () => p.manyToOne(Tag),
+    label: p.string().nullable(),
+  },
+});
+
+class Item extends ItemSchema.class {
+  constructor(tag: Tag) {
+    super();
+    this.tag = tag;
+  }
+}
+ItemSchema.setClass(Item);
+
 let orm: MikroORM;
 
 beforeAll(async () => {
   orm = await MikroORM.init({
-    entities: [Author, Tag],
+    entities: [Author, Tag, Item],
     dbName: ':memory:',
   });
   await orm.schema.create();
@@ -81,4 +98,31 @@ test('GH #8020: em.assign does not convert database-form custom primary key agai
   em.assign(author, { tags: [{ id: 'db-1' }] }, { convertCustomTypes: true });
 
   expect(author.tags[0]).toBe(tag);
+});
+
+test('GH #8020: entity constructor params reuse the managed relation target', () => {
+  const em = orm.em.fork();
+  const tag = em.map(Tag, { id: 'db-2' });
+  const item = em.create(Item, { id: 2, tag: 'js-2' });
+
+  expect(item.tag).toBe(tag);
+});
+
+test('GH #8020: merging a transactional fork back matches entities by their database-form key', async () => {
+  const setup = orm.em.fork();
+  setup.create(Item, { id: 3, tag: setup.create(Tag, { id: 'js-3' }), label: 'foo' });
+  await setup.flush();
+
+  const em = orm.em.fork();
+  const loaded = await em.findOneOrFail(Tag, 'js-3');
+
+  await em.transactional(async fork => {
+    // after clearing, hydrating the item yields a *managed but uninitialized* tag reference in the fork
+    fork.clear();
+    const item = await fork.findOneOrFail(Item, 3);
+    expect(item.tag).not.toBe(loaded);
+  });
+
+  // the uninitialized fork reference must not replace the loaded entity in the parent context
+  expect(em.map(Tag, { id: 'db-3' })).toBe(loaded);
 });


### PR DESCRIPTION
Fixes #8020

`em.map()` already marks raw result data with `convertCustomTypes: true`, but `merge()` dropped that flag before checking the identity map.

As a result, a custom primary key that was already in database form could be converted as if it were a JS value.

This passes the flag through the identity map lookup and adds a regression test for the reported case.