### PR TITLE
fix(sql): apply column comment changes in a single schema update pass

### DIFF
--- a/packages/sql/src/dialects/mysql/MySqlSchemaHelper.ts
+++ b/packages/sql/src/dialects/mysql/MySqlSchemaHelper.ts
@@ -731,6 +731,10 @@ export class MySqlSchemaHelper extends SchemaHelper {
     return [`alter table ${tableName} rename index ${oldIndexName} to ${keyName}`];
   }
 
+  protected override hasInlineColumnComment(): boolean {
+    return true;
+  }
+
   override getChangeColumnCommentSQL(tableName: string, to: Column, schemaName?: string): string {
     tableName = this.quote(tableName);
     const columnName = this.quote(to.name);

--- a/packages/sql/src/schema/SchemaHelper.ts
+++ b/packages/sql/src/schema/SchemaHelper.ts
@@ -590,6 +590,7 @@ export abstract class SchemaHelper {
       diff.changedProperties.has('comment'),
     )) {
       if (
+        this.hasInlineColumnComment() &&
         ['type', 'nullable', 'autoincrement', 'unsigned', 'default', 'enumItems', 'collation'].some(t =>
           changedProperties.has(t),
         )
@@ -660,7 +661,15 @@ export abstract class SchemaHelper {
       })
       .join(', ');
 
-    return [`alter table ${table.getQuotedName()} ${adds}`];
+    const ret = [`alter table ${table.getQuotedName()} ${adds}`];
+
+    if (!this.hasInlineColumnComment()) {
+      for (const column of columns.filter(column => column.comment)) {
+        ret.push(this.getChangeColumnCommentSQL(table.name, column, table.schema));
+      }
+    }
+
+    return ret;
   }
 
   getDropColumnsSQL(tableName: string, columns: Column[], schemaName?: string): string {
@@ -817,6 +826,11 @@ export abstract class SchemaHelper {
 
   getChangeColumnCommentSQL(tableName: string, to: Column, schemaName?: string): string {
     return '';
+  }
+
+  /** Whether the column comment is part of the column declaration, as opposed to a separate statement. */
+  protected hasInlineColumnComment(): boolean {
+    return false;
   }
 
   async getNamespaces(connection: AbstractSqlConnection, ctx?: Transaction): Promise<string[]> {

--- a/tests/features/schema-generator/__snapshots__/comment-diffing.mysql.test.ts.snap
+++ b/tests/features/schema-generator/__snapshots__/comment-diffing.mysql.test.ts.snap
@@ -19,3 +19,9 @@ exports[`comment diffing in mysql > schema orm.schema updates comments 3`] = `
 alter table \`book\` comment = '';
 "
 `;
+
+exports[`comment diffing in mysql > schema orm.schema updates comments 4`] = `
+"alter table \`book\` add \`description\` varchar(255) null comment 'comment of a newly added column';
+alter table \`book\` modify \`name\` varchar(100) not null comment 'new comment';
+"
+`;

--- a/tests/features/schema-generator/__snapshots__/comment-diffing.postgres.test.ts.snap
+++ b/tests/features/schema-generator/__snapshots__/comment-diffing.postgres.test.ts.snap
@@ -19,3 +19,11 @@ exports[`comment diffing in postgres 3`] = `
 comment on table "foo"."book" is '';
 "
 `;
+
+exports[`comment diffing in postgres 4`] = `
+"alter table "foo"."book" add "description" varchar(255) null;
+comment on column "foo"."book"."description" is 'comment of a newly added column';
+alter table "foo"."book" alter column "name" type varchar(100) using ("name"::varchar(100));
+comment on column "foo"."book"."name" is 'new comment';
+"
+`;

--- a/tests/features/schema-generator/changing-column-type.postgres.test.ts
+++ b/tests/features/schema-generator/changing-column-type.postgres.test.ts
@@ -89,6 +89,7 @@ alter table "book" alter column "sudoku_square" type integer[3][3] using ("sudok
     const diff3 = await orm.schema.getUpdateSchemaSQL({ wrap: false });
     expect(diff3).toBe(`alter table "book" drop column "sudoku_square";
 alter table "book" alter column "my_column" drop not null;
+comment on column "book"."my_column" is null;
 `);
     await orm.schema.execute(diff3);
 

--- a/tests/features/schema-generator/comment-diffing.mysql.test.ts
+++ b/tests/features/schema-generator/comment-diffing.mysql.test.ts
@@ -37,6 +37,18 @@ class Book3 {
   name!: string;
 }
 
+@Entity({ tableName: 'book' })
+class Book4 {
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ length: 100, comment: 'new comment' })
+  name!: string;
+
+  @Property({ nullable: true, comment: 'comment of a newly added column' })
+  description?: string;
+}
+
 describe('comment diffing in mysql', () => {
   let orm: MikroORM;
 
@@ -69,6 +81,14 @@ describe('comment diffing in mysql', () => {
     const diff3 = await orm.schema.getUpdateSchemaSQL({ wrap: false });
     expect(diff3).toMatchSnapshot();
     await orm.schema.execute(diff3);
+
+    await expect(orm.schema.getUpdateSchemaSQL({ wrap: false })).resolves.toBe('');
+
+    // comments of changed and newly added columns need to be applied in the same pass
+    orm.discoverEntity(Book4, Book3);
+    const diff4 = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(diff4).toMatchSnapshot();
+    await orm.schema.execute(diff4);
 
     await expect(orm.schema.getUpdateSchemaSQL({ wrap: false })).resolves.toBe('');
   });

--- a/tests/features/schema-generator/comment-diffing.postgres.test.ts
+++ b/tests/features/schema-generator/comment-diffing.postgres.test.ts
@@ -37,6 +37,18 @@ class Book3 {
   name!: string;
 }
 
+@Entity({ tableName: 'book' })
+class Book4 {
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ length: 100, comment: 'new comment' })
+  name!: string;
+
+  @Property({ nullable: true, comment: 'comment of a newly added column' })
+  description?: string;
+}
+
 let orm: MikroORM;
 
 beforeAll(async () => {
@@ -66,6 +78,14 @@ test('comment diffing in postgres', async () => {
   const diff3 = await orm.schema.getUpdateSchemaSQL({ wrap: false });
   expect(diff3).toMatchSnapshot();
   await orm.schema.execute(diff3);
+
+  await expect(orm.schema.getUpdateSchemaSQL({ wrap: false })).resolves.toBe('');
+
+  // comments of changed and newly added columns need to be applied in the same pass
+  orm.discoverEntity(Book4, Book3);
+  const diff4 = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+  expect(diff4).toMatchSnapshot();
+  await orm.schema.execute(diff4);
 
   await expect(orm.schema.getUpdateSchemaSQL({ wrap: false })).resolves.toBe('');
 });


### PR DESCRIPTION
`SchemaHelper.alterTable()` skipped the column comment change whenever the type, nullability or default changed in the same pass, assuming the comment gets re-emitted as part of the column declaration. That only holds for MySQL. Postgres emits a separate `comment on column` statement, so the comment change was silently dropped from the first pass and only applied on a second `getUpdateSchemaSQL()` run. Newly added columns had the same gap, the alter path never emitted their comments.

Adds a `hasInlineColumnComment()` hook (`false` by default, `true` in `MySqlSchemaHelper`) and gates both spots on it.

MSSQL and Oracle also emit comments as separate statements, but neither implements `getChangeColumnCommentSQL()` yet, so their comment changes still produce no SQL. That is unchanged here.
