### PR TITLE
fix(postgresql): don't crash the process when the server drops a connection

### DIFF
--- a/packages/postgresql/src/PostgreSqlConnection.ts
+++ b/packages/postgresql/src/PostgreSqlConnection.ts
@@ -13,6 +13,7 @@ export class PostgreSqlConnection extends AbstractSqlConnection {
     };
     const options = this.mapOptions(poolOverrides);
     const pool = new Pool(options);
+    this.handlePoolErrors(pool);
     void onPoolCreated?.(pool);
     return new PostgresDialect({
       pool,
@@ -20,6 +21,23 @@ export class PostgreSqlConnection extends AbstractSqlConnection {
       onCreateConnection: this.options.onCreateConnection ?? this.config.get('onCreateConnection'),
       onReserveConnection: this.options.onReserveConnection ?? this.config.get('onReserveConnection'),
     });
+  }
+
+  /**
+   * Keeps a connection dropped by the server from taking the process down. `pg` reports such a drop
+   * as an `'error'` event, and an `'error'` event without a listener is a fatal uncaught exception.
+   *
+   * Both of the paths that emit one are unguarded by default: `pg-pool` removes its own listener
+   * from a client while that client is checked out, deliberately leaving errors to whoever holds it,
+   * and it re-emits errors of idle clients on the pool itself. The query in flight still rejects on
+   * its own, so there is nothing to do here beyond logging — the pool has already discarded the
+   * broken client by the time we see it.
+   */
+  private handlePoolErrors(pool: Pool): void {
+    pool.on('connect', client => {
+      client.on('error', e => this.logger.warn('info', `PostgreSQL connection error: ${e.message}`));
+    });
+    pool.on('error', e => this.logger.warn('info', `PostgreSQL pool error: ${e.message}`));
   }
 
   mapOptions(overrides: PoolConfig): PoolConfig {

--- a/tests/features/entity-manager/EntityManager.postgre.test.ts
+++ b/tests/features/entity-manager/EntityManager.postgre.test.ts
@@ -147,7 +147,9 @@ describe('EntityManagerPostgre', () => {
     } as any);
 
     expect(receivedPool).toBeInstanceOf(Pool);
-    expect(receivedPool!.listenerCount('error')).toBe(1);
+    // the hook's own listener, plus the built-in one that keeps a dropped connection from killing
+    // the process
+    expect(receivedPool!.listenerCount('error')).toBe(2);
     // the hook key must not be forwarded into the pg PoolConfig
     expect(Object.prototype.hasOwnProperty.call((receivedPool as any).options, 'onPoolCreated')).toBe(false);
   });

--- a/tests/features/postgresql-terminated-connection.test.ts
+++ b/tests/features/postgresql-terminated-connection.test.ts
@@ -1,0 +1,73 @@
+import { MikroORM, PostgreSqlDriver } from '@mikro-orm/postgresql';
+import { Entity, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+
+@Entity()
+class TerminatedUser {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    metadataProvider: ReflectMetadataProvider,
+    entities: [TerminatedUser],
+    driver: PostgreSqlDriver,
+    dbName: `mikro_orm_test_terminated_${(Math.random() + 1).toString(36).substring(2, 8)}`,
+    ensureDatabase: { create: true },
+  });
+  await orm.schema.refresh();
+});
+
+afterAll(async () => {
+  await orm.schema.dropDatabase();
+  await orm.close(true);
+});
+
+/**
+ * `pg-pool` hands error handling for a checked-out client over to its consumer, so a backend that
+ * goes away mid-query used to emit an unhandled `'error'` event and take the whole process down.
+ * The run-level unhandled error reporter is what actually guards this — an escaped `'error'` event
+ * fails the suite even though every assertion here passes.
+ */
+test('a backend terminated mid-query rejects that query without crashing the process', async () => {
+  const uncaught: unknown[] = [];
+  const onUncaught = (e: unknown) => uncaught.push(e);
+  process.on('uncaughtException', onUncaught);
+
+  try {
+    // the marker and the database filter keep us from terminating a backend of some other test file
+    // running concurrently against the same server — several of them also sleep on purpose
+    const victim = orm.em.fork().execute(`select pg_sleep(30) /* terminated_connection_probe */`);
+    // give the query time to reach the server so it holds a checked-out connection
+    await new Promise(resolve => setTimeout(resolve, 300));
+
+    const killer = orm.em.fork();
+    const backends = await killer.execute<{ pid: number }[]>(
+      `select pid from pg_stat_activity where datname = current_database()
+        and query like '%terminated\\_connection\\_probe%' and pid <> pg_backend_pid()`,
+    );
+    expect(backends).toHaveLength(1);
+    await killer.execute(`select pg_terminate_backend(${backends[0].pid})`);
+
+    await expect(victim).rejects.toThrow();
+
+    // the socket only closes after the query rejects, so the 'error' event lands here
+    await new Promise(resolve => setTimeout(resolve, 500));
+    expect(uncaught).toEqual([]);
+  } finally {
+    process.off('uncaughtException', onUncaught);
+  }
+});
+
+test('the pool stays usable after one of its connections was terminated', async () => {
+  const em = orm.em.fork();
+  em.create(TerminatedUser, { name: 'survivor' });
+  await em.flush();
+
+  await expect(orm.em.fork().count(TerminatedUser, { name: 'survivor' })).resolves.toBe(1);
+});


### PR DESCRIPTION
`pg` reports a dropped connection as an `'error'` event on the client, and an `'error'` event with no listener is a fatal uncaught exception. Neither path that emits one was guarded: `pg-pool` removes its own listener from a client while that client is checked out, deliberately leaving errors to whoever holds it, and it re-emits errors of idle clients on the pool itself.

So an administrative disconnect, a server restart, a dropped database or a `pg_terminate_backend` could take the whole application down. The query in flight rejects on its own, and the pool has already discarded the broken client by the time we hear about it, so both listeners only log.

The added test terminates the backend of an in-flight query and asserts that no `uncaughtException` escapes. It fails on master with `Connection terminated unexpectedly`.
