### PR TITLE
fix(sql): load M:N collections of owners with a nested composite PK

### DIFF
--- a/packages/sql/src/AbstractSqlDriver.ts
+++ b/packages/sql/src/AbstractSqlDriver.ts
@@ -3064,7 +3064,24 @@ export abstract class AbstractSqlDriver<
 
     for (const prop of meta.relations) {
       if (prop.kind === ReferenceKind.MANY_TO_MANY && data[prop.name]) {
-        ret[prop.name] = data[prop.name].map((item: Primary<T>) => Utils.asArray(item));
+        // union targets are validated to have a single PK column, so a pivot row is always keyed
+        // by exactly `[discriminator, pk]` - anything else cannot address a target table
+        const discriminators = QueryHelper.isUnionTargetPolymorphic(prop)
+          ? Object.keys(prop.discriminatorMap!)
+          : undefined;
+        ret[prop.name] = data[prop.name].map((item: Primary<T>) => {
+          const values = Utils.asArray(item);
+
+          if (discriminators && !(values.length === 2 && discriminators.includes('' + values[0]))) {
+            throw new Error(
+              `Cannot resolve the discriminator value of ${meta.className}.${prop.name} from '${values.join(', ')}', ` +
+                `as the same primary key can exist in any of the target tables. ` +
+                `Pass the target as a [discriminator, ...primaryKey] tuple, e.g. ${JSON.stringify([discriminators[0], ...values])}.`,
+            );
+          }
+
+          return values;
+        });
         delete data[prop.name];
       }
     }

--- a/packages/sql/src/AbstractSqlDriver.ts
+++ b/packages/sql/src/AbstractSqlDriver.ts
@@ -1922,7 +1922,7 @@ export abstract class AbstractSqlDriver<
       }
     }
 
-    return this.buildPivotResultMap(owners, res, pivotProp2.name, pivotProp1.name);
+    return this.buildPivotResultMap(owners, res, pivotProp2.name, pivotProp1.name, ownerMeta);
   }
 
   /**
@@ -2080,7 +2080,7 @@ export abstract class AbstractSqlDriver<
       populateFilter: this.wrapPopulateFilter(options, ownerRelationName),
     });
 
-    return this.buildPivotResultMap(owners, res, tagProp.name, ownerRelationName);
+    return this.buildPivotResultMap(owners, res, tagProp.name, ownerRelationName, tagProp.targetMeta);
   }
 
   /**
@@ -2203,7 +2203,7 @@ export abstract class AbstractSqlDriver<
     }
 
     const result = orphanedRows.size > 0 ? pivotRows.filter(r => !orphanedRows.has(r)) : pivotRows;
-    return this.buildPivotResultMap<T, O>(owners, result, ownerProp.name, prop.discriminator!);
+    return this.buildPivotResultMap<T, O>(owners, result, ownerProp.name, prop.discriminator!, ownerMeta);
   }
 
   /**
@@ -2214,6 +2214,7 @@ export abstract class AbstractSqlDriver<
     results: object[],
     keyProp: string,
     valueProp: string,
+    ownerMeta?: EntityMetadata<O>,
   ): Dictionary<T[]> {
     const map: Dictionary<T[]> = {};
 
@@ -2223,7 +2224,11 @@ export abstract class AbstractSqlDriver<
     }
 
     for (const item of results) {
-      const key = Utils.getPrimaryKeyHash(Utils.asArray((item as any)[keyProp]));
+      const fk = (item as any)[keyProp];
+      // the owner PKs are always flat, while the pivot FK follows the owner PK structure,
+      // so a PK built from a relation to another composite PK entity needs flattening too
+      const pks = ownerMeta && fk != null ? Utils.getOrderedPrimaryKeys(fk, ownerMeta) : Utils.asArray(fk);
+      const key = Utils.getPrimaryKeyHash(pks as string[]);
       const entity = (item as any)[valueProp] as T;
 
       if (map[key]) {

--- a/tests/features/composite-keys/composite-pk-owner-m-n.test.ts
+++ b/tests/features/composite-keys/composite-pk-owner-m-n.test.ts
@@ -130,12 +130,23 @@ test('batch update with composite PK owner and non-empty M:N collection', async 
 
 test('insert with nested composite PK owner and non-empty M:N collection', async () => {
   const em = orm.em.fork();
-  await em.insert(Tag, { id: 40, name: 't6' });
+  await em.insertMany(Tag, [
+    { id: 40, name: 't6' },
+    { id: 41, name: 't9' },
+  ]);
   await em.insert(Param, { bar: 9, baz: 10 });
   await em.insert(NestedParam, { param: [9, 10], qux: 11, tags: [40] });
+  await em.insert(NestedParam, { param: [9, 10], qux: 12, tags: [41] });
 
-  // asserting on the pivot row rather than via `populate`, which does not yet load M:N collections
-  // of an owner whose composite PK contains a relation
-  const rows = await em.getConnection().execute('select * from nested_param_tags');
-  expect(rows).toEqual([{ nested_param_param_bar: 9, nested_param_param_baz: 10, nested_param_qux: 11, tag_id: 40 }]);
+  const rows = await em.getConnection().execute('select * from nested_param_tags order by nested_param_qux');
+  expect(rows).toEqual([
+    { nested_param_param_bar: 9, nested_param_param_baz: 10, nested_param_qux: 11, tag_id: 40 },
+    { nested_param_param_bar: 9, nested_param_param_baz: 10, nested_param_qux: 12, tag_id: 41 },
+  ]);
+
+  const np = await em.fork().findOneOrFail(NestedParam, { param: [9, 10], qux: 11 }, { populate: ['tags'] });
+  expect(np.tags.getIdentifiers()).toEqual([40]);
+
+  const nps = await em.fork().find(NestedParam, { param: [9, 10] }, { populate: ['tags'], orderBy: { qux: 'asc' } });
+  expect(nps.map(n => n.tags.getIdentifiers())).toEqual([[40], [41]]);
 });

--- a/tests/features/polymorphic-relations/polymorphic-m-n-nested-composite-pk-owner.sqlite.test.ts
+++ b/tests/features/polymorphic-relations/polymorphic-m-n-nested-composite-pk-owner.sqlite.test.ts
@@ -19,8 +19,7 @@ class Param {
   baz!: number;
 }
 
-// the owner's composite PK contains a relation to another composite PK entity, so the pivot
-// FK is nested while the owner PKs are flat - the two only line up when both get flattened
+// the composite PK contains a relation to another composite PK entity, so the pivot FK is nested
 @Entity()
 class NestedTag {
   [PrimaryKeyProp]?: ['param', 'qux'];
@@ -120,16 +119,8 @@ test('union target polymorphic M:N with nested composite PK owner', async () => 
   await em.insert(Param, { bar: 5, baz: 6 });
   await em.insert(Image, { id: 20, url: 'i1' });
   await em.insert(Clip, { id: 21, src: 'c1' });
-  await em.insert(NestedPost, { param: [5, 6], qux: 7 });
-  await em.insert(NestedPost, { param: [5, 6], qux: 8 });
-  // written directly, as persisting a union target pivot from a nested composite PK owner
-  // drops the trailing PK columns - a separate bug on the write path
-  await em
-    .getConnection()
-    .execute(
-      'insert into attachables (nested_post_param_bar, nested_post_param_baz, nested_post_qux, attachable_type, attachable_id) values (5, 6, 7, ?, 20), (5, 6, 8, ?, 21)',
-      ['image', 'clip'],
-    );
+  await em.insert(NestedPost, { param: [5, 6], qux: 7, attachments: [['image', 20]] as never });
+  await em.insert(NestedPost, { param: [5, 6], qux: 8, attachments: [['clip', 21]] as never });
 
   const posts = await em
     .fork()

--- a/tests/features/polymorphic-relations/polymorphic-m-n-nested-composite-pk-owner.sqlite.test.ts
+++ b/tests/features/polymorphic-relations/polymorphic-m-n-nested-composite-pk-owner.sqlite.test.ts
@@ -1,0 +1,138 @@
+import { Collection, MikroORM, PrimaryKeyProp } from '@mikro-orm/sqlite';
+import {
+  Entity,
+  ManyToMany,
+  ManyToOne,
+  PrimaryKey,
+  Property,
+  ReflectMetadataProvider,
+} from '@mikro-orm/decorators/legacy';
+
+@Entity()
+class Param {
+  [PrimaryKeyProp]?: ['bar', 'baz'];
+
+  @PrimaryKey()
+  bar!: number;
+
+  @PrimaryKey()
+  baz!: number;
+}
+
+// the owner's composite PK contains a relation to another composite PK entity, so the pivot
+// FK is nested while the owner PKs are flat - the two only line up when both get flattened
+@Entity()
+class NestedTag {
+  [PrimaryKeyProp]?: ['param', 'qux'];
+
+  @ManyToOne(() => Param, { joinColumns: ['param_bar', 'param_baz'], primary: true })
+  param!: Param;
+
+  @PrimaryKey()
+  qux!: number;
+
+  @ManyToMany(() => Post, post => post.tags)
+  posts = new Collection<Post>(this);
+}
+
+@Entity()
+class Post {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  title!: string;
+
+  @ManyToMany(() => NestedTag, tag => tag.posts, {
+    pivotTable: 'taggables',
+    discriminator: 'taggable',
+    owner: true,
+  })
+  tags = new Collection<NestedTag>(this);
+}
+
+@Entity()
+class Image {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  url!: string;
+}
+
+@Entity()
+class Clip {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  src!: string;
+}
+
+@Entity()
+class NestedPost {
+  [PrimaryKeyProp]?: ['param', 'qux'];
+
+  @ManyToOne(() => Param, { joinColumns: ['param_bar', 'param_baz'], primary: true })
+  param!: Param;
+
+  @PrimaryKey()
+  qux!: number;
+
+  @ManyToMany({
+    entity: () => [Image, Clip],
+    pivotTable: 'attachables',
+    discriminator: 'attachable',
+    owner: true,
+  })
+  attachments = new Collection<Image | Clip>(this);
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    entities: [Param, NestedTag, Post, Image, Clip, NestedPost],
+    dbName: ':memory:',
+    metadataProvider: ReflectMetadataProvider,
+  });
+  await orm.schema.refresh();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+test('inverse side of polymorphic M:N with nested composite PK owner', async () => {
+  const em = orm.em.fork();
+  await em.insert(Param, { bar: 1, baz: 2 });
+  await em.insert(NestedTag, { param: [1, 2], qux: 3 });
+  await em.insert(NestedTag, { param: [1, 2], qux: 4 });
+  await em.insert(Post, { id: 10, title: 'p1', tags: [[1, 2, 3]] });
+  await em.insert(Post, { id: 11, title: 'p2', tags: [[1, 2, 4]] });
+
+  const tags = await em.fork().find(NestedTag, { param: [1, 2] }, { populate: ['posts'], orderBy: { qux: 'asc' } });
+  expect(tags.map(t => t.posts.getIdentifiers())).toEqual([[10], [11]]);
+});
+
+test('union target polymorphic M:N with nested composite PK owner', async () => {
+  const em = orm.em.fork();
+  await em.insert(Param, { bar: 5, baz: 6 });
+  await em.insert(Image, { id: 20, url: 'i1' });
+  await em.insert(Clip, { id: 21, src: 'c1' });
+  await em.insert(NestedPost, { param: [5, 6], qux: 7 });
+  await em.insert(NestedPost, { param: [5, 6], qux: 8 });
+  // written directly, as persisting a union target pivot from a nested composite PK owner
+  // drops the trailing PK columns - a separate bug on the write path
+  await em
+    .getConnection()
+    .execute(
+      'insert into attachables (nested_post_param_bar, nested_post_param_baz, nested_post_qux, attachable_type, attachable_id) values (5, 6, 7, ?, 20), (5, 6, 8, ?, 21)',
+      ['image', 'clip'],
+    );
+
+  const posts = await em
+    .fork()
+    .find(NestedPost, { param: [5, 6] }, { populate: ['attachments'], orderBy: { qux: 'asc' } });
+  expect(posts.map(p => p.attachments.getIdentifiers())).toEqual([[20], [21]]);
+});

--- a/tests/issues/GHx65.test.ts
+++ b/tests/issues/GHx65.test.ts
@@ -1,0 +1,94 @@
+import { Collection, MikroORM } from '@mikro-orm/sqlite';
+import { Entity, ManyToMany, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+
+@Entity()
+class Image {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  url!: string;
+}
+
+@Entity()
+class Clip {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  src!: string;
+}
+
+@Entity()
+class Post {
+  @PrimaryKey()
+  id!: number;
+
+  @ManyToMany({ entity: () => [Image, Clip], pivotTable: 'attachables', discriminator: 'attachable', owner: true })
+  attachments = new Collection<Image | Clip>(this);
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    entities: [Image, Clip, Post],
+    dbName: ':memory:',
+    metadataProvider: ReflectMetadataProvider,
+  });
+  await orm.schema.refresh();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+// a union target pivot row is keyed by `[discriminator, ...pk]`
+test('persisting a union target M:N collection from a raw payload writes the discriminator', async () => {
+  const em = orm.em.fork();
+  await em.insertMany(Image, [
+    { id: 20, url: 'i1' },
+    { id: 21, url: 'i2' },
+  ]);
+  await em.insert(Clip, { id: 30, src: 'c1' });
+  await em.insert(Post, {
+    id: 1,
+    attachments: [
+      ['image', 20],
+      ['clip', 30],
+    ] as never,
+  });
+
+  expect(await em.getConnection().execute('select * from attachables order by attachable_id')).toEqual([
+    { post_id: 1, attachable_type: 'image', attachable_id: 20 },
+    { post_id: 1, attachable_type: 'clip', attachable_id: 30 },
+  ]);
+
+  // a union target is loaded per target table, so the collection is grouped by type, not by pivot order
+  const loaded = await em.fork().findOneOrFail(Post, 1, { populate: ['attachments'] });
+  expect(loaded.attachments.getIdentifiers().sort((a, b) => (a as number) - (b as number))).toEqual([20, 30]);
+
+  // nativeUpdate replaces the collection rather than appending to it
+  await em.nativeUpdate(Post, { id: 1 }, { attachments: [['image', 21]] as never });
+  expect(await em.getConnection().execute('select * from attachables')).toEqual([
+    { post_id: 1, attachable_type: 'image', attachable_id: 21 },
+  ]);
+});
+
+test('a bare primary key cannot address a union target', async () => {
+  const em = orm.em.fork();
+  await em.insert(Image, { id: 40, url: 'i3' });
+
+  await expect(em.insert(Post, { id: 2, attachments: [40] as never })).rejects.toThrow(
+    `Cannot resolve the discriminator value of Post.attachments from '40', as the same primary key can exist in any of the target tables. Pass the target as a [discriminator, ...primaryKey] tuple, e.g. ["image",40].`,
+  );
+
+  // a PK that happens to equal a discriminator value must not pass as the discriminator itself
+  await expect(em.insert(Post, { id: 3, attachments: ['image'] as never })).rejects.toThrow(
+    `Cannot resolve the discriminator value of Post.attachments from 'image'`,
+  );
+
+  await expect(em.nativeUpdate(Post, { id: 2 }, { attachments: [40] as never })).rejects.toThrow(
+    `Cannot resolve the discriminator value of Post.attachments from '40'`,
+  );
+});


### PR DESCRIPTION
Two related M:N pivot bugs around owners whose composite primary key contains a relation to another composite-PK entity.

### Loading (`6bdc91b74`)

Populating the collection returned an empty collection, with no error. The pivot rows were written correctly and the pivot query returned them, they were just dropped while mapping the results back to their owners.

`buildPivotResultMap` keys the owners by `helper(entity).__primaryKeys`, which is always flat (`[9, 10, 11]`), while each pivot row's owner FK is mapped following the owner's PK structure (`[[9, 10], 11]`). The hashes never matched, and since the map is pre-seeded with empty arrays, the miss was invisible.

Flattening the FK through `Utils.getOrderedPrimaryKeys`, the helper the identity map and the write path already use, lines the two shapes up. Scalar and plain composite PKs hash exactly as before. The polymorphic inverse-side and union-target loaders had the same gap.

### Persisting (`4c21af3af`)

A union target pivot row is keyed by `[discriminator, ...pk]`, which only the flush path produced. A raw `em.insert`/`nativeUpdate` payload passed the target PK on its own, and the persister then read that PK as the discriminator, writing the row one column short of the key list:

```sql
insert into attachables (attachable_type, attachable_id, post_id) values (20, 1, null)
```

A bare PK cannot be resolved to a target table, since the same key can exist in any of them, so it now throws and points at the tuple form instead of writing a misaligned row.

One thing worth knowing: `em.create(Post, { attachments: [1] })` followed by a flush silently guesses `polymorphTargets[0]` for a bare PK, so the two entry points now disagree. Left alone here.
