### PR TITLE
fix(sql): normalize implicit aggregate aliases and multi word casts

### DIFF
--- a/packages/sql/src/schema/SchemaComparator.ts
+++ b/packages/sql/src/schema/SchemaComparator.ts
@@ -1145,9 +1145,16 @@ export class SchemaComparator {
           // lookbehind: only strip a real charset introducer, never an underscore inside a literal like 'a_b'
           ?.replace(/(?<![\w'])_\w+'(.*?)'/g, '$1')
           .replace(/!=/g, '<>')
-          .replace(/in\s*\((.*?)\)/gi, '= any (array[$1])')
+          // `\b` keeps this from firing inside identifiers like `min(...)`
+          .replace(/\bin\s*\((.*?)\)/gi, '= any (array[$1])')
           // MySQL normalizes count(*) to count(0)
           .replace(/\bcount\s*\(\s*0\s*\)/gi, 'count(*)')
+          // multi word type names in casts, the generic `::\w+` below only covers single word ones
+          // the precision is kept, so `timestamptz(3)` and `timestamp(3) with time zone` leave the same residue
+          .replace(
+            /::\s*(?:character\s+varying|bit\s+varying|double\s+precision|(?:timestamp|time)\b(\s*\(\d+\))?(?:\s+with(?:out)?\s+time\s+zone)?)/gi,
+            '$1',
+          )
           // Remove quotes first so we can process identifiers
           .replace(/['"`]/g, '')
           // MySQL adds table/alias prefixes to columns (e.g., a.name or table_name.column vs just column)
@@ -1155,6 +1162,10 @@ export class SchemaComparator {
           .replace(/\b\w+\.(\w+)/g, '$1')
           // Normalize JOIN syntax: inner join -> join (equivalent in SQL)
           .replace(/\binner\s+join\b/gi, 'join')
+          // PostgreSQL names an unaliased bare function call after the function itself,
+          // so `max(created_at)` comes back as `max(created_at) AS max`
+          // the lookahead skips table function column alias lists like `unnest(a) AS unnest(c)`, which are meaningful
+          .replace(/\b(\w+)\s*\(((?:[^()]|\([^()]*\))*)\)\s+as\s+\1\b(?!\s*\()/gi, '$1($2)')
           // Remove redundant column aliases like `title AS title` -> `title`
           .replace(/\b(\w+)\s+as\s+\1\b/gi, '$1')
           // Remove AS keyword (optional in SQL, MySQL may add/remove it)

--- a/tests/features/schema-generator/view-expression-diffing.postgres.test.ts
+++ b/tests/features/schema-generator/view-expression-diffing.postgres.test.ts
@@ -1,0 +1,74 @@
+import { defineEntity, p, MikroORM } from '@mikro-orm/postgresql';
+
+const Donation = defineEntity({
+  name: 'Donation',
+  tableName: 'donation',
+  properties: {
+    id: p.integer().primary(),
+    createdAt: p.datetime(),
+  },
+});
+
+const Candidate = defineEntity({
+  name: 'Candidate',
+  tableName: 'candidate',
+  properties: {
+    id: p.string().primary(),
+    importYear: p.integer(),
+    principalCommitteeId: p.string().nullable(),
+  },
+});
+
+// PostgreSQL names the output column of a bare function call after the function itself,
+// so `max(created_at)` is stored back as `max(created_at) AS max`. `min` additionally
+// collides with the `in (...)` normalization rule.
+const ImportStats = defineEntity({
+  name: 'ImportStats',
+  tableName: 'import_stats_view',
+  view: true,
+  expression: `select 1 as id, (select max(created_at) from donation) as last_import_at, (select min(import_year) from candidate) as earliest_import_year`,
+  properties: {
+    id: p.integer().primary(),
+    lastImportAt: p.datetime().nullable(),
+    earliestImportYear: p.integer().nullable(),
+  },
+});
+
+// PostgreSQL adds a cast with a multi word type name here (`NULL::character varying`).
+const CandidateCommittees = defineEntity({
+  name: 'CandidateCommittees',
+  tableName: 'candidate_committees_view',
+  view: true,
+  expression: `select id, array_remove(array_agg(distinct principal_committee_id), null) as principal_committee_ids from candidate group by id`,
+  properties: {
+    id: p.string().primary(),
+    principalCommitteeIds: p.string().array(),
+  },
+});
+
+describe('view expression diffing in postgres', () => {
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      entities: [Donation, Candidate],
+      dbName: 'mikro_orm_test_view_expr_diffing',
+    });
+    await orm.schema.refresh({ dropDb: true });
+  });
+
+  afterAll(async () => {
+    await orm.schema.dropDatabase();
+    await orm.close(true);
+  });
+
+  test('implicit aggregate alias and multi word casts do not cause drift', async () => {
+    orm.discoverEntity([ImportStats, CandidateCommittees]);
+
+    const diff = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(diff).not.toBe('');
+    await orm.schema.execute(diff);
+
+    await expect(orm.schema.getUpdateSchemaSQL({ wrap: false })).resolves.toBe('');
+  });
+});


### PR DESCRIPTION
PostgreSQL rewrites a view definition when it stores it, so the expression on the entity never matched what introspection returned, and every generated migration dropped and recreated the view again.

Two gaps in `SchemaComparator.diffExpression` caused it:

- Casts were stripped with `::\w+`, which only covers single word type names. `NULL::character varying` lost the `::character` part and kept a stray `varying`.
- PostgreSQL names the output column of a bare function call after the function itself, so `max(created_at)` comes back as `max(created_at) AS max`. Only `count(*)` survived this, via a dedup rule that happened to work because stripping the `*` left the two tokens adjacent.

While fixing the second one it turned out the `in (...)` rule was matching inside identifiers, rewriting `min(x)` to `m= any (array[x])`, so it needed a word boundary.

Closes #8055
