### PR TITLE
fix(sql): load the owner side of a polymorphic M:N pivot shared by owners of different PK arity

### DIFF
--- a/packages/sql/src/AbstractSqlDriver.ts
+++ b/packages/sql/src/AbstractSqlDriver.ts
@@ -1992,9 +1992,12 @@ export abstract class AbstractSqlDriver<
     const childExclude = !Utils.isEmpty(options?.exclude)
       ? options!.exclude!.map(f => `${inverseProp!.name}.${f}`)
       : [];
-    // the owner relation is virtual, so the FK columns have to be selected via the per-column pivot
-    // props a composite owner PK gets; a single column owner PK is covered by the flat prop itself
-    const ownerFields = ownerMeta.compositePK ? prop.joinColumns : [prop.discriminator!];
+    // the owner relation is virtual, so its FK columns have to be selected via the pivot props that
+    // cover them; only the first owner of a shared pivot gets the flat prop named after the
+    // discriminator, and it keeps that owner's columns, so later owners get per-column props instead
+    const ownerFields = Utils.unique(
+      prop.joinColumns.map(col => (pivotMeta.properties[col] ? col : prop.discriminator!)),
+    );
     const fields = pivotJoin
       ? ([inverseProp!.name, ...ownerFields, prop.discriminatorColumn!] as any[])
       : [inverseProp!.name, ...ownerFields, prop.discriminatorColumn!, ...childFields];

--- a/tests/issues/GHx67.test.ts
+++ b/tests/issues/GHx67.test.ts
@@ -1,0 +1,80 @@
+import { Collection, MikroORM, PrimaryKeyProp } from '@mikro-orm/sqlite';
+import { Entity, ManyToMany, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+
+@Entity()
+class Tag {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @ManyToMany(() => Param, param => param.tags)
+  params = new Collection<Param>(this);
+
+  @ManyToMany(() => Post, post => post.tags)
+  posts = new Collection<Post>(this);
+}
+
+@Entity()
+class Param {
+  [PrimaryKeyProp]?: ['bar', 'baz'];
+
+  @PrimaryKey()
+  bar!: number;
+
+  @PrimaryKey()
+  baz!: number;
+
+  @ManyToMany(() => Tag, tag => tag.params, { pivotTable: 'taggables', discriminator: 'taggable', owner: true })
+  tags = new Collection<Tag>(this);
+}
+
+// shares the pivot with `Param` but has a single PK, so the two owners are keyed by different columns
+@Entity()
+class Post {
+  @PrimaryKey()
+  id!: number;
+
+  @ManyToMany(() => Tag, tag => tag.posts, { pivotTable: 'taggables', discriminator: 'taggable', owner: true })
+  tags = new Collection<Tag>(this);
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  // the composite owner has to be discovered first, otherwise the pivot puts the single PK owner's
+  // column in its primary key as not null and the composite owner can never write a row
+  orm = await MikroORM.init({
+    entities: [Tag, Param, Post],
+    dbName: ':memory:',
+    metadataProvider: ReflectMetadataProvider,
+  });
+  await orm.schema.refresh();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+// only the first owner of a shared pivot gets the flat property named after the discriminator, so
+// the columns of every later owner have to be selected through their own per-column pivot props
+test('owner side of a polymorphic M:N pivot shared by owners of different PK arity', async () => {
+  const em = orm.em.fork();
+  await em.insertMany(Tag, [
+    { id: 10, name: 't1' },
+    { id: 11, name: 't2' },
+  ]);
+  await em.insert(Param, { bar: 1, baz: 2, tags: [10] });
+  await em.insert(Post, { id: 5, tags: [10, 11] });
+
+  const param = await em.fork().findOneOrFail(Param, { bar: 1, baz: 2 }, { populate: ['tags'] });
+  expect(param.tags.getIdentifiers()).toEqual([10]);
+
+  const post = await em.fork().findOneOrFail(Post, 5, { populate: ['tags'] });
+  expect(post.tags.getIdentifiers()).toEqual([10, 11]);
+
+  const tag = await em.fork().findOneOrFail(Tag, 10, { populate: ['params', 'posts'] });
+  expect(tag.params.getIdentifiers()).toEqual([[1, 2]]);
+  expect(tag.posts.getIdentifiers()).toEqual([5]);
+});

--- a/tests/issues/GHx68.test.ts
+++ b/tests/issues/GHx68.test.ts
@@ -1,0 +1,79 @@
+import { Collection, MikroORM, PrimaryKeyProp } from '@mikro-orm/sqlite';
+import { Entity, ManyToMany, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+
+@Entity()
+class Tag {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @ManyToMany(() => Post, post => post.tags)
+  posts = new Collection<Post>(this);
+
+  @ManyToMany(() => Order, order => order.tags)
+  orders = new Collection<Order>(this);
+}
+
+// discovered first, so the pivot gets the flat property named after the discriminator over this
+// owner's single column
+@Entity()
+class Post {
+  @PrimaryKey()
+  id!: number;
+
+  @ManyToMany(() => Tag, tag => tag.posts, { pivotTable: 'taggables', discriminator: 'taggable', owner: true })
+  tags = new Collection<Tag>(this);
+}
+
+// the first PK column maps onto the already existing `taggable_id`, so only the second column gets
+// a per-column pivot prop of its own
+@Entity()
+class Order {
+  [PrimaryKeyProp]?: ['id', 'tenant'];
+
+  @PrimaryKey()
+  id!: number;
+
+  @PrimaryKey()
+  tenant!: number;
+
+  @ManyToMany(() => Tag, tag => tag.orders, { pivotTable: 'taggables', discriminator: 'taggable', owner: true })
+  tags = new Collection<Tag>(this);
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    entities: [Tag, Post, Order],
+    dbName: ':memory:',
+    metadataProvider: ReflectMetadataProvider,
+  });
+  await orm.schema.refresh();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+test('owner side of a polymorphic M:N pivot where the owner FK columns only partially overlap', async () => {
+  const em = orm.em.fork();
+  await em.insertMany(Tag, [
+    { id: 10, name: 't1' },
+    { id: 11, name: 't2' },
+  ]);
+  await em.insert(Post, { id: 5, tags: [10, 11] });
+  await em.insert(Order, { id: 1, tenant: 2, tags: [10] });
+
+  const post = await em.fork().findOneOrFail(Post, 5, { populate: ['tags'] });
+  expect(post.tags.getIdentifiers()).toEqual([10, 11]);
+
+  const order = await em.fork().findOneOrFail(Order, { id: 1, tenant: 2 }, { populate: ['tags'] });
+  expect(order.tags.getIdentifiers()).toEqual([10]);
+
+  const tag = await em.fork().findOneOrFail(Tag, 10, { populate: ['posts', 'orders'] });
+  expect(tag.posts.getIdentifiers()).toEqual([5]);
+  expect(tag.orders.getIdentifiers()).toEqual([[1, 2]]);
+});


### PR DESCRIPTION
Follow-up to #8081.

A Rails-style polymorphic M:N pivot shared by owners keyed on different columns loaded the later owner's collection as empty. The pivot rows were written correctly, and the query even filtered on the right columns, they just never made it into the projection.

Only the first owner discovered for a pivot runs the full `definePolymorphicPivotProperties` setup, which is what creates the flat property named after the discriminator. Later owners get their own per-column props plus a virtual M:1 relation, so the flat property keeps the first owner's columns. Selecting through it therefore fetched the wrong columns, and `buildPivotResultMap` found no FK to hash against the owners.

Resolving each join column through the pivot prop that actually covers it fixes both shapes:

- `Param { bar, baz }` first, then `Post { id }`: no overlap, so `Post` gets a `taggable_id` prop of its own (`GHx67`).
- `Post { id }` first, then `Order { id, tenant }`: `taggable_id` is already covered by the flat prop, so only `taggable_tenant` gets one, and the two have to be mixed (`GHx68`).

Owners that are alone on their pivot keep resolving to the flat property exactly as before.

Two related problems in the discovery layer are left alone here, both pre-existing and both needing `definePolymorphicPivotProperties` to stop being first-owner-only:

- Declaration order decides whether a mixed-arity pivot can be written at all. With the single-PK owner discovered first, its column lands in the pivot primary key as not null, so the composite owner can never insert a row. The test fixtures order the entities to avoid this, with a comment saying why.
- `addPolymorphicPivotColumns` never extends `pivotMeta.primaryKeys`, so two composite owners sharing their first FK column collide on insert.
