### PR TITLE
fix(core): map returning values back to entities after batch update

### DIFF
--- a/packages/core/src/unit-of-work/ChangeSetPersister.ts
+++ b/packages/core/src/unit-of-work/ChangeSetPersister.ts
@@ -364,9 +364,10 @@ export class ChangeSetPersister {
 
     const res = await this.#driver.nativeUpdateMany(meta.class, cond, payload, options);
     const map = new Map<string, Dictionary>();
-    res.rows?.forEach(item =>
-      map.set(Utils.getCompositeKeyHash(item as EntityData<T>, meta, true, this.#platform, true), item),
-    );
+    // returning rows are not mapped yet, so they are keyed by field names - we need to build the hash
+    // from those to be able to match them with `getSerializedPrimaryKey()` of the entity
+    const pkFields = meta.getPrimaryProps().flatMap(prop => prop.fieldNames);
+    res.rows?.forEach(item => map.set(Utils.getPrimaryKeyHash(pkFields.map(field => item[field])), item));
 
     for (const changeSet of changeSets) {
       if (res.rows) {

--- a/tests/features/composite-keys/composite-keys.sqlite.test.ts
+++ b/tests/features/composite-keys/composite-keys.sqlite.test.ts
@@ -633,6 +633,34 @@ describe('composite keys in sqlite', () => {
     }
   });
 
+  test('batch updates reload the version value', async () => {
+    const param1 = new FooParam12(new FooBar12('bar 1'), new FooBaz12('baz 1'), 'val 1');
+    const param2 = new FooParam12(new FooBar12('bar 2'), new FooBaz12('baz 2'), 'val 1');
+    await orm.em.persist([param1, param2]).flush();
+
+    // the version is stored with second precision, so we need to move it to the past
+    // to be sure the batch update below produces a different value
+    const oldVersion = new Date('2020-01-01T00:00:00Z');
+    await orm.em.nativeUpdate(FooParam12, {}, { version: oldVersion });
+    orm.em.clear();
+
+    const [p1, p2] = await orm.em.find(FooParam12, {}, { orderBy: { bar: 'asc' } });
+    expect(p1.version).toEqual(oldVersion);
+    p1.value += ' changed!';
+    p2.value += ' changed!';
+    await orm.em.flush();
+    expect(p1.version).not.toEqual(oldVersion);
+    expect(p2.version).not.toEqual(oldVersion);
+    // the returned rows are hydrated back, so a mismatched row would rewrite the composite PK
+    expect([p1.bar.id, p1.baz.id]).toEqual([param1.bar.id, param1.baz.id]);
+    expect([p2.bar.id, p2.baz.id]).toEqual([param2.bar.id, param2.baz.id]);
+
+    // with a stale version the optimistic lock check would fail here
+    p1.value += ' changed!!';
+    p2.value += ' changed!!';
+    await expect(orm.em.flush()).resolves.toBeUndefined();
+  });
+
   test('loadCount for composite keys', async () => {
     const car = new Car12('Audi A8', 2010, 200_000);
     const user = new User12('John', 'Doe');


### PR DESCRIPTION
Rows returned from a batch update are not mapped yet, so they are keyed by field names, but the lookup hash matching them with the entities used property names via `Utils.getCompositeKeyHash()`.

With a composite primary key made of relations (`FooParam12` keyed by `bar` + `baz`), the row columns are `bar_id`/`baz_id`, so every row hashed to the same empty key and the lookup always missed. The returned values never reached the entities, so the new version value was lost and the next flush failed the optimistic lock check.

This only shows up when the version actually changes between the two flushes. Sqlite stores it with second precision, so it stays hidden unless the flushes land in different seconds, which is what made `composite-keys.sqlite.test.ts > batch updates with optimistic locking` flaky on CI.

The hash now comes from `prop.fieldNames`, matching the raw row shape. That also drops a `convertToJSValue` conversion which ran opposite to the entity side, where the pk serializer uses `convertToDatabaseValue`.