### PR TITLE
fix(entity-generator): sanitize file names taken from database metadata

### DIFF
--- a/packages/entity-generator/src/EntityGenerator.ts
+++ b/packages/entity-generator/src/EntityGenerator.ts
@@ -19,7 +19,7 @@ import {
   type SchemaHelper,
 } from '@mikro-orm/sql';
 import { fs } from '@mikro-orm/core/fs-utils';
-import { dirname, isAbsolute, join, relative } from 'node:path';
+import { dirname, join, relative, resolve } from 'node:path';
 import { writeFile } from 'node:fs/promises';
 import { DefineEntitySourceFile } from './DefineEntitySourceFile.js';
 import { EntitySchemaSourceFile } from './EntitySchemaSourceFile.js';
@@ -102,13 +102,15 @@ export class EntityGenerator {
     const files = this.#sources.map(file => [file.getBaseName(), file.generate()]);
 
     if (options.save) {
-      // file names can be derived from database metadata (native enum and routine names), so they
-      // are validated before anything is written, nested names are still allowed
-      for (const [fileName] of files) {
-        const relativePath = relative(baseDir, join(baseDir, fileName));
+      // generated files may only land in the project folder, or under the configured path when
+      // that points elsewhere, so a file name can never reach an arbitrary filesystem location
+      const allowedRoots = [resolve(this.#config.get('baseDir')), resolve(baseDir)];
 
-        if (relativePath.startsWith('..') || isAbsolute(relativePath)) {
-          throw new Error(`Cannot generate '${fileName}', it resolves outside of the configured path`);
+      for (const [fileName] of files) {
+        const target = resolve(baseDir, fileName);
+
+        if (!allowedRoots.some(root => !relative(root, target).startsWith('..'))) {
+          throw new Error(`Cannot generate '${fileName}', it resolves outside of the project folder`);
         }
       }
 

--- a/packages/entity-generator/src/EntityGenerator.ts
+++ b/packages/entity-generator/src/EntityGenerator.ts
@@ -19,7 +19,7 @@ import {
   type SchemaHelper,
 } from '@mikro-orm/sql';
 import { fs } from '@mikro-orm/core/fs-utils';
-import { dirname, join } from 'node:path';
+import { dirname, isAbsolute, join, relative } from 'node:path';
 import { writeFile } from 'node:fs/promises';
 import { DefineEntitySourceFile } from './DefineEntitySourceFile.js';
 import { EntitySchemaSourceFile } from './EntitySchemaSourceFile.js';
@@ -102,6 +102,16 @@ export class EntityGenerator {
     const files = this.#sources.map(file => [file.getBaseName(), file.generate()]);
 
     if (options.save) {
+      // file names can be derived from database metadata (native enum and routine names), so they
+      // are validated before anything is written, nested names are still allowed
+      for (const [fileName] of files) {
+        const relativePath = relative(baseDir, join(baseDir, fileName));
+
+        if (relativePath.startsWith('..') || isAbsolute(relativePath)) {
+          throw new Error(`Cannot generate '${fileName}', it resolves outside of the configured path`);
+        }
+      }
+
       fs.ensureDir(baseDir);
       const promises = [];
 

--- a/packages/entity-generator/src/NativeEnumSourceFile.ts
+++ b/packages/entity-generator/src/NativeEnumSourceFile.ts
@@ -60,6 +60,10 @@ export class NativeEnumSourceFile extends SourceFile {
   }
 
   override getBaseName(extension = '.ts') {
-    return `${this.options.fileName!(this.nativeEnum.name)}${extension}`;
+    // the enum name comes from the database and ends up in a path, so path separators
+    // (and anything else that cannot appear in a file name) collapse to `_`
+    const name = this.nativeEnum.name.replaceAll(/[^\p{L}\p{N}$_-]+/gu, '_');
+
+    return `${this.options.fileName!(name)}${extension}`;
   }
 }

--- a/packages/entity-generator/src/RoutineSourceFile.ts
+++ b/packages/entity-generator/src/RoutineSourceFile.ts
@@ -28,7 +28,9 @@ function quoteMultiline(val: string): string {
 
 function toPascalCase(name: string): string {
   const pascal = name
-    .split(/[_\s-]+/)
+    // anything that cannot appear in an identifier acts as a word separator, which keeps
+    // path separators out of both the emitted const name and the generated file name
+    .split(/[^\p{L}\p{N}$]+/u)
     .filter(Boolean)
     .map(part => part.charAt(0).toUpperCase() + part.slice(1))
     .join('');

--- a/tests/features/entity-generator/OutputPathContainment.postgresql.test.ts
+++ b/tests/features/entity-generator/OutputPathContainment.postgresql.test.ts
@@ -1,0 +1,60 @@
+import { existsSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
+import { MikroORM } from '@mikro-orm/postgresql';
+import { ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+import { EntityGenerator } from '@mikro-orm/entity-generator';
+import { TEMP_DIR } from '../../helpers.js';
+
+// native enum and routine names come from the database and end up in the output file name,
+// so they must not be able to point the generator outside of the configured path
+const schema = `
+  create type "public"."../escaped_enum" as enum ('a', 'b');
+  create table "public"."t1" (
+    "id" int8 not null,
+    primary key ("id")
+  );
+`;
+
+const outDir = `${TEMP_DIR}/containment/nested`;
+
+describe('generated files stay inside the configured path', () => {
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      dbName: 'entity_gen_containment',
+      discovery: { warnWhenNoEntities: false },
+      ensureDatabase: false,
+      extensions: [EntityGenerator],
+    });
+
+    if (await orm.schema.ensureDatabase({ create: true })) {
+      await orm.schema.execute(schema);
+    }
+  });
+
+  afterAll(async () => {
+    await orm.schema.dropDatabase();
+    await orm.close(true);
+    await rm(`${TEMP_DIR}/containment`, { recursive: true, force: true });
+  });
+
+  test('a traversing name is rejected instead of written outside the path', async () => {
+    await expect(orm.entityGenerator.generate({ save: true, path: outDir })).rejects.toThrow(
+      /outside of the configured path/,
+    );
+
+    expect(existsSync(`${TEMP_DIR}/containment/escaped_enum.ts`)).toBe(false);
+  });
+
+  test('a nested file name is still allowed', async () => {
+    await orm.entityGenerator.generate({
+      save: true,
+      path: outDir,
+      fileName: className => `sub/dir/${className}`,
+    });
+
+    expect(existsSync(`${outDir}/sub/dir/T1.ts`)).toBe(true);
+  });
+});

--- a/tests/features/entity-generator/OutputPathContainment.postgresql.test.ts
+++ b/tests/features/entity-generator/OutputPathContainment.postgresql.test.ts
@@ -6,9 +6,10 @@ import { EntityGenerator } from '@mikro-orm/entity-generator';
 import { TEMP_DIR } from '../../helpers.js';
 
 // native enum and routine names come from the database and end up in the output file name,
-// so they must not be able to point the generator outside of the configured path
+// so path separators in them must not point the generator outside of the configured path
 const schema = `
   create type "public"."../escaped_enum" as enum ('a', 'b');
+  create function "public"."../escaped_routine"() returns int as $$ select 1 $$ language sql;
   create table "public"."t1" (
     "id" int8 not null,
     primary key ("id")
@@ -17,7 +18,7 @@ const schema = `
 
 const outDir = `${TEMP_DIR}/containment/nested`;
 
-describe('generated files stay inside the configured path', () => {
+describe('names taken from the database cannot escape the configured path', () => {
   let orm: MikroORM;
 
   beforeAll(async () => {
@@ -40,21 +41,32 @@ describe('generated files stay inside the configured path', () => {
     await rm(`${TEMP_DIR}/containment`, { recursive: true, force: true });
   });
 
-  test('a traversing name is rejected instead of written outside the path', async () => {
-    await expect(orm.entityGenerator.generate({ save: true, path: outDir })).rejects.toThrow(
-      /outside of the configured path/,
-    );
+  test('a traversing enum or routine name stays inside the configured path', async () => {
+    await orm.entityGenerator.generate({ save: true, path: outDir });
 
     expect(existsSync(`${TEMP_DIR}/containment/escaped_enum.ts`)).toBe(false);
+    expect(existsSync(`${TEMP_DIR}/containment/EscapedRoutine.ts`)).toBe(false);
+    expect(existsSync(`${outDir}/_escaped_enum.ts`)).toBe(true);
+    expect(existsSync(`${outDir}/EscapedRoutine.ts`)).toBe(true);
   });
 
-  test('a nested file name is still allowed', async () => {
+  test('a custom fileName pointing elsewhere in the project still works', async () => {
     await orm.entityGenerator.generate({
       save: true,
       path: outDir,
-      fileName: className => `sub/dir/${className}`,
+      fileName: className => `../sibling/${className}`,
     });
 
-    expect(existsSync(`${outDir}/sub/dir/T1.ts`)).toBe(true);
+    expect(existsSync(`${TEMP_DIR}/containment/sibling/T1.ts`)).toBe(true);
+  });
+
+  test('a file name leaving the project folder is rejected', async () => {
+    await expect(
+      orm.entityGenerator.generate({
+        save: true,
+        path: outDir,
+        fileName: className => `${'../'.repeat(20)}tmp/${className}`,
+      }),
+    ).rejects.toThrow(/outside of the project folder/);
   });
 });


### PR DESCRIPTION
Native enum type names and routine names are handed to the `fileName` option exactly as the database reports them, unlike entity class names which the naming strategy escapes first. A name containing `../` therefore resolved outside the configured `path`, and could overwrite an existing `.ts` file there.

Both are now normalized before they are used as a file name. For routines this also keeps slashes out of the emitted `export const` name, which was invalid TypeScript before.

On top of that, generated files must land inside the project folder, or inside the configured `path` when that points outside the project (a monorepo generating into a sibling package, for example). The wider boundary is deliberate: a custom `fileName` returning a nested or sibling directory is a supported use and keeps working, so nothing that resolves within the project breaks.
