### PR TITLE
fix(sql): keep multi line comments intact when grouping schema DDL

### DIFF
--- a/packages/sql/src/schema/SqlSchemaGenerator.ts
+++ b/packages/sql/src/schema/SqlSchemaGenerator.ts
@@ -601,7 +601,7 @@ export class SqlSchemaGenerator extends AbstractSchemaGenerator<AbstractSqlDrive
 
   override async execute(sql: string, options: { wrap?: boolean; ctx?: Transaction } = {}) {
     options.wrap ??= false;
-    const lines = this.wrapSchema(sql, options).split('\n');
+    const lines = this.splitOutsideLiterals(this.wrapSchema(sql, options), '\n');
     const groups: string[][] = [];
     let i = 0;
 
@@ -639,13 +639,35 @@ export class SqlSchemaGenerator extends AbstractSchemaGenerator<AbstractSqlDrive
     }
 
     const statements = groups.flatMap(group => {
-      return group
-        .join('\n')
-        .split(';\n')
+      return this.splitOutsideLiterals(group.join('\n'), ';\n')
         .map(s => s.trim())
         .filter(s => s);
     });
     await Utils.runSerial(statements, stmt => this.driver.execute(stmt));
+  }
+
+  /** Splits the SQL on the separator, keeping the separators that fall inside a string literal. */
+  private splitOutsideLiterals(sql: string, separator: string): string[] {
+    const [idOpen, idClose] = this.platform.quoteIdentifier('');
+    // mysql escapes quotes as `\'`, the other dialects double them, which pairs up on its own
+    const esc = this.platform.quoteValue(`'`).includes(`\\'`) ? '\\\\.|' : '';
+    // complete literals, quoted identifiers and `--` comments, so that an apostrophe inside an
+    // identifier or a comment is not mistaken for one opening a literal
+    const tokens = new RegExp(`'(?:${esc}[^'])*'|\\${idOpen}[^\\${idClose}]*\\${idClose}|--[^\n]*`, 'g');
+    const parts: string[] = [];
+
+    for (const chunk of sql.split(separator)) {
+      const prev = parts.at(-1);
+
+      // whatever quote is left once the complete tokens are gone opened a literal we are still inside of
+      if (prev?.replace(tokens, '').includes(`'`)) {
+        parts[parts.length - 1] = prev + separator + chunk;
+      } else {
+        parts.push(chunk);
+      }
+    }
+
+    return parts;
   }
 
   /** Whether the statement has to be the first one in a query batch, e.g. `create trigger` on MSSQL. */

--- a/tests/features/schema-generator/multi-line-comments.test.ts
+++ b/tests/features/schema-generator/multi-line-comments.test.ts
@@ -1,0 +1,108 @@
+import { DatabaseSchema, MikroORM as MsSqlORM } from '@mikro-orm/mssql';
+import { MikroORM as PgliteORM } from '@mikro-orm/pglite';
+import { MikroORM as MySqlORM } from '@mikro-orm/mysql';
+import { Entity, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+
+// the trailing whitespace, the `;\n`, the blank line and the indentation used to be destroyed by the
+// line based query batch grouping in `SqlSchemaGenerator.execute()`
+const COMMENT = `line one   \n  line two;\n\n  line three's end`;
+const COLUMN_COMMENT = `column line one   \n  column line two;\n\n  column line three`;
+
+@Entity({ tableName: 'book', comment: COMMENT })
+class Book {
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ nullable: true, comment: COLUMN_COMMENT })
+  name?: string;
+}
+
+// mysql keeps all comments on the single `create table` line, so the odd number of apostrophes above
+// only shows when another statement follows and gets swallowed as part of the comment
+@Entity({ tableName: 'shelf' })
+class Shelf {
+  @PrimaryKey()
+  id!: number;
+}
+
+// the apostrophe here is no string literal, the statements that follow must stay separate
+@Entity({ tableName: `it's` })
+class Weird {
+  @PrimaryKey()
+  id!: number;
+}
+
+@Entity({ tableName: 'zzz' })
+class Zzz {
+  @PrimaryKey()
+  id!: number;
+}
+
+async function assertComments(orm: MsSqlORM | PgliteORM | MySqlORM) {
+  const dbSchema = await DatabaseSchema.create(orm.em.getConnection(), orm.em.getPlatform(), orm.config);
+  const table = dbSchema.getTable('book')!;
+  expect(table.comment).toBe(COMMENT);
+  expect(table.getColumn('name')!.comment).toBe(COLUMN_COMMENT);
+
+  await expect(orm.schema.getUpdateSchemaSQL({ wrap: false })).resolves.toBe('');
+}
+
+describe('multi line comments', () => {
+  test('multi line comment survives create and produces no schema diff [mssql]', async () => {
+    const orm = await MsSqlORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      entities: [Book, Shelf],
+      dbName: `mikro_orm_test_multiline_comment`,
+      password: 'Root.Root',
+    });
+    await orm.schema.refresh();
+    await assertComments(orm);
+    await orm.schema.dropDatabase();
+    await orm.close(true);
+  });
+
+  test('multi line comment survives create and produces no schema diff [postgres]', async () => {
+    const orm = await PgliteORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      entities: [Book, Shelf],
+      dbName: 'memory://',
+    });
+    await orm.schema.create();
+    await assertComments(orm);
+    await orm.close(true);
+  });
+
+  test('multi line comment survives create and produces no schema diff [mysql]', async () => {
+    const orm = await MySqlORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      entities: [Book, Shelf],
+      dbName: `mikro_orm_test_multiline_comment`,
+      port: 3308,
+    });
+    await orm.schema.refresh();
+    await assertComments(orm);
+    await orm.schema.dropDatabase();
+    await orm.close(true);
+  });
+
+  test('apostrophes outside string literals are no statement boundary [postgres]', async () => {
+    const orm = await PgliteORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      entities: [Weird, Zzz],
+      dbName: 'memory://',
+    });
+
+    await orm.schema.create();
+    await orm.schema.execute(
+      `-- don't take this for a literal\ncreate table a (id int);\n\ncreate table b (id int);\n`,
+    );
+    const dbSchema = await DatabaseSchema.create(orm.em.getConnection(), orm.em.getPlatform(), orm.config);
+    expect(
+      dbSchema
+        .getTables()
+        .map(t => t.name)
+        .sort(),
+    ).toEqual(['a', 'b', `it's`, 'zzz']);
+    await orm.close(true);
+  });
+});


### PR DESCRIPTION
`SqlSchemaGenerator.execute()` grouped the generated DDL line by line. A blank line started a new query batch, and every line was trimmed. Comments are the only DDL that carries user text verbatim into a string literal, so a comment containing a newline got cut in half mid-literal:

```ts
@Property({ comment: 'line one\n\nline two' })
name?: string;
```

MSSQL failed with `Unclosed quotation mark after the character string 'line one'`, postgres with `unterminated quoted string`. The `;\n` statement split used by dialects without multiple statement support tore the same literal apart, and the `trim()` stripped indentation, so the stored comment stopped matching the metadata and `getUpdateSchemaSQL()` kept re-emitting the statement on every run.

Both splits are quote aware now. `endsInsideLiteral()` scans for an unterminated `'`, skipping over quoted identifiers and `--` comments so an apostrophe outside a literal is no boundary, and honouring the `\'` escapes mysql emits instead of doubling the quote. Lines that continue a literal keep their trailing whitespace and blank lines.

mysql escapes newlines inside the literal, so it was never affected. It is covered here to guard the quote counting.

Pre-existing on both the create and update paths, not a regression. The same tearing exists in `Migrator.getSchemaDiff()`, which does its own `;\n` split with a simpler quote parity check.