### PR TITLE
fix(sql): emit valid SQL for negated and empty condition groups

### DIFF
--- a/packages/sql/src/dialects/mssql/MsSqlNativeQueryBuilder.ts
+++ b/packages/sql/src/dialects/mssql/MsSqlNativeQueryBuilder.ts
@@ -206,7 +206,7 @@ export class MsSqlNativeQueryBuilder extends NativeQueryBuilder {
       this.parts.push(`group by ${fields.join(', ')}`);
     }
 
-    if (this.options.having) {
+    if (this.options.having?.sql.trim()) {
       this.parts.push(`having ${this.options.having.sql}`);
       this.params.push(...this.options.having.params);
     }

--- a/packages/sql/src/dialects/oracledb/OracleNativeQueryBuilder.ts
+++ b/packages/sql/src/dialects/oracledb/OracleNativeQueryBuilder.ts
@@ -280,7 +280,7 @@ export class OracleNativeQueryBuilder extends NativeQueryBuilder {
       this.parts.push(`group by ${fields.join(', ')}`);
     }
 
-    if (this.options.having) {
+    if (this.options.having?.sql.trim()) {
       this.parts.push(`having ${this.options.having.sql}`);
       this.params.push(...this.options.having.params);
     }

--- a/packages/sql/src/query/NativeQueryBuilder.ts
+++ b/packages/sql/src/query/NativeQueryBuilder.ts
@@ -457,7 +457,7 @@ export class NativeQueryBuilder implements Subquery {
       this.parts.push(`group by ${fields.join(', ')}`);
     }
 
-    if (this.options.having) {
+    if (this.options.having?.sql.trim()) {
       this.parts.push(`having ${this.options.having.sql}`);
       this.params.push(...this.options.having.params);
     }

--- a/packages/sql/src/query/QueryBuilderHelper.ts
+++ b/packages/sql/src/query/QueryBuilderHelper.ts
@@ -617,7 +617,8 @@ export class QueryBuilderHelper {
 
       if (k === '$not') {
         const res = this._appendQueryCondition(type, cond[k]);
-        parts.push(`not (${res.sql})`);
+        // negating a vacuously true condition (e.g. an empty `$and`) matches nothing
+        parts.push(res.sql ? `not (${res.sql})` : '1 = 0');
         res.params.forEach(p => params.push(p));
         continue;
       }

--- a/tests/features/native-query-builder/MsSqlNativeQueryBuilder.test.ts
+++ b/tests/features/native-query-builder/MsSqlNativeQueryBuilder.test.ts
@@ -66,6 +66,11 @@ test('MsSqlNativeQueryBuilder', async () => {
     params: ['bar', 2, 1],
   });
 
+  // an empty condition must not leave a dangling `having` behind
+  const qb7b = new MsSqlNativeQueryBuilder(orm.em.getPlatform());
+  qb7b.select('*').from('baz').groupBy(['foo']).having('', []);
+  expect(qb7b.compile()).toEqual({ sql: 'select * from [baz] group by [foo]', params: [] });
+
   const qb8 = new MsSqlNativeQueryBuilder(orm.em.getPlatform());
   const date = new Date();
   qb8

--- a/tests/features/native-query-builder/OracleNativeQueryBuilder.test.ts
+++ b/tests/features/native-query-builder/OracleNativeQueryBuilder.test.ts
@@ -66,6 +66,11 @@ test('OracleNativeQueryBuilder', async () => {
     params: ['bar', 2, 1],
   });
 
+  // an empty condition must not leave a dangling `having` behind
+  const qb7b = new OracleNativeQueryBuilder(orm.em.getPlatform());
+  qb7b.select('*').from('baz').groupBy(['foo']).having('', []);
+  expect(qb7b.compile()).toEqual({ sql: 'select * from "baz" group by "foo"', params: [] });
+
   const qb8 = new OracleNativeQueryBuilder(orm.em.getPlatform());
   const date = new Date();
   qb8

--- a/tests/features/query-builder/query-builder-empty-or.test.ts
+++ b/tests/features/query-builder/query-builder-empty-or.test.ts
@@ -3,8 +3,9 @@ import { Author4 } from '../../entities-schema/index.js';
 import { initORMSqlite } from '../../bootstrap.js';
 
 // an empty disjunction matches nothing, so it has to compile to an always-false predicate
-// rather than disappearing from the query, the way `$in: []` already does
-describe('empty $or', () => {
+// rather than disappearing from the query, the way `$in: []` already does, while an empty
+// conjunction is vacuously true and must not leave a dangling `not`/`having` behind
+describe('empty condition groups', () => {
   let orm: MikroORM;
 
   beforeAll(async () => {
@@ -49,5 +50,58 @@ describe('empty $or', () => {
     const qb = orm.em.createQueryBuilder(Author4).delete({ $or: [] });
 
     expect(qb.getFormattedQuery()).toBe('delete from `author4` where 1 = 0');
+  });
+
+  test('negating a vacuously true condition matches nothing', async () => {
+    const qb1 = orm.em.createQueryBuilder(Author4, 'a').where({ $not: {} });
+    const qb2 = orm.em.createQueryBuilder(Author4, 'a').where({ $not: { $and: [] } });
+    const qb3 = orm.em.createQueryBuilder(Author4, 'a').where({ $not: { $not: {} } });
+
+    expect(qb1.getFormattedQuery()).toBe('select `a`.* from `author4` as `a` where 1 = 0');
+    expect(qb2.getFormattedQuery()).toBe('select `a`.* from `author4` as `a` where 1 = 0');
+    expect(qb3.getFormattedQuery()).toBe('select `a`.* from `author4` as `a` where not (1 = 0)');
+
+    await expect(qb1.execute()).resolves.toEqual([]);
+    await expect(qb2.execute()).resolves.toEqual([]);
+    await expect(qb3.execute()).resolves.toEqual([]);
+  });
+
+  test('negating a vacuously true condition works nested in a group', async () => {
+    const qb1 = orm.em.createQueryBuilder(Author4, 'a').where({ $and: [{ name: 'foo' }, { $not: { $and: [] } }] });
+    const qb2 = orm.em.createQueryBuilder(Author4, 'a').where({ $or: [{ name: 'foo' }, { $not: { $and: [] } }] });
+
+    expect(qb1.getFormattedQuery()).toBe("select `a`.* from `author4` as `a` where `a`.`name` = 'foo' and 1 = 0");
+    expect(qb2.getFormattedQuery()).toBe("select `a`.* from `author4` as `a` where (`a`.`name` = 'foo' or 1 = 0)");
+
+    await expect(qb1.execute()).resolves.toEqual([]);
+    await expect(qb2.execute()).resolves.toEqual([]);
+  });
+
+  test('empty conditions are negated the same way when queried via the entity manager', async () => {
+    await expect(orm.em.fork().find(Author4, { $not: {} })).resolves.toEqual([]);
+    await expect(orm.em.fork().count(Author4, { $not: { $and: [] } })).resolves.toBe(0);
+  });
+
+  test('a vacuously true having condition is omitted', async () => {
+    const qb1 = orm.em.createQueryBuilder(Author4, 'a').groupBy('a.id').having({ $and: [] });
+    const qb2 = orm.em.createQueryBuilder(Author4, 'a').groupBy('a.id').having({});
+    const qb3 = orm.em.createQueryBuilder(Author4, 'a').groupBy('a.id');
+    qb3.having({ $or: [{ $and: [] }] });
+
+    expect(qb1.getFormattedQuery()).toBe('select `a`.* from `author4` as `a` group by `a`.`id`');
+    expect(qb2.getFormattedQuery()).toBe('select `a`.* from `author4` as `a` group by `a`.`id`');
+    expect(qb3.getFormattedQuery()).toBe('select `a`.* from `author4` as `a` group by `a`.`id`');
+
+    await expect(qb1.execute()).resolves.toEqual([]);
+    await expect(qb3.execute()).resolves.toEqual([]);
+  });
+
+  test('a negated empty group in having is always false', async () => {
+    const qb = orm.em.createQueryBuilder(Author4, 'a').groupBy('a.id');
+    qb.having({ $not: { $and: [] } });
+
+    expect(qb.getFormattedQuery()).toBe('select `a`.* from `author4` as `a` group by `a`.`id` having 1 = 0');
+
+    await expect(qb.execute()).resolves.toEqual([]);
   });
 });


### PR DESCRIPTION
Two empty-condition-group cases compiled to invalid SQL:

- `{ $not: { $and: [] } }` and `{ $not: {} }` produced `where not ()`
- `having({ $and: [] })` produced a dangling `group by x having`

Negating a vacuously true condition now compiles to an always-false predicate, since an empty `$and` matches everything and its negation matches nothing. That matches how an empty `$or` already compiles to `1 = 0`. An empty `having` condition is now skipped using the same guard `where` already had, in all three builders that assemble the clause (base, MSSQL, Oracle).

An empty `$and` on its own is unchanged: it stays vacuously true and emits no clause.