### PR TITLE
fix(core): duck-type `Routine.is()` to survive the CJS/ESM dual-package hazard

### DIFF
--- a/packages/core/src/metadata/Routine.ts
+++ b/packages/core/src/metadata/Routine.ts
@@ -173,6 +173,10 @@ export class Routine<
   }
 
   static is(item: unknown): item is Routine {
-    return item instanceof Routine;
+    if (item instanceof Routine) {
+      return true;
+    }
+
+    return item != null && typeof item === 'object' && item.constructor?.name === 'Routine' && 'type' in item;
   }
 }

--- a/tests/features/stored-routines/validator.test.ts
+++ b/tests/features/stored-routines/validator.test.ts
@@ -184,4 +184,27 @@ describe('stored routines — Routine + validator', () => {
 
     expect(r.returnCustomType).toBe(stringType);
   });
+
+  it('Routine.is', () => {
+    const routine = new Routine({
+      name: 'is_routine_test',
+      type: 'function',
+      returns: { runtimeType: 'number', columnType: 'int' },
+      body: 'select 1',
+    });
+    // real instances pass via instanceof
+    expect(Routine.is(routine)).toBe(true);
+    // duck-type fallback: object with matching constructor name and `type` property
+    const fake = Object.create({ constructor: { name: 'Routine' } });
+    Object.defineProperty(fake, 'type', { value: 'function', enumerable: true });
+    expect(Routine.is(fake)).toBe(true);
+    // non-matching values
+    expect(Routine.is(null)).toBe(false);
+    expect(Routine.is(undefined)).toBe(false);
+    expect(Routine.is({})).toBe(false);
+    expect(Routine.is('string')).toBe(false);
+    expect(Routine.is(42)).toBe(false);
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    expect(Routine.is(() => {})).toBe(false);
+  });
 });


### PR DESCRIPTION
`Routine.is()` used a bare `instanceof`, so a `Routine` coming from a second copy of `@mikro-orm/core` (the CJS/ESM dual-package hazard, hit under tsx/swc) failed the check and `MikroORM.init` rejected a valid `routines` config. This applies the same duck-typing fallback #7289 added to `EntitySchema.is()`, keyed on the `type` discriminator.

Fixes #8092