### PR TITLE
fix(sql): pass a flat PK array when persisting M:N of a composite PK owner

### DIFF
--- a/packages/oracledb/src/OracleDriver.ts
+++ b/packages/oracledb/src/OracleDriver.ts
@@ -12,6 +12,7 @@ import {
   isRaw,
   type LoggingOptions,
   type NativeInsertUpdateManyOptions,
+  type Primary,
   QueryFlag,
   type QueryResult,
   ReferenceKind,
@@ -83,7 +84,7 @@ export class OracleDriver extends AbstractSqlDriver<OracleConnection, OraclePlat
 
     if (pks.length > 1) {
       // owner has composite pk
-      pk = data.map(d => Utils.getPrimaryKeyCond(d as T, pks));
+      pk = data.map(d => Utils.getOrderedPrimaryKeys(d as Record<string, Primary<T>>, meta));
     } else {
       res.row ??= {};
       res.rows ??= [];

--- a/packages/sql/src/AbstractSqlDriver.ts
+++ b/packages/sql/src/AbstractSqlDriver.ts
@@ -952,7 +952,7 @@ export abstract class AbstractSqlDriver<
 
     if (meta.primaryKeys.length > 1) {
       // owner has composite pk
-      pk = Utils.getPrimaryKeyCond(data as T, meta.primaryKeys);
+      pk = Utils.getOrderedPrimaryKeys(data as Record<string, Primary<T>>, meta);
     } else {
       /* v8 ignore next */
       res.insertId = data[meta.primaryKeys[0]] ?? res.insertId ?? res.row[meta.primaryKeys[0]];
@@ -1351,10 +1351,9 @@ export abstract class AbstractSqlDriver<
     );
     let pk: any[];
 
-    /* v8 ignore next */
     if (pks.length > 1) {
       // owner has composite pk
-      pk = data.map(d => Utils.getPrimaryKeyCond(d as T, pks as EntityKey<T>[]));
+      pk = data.map(d => Utils.getOrderedPrimaryKeys(d as Record<string, Primary<T>>, meta));
     } else {
       res.row ??= {};
       res.rows ??= [];
@@ -1437,8 +1436,7 @@ export abstract class AbstractSqlDriver<
       res = await this.rethrow(qb.execute('run', false));
     }
 
-    /* v8 ignore next */
-    const pk = pks.map(pk => Utils.extractPK<T>(data[pk] || where, meta)!) as Primary<T>[];
+    const pk = Utils.getOrderedPrimaryKeys({ ...(where as Dictionary), ...data } as Record<string, Primary<T>>, meta);
     await this.processManyToMany<T>(meta, pk, collections, true, options);
 
     return res;
@@ -1652,7 +1650,8 @@ export abstract class AbstractSqlDriver<
     );
 
     for (let i = 0; i < collections.length; i++) {
-      await this.processManyToMany<T>(meta, where[i] as Primary<T>[], collections[i], false, options);
+      const pk = Utils.getOrderedPrimaryKeys(where[i] as Record<string, Primary<T>>, meta);
+      await this.processManyToMany<T>(meta, pk, collections[i], false, options);
     }
 
     return res;

--- a/tests/features/composite-keys/composite-keys.oracle.test.ts
+++ b/tests/features/composite-keys/composite-keys.oracle.test.ts
@@ -1,5 +1,12 @@
-import { MikroORM, PrimaryKeyProp } from '@mikro-orm/oracledb';
-import { Entity, ManyToOne, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+import { Collection, MikroORM, PrimaryKeyProp } from '@mikro-orm/oracledb';
+import {
+  Entity,
+  ManyToMany,
+  ManyToOne,
+  PrimaryKey,
+  Property,
+  ReflectMetadataProvider,
+} from '@mikro-orm/decorators/legacy';
 
 @Entity()
 class Owner {
@@ -11,6 +18,9 @@ class Owner {
 
   @Property()
   name!: string;
+
+  @ManyToMany(() => Tag)
+  tags = new Collection<Tag>(this);
 
   [PrimaryKeyProp]?: ['id1', 'id2'];
 }
@@ -85,6 +95,20 @@ async function createPairs() {
   await orm.em.flush();
   orm.em.clear();
 }
+
+test('batch insert with a composite PK owner and non-empty M:N collection', async () => {
+  await orm.em.insertMany(Tag, [
+    { id: 1, label: 't1' },
+    { id: 2, label: 't2' },
+  ]);
+  await orm.em.insertMany(Owner, [
+    { id1: 1, id2: 10, name: 'o1', tags: [1] },
+    { id1: 2, id2: 20, name: 'o2', tags: [1, 2] },
+  ]);
+
+  const owners = await orm.em.findAll(Owner, { populate: ['tags'], orderBy: { id1: 'asc' } });
+  expect(owners.map(o => o.tags.getIdentifiers())).toEqual([[1], [1, 2]]);
+});
 
 // a primary relation to an entity with a composite PK spans several columns, so the
 // `returning ... into` clause needs one OUT bind per column, not one per property

--- a/tests/features/composite-keys/composite-pk-owner-m-n.test.ts
+++ b/tests/features/composite-keys/composite-pk-owner-m-n.test.ts
@@ -1,0 +1,141 @@
+import { Collection, type EntityData, MikroORM, PrimaryKeyProp } from '@mikro-orm/sqlite';
+import {
+  Entity,
+  ManyToMany,
+  ManyToOne,
+  PrimaryKey,
+  Property,
+  ReflectMetadataProvider,
+} from '@mikro-orm/decorators/legacy';
+
+@Entity()
+class Tag {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+}
+
+@Entity()
+class Param {
+  [PrimaryKeyProp]?: ['bar', 'baz'];
+
+  @PrimaryKey()
+  bar!: number;
+
+  @PrimaryKey()
+  baz!: number;
+
+  @Property({ nullable: true })
+  name?: string;
+
+  @ManyToMany(() => Tag)
+  tags = new Collection<Tag>(this);
+}
+
+// composite PK built from a relation to another composite PK entity, so the pivot columns
+// only line up when the owner PKs are flattened all the way down
+@Entity()
+class NestedParam {
+  [PrimaryKeyProp]?: ['param', 'qux'];
+
+  @ManyToOne(() => Param, { joinColumns: ['param_bar', 'param_baz'], primary: true })
+  param!: Param;
+
+  @PrimaryKey()
+  qux!: number;
+
+  @ManyToMany(() => Tag)
+  tags = new Collection<Tag>(this);
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    entities: [Param, NestedParam, Tag],
+    dbName: ':memory:',
+    metadataProvider: ReflectMetadataProvider,
+  });
+  await orm.schema.refresh();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+test('insert with composite PK owner and non-empty M:N collection', async () => {
+  const em = orm.em.fork();
+  await em.insert(Tag, { id: 10, name: 't1' });
+  await em.insert(Tag, { id: 11, name: 't2' });
+  await em.insert(Param, { bar: 1, baz: 2, tags: [10, 11] });
+
+  const param = await em.fork().findOneOrFail(Param, { bar: 1, baz: 2 }, { populate: ['tags'] });
+  expect(param.tags.getIdentifiers()).toEqual([10, 11]);
+});
+
+test('insertMany with composite PK owner and non-empty M:N collection', async () => {
+  const em = orm.em.fork();
+  await em.insertMany(Tag, [
+    { id: 20, name: 't3' },
+    { id: 21, name: 't4' },
+  ]);
+  await em.insertMany(Param, [
+    { bar: 3, baz: 4, tags: [20] },
+    { bar: 5, baz: 6, tags: [20, 21] },
+  ]);
+
+  const params = await em.fork().find(Param, { bar: { $in: [3, 5] } }, { populate: ['tags'], orderBy: { bar: 'asc' } });
+  expect(params.map(p => p.tags.getIdentifiers())).toEqual([[20], [20, 21]]);
+});
+
+test('update with composite PK owner and non-empty M:N collection', async () => {
+  const em = orm.em.fork();
+  await em.insert(Tag, { id: 30, name: 't5' });
+  await em.insert(Param, { bar: 7, baz: 8 });
+  await em.nativeUpdate(Param, { bar: 7, baz: 8 }, { tags: [30] });
+
+  const param = await em.fork().findOneOrFail(Param, { bar: 7, baz: 8 }, { populate: ['tags'] });
+  expect(param.tags.getIdentifiers()).toEqual([30]);
+});
+
+test('batch update with composite PK owner and non-empty M:N collection', async () => {
+  const em = orm.em.fork();
+  await em.insertMany(Tag, [
+    { id: 50, name: 't7' },
+    { id: 51, name: 't8' },
+  ]);
+  await em.insertMany(Param, [
+    { bar: 12, baz: 13 },
+    { bar: 14, baz: 15 },
+  ]);
+  await em.getDriver().nativeUpdateMany(
+    Param,
+    [
+      { bar: 12, baz: 13 },
+      { bar: 14, baz: 15 },
+    ],
+    [
+      { name: 'p1', tags: [50] },
+      { name: 'p2', tags: [51] },
+    ] as EntityData<Param>[],
+  );
+
+  const params = await em
+    .fork()
+    .find(Param, { bar: { $in: [12, 14] } }, { populate: ['tags'], orderBy: { bar: 'asc' } });
+  expect(params.map(p => p.tags.getIdentifiers())).toEqual([[50], [51]]);
+});
+
+test('insert with nested composite PK owner and non-empty M:N collection', async () => {
+  const em = orm.em.fork();
+  await em.insert(Tag, { id: 40, name: 't6' });
+  await em.insert(Param, { bar: 9, baz: 10 });
+  await em.insert(NestedParam, { param: [9, 10], qux: 11, tags: [40] });
+
+  // asserting on the pivot row rather than via `populate`, which does not yet load M:N collections
+  // of an owner whose composite PK contains a relation
+  const rows = await em.getConnection().execute('select * from nested_param_tags');
+  expect(rows).toEqual([{ nested_param_param_bar: 9, nested_param_param_baz: 10, nested_param_qux: 11, tag_id: 40 }]);
+});


### PR DESCRIPTION
`processManyToMany` hands its `pks` argument to `PivotCollectionPersister`, which spreads it and zips it positionally against `prop.joinColumns`. The composite PK branches passed `Utils.getPrimaryKeyCond()`, which returns an object, so inserting an entity that has a composite PK and a non-empty M:N collection in the same payload threw `TypeError: pks is not iterable`:

```ts
await em.insert(Param, { bar: 1, baz: 2, tags: [10, 11] });
```

Empty collections early-out in the persister, which is why this went unnoticed.

Two neighbouring call sites were broken differently. `nativeUpdate` mapped over field names and produced one nested tuple per column, which failed with `5 values for 3 columns`. `nativeInsertMany` and the Oracle override indexed a property-name-keyed payload with field names from `getPrimaryKeyFields()`, so every relation PK came out `undefined`.

All of them now use `Utils.getOrderedPrimaryKeys()`, which already returns the flat, field-ordered array of scalar PK values the pivot rows need. It also recurses through relation PKs, so a composite PK built from a relation to another composite PK entity works too.
