### PR TITLE
fix(mssql): manage table and column comments via extended properties

### DIFF
--- a/packages/mssql/src/MsSqlSchemaHelper.ts
+++ b/packages/mssql/src/MsSqlSchemaHelper.ts
@@ -1069,34 +1069,65 @@ export class MsSqlSchemaHelper extends SchemaHelper {
       })
       .join(', ');
 
-    return [`alter table ${table.getQuotedName()} add ${adds}`];
-  }
+    const sql = [`alter table ${table.getQuotedName()} add ${adds}`];
 
-  override appendComments(table: DatabaseTable): string[] {
-    const sql: string[] = [];
-    const schema = this.platform.quoteValue(table.schema);
-    const tableName = this.platform.quoteValue(table.name);
-
-    if (table.comment) {
-      const comment = this.platform.quoteValue(table.comment);
-      sql.push(`if exists(select * from sys.fn_listextendedproperty(N'MS_Description', N'Schema', N${schema}, N'Table', N${tableName}, null, null))
-  exec sys.sp_updateextendedproperty N'MS_Description', N${comment}, N'Schema', N${schema}, N'Table', N${tableName}
-else
-  exec sys.sp_addextendedproperty N'MS_Description', N${comment}, N'Schema', N${schema}, N'Table', N${tableName}`);
-    }
-
-    for (const column of table.getColumns()) {
+    for (const column of columns) {
       if (column.comment) {
-        const comment = this.platform.quoteValue(column.comment);
-        const columnName = this.platform.quoteValue(column.name);
-        sql.push(`if exists(select * from sys.fn_listextendedproperty(N'MS_Description', N'Schema', N${schema}, N'Table', N${tableName}, N'Column', N${columnName}))
-  exec sys.sp_updateextendedproperty N'MS_Description', N${comment}, N'Schema', N${schema}, N'Table', N${tableName}, N'Column', N${columnName}
-else
-  exec sys.sp_addextendedproperty N'MS_Description', N${comment}, N'Schema', N${schema}, N'Table', N${tableName}, N'Column', N${columnName}`);
+        sql.push(this.getCommentSQL(table.schema, table.name, column.comment, column.name));
       }
     }
 
     return sql;
+  }
+
+  override appendComments(table: DatabaseTable): string[] {
+    const sql: string[] = [];
+
+    if (table.comment) {
+      sql.push(this.getCommentSQL(table.schema, table.name, table.comment));
+    }
+
+    for (const column of table.getColumns()) {
+      if (column.comment) {
+        sql.push(this.getCommentSQL(table.schema, table.name, column.comment, column.name));
+      }
+    }
+
+    return sql;
+  }
+
+  override alterTableComment(table: DatabaseTable, comment?: string): string {
+    return this.getCommentSQL(table.schema, table.name, comment);
+  }
+
+  override getChangeColumnCommentSQL(tableName: string, to: Column, schemaName?: string): string {
+    return this.getCommentSQL(schemaName, tableName, to.comment, to.name);
+  }
+
+  /** Comments are stored as `MS_Description` extended properties, which have separate add/update/drop procedures. */
+  private getCommentSQL(
+    schemaName: string | undefined,
+    tableName: string,
+    comment?: string,
+    columnName?: string,
+  ): string {
+    const schema = this.platform.quoteValue(schemaName ?? this.platform.getDefaultSchemaName());
+    const table = this.platform.quoteValue(tableName);
+    const level1 = `N'Schema', N${schema}, N'Table', N${table}`;
+    const level2 = columnName ? `N'Column', N${this.platform.quoteValue(columnName)}` : '';
+    const exists = `if exists(select * from sys.fn_listextendedproperty(N'MS_Description', ${level1}, ${level2 || 'null, null'}))`;
+    const target = level2 ? `${level1}, ${level2}` : level1;
+
+    if (!comment) {
+      return `${exists}\n  exec sys.sp_dropextendedproperty N'MS_Description', ${target}`;
+    }
+
+    const value = this.platform.quoteValue(comment);
+
+    return `${exists}
+  exec sys.sp_updateextendedproperty N'MS_Description', N${value}, ${target}
+else
+  exec sys.sp_addextendedproperty N'MS_Description', N${value}, ${target}`;
   }
 
   override inferLengthFromColumnType(type: string): number | undefined {

--- a/tests/features/schema-generator/__snapshots__/comment-diffing.mssql.test.ts.snap
+++ b/tests/features/schema-generator/__snapshots__/comment-diffing.mssql.test.ts.snap
@@ -1,0 +1,74 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`comment diffing [mssql] > adding, changing and removing table and column comments 1`] = `
+"if exists(select * from sys.fn_listextendedproperty(N'MS_Description', N'Schema', N'dbo', N'Table', N'book', N'Column', N'id'))
+  exec sys.sp_updateextendedproperty N'MS_Description', N'this is primary''s key', N'Schema', N'dbo', N'Table', N'book', N'Column', N'id'
+else
+  exec sys.sp_addextendedproperty N'MS_Description', N'this is primary''s key', N'Schema', N'dbo', N'Table', N'book', N'Column', N'id';
+if exists(select * from sys.fn_listextendedproperty(N'MS_Description', N'Schema', N'dbo', N'Table', N'book', N'Column', N'name'))
+  exec sys.sp_updateextendedproperty N'MS_Description', N'this is name of book', N'Schema', N'dbo', N'Table', N'book', N'Column', N'name'
+else
+  exec sys.sp_addextendedproperty N'MS_Description', N'this is name of book', N'Schema', N'dbo', N'Table', N'book', N'Column', N'name';
+if exists(select * from sys.fn_listextendedproperty(N'MS_Description', N'Schema', N'dbo', N'Table', N'book', null, null))
+  exec sys.sp_updateextendedproperty N'MS_Description', N'this is book''s table', N'Schema', N'dbo', N'Table', N'book'
+else
+  exec sys.sp_addextendedproperty N'MS_Description', N'this is book''s table', N'Schema', N'dbo', N'Table', N'book';
+"
+`;
+
+exports[`comment diffing [mssql] > adding, changing and removing table and column comments 2`] = `
+"if exists(select * from sys.fn_listextendedproperty(N'MS_Description', N'Schema', N'dbo', N'Table', N'book', N'Column', N'id'))
+  exec sys.sp_updateextendedproperty N'MS_Description', N'new comment', N'Schema', N'dbo', N'Table', N'book', N'Column', N'id'
+else
+  exec sys.sp_addextendedproperty N'MS_Description', N'new comment', N'Schema', N'dbo', N'Table', N'book', N'Column', N'id';
+if exists(select * from sys.fn_listextendedproperty(N'MS_Description', N'Schema', N'dbo', N'Table', N'book', N'Column', N'name'))
+  exec sys.sp_dropextendedproperty N'MS_Description', N'Schema', N'dbo', N'Table', N'book', N'Column', N'name';
+if exists(select * from sys.fn_listextendedproperty(N'MS_Description', N'Schema', N'dbo', N'Table', N'book', null, null))
+  exec sys.sp_updateextendedproperty N'MS_Description', N'table comment', N'Schema', N'dbo', N'Table', N'book'
+else
+  exec sys.sp_addextendedproperty N'MS_Description', N'table comment', N'Schema', N'dbo', N'Table', N'book';
+"
+`;
+
+exports[`comment diffing [mssql] > adding, changing and removing table and column comments 3`] = `
+"if exists(select * from sys.fn_listextendedproperty(N'MS_Description', N'Schema', N'dbo', N'Table', N'book', N'Column', N'id'))
+  exec sys.sp_dropextendedproperty N'MS_Description', N'Schema', N'dbo', N'Table', N'book', N'Column', N'id';
+if exists(select * from sys.fn_listextendedproperty(N'MS_Description', N'Schema', N'dbo', N'Table', N'book', null, null))
+  exec sys.sp_dropextendedproperty N'MS_Description', N'Schema', N'dbo', N'Table', N'book';
+"
+`;
+
+exports[`comment diffing [mssql] > adding, changing and removing table and column comments 4`] = `
+"alter table [book] add [description] nvarchar(255) null;
+if exists(select * from sys.fn_listextendedproperty(N'MS_Description', N'Schema', N'dbo', N'Table', N'book', N'Column', N'description'))
+  exec sys.sp_updateextendedproperty N'MS_Description', N'comment of a newly added column', N'Schema', N'dbo', N'Table', N'book', N'Column', N'description'
+else
+  exec sys.sp_addextendedproperty N'MS_Description', N'comment of a newly added column', N'Schema', N'dbo', N'Table', N'book', N'Column', N'description';
+"
+`;
+
+exports[`comment diffing [mssql] > comments are diffed in a non-default schema 1`] = `
+"if exists(select * from sys.fn_listextendedproperty(N'MS_Description', N'Schema', N'foo', N'Table', N'book', N'Column', N'id'))
+  exec sys.sp_updateextendedproperty N'MS_Description', N'this is primary''s key', N'Schema', N'foo', N'Table', N'book', N'Column', N'id'
+else
+  exec sys.sp_addextendedproperty N'MS_Description', N'this is primary''s key', N'Schema', N'foo', N'Table', N'book', N'Column', N'id';
+if exists(select * from sys.fn_listextendedproperty(N'MS_Description', N'Schema', N'foo', N'Table', N'book', N'Column', N'name'))
+  exec sys.sp_updateextendedproperty N'MS_Description', N'this is name of book', N'Schema', N'foo', N'Table', N'book', N'Column', N'name'
+else
+  exec sys.sp_addextendedproperty N'MS_Description', N'this is name of book', N'Schema', N'foo', N'Table', N'book', N'Column', N'name';
+if exists(select * from sys.fn_listextendedproperty(N'MS_Description', N'Schema', N'foo', N'Table', N'book', null, null))
+  exec sys.sp_updateextendedproperty N'MS_Description', N'this is book''s table', N'Schema', N'foo', N'Table', N'book'
+else
+  exec sys.sp_addextendedproperty N'MS_Description', N'this is book''s table', N'Schema', N'foo', N'Table', N'book';
+"
+`;
+
+exports[`comment diffing [mssql] > comments are diffed in a non-default schema 2`] = `
+"if exists(select * from sys.fn_listextendedproperty(N'MS_Description', N'Schema', N'foo', N'Table', N'book', N'Column', N'id'))
+  exec sys.sp_dropextendedproperty N'MS_Description', N'Schema', N'foo', N'Table', N'book', N'Column', N'id';
+if exists(select * from sys.fn_listextendedproperty(N'MS_Description', N'Schema', N'foo', N'Table', N'book', N'Column', N'name'))
+  exec sys.sp_dropextendedproperty N'MS_Description', N'Schema', N'foo', N'Table', N'book', N'Column', N'name';
+if exists(select * from sys.fn_listextendedproperty(N'MS_Description', N'Schema', N'foo', N'Table', N'book', null, null))
+  exec sys.sp_dropextendedproperty N'MS_Description', N'Schema', N'foo', N'Table', N'book';
+"
+`;

--- a/tests/features/schema-generator/comment-diffing.mssql.test.ts
+++ b/tests/features/schema-generator/comment-diffing.mssql.test.ts
@@ -1,0 +1,113 @@
+import { MikroORM, MsSqlDriver } from '@mikro-orm/mssql';
+import { Entity, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+
+@Entity({ tableName: 'book' })
+class Book0 {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+}
+
+@Entity({ tableName: 'book', comment: "this is book's table" })
+class Book1 {
+  @PrimaryKey({ comment: "this is primary's key" })
+  id!: number;
+
+  @Property({ comment: 'this is name of book' })
+  name!: string;
+}
+
+@Entity({ tableName: 'book', comment: 'table comment' })
+class Book2 {
+  @PrimaryKey({ comment: 'new comment' })
+  id!: number;
+
+  @Property({ comment: '' })
+  name!: string;
+}
+
+@Entity({ tableName: 'book' })
+class Book3 {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+}
+
+@Entity({ tableName: 'book' })
+class Book4 {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @Property({ nullable: true, comment: 'comment of a newly added column' })
+  description?: string;
+}
+
+async function bootstrap(schema?: string) {
+  const orm = await MikroORM.init({
+    driver: MsSqlDriver,
+    metadataProvider: ReflectMetadataProvider,
+    entities: [Book0],
+    dbName: `mikro_orm_test_comments`,
+    password: 'Root.Root',
+    schema,
+  });
+  await orm.schema.refresh();
+  return orm;
+}
+
+describe('comment diffing [mssql]', () => {
+  test('adding, changing and removing table and column comments', async () => {
+    const orm = await bootstrap();
+
+    orm.discoverEntity(Book1, Book0);
+    const diff1 = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(diff1).toMatchSnapshot();
+    await orm.schema.execute(diff1);
+    await expect(orm.schema.getUpdateSchemaSQL({ wrap: false })).resolves.toBe('');
+
+    orm.discoverEntity(Book2, Book1);
+    const diff2 = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(diff2).toMatchSnapshot();
+    await orm.schema.execute(diff2);
+    await expect(orm.schema.getUpdateSchemaSQL({ wrap: false })).resolves.toBe('');
+
+    orm.discoverEntity(Book3, Book2);
+    const diff3 = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(diff3).toMatchSnapshot();
+    await orm.schema.execute(diff3);
+    await expect(orm.schema.getUpdateSchemaSQL({ wrap: false })).resolves.toBe('');
+
+    orm.discoverEntity(Book4, Book3);
+    const diff4 = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(diff4).toMatchSnapshot();
+    await orm.schema.execute(diff4);
+    await expect(orm.schema.getUpdateSchemaSQL({ wrap: false })).resolves.toBe('');
+
+    await orm.close(true);
+  });
+
+  test('comments are diffed in a non-default schema', async () => {
+    const orm = await bootstrap('foo');
+
+    orm.discoverEntity(Book1, Book0);
+    const diff1 = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(diff1).toMatchSnapshot();
+    await orm.schema.execute(diff1);
+    await expect(orm.schema.getUpdateSchemaSQL({ wrap: false })).resolves.toBe('');
+
+    orm.discoverEntity(Book3, Book1);
+    const diff2 = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(diff2).toMatchSnapshot();
+    await orm.schema.execute(diff2);
+    await expect(orm.schema.getUpdateSchemaSQL({ wrap: false })).resolves.toBe('');
+
+    await orm.close(true);
+  });
+});


### PR DESCRIPTION
On mssql, changing an entity's `comment` produced `alter table [book] comment = '...'`. That is MySQL syntax inherited from the base `SchemaHelper`, and the driver rejects it with `Incorrect syntax near the keyword 'comment'`.

Column comments had the mirror-image problem. The base `getChangeColumnCommentSQL()` returns an empty string and `append()` filters those out, so a changed column comment emitted no SQL at all. No error, but the comment never applied and `getUpdateSchemaSQL()` kept reporting the same pending diff on every run.

MSSQL stores both as `MS_Description` extended properties, and `appendComments()` already built that statement inline for the create path, so both overrides reuse it. Removing a comment now drops the property rather than writing an empty one.

Also emits the property for a newly added column: `createTableColumn()` has no comment output and the base `alterTable()` only visits `changedColumns`, so the comment used to show up one `schema update` late.
