### PR TITLE
fix(sql): do not apply collection `where` of non-joined nested relations

### DIFF
--- a/packages/sql/src/AbstractSqlDriver.ts
+++ b/packages/sql/src/AbstractSqlDriver.ts
@@ -3105,7 +3105,7 @@ export abstract class AbstractSqlDriver<
   protected buildPopulateWhere<T extends object>(
     meta: EntityMetadata<T>,
     joinedProps: PopulateOptions<T>[],
-    options: Pick<FindOptions<any>, 'populateWhere'>,
+    options: Pick<FindOptions<any>, 'populateWhere' | 'strategy'>,
   ): ObjectQuery<T> {
     const where = {} as ObjectQuery<T>;
 
@@ -3120,7 +3120,9 @@ export abstract class AbstractSqlDriver<
       if (hint.children) {
         const targetMeta = prop.targetMeta;
         if (targetMeta) {
-          const inner = this.buildPopulateWhere(targetMeta, hint.children as any, {});
+          // only joined children contribute to the ON conditions, the rest is handled by the entity loader
+          const children = this.joinedProps(targetMeta, hint.children as any, options);
+          const inner = this.buildPopulateWhere(targetMeta, children, { strategy: options.strategy });
 
           if (!Utils.isEmpty(inner) || RawQueryFragment.hasObjectFragments(inner)) {
             where[prop.name] ??= {} as any;

--- a/tests/issues/GH8022.test.ts
+++ b/tests/issues/GH8022.test.ts
@@ -1,0 +1,117 @@
+import {
+  Entity,
+  ManyToOne,
+  OneToMany,
+  PrimaryKey,
+  Property,
+  ReflectMetadataProvider,
+} from '@mikro-orm/decorators/legacy';
+import { Collection, MikroORM, Rel } from '@mikro-orm/postgresql';
+
+@Entity({ inheritance: 'tpt' })
+abstract class BaseItem {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  createdAt = new Date();
+
+  @Property({ type: 'datetime', nullable: true })
+  archivedAt: Date | null = null;
+}
+
+@Entity()
+class Item extends BaseItem {
+  @ManyToOne(() => Folder)
+  folder!: Rel<Folder>;
+}
+
+@Entity()
+class Folder {
+  @PrimaryKey()
+  id!: number;
+
+  @OneToMany(() => Item, item => item.folder, { orderBy: { createdAt: 'DESC' } })
+  items = new Collection<Item>(this);
+
+  @OneToMany(() => Item, item => item.folder, {
+    where: { archivedAt: null },
+    orderBy: { createdAt: 'DESC' },
+  })
+  activeItems = new Collection<Item>(this);
+}
+
+let orm: MikroORM;
+let folderId: number;
+let itemId: number;
+let archivedId: number;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    entities: [BaseItem, Item, Folder],
+    metadataProvider: ReflectMetadataProvider,
+    dbName: 'mikro_orm_test_gh_8022',
+  });
+  await orm.schema.ensureDatabase();
+  await orm.schema.refresh();
+
+  const em = orm.em.fork();
+  const folder = em.create(Folder, {});
+  const active = em.create(Item, { folder, archivedAt: null, createdAt: new Date() });
+  const archived = em.create(Item, { folder, archivedAt: new Date(), createdAt: new Date() });
+  await em.flush();
+  folderId = folder.id;
+  itemId = active.id;
+  archivedId = archived.id;
+});
+
+afterAll(async () => orm.close(true));
+
+test('populating both collections from the owning side', async () => {
+  const folder = await orm.em.fork().findOneOrFail(Folder, folderId, {
+    populate: ['items', 'activeItems'],
+  });
+
+  expect(
+    folder.items
+      .getItems()
+      .map(i => i.id)
+      .sort(),
+  ).toEqual([itemId, archivedId].sort());
+  expect(folder.activeItems.getItems().map(i => i.id)).toEqual([itemId]);
+});
+
+// the `where` of the nested `activeItems` collection used to be merged into the ON condition of the
+// `folder` join even though the collection is loaded via a separate query under the balanced strategy,
+// producing SQL that referenced an alias which was not part of that join
+test('nested populate of two collections sharing the same inverse side', async () => {
+  const item = await orm.em.fork().findOneOrFail(Item, itemId, {
+    populate: ['folder.items', 'folder.activeItems'],
+    strategy: 'balanced',
+  });
+
+  expect(
+    item.folder.items
+      .getItems()
+      .map(i => i.id)
+      .sort(),
+  ).toEqual([itemId, archivedId].sort());
+  expect(item.folder.activeItems.getItems().map(i => i.id)).toEqual([itemId]);
+});
+
+// counterpart of the above: when the nested collections are joined, their `where` still has to end
+// up in the ON condition of the respective join
+test('nested populate of two collections with the joined strategy', async () => {
+  const item = await orm.em.fork().findOneOrFail(Item, itemId, {
+    populate: ['folder.items', 'folder.activeItems'],
+    strategy: 'joined',
+  });
+
+  expect(
+    item.folder.items
+      .getItems()
+      .map(i => i.id)
+      .sort(),
+  ).toEqual([itemId, archivedId].sort());
+  expect(item.folder.activeItems.getItems().map(i => i.id)).toEqual([itemId]);
+});


### PR DESCRIPTION
When building the `populateWhere` used for join `ON` conditions, `buildPopulateWhere()` recursed into nested populate hints without filtering them by load strategy — unlike `buildJoinedPropsOrderBy()` and `getFieldsForJoinedLoad()`, which run every recursion level through `joinedProps()`.

A nested collection that is loaded via a separate query therefore still contributed its `where` to the parent join, referencing an alias that was never created for that join. With `strategy: 'balanced'`, populating `folder.items` + `folder.activeItems` from the child side produced `invalid reference to FROM-clause entry for table "b1"`; without TPT inheritance the same setup crashed in `QueryBuilderHelper.mapper` instead. The lazy `Collection.load()` path was unaffected because `EntityLoader` applies `prop.where` itself.

Fixed by filtering nested children through `joinedProps()` and threading `strategy` down the recursion. The change is strictly narrowing — `joinedProps()` is a filter, so it can only remove conditions.

Closes #8022