### PR TITLE
fix(core): keep a nulled embedded array in the entity snapshot

### DIFF
--- a/packages/core/src/utils/EntityComparator.ts
+++ b/packages/core/src/utils/EntityComparator.ts
@@ -626,6 +626,8 @@ export class EntityComparator {
       ret.push(`${padding}  ret${dataKey} = cloneEmbeddable(ret${dataKey});`);
     }
 
+    ret.push(`${padding}} else if (entity${entityKey} === null) {`);
+    ret.push(`${padding}  ret${dataKey} = null;`);
     ret.push(`${padding}}`);
 
     return ret.join('\n');

--- a/tests/features/embeddables/__snapshots__/entities-in-embeddables.mongo.test.ts.snap
+++ b/tests/features/embeddables/__snapshots__/entities-in-embeddables.mongo.test.ts.snap
@@ -103,6 +103,8 @@ exports[`embedded entities in mongo > diffing 1`] = `
                 
                 }
               });
+            } else if (entity.profile1.identity.links[idx_0].metas === null) {
+              ret.profile1_identity_links[idx_0].metas = null;
             }
 
             if (typeof entity.profile1 !== 'undefined' && typeof entity.profile1.identity !== 'undefined' && typeof entity.profile1.identity.links !== 'undefined') {
@@ -118,6 +120,8 @@ exports[`embedded entities in mongo > diffing 1`] = `
           }
         });
         ret.profile1_identity_links = cloneEmbeddable(ret.profile1_identity_links);
+      } else if (entity.profile1.identity.links === null) {
+        ret.profile1_identity_links = null;
       }
 
       if (typeof entity.profile1 !== 'undefined' && typeof entity.profile1.identity !== 'undefined') {
@@ -219,6 +223,8 @@ exports[`embedded entities in mongo > diffing 1`] = `
                 
                 }
               });
+            } else if (entity.profile2.identity.links[idx_2].metas === null) {
+              ret.profile2.identity.links[idx_2].metas = null;
             }
 
             if (typeof entity.profile2 !== 'undefined' && typeof entity.profile2.identity !== 'undefined' && typeof entity.profile2.identity.links !== 'undefined') {
@@ -233,6 +239,8 @@ exports[`embedded entities in mongo > diffing 1`] = `
           
           }
         });
+      } else if (entity.profile2.identity.links === null) {
+        ret.profile2.identity.links = null;
       }
 
       if (typeof entity.profile2 !== 'undefined' && typeof entity.profile2.identity !== 'undefined') {

--- a/tests/features/embeddables/__snapshots__/entities-in-embeddables.postgres.test.ts.snap
+++ b/tests/features/embeddables/__snapshots__/entities-in-embeddables.postgres.test.ts.snap
@@ -103,6 +103,8 @@ exports[`embedded entities in postgres > diffing 1`] = `
                 
                 }
               });
+            } else if (entity.profile1.identity.links[idx_0].metas === null) {
+              ret.profile1_identity_links[idx_0].metas = null;
             }
 
             if (typeof entity.profile1 !== 'undefined' && typeof entity.profile1.identity !== 'undefined' && typeof entity.profile1.identity.links !== 'undefined') {
@@ -118,6 +120,8 @@ exports[`embedded entities in postgres > diffing 1`] = `
           }
         });
         ret.profile1_identity_links = cloneEmbeddable(ret.profile1_identity_links);
+      } else if (entity.profile1.identity.links === null) {
+        ret.profile1_identity_links = null;
       }
 
       if (typeof entity.profile1 !== 'undefined' && typeof entity.profile1.identity !== 'undefined') {
@@ -219,6 +223,8 @@ exports[`embedded entities in postgres > diffing 1`] = `
                 
                 }
               });
+            } else if (entity.profile2.identity.links[idx_2].metas === null) {
+              ret.profile2.identity.links[idx_2].metas = null;
             }
 
             if (typeof entity.profile2 !== 'undefined' && typeof entity.profile2.identity !== 'undefined' && typeof entity.profile2.identity.links !== 'undefined') {
@@ -233,6 +239,8 @@ exports[`embedded entities in postgres > diffing 1`] = `
           
           }
         });
+      } else if (entity.profile2.identity.links === null) {
+        ret.profile2.identity.links = null;
       }
 
       if (typeof entity.profile2 !== 'undefined' && typeof entity.profile2.identity !== 'undefined') {

--- a/tests/features/embeddables/__snapshots__/nested-embeddables.postgres.test.ts.snap
+++ b/tests/features/embeddables/__snapshots__/nested-embeddables.postgres.test.ts.snap
@@ -67,11 +67,15 @@ exports[`embedded entities in postgres > diffing 1`] = `
                   if (typeof entity.profile1.identity.links[idx_0].metas[idx_1].bar !== 'undefined') ret.profile1_identity_links[idx_0].metas[idx_1].bar = clone(entity.profile1.identity.links[idx_0].metas[idx_1].bar);
                 }
               });
+            } else if (entity.profile1.identity.links[idx_0].metas === null) {
+              ret.profile1_identity_links[idx_0].metas = null;
             }
 
           }
         });
         ret.profile1_identity_links = cloneEmbeddable(ret.profile1_identity_links);
+      } else if (entity.profile1.identity.links === null) {
+        ret.profile1_identity_links = null;
       }
 
     }
@@ -123,10 +127,14 @@ exports[`embedded entities in postgres > diffing 1`] = `
                   if (typeof entity.profile2.identity.links[idx_2].metas[idx_3].bar !== 'undefined') ret.profile2.identity.links[idx_2].metas[idx_3].bar = clone(entity.profile2.identity.links[idx_2].metas[idx_3].bar);
                 }
               });
+            } else if (entity.profile2.identity.links[idx_2].metas === null) {
+              ret.profile2.identity.links[idx_2].metas = null;
             }
 
           }
         });
+      } else if (entity.profile2.identity.links === null) {
+        ret.profile2.identity.links = null;
       }
 
     }

--- a/tests/features/embeddables/__snapshots__/polymorphic-embedded-entities.sqlite.test.ts.snap
+++ b/tests/features/embeddables/__snapshots__/polymorphic-embedded-entities.sqlite.test.ts.snap
@@ -670,6 +670,8 @@ exports[`polymorphic embeddables in sqlite > diffing 2`] = `
       }
     });
     ret.pets = cloneEmbeddable(ret.pets);
+  } else if (entity.pets === null) {
+    ret.pets = null;
   }
 
   return ret;

--- a/tests/issues/GH8045.test.ts
+++ b/tests/issues/GH8045.test.ts
@@ -1,0 +1,62 @@
+import { MikroORM } from '@mikro-orm/sqlite';
+import {
+  Embeddable,
+  Embedded,
+  Entity,
+  PrimaryKey,
+  Property,
+  ReflectMetadataProvider,
+} from '@mikro-orm/decorators/legacy';
+
+@Embeddable()
+class Format {
+  @Property()
+  name: string;
+
+  constructor(name: string) {
+    this.name = name;
+  }
+}
+
+@Entity()
+class Doc {
+  @PrimaryKey()
+  id!: number;
+
+  @Embedded(() => Format, { array: true, nullable: true })
+  formats: Format[] | null;
+
+  constructor(id: number, formats: Format[] | null) {
+    this.id = id;
+    this.formats = formats;
+  }
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    metadataProvider: ReflectMetadataProvider,
+    dbName: ':memory:',
+    entities: [Doc],
+  });
+  await orm.schema.refresh();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+test('nulling a nullable embedded array on an entity instance is included in the update', async () => {
+  await orm.em.insert(Doc, { id: 1, formats: [{ name: 'a' }] });
+
+  const entity = await orm.em.fork().findOneOrFail(Doc, 1);
+  entity.formats = null;
+
+  expect(orm.em.getComparator().prepareEntity(entity)).toEqual({ id: 1, formats: null });
+
+  await orm.em.createQueryBuilder(Doc).update(entity).where({ id: 1 }).execute();
+
+  const rows = await orm.em.getConnection().execute('select * from doc');
+  expect(rows).toEqual([{ id: 1, formats: null }]);
+});


### PR DESCRIPTION
Passing an entity instance to `qb().update()` routes it through `EntityComparator.prepareEntity`. The snapshot generated for a nullable `array: true` embedded property only covered the `Array.isArray` case, so setting the property to `null` fell through without any branch. The key never landed in the prepared data, the column dropped out of the `SET` clause, and the stale value stayed in the database.

Scalar and `object: true` embedded properties already keep their `null`, and a plain object payload with `formats: null` writes it correctly, so only the entity-instance array path was affected. The array branch now handles `null` the same way, recording `null` for the key.

Closes #8045