### PR TITLE
chore(tests): stop concurrent test runs from wiping each other's databases

### DIFF
--- a/tests/features/schema-generator/serial-property.postgres.test.ts
+++ b/tests/features/schema-generator/serial-property.postgres.test.ts
@@ -154,7 +154,6 @@ test('create schema dump with serial property', async () => {
     entities: [Something1],
     dbName: `mikro_orm_test_serial`,
     schemaGenerator: { disableForeignKeys: false },
-    debug: ['schema'],
   });
 
   await orm.schema.refresh();

--- a/tests/globalSetup.ts
+++ b/tests/globalSetup.ts
@@ -1,3 +1,6 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import { MongoMemoryReplSet } from 'mongodb-memory-server-core';
 import { Client as PgClient } from 'pg';
 import mysql from 'mysql2/promise';
@@ -18,6 +21,69 @@ const SQL_TARGETS: SqlTarget[] = [
 ];
 
 const BASELINE_KEY = '__DB_BASELINE__';
+const SETUP_DONE_KEY = '__DB_SETUP_DONE__';
+
+// Both cleanup passes below are destructive across the *whole* database server, which is shared
+// by every checkout/worktree on this machine. A concurrent run would have its in-flight databases
+// dropped from under it (`DROP DATABASE ... WITH (FORCE)` even kills the open connections), so we
+// register each run in a machine-wide directory and only clean up when we are the only run alive.
+const RUN_REGISTRY_DIR = path.join(os.tmpdir(), 'mikro-orm-test-runs');
+
+// A pid file left behind by a `kill -9`d run is only trusted for this long — pids get recycled, so
+// without a cutoff one unlucky recycled pid could disable cleanup forever.
+const RUN_REGISTRY_TTL = 6 * 60 * 60 * 1000;
+
+function isRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e: any) {
+    // EPERM means the pid exists but belongs to another user, so it still counts as alive.
+    return e.code === 'EPERM';
+  }
+}
+
+/** Registers this run and returns the number of other live runs, dropping entries of dead ones. */
+function registerRun(): number {
+  fs.mkdirSync(RUN_REGISTRY_DIR, { recursive: true });
+  fs.writeFileSync(path.join(RUN_REGISTRY_DIR, `${process.pid}`), '');
+
+  return countOtherRuns();
+}
+
+function countOtherRuns(): number {
+  let others = 0;
+
+  for (const name of fs.readdirSync(RUN_REGISTRY_DIR)) {
+    const pid = Number(name);
+
+    if (pid === process.pid) {
+      continue;
+    }
+
+    const file = path.join(RUN_REGISTRY_DIR, name);
+
+    try {
+      if (Number.isInteger(pid) && isRunning(pid) && Date.now() - fs.statSync(file).mtimeMs < RUN_REGISTRY_TTL) {
+        others++;
+      } else {
+        fs.unlinkSync(file);
+      }
+    } catch {
+      /* another run got there first */
+    }
+  }
+
+  return others;
+}
+
+function unregisterRun(): void {
+  try {
+    fs.unlinkSync(path.join(RUN_REGISTRY_DIR, `${process.pid}`));
+  } catch {
+    /* already gone */
+  }
+}
 
 async function withPg<T>(port: number, fn: (c: PgClient) => Promise<T>): Promise<T> {
   const client = new PgClient({
@@ -237,6 +303,15 @@ async function cleanupMssqlOrphanFiles(t: SqlTarget): Promise<number> {
 }
 
 export async function setup() {
+  // Every project in `vitest.config.ts` uses `extends: true`, so it inherits `globalSetup` and
+  // vitest calls this once per project on top of the root config. Everything here is process-wide,
+  // so run it only for the first call.
+  if ((globalThis as any)[SETUP_DONE_KEY]) {
+    return;
+  }
+
+  (globalThis as any)[SETUP_DONE_KEY] = true;
+
   // Narrow-scope test scripts (currently only `test:sqlite`, used by the Windows CI matrix) don't
   // touch MongoDB, so skip the ~781MB binary download and 3-process replica-set spawn entirely.
   // It's wasted work on every run and a flake source on Windows where worker startup occasionally
@@ -257,6 +332,14 @@ export async function setup() {
       // eslint-disable-next-line no-console
       console.warn('Failed to start MongoDB memory server');
     }
+  }
+
+  // Registering before counting is deliberate: if two runs start at the same instant they both see
+  // each other and both skip cleanup, which is the safe direction to lose the race in.
+  if (registerRun() > 0) {
+    // eslint-disable-next-line no-console
+    console.log('[globalSetup] another test run is in progress, skipping test database cleanup');
+    return;
   }
 
   // Drop test DBs leftover from prior crashed runs. MSSQL in particular spends idle CPU on
@@ -301,10 +384,27 @@ export async function setup() {
 }
 
 export async function teardown() {
+  // Mirrors the per-project guard in `setup()` — vitest calls this once per project too.
+  if (!(globalThis as any)[SETUP_DONE_KEY]) {
+    return;
+  }
+
+  delete (globalThis as any)[SETUP_DONE_KEY];
+
   const instance: MongoMemoryReplSet | undefined = (globalThis as any).__MONGOINSTANCE;
 
   if (instance) {
     await instance.stop({ force: true, doCleanup: true });
+  }
+
+  unregisterRun();
+
+  // Everything created since our baseline is assumed to be ours, which only holds while we are the
+  // only run — a run that started after us owns databases we never saw.
+  if (countOtherRuns() > 0) {
+    // eslint-disable-next-line no-console
+    console.log('[globalTeardown] another test run is in progress, skipping leftover DB cleanup');
+    return;
   }
 
   const baseline: Record<string, string[]> = (globalThis as any)[BASELINE_KEY] ?? {};

--- a/tests/issues/GH6160.test.ts
+++ b/tests/issues/GH6160.test.ts
@@ -56,7 +56,6 @@ beforeAll(async () => {
     metadataProvider: ReflectMetadataProvider,
     dbName: ':memory:',
     entities: [User, Address],
-    debug: ['query', 'query-params'],
     allowGlobalContext: true,
   });
   await orm.schema.refresh();

--- a/tests/issues/GH7796.test.ts
+++ b/tests/issues/GH7796.test.ts
@@ -55,7 +55,7 @@ describe('GH #7796 — snapshot flip-flop between migration:create and migration
       dbName: DB,
       port: 3308,
       user: 'root',
-      migrations: { path: PATH, snapshot: true },
+      migrations: { path: PATH, snapshot: true, silent: true },
       extensions: [Migrator],
     });
     await rm(PATH, { recursive: true, force: true });

--- a/tests/issues/GH7798.test.ts
+++ b/tests/issues/GH7798.test.ts
@@ -24,7 +24,7 @@ describe('GH #7798 — migrator.up() rewrites snapshot, dropping sqlite comments
       metadataProvider: ReflectMetadataProvider,
       entities: [Account7798],
       dbName: ':memory:',
-      migrations: { path: PATH, snapshot: true },
+      migrations: { path: PATH, snapshot: true, silent: true },
       extensions: [Migrator],
     });
     await rm(PATH, { recursive: true, force: true });

--- a/tests/issues/GH7798b.test.ts
+++ b/tests/issues/GH7798b.test.ts
@@ -84,7 +84,7 @@ describe('GH #7798 — snapshot flip-flop between migration:create and migration
       entities: [Account7798b, Order7798b],
       dbName: DB,
       port: 5433,
-      migrations: { path: PATH, snapshot: true },
+      migrations: { path: PATH, snapshot: true, silent: true },
       extensions: [Migrator],
     });
     await rm(PATH, { recursive: true, force: true });

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -58,21 +58,31 @@ function getCallSite(): string | null {
   return null;
 }
 
-for (const key of ['log', 'warn', 'error'] as const) {
-  const original = console[key].bind(console);
-  console[key] = (...args: unknown[]) => {
-    const loc = getCallSite();
+// Vitest re-imports setup files for every test file (it invalidates them explicitly), while
+// `isolate: false` keeps one `console` per worker — so without this guard every test file wraps the
+// previous wrapper. Each `console.log` would then capture one stack trace and print one `at ...`
+// line per test file the worker has already run.
+const PATCHED = Symbol.for('mikro-orm-tests:console-patched');
 
-    if (loc) {
-      // Prepend newline to first arg if it's a string (preserves format string substitution)
-      if (typeof args[0] === 'string') {
-        args[0] = '\n' + args[0];
+if (!(console as any)[PATCHED]) {
+  (console as any)[PATCHED] = true;
+
+  for (const key of ['log', 'warn', 'error'] as const) {
+    const original = console[key].bind(console);
+    console[key] = (...args: unknown[]) => {
+      const loc = getCallSite();
+
+      if (loc) {
+        // Prepend newline to first arg if it's a string (preserves format string substitution)
+        if (typeof args[0] === 'string') {
+          args[0] = '\n' + args[0];
+        } else {
+          args.unshift('\n');
+        }
+        original(...args, `\n\n  at ${loc}\n`);
       } else {
-        args.unshift('\n');
+        original(...args);
       }
-      original(...args, `\n\n  at ${loc}\n`);
-    } else {
-      original(...args);
-    }
-  };
+    };
+  }
 }


### PR DESCRIPTION
Running two test suites at once against the shared docker databases makes both fail. `globalSetup` drops every `mikro_orm_test*` database at startup, and at teardown every database that appeared since its baseline. Both sweeps run server-wide, so a run that starts while another is in flight destroys the other one's databases. On postgres the `WITH (FORCE)` drop kills its open connections too.

Reproduced by running the full suite alongside three runs that each execute one 20ms sqlite test: 13 files and 30 tests failed, 5 unhandled errors, 170s wall time, with the familiar `terminating connection due to administrator command`, `Connection terminated unexpectedly`, `Unknown database '...'` and mssql `session is in the kill state` signatures. The interfering runs did essentially no work; just starting vitest was enough. Alone the same suite is green in 53s.

Each run now registers itself in a machine-wide directory, and both sweeps stay out of the way while another run is alive. Same scenario afterwards: green, 55s. The trade-off is that while runs overlap nobody cleans up, so leftovers wait for the next run that starts alone.

Two output problems fixed alongside:

- `tests/setup.ts` wrapped `console` once per test file. Vitest re-imports setup files for every test file while `isolate: false` keeps one `console` per worker, so every file wrapped the previous wrapper. The Nth file in a worker printed N `at ...` lines and captured N stack traces per console call, 211 duplicated call-site lines across a full run.
- `globalSetup` and `globalTeardown` ran once per project on top of the root config, repeating the database sweeps three times per run.

Plus tests that logged queries, schema diffs or migration progress without asserting on them. Full run output is down from 933 lines to 90, with no unhandled errors.
