### PR TITLE
fix(sql): load the owner side of a polymorphic M:N with a composite PK owner

### DIFF
--- a/packages/sql/src/AbstractSqlDriver.ts
+++ b/packages/sql/src/AbstractSqlDriver.ts
@@ -1966,11 +1966,16 @@ export abstract class AbstractSqlDriver<
   ): Promise<Dictionary<T[]>> {
     const pivotMeta = this.metadata.get(prop.pivotEntity);
     const targetMeta = prop.targetMeta!;
+    // `prop.discriminator` spans all owner FK columns but carries no target metadata, so a composite
+    // owner PK neither expands to a tuple condition nor gets mapped back; the virtual M:1 relation
+    // to this discriminator's owner describes the same columns as an actual relation
+    const ownerMeta = this.metadata.get<O>(pivotMeta.polymorphicDiscriminatorMap![prop.discriminatorValue!]);
+    const ownerProp = pivotMeta.properties[`${prop.discriminator}_${ownerMeta.tableName}`];
 
-    // Build condition: discriminator = 'post' AND {discriminator} IN (...)
+    // Build condition: discriminator = 'post' AND {owner} IN (...)
     const cond: Dictionary = {
       [prop.discriminatorColumn!]: prop.discriminatorValue,
-      [prop.discriminator!]: { $in: owners.length === 1 && owners[0].length === 1 ? owners.map(o => o[0]) : owners },
+      [ownerProp.name]: { $in: owners.length === 1 && owners[0].length === 1 ? owners.map(o => o[0]) : owners },
     };
 
     if (!Utils.isEmpty(where)) {
@@ -1987,9 +1992,12 @@ export abstract class AbstractSqlDriver<
     const childExclude = !Utils.isEmpty(options?.exclude)
       ? options!.exclude!.map(f => `${inverseProp!.name}.${f}`)
       : [];
+    // the owner relation is virtual, so the FK columns have to be selected via the per-column pivot
+    // props a composite owner PK gets; a single column owner PK is covered by the flat prop itself
+    const ownerFields = ownerMeta.compositePK ? prop.joinColumns : [prop.discriminator!];
     const fields = pivotJoin
-      ? ([inverseProp!.name, prop.discriminator!, prop.discriminatorColumn!] as any[])
-      : [inverseProp!.name, prop.discriminator!, prop.discriminatorColumn!, ...childFields];
+      ? ([inverseProp!.name, ...ownerFields, prop.discriminatorColumn!] as any[])
+      : [inverseProp!.name, ...ownerFields, prop.discriminatorColumn!, ...childFields];
 
     const res = await this.find(pivotMeta.class, cond as FilterQuery<any>, {
       ctx,
@@ -2012,7 +2020,7 @@ export abstract class AbstractSqlDriver<
       populateFilter: this.wrapPopulateFilter(options, inverseProp!.name),
     });
 
-    return this.buildPivotResultMap(owners, res, prop.discriminator!, inverseProp!.name);
+    return this.buildPivotResultMap(owners, res, ownerProp.name, inverseProp!.name, ownerMeta);
   }
 
   /**

--- a/tests/issues/GHx66.test.ts
+++ b/tests/issues/GHx66.test.ts
@@ -1,0 +1,138 @@
+import { Collection, MikroORM, PrimaryKeyProp } from '@mikro-orm/sqlite';
+import {
+  Entity,
+  ManyToMany,
+  ManyToOne,
+  PrimaryKey,
+  Property,
+  ReflectMetadataProvider,
+} from '@mikro-orm/decorators/legacy';
+
+@Entity()
+class Tag {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @ManyToMany(() => Param, param => param.tags)
+  params = new Collection<Param>(this);
+
+  @ManyToMany(() => Config, config => config.tags)
+  configs = new Collection<Config>(this);
+
+  @ManyToMany(() => NestedParam, param => param.tags)
+  nestedParams = new Collection<NestedParam>(this);
+}
+
+@Entity()
+class Param {
+  [PrimaryKeyProp]?: ['bar', 'baz'];
+
+  @PrimaryKey()
+  bar!: number;
+
+  @PrimaryKey()
+  baz!: number;
+
+  @ManyToMany(() => Tag, tag => tag.params, { pivotTable: 'taggables', discriminator: 'taggable', owner: true })
+  tags = new Collection<Tag>(this);
+}
+
+// shares the pivot with `Param`, so each owner has to resolve its own metadata from the discriminator
+@Entity()
+class Config {
+  [PrimaryKeyProp]?: ['bar', 'baz'];
+
+  @PrimaryKey()
+  bar!: number;
+
+  @PrimaryKey()
+  baz!: number;
+
+  @ManyToMany(() => Tag, tag => tag.configs, { pivotTable: 'taggables', discriminator: 'taggable', owner: true })
+  tags = new Collection<Tag>(this);
+}
+
+// composite PK built from a relation to another composite PK entity, so the pivot FK is nested
+@Entity()
+class NestedParam {
+  [PrimaryKeyProp]?: ['param', 'qux'];
+
+  @ManyToOne(() => Param, { joinColumns: ['np_bar', 'np_baz'], primary: true })
+  param!: Param;
+
+  @PrimaryKey()
+  qux!: number;
+
+  @ManyToMany(() => Tag, tag => tag.nestedParams, {
+    pivotTable: 'nested_taggables',
+    discriminator: 'taggable',
+    owner: true,
+  })
+  tags = new Collection<Tag>(this);
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    entities: [Tag, Param, Config, NestedParam],
+    dbName: ':memory:',
+    metadataProvider: ReflectMetadataProvider,
+  });
+  await orm.schema.refresh();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+// the owner side of a Rails style polymorphic M:N keys the pivot query off the owner FK, which is
+// spread over several columns once the owner has a composite PK
+test('owner side of a polymorphic M:N with a composite PK owner', async () => {
+  const em = orm.em.fork();
+  await em.insertMany(Tag, [
+    { id: 10, name: 't1' },
+    { id: 11, name: 't2' },
+  ]);
+  await em.insert(Param, { bar: 1, baz: 2, tags: [10] });
+  await em.insert(Param, { bar: 3, baz: 4, tags: [10, 11] });
+  // same PK values under a different discriminator, so a query that ignores it would overmatch
+  await em.insert(Config, { bar: 1, baz: 2, tags: [11] });
+
+  const params = await em.fork().find(Param, { bar: { $in: [1, 3] } }, { populate: ['tags'], orderBy: { bar: 'asc' } });
+  expect(params.map(p => p.tags.getIdentifiers())).toEqual([[10], [10, 11]]);
+
+  const configs = await em.fork().find(Config, {}, { populate: ['tags'] });
+  expect(configs.map(c => c.tags.getIdentifiers())).toEqual([[11]]);
+
+  const tags = await em.fork().find(Tag, { id: { $in: [10, 11] } }, { populate: ['params'], orderBy: { id: 'asc' } });
+  expect(tags.map(t => t.params.getIdentifiers())).toEqual([
+    [
+      [1, 2],
+      [3, 4],
+    ],
+    [[3, 4]],
+  ]);
+});
+
+test('owner side of a polymorphic M:N with a nested composite PK owner', async () => {
+  const em = orm.em.fork();
+  await em.insert(Tag, { id: 20, name: 't3' });
+  await em.insert(Param, { bar: 5, baz: 6 });
+  await em.insert(NestedParam, { param: [5, 6], qux: 7, tags: [20] });
+
+  const params = await em.fork().find(NestedParam, {}, { populate: ['tags'] });
+  expect(params.map(p => p.tags.getIdentifiers())).toEqual([[20]]);
+});
+
+test('owner side of a polymorphic M:N with a composite PK owner via a :ref populate hint', async () => {
+  const em = orm.em.fork();
+  await em.insert(Tag, { id: 40, name: 't6' });
+  await em.insert(Param, { bar: 12, baz: 13, tags: [40] });
+
+  const param = await em.fork().findOneOrFail(Param, { bar: 12, baz: 13 }, { populate: ['tags:ref'] });
+  expect(param.tags.getIdentifiers()).toEqual([40]);
+});


### PR DESCRIPTION
Follow-up to #8080, found while reviewing it.

Loading a Rails-style polymorphic M:N from the owner side returned an empty collection whenever the owner had a composite primary key. Writes were fine, the pivot row went in with the right column values, only reads came back empty. Plain two-scalar composite PKs are affected, not just nested ones.

`loadPolymorphicPivotOwnerSide` keyed the query off `prop.discriminator`. For a composite-PK owner that property is a virtual scalar: it spans all the owner FK columns but has no `targetMeta`, and the real per-column props live under `prop.joinColumns`. So the `$in` collapsed to the first column, and the FK was never mapped back into the result:

```sql
select `t0`.`id`, `t0`.`tag_id`, `t0`.`taggable_type` from `taggables` as `t0`
  where `t0`.`taggable_type` = 'param' and `t0`.`taggable_bar` in (1, 2, 3, 4)
```

`buildPivotResultMap` then saw `fk === null` on every row and matched no owner.

Keying off the virtual M:1 relation to this discriminator's owner instead describes the same columns as an actual relation, so the condition expands to a tuple and the FK hashes against the owner PKs. That relation is `persist: false` and selects no columns of its own, so the FK columns are selected through the per-column pivot props that a composite owner PK gets:

```sql
select `t0`.`id`, `t0`.`tag_id`, `t0`.`taggable_bar`, `t0`.`taggable_baz`, `t0`.`taggable_type` from `taggables` as `t0`
  where `t0`.`taggable_type` = 'param' and (`t0`.`taggable_bar`, `t0`.`taggable_baz`) in ((1, 2), (3, 4))
```

Separately, a shared polymorphic pivot with mixed PK arity (one composite-PK owner alongside a single-PK owner) is still broken on master. Only the first owner of a pivot gets the flat discriminator property, so later owners inherit the first one's `fieldNames`. Not touched here.
