### PR TITLE
fix(oracledb): bind every returned column of a multi column property

### DIFF
--- a/packages/oracledb/src/OracleDriver.ts
+++ b/packages/oracledb/src/OracleDriver.ts
@@ -7,12 +7,14 @@ import {
   type EntityDictionary,
   type EntityKey,
   type EntityName,
+  type EntityProperty,
   type FilterQuery,
   isRaw,
   type LoggingOptions,
   type NativeInsertUpdateManyOptions,
   QueryFlag,
   type QueryResult,
+  ReferenceKind,
   type RequiredEntityData,
   type Transaction,
   type UpsertManyOptions,
@@ -120,8 +122,13 @@ export class OracleDriver extends AbstractSqlDriver<OracleConnection, OraclePlat
 
     for (const propName of returning) {
       const prop = meta.properties[propName];
-      into.push(`:out_${prop.fieldNames[0]}`);
-      outBindingsMap[`out_${prop.fieldNames[0]}`] = prop.runtimeType;
+      // the parent builds the `returning` list from all field names, so every column needs its own OUT bind
+      const runtimeTypes = this.getOutBindTypes(prop);
+
+      prop.fieldNames.forEach((fieldName, idx) => {
+        into.push(`:out_${fieldName}`);
+        outBindingsMap[`out_${fieldName}`] = runtimeTypes[idx];
+      });
     }
 
     const outBindings = this.platform.createOutBindings(outBindingsMap);
@@ -136,6 +143,22 @@ export class OracleDriver extends AbstractSqlDriver<OracleConnection, OraclePlat
 
       return `${sql} into ${into.join(', ')}`;
     });
+  }
+
+  /**
+   * Resolves the runtime type of every column a property maps to, aligned with its `fieldNames`.
+   * A relation covers one column per target PK column, and a target PK can be a relation itself,
+   * so we recurse down to the scalar leaves - `prop.runtimeType` is `unknown` for relations.
+   */
+  private getOutBindTypes(prop: EntityProperty): string[] {
+    if (!prop.targetMeta || ![ReferenceKind.MANY_TO_ONE, ReferenceKind.ONE_TO_ONE].includes(prop.kind)) {
+      return prop.fieldNames.map(() => prop.runtimeType);
+    }
+
+    const types = prop.referencedPKs.flatMap(pk => this.getOutBindTypes(prop.targetMeta!.properties[pk]));
+
+    // `fieldNames` of a polymorphic relation start with the discriminator column
+    return prop.polymorphic ? ['string', ...types] : types;
   }
 
   /** @inheritDoc */

--- a/tests/features/composite-keys/composite-keys.oracle.test.ts
+++ b/tests/features/composite-keys/composite-keys.oracle.test.ts
@@ -1,0 +1,151 @@
+import { MikroORM, PrimaryKeyProp } from '@mikro-orm/oracledb';
+import { Entity, ManyToOne, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+
+@Entity()
+class Owner {
+  @PrimaryKey()
+  id1!: number;
+
+  @PrimaryKey()
+  id2!: number;
+
+  @Property()
+  name!: string;
+
+  [PrimaryKeyProp]?: ['id1', 'id2'];
+}
+
+@Entity()
+class Tag {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  label!: string;
+}
+
+@Entity()
+class Pair {
+  @ManyToOne(() => Owner, { primary: true })
+  owner!: Owner;
+
+  @ManyToOne(() => Tag, { primary: true })
+  tag!: Tag;
+
+  @Property()
+  value!: string;
+
+  [PrimaryKeyProp]?: ['owner', 'tag'];
+}
+
+@Entity()
+class Note {
+  @ManyToOne(() => Pair, { primary: true })
+  pair!: Pair;
+
+  @PrimaryKey()
+  seq!: number;
+
+  @Property()
+  text!: string;
+
+  [PrimaryKeyProp]?: ['pair', 'seq'];
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    metadataProvider: ReflectMetadataProvider,
+    entities: [Owner, Tag, Pair, Note],
+    dbName: 'mikro_orm_test_composite_keys',
+    password: 'oracle123',
+    schemaGenerator: { managementDbName: 'system', tableSpace: 'mikro_orm' },
+  });
+  await orm.schema.refresh();
+});
+
+beforeEach(async () => {
+  await orm.schema.clear();
+  orm.em.clear();
+});
+
+afterAll(async () => {
+  await orm.schema.drop({ wrap: false });
+  await orm.close(true);
+});
+
+async function createPairs() {
+  const o1 = orm.em.create(Owner, { id1: 1, id2: 10, name: 'o1' });
+  const o2 = orm.em.create(Owner, { id1: 2, id2: 20, name: 'o2' });
+  const t1 = orm.em.create(Tag, { id: 1, label: 't1' });
+  const t2 = orm.em.create(Tag, { id: 2, label: 't2' });
+  orm.em.create(Pair, { owner: o1, tag: t1, value: 'v1' });
+  orm.em.create(Pair, { owner: o2, tag: t2, value: 'v2' });
+  await orm.em.flush();
+  orm.em.clear();
+}
+
+// a primary relation to an entity with a composite PK spans several columns, so the
+// `returning ... into` clause needs one OUT bind per column, not one per property
+test('batch update with a primary relation pointing to an entity with a composite PK', async () => {
+  await createPairs();
+
+  const pairs = await orm.em.findAll(Pair, { orderBy: { owner: { id1: 'asc' } } });
+  pairs[0].value = 'v1 updated';
+  pairs[1].value = 'v2 updated';
+  await orm.em.flush();
+  orm.em.clear();
+
+  const after = await orm.em.findAll(Pair, { orderBy: { owner: { id1: 'asc' } } });
+  expect(after.map(p => [p.owner.id1, p.owner.id2, p.tag.id, p.value])).toEqual([
+    [1, 10, 1, 'v1 updated'],
+    [2, 20, 2, 'v2 updated'],
+  ]);
+});
+
+// asserted on the driver result rather than on the entities - hydration resolves the relations
+// through the identity map, which would mask values that came back with the wrong type
+test('every returned column of a multi column primary relation round-trips', async () => {
+  await createPairs();
+
+  const res = await orm.em.getDriver().nativeUpdateMany(
+    Pair,
+    [
+      { owner: [1, 10], tag: 1 },
+      { owner: [2, 20], tag: 2 },
+    ],
+    [{ value: 'v1 updated' }, { value: 'v2 updated' }],
+  );
+
+  expect(res.rows).toEqual([
+    { owner_id1: 1, owner_id2: 10, tag_id: 1 },
+    { owner_id1: 2, owner_id2: 20, tag_id: 2 },
+  ]);
+});
+
+// the target PK is itself made of relations, so the column types have to be resolved
+// through both levels down to the scalar keys
+test('every returned column of a nested composite primary relation round-trips', async () => {
+  await createPairs();
+
+  const pair = await orm.em.findOneOrFail(Pair, { owner: [1, 10], tag: 1 });
+  orm.em.create(Note, { pair, seq: 1, text: 'n1' });
+  orm.em.create(Note, { pair, seq: 2, text: 'n2' });
+  await orm.em.flush();
+  orm.em.clear();
+
+  const res = await orm.em.getDriver().nativeUpdateMany(
+    Note,
+    [
+      { pair: [[1, 10], 1], seq: 1 },
+      { pair: [[1, 10], 1], seq: 2 },
+    ],
+    [{ text: 'n1 updated' }, { text: 'n2 updated' }],
+  );
+
+  expect(res.rows).toEqual([
+    { pair_owner_id1: 1, pair_owner_id2: 10, pair_tag_id: 1, seq: 1 },
+    { pair_owner_id1: 1, pair_owner_id2: 10, pair_tag_id: 1, seq: 2 },
+  ]);
+});

--- a/tests/features/schema-generator/__snapshots__/SchemaGenerator.mssql.test.ts.snap
+++ b/tests/features/schema-generator/__snapshots__/SchemaGenerator.mssql.test.ts.snap
@@ -183,22 +183,6 @@ if object_id('[base_user2]', 'U') is not null drop table [base_user2];
 
 exports[`SchemaGenerator > read-only schema tests > generate schema from metadata [mssql] > mssql-update-schema-dump 1`] = `""`;
 
-exports[`SchemaGenerator > rename column [mssql] > mssql-update-schema-alter-column 1`] = `
-"drop index [author2_born_index] on [author2];
-alter table [author2] alter column [born] nvarchar(max);
-alter table [author2] drop constraint [author2_favourite_author_id_foreign];
-
-declare @constraint0 varchar(100) = (select default_constraints.name from sys.all_columns join sys.tables on all_columns.object_id = tables.object_id join sys.schemas on tables.schema_id = schemas.schema_id join sys.default_constraints on all_columns.default_object_id = default_constraints.object_id where schemas.name = 'dbo' and tables.name = 'author2' and all_columns.name = 'age') if @constraint0 is not null exec('alter table [author2] drop constraint ' + @constraint0);
-alter table [author2] add constraint [author2_age_default] default 42 for [age];
-declare @constraint1 varchar(100) = (select default_constraints.name from sys.all_columns join sys.tables on all_columns.object_id = tables.object_id join sys.schemas on tables.schema_id = schemas.schema_id join sys.default_constraints on all_columns.default_object_id = default_constraints.object_id where schemas.name = 'dbo' and tables.name = 'author2' and all_columns.name = 'born') if @constraint1 is not null exec('alter table [author2] drop constraint ' + @constraint1);
-alter table [author2] alter column [born] int not null;
-alter table [author2] add constraint [author2_born_default] default 42 for [born];
-alter table [author2] add constraint [author2_favourite_author_id_foreign] foreign key ([favourite_author_id]) references [foo_bar2] ([id]) on delete set null;
-
-create index [author2_born_index] on [author2] ([born]);
-"
-`;
-
 exports[`SchemaGenerator > rename column [mssql] > mssql-update-schema-rename-column 1`] = `
 "alter table [author2] drop constraint [author2_favourite_author_id_foreign];
 

--- a/tests/features/schema-generator/__snapshots__/SchemaGenerator.mssql.test.ts.snap
+++ b/tests/features/schema-generator/__snapshots__/SchemaGenerator.mssql.test.ts.snap
@@ -183,6 +183,22 @@ if object_id('[base_user2]', 'U') is not null drop table [base_user2];
 
 exports[`SchemaGenerator > read-only schema tests > generate schema from metadata [mssql] > mssql-update-schema-dump 1`] = `""`;
 
+exports[`SchemaGenerator > rename column [mssql] > mssql-update-schema-alter-column 1`] = `
+"drop index [author2_born_index] on [author2];
+alter table [author2] alter column [born] nvarchar(max);
+alter table [author2] drop constraint [author2_favourite_author_id_foreign];
+
+declare @constraint0 varchar(100) = (select default_constraints.name from sys.all_columns join sys.tables on all_columns.object_id = tables.object_id join sys.schemas on tables.schema_id = schemas.schema_id join sys.default_constraints on all_columns.default_object_id = default_constraints.object_id where schemas.name = 'dbo' and tables.name = 'author2' and all_columns.name = 'age') if @constraint0 is not null exec('alter table [author2] drop constraint ' + @constraint0);
+alter table [author2] add constraint [author2_age_default] default 42 for [age];
+declare @constraint1 varchar(100) = (select default_constraints.name from sys.all_columns join sys.tables on all_columns.object_id = tables.object_id join sys.schemas on tables.schema_id = schemas.schema_id join sys.default_constraints on all_columns.default_object_id = default_constraints.object_id where schemas.name = 'dbo' and tables.name = 'author2' and all_columns.name = 'born') if @constraint1 is not null exec('alter table [author2] drop constraint ' + @constraint1);
+alter table [author2] alter column [born] int not null;
+alter table [author2] add constraint [author2_born_default] default 42 for [born];
+alter table [author2] add constraint [author2_favourite_author_id_foreign] foreign key ([favourite_author_id]) references [foo_bar2] ([id]) on delete set null;
+
+create index [author2_born_index] on [author2] ([born]);
+"
+`;
+
 exports[`SchemaGenerator > rename column [mssql] > mssql-update-schema-rename-column 1`] = `
 "alter table [author2] drop constraint [author2_favourite_author_id_foreign];
 


### PR DESCRIPTION
`AbstractSqlDriver.nativeUpdateMany` builds the returning clause from all field names of each returning property, but the Oracle override emitted only one OUT bind per property, taking `fieldNames[0]`. A primary relation pointing at an entity with a composite key spans several columns, so the statement came out as

```sql
returning "owner_id1", "owner_id2", "tag_id" into :out_owner_id1, :out_tag_id
```

and Oracle rejected it with `ORA-00917: missing comma`.

The runtime types were wrong as well. Relations report `runtimeType` as `unknown`, which `mapToOracleType` turns into a varchar bind, so numeric keys came back as strings even in the single column case that did work. Types are now resolved through the target keys rather than off the relation itself, recursing when a target key is a relation too, so a `Note` keyed by a `Pair` that is itself keyed by relations gets the right type for each of its columns. The polymorphic discriminator column is accounted for since it comes first in `fieldNames` but has no matching target key.

The round-trip tests assert on the driver result rather than on the entities. Hydration resolves relations through the identity map, which already holds the target with correctly typed keys, so wrongly typed values never surface at the entity level.