### PR TITLE
fix(sql): keep polymorphic pivot rows distinct when the fixed order column is not unique

### DIFF
--- a/packages/sql/src/AbstractSqlDriver.ts
+++ b/packages/sql/src/AbstractSqlDriver.ts
@@ -2432,10 +2432,9 @@ export abstract class AbstractSqlDriver<
 
     // with `fixedOrder` the pivot PK is the order column, which is not guaranteed to be unique when the
     // pivot table is managed externally, so we disambiguate the rows by their FKs on top of the PK
+    // (including virtual ones, as the owner FK of a polymorphic pivot is only mapped via non-persisted relations)
     const pivotRelations =
-      meta.pivotTable && !meta.compositePK
-        ? meta.relations.filter(p => p.kind === ReferenceKind.MANY_TO_ONE && p.persist !== false)
-        : [];
+      meta.pivotTable && !meta.compositePK ? meta.relations.filter(p => p.kind === ReferenceKind.MANY_TO_ONE) : [];
 
     for (const item of rawResults) {
       let pk = Utils.getCompositeKeyHash(item, meta);

--- a/tests/features/polymorphic-relations/polymorphic-m-n-non-unique-fixed-order.sqlite.test.ts
+++ b/tests/features/polymorphic-relations/polymorphic-m-n-non-unique-fixed-order.sqlite.test.ts
@@ -1,0 +1,104 @@
+import { Collection, MikroORM } from '@mikro-orm/sqlite';
+import { Entity, ManyToMany, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+
+@Entity()
+class Tag {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @ManyToMany(() => Post, post => post.tags)
+  posts = new Collection<Post>(this);
+
+  @ManyToMany(() => Video, video => video.tags)
+  videos = new Collection<Video>(this);
+}
+
+@Entity()
+class Post {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  title!: string;
+
+  @ManyToMany(() => Tag, tag => tag.posts, {
+    pivotTable: 'taggables',
+    discriminator: 'taggable',
+    fixedOrderColumn: 'sort_order',
+    owner: true,
+  })
+  tags = new Collection<Tag>(this);
+}
+
+@Entity()
+class Video {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  url!: string;
+
+  @ManyToMany(() => Tag, tag => tag.videos, {
+    pivotTable: 'taggables',
+    discriminator: 'taggable',
+    fixedOrderColumn: 'sort_order',
+    owner: true,
+  })
+  tags = new Collection<Tag>(this);
+}
+
+describe('polymorphic M:N with a non-unique fixed order column', () => {
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      entities: [Tag, Post, Video],
+      dbName: ':memory:',
+      metadataProvider: ReflectMetadataProvider,
+    });
+
+    // the pivot table is managed externally, so the order column is not a unique autoincrement PK
+    await orm.schema.execute(`
+      create table tag (id integer primary key, name text not null);
+      create table post (id integer primary key, title text not null);
+      create table video (id integer primary key, url text not null);
+      create table taggables (
+        taggable_type text not null,
+        taggable_id integer not null,
+        tag_id integer not null,
+        sort_order integer not null,
+        primary key (taggable_type, taggable_id, tag_id)
+      );
+      insert into tag (id, name) values (1, 'Shared'), (2, 't2'), (3, 't3');
+      insert into post (id, title) values (1, 'p1'), (2, 'p2');
+      insert into video (id, url) values (1, 'v1'), (2, 'v2');
+      insert into taggables (taggable_type, taggable_id, tag_id, sort_order) values
+        ('post', 1, 1, 1), ('post', 1, 2, 2),
+        ('post', 2, 1, 1), ('post', 2, 3, 2),
+        ('video', 1, 1, 1), ('video', 2, 1, 1);
+    `);
+  });
+
+  afterAll(async () => {
+    await orm.close(true);
+  });
+
+  test('populating the owner side keeps shared tags on every owner', async () => {
+    const posts = await orm.em.fork().find(Post, {}, { populate: ['tags'], orderBy: { id: 'asc' } });
+
+    expect(posts.map(post => post.tags.getItems().map(tag => tag.id))).toEqual([
+      [1, 2],
+      [1, 3],
+    ]);
+  });
+
+  test('populating the inverse side keeps owners of the same type distinct', async () => {
+    const tag = await orm.em.fork().findOneOrFail(Tag, 1, { populate: ['posts', 'videos'] });
+
+    expect(tag.posts.getItems().map(post => post.id)).toEqual([1, 2]);
+    expect(tag.videos.getItems().map(video => video.id)).toEqual([1, 2]);
+  });
+});


### PR DESCRIPTION
Follow-up to #8078. The FK disambiguator added there never fired for polymorphic pivots. The owner FK of such a pivot is only mapped through the virtual `${discriminator}_${tableName}` relations, which `definePolymorphicOwnerRelation` creates with `persist: false`, so the `p.persist !== false` filter dropped exactly the relations carrying the owner identity. That left only the target FK, and pivot rows belonging to two different owners hashed identically.

This is reachable when the pivot table is managed externally and `fixedOrderColumn` points at a column that is not a unique autoincrement PK. An item shared by two owners then shows up on only one of them, in both directions: `Post.tags` loses a tag and `Tag.posts` loses a post.

Non-persisted M:1 relations now count towards the hash too. They are to-one values derived from the pivot row, so the key can only get more specific, never less.