### PR TITLE
fix(oracle): resolve the default schema name from the connection user

### DIFF
--- a/packages/oracledb/src/OraclePlatform.ts
+++ b/packages/oracledb/src/OraclePlatform.ts
@@ -187,7 +187,7 @@ export class OraclePlatform extends AbstractSqlPlatform {
   }
 
   override getDefaultSchemaName(): string | undefined {
-    return this.config.get('dbName');
+    return this.config.get('user', this.config.get('dbName'));
   }
 
   override getVarcharTypeDeclarationSQL(column: { length?: number }): string {

--- a/tests/features/schema-generator/default-schema-name.oracle.test.ts
+++ b/tests/features/schema-generator/default-schema-name.oracle.test.ts
@@ -1,0 +1,29 @@
+import { MikroORM, OracleDriver, OraclePlatform, type Options } from '@mikro-orm/oracledb';
+
+async function init(options: Partial<Options>) {
+  return MikroORM.init({
+    driver: OracleDriver,
+    entities: [],
+    dbName: 'mikro_orm_test',
+    password: 'oracle123',
+    discovery: { warnWhenNoEntities: false },
+    connect: false,
+    ...options,
+  } as Options);
+}
+
+describe('default schema name [oracle]', () => {
+  test('falls back to dbName when no user is configured', async () => {
+    const orm = await init({});
+    expect(orm.em.getPlatform().getDefaultSchemaName()).toBe('mikro_orm_test');
+    await orm.close(true);
+  });
+
+  test('uses the connection user when it differs from dbName', async () => {
+    const orm = await init({ user: 'app_user' });
+    const platform = orm.em.getPlatform() as OraclePlatform;
+    expect(platform.getDefaultSchemaName()).toBe('app_user');
+    expect(platform.getSchemaHelper()!.getListTablesSQL()).toContain(`at.owner = 'app_user'`);
+    await orm.close(true);
+  });
+});


### PR DESCRIPTION
On Oracle the connection opens as the configured `user` and only falls back to `dbName` when no user is set, so tables end up owned by that user's schema. `getDefaultSchemaName()` returned `dbName` regardless, so when the two differ the schema introspection filtered `all_tables` by the wrong owner, never saw the existing tables, and re-emitted `CREATE TABLE`, which fails with `ORA-00955: name is already used by an existing object`.

This resolves the default schema from the connection user the same way `OracleConnection` does, and keeps the `dbName` fallback so setups where the user is not set behave exactly as before.

Fixes #8040
