### PR TITLE
fix(core): don't let a partially loaded fork entity clobber the parent context

### DIFF
--- a/packages/core/src/utils/TransactionManager.ts
+++ b/packages/core/src/utils/TransactionManager.ts
@@ -228,35 +228,18 @@ export class TransactionManager {
 
         for (const prop of meta.hydrateProps) {
           const tracked = this.getTrackedValues(prop, entity[prop.name]);
-          let loaded = true;
-          let known = true;
-
-          for (const [key, value] of tracked) {
-            const has = wrapped.__loadedProperties.has(key);
-            loaded &&= has;
-            known &&= has || value !== undefined;
-          }
 
           // the fork entity can be partially loaded, and propagating a property it does not know about
           // would clobber the parent state, so we restore both its value and its snapshot entries
-          if (!known) {
+          if (!tracked.every(([key, value]) => value !== undefined || wrapped.__loadedProperties.has(key))) {
             this.restore(parentWrapped.__data, parentData, prop.name);
-
-            for (const [key] of tracked) {
-              this.restore(originalEntityData, parentSnapshot, key);
-            }
+            tracked.forEach(([key]) => this.restore(originalEntityData, parentSnapshot, key));
 
             continue;
           }
 
           if (prop.kind === ReferenceKind.SCALAR) {
             (parentEntity as Dictionary)[prop.name] = entity[prop.name];
-          }
-
-          if (loaded) {
-            for (const [key] of tracked) {
-              parentWrapped.__loadedProperties.add(key);
-            }
           }
         }
 

--- a/packages/core/src/utils/TransactionManager.ts
+++ b/packages/core/src/utils/TransactionManager.ts
@@ -7,7 +7,7 @@ import { ChangeSetType } from '../unit-of-work/ChangeSet.js';
 import { TransactionStateError } from '../errors.js';
 import type { Transaction } from '../connections/Connection.js';
 import { helper } from '../entity/wrap.js';
-import type { Dictionary } from '../typings.js';
+import type { Dictionary, EntityProperty } from '../typings.js';
 
 /**
  * Manages transaction lifecycle and propagation for EntityManager.
@@ -221,17 +221,73 @@ export class TransactionManager {
         if (!wrapped.__initialized && parentWrapped.__initialized) {
           continue;
         }
-        parentWrapped.__data = wrapped.__data;
-        parentWrapped.__originalEntityData = wrapped.__originalEntityData;
+        const parentData = parentWrapped.__data;
+        const parentSnapshot = parentWrapped.__originalEntityData;
+        parentWrapped.__data = { ...wrapped.__data };
+        const originalEntityData = { ...wrapped.__originalEntityData } as Dictionary;
 
         for (const prop of meta.hydrateProps) {
+          const tracked = this.getTrackedValues(prop, entity[prop.name]);
+          let loaded = true;
+          let known = true;
+
+          for (const [key, value] of tracked) {
+            const has = wrapped.__loadedProperties.has(key);
+            loaded &&= has;
+            known &&= has || value !== undefined;
+          }
+
+          // the fork entity can be partially loaded, and propagating a property it does not know about
+          // would clobber the parent state, so we restore both its value and its snapshot entries
+          if (!known) {
+            this.restore(parentWrapped.__data, parentData, prop.name);
+
+            for (const [key] of tracked) {
+              this.restore(originalEntityData, parentSnapshot, key);
+            }
+
+            continue;
+          }
+
           if (prop.kind === ReferenceKind.SCALAR) {
             (parentEntity as Dictionary)[prop.name] = entity[prop.name];
           }
+
+          if (loaded) {
+            for (const [key] of tracked) {
+              parentWrapped.__loadedProperties.add(key);
+            }
+          }
+        }
+
+        if (wrapped.__originalEntityData) {
+          parentWrapped.__originalEntityData = originalEntityData;
         }
       } else {
         parentUoW.merge(entity, new Set([entity]));
       }
+    }
+  }
+
+  /**
+   * Returns the property names a given property is tracked and snapshotted under, paired with their values.
+   * Inlined embeddables are hydrated as a single object, so only their leaves tell whether it is complete.
+   */
+  private getTrackedValues(prop: EntityProperty, value: unknown): [string, unknown][] {
+    if (prop.kind === ReferenceKind.EMBEDDED && !prop.object) {
+      return Object.values(prop.embeddedProps).flatMap(child => {
+        return this.getTrackedValues(child, (value as Dictionary)?.[child.embedded![1]]);
+      });
+    }
+
+    return [[prop.name, value]];
+  }
+
+  private restore(target: Dictionary, source: Dictionary | undefined, key: string): void {
+    if (source && key in source) {
+      target[key] = source[key];
+    } else {
+      delete target[key];
     }
   }
 

--- a/tests/issues/GHx62.test.ts
+++ b/tests/issues/GHx62.test.ts
@@ -1,0 +1,176 @@
+import { MikroORM, wrap } from '@mikro-orm/sqlite';
+import {
+  Embeddable,
+  Embedded,
+  Entity,
+  ManyToOne,
+  PrimaryKey,
+  Property,
+  ReflectMetadataProvider,
+} from '@mikro-orm/decorators/legacy';
+import { mockLogger } from '../helpers.js';
+
+@Embeddable()
+class Profile {
+  @Property()
+  a!: string;
+
+  @Property()
+  b!: string;
+}
+
+@Entity()
+class Author {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+}
+
+@Entity()
+class Book {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  label!: string;
+
+  @Property({ nullable: true })
+  note?: string | null;
+
+  @ManyToOne(() => Author)
+  author!: Author;
+
+  @Embedded(() => Profile, { object: false })
+  profile!: Profile;
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    metadataProvider: ReflectMetadataProvider,
+    dbName: ':memory:',
+    entities: [Author, Book, Profile],
+  });
+  await orm.schema.create();
+
+  const em = orm.em.fork();
+  const author = em.create(Author, { id: 1, name: 'Lu' });
+
+  for (const id of [1, 2, 3, 4, 5]) {
+    em.create(Book, { id, label: 'foo', note: 'bar', author, profile: { a: 'A', b: 'B' } });
+  }
+
+  await em.flush();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+test('partially loaded entity from a transactional fork does not clobber the parent context', async () => {
+  const em = orm.em.fork();
+  const loaded = await em.findOneOrFail(Book, 1, { populate: ['author'] });
+
+  await em.transactional(
+    async fork => {
+      const partial = await fork.findOneOrFail(Book, 1, { fields: ['id'] });
+      expect(wrap(partial).isInitialized()).toBe(true);
+    },
+    // `em.transactional()` reuses the parent instances unless we clear the fork
+    { clear: true },
+  );
+
+  const again = await em.findOneOrFail(Book, 1);
+  expect(again).toBe(loaded);
+  expect(again.label).toBe('foo');
+  expect(again.note).toBe('bar');
+  expect(again.profile).toEqual({ a: 'A', b: 'B' });
+  expect(wrap(again.author).isInitialized()).toBe(true);
+  expect(again.author.name).toBe('Lu');
+
+  // the partial snapshot must not leak into change detection
+  const mock = mockLogger(orm);
+  await em.flush();
+  expect(mock).not.toHaveBeenCalled();
+});
+
+test('partially selected inline embeddable is not propagated to the parent context', async () => {
+  const em = orm.em.fork();
+  const loaded = await em.findOneOrFail(Book, 2);
+
+  await em.transactional(
+    async fork => {
+      await fork.findOneOrFail(Book, 2, { fields: ['id', 'profile.a'] });
+    },
+    { clear: true },
+  );
+
+  expect(loaded.profile).toEqual({ a: 'A', b: 'B' });
+
+  const mock = mockLogger(orm);
+  await em.flush();
+  expect(mock).not.toHaveBeenCalled();
+});
+
+test('values known to the fork win over the parent state', async () => {
+  const em = orm.em.fork();
+  const loaded = await em.findOneOrFail(Book, 3);
+
+  await em.transactional(
+    async fork => {
+      const book: Book = await fork.findOneOrFail(Book, 3, { fields: ['id', 'label', 'author', 'profile'] });
+      book.label = 'baz';
+      // `note` was not selected, but the assigned value is still propagated
+      book.note = null;
+    },
+    { clear: true },
+  );
+
+  expect(loaded.label).toBe('baz');
+  expect(loaded.note).toBeNull();
+});
+
+test('embeddable assigned in a partially loaded fork is propagated to the parent context', async () => {
+  const em = orm.em.fork();
+  const loaded = await em.findOneOrFail(Book, 4);
+
+  await em.transactional(
+    async fork => {
+      const book = await fork.findOneOrFail(Book, 4, { fields: ['id', 'label', 'author'] });
+      wrap(book).assign({ profile: { a: 'C', b: 'D' } });
+    },
+    { clear: true },
+  );
+
+  expect(loaded.profile).toEqual({ a: 'C', b: 'D' });
+
+  const mock = mockLogger(orm);
+  await em.flush();
+  expect(mock).not.toHaveBeenCalled();
+});
+
+test('nested transactional fork does not clobber the parent context', async () => {
+  const em = orm.em.fork();
+  const loaded = await em.findOneOrFail(Book, 5, { populate: ['author'] });
+
+  await em.transactional(
+    async fork => {
+      await fork.findOneOrFail(Book, 5, { fields: ['id', 'label'] });
+      await fork.transactional(
+        async nested => {
+          await nested.findOneOrFail(Book, 5, { fields: ['id'] });
+        },
+        { clear: true },
+      );
+    },
+    { clear: true },
+  );
+
+  expect(loaded.label).toBe('foo');
+  expect(loaded.note).toBe('bar');
+  expect(loaded.profile).toEqual({ a: 'A', b: 'B' });
+  expect(wrap(loaded.author).isInitialized()).toBe(true);
+});


### PR DESCRIPTION
When a transactional fork is merged back, `mergeEntitiesToParent()` replaced the parent entity's `__data` and `__originalEntityData` wholesale with the fork's and then copied every scalar. The only guard skipped *uninitialized* fork entities, but a `fields: [...]` load is initialized — so a partially loaded entity overwrote the parent's fully loaded state with `undefined`, and the shrunken snapshot then produced spurious `UPDATE`s (including `SET col = NULL` on non-nullable columns).

Propagation is now decided per property, at tracked-key level: a value is propagated when the fork either loaded it or assigned it, and otherwise the parent's value and its snapshot entries are restored together so the two cannot desync. Inlined embeddables hydrate as a single object, so their leaves are checked individually.

Unchanged from before, and deliberately out of scope: `hydrate: false` props are still dropped, an object-mode embeddable selected partially still shrinks, and `fields: ['id', 'author']` still replaces a populated relation with the fork's stub.