### PR TITLE
fix(core): convert custom types when querying composite PK via array form

### DIFF
--- a/packages/core/src/utils/QueryHelper.ts
+++ b/packages/core/src/utils/QueryHelper.ts
@@ -326,6 +326,14 @@ export class QueryHelper {
 
       if (prop?.customType && convertCustomTypes && !isRaw(value)) {
         value = QueryHelper.processCustomType<T>(prop, value, platform, undefined, true);
+      } else if (
+        !prop &&
+        meta?.compositePK &&
+        convertCustomTypes &&
+        Array.isArray(value) &&
+        key === Utils.getPrimaryKeyHash(meta.primaryKeys)
+      ) {
+        value = QueryHelper.processCompositeCustomTypes(value, meta, platform) as typeof value;
       }
 
       // oxfmt-ignore
@@ -466,6 +474,34 @@ export class QueryHelper {
     }
 
     return prop.customType!.convertToDatabaseValue(cond, platform, { fromQuery, key, mode: 'query' });
+  }
+
+  /**
+   * Composite PK conditions are keyed by a hash of all the PK names, which `findProperty` cannot
+   * resolve, so the custom types have to be applied positionally instead.
+   */
+  private static processCompositeCustomTypes<T extends object>(
+    value: unknown[],
+    meta: EntityMetadata<T>,
+    platform: Platform,
+  ): unknown[] {
+    const props = meta.primaryKeys.map(pk => meta.properties[pk]);
+
+    if (!props.some(prop => prop.customType)) {
+      return value;
+    }
+
+    // the tuple can be longer than the PK when the user passes a malformed condition
+    const convert = (tuple: unknown[]) =>
+      tuple.map((val, idx) => {
+        if (!props[idx]?.customType) {
+          return val;
+        }
+
+        return QueryHelper.processCustomType(props[idx], val as FilterQuery<T>, platform, undefined, true);
+      });
+
+    return value.every(val => Array.isArray(val)) ? value.map(val => convert(val as unknown[])) : convert(value);
   }
 
   private static isSupportedOperator(key: string): boolean {

--- a/tests/issues/GHx61.test.ts
+++ b/tests/issues/GHx61.test.ts
@@ -1,0 +1,132 @@
+import { MikroORM, PrimaryKeyProp, sql, Type } from '@mikro-orm/sqlite';
+import { Entity, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+
+// querying a composite primary key via the positional array form (`em.find(Range, [from, to])`) skipped the
+// custom type conversion — such conditions are keyed by a hash of all the PK names, which `findProperty`
+// cannot resolve, so the per-property `customType` branch never kicked in and the raw JS values were passed
+// to the driver, matching nothing.
+
+class DateOnlyType extends Type<Date, string> {
+  override convertToDatabaseValue(value: Date | string): string {
+    if (value instanceof Date) {
+      return value.toISOString().substring(0, 10);
+    }
+
+    return value;
+  }
+
+  override convertToJSValue(value: Date | string): Date {
+    return value instanceof Date ? value : new Date(value);
+  }
+
+  override getColumnType(): string {
+    return 'date(10)';
+  }
+}
+
+@Entity()
+class Range {
+  [PrimaryKeyProp]?: ['from', 'to'];
+
+  @PrimaryKey({ type: DateOnlyType })
+  from!: Date;
+
+  @PrimaryKey({ type: DateOnlyType })
+  to!: Date;
+
+  @Property({ nullable: true })
+  label?: string;
+}
+
+@Entity()
+class Shift {
+  [PrimaryKeyProp]?: ['day', 'index'];
+
+  @PrimaryKey({ type: DateOnlyType })
+  day!: Date;
+
+  @PrimaryKey()
+  index!: number;
+
+  @Property({ nullable: true })
+  label?: string;
+}
+
+@Entity()
+class Slot {
+  [PrimaryKeyProp]?: ['group', 'index'];
+
+  @PrimaryKey()
+  group!: string;
+
+  @PrimaryKey()
+  index!: number;
+
+  @Property({ nullable: true })
+  label?: string;
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    metadataProvider: ReflectMetadataProvider,
+    dbName: ':memory:',
+    entities: [Range, Shift, Slot],
+  });
+  await orm.schema.create();
+
+  const em = orm.em.fork();
+  em.create(Range, { from: new Date('2024-01-01'), to: new Date('2024-01-02'), label: 'foo' });
+  em.create(Range, { from: new Date('2024-02-01'), to: new Date('2024-02-02'), label: 'bar' });
+  em.create(Shift, { day: new Date('2024-01-01'), index: 1, label: 'foo' });
+  em.create(Slot, { group: 'a', index: 1, label: 'foo' });
+  em.create(Slot, { group: 'a', index: 2, label: 'bar' });
+  await em.flush();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+test('composite primary key with custom types can be queried via the positional array form', async () => {
+  const em = orm.em.fork();
+  const range = await em.findOneOrFail(Range, [new Date('2024-01-01'), new Date('2024-01-02')]);
+  expect(range.label).toBe('foo');
+});
+
+test('composite primary key with custom types can be queried via an array of tuples', async () => {
+  const em = orm.em.fork();
+  const ranges = await em.find(Range, [
+    [new Date('2024-01-01'), new Date('2024-01-02')],
+    [new Date('2024-02-01'), new Date('2024-02-02')],
+  ]);
+  expect(ranges.map(r => r.label)).toEqual(['foo', 'bar']);
+
+  const single = await em.find(Range, [[new Date('2024-01-01'), new Date('2024-01-02')]]);
+  expect(single.map(r => r.label)).toEqual(['foo']);
+});
+
+test('only the composite primary key parts that have a custom type are converted', async () => {
+  const em = orm.em.fork();
+  const shift = await em.findOneOrFail(Shift, [new Date('2024-01-01'), 1]);
+  expect(shift.label).toBe('foo');
+});
+
+test('composite primary key without custom types can be queried via the positional array form', async () => {
+  const em = orm.em.fork();
+  const slot = await em.findOneOrFail(Slot, ['a', 1]);
+  expect(slot.label).toBe('foo');
+
+  const slots = await em.find(Slot, [
+    ['a', 1],
+    ['a', 2],
+  ]);
+  expect(slots.map(s => s.label)).toEqual(['foo', 'bar']);
+});
+
+test('raw fragment keys with array values are not mistaken for composite primary key tuples', async () => {
+  const em = orm.em.fork();
+  const ranges = await em.find(Range, { [sql.upper('label')]: ['FOO'] });
+  expect(ranges.map(r => r.label)).toEqual(['foo']);
+});


### PR DESCRIPTION
`em.find(Range, [from, to])` on a composite primary key whose parts use a custom type matched nothing, while the equivalent `{ from, to }` where clause worked.

`processWhere` normalises a positional PK array into a key that is a hash of all the PK names (`from~~~to`). The reduce that follows resolves keys through `findProperty`, which knows nothing about the separator, so the key resolves to `undefined` and the per-property custom type conversion is never reached — the raw JS values go to the driver untouched, and nothing downstream re-converts them.

The conversion is now also applied when the key is exactly the primary key hash, mapping the tuple positionally onto `meta.primaryKeys`. Composite keys where only some parts have a custom type are handled, and plain composite keys are unaffected.