### PR TITLE
feat(migrations): allow opting out of snapshot updates on migrate

### DIFF
--- a/docs/docs/migrations.md
+++ b/docs/docs/migrations.md
@@ -101,6 +101,8 @@ Both paths produce the same serialized shape for a given schema, so running migr
 
 Snapshotting can be disabled via `migrations.snapshot: false` in the ORM config.
 
+If you want the snapshot to only ever describe your entity metadata, use `migrations.snapshotOnMigrate: false` to skip the introspection-based rewrite in `migration:up` and `migration:down`. Note that with this option disabled, the snapshot no longer follows the database, so `migration:create` after a `migration:down` still diffs against the state from before the revert — the reverted changes will be missing from the new migration (often an empty diff). Re-apply the existing migration with `migration:up` instead of regenerating it.
+
 ## Configuration
 
 > The `pattern` option has been replaced with `glob`.
@@ -122,6 +124,7 @@ await MikroORM.init({
     dropTables: true,
     safe: false,
     snapshot: true,
+    snapshotOnMigrate: true,
     emit: 'ts',
     generator: TSMigrationGenerator,
     fileName: (timestamp: string, name?: string) => `Migration${timestamp}${name ? '_' + name : ''}`,
@@ -144,6 +147,7 @@ await MikroORM.init({
 | `dropTables: boolean`                                        | Whether to allow dropping tables during migrations. Defaults to `true`. When `false`, table drop operations are skipped.                                                             |
 | `safe: boolean`                                              | Whether to run migrations in safe mode. Defaults to `false`. When `true`, disables both table dropping and column dropping for safety.                                               |
 | `snapshot: boolean`                                          | Whether to save schema snapshots when creating new migrations. Defaults to `true`. Snapshots help with migration diffing and should be versioned alongside migration files.          |
+| `snapshotOnMigrate: boolean`                                 | Whether to update the snapshot from the database schema when running migrations. Defaults to `true`. Set to `false` to keep the snapshot managed only by `migration:create`.         |
 | `snapshotName: string`                                       | Custom name for schema snapshot files. By default, uses a generated name based on the migration timestamp.                                                                           |
 | `emit: 'js' \| 'ts' \| 'cjs'`                                | Format for generated migration files. Defaults to `'ts'`. Use `'js'` for plain JavaScript, `'cjs'` for CommonJS format.                                                              |
 | `generator: Constructor<IMigrationGenerator>`                | Migration generator class to use for creating migration file contents. Defaults to `TSMigrationGenerator` for TypeScript files. Can be customized to change formatting or structure. |
@@ -188,6 +192,7 @@ You can also override those options using the [environment variables](./configur
 - `MIKRO_ORM_MIGRATIONS_SILENT`
 - `MIKRO_ORM_MIGRATIONS_EMIT`
 - `MIKRO_ORM_MIGRATIONS_SNAPSHOT`
+- `MIKRO_ORM_MIGRATIONS_SNAPSHOT_ON_MIGRATE`
 - `MIKRO_ORM_MIGRATIONS_SNAPSHOT_NAME`
 
 ## Running migrations in production

--- a/packages/core/src/utils/Configuration.ts
+++ b/packages/core/src/utils/Configuration.ts
@@ -121,6 +121,7 @@ const DEFAULTS = {
     dropTables: true,
     safe: false,
     snapshot: true,
+    snapshotOnMigrate: true,
     emit: 'ts',
     fileName: (timestamp: string, name?: string) => `Migration${timestamp}${name ? '_' + name : ''}`,
   },
@@ -702,6 +703,12 @@ export type MigrationsOptions = {
    * @default true
    */
   snapshot?: boolean;
+  /**
+   * Update the snapshot from the database schema when running migrations up or down.
+   * Disable to keep the snapshot managed solely by `migration:create`.
+   * @default true
+   */
+  snapshotOnMigrate?: boolean;
   /** Custom name for the snapshot file. */
   snapshotName?: string;
   /**

--- a/packages/core/src/utils/env-vars.ts
+++ b/packages/core/src/utils/env-vars.ts
@@ -91,6 +91,7 @@ export function loadEnvironmentVars(): Partial<Options> {
   read2('silent', bool);
   read2('emit');
   read2('snapshot', bool);
+  read2('snapshotOnMigrate', bool);
   read2('snapshotName');
   cleanup(ret, 'migrations');
 

--- a/packages/migrations/src/Migrator.ts
+++ b/packages/migrations/src/Migrator.ts
@@ -204,7 +204,7 @@ export class Migrator extends AbstractMigrator<AbstractSqlDriver> {
   ): Promise<MigrationInfo[]> {
     const result = await super.runMigrations(method, options);
 
-    if (result.length > 0 && this.options.snapshot) {
+    if (result.length > 0 && this.options.snapshot && this.options.snapshotOnMigrate) {
       const ctx = Utils.isObject<MigrateOptions>(options) ? options.transaction : undefined;
       const { skipTables, skipViews } = this.config.get('schemaGenerator');
       const schema = await DatabaseSchema.create(

--- a/tests/features/migrations/Migrator.postgres.test.ts
+++ b/tests/features/migrations/Migrator.postgres.test.ts
@@ -228,6 +228,44 @@ describe('Migrator (postgres)', () => {
     }
   });
 
+  test('migration:up and migration:down keep the snapshot intact with snapshotOnMigrate: false', async () => {
+    const migrations = orm.config.get('migrations');
+    migrations.snapshot = true;
+    migrations.snapshotOnMigrate = false;
+
+    const { readFileSync } = await import('node:fs');
+    const path = process.cwd() + '/temp/migrations-456';
+    const snapshotPath = path + '/.snapshot-mikro_orm_test_migrations.json';
+
+    await rm(snapshotPath, { force: true });
+
+    const migration1 = await orm.migrator.create();
+    expect(migration1.diff.up.length).toBeGreaterThan(0);
+    const snapshotAfterCreate = readFileSync(snapshotPath, 'utf8');
+
+    const executeMock = vi.spyOn(Migrator.prototype as any, 'executeMigrations');
+    executeMock.mockResolvedValueOnce([{ name: migration1.fileName }]); // up
+    executeMock.mockResolvedValueOnce([{ name: migration1.fileName }]); // down
+
+    try {
+      await orm.migrator.up(migration1.fileName);
+      expect(readFileSync(snapshotPath, 'utf8')).toEqual(snapshotAfterCreate);
+
+      await orm.migrator.down(migration1.fileName);
+      expect(readFileSync(snapshotPath, 'utf8')).toEqual(snapshotAfterCreate);
+
+      // the snapshot still describes the entities, so creating again yields an empty diff
+      const migration2 = await orm.migrator.create();
+      expect(migration2.diff).toEqual({ down: [], up: [] });
+    } finally {
+      await rm(path + '/' + migration1.fileName, { force: true });
+      await rm(snapshotPath, { force: true });
+      executeMock.mockRestore();
+      migrations.snapshot = false;
+      migrations.snapshotOnMigrate = true;
+    }
+  });
+
   test('migrator.up with external transaction and snapshot: true does not deadlock (GH #7424)', async () => {
     const migrations = orm.config.get('migrations');
     migrations.snapshot = true;


### PR DESCRIPTION
Adds a `migrations.snapshotOnMigrate` option (default `true`). When set to `false`, `migration:up` and `migration:down` no longer rewrite the snapshot from database introspection — it stays managed solely by `migration:create`, so it always describes the entity metadata.

This is the opt-out discussed in https://github.com/mikro-orm/mikro-orm/discussions/7831: teams that generate migrations without a live database (and enforce snapshot freshness in CI) get a single source of truth for the file, at the cost of the snapshot no longer following the DB after a `migration:down`. Documented in the Snapshots section, alongside `MIKRO_ORM_MIGRATIONS_SNAPSHOT_ON_MIGRATE`.