### PR TITLE
fix(migrations): sanitize custom migration names into valid class identifiers

### DIFF
--- a/packages/core/src/naming-strategy/AbstractNamingStrategy.ts
+++ b/packages/core/src/naming-strategy/AbstractNamingStrategy.ts
@@ -16,7 +16,8 @@ export abstract class AbstractNamingStrategy implements NamingStrategy {
     let migrationName = `Migration${timestamp}`;
 
     if (customMigrationName) {
-      migrationName += `_${customMigrationName}`;
+      // the name becomes part of a class identifier
+      migrationName += `_${customMigrationName.replace(/[^$\p{ID_Continue}]+/gu, '_')}`;
     }
 
     return migrationName;

--- a/packages/core/src/naming-strategy/NamingStrategy.ts
+++ b/packages/core/src/naming-strategy/NamingStrategy.ts
@@ -12,7 +12,8 @@ export interface NamingStrategy {
   classToTableName(entityName: string, tableName?: string): string;
 
   /**
-   * Return a migration name. This name should allow ordering.
+   * Return a migration name. This name should allow ordering, and has to be a valid class identifier,
+   * as it is used as the class name in the generated migration file.
    */
   classToMigrationName(timestamp: string, customMigrationName?: string): string;
 

--- a/packages/core/src/utils/Configuration.ts
+++ b/packages/core/src/utils/Configuration.ts
@@ -122,7 +122,9 @@ const DEFAULTS = {
     safe: false,
     snapshot: true,
     emit: 'ts',
-    fileName: (timestamp: string, name?: string) => `Migration${timestamp}${name ? '_' + name : ''}`,
+    // mirrors `NamingStrategy.classToMigrationName`, so the file name matches the class it declares
+    fileName: (timestamp: string, name?: string) =>
+      `Migration${timestamp}${name ? '_' + name.replace(/[^$\p{ID_Continue}]+/gu, '_') : ''}`,
   },
   schemaGenerator: {
     createForeignKeyConstraints: true,

--- a/tests/features/migrations/__snapshots__/Migrator.test.ts.snap
+++ b/tests/features/migrations/__snapshots__/Migrator.test.ts.snap
@@ -1038,7 +1038,7 @@ exports[`Migrator > snapshot should not be updated when custom migration fileNam
 {
   "code": "import { Migration } from '@mikro-orm/migrations';
 
-export class Migration20191013214813_with-custom-name extends Migration {
+export class Migration20191013214813_with_custom_name extends Migration {
 
   override up(): void | Promise<void> {
     this.addSql(\`alter table \\\`foo_param2\\\` drop foreign key \\\`foo_param2_bar_id_foreign\\\`;\`);

--- a/tests/issues/GHx63.test.ts
+++ b/tests/issues/GHx63.test.ts
@@ -1,0 +1,29 @@
+import { UnderscoreNamingStrategy } from '@mikro-orm/core';
+
+// a custom migration name ends up as part of a class identifier, so characters that are
+// not valid there (spaces, dashes, dots) used to produce a migration file that never compiled
+describe('custom migration names produce valid class identifiers', () => {
+  const namingStrategy = new UnderscoreNamingStrategy();
+  const timestamp = '20260729120000';
+
+  test.each([
+    ['add user table', 'Migration20260729120000_add_user_table'],
+    ['add-user-table', 'Migration20260729120000_add_user_table'],
+    ['add.user', 'Migration20260729120000_add_user'],
+    ['2024 stuff', 'Migration20260729120000_2024_stuff'],
+    ['add_user_table', 'Migration20260729120000_add_user_table'],
+    ['añadir', 'Migration20260729120000_añadir'],
+    ['add 🎉', 'Migration20260729120000_add_'],
+    ['a$b', 'Migration20260729120000_a$b'],
+    ['---', 'Migration20260729120000__'],
+  ])('%s', (name, expected) => {
+    const className = namingStrategy.classToMigrationName(timestamp, name);
+
+    expect(className).toBe(expected);
+    expect(() => new Function(`class ${className} {}`)).not.toThrow();
+  });
+
+  test('no custom name', () => {
+    expect(namingStrategy.classToMigrationName(timestamp)).toBe('Migration20260729120000');
+  });
+});

--- a/tests/issues/GHx63.test.ts
+++ b/tests/issues/GHx63.test.ts
@@ -1,4 +1,12 @@
 import { UnderscoreNamingStrategy } from '@mikro-orm/core';
+import { MikroORM } from '@mikro-orm/sqlite';
+import { Entity, PrimaryKey, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+
+@Entity()
+class User {
+  @PrimaryKey()
+  id!: number;
+}
 
 // a custom migration name ends up as part of a class identifier, so characters that are
 // not valid there (spaces, dashes, dots) used to produce a migration file that never compiled
@@ -25,5 +33,20 @@ describe('custom migration names produce valid class identifiers', () => {
 
   test('no custom name', () => {
     expect(namingStrategy.classToMigrationName(timestamp)).toBe('Migration20260729120000');
+  });
+
+  test('the default file name agrees with the class name it declares', async () => {
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      dbName: ':memory:',
+      entities: [User],
+    });
+    const { fileName } = orm.config.get('migrations');
+
+    for (const name of ['add user table', 'add-user-table', 'añadir', undefined]) {
+      expect(fileName!(timestamp, name)).toBe(orm.config.getNamingStrategy().classToMigrationName(timestamp, name));
+    }
+
+    await orm.close(true);
   });
 });


### PR DESCRIPTION
`migration:create -n "add user table"` generated a file that did not compile. The custom name is concatenated straight into the migration class identifier, so any character that is not valid there ended up in `export class Migration20260729120000_add user table`.

Spaces, dashes and dots all hit this, which covers most of what anyone would naturally type:

```
-n "add user table"  ->  class Migration20260729120000_add user table
-n "add-user-table"  ->  class Migration20260729120000_add-user-table
-n "add.user"        ->  class Migration20260729120000_add.user
```

Runs of invalid characters now collapse to `_`. Unicode identifier characters are preserved, so `-n "añadir"` keeps working, and names that were already valid identifiers are unchanged.

`classToMigrationName` is shared by the SQL and MongoDB generators, so both are covered.

The default `fileName` gets the same treatment, since the generator passes the raw name to it separately from the class name. Otherwise the two disagree, which matters for `migrationsList` entries registered as a bare class: the storage key comes from `migration.name` there, while glob discovery derives it from the file name, so the same migration could be tracked under two keys and re-run.

A committed snapshot in `Migrator.test.ts` expected `export class Migration20191013214813_with-custom-name`, which is not a valid identifier either. Updated here.
