### PR TITLE
fix(sql): include composite FK values in the pivot row hash

### DIFF
--- a/packages/sql/src/AbstractSqlDriver.ts
+++ b/packages/sql/src/AbstractSqlDriver.ts
@@ -2435,7 +2435,11 @@ export abstract class AbstractSqlDriver<
       if (pivotRelations.length > 0) {
         pk = Utils.getPrimaryKeyHash([
           pk,
-          ...pivotRelations.map(p => Utils.extractPK(item[p.name as EntityKey<T>], p.targetMeta) as string),
+          ...pivotRelations.flatMap(p => {
+            const value = item[p.name as EntityKey<T>];
+            // composite FKs are mapped to an array of values, which `extractPK` does not accept
+            return (Array.isArray(value) ? value : Utils.extractPK(value, p.targetMeta)) as string | string[];
+          }),
         ]);
       }
 

--- a/tests/issues/GH8075.test.ts
+++ b/tests/issues/GH8075.test.ts
@@ -62,6 +62,62 @@ describe('non-unique fixed order column', () => {
   });
 });
 
+const Tenant = defineEntity({
+  name: 'Tenant',
+  properties: {
+    tenant: p.integer().primary(),
+    id: p.integer().primary(),
+    name: p.string(),
+    books: () =>
+      p
+        .manyToMany(Book)
+        .pivotTable('tenant_books')
+        .fixedOrderColumn('sort_order')
+        .joinColumns('tenant_tenant', 'tenant_id')
+        .inverseJoinColumns('book_id'),
+  },
+});
+
+describe('non-unique fixed order column with a composite key owner', () => {
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      entities: [Tenant, Book],
+      dbName: ':memory:',
+    });
+
+    await orm.schema.execute(`
+      create table book (id integer primary key, title text not null);
+      create table tenant (tenant integer not null, id integer not null, name text not null, primary key (tenant, id));
+      create table tenant_books (
+        tenant_tenant integer not null,
+        tenant_id integer not null,
+        book_id integer not null,
+        sort_order integer not null,
+        primary key (tenant_tenant, tenant_id, book_id)
+      );
+      insert into book (id, title) values (1, 'Shared'), (2, 'B2'), (3, 'B3');
+      insert into tenant (tenant, id, name) values (1, 1, 'T1'), (1, 2, 'T2');
+      insert into tenant_books (tenant_tenant, tenant_id, book_id, sort_order)
+        values (1, 1, 1, 10), (1, 1, 2, 11), (1, 2, 1, 10), (1, 2, 3, 12);
+    `);
+  });
+
+  afterAll(async () => {
+    await orm.close(true);
+  });
+
+  test('populating m:n keeps shared items on every owner', async () => {
+    const tenants = await orm.em.fork().find(Tenant, {}, { populate: ['books'], orderBy: { id: 'asc' } });
+
+    expect(tenants.map(t => t.books.getItems().map(b => b.id))).toEqual([
+      [1, 2],
+      [1, 3],
+    ]);
+  });
+});
+
 const Tag = defineEntity({
   name: 'Tag',
   properties: {


### PR DESCRIPTION
Follow-up to #8078. The FK disambiguator added there never fired when the M:N owner has a composite PK: such an FK is mapped to an array of values, `Utils.extractPK` returns `null` for arrays, so every row contributed the same `null` component and collided on the order column exactly as before.

The array case now contributes its values. Restricting `pivotRelations` to owning M:1 relations (also from #8078) is what makes that safe, since a joined to-many is mapped to an array too and would vary per row.

Test added to `GH8075.test.ts`: a composite-PK owner with an externally managed pivot, which fails on master with `[[1, 2], [3]]`.