### PR TITLE
fix(migrations): store the create snapshot in the resolved migrations folder

### DIFF
--- a/packages/core/src/utils/AbstractMigrator.ts
+++ b/packages/core/src/utils/AbstractMigrator.ts
@@ -48,6 +48,7 @@ export abstract class AbstractMigrator<D extends IDatabaseDriver> implements IMi
   protected readonly options: MigrationsOptions;
   protected absolutePath!: string;
   protected initialized = false;
+  #pathsEnsured = false;
   readonly #listeners = new Map<string, Set<(event: MigrationInfo) => MaybePromise<void>>>();
 
   constructor(protected readonly em: D[typeof EntityManagerType]) {
@@ -419,7 +420,8 @@ export abstract class AbstractMigrator<D extends IDatabaseDriver> implements IMi
     await this.initPaths();
   }
 
-  protected async initPaths(): Promise<void> {
+  /** Resolves the migrations path (including source folder auto-detection) without touching the filesystem. */
+  protected async resolvePaths(): Promise<void> {
     if (this.absolutePath || this.options.migrationsList) {
       return;
     }
@@ -430,6 +432,17 @@ export abstract class AbstractMigrator<D extends IDatabaseDriver> implements IMi
     /* v8 ignore next */
     const key = this.config.get('preferTs', Utils.detectTypeScriptSupport()) && this.options.pathTs ? 'pathTs' : 'path';
     this.absolutePath = fs.absolutePath(this.options[key]!, this.config.get('baseDir'));
+  }
+
+  protected async initPaths(): Promise<void> {
+    await this.resolvePaths();
+
+    if (this.#pathsEnsured || this.options.migrationsList) {
+      return;
+    }
+
+    this.#pathsEnsured = true;
+    const { fs } = await import('@mikro-orm/core/fs-utils');
 
     try {
       fs.ensureDir(this.absolutePath);

--- a/packages/migrations/src/Migrator.ts
+++ b/packages/migrations/src/Migrator.ts
@@ -58,9 +58,9 @@ export class Migrator extends AbstractMigrator<AbstractSqlDriver> {
 
   private async getSnapshotPath(): Promise<string> {
     if (!this.#snapshotPath) {
-      // resolve the migrations path first (source-folder auto-detection), otherwise `migration:create`
-      // probes the snapshot before init and derives it from an unresolved path, landing it in `baseDir`
-      await this.initPaths();
+      // the snapshot is probed before `init()`, so the source folder auto-detection has to run first,
+      // otherwise the path stays unresolved and the snapshot is looked up in `baseDir`
+      await this.resolvePaths();
       const { fs } = await import('@mikro-orm/core/fs-utils');
       // for snapshots, we always want to use the path based on `emit` option, regardless of whether we run in TS context
       /* v8 ignore next */

--- a/packages/migrations/src/Migrator.ts
+++ b/packages/migrations/src/Migrator.ts
@@ -58,6 +58,9 @@ export class Migrator extends AbstractMigrator<AbstractSqlDriver> {
 
   private async getSnapshotPath(): Promise<string> {
     if (!this.#snapshotPath) {
+      // resolve the migrations path first (source-folder auto-detection), otherwise `migration:create`
+      // probes the snapshot before init and derives it from an unresolved path, landing it in `baseDir`
+      await this.initPaths();
       const { fs } = await import('@mikro-orm/core/fs-utils');
       // for snapshots, we always want to use the path based on `emit` option, regardless of whether we run in TS context
       /* v8 ignore next */

--- a/tests/features/migrations/Migrator.sqlite.test.ts
+++ b/tests/features/migrations/Migrator.sqlite.test.ts
@@ -272,6 +272,35 @@ describe('Migrator (sqlite)', () => {
     }
   });
 
+  test('snapshot from create lands in the auto-detected migrations folder (GH #8024)', async () => {
+    const { mkdtempSync, mkdirSync, existsSync } = await import('node:fs');
+    mkdirSync(TEMP_DIR, { recursive: true });
+    const baseDir = mkdtempSync(TEMP_DIR + '/gh8024-');
+    mkdirSync(baseDir + '/src');
+
+    const orm2 = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      driver: SqliteDriver,
+      entities: [FooBar4, FooBaz4, BaseEntity5],
+      dbName: ':memory:',
+      baseDir,
+      extensions: [Migrator],
+      migrations: { snapshot: true },
+    });
+
+    try {
+      await orm2.migrator.create(undefined, true);
+
+      // `migration:create` must store the snapshot in the detected `src/migrations` folder,
+      // the same place `migration:up` uses, not in the project root
+      expect(existsSync(baseDir + '/src/migrations/.snapshot-memory.json')).toBe(true);
+      expect(existsSync(baseDir + '/.snapshot-memory.json')).toBe(false);
+    } finally {
+      await orm2.close();
+      await rm(baseDir, { recursive: true, force: true });
+    }
+  });
+
   test('checkSchema works without database connection when snapshot exists', async () => {
     const migrations = orm.config.get('migrations');
     migrations.snapshot = true;

--- a/tests/features/migrations/Migrator.sqlite.test.ts
+++ b/tests/features/migrations/Migrator.sqlite.test.ts
@@ -278,7 +278,8 @@ describe('Migrator (sqlite)', () => {
     const baseDir = mkdtempSync(TEMP_DIR + '/gh8024-');
     mkdirSync(baseDir + '/src');
 
-    const orm2 = await MikroORM.init({
+    // a fresh options object per ORM, the migrations options are mutated by the source folder detection
+    const createOptions = () => ({
       metadataProvider: ReflectMetadataProvider,
       driver: SqliteDriver,
       entities: [FooBar4, FooBaz4, BaseEntity5],
@@ -287,6 +288,8 @@ describe('Migrator (sqlite)', () => {
       extensions: [Migrator],
       migrations: { snapshot: true },
     });
+
+    const orm2 = await MikroORM.init(createOptions());
 
     try {
       await orm2.migrator.create(undefined, true);
@@ -297,6 +300,25 @@ describe('Migrator (sqlite)', () => {
       expect(existsSync(baseDir + '/.snapshot-memory.json')).toBe(false);
     } finally {
       await orm2.close();
+    }
+
+    // the path resolution has to happen in `getSnapshotPath()`, not just in `create()` — a later
+    // `migration:check` process probes the snapshot before `init()` too, and has to find it without a database
+    const orm3 = await MikroORM.init(createOptions());
+    const ensureDbMock = vi.spyOn(orm3.schema, 'ensureDatabase');
+    ensureDbMock.mockRejectedValue(new Error('should not connect to database'));
+    const { fs } = await import('@mikro-orm/core/fs-utils');
+    const ensureDirMock = vi.spyOn(fs, 'ensureDir');
+
+    try {
+      await expect(orm3.migrator.checkSchema()).resolves.toBe(false);
+
+      // `migration:check` is a read-only command, resolving the snapshot path must not create anything
+      expect(ensureDirMock).not.toHaveBeenCalled();
+    } finally {
+      ensureDbMock.mockRestore();
+      ensureDirMock.mockRestore();
+      await orm3.close();
       await rm(baseDir, { recursive: true, force: true });
     }
   });


### PR DESCRIPTION
`migration:create` probes the snapshot before the migrations paths are initialized, so on projects that rely on source-folder auto-detection the snapshot path is derived while `path`/`pathTs` are still unset and it ends up in the project root. `migration:up` resolves the paths first and writes it under the migrations folder, so the two commands leave two snapshots in different places.

Resolving the paths before computing the snapshot path makes both commands agree.

Fixes #8024