### PR TITLE
fix(sql): keep the original error when the rollback of a failed transaction also fails

### DIFF
--- a/packages/sql/src/AbstractSqlConnection.ts
+++ b/packages/sql/src/AbstractSqlConnection.ts
@@ -162,7 +162,15 @@ export abstract class AbstractSqlConnection extends Connection {
 
       return ret;
     } catch (error) {
-      await this.rollback(trx, options.eventBroadcaster, options.loggerContext);
+      // A failing rollback must not mask why the transaction failed in the first place — the
+      // `'kill session'` abort strategy tears the connection down, so the rollback that follows can
+      // only ever report the dead connection.
+      try {
+        await this.rollback(trx, options.eventBroadcaster, options.loggerContext);
+      } catch (rollbackError: any) {
+        this.logger.warn('query', `Failed to roll back transaction: ${rollbackError.message}`);
+      }
+
       throw error;
     }
   }

--- a/tests/features/transactions/transaction-propagation.sqlite.test.ts
+++ b/tests/features/transactions/transaction-propagation.sqlite.test.ts
@@ -655,4 +655,20 @@ describe('Transaction Propagation - SQLite', () => {
     const count = await orm.em.count(TestEntity);
     expect(count).toBe(1); // Only outer entity should exist
   });
+
+  test('a failing rollback does not mask the error that caused it', async () => {
+    const em = orm.em.fork();
+    const rollback = vi
+      .spyOn(em.getConnection(), 'rollback')
+      .mockRejectedValue(new Error('Connection terminated unexpectedly'));
+
+    await expect(
+      em.transactional(async () => {
+        throw new Error('why the transaction failed');
+      }),
+    ).rejects.toThrow('why the transaction failed');
+
+    expect(rollback).toHaveBeenCalled();
+    rollback.mockRestore();
+  });
 });


### PR DESCRIPTION
`transactional()` rolled back and then rethrew, so a rollback that itself failed replaced the error that caused it. Callers were told the connection had gone away rather than why the transaction failed.

This is reachable whenever the transaction's connection dies with the transaction, for example under the `kill session` abort strategy, where the rollback can only ever report the dead connection. The rollback failure is now logged as a warning instead.
