### PR TITLE
chore: default new tests to tests/features instead of tests/issues

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -80,7 +80,8 @@ When reviewing or editing code, do NOT remove code (assertions, type casts, etc.
 
 - When fixing bugs, write the test FIRST that reproduces the issue, then implement the fix. Do not implement fixes before having a failing test.
 - In test files, never leave debug artifacts (console.log, debug mode flags, commented-out code). Clean up before committing.
-- **Never invent GitHub issue or PR numbers.** Only reference an issue/PR number if the user explicitly provided it, or if it came from a tool output (`gh issue view`, `gh pr create`, etc.). When fixing a bug reported inline (no issue number given), name the test using the `GHx<n>` convention (next free number under `tests/issues/GHx*.test.ts`) and describe the bug in comments instead of citing a fabricated `#NNNN`. Same rule applies to commit messages, PR descriptions, and code comments.
+- Put new tests under `tests/features/<area>/` with a descriptive, behavior-named file. `tests/issues/` is reserved for regressions tied to an actual bug report, so a bug found while working on something else belongs in `tests/features/`, not in a `GHx*` file.
+- **Never invent GitHub issue or PR numbers.** Only reference an issue/PR number if the user explicitly provided it, or if it came from a tool output (`gh issue view`, `gh pr create`, etc.). For a reported bug with no number given, name the test using the `GHx<n>` convention (next free number under `tests/issues/GHx*.test.ts`) and describe the bug in comments instead of citing a fabricated `#NNNN`. Same rule applies to commit messages, PR descriptions, and code comments.
 
 ## PRs
 


### PR DESCRIPTION
The testing section only described the `GHx<n>` fallback for a bug with no issue number, which reads as "inline bug report goes to `tests/issues`". A bug found while working on something else is not a reported regression, and it is easier to find under `tests/features/<area>` with a behavior-named file.