### PR TITLE
fix(libsql): stop recycling local connections every 10 seconds

### DIFF
--- a/packages/libsql/src/LibSqlConnection.ts
+++ b/packages/libsql/src/LibSqlConnection.ts
@@ -23,13 +23,15 @@ export class LibSqlConnection extends BaseSqliteConnection {
       },
       onCreateConnection: this.options.onCreateConnection ?? this.config.get('onCreateConnection'),
       recycleConnection: !!options.syncUrl || REMOTE_URL.test(dbName),
-      // the replacement connection starts blank, so run the setup straight on it, bypassing the held mutex
-      onRecycleConnection: async () => {
-        for (const sql of await this.getConnectionSetupSql()) {
-          this.database.exec(sql);
-        }
-      },
+      onRecycleConnection: this.replayConnectionSetup.bind(this),
     });
+  }
+
+  /** Restores the state a recycled connection was replaced with, run on the raw handle to skip the held mutex. */
+  protected async replayConnectionSetup(): Promise<void> {
+    for (const sql of await this.getConnectionSetupSql()) {
+      this.database.exec(sql);
+    }
   }
 
   /** libsql's `Database.function()` is declared but throws "not implemented"; better-sqlite3 has the UDF bridge. */

--- a/packages/libsql/src/LibSqlConnection.ts
+++ b/packages/libsql/src/LibSqlConnection.ts
@@ -3,6 +3,8 @@ import Database, { type Options } from 'libsql';
 import type { Routine, Transaction } from '@mikro-orm/core';
 import { LibSqlDialect } from './LibSqlDialect.js';
 
+const REMOTE_URL = /^(https?|libsql):\/\//;
+
 /** libSQL database connection supporting both local and remote databases. */
 export class LibSqlConnection extends BaseSqliteConnection {
   private database!: Database.Database;
@@ -20,6 +22,13 @@ export class LibSqlConnection extends BaseSqliteConnection {
         return (this.database = new Database(dbName, options));
       },
       onCreateConnection: this.options.onCreateConnection ?? this.config.get('onCreateConnection'),
+      recycleConnection: !!options.syncUrl || REMOTE_URL.test(dbName),
+      // the replacement connection starts blank, so run the setup straight on it, bypassing the held mutex
+      onRecycleConnection: async () => {
+        for (const sql of await this.getConnectionSetupSql()) {
+          this.database.exec(sql);
+        }
+      },
     });
   }
 
@@ -42,7 +51,7 @@ export class LibSqlConnection extends BaseSqliteConnection {
       return;
     }
     const dbName = this.config.get('dbName') as string;
-    if (/^(https?|libsql):\/\//.exec(dbName)) {
+    if (REMOTE_URL.test(dbName)) {
       throw new Error(
         'ATTACH DATABASE is not supported for remote libSQL connections. ' + 'Use local file-based databases only.',
       );

--- a/packages/libsql/src/LibSqlDialect.ts
+++ b/packages/libsql/src/LibSqlDialect.ts
@@ -9,6 +9,19 @@ import {
 
 const CONNECTION_TIMEOUT = 10_000;
 
+/** Kysely SQLite dialect config extended with the connection recycling libSQL needs for embedded replicas. */
+export interface LibSqlDialectConfig extends SqliteDialectConfig {
+  /**
+   * Recreates the underlying connection once it gets stale. Embedded replicas swap the local file out when
+   * syncing, so a long lived handle would keep serving the pre-sync data. A plain local database never goes
+   * stale, and recycling it would silently drop per-connection state like pragmas and attached databases.
+   */
+  recycleConnection?: boolean;
+
+  /** Re-applies the per-connection state after a stale connection was replaced. */
+  onRecycleConnection?: () => Promise<void>;
+}
+
 class ConnectionMutex {
   #promise?: Promise<void>;
   #resolve?: () => void;
@@ -35,7 +48,6 @@ class ConnectionMutex {
 
 class LibSqlConnection implements DatabaseConnection {
   readonly #created = Date.now();
-  declare memory: boolean;
   readonly #db: SqliteDatabase;
 
   constructor(db: SqliteDatabase) {
@@ -43,7 +55,7 @@ class LibSqlConnection implements DatabaseConnection {
   }
 
   isValid(): boolean {
-    return this.memory || this.#created > Date.now() - CONNECTION_TIMEOUT;
+    return this.#created > Date.now() - CONNECTION_TIMEOUT;
   }
 
   async executeQuery<R>(compiledQuery: any): Promise<QueryResult<R>> {
@@ -97,9 +109,9 @@ class LibSqlKyselyDriver extends SqliteDriver {
   #db!: SqliteDatabase;
   #connection!: LibSqlConnection;
   #connectionMutex = new ConnectionMutex();
-  readonly #config: SqliteDialectConfig;
+  readonly #config: LibSqlDialectConfig;
 
-  constructor(config: SqliteDialectConfig) {
+  constructor(config: LibSqlDialectConfig) {
     super(config);
     this.#config = config;
   }
@@ -117,10 +129,10 @@ class LibSqlKyselyDriver extends SqliteDriver {
   override async acquireConnection() {
     await this.#connectionMutex.lock();
 
-    /* v8 ignore next */
-    if (!this.#connection.isValid()) {
+    if (this.#config.recycleConnection && !this.#connection.isValid()) {
       await this.destroy();
       await this.init();
+      await this.#config.onRecycleConnection?.();
     }
 
     return this.#connection;
@@ -137,9 +149,9 @@ class LibSqlKyselyDriver extends SqliteDriver {
 
 /** Kysely dialect adapter for libSQL. */
 export class LibSqlDialect extends SqliteDialect {
-  readonly #config: SqliteDialectConfig;
+  readonly #config: LibSqlDialectConfig;
 
-  constructor(config: SqliteDialectConfig) {
+  constructor(config: LibSqlDialectConfig) {
     super(config);
     this.#config = config;
   }

--- a/packages/sql/src/dialects/sqlite/BaseSqliteConnection.ts
+++ b/packages/sql/src/dialects/sqlite/BaseSqliteConnection.ts
@@ -2,6 +2,8 @@ import { CompiledQuery, type Dialect } from 'kysely';
 import type { Dictionary } from '@mikro-orm/core';
 import { AbstractSqlConnection } from '../../AbstractSqlConnection.js';
 
+const FOREIGN_KEYS_PRAGMA = 'pragma foreign_keys = on';
+
 export class BaseSqliteConnection extends AbstractSqlConnection {
   override createKyselyDialect(options: Dictionary): Dialect {
     throw new Error(
@@ -12,23 +14,34 @@ export class BaseSqliteConnection extends AbstractSqlConnection {
 
   override async connect(options?: { skipOnConnect?: boolean }): Promise<void> {
     await super.connect(options);
-    await this.getClient().executeQuery(CompiledQuery.raw('pragma foreign_keys = on'));
+    await this.getClient().executeQuery(CompiledQuery.raw(FOREIGN_KEYS_PRAGMA));
     await this.attachDatabases();
   }
 
   protected async attachDatabases(): Promise<void> {
+    for (const sql of await this.getAttachDatabasesSql()) {
+      await this.execute(sql);
+    }
+  }
+
+  /** Per-connection state, lost whenever the underlying connection is recreated, so it has to be replayed. */
+  protected async getConnectionSetupSql(): Promise<string[]> {
+    return [FOREIGN_KEYS_PRAGMA, ...(await this.getAttachDatabasesSql())];
+  }
+
+  private async getAttachDatabasesSql(): Promise<string[]> {
     const attachDatabases = this.config.get('attachDatabases');
 
     if (!attachDatabases?.length) {
-      return;
+      return [];
     }
 
     const { fs } = await import('@mikro-orm/core/fs-utils');
     const baseDir = this.config.get('baseDir');
 
-    for (const db of attachDatabases) {
+    return attachDatabases.map(db => {
       const path = fs.absolutePath(db.path, baseDir);
-      await this.execute(`attach database '${path}' as ${this.platform.quoteIdentifier(db.name)}`);
-    }
+      return `attach database '${path}' as ${this.platform.quoteIdentifier(db.name)}`;
+    });
   }
 }

--- a/tests/features/attach-database/attach-database.sqlite.test.ts
+++ b/tests/features/attach-database/attach-database.sqlite.test.ts
@@ -476,10 +476,12 @@ describe('ATTACH DATABASE - libSQL connection lifetime', () => {
 
   test('the connection setup SQL covers the pragmas and the attached databases', async () => {
     const connection = orm.em.getConnection() as any;
+    // the paths are normalized to forward slashes, so compare them that way to stay portable
+    const setupSql = ((await connection.getConnectionSetupSql()) as string[]).map(sql => sql.replaceAll('\\', '/'));
 
-    await expect(connection.getConnectionSetupSql()).resolves.toEqual([
+    expect(setupSql).toEqual([
       'pragma foreign_keys = on',
-      `attach database '${join(tempDir, 'lifetime.db')}' as \`lifetime_db\``,
+      `attach database '${join(tempDir, 'lifetime.db').replaceAll('\\', '/')}' as \`lifetime_db\``,
     ]);
   });
 });

--- a/tests/features/attach-database/attach-database.sqlite.test.ts
+++ b/tests/features/attach-database/attach-database.sqlite.test.ts
@@ -484,6 +484,21 @@ describe('ATTACH DATABASE - libSQL connection lifetime', () => {
       `attach database '${join(tempDir, 'lifetime.db').replaceAll('\\', '/')}' as \`lifetime_db\``,
     ]);
   });
+
+  test('replaying the setup restores the state a recycled connection lost', async () => {
+    const connection = orm.em.getConnection();
+    // a recycled connection comes back blank, which detaching reproduces without a Turso endpoint
+    await connection.execute('detach database lifetime_db');
+    await connection.execute('pragma foreign_keys = off');
+
+    await (connection as any).replayConnectionSetup();
+
+    expect((await connection.execute<{ name: string }[]>('pragma database_list')).map(d => d.name)).toContain(
+      'lifetime_db',
+    );
+    expect(await connection.execute<{ foreign_keys: number }[]>('pragma foreign_keys')).toEqual([{ foreign_keys: 1 }]);
+    await expect(orm.em.fork().count(LifetimeTestEntity)).resolves.toBeGreaterThanOrEqual(0);
+  });
 });
 
 describe('ATTACH DATABASE - libSQL remote validation', () => {

--- a/tests/features/attach-database/attach-database.sqlite.test.ts
+++ b/tests/features/attach-database/attach-database.sqlite.test.ts
@@ -363,6 +363,15 @@ class RemoteTestEntity {
   id!: number;
 }
 
+@Entity({ schema: 'lifetime_db' })
+class LifetimeTestEntity {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  value!: string;
+}
+
 describe('ATTACH DATABASE - relative path resolution', () => {
   const tempDir = join(tmpdir(), `mikro-orm-attach-relpath-${Date.now()}`);
   let orm: MikroORM<SqliteDriver>;
@@ -410,6 +419,68 @@ describe('ATTACH DATABASE - relative path resolution', () => {
     const databases = await connection.execute<{ name: string }[]>('pragma database_list');
     const dbNames = databases.map(d => d.name);
     expect(dbNames).toContain('attached_db');
+  });
+});
+
+describe('ATTACH DATABASE - libSQL connection lifetime', () => {
+  const tempDir = join(tmpdir(), `mikro-orm-attach-lifetime-${Date.now()}`);
+  let orm: MikroORM<LibSqlDriver>;
+
+  beforeAll(async () => {
+    if (!existsSync(tempDir)) {
+      mkdirSync(tempDir, { recursive: true });
+    }
+
+    orm = await MikroORM.init({
+      entities: [LifetimeTestEntity],
+      dbName: join(tempDir, 'main.db'),
+      driver: LibSqlDriver,
+      metadataProvider: ReflectMetadataProvider,
+      logger: i => i,
+      loggerFactory: SimpleLogger.create,
+      attachDatabases: [{ name: 'lifetime_db', path: join(tempDir, 'lifetime.db') }],
+    });
+    await orm.schema.create();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  afterAll(async () => {
+    await orm?.close(true);
+    // Clean up temp directory - ignore errors on Windows where files may still be locked
+    try {
+      rmSync(tempDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+    } catch {
+      // noop
+    }
+  });
+
+  test('attached databases survive a long-lived connection', async () => {
+    const connection = orm.em.getConnection();
+    expect((await connection.execute<{ name: string }[]>('pragma database_list')).map(d => d.name)).toContain(
+      'lifetime_db',
+    );
+
+    // the connection used to be recycled after 10s, silently dropping the attached databases
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(Date.now() + 60_000);
+
+    expect((await connection.execute<{ name: string }[]>('pragma database_list')).map(d => d.name)).toContain(
+      'lifetime_db',
+    );
+    await orm.em.insert(LifetimeTestEntity, { value: 'foo' });
+    expect(await orm.em.count(LifetimeTestEntity)).toBe(1);
+  });
+
+  test('the connection setup SQL covers the pragmas and the attached databases', async () => {
+    const connection = orm.em.getConnection() as any;
+
+    await expect(connection.getConnectionSetupSql()).resolves.toEqual([
+      'pragma foreign_keys = on',
+      `attach database '${join(tempDir, 'lifetime.db')}' as \`lifetime_db\``,
+    ]);
   });
 });
 

--- a/tests/features/libsql/connection-recycling.sqlite.test.ts
+++ b/tests/features/libsql/connection-recycling.sqlite.test.ts
@@ -1,0 +1,57 @@
+import type { SqliteDatabase } from 'kysely';
+import { LibSqlDialect } from '../../../packages/libsql/src/LibSqlDialect.js';
+
+function mockDialect(recycleConnection: boolean) {
+  let opened = 0;
+  let setUp = 0;
+  const database = async () => {
+    opened++;
+    return { prepare: () => ({ reader: true, all: () => [] }), close: () => undefined } as unknown as SqliteDatabase;
+  };
+  const dialect = new LibSqlDialect({
+    database,
+    recycleConnection,
+    onRecycleConnection: async () => {
+      setUp++;
+    },
+  });
+
+  return { dialect, opened: () => opened, setUp: () => setUp };
+}
+
+async function acquireAfter(dialect: LibSqlDialect, ms: number) {
+  const driver = dialect.createDriver();
+  await driver.init();
+  await driver.acquireConnection();
+  await driver.releaseConnection();
+
+  vi.useFakeTimers({ toFake: ['Date'] });
+  vi.setSystemTime(Date.now() + ms);
+  await driver.acquireConnection();
+  await driver.releaseConnection();
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+test('a plain local database keeps the same connection', async () => {
+  const { dialect, opened, setUp } = mockDialect(false);
+  await acquireAfter(dialect, 60_000);
+  expect(opened()).toBe(1);
+  expect(setUp()).toBe(0);
+});
+
+test('an embedded replica recycles the connection once it goes stale and re-applies its setup', async () => {
+  const { dialect, opened, setUp } = mockDialect(true);
+  await acquireAfter(dialect, 60_000);
+  expect(opened()).toBe(2);
+  expect(setUp()).toBe(1);
+});
+
+test('an embedded replica keeps the connection while it is fresh', async () => {
+  const { dialect, opened, setUp } = mockDialect(true);
+  await acquireAfter(dialect, 1_000);
+  expect(opened()).toBe(1);
+  expect(setUp()).toBe(0);
+});


### PR DESCRIPTION
Windows CI intermittently failed `attach-database.sqlite.test.ts`, but only the libSQL half of the suite. Partway through, the attached databases vanished from the connection and every query against them failed with `unknown database users_db` or `no such table`.

libSQL recreates a stale connection so embedded replicas pick up the local file that syncing swaps out. That was added in 6324487cb alongside `syncUrl`/`syncPeriod`. Two things went wrong when the check moved from knex to kysely:

- In knex, `validateConnection(connection)` received the libsql `Database`, and `connection.memory` is a real property on it. The kysely port moved the check onto the connection wrapper as `declare memory: boolean`, which is type-only and never assigned, so it always read `undefined`. The in-memory escape hatch was dead, and `:memory:` databases were being wiped every 10 seconds.
- knex only recycled pooled connections. The kysely port applied it to every libSQL connection, including plain local files, where nothing can go stale. Recycling those silently dropped `pragma foreign_keys = on` and every `ATTACH DATABASE`.

Recycling is now limited to embedded replicas (`driverOptions.syncUrl`) and remote databases, which is where it does something. The per-connection state is also replayed onto the replacement connection rather than dropped, so an embedded replica keeps its pragmas and attached databases across a recycle.

The flake only showed up on slow runs: the test file takes about 16s on Windows CI and the libSQL half starts around 9s in, crossing the 10s threshold mid-suite. Locally it finishes well under 10s.
