### PR TITLE
chore(sql): drop unreachable savepoint branch in AbstractSqlConnection.begin()

### DIFF
--- a/packages/sql/src/AbstractSqlConnection.ts
+++ b/packages/sql/src/AbstractSqlConnection.ts
@@ -205,17 +205,8 @@ export abstract class AbstractSqlConnection extends Connection {
 
     const trx = await trxBuilder.execute();
 
-    if (options.ctx) {
-      const ctx = options.ctx as Dictionary;
-      ctx.index ??= 0;
-      const savepointName = `trx${ctx.index + 1}`;
-      Reflect.defineProperty(trx, 'index', { value: ctx.index + 1 });
-      Reflect.defineProperty(trx, 'savepointName', { value: savepointName });
-      this.logQuery(this.platform.getSavepointSQL(savepointName), options.loggerContext);
-    } else {
-      for (const query of this.platform.getBeginTransactionSQL(options)) {
-        this.logQuery(query, options.loggerContext);
-      }
+    for (const query of this.platform.getBeginTransactionSQL(options)) {
+      this.logQuery(query, options.loggerContext);
     }
 
     await options.eventBroadcaster?.dispatchEvent(EventType.afterTransactionStart, trx);


### PR DESCRIPTION
`begin()` opens with `if (options.ctx) { ... return trx; }` for the savepoint path, which always returns. The second `options.ctx` check further down, after the transaction has already started, can never be true, so only its `else` arm logging the begin-transaction SQL was reachable.

Removing it also helps codecov. Those lines are permanently uncovered, so any PR that shifts line numbers above them gets them misattributed as newly uncovered patch lines, which happened on #8067.

No behavioral change. The `index` and `savepointName` properties the dead arm defined are only read via `'savepointName' in ctx` in `commit()`/`rollback()` and `ctx.index ??= 0` in the savepoint path, and neither was ever set on the top-level path.