### PR TITLE
fix(sql): normalize trigger bodies when generating DDL

### DIFF
--- a/packages/mssql/src/MsSqlSchemaHelper.ts
+++ b/packages/mssql/src/MsSqlSchemaHelper.ts
@@ -466,7 +466,7 @@ export class MsSqlSchemaHelper extends SchemaHelper {
     const timing = trigger.timing.toUpperCase();
     const events = trigger.events.map(e => e.toUpperCase()).join(', ');
     const qualifiedName = this.getSchemaQualifiedName(table, trigger.name);
-    return `create trigger ${qualifiedName} on ${table.getQuotedName()} ${timing} ${events} as begin ${trigger.body}; end`;
+    return `create trigger ${qualifiedName} on ${table.getQuotedName()} ${timing} ${events} as begin ${this.normalizeTriggerBody(trigger.body)} end`;
   }
 
   /** Generates SQL to drop an MSSQL trigger. */

--- a/packages/sql/src/dialects/mysql/MySqlSchemaHelper.ts
+++ b/packages/sql/src/dialects/mysql/MySqlSchemaHelper.ts
@@ -447,7 +447,7 @@ export class MySqlSchemaHelper extends SchemaHelper {
     for (const event of trigger.events) {
       const name = trigger.events.length > 1 ? `${trigger.name}_${event}` : trigger.name;
       ret.push(
-        `create trigger ${this.quote(name)} ${timing} ${event.toUpperCase()} on ${table.getQuotedName()} for each ROW begin ${trigger.body}; end`,
+        `create trigger ${this.quote(name)} ${timing} ${event.toUpperCase()} on ${table.getQuotedName()} for each ROW begin ${this.normalizeTriggerBody(trigger.body)} end`,
       );
     }
 

--- a/packages/sql/src/dialects/postgresql/PostgreSqlSchemaHelper.ts
+++ b/packages/sql/src/dialects/postgresql/PostgreSqlSchemaHelper.ts
@@ -721,7 +721,7 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
     const fnName = this.getSchemaQualifiedTriggerFnName(table, trigger);
     const triggerName = this.platform.quoteIdentifier(trigger.name);
 
-    const fnSql = `create or replace function ${fnName}() returns trigger as $$ begin ${trigger.body}; end; $$ language plpgsql`;
+    const fnSql = `create or replace function ${fnName}() returns trigger as $$ begin ${this.normalizeTriggerBody(trigger.body)} end; $$ language plpgsql`;
     const triggerSql = `create trigger ${triggerName} ${timing} ${events} on ${table.getQuotedName()} for each ${forEach}${when} execute function ${fnName}()`;
 
     return `${fnSql};\n${triggerSql}`;

--- a/packages/sql/src/dialects/sqlite/SqliteSchemaHelper.ts
+++ b/packages/sql/src/dialects/sqlite/SqliteSchemaHelper.ts
@@ -787,7 +787,7 @@ export class SqliteSchemaHelper extends SchemaHelper {
       const name = trigger.events.length > 1 ? `${trigger.name}_${event}` : trigger.name;
       const when = trigger.when ? `\n  when ${trigger.when}` : '';
       ret.push(
-        `create trigger ${this.quote(name)} ${timing} ${event.toUpperCase()} on ${table.getQuotedName()} for each ${forEach}${when} begin ${trigger.body}; end`,
+        `create trigger ${this.quote(name)} ${timing} ${event.toUpperCase()} on ${table.getQuotedName()} for each ${forEach}${when} begin ${this.normalizeTriggerBody(trigger.body)} end`,
       );
     }
 

--- a/packages/sql/src/schema/SchemaHelper.ts
+++ b/packages/sql/src/schema/SchemaHelper.ts
@@ -1136,7 +1136,7 @@ export abstract class SchemaHelper {
     const events = trigger.events.map(e => e.toUpperCase()).join(' OR ');
     const forEach = trigger.forEach === 'statement' ? 'STATEMENT' : 'ROW';
     const when = trigger.when ? ` when (${trigger.when})` : '';
-    return `create trigger ${this.quote(trigger.name)} ${timing} ${events} on ${table.getQuotedName()} for each ${forEach}${when} begin ${trigger.body}; end`;
+    return `create trigger ${this.quote(trigger.name)} ${timing} ${events} on ${table.getQuotedName()} for each ${forEach}${when} begin ${this.normalizeTriggerBody(trigger.body)} end`;
   }
 
   /**
@@ -1164,6 +1164,12 @@ export abstract class SchemaHelper {
 
   async getAllRoutines(_connection: AbstractSqlConnection, _schemas: string[] = []): Promise<SqlRoutineDef[]> {
     return [];
+  }
+
+  /** Flattens internal `;\n` so the statement splitter doesn't tear the DDL, and ensures exactly one trailing `;` for the enclosing `begin ... end` block. */
+  protected normalizeTriggerBody(body: string): string {
+    const trimmed = stripStatementNewlines(body).trim();
+    return /;\s*$/.test(trimmed) ? trimmed : `${trimmed};`;
   }
 
   /** Wraps the body in `BEGIN ... END` if not already, and flattens internal `;\n` so the schema-generator's statement splitter doesn't tear the DDL. */

--- a/tests/issues/GH8061.test.ts
+++ b/tests/issues/GH8061.test.ts
@@ -1,0 +1,130 @@
+import { rm } from 'node:fs/promises';
+import { EntitySchema } from '@mikro-orm/core';
+import { MikroORM as PostgreSqlORM } from '@mikro-orm/postgresql';
+import { MikroORM as MySqlORM } from '@mikro-orm/mysql';
+import { MikroORM as SqliteORM } from '@mikro-orm/sqlite';
+import { MikroORM as MsSqlORM } from '@mikro-orm/mssql';
+import { Migrator } from '@mikro-orm/migrations';
+import { TEMP_DIR } from '../helpers.js';
+
+const migrationPath = TEMP_DIR + '/migrations-8061';
+
+class Item {
+  id!: number;
+  value!: number;
+}
+
+// a body with a `;\n` boundary and a trailing `;`, both of which used to leak into the generated DDL
+const body = (second: string) => `update items set value = value + 1 where id = NEW.id;\n${second};`;
+
+const schema = (second: string) =>
+  new EntitySchema({
+    class: Item,
+    tableName: 'items',
+    properties: {
+      id: { type: 'number', primary: true },
+      value: { type: 'number' },
+    },
+    triggers: [
+      {
+        name: 'items_increment_after_insert',
+        timing: 'after',
+        events: ['insert'],
+        body: body(second),
+      },
+    ],
+  });
+
+describe('GH #8061 — multi statement trigger bodies stay a single DDL statement', () => {
+  beforeAll(async () => {
+    await rm(migrationPath, { recursive: true, force: true });
+  });
+
+  afterAll(async () => {
+    await rm(migrationPath, { recursive: true, force: true });
+  });
+
+  test('postgres', async () => {
+    const orm = await PostgreSqlORM.init({
+      dbName: 'mikro_orm_test_gh8061',
+      entities: [schema('return NEW')],
+      extensions: [Migrator],
+      migrations: { path: migrationPath, snapshot: false, emit: 'ts' },
+    });
+
+    // the whole plpgsql function is one statement, not two fragments split at the internal `;\n`
+    expect(await orm.schema.getCreateSchemaSQL({ wrap: false })).toMatchInlineSnapshot(`
+      "create table "items" ("id" serial primary key, "value" int not null);
+      create or replace function "items_items_increment_after_insert_fn"() returns trigger as $$ begin update items set value = value + 1 where id = NEW.id; return NEW; end; $$ language plpgsql;
+      create trigger "items_increment_after_insert" AFTER INSERT on "items" for each ROW execute function "items_items_increment_after_insert_fn"();
+      "
+    `);
+
+    await orm.schema.refresh();
+    expect(await orm.schema.getUpdateSchemaSQL({ wrap: false })).toBe('');
+
+    await orm.schema.drop();
+    const { diff } = await orm.migrator.createInitial(migrationPath);
+    const fnStatements = diff.up.filter(sql => sql.includes('create or replace function'));
+    expect(fnStatements).toHaveLength(1);
+    expect(fnStatements[0]).toContain('language plpgsql');
+
+    await orm.schema.dropDatabase();
+    await orm.close(true);
+  });
+
+  test('mysql', async () => {
+    const orm = await MySqlORM.init({
+      dbName: 'mikro_orm_test_gh8061',
+      port: 3308,
+      entities: [schema('set @sum = value')],
+    });
+
+    expect(await orm.schema.getCreateSchemaSQL({ wrap: false })).toMatchInlineSnapshot(`
+      "create table \`items\` (\`id\` int unsigned not null auto_increment primary key, \`value\` int not null) default character set utf8mb4 engine = InnoDB;
+      create trigger \`items_increment_after_insert\` AFTER INSERT on \`items\` for each ROW begin update items set value = value + 1 where id = NEW.id; set @sum = value; end;
+      "
+    `);
+
+    await orm.schema.refresh();
+    expect(await orm.schema.getUpdateSchemaSQL({ wrap: false })).toBe('');
+
+    await orm.schema.dropDatabase();
+    await orm.close(true);
+  });
+
+  test('sqlite', async () => {
+    const orm = await SqliteORM.init({
+      dbName: ':memory:',
+      entities: [schema('update items set value = value where id = NEW.id')],
+    });
+
+    expect(await orm.schema.getCreateSchemaSQL({ wrap: false })).toMatchInlineSnapshot(`
+      "create table \`items\` (\`id\` integer not null primary key autoincrement, \`value\` integer not null);
+      create trigger \`items_increment_after_insert\` AFTER INSERT on \`items\` for each ROW begin update items set value = value + 1 where id = NEW.id; update items set value = value where id = NEW.id; end;
+      "
+    `);
+
+    await orm.schema.refresh();
+    expect(await orm.schema.getUpdateSchemaSQL({ wrap: false })).toBe('');
+
+    await orm.close(true);
+  });
+
+  // the DDL is only asserted as a string here, as `schema.create()` cannot install triggers on mssql
+  test('mssql', async () => {
+    const orm = await MsSqlORM.init({
+      dbName: 'mikro_orm_test_gh8061',
+      password: 'Root.Root',
+      entities: [schema('set @sum = 1')],
+    });
+
+    expect(await orm.schema.getCreateSchemaSQL({ wrap: false })).toMatchInlineSnapshot(`
+      "create table [items] ([id] int identity(1,1) not null primary key, [value] int not null);
+      create trigger [items_increment_after_insert] on [items] AFTER INSERT as begin update items set value = value + 1 where id = NEW.id; set @sum = 1; end;
+      "
+    `);
+
+    await orm.close(true);
+  });
+});


### PR DESCRIPTION
`;\n` is the statement boundary marker for both the migration statement splitter and `SqlSchemaGenerator.execute`, so generated DDL must not contain it. That is what `stripStatementNewlines` exists for, and every `createRoutine` already uses it. `createTrigger` embedded `trigger.body` verbatim, so a body with more than one statement got torn in half: the migration ended up with two `addSql()` fragments, and `schema.create/refresh` failed on every dialect whose connection takes one statement per call.

It also appended `;` unconditionally, so a body already ending with one produced `;;`. That is the `syntax error at or near ";"` from the report, and it hits postgres too, where the splitting is otherwise harmless.

Both are now handled by a `normalizeTriggerBody` helper sitting next to the routine equivalent.

Closes #8061
