### PR TITLE
fix(sql): compile an empty `$or` to an always-false predicate

### DIFF
--- a/packages/sql/src/query/QueryBuilderHelper.ts
+++ b/packages/sql/src/query/QueryBuilderHelper.ts
@@ -1132,6 +1132,11 @@ export class QueryBuilderHelper {
     const parts: string[] = [];
     const params: unknown[] = [];
 
+    // an empty disjunction is false, same as `$in: []`, while an empty conjunction is vacuously true
+    if (operator === '$or' && subCondition.length === 0) {
+      return { sql: '1 = 0', params };
+    }
+
     // single sub-condition can be ignored to reduce nesting of parens
     if (subCondition.length === 1 || operator === '$and') {
       for (const sub of subCondition) {

--- a/tests/features/query-builder/query-builder-empty-or.test.ts
+++ b/tests/features/query-builder/query-builder-empty-or.test.ts
@@ -1,0 +1,53 @@
+import { MikroORM } from '@mikro-orm/sqlite';
+import { Author4 } from '../../entities-schema/index.js';
+import { initORMSqlite } from '../../bootstrap.js';
+
+// an empty disjunction matches nothing, so it has to compile to an always-false predicate
+// rather than disappearing from the query, the way `$in: []` already does
+describe('empty $or', () => {
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await initORMSqlite();
+  });
+
+  afterAll(async () => {
+    await orm.close(true);
+  });
+
+  test('compiles to an always-false predicate', () => {
+    const qb = orm.em.createQueryBuilder(Author4, 'a').where({ $or: [] });
+
+    expect(qb.getFormattedQuery()).toBe('select `a`.* from `author4` as `a` where 1 = 0');
+  });
+
+  test('stays always-false when nested in a conjunction', () => {
+    const qb = orm.em.createQueryBuilder(Author4, 'a').where({ $and: [{ name: 'foo' }, { $or: [] }] });
+
+    expect(qb.getFormattedQuery()).toBe("select `a`.* from `author4` as `a` where `a`.`name` = 'foo' and 1 = 0");
+  });
+
+  test('an empty $and is still vacuously true', () => {
+    const qb = orm.em.createQueryBuilder(Author4, 'a').where({ $and: [] });
+
+    expect(qb.getFormattedQuery()).toBe('select `a`.* from `author4` as `a`');
+  });
+
+  test('negating an empty $or produces valid sql', () => {
+    const qb = orm.em.createQueryBuilder(Author4, 'a').where({ $not: { $or: [] } });
+
+    expect(qb.getFormattedQuery()).toBe('select `a`.* from `author4` as `a` where not (1 = 0)');
+  });
+
+  test('does not leave a dangling having clause', () => {
+    const qb = orm.em.createQueryBuilder(Author4, 'a').groupBy('a.id').having({ $or: [] });
+
+    expect(qb.getFormattedQuery()).toBe('select `a`.* from `author4` as `a` group by `a`.`id` having 1 = 0');
+  });
+
+  test('deletes are scoped rather than affecting the whole table', () => {
+    const qb = orm.em.createQueryBuilder(Author4).delete({ $or: [] });
+
+    expect(qb.getFormattedQuery()).toBe('delete from `author4` where 1 = 0');
+  });
+});


### PR DESCRIPTION
`{ $or: [] }` was dropped from the generated SQL entirely instead of compiling to a predicate that matches nothing, so a condition built from an empty list quietly widened the result set rather than narrowing it. `$in: []` and `$nin: []` already handled the empty case correctly. `$and: []` stays vacuously true, which is right for an empty conjunction.

The same code path produced two syntax errors, both fixed by the same change:

```
{ $not: { $or: [] } }        ->  where not ()
having({ $or: [] })          ->  group by `a`.`id` having
```

Worth calling out in the release notes: `{ $or: [] }` now matches no rows where it previously matched every row. That includes `nativeDelete` and `nativeUpdate`, which previously ran completely unscoped for an empty `$or`.

The `$elemMatch` / JSON-array builder is deliberately left alone. Its empty-`$or` semantics are asserted by an existing test, so changing them is a separate decision rather than part of this fix.
