### PR TITLE
fix(core): key composite primary keys with custom types by their database form

### DIFF
--- a/packages/core/src/unit-of-work/IdentityMap.ts
+++ b/packages/core/src/unit-of-work/IdentityMap.ts
@@ -52,6 +52,14 @@ export class IdentityMap {
     }
   }
 
+  /**
+   * Retrieves the entity occupying the same slot as the given one, if any. Hashes the entity the same way `store()`
+   * does, so it matches regardless of the primary key shape — unlike hashing a primary key value obtained elsewhere.
+   */
+  getByEntity<T>(item: T): T | undefined {
+    return this.getStore((item as AnyEntity).__meta!.root).get(this.getPkHash(item)) as T | undefined;
+  }
+
   /** Retrieves an entity by its hash key from the identity map. */
   getByHash<T>(meta: EntityMetadata<T>, hash: string): T | undefined {
     const store = this.getStore(meta);

--- a/packages/core/src/utils/EntityComparator.ts
+++ b/packages/core/src/utils/EntityComparator.ts
@@ -240,6 +240,9 @@ export class EntityComparator {
           lines.push(
             `    (entity${this.wrap(pk)} != null && isEntityOrRef(entity${this.wrap(pk)})) ? entity${this.wrap(pk)}.__helper.getSerializedPrimaryKey() : entity${this.wrap(pk)},`,
           );
+        } else if (meta.properties[pk].customType) {
+          const convertorKey = this.registerCustomType(meta.properties[pk], context);
+          lines.push(`    convertToDatabaseValue_${convertorKey}(entity${this.wrap(pk)}),`);
         } else {
           lines.push(`    entity${this.wrap(pk)},`);
         }

--- a/packages/core/src/utils/TransactionManager.ts
+++ b/packages/core/src/utils/TransactionManager.ts
@@ -212,8 +212,7 @@ export class TransactionManager {
     for (const entity of fork.getUnitOfWork(false).getIdentityMap()) {
       const wrapped = helper(entity);
       const meta = wrapped.__meta;
-      // the identity map is keyed by the database form, so the lookup has to use it too
-      const parentEntity = parentUoW.getById(meta.class, wrapped.getPrimaryKey(true), parent.schema, true);
+      const parentEntity = parentUoW.getIdentityMap().getByEntity(entity);
 
       if (parentEntity && parentEntity !== entity) {
         const parentWrapped = helper(parentEntity);

--- a/tests/issues/GHx60.test.ts
+++ b/tests/issues/GHx60.test.ts
@@ -1,0 +1,115 @@
+import { MikroORM, PrimaryKeyProp, Type, wrap } from '@mikro-orm/sqlite';
+import { Entity, ManyToOne, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+
+class DateOnlyType extends Type<Date, string> {
+  override convertToDatabaseValue(value: Date | string): string {
+    if (value instanceof Date) {
+      return value.toISOString().substring(0, 10);
+    }
+
+    return value;
+  }
+
+  override convertToJSValue(value: Date | string): Date {
+    return value instanceof Date ? value : new Date(value);
+  }
+
+  override getColumnType(): string {
+    return 'date(10)';
+  }
+}
+
+@Entity()
+class User {
+  @PrimaryKey()
+  name!: string;
+}
+
+@Entity()
+class Range {
+  [PrimaryKeyProp]?: ['from', 'to'];
+
+  @PrimaryKey({ type: DateOnlyType })
+  from!: Date;
+
+  @PrimaryKey({ type: DateOnlyType })
+  to!: Date;
+
+  @ManyToOne(() => User)
+  user!: User;
+
+  @Property({ nullable: true })
+  label?: string;
+}
+
+@Entity()
+class Booking {
+  @PrimaryKey()
+  id!: number;
+
+  @ManyToOne(() => Range)
+  range!: Range;
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    metadataProvider: ReflectMetadataProvider,
+    dbName: ':memory:',
+    entities: [User, Range, Booking],
+  });
+  await orm.schema.create();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+test('composite primary key with custom types is keyed by its database form in the identity map', () => {
+  const em = orm.em.fork();
+  const range = em.create(Range, {
+    user: em.create(User, { name: 'Nik' }),
+    from: new Date('2023-01-01'),
+    to: new Date('2023-01-02'),
+  });
+
+  const hash = em
+    .getUnitOfWork()
+    .getIdentityMap()
+    .keys()
+    .find(k => k.startsWith('Range-'));
+  expect(hash).toBe('Range-2023-01-01~~~2023-01-02');
+
+  // the identity map must be reachable through a plain PK lookup
+  const found = em.getUnitOfWork().getById(Range, [new Date('2023-01-01'), new Date('2023-01-02')]);
+  expect(found).toBe(range);
+});
+
+test('composite primary key with custom types is matched when merging a transactional fork back', async () => {
+  const setup = orm.em.fork();
+  const range = setup.create(Range, {
+    user: setup.create(User, { name: 'Lu' }),
+    from: new Date('2024-01-01'),
+    to: new Date('2024-01-02'),
+    label: 'foo',
+  });
+  setup.create(Booking, { id: 1, range });
+  await setup.flush();
+
+  const em = orm.em.fork();
+  const loaded = await em.findOneOrFail(Range, { from: new Date('2024-01-01'), to: new Date('2024-01-02') });
+  expect(loaded.label).toBe('foo');
+
+  await em.transactional(async fork => {
+    // after clearing, hydrating the booking yields a *managed but uninitialized* range reference in the fork
+    fork.clear();
+    const booking = await fork.findOneOrFail(Booking, 1);
+    expect(wrap(booking.range).isInitialized()).toBe(false);
+  });
+
+  // the uninitialized fork reference must not replace the loaded entity in the parent context
+  const again = await em.findOneOrFail(Range, { from: new Date('2024-01-01'), to: new Date('2024-01-02') });
+  expect(again).toBe(loaded);
+  expect(again.label).toBe('foo');
+});


### PR DESCRIPTION
Follow-up to #8021.

The compiled pk serializer converts custom types when reading `__pk` and when the entity has a single primary key, but the composite fallback branch pushed the raw property value. The same entity therefore hashed two different ways depending on whether `__pk` happened to be set — a `Range` keyed by two date-only custom types landed in the identity map as `Sun Jan 01 2023 01:00:00 GMT+0100 (…)~~~…` instead of `2023-01-01~~~2023-01-02`. Every identity map lookup for such an entity missed.

`mergeEntitiesToParent()` additionally could not be fixed by passing a converted primary key, because `getPrimaryKey(true)` returns an object rather than an array for composite keys and `getById()` cannot hash that. It now asks the identity map for the entity occupying the same slot, hashing the entity the same way `store()` does, which is correct for every primary key shape.