### PR TITLE
fix(sql): prevent forward join alias references when applying joined filters

### DIFF
--- a/packages/sql/src/query/QueryBuilder.ts
+++ b/packages/sql/src/query/QueryBuilder.ts
@@ -1500,6 +1500,7 @@ export class QueryBuilder<
       filterOptions = QueryHelper.mergePropertyFilters(join.prop.filters, filterOptions);
       let cond = await em.applyFilters(join.prop.targetMeta!.class, join.cond, filterOptions, 'read');
       const criteriaNode = CriteriaNodeFactory.createNode<Entity>(this.metadata, join.prop.targetMeta!.class, cond);
+      const joinCountBefore = Object.keys(this.#state.joins).length;
       cond = criteriaNode.process(this as IQueryBuilder<Entity>, {
         matchPopulateJoins: true,
         filter: true,
@@ -1507,6 +1508,7 @@ export class QueryBuilder<
         ignoreBranching: true,
         parentPath: join.path,
       });
+      this.nestNewJoins(join, joinCountBefore);
 
       if (Utils.hasObjectKeys(cond) || RawQueryFragment.hasObjectFragments(cond)) {
         // remove nested filters, we only care about scalars here, nesting would require another join branch
@@ -1555,6 +1557,32 @@ export class QueryBuilder<
           }
         }
       }
+    }
+  }
+
+  /**
+   * Auto-joins added while processing a condition of `condJoin` would render after it and produce a
+   * forward alias reference in its `on` clause. Fold them into `condJoin`, so they render as a single
+   * parenthesized join group and share the scope of the outer `on` clause (issue #7681).
+   */
+  private nestNewJoins(condJoin: JoinOptions | undefined, joinCountBefore: number): void {
+    // m:n pivot joins might not have the target join entry created
+    if (!condJoin) {
+      return;
+    }
+
+    const joinKeys = Object.keys(this.#state.joins);
+
+    for (let i = joinCountBefore; i < joinKeys.length; i++) {
+      const j = this.#state.joins[joinKeys[i]];
+
+      if (j === condJoin || j.ownerAlias !== condJoin.alias) {
+        continue;
+      }
+
+      const nested = (condJoin.nested ??= new Set());
+      j.type = j.type === JoinType.innerJoin ? JoinType.nestedInnerJoin : JoinType.nestedLeftJoin;
+      nested.add(j);
     }
   }
 
@@ -3168,23 +3196,7 @@ export class QueryBuilder<
       this.#state.joins[aliasedName].path ??= path;
     }
 
-    // auto-joins added by cond processing that depend on the new alias would otherwise produce a
-    // forward reference (the auto-join's ON refers to alias, while alias's ON refers back to it);
-    // fold them into the new join so both aliases share scope in the outer ON clause (issue #7681)
-    const condJoin = this.#state.joins[aliasedName];
-    const joinKeys = Object.keys(this.#state.joins);
-
-    for (let i = joinCountBefore; i < joinKeys.length; i++) {
-      const j = this.#state.joins[joinKeys[i]];
-
-      if (j === condJoin || j.ownerAlias !== alias) {
-        continue;
-      }
-
-      const nested = (condJoin.nested ??= new Set());
-      j.type = j.type === JoinType.innerJoin ? JoinType.nestedInnerJoin : JoinType.nestedLeftJoin;
-      nested.add(j);
-    }
+    this.nestNewJoins(this.#state.joins[aliasedName], joinCountBefore);
 
     return { prop, key: aliasedName };
   }

--- a/tests/issues/GH8090.test.ts
+++ b/tests/issues/GH8090.test.ts
@@ -1,0 +1,166 @@
+import type { Rel } from '@mikro-orm/postgresql';
+import { BaseEntity, Collection, MikroORM } from '@mikro-orm/postgresql';
+import {
+  Entity,
+  Filter,
+  ManyToOne,
+  OneToMany,
+  PrimaryKey,
+  Property,
+  ReflectMetadataProvider,
+} from '@mikro-orm/decorators/legacy';
+
+@Entity()
+@Filter({
+  name: 'auth',
+  cond: ({ company, locations }) => ({
+    $or: [{ id: company }, { locations }],
+  }),
+})
+class Company extends BaseEntity {
+  @PrimaryKey({ autoincrement: true })
+  readonly id!: number;
+
+  @Property()
+  code!: string;
+
+  @OneToMany(() => Location, location => location.company)
+  locations = new Collection<Location>(this);
+}
+
+@Entity()
+class Location extends BaseEntity {
+  @PrimaryKey({ autoincrement: true })
+  readonly id!: number;
+
+  @Property()
+  name!: string;
+
+  @ManyToOne(() => Company)
+  company!: Rel<Company>;
+}
+
+@Entity()
+class Product extends BaseEntity {
+  @PrimaryKey({ autoincrement: true })
+  readonly id!: number;
+
+  @Property()
+  name!: string;
+
+  @ManyToOne(() => Company)
+  company!: Rel<Company>;
+}
+
+@Entity()
+class User extends BaseEntity {
+  @PrimaryKey({ autoincrement: true })
+  readonly id!: number;
+
+  @Property()
+  name!: string;
+
+  @ManyToOne(() => Location)
+  location!: Rel<Location>;
+}
+
+@Entity()
+@Filter({
+  name: 'auth',
+  cond: ({ company, locations }) => ({
+    $or: [{ company }, { user: { location: locations } }],
+  }),
+})
+class ClientManagementObject extends BaseEntity {
+  @PrimaryKey({ autoincrement: true })
+  readonly id!: number;
+
+  @ManyToOne(() => Client)
+  client!: Rel<Client>;
+
+  @ManyToOne(() => User, { nullable: true })
+  user?: Rel<User>;
+
+  @ManyToOne(() => Company)
+  company!: Rel<Company>;
+}
+
+@Entity()
+class Client extends BaseEntity {
+  @PrimaryKey({ autoincrement: true })
+  readonly id!: number;
+
+  @Property()
+  name!: string;
+
+  @OneToMany(() => ClientManagementObject, cmo => cmo.client)
+  managementObjects = new Collection<ClientManagementObject>(this);
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    dbName: 'mikro_orm_test_gh_8090',
+    entities: [Company, Location, Product, User, Client, ClientManagementObject],
+    autoJoinRefsForFilters: false,
+    metadataProvider: ReflectMetadataProvider,
+  });
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+beforeEach(async () => {
+  await orm.schema.refresh();
+});
+
+test('filter referencing to-many relation on auto-joined entity', async () => {
+  const company = orm.em.create(Company, { code: 'ACME' });
+  orm.em.create(Location, { name: 'Location 1', company });
+  orm.em.create(Product, { name: 'Product 1', company });
+
+  // matches the filter only via the `locations` leg of the `$or` condition
+  const company2 = orm.em.create(Company, { code: 'ACME' });
+  const location2 = orm.em.create(Location, { name: 'Location 2', company: company2 });
+  orm.em.create(Product, { name: 'Product 2', company: company2 });
+
+  // matches neither leg
+  const company3 = orm.em.create(Company, { code: 'ACME' });
+  orm.em.create(Location, { name: 'Location 3', company: company3 });
+  orm.em.create(Product, { name: 'Product 3', company: company3 });
+
+  await orm.em.flush();
+  orm.em.clear();
+
+  orm.em.setFilterParams('auth', { company: [company.id], locations: [location2.id] });
+
+  const products = await orm.em.find(
+    Product,
+    { company: { code: 'ACME' } },
+    { filters: ['auth'], orderBy: { name: 'asc' } },
+  );
+  expect(products.map(p => p.name)).toEqual(['Product 1', 'Product 2']);
+});
+
+test('filter referencing a relation resolved via populate alias', async () => {
+  const company = orm.em.create(Company, { code: 'ACME' });
+  const location = orm.em.create(Location, { name: 'Location 1', company });
+  const user = orm.em.create(User, { name: 'User 1', location });
+  const client = orm.em.create(Client, { name: 'Client 1' });
+  orm.em.create(ClientManagementObject, { client, user, company });
+
+  await orm.em.flush();
+  orm.em.clear();
+
+  orm.em.setFilterParams('auth', { company: [company.id], locations: [location.id] });
+
+  const clients = await orm.em.find(
+    Client,
+    {},
+    { filters: ['auth'], populate: ['managementObjects.user.location'], strategy: 'joined' },
+  );
+  expect(clients).toHaveLength(1);
+  expect(clients[0].managementObjects).toHaveLength(1);
+});


### PR DESCRIPTION
When `autoJoinRefsForFilters: false` is set and a `@Filter` on an auto-joined entity references a relation, `applyJoinedFilters` generates SQL that references a join alias before it is defined in the FROM clause (`missing FROM-clause entry for table "l2"` on PostgreSQL).

Processing the filter condition auto-joins the referenced relation after the current join, but the produced condition lands in the current join's `on` clause, which references the new alias before its join is emitted. The fix applies the same nesting mechanism introduced for #7681: the new joins are folded into the filtered join's parenthesized group, so the aliases share the scope of the outer `on` clause. The inline #7681 logic in `joinReference` is extracted into a shared `nestNewJoins` helper used by both call sites.

Closes #8090
