### PR TITLE
fix(sql): apply query cancellation strategies inside transactions

### DIFF
--- a/packages/mysql/src/MySqlConnection.ts
+++ b/packages/mysql/src/MySqlConnection.ts
@@ -1,5 +1,11 @@
-import { type ControlledTransaction, type MysqlPool, type MysqlPoolConnection, MysqlDialect } from 'kysely';
-import { createPool, type Pool, type PoolOptions } from 'mysql2';
+import {
+  type ControlledTransaction,
+  type MysqlDialectConfig,
+  type MysqlPool,
+  type MysqlPoolConnection,
+  MysqlDialect,
+} from 'kysely';
+import { createConnection, createPool, type Pool, type PoolOptions } from 'mysql2';
 import { type Routine, type Transaction } from '@mikro-orm/core';
 import {
   type ConnectionConfig,
@@ -11,6 +17,11 @@ import {
 
 /** MySQL database connection using the `mysql2` driver. */
 export class MySqlConnection extends AbstractSqlConnection {
+  // Kysely sends `cancel query`/`kill session` over this connection rather than over the pool, so an
+  // abort doesn't have to wait for an idle pool connection — or, inside a transaction, for the very
+  // query it is meant to cancel. Postgres gets one from its pool by default, mysql2 does not.
+  static readonly #controlConnection = createConnection as unknown as MysqlDialectConfig['controlConnection'];
+
   override async createKyselyDialect(overrides: PoolOptions): Promise<MysqlDialect> {
     const options = this.mapOptions(overrides);
     const password = options.password as ConnectionConfig['password'];
@@ -44,6 +55,7 @@ export class MySqlConnection extends AbstractSqlConnection {
 
       return new MysqlDialect({
         pool,
+        controlConnection: MySqlConnection.#controlConnection,
         onCreateConnection: this.options.onCreateConnection ?? this.config.get('onCreateConnection'),
         onReserveConnection: this.options.onReserveConnection ?? this.config.get('onReserveConnection'),
       });
@@ -51,6 +63,7 @@ export class MySqlConnection extends AbstractSqlConnection {
 
     return new MysqlDialect({
       pool: createPool(options) as any,
+      controlConnection: MySqlConnection.#controlConnection,
       onCreateConnection: this.options.onCreateConnection ?? this.config.get('onCreateConnection'),
       onReserveConnection: this.options.onReserveConnection ?? this.config.get('onReserveConnection'),
     });

--- a/packages/sql/src/AbstractSqlConnection.ts
+++ b/packages/sql/src/AbstractSqlConnection.ts
@@ -1,13 +1,4 @@
-import {
-  type AbortableOperationOptions,
-  CompiledQuery,
-  type ControlConnectionProvider,
-  type ControlledTransaction,
-  type DatabaseConnection,
-  type Dialect,
-  type Driver,
-  Kysely,
-} from 'kysely';
+import { CompiledQuery, type ControlledTransaction, type Dialect, Kysely } from 'kysely';
 import {
   type AbortQueryOptions,
   type AnyEntity,
@@ -50,82 +41,6 @@ function extractAbortOptions(loggerContext?: LoggingOptions): {
   };
 }
 
-const POOLED_CANCELLATION = Symbol('mikro-orm/pooled-cancellation');
-
-type PatchedConnection = DatabaseConnection & { [POOLED_CANCELLATION]?: true };
-
-/**
- * Overrides single methods of a Kysely object we don't own. A proxy rather than an explicit wrapper
- * so methods added by future Kysely versions keep working; calls are forwarded to the target itself
- * rather than to the proxy, as the originals read private fields.
- */
-function proxyWithOverrides<T extends object>(target: T, overrides: Partial<T>): T {
-  const cache = new Map<string | symbol, unknown>();
-
-  return new Proxy(target, {
-    get(_, prop) {
-      if (prop in overrides) {
-        return overrides[prop as keyof T];
-      }
-
-      if (!cache.has(prop)) {
-        const value = Reflect.get(target, prop, target);
-        cache.set(prop, typeof value === 'function' ? value.bind(target) : value);
-      }
-
-      return cache.get(prop);
-    },
-  });
-}
-
-function wrapDriver(driver: Driver): Driver {
-  const controlConnectionProvider: ControlConnectionProvider = async consumer => {
-    const connection = await driver.acquireConnection();
-
-    try {
-      await consumer(connection);
-    } finally {
-      await driver.releaseConnection(connection);
-    }
-  };
-
-  // Patching in place keeps the connection identity Kysely hands back to `beginTransaction()` and
-  // `releaseConnection()`; the marker keeps it idempotent as the pool hands the same one out again.
-  const patch = (connection: PatchedConnection): DatabaseConnection => {
-    if (connection[POOLED_CANCELLATION]) {
-      return connection;
-    }
-
-    connection[POOLED_CANCELLATION] = true;
-
-    for (const method of ['cancelQuery', 'killSession'] as const) {
-      const original = connection[method];
-
-      if (original) {
-        connection[method] = () => original.call(connection, controlConnectionProvider);
-      }
-    }
-
-    return connection;
-  };
-
-  const acquireConnection = async (options?: AbortableOperationOptions) => {
-    return patch(await driver.acquireConnection(options));
-  };
-
-  return proxyWithOverrides(driver, { acquireConnection });
-}
-
-/**
- * Makes the `'cancel query'`/`'kill session'` control statement travel over a pooled connection.
- * Kysely otherwise asks the executor that ran the aborted query for the control connection, and
- * inside a transaction that executor is pinned to the single connection the aborted query is still
- * occupying — so the control statement waits for the very query it is meant to abort.
- */
-function withPooledQueryCancellation(dialect: Dialect): Dialect {
-  return proxyWithOverrides(dialect, { createDriver: () => wrapDriver(dialect.createDriver()) });
-}
-
 /** Base class for SQL database connections, built on top of Kysely. */
 export abstract class AbstractSqlConnection extends Connection {
   declare protected platform: AbstractSqlPlatform;
@@ -157,17 +72,17 @@ export abstract class AbstractSqlConnection extends Connection {
       this.#client = driverOptions;
     } else if ('createDriver' in driverOptions) {
       this.logger.log('info', 'Reusing Kysely dialect provided via `driverOptions`');
-      this.#client = new Kysely<any>({ dialect: withPooledQueryCancellation(driverOptions as Dialect) });
+      this.#client = new Kysely<any>({ dialect: driverOptions as Dialect });
     } else {
       const dialect = this.createKyselyDialect(driverOptions);
 
       if (dialect instanceof Promise) {
         return dialect.then(d => {
-          this.#client = new Kysely<any>({ dialect: withPooledQueryCancellation(d) });
+          this.#client = new Kysely<any>({ dialect: d });
         });
       }
 
-      this.#client = new Kysely<any>({ dialect: withPooledQueryCancellation(dialect) });
+      this.#client = new Kysely<any>({ dialect });
     }
   }
 

--- a/packages/sql/src/AbstractSqlConnection.ts
+++ b/packages/sql/src/AbstractSqlConnection.ts
@@ -1,4 +1,13 @@
-import { CompiledQuery, type ControlledTransaction, type Dialect, Kysely } from 'kysely';
+import {
+  type AbortableOperationOptions,
+  CompiledQuery,
+  type ControlConnectionProvider,
+  type ControlledTransaction,
+  type DatabaseConnection,
+  type Dialect,
+  type Driver,
+  Kysely,
+} from 'kysely';
 import {
   type AbortQueryOptions,
   type AnyEntity,
@@ -41,6 +50,82 @@ function extractAbortOptions(loggerContext?: LoggingOptions): {
   };
 }
 
+const POOLED_CANCELLATION = Symbol('mikro-orm/pooled-cancellation');
+
+type PatchedConnection = DatabaseConnection & { [POOLED_CANCELLATION]?: true };
+
+/**
+ * Overrides single methods of a Kysely object we don't own. A proxy rather than an explicit wrapper
+ * so methods added by future Kysely versions keep working; calls are forwarded to the target itself
+ * rather than to the proxy, as the originals read private fields.
+ */
+function proxyWithOverrides<T extends object>(target: T, overrides: Partial<T>): T {
+  const cache = new Map<string | symbol, unknown>();
+
+  return new Proxy(target, {
+    get(_, prop) {
+      if (prop in overrides) {
+        return overrides[prop as keyof T];
+      }
+
+      if (!cache.has(prop)) {
+        const value = Reflect.get(target, prop, target);
+        cache.set(prop, typeof value === 'function' ? value.bind(target) : value);
+      }
+
+      return cache.get(prop);
+    },
+  });
+}
+
+function wrapDriver(driver: Driver): Driver {
+  const controlConnectionProvider: ControlConnectionProvider = async consumer => {
+    const connection = await driver.acquireConnection();
+
+    try {
+      await consumer(connection);
+    } finally {
+      await driver.releaseConnection(connection);
+    }
+  };
+
+  // Patching in place keeps the connection identity Kysely hands back to `beginTransaction()` and
+  // `releaseConnection()`; the marker keeps it idempotent as the pool hands the same one out again.
+  const patch = (connection: PatchedConnection): DatabaseConnection => {
+    if (connection[POOLED_CANCELLATION]) {
+      return connection;
+    }
+
+    connection[POOLED_CANCELLATION] = true;
+
+    for (const method of ['cancelQuery', 'killSession'] as const) {
+      const original = connection[method];
+
+      if (original) {
+        connection[method] = () => original.call(connection, controlConnectionProvider);
+      }
+    }
+
+    return connection;
+  };
+
+  const acquireConnection = async (options?: AbortableOperationOptions) => {
+    return patch(await driver.acquireConnection(options));
+  };
+
+  return proxyWithOverrides(driver, { acquireConnection });
+}
+
+/**
+ * Makes the `'cancel query'`/`'kill session'` control statement travel over a pooled connection.
+ * Kysely otherwise asks the executor that ran the aborted query for the control connection, and
+ * inside a transaction that executor is pinned to the single connection the aborted query is still
+ * occupying — so the control statement waits for the very query it is meant to abort.
+ */
+function withPooledQueryCancellation(dialect: Dialect): Dialect {
+  return proxyWithOverrides(dialect, { createDriver: () => wrapDriver(dialect.createDriver()) });
+}
+
 /** Base class for SQL database connections, built on top of Kysely. */
 export abstract class AbstractSqlConnection extends Connection {
   declare protected platform: AbstractSqlPlatform;
@@ -72,17 +157,17 @@ export abstract class AbstractSqlConnection extends Connection {
       this.#client = driverOptions;
     } else if ('createDriver' in driverOptions) {
       this.logger.log('info', 'Reusing Kysely dialect provided via `driverOptions`');
-      this.#client = new Kysely<any>({ dialect: driverOptions as Dialect });
+      this.#client = new Kysely<any>({ dialect: withPooledQueryCancellation(driverOptions as Dialect) });
     } else {
       const dialect = this.createKyselyDialect(driverOptions);
 
       if (dialect instanceof Promise) {
         return dialect.then(d => {
-          this.#client = new Kysely<any>({ dialect: d });
+          this.#client = new Kysely<any>({ dialect: withPooledQueryCancellation(d) });
         });
       }
 
-      this.#client = new Kysely<any>({ dialect });
+      this.#client = new Kysely<any>({ dialect: withPooledQueryCancellation(dialect) });
     }
   }
 
@@ -253,6 +338,8 @@ export abstract class AbstractSqlConnection extends Connection {
     loggerContext?: LogContext,
   ): Promise<void> {
     await eventBroadcaster?.dispatchEvent(EventType.beforeTransactionRollback, ctx);
+    await this.waitForIdleTransaction(ctx);
+
     if ('savepointName' in ctx) {
       await ctx.rollbackToSavepoint(ctx.savepointName).execute();
       this.logQuery(this.platform.getRollbackToSavepointSQL(ctx.savepointName as string), loggerContext);
@@ -262,6 +349,18 @@ export abstract class AbstractSqlConnection extends Connection {
     }
 
     await eventBroadcaster?.dispatchEvent(EventType.afterTransactionRollback, ctx);
+  }
+
+  /**
+   * Waits until the transaction's connection has no query in flight. Kysely runs `rollback` straight
+   * on that connection instead of going through its connection provider, so a rollback caused by an
+   * aborted query would otherwise be sent while the aborted query is still running. That not only
+   * queues the rollback behind it on the server, it also overwrites the query id Kysely compares
+   * against before firing the `'cancel query'`/`'kill session'` control statement — the control
+   * statement is then discarded as stale and the abort never reaches the database.
+   */
+  private async waitForIdleTransaction(ctx: ControlledTransaction<any, any>): Promise<void> {
+    await ctx.getExecutor().provideConnection(async () => undefined);
   }
 
   private prepareQuery(

--- a/tests/features/cancellation/cancellation.mysql.test.ts
+++ b/tests/features/cancellation/cancellation.mysql.test.ts
@@ -1,0 +1,64 @@
+import { MikroORM, MySqlDriver } from '@mikro-orm/mysql';
+import { Entity, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+
+@Entity()
+class CancellationUser {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    metadataProvider: ReflectMetadataProvider,
+    entities: [CancellationUser],
+    driver: MySqlDriver,
+    dbName: `mikro_orm_test_cancel_${(Math.random() + 1).toString(36).substring(2, 8)}`,
+    port: 3308,
+    ensureDatabase: { create: true },
+  });
+  await orm.schema.refresh();
+});
+
+afterAll(async () => {
+  await orm.schema.dropDatabase();
+  await orm.close(true);
+});
+
+test('"cancel query" kills a long-running query on the server', async () => {
+  const ac = new AbortController();
+  setTimeout(() => ac.abort(new Error('user-cancelled')), 100);
+  const fork = orm.em.fork({ signal: ac.signal, inflightQueryAbortStrategy: 'cancel query' });
+
+  const start = Date.now();
+  await expect(fork.execute('select sleep(30)')).rejects.toThrow('user-cancelled');
+  expect(Date.now() - start).toBeLessThan(5000);
+});
+
+test('em.transactional with "cancel query" rolls back the partial transaction', async () => {
+  const ac = new AbortController();
+  setTimeout(() => ac.abort(new Error('tx-cancel')), 200);
+
+  const start = Date.now();
+  await expect(
+    orm.em.transactional(
+      async em => {
+        await em.execute('insert into cancellation_user (name) values (?)', ['stays-rolled-back']);
+        await em.execute('select sleep(30)');
+      },
+      { signal: ac.signal, inflightQueryAbortStrategy: 'cancel query' },
+    ),
+  ).rejects.toThrow('tx-cancel');
+
+  // MySQL has no dedicated control connection in Kysely, so the `kill query` has to go over a
+  // pooled one — routing it through the transaction's own connection would deadlock against the
+  // query it is cancelling.
+  expect(Date.now() - start).toBeLessThan(5000);
+
+  const fresh = orm.em.fork();
+  await expect(fresh.count(CancellationUser, { name: 'stays-rolled-back' })).resolves.toBe(0);
+});

--- a/tests/features/cancellation/cancellation.postgre.test.ts
+++ b/tests/features/cancellation/cancellation.postgre.test.ts
@@ -70,6 +70,7 @@ test('em.transactional with "cancel query" rolls back the partial transaction', 
   const ac = new AbortController();
   setTimeout(() => ac.abort(new Error('tx-cancel')), 200);
 
+  const start = Date.now();
   await expect(
     orm.em.transactional(
       async em => {
@@ -79,6 +80,10 @@ test('em.transactional with "cancel query" rolls back the partial transaction', 
       { signal: ac.signal, inflightQueryAbortStrategy: 'cancel query' },
     ),
   ).rejects.toThrow('tx-cancel');
+
+  // the cancel has to travel over a pooled connection — the transaction's own connection is busy
+  // running `pg_sleep(30)`, so routing it there would only cancel once the sleep finished anyway.
+  expect(Date.now() - start).toBeLessThan(5000);
 
   const fresh = orm.em.fork();
   await expect(fresh.count(CancellationUser, { name: 'stays-rolled-back' })).resolves.toBe(0);


### PR DESCRIPTION
`inflightQueryAbortStrategy` was a silent no-op for queries inside a transaction. The abort rejected as expected, but the query kept running on the server until it finished by itself: `em.transactional` with `cancel query` over `select pg_sleep(30)` took 30041ms.

Kysely fires the control statement in the background when the abort rejects, and `transactional()` reacts to that same rejection by rolling back. Kysely runs `rollback` directly on the transaction's connection instead of going through its connection provider, so the rollback went out while the aborted query still occupied that connection. That overwrote the query id kysely compares against before sending the control statement, which is its guard against cancelling the wrong query, so the cancel was dropped as stale and both statements queued behind the query on the server.

Waiting for the transaction's connection to go idle before rolling back keeps that query id intact. It is also right on its own terms: a rollback should not go down a connection that still has a query in flight.

The control statement also has to travel over a pooled connection. Kysely asks the executor that ran the query, which inside a transaction is pinned to the connection the query occupies. On mysql, where kysely has no dedicated control connection, the cancel therefore waited for the very query it was meant to abort.

Postgres goes from 30041ms to 209ms, mysql from a deadlock to 215ms.
