### PR TITLE
fix(mssql): execute `create trigger` in its own query batch

### DIFF
--- a/packages/mssql/src/MsSqlSchemaGenerator.ts
+++ b/packages/mssql/src/MsSqlSchemaGenerator.ts
@@ -1,6 +1,9 @@
 import { type ClearDatabaseOptions, type DropSchemaOptions, type MikroORM, SchemaGenerator } from '@mikro-orm/sql';
 import type { MsSqlDriver } from './MsSqlDriver.js';
 
+/** MSSQL rejects these unless they are the first statement in a query batch. */
+const BATCH_FIRST_STATEMENT = /^create\s+(or\s+alter\s+)?(trigger|view|proc(edure)?|function|schema)\b/i;
+
 /** Schema generator with MSSQL-specific behavior for clearing and dropping schemas. */
 export class MsSqlSchemaGenerator extends SchemaGenerator {
   static override register(orm: MikroORM<MsSqlDriver>): void {
@@ -47,5 +50,9 @@ export class MsSqlSchemaGenerator extends SchemaGenerator {
 
   override async getDropSchemaSQL(options: Omit<DropSchemaOptions, 'dropDb'> = {}): Promise<string> {
     return super.getDropSchemaSQL({ dropForeignKeys: true, ...options });
+  }
+
+  protected override startsBatch(statement: string): boolean {
+    return BATCH_FIRST_STATEMENT.test(statement);
   }
 }

--- a/packages/sql/src/schema/SqlSchemaGenerator.ts
+++ b/packages/sql/src/schema/SqlSchemaGenerator.ts
@@ -606,7 +606,9 @@ export class SqlSchemaGenerator extends AbstractSchemaGenerator<AbstractSqlDrive
     let i = 0;
 
     for (const line of lines) {
-      if (line.trim() === '') {
+      const stmt = line.trim();
+
+      if (stmt === '') {
         if (groups[i]?.length > 0) {
           i++;
         }
@@ -614,8 +616,13 @@ export class SqlSchemaGenerator extends AbstractSchemaGenerator<AbstractSqlDrive
         continue;
       }
 
+      // same boundary an empty line creates, for statements that have to start their own batch
+      if (groups[i]?.length > 0 && this.startsBatch(stmt)) {
+        i++;
+      }
+
       groups[i] ??= [];
-      groups[i].push(line.trim());
+      groups[i].push(stmt);
     }
 
     if (groups.length === 0) {
@@ -639,6 +646,11 @@ export class SqlSchemaGenerator extends AbstractSchemaGenerator<AbstractSqlDrive
         .filter(s => s);
     });
     await Utils.runSerial(statements, stmt => this.driver.execute(stmt));
+  }
+
+  /** Whether the statement has to be the first one in a query batch, e.g. `create trigger` on MSSQL. */
+  protected startsBatch(_statement: string): boolean {
+    return false;
   }
 
   async dropTableIfExists(name: string, schema?: string): Promise<void> {

--- a/tests/features/schema-generator/trigger.mssql.test.ts
+++ b/tests/features/schema-generator/trigger.mssql.test.ts
@@ -44,6 +44,49 @@ describe('trigger [mssql]', () => {
     await orm.close();
   });
 
+  test('triggers are executed in their own batch [mssql]', async () => {
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      entities: [TriggerEntity],
+      dbName: `mikro_orm_test_trigger_mssql_refresh`,
+      password: 'Root.Root',
+    });
+    const meta = orm.getMetadata();
+    await orm.schema.ensureDatabase();
+
+    const alteredMeta = new EntitySchema({
+      properties: {
+        id: { primary: true, name: 'id', type: 'number', fieldName: 'id', columnType: 'int' },
+      },
+      name: 'AlterTrg',
+      tableName: 'alter_trg',
+    }).init().meta;
+    meta.set(alteredMeta.class, alteredMeta);
+
+    // `create trigger` has to be the first statement in a query batch
+    await orm.schema.refresh();
+
+    const { DatabaseSchema } = await import('@mikro-orm/mssql');
+    const connection = orm.em.getConnection();
+    let dbSchema = await DatabaseSchema.create(connection, orm.em.getPlatform(), orm.config);
+    const triggers = dbSchema.getTable('trigger_entity')!.getTriggers();
+    expect(triggers).toHaveLength(1);
+    expect(triggers[0].name).toBe('trg_price');
+
+    // adding triggers to an existing table goes through the alter path
+    alteredMeta.triggers = [
+      { name: 'trg_alter_ins', timing: 'after', events: ['insert'], body: `PRINT 'inserted'` },
+      { name: 'trg_alter_upd', timing: 'after', events: ['update'], body: `PRINT 'updated'` },
+    ];
+    await orm.schema.update();
+
+    dbSchema = await DatabaseSchema.create(connection, orm.em.getPlatform(), orm.config);
+    expect(dbSchema.getTable('alter_trg')!.getTriggers()).toHaveLength(2);
+
+    await orm.schema.dropDatabase();
+    await orm.close();
+  });
+
   test('trigger diff [mssql]', async () => {
     const orm = await MikroORM.init({
       metadataProvider: ReflectMetadataProvider,


### PR DESCRIPTION
SQL Server requires `create trigger` (and `create view`/`procedure`/`function`) to be the first statement in a query batch. The schema generator groups consecutive statements into a single batch on platforms that support multiple statements, so `schema.create()`, `refresh()` and `update()` always failed with `'CREATE TRIGGER' must be the first statement in a query batch` once an entity declared a trigger.

The grouping already starts a new batch on empty lines, so this reuses that boundary for statements that have to start their own batch, via a `startsBatch()` hook that only the MSSQL generator overrides. Generated SQL is unchanged and other platforms are unaffected.

The existing mssql trigger tests only asserted the generated SQL string, which is why nothing caught this. The new test executes `schema.refresh()` and `schema.update()`.