### PR TITLE
fix(entity-generator): correctly escape generated string literals and keys

### DIFF
--- a/packages/entity-generator/src/EntitySchemaSourceFile.ts
+++ b/packages/entity-generator/src/EntitySchemaSourceFile.ts
@@ -95,7 +95,7 @@ export class EntitySchemaSourceFile extends SourceFile {
     }
 
     if (primaryProps.length > 0) {
-      const primaryPropNames = primaryProps.map(prop => `'${prop.name}'`);
+      const primaryPropNames = primaryProps.map(prop => this.quoteKey(prop.name));
 
       if (primaryProps.length > 1) {
         classBody += `${' '.repeat(2)}[${this.referenceCoreImport('PrimaryKeyProp')}]?: [${primaryPropNames.join(', ')}];\n`;
@@ -105,7 +105,7 @@ export class EntitySchemaSourceFile extends SourceFile {
     }
 
     if (eagerProperties.length > 0) {
-      const eagerPropertyNames = eagerProperties.map(prop => `'${prop.name}'`).sort();
+      const eagerPropertyNames = eagerProperties.map(prop => this.quoteKey(prop.name)).sort();
       classBody += `${' '.repeat(2)}[${this.referenceCoreImport('EagerProps')}]?: ${eagerPropertyNames.join(' | ')};\n`;
     }
 

--- a/packages/entity-generator/src/NativeEnumSourceFile.ts
+++ b/packages/entity-generator/src/NativeEnumSourceFile.ts
@@ -40,9 +40,9 @@ export class NativeEnumSourceFile extends SourceFile {
       );
 
       if (enumMode === 'dictionary') {
-        ret += `${padding}${identifierRegex.test(enumName) ? enumName : this.quote(enumName)}: ${this.quote(enumValue)},\n`;
+        ret += `${padding}${identifierRegex.test(enumName) ? enumName : this.quoteKey(enumName)}: ${this.quote(enumValue)},\n`;
       } else {
-        ret += `${padding}${identifierRegex.test(enumName) ? enumName : this.quote(enumName)} = ${this.quote(enumValue)},\n`;
+        ret += `${padding}${identifierRegex.test(enumName) ? enumName : this.quoteKey(enumName)} = ${this.quote(enumValue)},\n`;
       }
     }
 

--- a/packages/entity-generator/src/SourceFile.ts
+++ b/packages/entity-generator/src/SourceFile.ts
@@ -113,7 +113,7 @@ export class SourceFile {
     });
 
     if (primaryProps.length > 0) {
-      const primaryPropNames = primaryProps.map(prop => `'${prop.name}'`);
+      const primaryPropNames = primaryProps.map(prop => this.quoteKey(prop.name));
 
       if (primaryProps.length > 1) {
         classHead += `\n${' '.repeat(2)}[${this.referenceCoreImport('PrimaryKeyProp')}]?: [${primaryPropNames.join(', ')}];\n`;
@@ -123,7 +123,7 @@ export class SourceFile {
     }
 
     if (eagerProperties.length > 0) {
-      const eagerPropertyNames = eagerProperties.map(prop => `'${prop.name}'`).sort();
+      const eagerPropertyNames = eagerProperties.map(prop => this.quoteKey(prop.name)).sort();
       classHead += `\n${' '.repeat(2)}[${this.referenceCoreImport('EagerProps')}]?: ${eagerPropertyNames.join(' | ')};\n`;
     }
 
@@ -315,24 +315,24 @@ export class SourceFile {
         if (file.name === '') {
           continue;
         }
-        importMap.set(file.path, `import ${this.quote(file.name)};`);
+        importMap.set(file.path, `import ${this.quoteKey(file.name)};`);
         continue;
       }
       if (file.name === '') {
-        importMap.set(file.path, `import * as ${entity} from ${this.quote(file.path)};`);
+        importMap.set(file.path, `import * as ${entity} from ${this.quoteKey(file.path)};`);
         continue;
       }
       if (file.name === 'default') {
-        importMap.set(file.path, `import ${entity} from ${this.quote(file.path)};`);
+        importMap.set(file.path, `import ${entity} from ${this.quoteKey(file.path)};`);
         continue;
       }
       if (file.name === entity) {
-        importMap.set(file.path, `import { ${entity} } from ${this.quote(file.path)};`);
+        importMap.set(file.path, `import { ${entity} } from ${this.quoteKey(file.path)};`);
         continue;
       }
       importMap.set(
         file.path,
-        `import { ${identifierRegex.test(file.name) ? file.name : this.quote(file.name)} as ${entity} } from ${this.quote(file.path)};`,
+        `import { ${identifierRegex.test(file.name) ? file.name : this.quoteKey(file.name)} as ${entity} } from ${this.quoteKey(file.path)};`,
       );
     }
 
@@ -342,7 +342,7 @@ export class SourceFile {
           path: `${basePath}/${this.options.fileName!(name)}${extension}`,
           name,
         };
-        importMap.set(file.path, `import { ${exports.join(', ')} } from ${this.quote(file.path)};`);
+        importMap.set(file.path, `import { ${exports.join(', ')} } from ${this.quoteKey(file.path)};`);
       }
     }
 
@@ -375,13 +375,30 @@ export class SourceFile {
 
   protected quote(val: string) {
     const backtick = val.startsWith(`'`) || val.includes('\n');
-    /* v8 ignore next */
-    return backtick ? `\`${val.replaceAll('`', '\\``')}\`` : `'${val.replaceAll(`'`, `\\'`)}'`;
+    // Backslashes first, so the escapes added below don't get neutralized by a preceding `\`.
+    // A raw `\r` is a syntax error in a string literal and silently normalizes to `\n` in a template one.
+    const escaped = val.replaceAll('\\', '\\\\').replaceAll('\r', '\\r');
+
+    return backtick
+      ? `\`${escaped.replaceAll('`', '\\`').replaceAll('${', '\\${')}\``
+      : `'${escaped.replaceAll(`'`, `\\'`)}'`;
+  }
+
+  /** For positions that reject a template literal: object keys, import bindings/specifiers, string literal types. */
+  protected quoteKey(val: string) {
+    const escaped = val
+      .replaceAll('\\', '\\\\')
+      .replaceAll('\r', '\\r')
+      .replaceAll('\n', '\\n')
+      .replaceAll('\t', '\\t')
+      .replaceAll(`'`, `\\'`);
+
+    return `'${escaped}'`;
   }
 
   protected getPropertyDefinition(prop: EntityProperty, padLeft: number): string {
     const padding = ' '.repeat(padLeft);
-    const propName = identifierRegex.test(prop.name) ? prop.name : this.quote(prop.name);
+    const propName = identifierRegex.test(prop.name) ? prop.name : this.quoteKey(prop.name);
     const enumMode = this.options.enumMode;
     let hiddenType = '';
 
@@ -557,9 +574,9 @@ export class SourceFile {
       );
 
       if (enumMode === 'dictionary') {
-        ret += `${padding}${identifierRegex.test(enumName) ? enumName : this.quote(enumName)}: ${formatValue(enumValue)},\n`;
+        ret += `${padding}${identifierRegex.test(enumName) ? enumName : this.quoteKey(enumName)}: ${formatValue(enumValue)},\n`;
       } else {
-        ret += `${padding}${identifierRegex.test(enumName) ? enumName : this.quote(enumName)} = ${formatValue(enumValue)},\n`;
+        ret += `${padding}${identifierRegex.test(enumName) ? enumName : this.quoteKey(enumName)} = ${formatValue(enumValue)},\n`;
       }
     }
 
@@ -592,7 +609,7 @@ export class SourceFile {
     const entries = Object.entries(options);
     return `{${doIndent ? `\n${' '.repeat(spaces)}` : ' '}${entries
       .map(([opt, val]) => {
-        const key = identifierRegex.test(opt) ? opt : this.quote(opt);
+        const key = identifierRegex.test(opt) ? opt : this.quoteKey(opt);
         return `${doIndent ? ' '.repeat(level * 2 + (spaces + 2)) : ''}${key}: ${this.serializeValue(val, typeof nextWordwrap === 'number' ? nextWordwrap - key.length - 2 /* ': '.length*/ : undefined, doIndent ? spaces : undefined, level + 1)}`;
       })
       .join(sep)}${doIndent ? `${entries.length > 0 ? ',\n' : ''}${' '.repeat(spaces + level * 2)}` : ' '}}`;
@@ -869,7 +886,8 @@ export class SourceFile {
         prop.defaultRaw !== '' &&
         prop.defaultRaw !== (typeof prop.default === 'string' ? this.quote(prop.default) : `${prop.default}`)
       ) {
-        options.defaultRaw = `\`${prop.defaultRaw}\``;
+        // kept as a template literal for readability, but raw SQL may contain `${`, which would otherwise interpolate
+        options.defaultRaw = `\`${prop.defaultRaw.replaceAll('\\', '\\\\').replaceAll('`', '\\`').replaceAll('${', '\\${')}\``;
       } else if (
         !(typeof prop.default === 'undefined' || prop.default === null) &&
         (prop.ref ||

--- a/tests/features/entity-generator/NativeEnumSourceFile.test.ts
+++ b/tests/features/entity-generator/NativeEnumSourceFile.test.ts
@@ -1,0 +1,61 @@
+import { type NamingStrategy, type Platform, UnderscoreNamingStrategy } from '@mikro-orm/core';
+import { NativeEnumSourceFile } from '../../../packages/entity-generator/src/NativeEnumSourceFile.js';
+
+describe('NativeEnumSourceFile', () => {
+  const namingStrategy: NamingStrategy = new UnderscoreNamingStrategy();
+  const platform = {} as Platform;
+
+  const createSourceFile = (items: string[], enumMode: 'union-type' | 'dictionary' = 'union-type') =>
+    new NativeEnumSourceFile({} as any, namingStrategy, platform, { enumMode, fileName: (n: string) => n } as any, {
+      name: 'status',
+      items,
+    });
+
+  it('escapes backslashes so a trailing `\\` cannot terminate the literal early', () => {
+    const source = createSourceFile([String.raw`ok`, String.raw`x\'`]).generate();
+
+    expect(source).toMatchInlineSnapshot(`
+      "export type TStatus = 'ok' | 'x\\\\\\'';
+      "
+    `);
+  });
+
+  it('escapes backticks and ${} when a newline forces the template-literal branch', () => {
+    const source = createSourceFile(['a`b', 'c\n${d}', "'a`b"]).generate();
+
+    expect(source).toMatchInlineSnapshot(`
+      "export type TStatus = 'a\`b' | \`c
+      \\\${d}\` | \`'a\\\`b\`;
+      "
+    `);
+  });
+
+  it('round-trips every label through the generated literal', () => {
+    const items = [
+      String.raw`x\'`,
+      'a`b',
+      "it's",
+      'c\n${d}',
+      String.raw`back\\slash`,
+      "'leading quote",
+      "'a`b",
+      'a\rb',
+      'a\r\nb',
+    ];
+
+    for (const item of items) {
+      const source = createSourceFile([item]).generate();
+      const literal = source.slice(source.indexOf(' = ') + 3, source.lastIndexOf(';'));
+
+      expect(new Function(`return ${literal}`)()).toBe(item);
+    }
+  });
+
+  it('emits string-literal keys for labels that are not valid identifiers', () => {
+    const items = [String.raw`x\'`, 'a`b', 'c\n${d}', "'leading quote", 'a\rb', 'a\tb'];
+    const source = createSourceFile(items, 'dictionary').generate();
+    const expression = source.slice(source.indexOf('{'), source.lastIndexOf('} as const;') + 1);
+
+    expect(Object.values(new Function(`return ${expression}`)())).toEqual(items);
+  });
+});

--- a/tests/features/entity-generator/__snapshots__/OddTableNames.postgres.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/OddTableNames.postgres.test.ts.snap
@@ -127,7 +127,7 @@ export class Table$39s$32name$32has$32apostrophe$44$32Also$32$96$96$32this {
   '!cool'!: Ref<E_$42misc>;
 
   @Property({ length: 45, nullable: true })
-  \`'derive\`?: string;
+  '\\'derive'?: string;
 
   @OneToMany({ entity: () => E123TableName, mappedBy: 'prototype' })
   e123TableNameCollection = new Collection<E123TableName>(this);
@@ -311,7 +311,7 @@ import { E_$42misc } from './E_$42misc';
 export class Table$39s$32name$32has$32apostrophe$44$32Also$32$96$96$32this {
   [PrimaryKeyProp]?: '!cool';
   '!cool'!: Ref<E_$42misc>;
-  \`'derive\`?: string;
+  '\\'derive'?: string;
   e123TableNameCollection = new Collection<E123TableName>(this);
 }
 
@@ -329,7 +329,7 @@ export const Table$39s$32name$32has$32apostrophe$44$32Also$32$96$96$32thisSchema
       updateRule: 'no action',
       deleteRule: 'no action',
     },
-    \`'derive\`: {
+    '\\'derive': {
       type: 'string',
       length: 45,
       nullable: true,


### PR DESCRIPTION
`SourceFile#quote()` escaped single quotes but not backslashes, so a value ending in `\` combined with the escape it inserted and closed the literal early. The same helper left `${` unescaped in its template-literal branch, mangled any value containing a backtick, and produced a raw `\r` that either fails to parse or silently normalizes to `\n`.

These strings come from schema introspection (column and table comments, native enum labels, column defaults, collations, index expressions), so the generated file could fail to compile or, in the `${}` case, evaluate an expression on import.

Object keys, named import bindings and module specifiers accept a string literal but never a template literal. Those positions now use a dedicated `quoteKey()` helper. This was already producing broken output: the postgres fixture has a column named `'derive`, and the committed snapshot showed it emitted as a template-literal class property name, which does not compile. That snapshot is updated here.

`RoutineSourceFile` already handled all of this correctly; this brings `SourceFile` in line.
