### PR TITLE
fix(sql): avoid invalid join when nested populate mixes joined and select-in loads

### DIFF
--- a/packages/sql/src/AbstractSqlDriver.ts
+++ b/packages/sql/src/AbstractSqlDriver.ts
@@ -3105,7 +3105,7 @@ export abstract class AbstractSqlDriver<
   protected buildPopulateWhere<T extends object>(
     meta: EntityMetadata<T>,
     joinedProps: PopulateOptions<T>[],
-    options: Pick<FindOptions<any>, 'populateWhere'>,
+    options: Pick<FindOptions<any>, 'populateWhere' | 'strategy'>,
   ): ObjectQuery<T> {
     const where = {} as ObjectQuery<T>;
 
@@ -3120,7 +3120,14 @@ export abstract class AbstractSqlDriver<
       if (hint.children) {
         const targetMeta = prop.targetMeta;
         if (targetMeta) {
-          const inner = this.buildPopulateWhere(targetMeta, hint.children as any, {});
+          // Only recurse into children that actually end up in the joined-load tree at
+          // this nesting level. A child resolved via a separate SELECT_IN query already
+          // applies its own `where` filter there, so folding its condition in here would
+          // attach it to the wrong (unrelated) join, or force an extra join to be created
+          // just to express it (see GHx60 for a case where that extra join ends up
+          // referencing a TPT parent alias that is out of scope).
+          const childJoinedProps = this.joinedProps(targetMeta, hint.children as any, options);
+          const inner = this.buildPopulateWhere(targetMeta, childJoinedProps, { strategy: options.strategy });
 
           if (!Utils.isEmpty(inner) || RawQueryFragment.hasObjectFragments(inner)) {
             where[prop.name] ??= {} as any;

--- a/tests/issues/GHx60.test.ts
+++ b/tests/issues/GHx60.test.ts
@@ -1,0 +1,79 @@
+import {
+  Entity,
+  ManyToOne,
+  OneToMany,
+  PrimaryKey,
+  Property,
+  ReflectMetadataProvider,
+} from '@mikro-orm/decorators/legacy';
+import { Collection, MikroORM, Rel } from '@mikro-orm/sqlite';
+
+// GHx60 - populating two OneToMany collections sharing the same `mappedBy` inverse
+// (one with a `where` filter), nested from the child entity (`folder.items` and
+// `folder.activeItems` populated starting from `Item`), used to generate an unnecessary
+// join whose alias referenced the TPT parent table from an out-of-scope nested join,
+// producing invalid SQL (`no such column: b1.archived_at` on sqlite, `invalid reference
+// to FROM-clause entry for table "b1"` on postgres).
+
+@Entity({ inheritance: 'tpt' })
+abstract class BaseItemGHx60 {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  createdAt = new Date();
+
+  @Property({ type: 'datetime', nullable: true })
+  archivedAt: Date | null = null;
+}
+
+@Entity()
+class ItemGHx60 extends BaseItemGHx60 {
+  @ManyToOne(() => FolderGHx60)
+  folder!: Rel<FolderGHx60>;
+}
+
+@Entity()
+class FolderGHx60 {
+  @PrimaryKey()
+  id!: number;
+
+  @OneToMany(() => ItemGHx60, item => item.folder, { orderBy: { createdAt: 'DESC' } })
+  items = new Collection<ItemGHx60>(this);
+
+  @OneToMany(() => ItemGHx60, item => item.folder, {
+    where: { archivedAt: null },
+    orderBy: { createdAt: 'DESC' },
+  })
+  activeItems = new Collection<ItemGHx60>(this);
+}
+
+test('GHx60 - nested populate of two OneToMany collections sharing the same inverse on a TPT entity', async () => {
+  const orm = await MikroORM.init({
+    metadataProvider: ReflectMetadataProvider,
+    dbName: ':memory:',
+    entities: [BaseItemGHx60, ItemGHx60, FolderGHx60],
+  });
+  await orm.schema.create();
+
+  const folder = orm.em.create(FolderGHx60, {});
+  const active = orm.em.create(ItemGHx60, { folder, archivedAt: null, createdAt: new Date() });
+  const archived = orm.em.create(ItemGHx60, { folder, archivedAt: new Date(), createdAt: new Date() });
+  await orm.em.flush();
+  orm.em.clear();
+
+  const item = await orm.em.findOneOrFail(ItemGHx60, active.id, {
+    populate: ['folder.items', 'folder.activeItems'],
+    strategy: 'balanced',
+  });
+
+  expect(
+    item.folder.items
+      .getItems()
+      .map((i: ItemGHx60) => i.id)
+      .sort(),
+  ).toEqual([active.id, archived.id].sort());
+  expect(item.folder.activeItems.getItems().map((i: ItemGHx60) => i.id)).toEqual([active.id]);
+
+  await orm.close();
+});


### PR DESCRIPTION
Nested populate of two `OneToMany` collections that share the same inverse side, where one has a `where` filter, could generate invalid SQL when the load strategy splits them across a JOIN and a separate SELECT_IN query.

`buildPopulateWhere` recursed into every child hint unconditionally. A child that gets loaded via SELECT_IN already applies its own `where` in that query, so folding the same condition into the join tree here either attached it to the wrong join or forced an extra join just to express it.

With a TPT entity that extra join ended up referencing a parent-table alias from an out-of-scope nested join:

- sqlite: `no such column: b1.archived_at`
- postgres: `invalid reference to FROM-clause entry for table "b1"`

Fix restricts the recursion to children that actually land in the joined-load tree at that nesting level, using `joinedProps` with the resolved strategy.

Repro in `tests/issues/GHx60.test.ts`.