### PR TITLE
fix(oracle): set the session schema when the connection user differs from `dbName`

### DIFF
--- a/packages/oracledb/src/OracleConnection.ts
+++ b/packages/oracledb/src/OracleConnection.ts
@@ -54,11 +54,33 @@ export class OracleConnection extends AbstractSqlConnection {
     const onCreateConnection = this.options.onCreateConnection ?? this.config.get('onCreateConnection');
 
     const initialPassword = typeof password === 'function' ? await password() : password;
+    const dbName = this.config.get('dbName')!;
+    // unqualified names resolve against the login user's schema, but we manage `dbName`
+    const setSchemaSql =
+      this.config.get('user', dbName) === dbName ? undefined : this.platform.getSchemaHelper()!.getSetSchemaSQL(dbName);
 
-    const poolOptions = {
+    const poolOptions: PoolAttributes = {
       ...options,
       password: initialPassword,
-      sessionCallback: onCreateConnection as PoolAttributes['sessionCallback'],
+      sessionCallback:
+        setSchemaSql || onCreateConnection
+          ? (conn, _requestedTag, cb) => {
+              const initSession = async () => {
+                if (setSchemaSql) {
+                  // ORA-01435: the schema might not exist yet, `ensureDatabase()` creates it later on
+                  await conn.execute(setSchemaSql).catch((e: any) => {
+                    if (e.errorNum !== 1435) {
+                      throw e;
+                    }
+                  });
+                }
+
+                await onCreateConnection?.(conn);
+              };
+
+              initSession().then(() => cb(), cb);
+            }
+          : undefined,
     };
 
     // Retry pool creation for transient Oracle errors (e.g. ORA-01017 under load)

--- a/packages/oracledb/src/OracleConnection.ts
+++ b/packages/oracledb/src/OracleConnection.ts
@@ -69,6 +69,7 @@ export class OracleConnection extends AbstractSqlConnection {
                 if (setSchemaSql) {
                   // ORA-01435: the schema might not exist yet, `ensureDatabase()` creates it later on
                   await conn.execute(setSchemaSql).catch((e: any) => {
+                    /* v8 ignore next 3: other failures of `alter session` are not reproducible in tests */
                     if (e.errorNum !== 1435) {
                       throw e;
                     }

--- a/tests/issues/GH8040.test.ts
+++ b/tests/issues/GH8040.test.ts
@@ -1,0 +1,45 @@
+import { MikroORM } from '@mikro-orm/core';
+import { Entity, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+import { OracleDriver } from '@mikro-orm/oracledb';
+
+@Entity()
+class Gh8040Sample {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+}
+
+const options = {
+  metadataProvider: ReflectMetadataProvider,
+  driver: OracleDriver,
+  dbName: 'mikro_orm_test_gh8040',
+  user: 'system',
+  password: 'oracle123',
+  schemaGenerator: { managementDbName: 'system', tableSpace: 'mikro_orm' },
+  entities: [Gh8040Sample],
+} as const;
+
+test('GH #8040 — schema is managed in `dbName` when it differs from the connection user', async () => {
+  // `ensureDatabase()` creates the schema and switches the connection over to it
+  const orm1 = await MikroORM.init(options);
+  await orm1.schema.refresh();
+  await orm1.close(true);
+
+  // now the schema exists, so we stay connected as the configured `system` user
+  const orm2 = await MikroORM.init(options);
+  await orm2.schema.refresh();
+  expect(await orm2.schema.getUpdateSchemaSQL({ wrap: false })).toBe('');
+
+  await orm2.em.insert(Gh8040Sample, { name: 'foo' });
+  await expect(orm2.em.fork().find(Gh8040Sample, {})).resolves.toHaveLength(1);
+
+  // the qualified name proves the row landed in `dbName`, not in the login user's schema
+  const rows = await orm2.em
+    .getConnection()
+    .execute<{ name: string }[]>(`select "name" from "mikro_orm_test_gh8040"."gh8040sample"`);
+  expect(rows).toEqual([{ name: 'foo' }]);
+
+  await orm2.close(true);
+});


### PR DESCRIPTION
In the Oracle driver, `dbName` is the schema we manage, but unqualified identifiers resolve against the login user's schema. With `user !== dbName`, DDL and DML landed in the login user's schema while introspection queried `all_tables where owner = <dbName>`, so the schema diff kept re-emitting `create table` and eventually failed with ORA-00955.

The pool's `sessionCallback` now issues `alter session set current_schema` for every new connection when the configured user differs from `dbName`, chaining the user's own `onCreateConnection` hook. ORA-01435 is tolerated because the schema may not exist yet at that point, `ensureDatabase()` creates it later.

Closes #8040