### PR TITLE
fix(core): fix batch updates when the whole primary key is one relation

### DIFF
--- a/packages/core/src/unit-of-work/ChangeSet.ts
+++ b/packages/core/src/unit-of-work/ChangeSet.ts
@@ -1,4 +1,4 @@
-import type { EntityData, EntityMetadata, EntityDictionary, Primary, Dictionary, EntityKey } from '../typings.js';
+import type { EntityData, EntityMetadata, EntityDictionary, Primary, Dictionary } from '../typings.js';
 import { helper } from '../entity/wrap.js';
 import { Utils } from '../utils/Utils.js';
 import { inspect } from '../logging/inspect.js';
@@ -29,18 +29,21 @@ export class ChangeSet<T extends object> {
       this.primaryKey = (this.originalEntity as T)[this.meta.primaryKeys[0]] as Primary<T>;
     }
 
-    if (
-      !this.meta.compositePK &&
-      this.meta.getPrimaryProp().targetMeta?.compositePK &&
-      typeof this.primaryKey === 'object' &&
-      this.primaryKey !== null
-    ) {
-      this.primaryKey = this.meta.getPrimaryProp().targetMeta!.primaryKeys.map(childPK => {
-        return this.primaryKey![childPK as EntityKey];
-      }) as Primary<T>;
+    const primaryProp = this.meta.getPrimaryProp();
+    const relationPK = !this.meta.compositePK && !!primaryProp.targetMeta?.compositePK;
+
+    // arrays are already the ordered tuple of the target's primary keys
+    if (relationPK && Utils.isPlainObject(this.primaryKey)) {
+      const pk = this.primaryKey as Dictionary;
+      this.primaryKey = primaryProp.targetMeta!.primaryKeys.map(childPK => pk[childPK]) as Primary<T>;
     }
 
     if (object && this.primaryKey != null) {
+      // the whole tuple belongs to the single relation PK, it must not be spread over the (single) PK prop
+      if (relationPK) {
+        return { [primaryProp.name]: this.primaryKey } as any;
+      }
+
       return Utils.primaryKeyToObject(this.meta, this.primaryKey) as any;
     }
 

--- a/packages/sql/src/AbstractSqlDriver.ts
+++ b/packages/sql/src/AbstractSqlDriver.ts
@@ -1601,7 +1601,8 @@ export abstract class AbstractSqlDriver<
       : `(${pks.map(pk => `${this.platform.quoteIdentifier(pk)} = ?`).join(' and ')})`;
 
     const conds = where.map(cond => {
-      if (Utils.isPlainObject(cond) && Utils.getObjectKeysSize(cond) === 1) {
+      // with multiple PK columns the condition is looked up by property name, so it needs to stay an object
+      if (pks.length === 1 && Utils.isPlainObject(cond) && Utils.getObjectKeysSize(cond) === 1) {
         cond = Object.values(cond)[0] as object;
       }
 

--- a/tests/features/composite-keys/batch-update-relation-only-pk.sqlite.test.ts
+++ b/tests/features/composite-keys/batch-update-relation-only-pk.sqlite.test.ts
@@ -1,0 +1,70 @@
+import { MikroORM, PrimaryKeyProp } from '@mikro-orm/sqlite';
+import { Entity, ManyToOne, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+import { mockLogger } from '../../helpers.js';
+
+@Entity()
+class Owner {
+  @PrimaryKey()
+  id1!: number;
+
+  @PrimaryKey()
+  id2!: number;
+
+  [PrimaryKeyProp]?: ['id1', 'id2'];
+}
+
+@Entity()
+class OwnerDetail {
+  @ManyToOne(() => Owner, { primary: true })
+  owner!: Owner;
+
+  @Property()
+  name!: string;
+
+  [PrimaryKeyProp]?: 'owner';
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    metadataProvider: ReflectMetadataProvider,
+    entities: [Owner, OwnerDetail],
+    dbName: ':memory:',
+  });
+  await orm.schema.refresh();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+test('batch update of entities whose only PK is a relation to a composite PK entity', async () => {
+  orm.em.create(OwnerDetail, { owner: { id1: 1, id2: 10 }, name: 'a' });
+  orm.em.create(OwnerDetail, { owner: { id1: 2, id2: 20 }, name: 'b' });
+  await orm.em.flush();
+  orm.em.clear();
+
+  const mock = mockLogger(orm);
+  const details = await orm.em.findAll(OwnerDetail, { orderBy: { owner: { id1: 'asc' } } });
+  details[0].name = 'a1';
+  details[1].name = 'b1';
+  await orm.em.flush();
+  orm.em.clear();
+  expect(mock.mock.calls[2][0]).toMatch('where (`owner_id1`, `owner_id2`) in ((1, 10), (2, 20))');
+
+  const after = await orm.em.findAll(OwnerDetail, { orderBy: { owner: { id1: 'asc' } } });
+  expect(after.map(d => d.name)).toEqual(['a1', 'b1']);
+
+  // single changeset goes through `nativeUpdate` instead
+  mock.mockClear();
+  after[0].name = 'a2';
+  await orm.em.flush();
+  orm.em.clear();
+  expect(mock.mock.calls[1][0]).toMatch(
+    "update `owner_detail` set `name` = 'a2' where (`owner_id1`, `owner_id2`) = (1, 10)",
+  );
+
+  const after2 = await orm.em.findAll(OwnerDetail, { orderBy: { owner: { id1: 'asc' } } });
+  expect(after2.map(d => d.name)).toEqual(['a2', 'b1']);
+});


### PR DESCRIPTION
When an entity's only primary key is a relation to an entity with a composite key, updates never reached the right row.

`ChangeSet.getPrimaryKey(true)` handed the key tuple to `Utils.primaryKeyToObject`, which spreads a tuple across the meta's primary key properties. There is only one such property here, so everything past the first column was dropped. The tuple now stays under the relation property, where it belongs.

The same method also normalised the key by indexing it with the target's key names. That branch was gated on `typeof === 'object'`, which matches arrays too, so an already ordered tuple coming from the change set snapshot turned into a row of `undefined`. It is gated on plain objects now.

On the driver side, the batch update builder unwraps a condition that has a single key so the single column branch can push the bare value. A relation primary key is also a single key, but it spans several columns, and the multi column branch below then looks the condition up by property name and finds nothing. The unwrap is limited to entities that really do have one primary key column.

The single entity `nativeUpdate` path was broken the same way and is covered by the same test.