### PR TITLE
fix(sql): keep pivot rows distinct when the fixed order column is not unique

### DIFF
--- a/packages/sql/src/AbstractSqlDriver.ts
+++ b/packages/sql/src/AbstractSqlDriver.ts
@@ -2419,7 +2419,10 @@ export abstract class AbstractSqlDriver<
 
     // with `fixedOrder` the pivot PK is the order column, which is not guaranteed to be unique when the
     // pivot table is managed externally, so we disambiguate the rows by their FKs on top of the PK
-    const pivotRelations = meta.pivotTable && !meta.compositePK ? meta.relations.filter(p => p.persist !== false) : [];
+    const pivotRelations =
+      meta.pivotTable && !meta.compositePK
+        ? meta.relations.filter(p => p.kind === ReferenceKind.MANY_TO_ONE && p.persist !== false)
+        : [];
 
     for (const item of rawResults) {
       let pk = Utils.getCompositeKeyHash(item, meta);

--- a/packages/sql/src/AbstractSqlDriver.ts
+++ b/packages/sql/src/AbstractSqlDriver.ts
@@ -2417,8 +2417,19 @@ export abstract class AbstractSqlDriver<
       return { propName, ref, children: hint.children };
     });
 
+    // with `fixedOrder` the pivot PK is the order column, which is not guaranteed to be unique when the
+    // pivot table is managed externally, so we disambiguate the rows by their FKs on top of the PK
+    const pivotRelations = meta.pivotTable && !meta.compositePK ? meta.relations.filter(p => p.persist !== false) : [];
+
     for (const item of rawResults) {
-      const pk = Utils.getCompositeKeyHash(item, meta);
+      let pk = Utils.getCompositeKeyHash(item, meta);
+
+      if (pivotRelations.length > 0) {
+        pk = Utils.getPrimaryKeyHash([
+          pk,
+          ...pivotRelations.map(p => Utils.extractPK(item[p.name as EntityKey<T>], p.targetMeta) as string),
+        ]);
+      }
 
       if (map[pk]) {
         for (const { propName } of hints) {

--- a/tests/issues/GH8075.test.ts
+++ b/tests/issues/GH8075.test.ts
@@ -1,0 +1,144 @@
+import { defineEntity, MikroORM, p } from '@mikro-orm/sqlite';
+
+const Book = defineEntity({
+  name: 'Book',
+  properties: {
+    id: p.integer().primary(),
+    title: p.string(),
+  },
+});
+
+const Author = defineEntity({
+  name: 'Author',
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+    books: () =>
+      p
+        .manyToMany(Book)
+        .pivotTable('author_books')
+        .fixedOrderColumn('sort_order')
+        .joinColumn('author_id')
+        .inverseJoinColumn('book_id'),
+  },
+});
+
+describe('non-unique fixed order column', () => {
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      entities: [Author, Book],
+      dbName: ':memory:',
+    });
+
+    // the pivot table is managed externally, the order column is not unique
+    await orm.schema.execute(`
+      create table book (id integer primary key, title text not null);
+      create table author (id integer primary key, name text not null);
+      create table author_books (
+        author_id integer not null,
+        book_id integer not null,
+        sort_order integer not null,
+        primary key (author_id, book_id)
+      );
+      insert into book (id, title) values (1, 'Shared'), (2, 'B2'), (3, 'B3');
+      insert into author (id, name) values (1, 'A1'), (2, 'A2');
+      insert into author_books (author_id, book_id, sort_order) values (1, 1, 10), (1, 2, 11), (2, 1, 10), (2, 3, 12);
+    `);
+  });
+
+  afterAll(async () => {
+    await orm.close(true);
+  });
+
+  test('populating m:n keeps shared items on every owner', async () => {
+    const authors = await orm.em.fork().find(Author, {}, { populate: ['books'], orderBy: { id: 'asc' } });
+
+    expect(authors.map(a => a.books.getItems().map(b => b.id))).toEqual([
+      [1, 2],
+      [1, 3],
+    ]);
+  });
+});
+
+const Tag = defineEntity({
+  name: 'Tag',
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+  },
+});
+
+const PostTag = defineEntity({
+  name: 'PostTag',
+  properties: {
+    id: p.integer().primary(),
+    post: () => p.manyToOne(Post),
+    tag: () => p.manyToOne(Tag).nullable(),
+    note: p.string(),
+  },
+});
+
+const Post = defineEntity({
+  name: 'Post',
+  properties: {
+    id: p.integer().primary(),
+    title: p.string(),
+    tags: () =>
+      p
+        .manyToMany(Tag)
+        .pivotEntity(() => PostTag)
+        .owner(),
+  },
+});
+
+describe('pivot entity with a surrogate primary key', () => {
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      entities: [Post, Tag, PostTag],
+      dbName: ':memory:',
+    });
+
+    await orm.schema.create();
+
+    const conn = orm.em.getConnection();
+    await conn.execute(`insert into tag (id, name) values (1, 't1'), (2, 't2')`);
+    await conn.execute(`insert into post (id, title) values (1, 'p1'), (2, 'p2')`);
+    await conn.execute(
+      `insert into post_tag (id, post_id, tag_id, note) values (1, 1, 1, 'a'), (2, 1, 1, 'b'), (3, 1, 2, 'c'), (4, 1, null, 'd'), (5, 2, null, 'e')`,
+    );
+  });
+
+  afterAll(async () => {
+    await orm.close(true);
+  });
+
+  test('rows sharing the same FK pair are not merged', async () => {
+    const rows = await orm.em.fork().find(PostTag, {}, { populate: ['tag'], orderBy: { id: 'asc' } });
+
+    expect(rows.map(r => r.note)).toEqual(['a', 'b', 'c', 'd', 'e']);
+  });
+
+  test('rows are not merged when the FKs are not selected', async () => {
+    const rows = await orm.em
+      .fork()
+      .find(PostTag, {}, { populate: ['tag'], fields: ['note', 'tag.name'], orderBy: { id: 'asc' } });
+
+    expect(rows.map(r => r.note)).toEqual(['a', 'b', 'c', 'd', 'e']);
+  });
+
+  test('rows are not merged when a joined FK is null', async () => {
+    const rows = await orm.em
+      .fork()
+      .createQueryBuilder(PostTag, 'pt')
+      .select('*')
+      .leftJoinAndSelect('pt.tag', 't')
+      .orderBy({ id: 'asc' })
+      .getResultList();
+
+    expect(rows.map(r => r.note)).toEqual(['a', 'b', 'c', 'd', 'e']);
+  });
+});

--- a/tests/issues/GH8075.test.ts
+++ b/tests/issues/GH8075.test.ts
@@ -70,6 +70,15 @@ const Tag = defineEntity({
   },
 });
 
+const Comment = defineEntity({
+  name: 'Comment',
+  properties: {
+    id: p.integer().primary(),
+    text: p.string(),
+    postTag: () => p.manyToOne(PostTag),
+  },
+});
+
 const PostTag = defineEntity({
   name: 'PostTag',
   properties: {
@@ -77,6 +86,7 @@ const PostTag = defineEntity({
     post: () => p.manyToOne(Post),
     tag: () => p.manyToOne(Tag).nullable(),
     note: p.string(),
+    comments: () => p.oneToMany(Comment).mappedBy('postTag'),
   },
 });
 
@@ -98,7 +108,7 @@ describe('pivot entity with a surrogate primary key', () => {
 
   beforeAll(async () => {
     orm = await MikroORM.init({
-      entities: [Post, Tag, PostTag],
+      entities: [Post, Tag, PostTag, Comment],
       dbName: ':memory:',
     });
 
@@ -110,6 +120,7 @@ describe('pivot entity with a surrogate primary key', () => {
     await conn.execute(
       `insert into post_tag (id, post_id, tag_id, note) values (1, 1, 1, 'a'), (2, 1, 1, 'b'), (3, 1, 2, 'c'), (4, 1, null, 'd'), (5, 2, null, 'e')`,
     );
+    await conn.execute(`insert into comment (id, text, post_tag_id) values (1, 'c1', 1), (2, 'c2', 1), (3, 'c3', 3)`);
   });
 
   afterAll(async () => {
@@ -128,6 +139,13 @@ describe('pivot entity with a surrogate primary key', () => {
       .find(PostTag, {}, { populate: ['tag'], fields: ['note', 'tag.name'], orderBy: { id: 'asc' } });
 
     expect(rows.map(r => r.note)).toEqual(['a', 'b', 'c', 'd', 'e']);
+  });
+
+  test('rows are still merged when a to-many relation is joined', async () => {
+    const rows = await orm.em.fork().find(PostTag, {}, { populate: ['comments'], orderBy: { id: 'asc' } });
+
+    expect(rows.map(r => r.note)).toEqual(['a', 'b', 'c', 'd', 'e']);
+    expect(rows.map(r => r.comments.getItems().map(c => c.text))).toEqual([['c1', 'c2'], [], ['c3'], [], []]);
   });
 
   test('rows are not merged when a joined FK is null', async () => {


### PR DESCRIPTION
When merging joined results, pivot rows were deduplicated by the pivot entity primary key. With `fixedOrder` that key is just the order column, which is only unique when MikroORM owns the pivot schema: the schema generator makes it an autoincrement PK. If `fixedOrderColumn` points at a column of an externally managed table, rows of different owners collide, and an item shared by two owners shows up only in the first owner's collection.

The FK values now extend the hash on top of the PK instead of replacing it, so the key can only get more specific, never less.

Closes #8075