### PR TITLE
fix(migrations): keep dollar-quoted blocks intact when splitting statements

### DIFF
--- a/packages/migrations/src/Migrator.ts
+++ b/packages/migrations/src/Migrator.ts
@@ -379,16 +379,54 @@ export class Migrator extends AbstractMigrator<AbstractSqlDriver> {
     // Split SQL by statement boundaries (semicolons followed by newline) rather than
     // just newlines, to preserve multiline statements like view definitions.
     // Blank lines (from double newlines) are preserved as empty strings for grouping.
-    // Splits inside single-quoted string literals are re-merged (GH #7185).
+    // Splits inside single-quoted string literals (GH #7185) or dollar-quoted blocks
+    // like PL/pgSQL function bodies (GH #8061) are re-merged.
     const splitStatements = (sql: string) => {
       const result: string[] = [];
       let buf = '';
 
+      // an unterminated single-quoted string or dollar-quoted block ($$ or $tag$) means the boundary is inside a literal
+      const insideLiteral = (s: string) => {
+        let inString = false;
+        let dollarTag: string | null = null;
+
+        for (let i = 0; i < s.length; i++) {
+          if (dollarTag) {
+            if (s.startsWith(dollarTag, i)) {
+              i += dollarTag.length - 1;
+              dollarTag = null;
+            }
+
+            continue;
+          }
+
+          if (inString) {
+            inString = s[i] !== `'`;
+            continue;
+          }
+
+          if (s[i] === `'`) {
+            inString = true;
+            continue;
+          }
+
+          if (s[i] === '$') {
+            const match = /^\$(?:[a-z_]\w*)?\$/i.exec(s.slice(i));
+
+            if (match) {
+              dollarTag = match[0];
+              i += dollarTag.length - 1;
+            }
+          }
+        }
+
+        return inString || dollarTag !== null;
+      };
+
       for (const chunk of sql.split(/;\n/)) {
         buf += (buf ? ';\n' : '') + chunk;
 
-        // odd number of single quotes means we're inside a string literal
-        if (buf.split(`'`).length % 2 === 0) {
+        if (insideLiteral(buf)) {
           continue;
         }
 

--- a/tests/features/migrations/GH8061.test.ts
+++ b/tests/features/migrations/GH8061.test.ts
@@ -1,0 +1,54 @@
+import { rm } from 'node:fs/promises';
+import { EntitySchema, MikroORM } from '@mikro-orm/postgresql';
+import { Migrator } from '@mikro-orm/migrations';
+
+class Item {
+  id!: number;
+  value!: number;
+}
+
+const ItemSchema = new EntitySchema({
+  class: Item,
+  tableName: 'items',
+  properties: {
+    id: { type: 'number', primary: true },
+    value: { type: 'number' },
+  },
+  triggers: [
+    {
+      name: 'items_increment_after_insert',
+      timing: 'after',
+      events: ['insert'],
+      body: ['update items set value = value + 1 where id = NEW.id;', 'return NEW'].join('\n'),
+    },
+  ],
+});
+
+describe('GH8061', () => {
+  let orm: MikroORM;
+  const migrationPath = process.cwd() + '/temp/migrations-8061';
+
+  beforeAll(async () => {
+    await rm(migrationPath, { recursive: true, force: true });
+    orm = await MikroORM.init({
+      dbName: '8061',
+      entities: [ItemSchema],
+      extensions: [Migrator],
+      migrations: { path: migrationPath, snapshot: false },
+    });
+    await orm.schema.refresh();
+  });
+
+  afterAll(async () => {
+    await orm.close(true);
+  });
+
+  test('dollar-quoted trigger body is kept as a single statement', async () => {
+    await orm.schema.drop();
+    const migration = await orm.migrator.createInitial(migrationPath);
+    const fnStatements = migration.diff.up.filter(sql => sql.includes('create or replace function'));
+    expect(fnStatements).toHaveLength(1);
+    expect(fnStatements[0]).toContain('language plpgsql');
+    await orm.schema.refresh();
+  });
+});


### PR DESCRIPTION
The migration statement splitter breaks a SQL dump on `;\n` boundaries and re-merges the pieces that fall inside a single-quoted string. It has no notion of PostgreSQL dollar quoting, so a PL/pgSQL trigger body with more than one statement gets cut at the first internal `;\n`. `createInitial()` then emits the function as two `addSql()` fragments, and neither fragment is valid on its own.

Dollar-quoted blocks (`$$ ... $$` and the tagged `$tag$ ... $tag$` form) are now tracked the same way as string literals, so their contents stay in one statement.

Fixes #8061