### PR TITLE
fix(sql): order introspection queries so generated schema diffs are stable

### DIFF
--- a/packages/mssql/src/MsSqlSchemaHelper.ts
+++ b/packages/mssql/src/MsSqlSchemaHelper.ts
@@ -528,6 +528,7 @@ export class MsSqlSchemaHelper extends SchemaHelper {
         on ep.major_id = o.object_id and ep.minor_id = 0 and ep.name = 'MS_Description'
       where o.type in ('P', 'FN', 'IF', 'TF')
         and o.is_ms_shipped = 0
+      order by s.name, o.name
     `;
 
     const [rows, paramsAndReturns] = await Promise.all([

--- a/packages/oracledb/src/OracleSchemaHelper.ts
+++ b/packages/oracledb/src/OracleSchemaHelper.ts
@@ -953,6 +953,7 @@ export class OracleSchemaHelper extends SchemaHelper {
       from USER_PROCEDURES p
       where p.OBJECT_TYPE in ('PROCEDURE', 'FUNCTION')
         and p.PROCEDURE_NAME is null
+      order by p.OBJECT_NAME
     `;
 
     const [rows, paramsAndReturns] = await Promise.all([

--- a/packages/sql/src/dialects/mysql/MySqlSchemaHelper.ts
+++ b/packages/sql/src/dialects/mysql/MySqlSchemaHelper.ts
@@ -94,11 +94,11 @@ export class MySqlSchemaHelper extends SchemaHelper {
   }
 
   override getListTablesSQL(): string {
-    return `select table_name as table_name, nullif(table_schema, schema()) as schema_name, table_comment as table_comment, table_collation as table_collation from information_schema.tables where table_type = 'BASE TABLE' and table_schema = schema()`;
+    return `select table_name as table_name, nullif(table_schema, schema()) as schema_name, table_comment as table_comment, table_collation as table_collation from information_schema.tables where table_type = 'BASE TABLE' and table_schema = schema() order by table_name`;
   }
 
   override getListViewsSQL(): string {
-    return `select table_name as view_name, nullif(table_schema, schema()) as schema_name, view_definition from information_schema.views where table_schema = schema()`;
+    return `select table_name as view_name, nullif(table_schema, schema()) as schema_name, view_definition from information_schema.views where table_schema = schema() order by table_name`;
   }
 
   override async loadViews(
@@ -507,6 +507,7 @@ export class MySqlSchemaHelper extends SchemaHelper {
       from information_schema.routines r
       where r.routine_schema = database()
         and r.routine_type in ('PROCEDURE', 'FUNCTION')
+      order by r.routine_name
     `;
 
     const [rows, params] = await Promise.all([

--- a/packages/sql/src/dialects/postgresql/PostgreSqlSchemaHelper.ts
+++ b/packages/sql/src/dialects/postgresql/PostgreSqlSchemaHelper.ts
@@ -798,6 +798,7 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
         )
         -- exclude trigger-helper functions; they're managed alongside their owning trigger.
         and p.prorettype <> 'trigger'::regtype
+      order by n.nspname, p.proname
     `;
     const rows = await connection.execute<
       {
@@ -1071,7 +1072,8 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
         left join pg_enum e on t.oid = e.enumtypid
         join pg_catalog.pg_namespace n on n.oid = t.typnamespace
         where t.typtype = 'e' and n.nspname in (${Array(uniqueSchemas.length).fill('?').join(', ')})
-        group by t.typname, n.nspname`,
+        group by t.typname, n.nspname
+        order by n.nspname, t.typname`,
       uniqueSchemas,
       'all',
       ctx,

--- a/packages/sql/src/dialects/sqlite/SqliteSchemaHelper.ts
+++ b/packages/sql/src/dialects/sqlite/SqliteSchemaHelper.ts
@@ -86,7 +86,7 @@ export class SqliteSchemaHelper extends SchemaHelper {
       const prefix = this.getSchemaPrefix(dbName);
       const tables = await connection.execute<{ name: string }[]>(
         `select name from ${prefix}sqlite_master where type = 'table' ` +
-          `and name != 'sqlite_sequence' and name != 'geometry_columns' and name != 'spatial_ref_sys'`,
+          `and name != 'sqlite_sequence' and name != 'geometry_columns' and name != 'spatial_ref_sys' order by name`,
         [],
         'all',
         ctx,

--- a/tests/SchemaHelper.test.ts
+++ b/tests/SchemaHelper.test.ts
@@ -1,6 +1,9 @@
 import { Configuration, Dictionary } from '@mikro-orm/core';
-import { SchemaHelper, SqlitePlatform } from '@mikro-orm/sqlite';
-import { MySqlPlatform } from '@mikro-orm/mysql';
+import { SchemaHelper, SqliteDriver, SqlitePlatform } from '@mikro-orm/sqlite';
+import { MySqlDriver, MySqlPlatform } from '@mikro-orm/mysql';
+import { MariaDbDriver } from '@mikro-orm/mariadb';
+import { MsSqlDriver } from '@mikro-orm/mssql';
+import { OracleDriver } from '@mikro-orm/oracledb';
 import { DatabaseTable } from '@mikro-orm/sql';
 import type { AbstractSqlConnection, Column, DatabaseSchema, Table } from '@mikro-orm/sqlite';
 import {
@@ -171,6 +174,20 @@ describe('SchemaHelper', () => {
       { name: 'col1', sort: 'DESC' },
       { name: 'col2', sort: 'ASC' },
     ]);
+  });
+
+  // the introspected table order drives the order of statements in schema diffs, so an
+  // unordered listing makes the generated SQL (and snapshots based on it) flaky
+  test('table and view listings are explicitly ordered', () => {
+    const drivers = [MySqlDriver, MariaDbDriver, PostgreSqlDriver, SqliteDriver, MsSqlDriver, OracleDriver];
+
+    for (const driver of drivers) {
+      const helper = new Configuration({ driver, dbName: 'test' }, false)
+        .getPlatform()
+        .getSchemaHelper() as SchemaHelper;
+      expect(helper.getListTablesSQL()).toMatch(/order by/);
+      expect(helper.getListViewsSQL()).toMatch(/order by/);
+    }
   });
 
   test('mysql schema helper', async () => {


### PR DESCRIPTION
Snapshot tests in `Migrator.test.ts` were flaky on CI — same statements, different grouping order in the `down` section.

`SchemaComparator.compare()` builds `diff.changedTables` by iterating `toSchema.getTables()`, and for the `down` direction of a migration `toSchema` is the introspected database. So the introspection row order determines the order of the emitted SQL. MySQL's table listing had no `order by`:

```sql
select table_name, ... from information_schema.tables where table_type = 'BASE TABLE' and table_schema = schema()
```

MySQL 8's data-dictionary scan usually returns name order — which is what the committed snapshots encode — until the plan changes and it doesn't. Every other dialect already ordered this query, so MySQL/MariaDB was the outlier.

`DatabaseSchema.toJSON()` already sorts tables, but that only stabilizes the snapshot *file*, not the in-memory order driving the diff SQL.

Added `order by` to every introspection listing that lacked one:

| File | Query |
|---|---|
| `MySqlSchemaHelper` | tables, views, routines |
| `PostgreSqlSchemaHelper` | routines, native enums |
| `MsSqlSchemaHelper` | routines |
| `OracleSchemaHelper` | routines |
| `SqliteSchemaHelper` | attached-db table listing |

The tables/views fix addresses the observed flake (and covers MariaDB via inheritance). The routine listings have the identical defect — `compareRoutines` iterates `toSchema.getRoutines()` in introspection order — so stored-routine migration SQL was non-deterministic the same way.

No snapshots needed updating, which is the expected outcome: the fix locks in the alphabetical order they already recorded.

The added test asserts the listing SQL is explicitly ordered rather than introspecting a live schema — a behavioural version passes with and without the fix locally, since MySQL happens to return name order anyway.