### PR TITLE
fix(sql): keep multi line trigger bodies stable across schema updates

### DIFF
--- a/packages/sql/src/schema/SchemaComparator.ts
+++ b/packages/sql/src/schema/SchemaComparator.ts
@@ -1171,7 +1171,9 @@ export class SchemaComparator {
           // Remove AS keyword (optional in SQL, MySQL may add/remove it)
           .replace(/\bas\b/gi, '')
           // Remove remaining special chars, parentheses, type casts, asterisks, and normalize whitespace
-          .replace(/[()\n[\]*]|::\w+| +/g, '')
+          // tabs and CRs included — the schema generator trims every line before executing the DDL,
+          // so indentation and CRLF endings can never come back from introspection
+          .replace(/[()\n\r\t[\]*]|::\w+| +/g, '')
           .replace(/anyarray\[(.*)]/gi, '$1')
           .toLowerCase()
           // PostgreSQL adds default aliases to aggregate functions (e.g., count(*) AS count)

--- a/packages/sql/src/schema/SchemaHelper.ts
+++ b/packages/sql/src/schema/SchemaHelper.ts
@@ -22,9 +22,19 @@ import type {
 import type { DatabaseSchema } from './DatabaseSchema.js';
 import type { DatabaseTable } from './DatabaseTable.js';
 
-/** Flattens `;\n` boundaries so the schema-generator's statement splitter doesn't break the routine DDL apart. Other whitespace is preserved. */
+/**
+ * Flattens `;\n` boundaries and drops blank lines so the schema-generator's statement splitter
+ * doesn't break the routine or trigger DDL apart — it treats both as statement/group separators.
+ * Blank lines go first, otherwise a `;` followed by one would keep its newline. Like
+ * `normalizeViewDefinition`, this is not string-literal aware, so a blank line inside a multi-line
+ * literal is dropped too. Other whitespace is preserved.
+ */
 export function stripStatementNewlines(body: string): string {
-  return body.replace(/;[\t ]*\r?\n/g, '; ');
+  return body
+    .split('\n')
+    .filter(line => line.trim() !== '')
+    .join('\n')
+    .replace(/;[\t ]*\r?\n/g, '; ');
 }
 
 /**

--- a/tests/features/stored-routines/helpers.test.ts
+++ b/tests/features/stored-routines/helpers.test.ts
@@ -26,6 +26,12 @@ SELECT y`;
       expect(out).toContain('-- header comment\nSET x = 1');
       expect(out).toContain("'hello\nworld'");
     });
+
+    it('drops blank lines, including the one that follows a statement', () => {
+      expect(stripStatementNewlines('SET a = 1;\n\nSET b = 2')).toBe('SET a = 1; SET b = 2');
+      expect(stripStatementNewlines('IF x THEN\n\n\tSET a = 1\nEND IF')).toBe('IF x THEN\n\tSET a = 1\nEND IF');
+      expect(stripStatementNewlines('SET a = 1;\r\n\r\nSET b = 2')).toBe('SET a = 1; SET b = 2');
+    });
   });
 
   describe('MySQL', () => {

--- a/tests/issues/GHx64.test.ts
+++ b/tests/issues/GHx64.test.ts
@@ -1,0 +1,107 @@
+import { EntitySchema, type MikroORM } from '@mikro-orm/core';
+import { MikroORM as SqliteMikroORM } from '@mikro-orm/sqlite';
+import { MikroORM as PostgreSqlMikroORM } from '@mikro-orm/postgresql';
+import { MikroORM as MySqlMikroORM } from '@mikro-orm/mysql';
+
+/**
+ * Multi-line trigger bodies were broken in several ways:
+ * - tab indentation and CRLF endings were kept by the comparator but stripped by the schema
+ *   generator before execution, so the trigger was dropped and recreated on every schema update
+ * - a blank line inside the body acted as a statement group separator, tearing the DDL apart
+ */
+function entity(tableName: string, columnType: string, body: string) {
+  return new EntitySchema({
+    name: 'Product',
+    tableName,
+    properties: {
+      id: { primary: true, type: 'number', columnType },
+      price: { type: 'number', columnType },
+    },
+    triggers: [{ name: `${tableName}_trg`, timing: 'before', events: ['insert'], body }],
+  });
+}
+
+async function assertNoChurn(orm: MikroORM) {
+  await orm.schema.refresh();
+  expect(await orm.schema.getUpdateSchemaSQL({ wrap: false })).toBe('');
+}
+
+describe('GHx64 — multi-line trigger bodies', () => {
+  describe('sqlite', () => {
+    const table = 'ghx64_sqlite';
+    const init = (body: string) =>
+      SqliteMikroORM.init({ entities: [entity(table, 'integer', body)], dbName: ':memory:' });
+
+    test('tab indented body does not produce a perpetual diff', async () => {
+      const orm = await init(`update ${table}\n\tset price = price + 1\nwhere id = NEW.id`);
+      await assertNoChurn(orm);
+      await orm.close(true);
+    });
+
+    test('crlf body does not produce a perpetual diff', async () => {
+      const orm = await init(`update ${table}\r\nset price = price + 1\r\nwhere id = NEW.id`);
+      await assertNoChurn(orm);
+      await orm.close(true);
+    });
+
+    test('blank line inside the body does not tear the DDL', async () => {
+      const orm = await init(`update ${table}\n\nset price = price + 1\nwhere id = NEW.id`);
+      await assertNoChurn(orm);
+      await orm.close(true);
+    });
+
+    test('blank line after a statement does not tear the DDL', async () => {
+      const orm = await init(`update ${table} set price = price + 1;\n\nupdate ${table} set price = price + 2`);
+      await assertNoChurn(orm);
+      await orm.close(true);
+    });
+  });
+
+  describe('postgres', () => {
+    const table = 'ghx64_postgres';
+    const init = (body: string) =>
+      PostgreSqlMikroORM.init({ entities: [entity(table, 'int', body)], dbName: 'mikro_orm_test_ghx64_pg' });
+
+    test('tab indented body does not produce a perpetual diff', async () => {
+      const orm = await init(`if (NEW.price is null) then\n\tNEW.price = 0;\nend if;\nreturn NEW`);
+      await orm.schema.ensureDatabase();
+      await assertNoChurn(orm);
+      await orm.schema.dropDatabase();
+      await orm.close(true);
+    });
+
+    test('blank line after a statement does not tear the DDL', async () => {
+      const orm = await init(`NEW.price = coalesce(NEW.price, 0);\n\nreturn NEW`);
+      await orm.schema.ensureDatabase();
+      await assertNoChurn(orm);
+      await orm.schema.dropDatabase();
+      await orm.close(true);
+    });
+  });
+
+  describe('mysql', () => {
+    const table = 'ghx64_mysql';
+    const init = (body: string) =>
+      MySqlMikroORM.init({
+        entities: [entity(table, 'int', body)],
+        dbName: 'mikro_orm_test_ghx64_mysql',
+        port: 3308,
+      });
+
+    test('tab indented body does not produce a perpetual diff', async () => {
+      const orm = await init(`if (NEW.price is null) then\n\tset NEW.price = 0;\nend if`);
+      await orm.schema.ensureDatabase();
+      await assertNoChurn(orm);
+      await orm.schema.dropDatabase();
+      await orm.close(true);
+    });
+
+    test('blank line after a statement does not tear the DDL', async () => {
+      const orm = await init(`set NEW.price = coalesce(NEW.price, 0);\n\nset NEW.price = NEW.price + 1`);
+      await orm.schema.ensureDatabase();
+      await assertNoChurn(orm);
+      await orm.schema.dropDatabase();
+      await orm.close(true);
+    });
+  });
+});


### PR DESCRIPTION
Multi-line trigger bodies had two pre-existing problems.

The first was a perpetual schema diff. `SchemaComparator.diffExpression` strips spaces and newlines from both sides before comparing, but not tabs or CRs. `SqlSchemaGenerator.execute` trims every line before executing the DDL, so indentation and CRLF endings never reach the database, yet they stay on the metadata side. `diffTrigger` saw a difference, and the trigger was dropped and recreated on every `schema.update()` and every migration diff. Space-indented bodies were unaffected, since spaces were already stripped.

The second was torn DDL. `stripStatementNewlines` only collapsed `;\n`, so a blank line survived into the generated DDL. Both `SqlSchemaGenerator.execute` and `Migrator.getSchemaDiff` treat a blank line as a statement group separator, which split the statement in half, and postgres reported `unterminated dollar-quoted string`. `normalizeViewDefinition` already drops blank lines from view definitions for exactly this reason; routine and trigger bodies did not.

The blank-line filter runs before the `;\n` collapse rather than after. In the other order, a `;` followed directly by a blank line keeps one of its two newlines, and `execute` trims that back into a `;\n` statement boundary.

Follows #8063, which fixed the `;\n` tearing in trigger DDL but neither of these.