### PR TITLE
fix(oracle): keep the config user in sync with the pool after `dropDatabase()`

### DIFF
--- a/packages/oracledb/src/OracleSchemaGenerator.ts
+++ b/packages/oracledb/src/OracleSchemaGenerator.ts
@@ -32,7 +32,7 @@ export class OracleSchemaGenerator extends SchemaGenerator {
   /**
    * creates new database and connects to it
    */
-  override async createDatabase(name?: string): Promise<void> {
+  override async createDatabase(name?: string, options?: { skipOnConnect?: boolean }): Promise<void> {
     name ??= this.config.get('user')!;
     /* v8 ignore next: tableSpace fallback */
     const tableSpace = this.config.get('schemaGenerator').tableSpace ?? 'mikro_orm';
@@ -58,15 +58,26 @@ export class OracleSchemaGenerator extends SchemaGenerator {
     await this.execute(`grant connect, resource to ${this.platform.quoteIdentifier(name)}`);
 
     this.config.set('user', name);
-    await this.driver.reconnect();
+    await this.driver.reconnect(options);
   }
 
+  /**
+   * Drops the user representing the database. When dropping the user we are connected as, we stay
+   * connected as the management user, as the dropped one can no longer authenticate.
+   */
   override async dropDatabase(name?: string): Promise<void> {
     name ??= this.config.get('dbName')!;
+    const originalUser = this.getOriginalUser();
     this.config.set('user', this.helper.getManagementDbName());
-    await this.driver.reconnect();
+    await this.driver.reconnect({ skipOnConnect: true });
     await this.execute(this.helper.getDropDatabaseSQL(name));
-    this.config.set('user', name);
+    // the dropped user is gone, so a cached `ensureDatabase` result for it is stale
+    this.lastEnsuredDatabase = undefined;
+
+    if (originalUser !== name) {
+      this.config.set('user', originalUser);
+      await this.driver.reconnect({ skipOnConnect: true });
+    }
   }
 
   /**
@@ -117,7 +128,7 @@ export class OracleSchemaGenerator extends SchemaGenerator {
     } catch (e: any) {
       if (e.code === 'ORA-01017' && this.config.get('user') !== this.helper.getManagementDbName()) {
         this.config.set('user', this.helper.getManagementDbName());
-        await this.driver.reconnect();
+        await this.driver.reconnect({ skipOnConnect: true });
         const result = await this.ensureDatabase();
 
         // Restore connection to the original user (createDatabase does this
@@ -125,7 +136,7 @@ export class OracleSchemaGenerator extends SchemaGenerator {
         // the user already exists and ensureDatabase returned early)
         if (this.config.get('user') !== dbName) {
           this.config.set('user', dbName);
-          await this.driver.reconnect();
+          await this.driver.reconnect({ skipOnConnect: true });
         }
 
         return result;
@@ -138,8 +149,8 @@ export class OracleSchemaGenerator extends SchemaGenerator {
 
     if (!exists) {
       this.config.set('user', this.helper.getManagementDbName());
-      await this.driver.reconnect();
-      await this.createDatabase(dbName);
+      await this.driver.reconnect({ skipOnConnect: true });
+      await this.createDatabase(dbName, { skipOnConnect: true });
 
       if (options?.create) {
         await this.create(options);
@@ -180,7 +191,7 @@ export class OracleSchemaGenerator extends SchemaGenerator {
 
     const originalUser = this.getOriginalUser();
     this.config.set('user', this.helper.getManagementDbName());
-    await this.driver.reconnect();
+    await this.driver.reconnect({ skipOnConnect: true });
 
     return originalUser;
   }
@@ -194,7 +205,7 @@ export class OracleSchemaGenerator extends SchemaGenerator {
     }
 
     this.config.set('user', originalUser);
-    await this.driver.reconnect();
+    await this.driver.reconnect({ skipOnConnect: true });
   }
 
   /**

--- a/tests/features/schema-generator/SchemaGenerator.oracle2.test.ts
+++ b/tests/features/schema-generator/SchemaGenerator.oracle2.test.ts
@@ -44,6 +44,19 @@ describe('SchemaGenerator2 [oracle]', () => {
 
     await orm.schema.ensureDatabase();
     await orm.schema.dropDatabase(dbName);
+
+    // the pool stays logged in as the management user, as the dropped one can no longer authenticate
+    const res = await orm.em.getConnection().execute<{ user: string }[]>('select user as "user" from dual');
+    expect(res[0].user.toLowerCase()).toBe(orm.config.get('user')!.toLowerCase());
+
+    // the generator must no longer believe the dropped database exists
+    await orm.schema.ensureDatabase();
+    const users = await orm.em
+      .getConnection()
+      .execute<{ username: string }[]>(`select username from all_users where upper(username) = upper('${dbName}')`);
+    expect(users).toHaveLength(1);
+
+    await orm.schema.dropDatabase(dbName);
     await orm.close(true);
   });
 

--- a/tests/features/schema-generator/SchemaGenerator.oracle3.test.ts
+++ b/tests/features/schema-generator/SchemaGenerator.oracle3.test.ts
@@ -833,4 +833,77 @@ describe('SchemaGenerator3 [oracle]', () => {
     const result2 = await connection.execute(qb as any);
     expect(result2).toBeDefined();
   });
+
+  test('dropDatabase reconnects as the original user when dropping a different one', async () => {
+    const gen = orm.schema as OracleSchemaGenerator;
+    const dbName = orm.config.get('dbName')!;
+    orm.config.set('user', dbName);
+    // the user the pool would log in as, captured on every reconnect
+    const connectedAs: (string | undefined)[] = [];
+    const reconnectSpy = vi.spyOn((gen as any).driver, 'reconnect').mockImplementation((() => {
+      connectedAs.push(orm.config.get('user'));
+      return Promise.resolve();
+    }) as any);
+    const executeSpy = vi.spyOn(gen, 'execute' as any).mockResolvedValue(undefined);
+
+    await gen.dropDatabase('some_other_user');
+
+    expect(executeSpy).toHaveBeenCalledWith('drop user "some_other_user" cascade');
+    expect(connectedAs).toEqual(['system', dbName]);
+    expect(orm.config.get('user')).toBe(dbName);
+    expect(reconnectSpy).toHaveBeenCalledWith({ skipOnConnect: true });
+    executeSpy.mockRestore();
+    reconnectSpy.mockRestore();
+  });
+
+  test('dropDatabase stays connected as the management user when dropping itself', async () => {
+    const gen = orm.schema as OracleSchemaGenerator;
+    const dbName = orm.config.get('dbName')!;
+    orm.config.set('user', dbName);
+    (gen as any).lastEnsuredDatabase = dbName;
+    const connectedAs: (string | undefined)[] = [];
+    const reconnectSpy = vi.spyOn((gen as any).driver, 'reconnect').mockImplementation((() => {
+      connectedAs.push(orm.config.get('user'));
+      return Promise.resolve();
+    }) as any);
+    const executeSpy = vi.spyOn(gen, 'execute' as any).mockResolvedValue(undefined);
+
+    await gen.dropDatabase();
+
+    // the dropped user can no longer authenticate, so the config must not claim it
+    expect(connectedAs).toEqual(['system']);
+    expect(orm.config.get('user')).toBe('system');
+    expect((gen as any).lastEnsuredDatabase).toBeUndefined();
+    executeSpy.mockRestore();
+    reconnectSpy.mockRestore();
+    orm.config.set('user', dbName);
+  });
+
+  test('internal reconnects skip the onConnect hook', async () => {
+    const gen = orm.schema as any;
+    const reconnectSpy = vi.spyOn(gen.driver, 'reconnect').mockResolvedValue(undefined);
+    const executeSpy = vi.spyOn(gen, 'execute').mockResolvedValue(undefined);
+    const connExecuteSpy = vi.spyOn(gen.connection, 'execute').mockResolvedValue([]);
+    const helperSpy = vi.spyOn(gen.helper, 'databaseExists').mockResolvedValue(false);
+    const createDbSpy = vi.spyOn(gen, 'createDatabase').mockResolvedValue(undefined);
+    gen.lastEnsuredDatabase = undefined;
+    gen.hasDbaGrant = false;
+
+    await gen.ensureDatabase();
+    await gen.createNamespace('test_schema');
+
+    expect(reconnectSpy).toHaveBeenCalled();
+    expect(createDbSpy).toHaveBeenCalledWith(orm.config.get('dbName'), { skipOnConnect: true });
+    // onConnect() would re-enter ensureDatabase() on every internal reconnect, recreating a just-dropped user
+    for (const call of reconnectSpy.mock.calls) {
+      expect(call[0]).toEqual({ skipOnConnect: true });
+    }
+
+    createDbSpy.mockRestore();
+    helperSpy.mockRestore();
+    connExecuteSpy.mockRestore();
+    executeSpy.mockRestore();
+    reconnectSpy.mockRestore();
+    orm.config.set('user', orm.config.get('dbName'));
+  });
 });


### PR DESCRIPTION
`OracleSchemaGenerator.dropDatabase()` reconnected as the management user to run `drop user`, then restored `user` in the config *without* reconnecting. After it returned, `config.get('user')` named the dropped user while the live `oracledb` pool was still logged in as `system` — anything running before the next reconnect silently used the management user's schema and privileges. Dropping a user other than the current one also clobbered `user` with the dropped name.

The connection is now left as the management user when we drop ourselves (only `createDatabase()` can connect back, once the user is recreated), and the original user is restored with a reconnect otherwise. `lastEnsuredDatabase` is invalidated as well, so `ensureDatabase()` no longer reports a dropped user as existing.

The internal reconnects also pass `skipOnConnect: true` now, matching `SqlSchemaGenerator` — without it `onConnect()` re-enters `ensureDatabase()` mid-operation, which could recreate a user that was just dropped.

The base `SqlSchemaGenerator` has the same no-reconnect shape but deliberately keeps the (valid) management connection alive so `ensureDatabase()`/`createDatabase()` can still run afterwards, and nothing there derives session state from `dbName`. Its un-skipped `onConnect()` is also what resets `lastEnsuredDatabase` today, so both changes are Oracle-only on purpose.