### PR TITLE
fix(core): keep `null` value of embedded arrays in snapshots and hydration

### DIFF
--- a/packages/core/src/hydration/ObjectHydrator.ts
+++ b/packages/core/src/hydration/ObjectHydrator.ts
@@ -525,6 +525,9 @@ export class ObjectHydrator extends Hydrator {
       ret.push(`    data${dataKey}.forEach((_, idx_${idx}) => {`);
       ret.push(...hydrateEmbedded(prop, [...path, `[idx_${idx}]`], `${dataKey}[idx_${idx}]`).map(l => '    ' + l));
       ret.push(`    });`);
+      ret.push(`  } else if (data${dataKey} === null) {`);
+      /* v8 ignore next */
+      ret.push(`    entity${entityKey} = ${this.config.get('forceUndefined') ? 'undefined' : 'null'};`);
       ret.push(`  }`);
 
       return ret;

--- a/packages/core/src/utils/EntityComparator.ts
+++ b/packages/core/src/utils/EntityComparator.ts
@@ -606,6 +606,7 @@ export class EntityComparator {
     const padding = ' '.repeat(level * 2);
     const idx = this.#tmpIndex++;
 
+    ret.push(`${padding}if (entity${entityKey} === null) ret${dataKey} = null;`);
     ret.push(`${padding}if (Array.isArray(entity${entityKey})) {`);
     ret.push(`${padding}  ret${dataKey} = [];`);
     ret.push(`${padding}  entity${entityKey}.forEach((_, idx_${idx}) => {`);

--- a/tests/features/embeddables/__snapshots__/entities-in-embeddables.mongo.test.ts.snap
+++ b/tests/features/embeddables/__snapshots__/entities-in-embeddables.mongo.test.ts.snap
@@ -55,6 +55,7 @@ exports[`embedded entities in mongo > diffing 1`] = `
       
       }
 
+      if (entity.profile1.identity.links === null) ret.profile1_identity_links = null;
       if (Array.isArray(entity.profile1.identity.links)) {
         ret.profile1_identity_links = [];
         entity.profile1.identity.links.forEach((_, idx_0) => {
@@ -82,6 +83,7 @@ exports[`embedded entities in mongo > diffing 1`] = `
             
             }
 
+            if (entity.profile1.identity.links[idx_0].metas === null) ret.profile1_identity_links[idx_0].metas = null;
             if (Array.isArray(entity.profile1.identity.links[idx_0].metas)) {
               ret.profile1_identity_links[idx_0].metas = [];
               entity.profile1.identity.links[idx_0].metas.forEach((_, idx_1) => {
@@ -171,6 +173,7 @@ exports[`embedded entities in mongo > diffing 1`] = `
       
       }
 
+      if (entity.profile2.identity.links === null) ret.profile2.identity.links = null;
       if (Array.isArray(entity.profile2.identity.links)) {
         ret.profile2.identity.links = [];
         entity.profile2.identity.links.forEach((_, idx_2) => {
@@ -198,6 +201,7 @@ exports[`embedded entities in mongo > diffing 1`] = `
             
             }
 
+            if (entity.profile2.identity.links[idx_2].metas === null) ret.profile2.identity.links[idx_2].metas = null;
             if (Array.isArray(entity.profile2.identity.links[idx_2].metas)) {
               ret.profile2.identity.links[idx_2].metas = [];
               entity.profile2.identity.links[idx_2].metas.forEach((_, idx_3) => {
@@ -445,6 +449,8 @@ exports[`embedded entities in mongo > diffing 2`] = `
                   entity.profile1.identity.links[idx_16].metas[idx_25] = null;
                 }
               });
+            } else if (data.profile1_identity_links[idx_16].metas === null) {
+              entity.profile1.identity.links[idx_16].metas = null;
             }
             if (data.profile1_identity_links[idx_16].source === null) {
     entity.profile1.identity.links[idx_16].source = null;
@@ -459,6 +465,8 @@ exports[`embedded entities in mongo > diffing 2`] = `
             entity.profile1.identity.links[idx_16] = null;
           }
         });
+      } else if (data.profile1_identity_links === null) {
+        entity.profile1.identity.links = null;
       }
       if (data.profile1_identity_source === null) {
     entity.profile1.identity.source = null;
@@ -622,6 +630,8 @@ exports[`embedded entities in mongo > diffing 2`] = `
                   entity.profile1.identity.links[idx_47].metas[idx_56] = null;
                 }
               });
+            } else if (data.profile1_identity.links[idx_47].metas === null) {
+              entity.profile1.identity.links[idx_47].metas = null;
             }
             if (data.profile1_identity.links[idx_47].source === null) {
     entity.profile1.identity.links[idx_47].source = null;
@@ -636,6 +646,8 @@ exports[`embedded entities in mongo > diffing 2`] = `
             entity.profile1.identity.links[idx_47] = null;
           }
         });
+      } else if (data.profile1_identity.links === null) {
+        entity.profile1.identity.links = null;
       }
       if (data.profile1_identity.source === null) {
     entity.profile1.identity.source = null;
@@ -826,6 +838,8 @@ exports[`embedded entities in mongo > diffing 2`] = `
                   entity.profile1.identity.links[idx_82].metas[idx_91] = null;
                 }
               });
+            } else if (data.profile1_identity_links[idx_82].metas === null) {
+              entity.profile1.identity.links[idx_82].metas = null;
             }
             if (data.profile1_identity_links[idx_82].source === null) {
     entity.profile1.identity.links[idx_82].source = null;
@@ -840,6 +854,8 @@ exports[`embedded entities in mongo > diffing 2`] = `
             entity.profile1.identity.links[idx_82] = null;
           }
         });
+      } else if (data.profile1_identity_links === null) {
+        entity.profile1.identity.links = null;
       }
       if (data.profile1_identity_source === null) {
     entity.profile1.identity.source = null;
@@ -1003,6 +1019,8 @@ exports[`embedded entities in mongo > diffing 2`] = `
                   entity.profile1.identity.links[idx_113].metas[idx_122] = null;
                 }
               });
+            } else if (data.profile1.identity.links[idx_113].metas === null) {
+              entity.profile1.identity.links[idx_113].metas = null;
             }
             if (data.profile1.identity.links[idx_113].source === null) {
     entity.profile1.identity.links[idx_113].source = null;
@@ -1017,6 +1035,8 @@ exports[`embedded entities in mongo > diffing 2`] = `
             entity.profile1.identity.links[idx_113] = null;
           }
         });
+      } else if (data.profile1.identity.links === null) {
+        entity.profile1.identity.links = null;
       }
       if (data.profile1.identity.source === null) {
     entity.profile1.identity.source = null;
@@ -1171,6 +1191,8 @@ exports[`embedded entities in mongo > diffing 2`] = `
                   entity.profile2.identity.links[idx_143].metas[idx_152] = null;
                 }
               });
+            } else if (data.profile2.identity.links[idx_143].metas === null) {
+              entity.profile2.identity.links[idx_143].metas = null;
             }
             if (data.profile2.identity.links[idx_143].source === null) {
     entity.profile2.identity.links[idx_143].source = null;
@@ -1185,6 +1207,8 @@ exports[`embedded entities in mongo > diffing 2`] = `
             entity.profile2.identity.links[idx_143] = null;
           }
         });
+      } else if (data.profile2.identity.links === null) {
+        entity.profile2.identity.links = null;
       }
       if (data.profile2.identity.source === null) {
     entity.profile2.identity.source = null;

--- a/tests/features/embeddables/__snapshots__/entities-in-embeddables.postgres.test.ts.snap
+++ b/tests/features/embeddables/__snapshots__/entities-in-embeddables.postgres.test.ts.snap
@@ -55,6 +55,7 @@ exports[`embedded entities in postgres > diffing 1`] = `
       
       }
 
+      if (entity.profile1.identity.links === null) ret.profile1_identity_links = null;
       if (Array.isArray(entity.profile1.identity.links)) {
         ret.profile1_identity_links = [];
         entity.profile1.identity.links.forEach((_, idx_0) => {
@@ -82,6 +83,7 @@ exports[`embedded entities in postgres > diffing 1`] = `
             
             }
 
+            if (entity.profile1.identity.links[idx_0].metas === null) ret.profile1_identity_links[idx_0].metas = null;
             if (Array.isArray(entity.profile1.identity.links[idx_0].metas)) {
               ret.profile1_identity_links[idx_0].metas = [];
               entity.profile1.identity.links[idx_0].metas.forEach((_, idx_1) => {
@@ -171,6 +173,7 @@ exports[`embedded entities in postgres > diffing 1`] = `
       
       }
 
+      if (entity.profile2.identity.links === null) ret.profile2.identity.links = null;
       if (Array.isArray(entity.profile2.identity.links)) {
         ret.profile2.identity.links = [];
         entity.profile2.identity.links.forEach((_, idx_2) => {
@@ -198,6 +201,7 @@ exports[`embedded entities in postgres > diffing 1`] = `
             
             }
 
+            if (entity.profile2.identity.links[idx_2].metas === null) ret.profile2.identity.links[idx_2].metas = null;
             if (Array.isArray(entity.profile2.identity.links[idx_2].metas)) {
               ret.profile2.identity.links[idx_2].metas = [];
               entity.profile2.identity.links[idx_2].metas.forEach((_, idx_3) => {
@@ -445,6 +449,8 @@ exports[`embedded entities in postgres > diffing 2`] = `
                   entity.profile1.identity.links[idx_16].metas[idx_25] = null;
                 }
               });
+            } else if (data.profile1_identity_links[idx_16].metas === null) {
+              entity.profile1.identity.links[idx_16].metas = null;
             }
             if (data.profile1_identity_links[idx_16].source === null) {
     entity.profile1.identity.links[idx_16].source = null;
@@ -459,6 +465,8 @@ exports[`embedded entities in postgres > diffing 2`] = `
             entity.profile1.identity.links[idx_16] = null;
           }
         });
+      } else if (data.profile1_identity_links === null) {
+        entity.profile1.identity.links = null;
       }
       if (data.profile1_identity_source === null) {
     entity.profile1.identity.source = null;
@@ -622,6 +630,8 @@ exports[`embedded entities in postgres > diffing 2`] = `
                   entity.profile1.identity.links[idx_47].metas[idx_56] = null;
                 }
               });
+            } else if (data.profile1_identity.links[idx_47].metas === null) {
+              entity.profile1.identity.links[idx_47].metas = null;
             }
             if (data.profile1_identity.links[idx_47].source === null) {
     entity.profile1.identity.links[idx_47].source = null;
@@ -636,6 +646,8 @@ exports[`embedded entities in postgres > diffing 2`] = `
             entity.profile1.identity.links[idx_47] = null;
           }
         });
+      } else if (data.profile1_identity.links === null) {
+        entity.profile1.identity.links = null;
       }
       if (data.profile1_identity.source === null) {
     entity.profile1.identity.source = null;
@@ -826,6 +838,8 @@ exports[`embedded entities in postgres > diffing 2`] = `
                   entity.profile1.identity.links[idx_82].metas[idx_91] = null;
                 }
               });
+            } else if (data.profile1_identity_links[idx_82].metas === null) {
+              entity.profile1.identity.links[idx_82].metas = null;
             }
             if (data.profile1_identity_links[idx_82].source === null) {
     entity.profile1.identity.links[idx_82].source = null;
@@ -840,6 +854,8 @@ exports[`embedded entities in postgres > diffing 2`] = `
             entity.profile1.identity.links[idx_82] = null;
           }
         });
+      } else if (data.profile1_identity_links === null) {
+        entity.profile1.identity.links = null;
       }
       if (data.profile1_identity_source === null) {
     entity.profile1.identity.source = null;
@@ -1003,6 +1019,8 @@ exports[`embedded entities in postgres > diffing 2`] = `
                   entity.profile1.identity.links[idx_113].metas[idx_122] = null;
                 }
               });
+            } else if (data.profile1.identity.links[idx_113].metas === null) {
+              entity.profile1.identity.links[idx_113].metas = null;
             }
             if (data.profile1.identity.links[idx_113].source === null) {
     entity.profile1.identity.links[idx_113].source = null;
@@ -1017,6 +1035,8 @@ exports[`embedded entities in postgres > diffing 2`] = `
             entity.profile1.identity.links[idx_113] = null;
           }
         });
+      } else if (data.profile1.identity.links === null) {
+        entity.profile1.identity.links = null;
       }
       if (data.profile1.identity.source === null) {
     entity.profile1.identity.source = null;
@@ -1171,6 +1191,8 @@ exports[`embedded entities in postgres > diffing 2`] = `
                   entity.profile2.identity.links[idx_143].metas[idx_152] = null;
                 }
               });
+            } else if (data.profile2.identity.links[idx_143].metas === null) {
+              entity.profile2.identity.links[idx_143].metas = null;
             }
             if (data.profile2.identity.links[idx_143].source === null) {
     entity.profile2.identity.links[idx_143].source = null;
@@ -1185,6 +1207,8 @@ exports[`embedded entities in postgres > diffing 2`] = `
             entity.profile2.identity.links[idx_143] = null;
           }
         });
+      } else if (data.profile2.identity.links === null) {
+        entity.profile2.identity.links = null;
       }
       if (data.profile2.identity.source === null) {
     entity.profile2.identity.source = null;

--- a/tests/features/embeddables/__snapshots__/nested-embeddables.postgres.test.ts.snap
+++ b/tests/features/embeddables/__snapshots__/nested-embeddables.postgres.test.ts.snap
@@ -39,6 +39,7 @@ exports[`embedded entities in postgres > diffing 1`] = `
         if (typeof entity.profile1.identity.meta.bar !== 'undefined') ret.profile1_identity_meta_bar = clone(entity.profile1.identity.meta.bar);
       }
 
+      if (entity.profile1.identity.links === null) ret.profile1_identity_links = null;
       if (Array.isArray(entity.profile1.identity.links)) {
         ret.profile1_identity_links = [];
         entity.profile1.identity.links.forEach((_, idx_0) => {
@@ -56,6 +57,7 @@ exports[`embedded entities in postgres > diffing 1`] = `
               if (typeof entity.profile1.identity.links[idx_0].meta.bar !== 'undefined') ret.profile1_identity_links[idx_0].meta.bar = clone(entity.profile1.identity.links[idx_0].meta.bar);
             }
 
+            if (entity.profile1.identity.links[idx_0].metas === null) ret.profile1_identity_links[idx_0].metas = null;
             if (Array.isArray(entity.profile1.identity.links[idx_0].metas)) {
               ret.profile1_identity_links[idx_0].metas = [];
               entity.profile1.identity.links[idx_0].metas.forEach((_, idx_1) => {
@@ -95,6 +97,7 @@ exports[`embedded entities in postgres > diffing 1`] = `
         if (typeof entity.profile2.identity.meta.bar !== 'undefined') ret.profile2.identity.meta.bar = clone(entity.profile2.identity.meta.bar);
       }
 
+      if (entity.profile2.identity.links === null) ret.profile2.identity.links = null;
       if (Array.isArray(entity.profile2.identity.links)) {
         ret.profile2.identity.links = [];
         entity.profile2.identity.links.forEach((_, idx_2) => {
@@ -112,6 +115,7 @@ exports[`embedded entities in postgres > diffing 1`] = `
               if (typeof entity.profile2.identity.links[idx_2].meta.bar !== 'undefined') ret.profile2.identity.links[idx_2].meta.bar = clone(entity.profile2.identity.links[idx_2].meta.bar);
             }
 
+            if (entity.profile2.identity.links[idx_2].metas === null) ret.profile2.identity.links[idx_2].metas = null;
             if (Array.isArray(entity.profile2.identity.links[idx_2].metas)) {
               ret.profile2.identity.links[idx_2].metas = [];
               entity.profile2.identity.links[idx_2].metas.forEach((_, idx_3) => {

--- a/tests/features/embeddables/__snapshots__/polymorphic-embedded-entities.sqlite.test.ts.snap
+++ b/tests/features/embeddables/__snapshots__/polymorphic-embedded-entities.sqlite.test.ts.snap
@@ -590,6 +590,8 @@ exports[`polymorphic embeddables in sqlite > diffing 1`] = `
         entity.pets[idx_62] = null;
       }
     });
+  } else if (data.pets === null) {
+    entity.pets = null;
   }
 }"
 `;
@@ -648,6 +650,7 @@ exports[`polymorphic embeddables in sqlite > diffing 2`] = `
     ret.pet2 = cloneEmbeddable(ret.pet2);
   }
 
+  if (entity.pets === null) ret.pets = null;
   if (Array.isArray(entity.pets)) {
     ret.pets = [];
     entity.pets.forEach((_, idx_0) => {

--- a/tests/issues/GH8045.test.ts
+++ b/tests/issues/GH8045.test.ts
@@ -1,0 +1,66 @@
+import { MikroORM } from '@mikro-orm/sqlite';
+import {
+  Embeddable,
+  Embedded,
+  Entity,
+  PrimaryKey,
+  Property,
+  ReflectMetadataProvider,
+} from '@mikro-orm/decorators/legacy';
+
+@Embeddable()
+class Format {
+  @Property()
+  name!: string;
+}
+
+@Entity()
+class Doc {
+  @PrimaryKey()
+  id!: number;
+
+  @Embedded(() => Format, { array: true, nullable: true })
+  formats?: Format[] | null;
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    metadataProvider: ReflectMetadataProvider,
+    dbName: ':memory:',
+    entities: [Format, Doc],
+  });
+  await orm.schema.create();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+test('GH #8045 — setting a nullable embedded array to `null` is kept in the entity snapshot', async () => {
+  const em = orm.em.fork();
+  await em.insert(Doc, { id: 1, formats: [{ name: 'a' }] });
+
+  const entity = em.create(Doc, { id: 1, formats: [{ name: 'x' }] }, { persist: false });
+  entity.formats = null;
+
+  expect(em.getComparator().prepareEntity(entity)).toEqual({ id: 1, formats: null });
+
+  const qb = em.createQueryBuilder(Doc).update(entity).where({ id: 1 });
+  expect(qb.getFormattedQuery()).toBe('update `doc` set `id` = 1, `formats` = null where `id` = 1');
+  await qb.execute();
+
+  await expect(em.fork().findOne(Doc, 1)).resolves.toMatchObject({ id: 1, formats: null });
+});
+
+test('GH #8045 — flushing a nullable embedded array set to `null` persists the change', async () => {
+  const em = orm.em.fork();
+  await em.insert(Doc, { id: 2, formats: [{ name: 'a' }] });
+
+  const doc = await em.findOneOrFail(Doc, 2);
+  doc.formats = null;
+  await em.flush();
+
+  await expect(em.fork().findOne(Doc, 2)).resolves.toMatchObject({ id: 2, formats: null });
+});


### PR DESCRIPTION
Passing an entity to `qb().update()` silently dropped a nullable `array: true` embedded property that was set to `null`. The compiled snapshot guards embedded arrays with `Array.isArray()`, which is `false` for `null`, so the key never landed in the prepared data and the column was left out of the `SET` clause. Scalars and `object: true` embeddeds do handle `null` on the same path, which is where the inconsistency came from.

The hydrator had the same gap in the other direction: a `null` column ended up as `undefined` on the entity instead of `null`, so the value never round-tripped.

Closes #8045