### PR TITLE
fix(core): support version and optimistic locking on nested composite keys

### DIFF
--- a/packages/core/src/unit-of-work/ChangeSetPersister.ts
+++ b/packages/core/src/unit-of-work/ChangeSetPersister.ts
@@ -20,7 +20,7 @@ import { helper } from '../entity/wrap.js';
 import { ChangeSetType, type ChangeSet } from './ChangeSet.js';
 import type { QueryResult } from '../connections/Connection.js';
 import { isRaw } from '../utils/RawQueryFragment.js';
-import { Utils } from '../utils/Utils.js';
+import { equals, Utils } from '../utils/Utils.js';
 import { type Configuration } from '../utils/Configuration.js';
 import { type EntityComparator } from '../utils/EntityComparator.js';
 import type { DriverMethodOptions, IDatabaseDriver } from '../drivers/IDatabaseDriver.js';
@@ -519,7 +519,8 @@ export class ChangeSetPersister {
     const res = await this.#driver.find<T>(meta.root.class, { $or } as FilterQuery<T>, options);
 
     if (res.length !== changeSets.length) {
-      const compare = (a: Dictionary, b: Dictionary, keys: string[]) => keys.every(k => a[k] === b[k]);
+      // a FK pointing to a composite PK is an array, so the values need to be compared deeply
+      const compare = (a: Dictionary, b: Dictionary, keys: string[]) => keys.every(k => equals(a[k], b[k]));
       const entity = changeSets.find(cs => {
         return !res.some(row => compare(Utils.getPrimaryKeyCond(cs.entity, primaryKeys)!, row, primaryKeys));
       })!.entity;

--- a/packages/core/src/utils/Utils.ts
+++ b/packages/core/src/utils/Utils.ts
@@ -602,7 +602,9 @@ export class Utils {
 
   static getPrimaryKeyCond<T>(entity: T, primaryKeys: EntityKey<T>[]): Record<string, Primary<T>> | null {
     const cond = primaryKeys.reduce((o, pk) => {
-      o[pk] = Utils.extractPK(entity[pk]);
+      const value = entity[pk];
+      // FKs pointing to a composite PK are arrays, which `extractPK` rejects
+      o[pk] = Utils.isPrimaryKey(value, true) ? value : Utils.extractPK(value);
       return o;
     }, {} as any);
 

--- a/tests/features/composite-keys/nested-composite-key-optimistic-lock.sqlite.test.ts
+++ b/tests/features/composite-keys/nested-composite-key-optimistic-lock.sqlite.test.ts
@@ -1,0 +1,96 @@
+import { MikroORM, OptimisticLockError, PrimaryKeyProp } from '@mikro-orm/sqlite';
+import { Entity, ManyToOne, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+
+@Entity()
+class Bar {
+  @PrimaryKey()
+  id!: number;
+}
+
+@Entity()
+class Baz {
+  @PrimaryKey()
+  id!: number;
+}
+
+@Entity()
+class Param {
+  [PrimaryKeyProp]?: ['bar', 'baz'];
+
+  @ManyToOne(() => Bar, { primary: true })
+  bar!: Bar;
+
+  @ManyToOne(() => Baz, { primary: true })
+  baz!: Baz;
+
+  constructor(bar: Bar, baz: Baz) {
+    this.bar = bar;
+    this.baz = baz;
+  }
+}
+
+@Entity()
+class Detail {
+  [PrimaryKeyProp]?: ['param', 'idx'];
+
+  /** this FK spans two columns, so its value is a composite (array) primary key */
+  @ManyToOne(() => Param, { primary: true })
+  param!: Param;
+
+  @PrimaryKey()
+  idx!: number;
+
+  @Property()
+  value: string;
+
+  @Property({ version: true })
+  version!: Date;
+
+  constructor(param: Param, idx: number, value: string) {
+    this.param = param;
+    this.idx = idx;
+    this.value = value;
+  }
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    metadataProvider: ReflectMetadataProvider,
+    dbName: ':memory:',
+    entities: [Bar, Baz, Param, Detail],
+  });
+  await orm.schema.refresh();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+test('batch update with optimistic locking on a nested composite key', async () => {
+  const param = new Param(new Bar(), new Baz());
+  const d1 = new Detail(param, 1, 'a');
+  const d2 = new Detail(param, 2, 'b');
+  await orm.em.persist([d1, d2]).flush();
+
+  d1.value += ' changed!';
+  d2.value += ' changed!';
+  await orm.em.flush();
+
+  // each update has to land on its own row, addressed via the nested composite key
+  const rows = await orm.em.fork().find(Detail, { param }, { orderBy: { idx: 'asc' } });
+  expect(rows.map(r => [r.idx, r.value])).toEqual([
+    [1, 'a changed!'],
+    [2, 'b changed!'],
+  ]);
+
+  // simulate a concurrent update so the optimistic lock check fails
+  await orm.em.nativeUpdate(Detail, { idx: 2 }, { version: new Date('2020-01-01T00:00:00Z') });
+  d1.value += '!';
+  d2.value += '!';
+  const err = await orm.em.flush().catch(e => e);
+  expect(err).toBeInstanceOf(OptimisticLockError);
+  // the reported entity has to be the one that was updated concurrently
+  expect(err.getEntity()).toBe(d2);
+});


### PR DESCRIPTION
When a primary key relation points at an entity that itself has a composite key, the key value is an array. `Utils.extractPK` calls `isPrimaryKey` without allowing composites, so it rejected the array and `getPrimaryKeyCond` returned `null` for the whole condition. The optimistic lock check then threw `Cannot set properties of null` while putting the version on it.

`getPrimaryKeyCond` now passes such values through. For everything else the behaviour is unchanged, since `extractPK` already returns non-array primary keys as they are.

That check has a second half. On a lock failure it looks for the change set whose row did not come back, comparing key values with `===`, which is identity for arrays and so always picked the first change set instead of the one that actually lost the race. It compares deeply now.

Sitting behind the same `null` was a silent bug in `lockPessimistic`: `qb.where(null)` is coerced to `{}`, so an entity with this key shape produced a lock statement with no where clause. It now emits the key condition.