### PR TITLE
fix(mssql): support predictable primary key names

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 yarn.lock   -diff -merge
 yarn.lock   linguist-generated=true
+
+*.snap      text eol=lf

--- a/packages/mssql/src/MsSqlPlatform.ts
+++ b/packages/mssql/src/MsSqlPlatform.ts
@@ -203,7 +203,7 @@ export class MsSqlPlatform extends AbstractSqlPlatform {
   }
 
   override getDefaultPrimaryName(tableName: string, columns: string[]): string {
-    return this.getConfig().getNamingStrategy().indexName(tableName, columns, 'primary');
+    return this.getIndexName(tableName, columns, 'primary');
   }
 
   override getUuidTypeDeclarationSQL(column: { length?: number }): string {

--- a/packages/mssql/src/MsSqlPlatform.ts
+++ b/packages/mssql/src/MsSqlPlatform.ts
@@ -206,6 +206,10 @@ export class MsSqlPlatform extends AbstractSqlPlatform {
     return this.getIndexName(tableName, columns, 'primary');
   }
 
+  override supportsCustomPrimaryKeyNames(): boolean {
+    return true;
+  }
+
   override getUuidTypeDeclarationSQL(column: { length?: number }): string {
     return 'uniqueidentifier';
   }

--- a/packages/mssql/src/MsSqlPlatform.ts
+++ b/packages/mssql/src/MsSqlPlatform.ts
@@ -202,6 +202,10 @@ export class MsSqlPlatform extends AbstractSqlPlatform {
     return 'dbo';
   }
 
+  override getDefaultPrimaryName(tableName: string, columns: string[]): string {
+    return this.getConfig().getNamingStrategy().indexName(tableName, columns, 'primary');
+  }
+
   override getUuidTypeDeclarationSQL(column: { length?: number }): string {
     return 'uniqueidentifier';
   }

--- a/packages/mssql/src/MsSqlSchemaHelper.ts
+++ b/packages/mssql/src/MsSqlSchemaHelper.ts
@@ -923,6 +923,11 @@ export class MsSqlSchemaHelper extends SchemaHelper {
     return col.join(' ');
   }
 
+  // SQL Server generates a random `PK__…` name when the constraint is unnamed, so always name it
+  protected override getPrimaryKeyConstraintPrefix(table: DatabaseTable, index: IndexDef): string {
+    return `constraint ${this.quote(index.keyName)} `;
+  }
+
   override alterTableColumn(column: Column, table: DatabaseTable, changedProperties: Set<string>): string[] {
     const parts: string[] = [];
 

--- a/packages/mssql/src/MsSqlSchemaHelper.ts
+++ b/packages/mssql/src/MsSqlSchemaHelper.ts
@@ -908,8 +908,10 @@ export class MsSqlSchemaHelper extends SchemaHelper {
       (!changedProperties || changedProperties.has('autoincrement') || changedProperties.has('type'))
     ) {
       const primaryKeyName = this.platform.getDefaultPrimaryName(table.name, [column.name]);
-      Utils.runIfNotEmpty(() => col.push(`constraint ${this.quote(primaryKeyName)}`), primaryKey && column.primary);
-      Utils.runIfNotEmpty(() => col.push('primary key'), primaryKey && column.primary);
+      Utils.runIfNotEmpty(
+        () => col.push(`constraint ${this.quote(primaryKeyName)} primary key`),
+        primaryKey && column.primary,
+      );
     }
 
     const useDefault = changedProperties

--- a/packages/mssql/src/MsSqlSchemaHelper.ts
+++ b/packages/mssql/src/MsSqlSchemaHelper.ts
@@ -906,6 +906,8 @@ export class MsSqlSchemaHelper extends SchemaHelper {
       !compositePK &&
       (!changedProperties || changedProperties.has('autoincrement') || changedProperties.has('type'))
     ) {
+      const primaryKeyName = this.platform.getDefaultPrimaryName(table.name, [column.name]);
+      Utils.runIfNotEmpty(() => col.push(`constraint ${this.quote(primaryKeyName)}`), primaryKey && column.primary);
       Utils.runIfNotEmpty(() => col.push('primary key'), primaryKey && column.primary);
     }
 

--- a/packages/sql/src/schema/SchemaHelper.ts
+++ b/packages/sql/src/schema/SchemaHelper.ts
@@ -691,6 +691,11 @@ export abstract class SchemaHelper {
     return pkIndex?.keyName !== defaultName;
   }
 
+  /** Returns the `constraint <name> ` prefix for a primary key definition, empty when the server assigns the default name on its own. */
+  protected getPrimaryKeyConstraintPrefix(table: DatabaseTable, index: IndexDef): string {
+    return this.hasNonDefaultPrimaryKeyName(table) ? `constraint ${this.quote(index.keyName)} ` : '';
+  }
+
   /* v8 ignore next */
   castColumn(name: string, type: string): string {
     return '';
@@ -1006,7 +1011,7 @@ export abstract class SchemaHelper {
       !table.getColumns().some(c => c.autoincrement && c.primary) || this.hasNonDefaultPrimaryKeyName(table);
 
     if (createPrimary && primaryKey) {
-      const name = this.hasNonDefaultPrimaryKeyName(table) ? `constraint ${this.quote(primaryKey.keyName)} ` : '';
+      const name = this.getPrimaryKeyConstraintPrefix(table, primaryKey);
       sql += `, ${name}primary key (${primaryKey.columnNames.map(c => this.quote(c)).join(', ')})`;
     }
 
@@ -1120,7 +1125,7 @@ export abstract class SchemaHelper {
     const defer = index.deferMode ? ` deferrable initially ${index.deferMode}` : '';
 
     if (index.primary) {
-      const keyName = this.hasNonDefaultPrimaryKeyName(table) ? `constraint ${index.keyName} ` : '';
+      const keyName = this.getPrimaryKeyConstraintPrefix(table, index);
       return `alter table ${table.getQuotedName()} add ${keyName}primary key (${columns})${defer}`;
     }
 

--- a/tests/features/generated-columns/__snapshots__/generated-columns.mssql.test.ts.snap
+++ b/tests/features/generated-columns/__snapshots__/generated-columns.mssql.test.ts.snap
@@ -1,10 +1,10 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`schema 1`] = `
-"create table [foo] ([id] int identity(1,1) not null primary key, [col1] nvarchar(255) not null, [col2] nvarchar(255) not null, [col3] nvarchar(255) not null, [generated] as (CASE WHEN (col1 IS NOT NULL) THEN 'one' WHEN (col2 IS NOT NULL) THEN 'two' WHEN (col3 IS NOT NULL) THEN 'three' ELSE 'four' END) PERSISTED, [generated2] as (CONCAT([col1], ' ', [col2])) PERSISTED);
+"create table [foo] ([id] int identity(1,1) not null constraint [foo_pkey] primary key, [col1] nvarchar(255) not null, [col2] nvarchar(255) not null, [col3] nvarchar(255) not null, [generated] as (CASE WHEN (col1 IS NOT NULL) THEN 'one' WHEN (col2 IS NOT NULL) THEN 'two' WHEN (col3 IS NOT NULL) THEN 'three' ELSE 'four' END) PERSISTED, [generated2] as (CONCAT([col1], ' ', [col2])) PERSISTED);
 create unique index [foo_col3_unique] on [foo] ([col3]);
 
-create table [user] ([id] int identity(1,1) not null primary key, [first_name] nvarchar(50) not null, [last_name] nvarchar(50) not null, [full_name] as (concat([first_name],' ',[last_name])) persisted, [full_name2] as (concat([first_name],' ',[last_name])) persisted);
+create table [user] ([id] int identity(1,1) not null constraint [user_pkey] primary key, [first_name] nvarchar(50) not null, [last_name] nvarchar(50) not null, [full_name] as (concat([first_name],' ',[last_name])) persisted, [full_name2] as (concat([first_name],' ',[last_name])) persisted);
 "
 `;
 

--- a/tests/features/migrations/Migrator.mssql.test.ts
+++ b/tests/features/migrations/Migrator.mssql.test.ts
@@ -465,7 +465,7 @@ test('ensureTable when the schema does not exist', async () => {
     `if (schema_id('custom2') is null) begin exec ('create schema [custom2] authorization [dbo]') end`,
   );
   expect(mock.mock.calls[3][0]).toMatch(
-    `create table [custom2].[mikro_orm_migrations] ([id] int identity(1,1) not null primary key, [name] varchar(255) not null, [executed_at] datetime2(7) not null constraint [mikro_orm_migrations_executed_at_default] default current_timestamp)`,
+    `create table [custom2].[mikro_orm_migrations] ([id] int identity(1,1) not null constraint [mikro_orm_migrations_pkey] primary key, [name] varchar(255) not null, [executed_at] datetime2(7) not null constraint [mikro_orm_migrations_executed_at_default] default current_timestamp)`,
   );
   await orm.close();
 });

--- a/tests/features/migrations/__snapshots__/GH7185.test.ts.snap
+++ b/tests/features/migrations/__snapshots__/GH7185.test.ts.snap
@@ -23,7 +23,7 @@ exports[`GH7185 [mssql] > multiline comments are not split in migration SQL 1`] 
 export class Migration20250101000000 extends Migration {
 
   override up(): void | Promise<void> {
-    this.addSql(\`create table [test_entity] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) not null);\`);
+    this.addSql(\`create table [test_entity] ([id] int identity(1,1) not null constraint [test_entity_pkey] primary key, [name] nvarchar(255) not null);\`);
     this.addSql(\`if exists(select * from sys.fn_listextendedproperty(N'MS_Description', N'Schema', N'dbo', N'Table', N'test_entity', null, null))
   exec sys.sp_updateextendedproperty N'MS_Description', N'line1;
 line2;

--- a/tests/features/migrations/__snapshots__/Migrator.mssql.test.ts.snap
+++ b/tests/features/migrations/__snapshots__/Migrator.mssql.test.ts.snap
@@ -8,22 +8,22 @@ export class Migration20191013214813 extends Migration {
 
   override up(): void | Promise<void> {
     this.addSql(\`if (schema_id('custom') is null) begin exec ('create schema [custom] authorization [dbo]') end;\`);
-    this.addSql(\`create table [custom].[book_tag2] ([id] bigint identity(1,1) not null primary key, [name] nvarchar(50) not null);\`);
+    this.addSql(\`create table [custom].[book_tag2] ([id] bigint identity(1,1) not null constraint [book_tag2_pkey] primary key, [name] nvarchar(50) not null);\`);
 
-    this.addSql(\`create table [custom].[foo_baz2] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) not null, [code] varchar(255) not null, [version] datetime2(3) not null constraint [foo_baz2_version_default] default current_timestamp);\`);
+    this.addSql(\`create table [custom].[foo_baz2] ([id] int identity(1,1) not null constraint [foo_baz2_pkey] primary key, [name] nvarchar(255) not null, [code] varchar(255) not null, [version] datetime2(3) not null constraint [foo_baz2_version_default] default current_timestamp);\`);
 
-    this.addSql(\`create table [custom].[foo_bar2] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) not null, [baz_id] int null, [foo_bar_id] int null, [version] datetime2(0) not null constraint [foo_bar2_version_default] default current_timestamp, [blob] varbinary(max) null, [array] text null, [object] nvarchar(max) null);\`);
+    this.addSql(\`create table [custom].[foo_bar2] ([id] int identity(1,1) not null constraint [foo_bar2_pkey] primary key, [name] nvarchar(255) not null, [baz_id] int null, [foo_bar_id] int null, [version] datetime2(0) not null constraint [foo_bar2_version_default] default current_timestamp, [blob] varbinary(max) null, [array] text null, [object] nvarchar(max) null);\`);
     this.addSql(\`create unique index [foo_bar2_baz_id_unique] on [custom].[foo_bar2] ([baz_id]) where [baz_id] is not null;\`);
     this.addSql(\`create unique index [foo_bar2_foo_bar_id_unique] on [custom].[foo_bar2] ([foo_bar_id]) where [foo_bar_id] is not null;\`);
 
     this.addSql(\`create table [custom].[foo_param2] ([bar_id] int not null, [baz_id] int not null, [value] nvarchar(255) not null, primary key ([bar_id], [baz_id]));\`);
 
-    this.addSql(\`create table [custom].[publisher2] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) not null constraint [publisher2_name_default] default 'asd', [type] nvarchar(100) not null constraint [publisher2_type_default] default 'local', [type2] nvarchar(100) not null constraint [publisher2_type2_default] default 'LOCAL', [enum1] tinyint null, [enum2] tinyint null, [enum3] tinyint null, [enum4] nvarchar(100) null);\`);
+    this.addSql(\`create table [custom].[publisher2] ([id] int identity(1,1) not null constraint [publisher2_pkey] primary key, [name] nvarchar(255) not null constraint [publisher2_name_default] default 'asd', [type] nvarchar(100) not null constraint [publisher2_type_default] default 'local', [type2] nvarchar(100) not null constraint [publisher2_type2_default] default 'LOCAL', [enum1] tinyint null, [enum2] tinyint null, [enum3] tinyint null, [enum4] nvarchar(100) null);\`);
     this.addSql(\`alter table [custom].[publisher2] add constraint [publisher2_type_check] check ([type] in ('local', 'global'));\`);
     this.addSql(\`alter table [custom].[publisher2] add constraint [publisher2_type2_check] check ([type2] in ('LOCAL', 'GLOBAL'));\`);
     this.addSql(\`alter table [custom].[publisher2] add constraint [publisher2_enum4_check] check ([enum4] in ('a', 'b', 'c'));\`);
 
-    this.addSql(\`create table [custom].[author2] ([id] int identity(1,1) not null primary key, [created_at] datetime2(3) not null constraint [author2_created_at_default] default current_timestamp, [updated_at] datetime2(3) not null constraint [author2_updated_at_default] default current_timestamp, [name] nvarchar(255) not null, [email] nvarchar(255) not null, [age] int null, [terms_accepted] bit not null constraint [author2_terms_accepted_default] default 0, [optional] bit null, [identities] text null, [born] date null, [born_time] time null, [favourite_book_uuid_pk] uniqueidentifier null, [favourite_author_id] int null);\`);
+    this.addSql(\`create table [custom].[author2] ([id] int identity(1,1) not null constraint [author2_pkey] primary key, [created_at] datetime2(3) not null constraint [author2_created_at_default] default current_timestamp, [updated_at] datetime2(3) not null constraint [author2_updated_at_default] default current_timestamp, [name] nvarchar(255) not null, [email] nvarchar(255) not null, [age] int null, [terms_accepted] bit not null constraint [author2_terms_accepted_default] default 0, [optional] bit null, [identities] text null, [born] date null, [born_time] time null, [favourite_book_uuid_pk] uniqueidentifier null, [favourite_author_id] int null);\`);
     this.addSql(\`create index [custom_email_index_name] on [custom].[author2] ([email]);\`);
     this.addSql(\`create unique index [custom_email_unique_name] on [custom].[author2] ([email]);\`);
     this.addSql(\`create index [author2_terms_accepted_index] on [custom].[author2] ([terms_accepted]);\`);
@@ -36,7 +36,7 @@ export class Migration20191013214813 extends Migration {
     this.addSql(\`create table [custom].[book2] ([uuid_pk] uniqueidentifier not null, [created_at] datetime2(3) not null constraint [book2_created_at_default] default current_timestamp, [isbn] nchar(13) null, [title] nvarchar(255) null constraint [book2_title_default] default '', [perex] text null, [price] numeric(8,2) null, [float] float(24) null, [float36] float(36) null, [double] float(53) null, [meta] nvarchar(max) null, [author_id] int not null, [publisher_id] int null, primary key ([uuid_pk]));\`);
     this.addSql(\`create unique index [book2_isbn_unique] on [custom].[book2] ([isbn]) where [isbn] is not null;\`);
 
-    this.addSql(\`create table [custom].[book2_tags] ([order] int identity(1,1) not null primary key, [book2_uuid_pk] uniqueidentifier not null, [book_tag2_id] bigint not null);\`);
+    this.addSql(\`create table [custom].[book2_tags] ([order] int identity(1,1) not null constraint [book2_tags_pkey] primary key, [book2_uuid_pk] uniqueidentifier not null, [book_tag2_id] bigint not null);\`);
 
     this.addSql(\`create table [custom].[book_to_tag_unordered] ([book2_uuid_pk] uniqueidentifier not null, [book_tag2_id] bigint not null, primary key ([book2_uuid_pk], [book_tag2_id]));\`);
 
@@ -54,10 +54,10 @@ else
 else
   exec sys.sp_addextendedproperty N'MS_Description', N'This is address property', N'Schema', N'custom', N'Table', N'address2', N'Column', N'value';\`);
 
-    this.addSql(\`create table [custom].[test2] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) null, [book_uuid_pk] uniqueidentifier null, [version] int not null constraint [test2_version_default] default 1);\`);
+    this.addSql(\`create table [custom].[test2] ([id] int identity(1,1) not null constraint [test2_pkey] primary key, [name] nvarchar(255) null, [book_uuid_pk] uniqueidentifier null, [version] int not null constraint [test2_version_default] default 1);\`);
     this.addSql(\`create unique index [test2_book_uuid_pk_unique] on [custom].[test2] ([book_uuid_pk]) where [book_uuid_pk] is not null;\`);
 
-    this.addSql(\`create table [custom].[publisher2_tests] ([id] int identity(1,1) not null primary key, [publisher2_id] int not null, [test2_id] int not null);\`);
+    this.addSql(\`create table [custom].[publisher2_tests] ([id] int identity(1,1) not null constraint [publisher2_tests_pkey] primary key, [publisher2_id] int not null, [test2_id] int not null);\`);
 
     this.addSql(\`create table [custom].[configuration2] ([property] nvarchar(255) not null, [test_id] int not null, [value] nvarchar(255) not null, primary key ([property], [test_id]));\`);
 
@@ -101,22 +101,22 @@ else
     "down": [],
     "up": [
       "if (schema_id('custom') is null) begin exec ('create schema [custom] authorization [dbo]') end;",
-      "create table [custom].[book_tag2] ([id] bigint identity(1,1) not null primary key, [name] nvarchar(50) not null);",
+      "create table [custom].[book_tag2] ([id] bigint identity(1,1) not null constraint [book_tag2_pkey] primary key, [name] nvarchar(50) not null);",
       "",
-      "create table [custom].[foo_baz2] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) not null, [code] varchar(255) not null, [version] datetime2(3) not null constraint [foo_baz2_version_default] default current_timestamp);",
+      "create table [custom].[foo_baz2] ([id] int identity(1,1) not null constraint [foo_baz2_pkey] primary key, [name] nvarchar(255) not null, [code] varchar(255) not null, [version] datetime2(3) not null constraint [foo_baz2_version_default] default current_timestamp);",
       "",
-      "create table [custom].[foo_bar2] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) not null, [baz_id] int null, [foo_bar_id] int null, [version] datetime2(0) not null constraint [foo_bar2_version_default] default current_timestamp, [blob] varbinary(max) null, [array] text null, [object] nvarchar(max) null);",
+      "create table [custom].[foo_bar2] ([id] int identity(1,1) not null constraint [foo_bar2_pkey] primary key, [name] nvarchar(255) not null, [baz_id] int null, [foo_bar_id] int null, [version] datetime2(0) not null constraint [foo_bar2_version_default] default current_timestamp, [blob] varbinary(max) null, [array] text null, [object] nvarchar(max) null);",
       "create unique index [foo_bar2_baz_id_unique] on [custom].[foo_bar2] ([baz_id]) where [baz_id] is not null;",
       "create unique index [foo_bar2_foo_bar_id_unique] on [custom].[foo_bar2] ([foo_bar_id]) where [foo_bar_id] is not null;",
       "",
       "create table [custom].[foo_param2] ([bar_id] int not null, [baz_id] int not null, [value] nvarchar(255) not null, primary key ([bar_id], [baz_id]));",
       "",
-      "create table [custom].[publisher2] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) not null constraint [publisher2_name_default] default 'asd', [type] nvarchar(100) not null constraint [publisher2_type_default] default 'local', [type2] nvarchar(100) not null constraint [publisher2_type2_default] default 'LOCAL', [enum1] tinyint null, [enum2] tinyint null, [enum3] tinyint null, [enum4] nvarchar(100) null);",
+      "create table [custom].[publisher2] ([id] int identity(1,1) not null constraint [publisher2_pkey] primary key, [name] nvarchar(255) not null constraint [publisher2_name_default] default 'asd', [type] nvarchar(100) not null constraint [publisher2_type_default] default 'local', [type2] nvarchar(100) not null constraint [publisher2_type2_default] default 'LOCAL', [enum1] tinyint null, [enum2] tinyint null, [enum3] tinyint null, [enum4] nvarchar(100) null);",
       "alter table [custom].[publisher2] add constraint [publisher2_type_check] check ([type] in ('local', 'global'));",
       "alter table [custom].[publisher2] add constraint [publisher2_type2_check] check ([type2] in ('LOCAL', 'GLOBAL'));",
       "alter table [custom].[publisher2] add constraint [publisher2_enum4_check] check ([enum4] in ('a', 'b', 'c'));",
       "",
-      "create table [custom].[author2] ([id] int identity(1,1) not null primary key, [created_at] datetime2(3) not null constraint [author2_created_at_default] default current_timestamp, [updated_at] datetime2(3) not null constraint [author2_updated_at_default] default current_timestamp, [name] nvarchar(255) not null, [email] nvarchar(255) not null, [age] int null, [terms_accepted] bit not null constraint [author2_terms_accepted_default] default 0, [optional] bit null, [identities] text null, [born] date null, [born_time] time null, [favourite_book_uuid_pk] uniqueidentifier null, [favourite_author_id] int null);",
+      "create table [custom].[author2] ([id] int identity(1,1) not null constraint [author2_pkey] primary key, [created_at] datetime2(3) not null constraint [author2_created_at_default] default current_timestamp, [updated_at] datetime2(3) not null constraint [author2_updated_at_default] default current_timestamp, [name] nvarchar(255) not null, [email] nvarchar(255) not null, [age] int null, [terms_accepted] bit not null constraint [author2_terms_accepted_default] default 0, [optional] bit null, [identities] text null, [born] date null, [born_time] time null, [favourite_book_uuid_pk] uniqueidentifier null, [favourite_author_id] int null);",
       "create index [custom_email_index_name] on [custom].[author2] ([email]);",
       "create unique index [custom_email_unique_name] on [custom].[author2] ([email]);",
       "create index [author2_terms_accepted_index] on [custom].[author2] ([terms_accepted]);",
@@ -129,7 +129,7 @@ else
       "create table [custom].[book2] ([uuid_pk] uniqueidentifier not null, [created_at] datetime2(3) not null constraint [book2_created_at_default] default current_timestamp, [isbn] nchar(13) null, [title] nvarchar(255) null constraint [book2_title_default] default '', [perex] text null, [price] numeric(8,2) null, [float] float(24) null, [float36] float(36) null, [double] float(53) null, [meta] nvarchar(max) null, [author_id] int not null, [publisher_id] int null, primary key ([uuid_pk]));",
       "create unique index [book2_isbn_unique] on [custom].[book2] ([isbn]) where [isbn] is not null;",
       "",
-      "create table [custom].[book2_tags] ([order] int identity(1,1) not null primary key, [book2_uuid_pk] uniqueidentifier not null, [book_tag2_id] bigint not null);",
+      "create table [custom].[book2_tags] ([order] int identity(1,1) not null constraint [book2_tags_pkey] primary key, [book2_uuid_pk] uniqueidentifier not null, [book_tag2_id] bigint not null);",
       "",
       "create table [custom].[book_to_tag_unordered] ([book2_uuid_pk] uniqueidentifier not null, [book_tag2_id] bigint not null, primary key ([book2_uuid_pk], [book_tag2_id]));",
       "",
@@ -147,10 +147,10 @@ else
 else
   exec sys.sp_addextendedproperty N'MS_Description', N'This is address property', N'Schema', N'custom', N'Table', N'address2', N'Column', N'value';",
       "",
-      "create table [custom].[test2] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) null, [book_uuid_pk] uniqueidentifier null, [version] int not null constraint [test2_version_default] default 1);",
+      "create table [custom].[test2] ([id] int identity(1,1) not null constraint [test2_pkey] primary key, [name] nvarchar(255) null, [book_uuid_pk] uniqueidentifier null, [version] int not null constraint [test2_version_default] default 1);",
       "create unique index [test2_book_uuid_pk_unique] on [custom].[test2] ([book_uuid_pk]) where [book_uuid_pk] is not null;",
       "",
-      "create table [custom].[publisher2_tests] ([id] int identity(1,1) not null primary key, [publisher2_id] int not null, [test2_id] int not null);",
+      "create table [custom].[publisher2_tests] ([id] int identity(1,1) not null constraint [publisher2_tests_pkey] primary key, [publisher2_id] int not null, [test2_id] int not null);",
       "",
       "create table [custom].[configuration2] ([property] nvarchar(255) not null, [test_id] int not null, [value] nvarchar(255) not null, primary key ([property], [test_id]));",
       "",
@@ -200,22 +200,22 @@ export class Migration20191013214813 extends Migration {
 
   override up(): void | Promise<void> {
     this.addSql(\`if (schema_id('custom') is null) begin exec ('create schema [custom] authorization [dbo]') end;\`);
-    this.addSql(\`create table [custom].[book_tag2] ([id] bigint identity(1,1) not null primary key, [name] nvarchar(50) not null);\`);
+    this.addSql(\`create table [custom].[book_tag2] ([id] bigint identity(1,1) not null constraint [book_tag2_pkey] primary key, [name] nvarchar(50) not null);\`);
 
-    this.addSql(\`create table [custom].[foo_baz2] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) not null, [code] varchar(255) not null, [version] datetime2(3) not null constraint [foo_baz2_version_default] default current_timestamp);\`);
+    this.addSql(\`create table [custom].[foo_baz2] ([id] int identity(1,1) not null constraint [foo_baz2_pkey] primary key, [name] nvarchar(255) not null, [code] varchar(255) not null, [version] datetime2(3) not null constraint [foo_baz2_version_default] default current_timestamp);\`);
 
-    this.addSql(\`create table [custom].[foo_bar2] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) not null, [baz_id] int null, [foo_bar_id] int null, [version] datetime2(0) not null constraint [foo_bar2_version_default] default current_timestamp, [blob] varbinary(max) null, [array] text null, [object] nvarchar(max) null);\`);
+    this.addSql(\`create table [custom].[foo_bar2] ([id] int identity(1,1) not null constraint [foo_bar2_pkey] primary key, [name] nvarchar(255) not null, [baz_id] int null, [foo_bar_id] int null, [version] datetime2(0) not null constraint [foo_bar2_version_default] default current_timestamp, [blob] varbinary(max) null, [array] text null, [object] nvarchar(max) null);\`);
     this.addSql(\`create unique index [foo_bar2_baz_id_unique] on [custom].[foo_bar2] ([baz_id]) where [baz_id] is not null;\`);
     this.addSql(\`create unique index [foo_bar2_foo_bar_id_unique] on [custom].[foo_bar2] ([foo_bar_id]) where [foo_bar_id] is not null;\`);
 
     this.addSql(\`create table [custom].[foo_param2] ([bar_id] int not null, [baz_id] int not null, [value] nvarchar(255) not null, primary key ([bar_id], [baz_id]));\`);
 
-    this.addSql(\`create table [custom].[publisher2] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) not null constraint [publisher2_name_default] default 'asd', [type] nvarchar(100) not null constraint [publisher2_type_default] default 'local', [type2] nvarchar(100) not null constraint [publisher2_type2_default] default 'LOCAL', [enum1] tinyint null, [enum2] tinyint null, [enum3] tinyint null, [enum4] nvarchar(100) null);\`);
+    this.addSql(\`create table [custom].[publisher2] ([id] int identity(1,1) not null constraint [publisher2_pkey] primary key, [name] nvarchar(255) not null constraint [publisher2_name_default] default 'asd', [type] nvarchar(100) not null constraint [publisher2_type_default] default 'local', [type2] nvarchar(100) not null constraint [publisher2_type2_default] default 'LOCAL', [enum1] tinyint null, [enum2] tinyint null, [enum3] tinyint null, [enum4] nvarchar(100) null);\`);
     this.addSql(\`alter table [custom].[publisher2] add constraint [publisher2_type_check] check ([type] in ('local', 'global'));\`);
     this.addSql(\`alter table [custom].[publisher2] add constraint [publisher2_type2_check] check ([type2] in ('LOCAL', 'GLOBAL'));\`);
     this.addSql(\`alter table [custom].[publisher2] add constraint [publisher2_enum4_check] check ([enum4] in ('a', 'b', 'c'));\`);
 
-    this.addSql(\`create table [custom].[author2] ([id] int identity(1,1) not null primary key, [created_at] datetime2(3) not null constraint [author2_created_at_default] default current_timestamp, [updated_at] datetime2(3) not null constraint [author2_updated_at_default] default current_timestamp, [name] nvarchar(255) not null, [email] nvarchar(255) not null, [age] int null, [terms_accepted] bit not null constraint [author2_terms_accepted_default] default 0, [optional] bit null, [identities] text null, [born] date null, [born_time] time null, [favourite_book_uuid_pk] uniqueidentifier null, [favourite_author_id] int null);\`);
+    this.addSql(\`create table [custom].[author2] ([id] int identity(1,1) not null constraint [author2_pkey] primary key, [created_at] datetime2(3) not null constraint [author2_created_at_default] default current_timestamp, [updated_at] datetime2(3) not null constraint [author2_updated_at_default] default current_timestamp, [name] nvarchar(255) not null, [email] nvarchar(255) not null, [age] int null, [terms_accepted] bit not null constraint [author2_terms_accepted_default] default 0, [optional] bit null, [identities] text null, [born] date null, [born_time] time null, [favourite_book_uuid_pk] uniqueidentifier null, [favourite_author_id] int null);\`);
     this.addSql(\`create index [custom_email_index_name] on [custom].[author2] ([email]);\`);
     this.addSql(\`create unique index [custom_email_unique_name] on [custom].[author2] ([email]);\`);
     this.addSql(\`create index [author2_terms_accepted_index] on [custom].[author2] ([terms_accepted]);\`);
@@ -228,7 +228,7 @@ export class Migration20191013214813 extends Migration {
     this.addSql(\`create table [custom].[book2] ([uuid_pk] uniqueidentifier not null, [created_at] datetime2(3) not null constraint [book2_created_at_default] default current_timestamp, [isbn] nchar(13) null, [title] nvarchar(255) null constraint [book2_title_default] default '', [perex] text null, [price] numeric(8,2) null, [float] float(24) null, [float36] float(36) null, [double] float(53) null, [meta] nvarchar(max) null, [author_id] int not null, [publisher_id] int null, primary key ([uuid_pk]));\`);
     this.addSql(\`create unique index [book2_isbn_unique] on [custom].[book2] ([isbn]) where [isbn] is not null;\`);
 
-    this.addSql(\`create table [custom].[book2_tags] ([order] int identity(1,1) not null primary key, [book2_uuid_pk] uniqueidentifier not null, [book_tag2_id] bigint not null);\`);
+    this.addSql(\`create table [custom].[book2_tags] ([order] int identity(1,1) not null constraint [book2_tags_pkey] primary key, [book2_uuid_pk] uniqueidentifier not null, [book_tag2_id] bigint not null);\`);
 
     this.addSql(\`create table [custom].[book_to_tag_unordered] ([book2_uuid_pk] uniqueidentifier not null, [book_tag2_id] bigint not null, primary key ([book2_uuid_pk], [book_tag2_id]));\`);
 
@@ -246,10 +246,10 @@ else
 else
   exec sys.sp_addextendedproperty N'MS_Description', N'This is address property', N'Schema', N'custom', N'Table', N'address2', N'Column', N'value';\`);
 
-    this.addSql(\`create table [custom].[test2] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) null, [book_uuid_pk] uniqueidentifier null, [version] int not null constraint [test2_version_default] default 1);\`);
+    this.addSql(\`create table [custom].[test2] ([id] int identity(1,1) not null constraint [test2_pkey] primary key, [name] nvarchar(255) null, [book_uuid_pk] uniqueidentifier null, [version] int not null constraint [test2_version_default] default 1);\`);
     this.addSql(\`create unique index [test2_book_uuid_pk_unique] on [custom].[test2] ([book_uuid_pk]) where [book_uuid_pk] is not null;\`);
 
-    this.addSql(\`create table [custom].[publisher2_tests] ([id] int identity(1,1) not null primary key, [publisher2_id] int not null, [test2_id] int not null);\`);
+    this.addSql(\`create table [custom].[publisher2_tests] ([id] int identity(1,1) not null constraint [publisher2_tests_pkey] primary key, [publisher2_id] int not null, [test2_id] int not null);\`);
 
     this.addSql(\`create table [custom].[configuration2] ([property] nvarchar(255) not null, [test_id] int not null, [value] nvarchar(255) not null, primary key ([property], [test_id]));\`);
 
@@ -293,22 +293,22 @@ else
     "down": [],
     "up": [
       "if (schema_id('custom') is null) begin exec ('create schema [custom] authorization [dbo]') end;",
-      "create table [custom].[book_tag2] ([id] bigint identity(1,1) not null primary key, [name] nvarchar(50) not null);",
+      "create table [custom].[book_tag2] ([id] bigint identity(1,1) not null constraint [book_tag2_pkey] primary key, [name] nvarchar(50) not null);",
       "",
-      "create table [custom].[foo_baz2] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) not null, [code] varchar(255) not null, [version] datetime2(3) not null constraint [foo_baz2_version_default] default current_timestamp);",
+      "create table [custom].[foo_baz2] ([id] int identity(1,1) not null constraint [foo_baz2_pkey] primary key, [name] nvarchar(255) not null, [code] varchar(255) not null, [version] datetime2(3) not null constraint [foo_baz2_version_default] default current_timestamp);",
       "",
-      "create table [custom].[foo_bar2] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) not null, [baz_id] int null, [foo_bar_id] int null, [version] datetime2(0) not null constraint [foo_bar2_version_default] default current_timestamp, [blob] varbinary(max) null, [array] text null, [object] nvarchar(max) null);",
+      "create table [custom].[foo_bar2] ([id] int identity(1,1) not null constraint [foo_bar2_pkey] primary key, [name] nvarchar(255) not null, [baz_id] int null, [foo_bar_id] int null, [version] datetime2(0) not null constraint [foo_bar2_version_default] default current_timestamp, [blob] varbinary(max) null, [array] text null, [object] nvarchar(max) null);",
       "create unique index [foo_bar2_baz_id_unique] on [custom].[foo_bar2] ([baz_id]) where [baz_id] is not null;",
       "create unique index [foo_bar2_foo_bar_id_unique] on [custom].[foo_bar2] ([foo_bar_id]) where [foo_bar_id] is not null;",
       "",
       "create table [custom].[foo_param2] ([bar_id] int not null, [baz_id] int not null, [value] nvarchar(255) not null, primary key ([bar_id], [baz_id]));",
       "",
-      "create table [custom].[publisher2] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) not null constraint [publisher2_name_default] default 'asd', [type] nvarchar(100) not null constraint [publisher2_type_default] default 'local', [type2] nvarchar(100) not null constraint [publisher2_type2_default] default 'LOCAL', [enum1] tinyint null, [enum2] tinyint null, [enum3] tinyint null, [enum4] nvarchar(100) null);",
+      "create table [custom].[publisher2] ([id] int identity(1,1) not null constraint [publisher2_pkey] primary key, [name] nvarchar(255) not null constraint [publisher2_name_default] default 'asd', [type] nvarchar(100) not null constraint [publisher2_type_default] default 'local', [type2] nvarchar(100) not null constraint [publisher2_type2_default] default 'LOCAL', [enum1] tinyint null, [enum2] tinyint null, [enum3] tinyint null, [enum4] nvarchar(100) null);",
       "alter table [custom].[publisher2] add constraint [publisher2_type_check] check ([type] in ('local', 'global'));",
       "alter table [custom].[publisher2] add constraint [publisher2_type2_check] check ([type2] in ('LOCAL', 'GLOBAL'));",
       "alter table [custom].[publisher2] add constraint [publisher2_enum4_check] check ([enum4] in ('a', 'b', 'c'));",
       "",
-      "create table [custom].[author2] ([id] int identity(1,1) not null primary key, [created_at] datetime2(3) not null constraint [author2_created_at_default] default current_timestamp, [updated_at] datetime2(3) not null constraint [author2_updated_at_default] default current_timestamp, [name] nvarchar(255) not null, [email] nvarchar(255) not null, [age] int null, [terms_accepted] bit not null constraint [author2_terms_accepted_default] default 0, [optional] bit null, [identities] text null, [born] date null, [born_time] time null, [favourite_book_uuid_pk] uniqueidentifier null, [favourite_author_id] int null);",
+      "create table [custom].[author2] ([id] int identity(1,1) not null constraint [author2_pkey] primary key, [created_at] datetime2(3) not null constraint [author2_created_at_default] default current_timestamp, [updated_at] datetime2(3) not null constraint [author2_updated_at_default] default current_timestamp, [name] nvarchar(255) not null, [email] nvarchar(255) not null, [age] int null, [terms_accepted] bit not null constraint [author2_terms_accepted_default] default 0, [optional] bit null, [identities] text null, [born] date null, [born_time] time null, [favourite_book_uuid_pk] uniqueidentifier null, [favourite_author_id] int null);",
       "create index [custom_email_index_name] on [custom].[author2] ([email]);",
       "create unique index [custom_email_unique_name] on [custom].[author2] ([email]);",
       "create index [author2_terms_accepted_index] on [custom].[author2] ([terms_accepted]);",
@@ -321,7 +321,7 @@ else
       "create table [custom].[book2] ([uuid_pk] uniqueidentifier not null, [created_at] datetime2(3) not null constraint [book2_created_at_default] default current_timestamp, [isbn] nchar(13) null, [title] nvarchar(255) null constraint [book2_title_default] default '', [perex] text null, [price] numeric(8,2) null, [float] float(24) null, [float36] float(36) null, [double] float(53) null, [meta] nvarchar(max) null, [author_id] int not null, [publisher_id] int null, primary key ([uuid_pk]));",
       "create unique index [book2_isbn_unique] on [custom].[book2] ([isbn]) where [isbn] is not null;",
       "",
-      "create table [custom].[book2_tags] ([order] int identity(1,1) not null primary key, [book2_uuid_pk] uniqueidentifier not null, [book_tag2_id] bigint not null);",
+      "create table [custom].[book2_tags] ([order] int identity(1,1) not null constraint [book2_tags_pkey] primary key, [book2_uuid_pk] uniqueidentifier not null, [book_tag2_id] bigint not null);",
       "",
       "create table [custom].[book_to_tag_unordered] ([book2_uuid_pk] uniqueidentifier not null, [book_tag2_id] bigint not null, primary key ([book2_uuid_pk], [book_tag2_id]));",
       "",
@@ -339,10 +339,10 @@ else
 else
   exec sys.sp_addextendedproperty N'MS_Description', N'This is address property', N'Schema', N'custom', N'Table', N'address2', N'Column', N'value';",
       "",
-      "create table [custom].[test2] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) null, [book_uuid_pk] uniqueidentifier null, [version] int not null constraint [test2_version_default] default 1);",
+      "create table [custom].[test2] ([id] int identity(1,1) not null constraint [test2_pkey] primary key, [name] nvarchar(255) null, [book_uuid_pk] uniqueidentifier null, [version] int not null constraint [test2_version_default] default 1);",
       "create unique index [test2_book_uuid_pk_unique] on [custom].[test2] ([book_uuid_pk]) where [book_uuid_pk] is not null;",
       "",
-      "create table [custom].[publisher2_tests] ([id] int identity(1,1) not null primary key, [publisher2_id] int not null, [test2_id] int not null);",
+      "create table [custom].[publisher2_tests] ([id] int identity(1,1) not null constraint [publisher2_tests_pkey] primary key, [publisher2_id] int not null, [test2_id] int not null);",
       "",
       "create table [custom].[configuration2] ([property] nvarchar(255) not null, [test_id] int not null, [value] nvarchar(255) not null, primary key ([property], [test_id]));",
       "",

--- a/tests/features/migrations/__snapshots__/Migrator.mssql.test.ts.snap
+++ b/tests/features/migrations/__snapshots__/Migrator.mssql.test.ts.snap
@@ -16,7 +16,7 @@ export class Migration20191013214813 extends Migration {
     this.addSql(\`create unique index [foo_bar2_baz_id_unique] on [custom].[foo_bar2] ([baz_id]) where [baz_id] is not null;\`);
     this.addSql(\`create unique index [foo_bar2_foo_bar_id_unique] on [custom].[foo_bar2] ([foo_bar_id]) where [foo_bar_id] is not null;\`);
 
-    this.addSql(\`create table [custom].[foo_param2] ([bar_id] int not null, [baz_id] int not null, [value] nvarchar(255) not null, primary key ([bar_id], [baz_id]));\`);
+    this.addSql(\`create table [custom].[foo_param2] ([bar_id] int not null, [baz_id] int not null, [value] nvarchar(255) not null, constraint [foo_param2_pkey] primary key ([bar_id], [baz_id]));\`);
 
     this.addSql(\`create table [custom].[publisher2] ([id] int identity(1,1) not null constraint [publisher2_pkey] primary key, [name] nvarchar(255) not null constraint [publisher2_name_default] default 'asd', [type] nvarchar(100) not null constraint [publisher2_type_default] default 'local', [type2] nvarchar(100) not null constraint [publisher2_type2_default] default 'LOCAL', [enum1] tinyint null, [enum2] tinyint null, [enum3] tinyint null, [enum4] nvarchar(100) null);\`);
     this.addSql(\`alter table [custom].[publisher2] add constraint [publisher2_type_check] check ([type] in ('local', 'global'));\`);
@@ -33,18 +33,18 @@ export class Migration20191013214813 extends Migration {
     this.addSql(\`create index [author2_name_age_index] on [custom].[author2] ([name], [age]);\`);
     this.addSql(\`create unique index [author2_name_email_unique] on [custom].[author2] ([name], [email]);\`);
 
-    this.addSql(\`create table [custom].[book2] ([uuid_pk] uniqueidentifier not null, [created_at] datetime2(3) not null constraint [book2_created_at_default] default current_timestamp, [isbn] nchar(13) null, [title] nvarchar(255) null constraint [book2_title_default] default '', [perex] text null, [price] numeric(8,2) null, [float] float(24) null, [float36] float(36) null, [double] float(53) null, [meta] nvarchar(max) null, [author_id] int not null, [publisher_id] int null, primary key ([uuid_pk]));\`);
+    this.addSql(\`create table [custom].[book2] ([uuid_pk] uniqueidentifier not null, [created_at] datetime2(3) not null constraint [book2_created_at_default] default current_timestamp, [isbn] nchar(13) null, [title] nvarchar(255) null constraint [book2_title_default] default '', [perex] text null, [price] numeric(8,2) null, [float] float(24) null, [float36] float(36) null, [double] float(53) null, [meta] nvarchar(max) null, [author_id] int not null, [publisher_id] int null, constraint [book2_pkey] primary key ([uuid_pk]));\`);
     this.addSql(\`create unique index [book2_isbn_unique] on [custom].[book2] ([isbn]) where [isbn] is not null;\`);
 
     this.addSql(\`create table [custom].[book2_tags] ([order] int identity(1,1) not null constraint [book2_tags_pkey] primary key, [book2_uuid_pk] uniqueidentifier not null, [book_tag2_id] bigint not null);\`);
 
-    this.addSql(\`create table [custom].[book_to_tag_unordered] ([book2_uuid_pk] uniqueidentifier not null, [book_tag2_id] bigint not null, primary key ([book2_uuid_pk], [book_tag2_id]));\`);
+    this.addSql(\`create table [custom].[book_to_tag_unordered] ([book2_uuid_pk] uniqueidentifier not null, [book_tag2_id] bigint not null, constraint [book_to_tag_unordered_pkey] primary key ([book2_uuid_pk], [book_tag2_id]));\`);
 
-    this.addSql(\`create table [custom].[author2_following] ([author2_1_id] int not null, [author2_2_id] int not null, primary key ([author2_1_id], [author2_2_id]));\`);
+    this.addSql(\`create table [custom].[author2_following] ([author2_1_id] int not null, [author2_2_id] int not null, constraint [author2_following_pkey] primary key ([author2_1_id], [author2_2_id]));\`);
 
-    this.addSql(\`create table [custom].[author_to_friend] ([author2_1_id] int not null, [author2_2_id] int not null, primary key ([author2_1_id], [author2_2_id]));\`);
+    this.addSql(\`create table [custom].[author_to_friend] ([author2_1_id] int not null, [author2_2_id] int not null, constraint [author_to_friend_pkey] primary key ([author2_1_id], [author2_2_id]));\`);
 
-    this.addSql(\`create table [custom].[address2] ([author_id] int not null, [value] nvarchar(255) not null, primary key ([author_id]));\`);
+    this.addSql(\`create table [custom].[address2] ([author_id] int not null, [value] nvarchar(255) not null, constraint [address2_pkey] primary key ([author_id]));\`);
     this.addSql(\`if exists(select * from sys.fn_listextendedproperty(N'MS_Description', N'Schema', N'custom', N'Table', N'address2', null, null))
   exec sys.sp_updateextendedproperty N'MS_Description', N'This is address table', N'Schema', N'custom', N'Table', N'address2'
 else
@@ -59,7 +59,7 @@ else
 
     this.addSql(\`create table [custom].[publisher2_tests] ([id] int identity(1,1) not null constraint [publisher2_tests_pkey] primary key, [publisher2_id] int not null, [test2_id] int not null);\`);
 
-    this.addSql(\`create table [custom].[configuration2] ([property] nvarchar(255) not null, [test_id] int not null, [value] nvarchar(255) not null, primary key ([property], [test_id]));\`);
+    this.addSql(\`create table [custom].[configuration2] ([property] nvarchar(255) not null, [test_id] int not null, [value] nvarchar(255) not null, constraint [configuration2_pkey] primary key ([property], [test_id]));\`);
 
     this.addSql(\`alter table [custom].[foo_bar2] add constraint [foo_bar2_baz_id_foreign] foreign key ([baz_id]) references [custom].[foo_baz2] ([id]) on delete set null;\`);
     this.addSql(\`alter table [custom].[foo_bar2] add constraint [foo_bar2_foo_bar_id_foreign] foreign key ([foo_bar_id]) references [custom].[foo_bar2] ([id]);\`);
@@ -109,7 +109,7 @@ else
       "create unique index [foo_bar2_baz_id_unique] on [custom].[foo_bar2] ([baz_id]) where [baz_id] is not null;",
       "create unique index [foo_bar2_foo_bar_id_unique] on [custom].[foo_bar2] ([foo_bar_id]) where [foo_bar_id] is not null;",
       "",
-      "create table [custom].[foo_param2] ([bar_id] int not null, [baz_id] int not null, [value] nvarchar(255) not null, primary key ([bar_id], [baz_id]));",
+      "create table [custom].[foo_param2] ([bar_id] int not null, [baz_id] int not null, [value] nvarchar(255) not null, constraint [foo_param2_pkey] primary key ([bar_id], [baz_id]));",
       "",
       "create table [custom].[publisher2] ([id] int identity(1,1) not null constraint [publisher2_pkey] primary key, [name] nvarchar(255) not null constraint [publisher2_name_default] default 'asd', [type] nvarchar(100) not null constraint [publisher2_type_default] default 'local', [type2] nvarchar(100) not null constraint [publisher2_type2_default] default 'LOCAL', [enum1] tinyint null, [enum2] tinyint null, [enum3] tinyint null, [enum4] nvarchar(100) null);",
       "alter table [custom].[publisher2] add constraint [publisher2_type_check] check ([type] in ('local', 'global'));",
@@ -126,18 +126,18 @@ else
       "create index [author2_name_age_index] on [custom].[author2] ([name], [age]);",
       "create unique index [author2_name_email_unique] on [custom].[author2] ([name], [email]);",
       "",
-      "create table [custom].[book2] ([uuid_pk] uniqueidentifier not null, [created_at] datetime2(3) not null constraint [book2_created_at_default] default current_timestamp, [isbn] nchar(13) null, [title] nvarchar(255) null constraint [book2_title_default] default '', [perex] text null, [price] numeric(8,2) null, [float] float(24) null, [float36] float(36) null, [double] float(53) null, [meta] nvarchar(max) null, [author_id] int not null, [publisher_id] int null, primary key ([uuid_pk]));",
+      "create table [custom].[book2] ([uuid_pk] uniqueidentifier not null, [created_at] datetime2(3) not null constraint [book2_created_at_default] default current_timestamp, [isbn] nchar(13) null, [title] nvarchar(255) null constraint [book2_title_default] default '', [perex] text null, [price] numeric(8,2) null, [float] float(24) null, [float36] float(36) null, [double] float(53) null, [meta] nvarchar(max) null, [author_id] int not null, [publisher_id] int null, constraint [book2_pkey] primary key ([uuid_pk]));",
       "create unique index [book2_isbn_unique] on [custom].[book2] ([isbn]) where [isbn] is not null;",
       "",
       "create table [custom].[book2_tags] ([order] int identity(1,1) not null constraint [book2_tags_pkey] primary key, [book2_uuid_pk] uniqueidentifier not null, [book_tag2_id] bigint not null);",
       "",
-      "create table [custom].[book_to_tag_unordered] ([book2_uuid_pk] uniqueidentifier not null, [book_tag2_id] bigint not null, primary key ([book2_uuid_pk], [book_tag2_id]));",
+      "create table [custom].[book_to_tag_unordered] ([book2_uuid_pk] uniqueidentifier not null, [book_tag2_id] bigint not null, constraint [book_to_tag_unordered_pkey] primary key ([book2_uuid_pk], [book_tag2_id]));",
       "",
-      "create table [custom].[author2_following] ([author2_1_id] int not null, [author2_2_id] int not null, primary key ([author2_1_id], [author2_2_id]));",
+      "create table [custom].[author2_following] ([author2_1_id] int not null, [author2_2_id] int not null, constraint [author2_following_pkey] primary key ([author2_1_id], [author2_2_id]));",
       "",
-      "create table [custom].[author_to_friend] ([author2_1_id] int not null, [author2_2_id] int not null, primary key ([author2_1_id], [author2_2_id]));",
+      "create table [custom].[author_to_friend] ([author2_1_id] int not null, [author2_2_id] int not null, constraint [author_to_friend_pkey] primary key ([author2_1_id], [author2_2_id]));",
       "",
-      "create table [custom].[address2] ([author_id] int not null, [value] nvarchar(255) not null, primary key ([author_id]));",
+      "create table [custom].[address2] ([author_id] int not null, [value] nvarchar(255) not null, constraint [address2_pkey] primary key ([author_id]));",
       "if exists(select * from sys.fn_listextendedproperty(N'MS_Description', N'Schema', N'custom', N'Table', N'address2', null, null))
   exec sys.sp_updateextendedproperty N'MS_Description', N'This is address table', N'Schema', N'custom', N'Table', N'address2'
 else
@@ -152,7 +152,7 @@ else
       "",
       "create table [custom].[publisher2_tests] ([id] int identity(1,1) not null constraint [publisher2_tests_pkey] primary key, [publisher2_id] int not null, [test2_id] int not null);",
       "",
-      "create table [custom].[configuration2] ([property] nvarchar(255) not null, [test_id] int not null, [value] nvarchar(255) not null, primary key ([property], [test_id]));",
+      "create table [custom].[configuration2] ([property] nvarchar(255) not null, [test_id] int not null, [value] nvarchar(255) not null, constraint [configuration2_pkey] primary key ([property], [test_id]));",
       "",
       "alter table [custom].[foo_bar2] add constraint [foo_bar2_baz_id_foreign] foreign key ([baz_id]) references [custom].[foo_baz2] ([id]) on delete set null;",
       "alter table [custom].[foo_bar2] add constraint [foo_bar2_foo_bar_id_foreign] foreign key ([foo_bar_id]) references [custom].[foo_bar2] ([id]);",
@@ -208,7 +208,7 @@ export class Migration20191013214813 extends Migration {
     this.addSql(\`create unique index [foo_bar2_baz_id_unique] on [custom].[foo_bar2] ([baz_id]) where [baz_id] is not null;\`);
     this.addSql(\`create unique index [foo_bar2_foo_bar_id_unique] on [custom].[foo_bar2] ([foo_bar_id]) where [foo_bar_id] is not null;\`);
 
-    this.addSql(\`create table [custom].[foo_param2] ([bar_id] int not null, [baz_id] int not null, [value] nvarchar(255) not null, primary key ([bar_id], [baz_id]));\`);
+    this.addSql(\`create table [custom].[foo_param2] ([bar_id] int not null, [baz_id] int not null, [value] nvarchar(255) not null, constraint [foo_param2_pkey] primary key ([bar_id], [baz_id]));\`);
 
     this.addSql(\`create table [custom].[publisher2] ([id] int identity(1,1) not null constraint [publisher2_pkey] primary key, [name] nvarchar(255) not null constraint [publisher2_name_default] default 'asd', [type] nvarchar(100) not null constraint [publisher2_type_default] default 'local', [type2] nvarchar(100) not null constraint [publisher2_type2_default] default 'LOCAL', [enum1] tinyint null, [enum2] tinyint null, [enum3] tinyint null, [enum4] nvarchar(100) null);\`);
     this.addSql(\`alter table [custom].[publisher2] add constraint [publisher2_type_check] check ([type] in ('local', 'global'));\`);
@@ -225,18 +225,18 @@ export class Migration20191013214813 extends Migration {
     this.addSql(\`create index [author2_name_age_index] on [custom].[author2] ([name], [age]);\`);
     this.addSql(\`create unique index [author2_name_email_unique] on [custom].[author2] ([name], [email]);\`);
 
-    this.addSql(\`create table [custom].[book2] ([uuid_pk] uniqueidentifier not null, [created_at] datetime2(3) not null constraint [book2_created_at_default] default current_timestamp, [isbn] nchar(13) null, [title] nvarchar(255) null constraint [book2_title_default] default '', [perex] text null, [price] numeric(8,2) null, [float] float(24) null, [float36] float(36) null, [double] float(53) null, [meta] nvarchar(max) null, [author_id] int not null, [publisher_id] int null, primary key ([uuid_pk]));\`);
+    this.addSql(\`create table [custom].[book2] ([uuid_pk] uniqueidentifier not null, [created_at] datetime2(3) not null constraint [book2_created_at_default] default current_timestamp, [isbn] nchar(13) null, [title] nvarchar(255) null constraint [book2_title_default] default '', [perex] text null, [price] numeric(8,2) null, [float] float(24) null, [float36] float(36) null, [double] float(53) null, [meta] nvarchar(max) null, [author_id] int not null, [publisher_id] int null, constraint [book2_pkey] primary key ([uuid_pk]));\`);
     this.addSql(\`create unique index [book2_isbn_unique] on [custom].[book2] ([isbn]) where [isbn] is not null;\`);
 
     this.addSql(\`create table [custom].[book2_tags] ([order] int identity(1,1) not null constraint [book2_tags_pkey] primary key, [book2_uuid_pk] uniqueidentifier not null, [book_tag2_id] bigint not null);\`);
 
-    this.addSql(\`create table [custom].[book_to_tag_unordered] ([book2_uuid_pk] uniqueidentifier not null, [book_tag2_id] bigint not null, primary key ([book2_uuid_pk], [book_tag2_id]));\`);
+    this.addSql(\`create table [custom].[book_to_tag_unordered] ([book2_uuid_pk] uniqueidentifier not null, [book_tag2_id] bigint not null, constraint [book_to_tag_unordered_pkey] primary key ([book2_uuid_pk], [book_tag2_id]));\`);
 
-    this.addSql(\`create table [custom].[author2_following] ([author2_1_id] int not null, [author2_2_id] int not null, primary key ([author2_1_id], [author2_2_id]));\`);
+    this.addSql(\`create table [custom].[author2_following] ([author2_1_id] int not null, [author2_2_id] int not null, constraint [author2_following_pkey] primary key ([author2_1_id], [author2_2_id]));\`);
 
-    this.addSql(\`create table [custom].[author_to_friend] ([author2_1_id] int not null, [author2_2_id] int not null, primary key ([author2_1_id], [author2_2_id]));\`);
+    this.addSql(\`create table [custom].[author_to_friend] ([author2_1_id] int not null, [author2_2_id] int not null, constraint [author_to_friend_pkey] primary key ([author2_1_id], [author2_2_id]));\`);
 
-    this.addSql(\`create table [custom].[address2] ([author_id] int not null, [value] nvarchar(255) not null, primary key ([author_id]));\`);
+    this.addSql(\`create table [custom].[address2] ([author_id] int not null, [value] nvarchar(255) not null, constraint [address2_pkey] primary key ([author_id]));\`);
     this.addSql(\`if exists(select * from sys.fn_listextendedproperty(N'MS_Description', N'Schema', N'custom', N'Table', N'address2', null, null))
   exec sys.sp_updateextendedproperty N'MS_Description', N'This is address table', N'Schema', N'custom', N'Table', N'address2'
 else
@@ -251,7 +251,7 @@ else
 
     this.addSql(\`create table [custom].[publisher2_tests] ([id] int identity(1,1) not null constraint [publisher2_tests_pkey] primary key, [publisher2_id] int not null, [test2_id] int not null);\`);
 
-    this.addSql(\`create table [custom].[configuration2] ([property] nvarchar(255) not null, [test_id] int not null, [value] nvarchar(255) not null, primary key ([property], [test_id]));\`);
+    this.addSql(\`create table [custom].[configuration2] ([property] nvarchar(255) not null, [test_id] int not null, [value] nvarchar(255) not null, constraint [configuration2_pkey] primary key ([property], [test_id]));\`);
 
     this.addSql(\`alter table [custom].[foo_bar2] add constraint [foo_bar2_baz_id_foreign] foreign key ([baz_id]) references [custom].[foo_baz2] ([id]) on delete set null;\`);
     this.addSql(\`alter table [custom].[foo_bar2] add constraint [foo_bar2_foo_bar_id_foreign] foreign key ([foo_bar_id]) references [custom].[foo_bar2] ([id]);\`);
@@ -301,7 +301,7 @@ else
       "create unique index [foo_bar2_baz_id_unique] on [custom].[foo_bar2] ([baz_id]) where [baz_id] is not null;",
       "create unique index [foo_bar2_foo_bar_id_unique] on [custom].[foo_bar2] ([foo_bar_id]) where [foo_bar_id] is not null;",
       "",
-      "create table [custom].[foo_param2] ([bar_id] int not null, [baz_id] int not null, [value] nvarchar(255) not null, primary key ([bar_id], [baz_id]));",
+      "create table [custom].[foo_param2] ([bar_id] int not null, [baz_id] int not null, [value] nvarchar(255) not null, constraint [foo_param2_pkey] primary key ([bar_id], [baz_id]));",
       "",
       "create table [custom].[publisher2] ([id] int identity(1,1) not null constraint [publisher2_pkey] primary key, [name] nvarchar(255) not null constraint [publisher2_name_default] default 'asd', [type] nvarchar(100) not null constraint [publisher2_type_default] default 'local', [type2] nvarchar(100) not null constraint [publisher2_type2_default] default 'LOCAL', [enum1] tinyint null, [enum2] tinyint null, [enum3] tinyint null, [enum4] nvarchar(100) null);",
       "alter table [custom].[publisher2] add constraint [publisher2_type_check] check ([type] in ('local', 'global'));",
@@ -318,18 +318,18 @@ else
       "create index [author2_name_age_index] on [custom].[author2] ([name], [age]);",
       "create unique index [author2_name_email_unique] on [custom].[author2] ([name], [email]);",
       "",
-      "create table [custom].[book2] ([uuid_pk] uniqueidentifier not null, [created_at] datetime2(3) not null constraint [book2_created_at_default] default current_timestamp, [isbn] nchar(13) null, [title] nvarchar(255) null constraint [book2_title_default] default '', [perex] text null, [price] numeric(8,2) null, [float] float(24) null, [float36] float(36) null, [double] float(53) null, [meta] nvarchar(max) null, [author_id] int not null, [publisher_id] int null, primary key ([uuid_pk]));",
+      "create table [custom].[book2] ([uuid_pk] uniqueidentifier not null, [created_at] datetime2(3) not null constraint [book2_created_at_default] default current_timestamp, [isbn] nchar(13) null, [title] nvarchar(255) null constraint [book2_title_default] default '', [perex] text null, [price] numeric(8,2) null, [float] float(24) null, [float36] float(36) null, [double] float(53) null, [meta] nvarchar(max) null, [author_id] int not null, [publisher_id] int null, constraint [book2_pkey] primary key ([uuid_pk]));",
       "create unique index [book2_isbn_unique] on [custom].[book2] ([isbn]) where [isbn] is not null;",
       "",
       "create table [custom].[book2_tags] ([order] int identity(1,1) not null constraint [book2_tags_pkey] primary key, [book2_uuid_pk] uniqueidentifier not null, [book_tag2_id] bigint not null);",
       "",
-      "create table [custom].[book_to_tag_unordered] ([book2_uuid_pk] uniqueidentifier not null, [book_tag2_id] bigint not null, primary key ([book2_uuid_pk], [book_tag2_id]));",
+      "create table [custom].[book_to_tag_unordered] ([book2_uuid_pk] uniqueidentifier not null, [book_tag2_id] bigint not null, constraint [book_to_tag_unordered_pkey] primary key ([book2_uuid_pk], [book_tag2_id]));",
       "",
-      "create table [custom].[author2_following] ([author2_1_id] int not null, [author2_2_id] int not null, primary key ([author2_1_id], [author2_2_id]));",
+      "create table [custom].[author2_following] ([author2_1_id] int not null, [author2_2_id] int not null, constraint [author2_following_pkey] primary key ([author2_1_id], [author2_2_id]));",
       "",
-      "create table [custom].[author_to_friend] ([author2_1_id] int not null, [author2_2_id] int not null, primary key ([author2_1_id], [author2_2_id]));",
+      "create table [custom].[author_to_friend] ([author2_1_id] int not null, [author2_2_id] int not null, constraint [author_to_friend_pkey] primary key ([author2_1_id], [author2_2_id]));",
       "",
-      "create table [custom].[address2] ([author_id] int not null, [value] nvarchar(255) not null, primary key ([author_id]));",
+      "create table [custom].[address2] ([author_id] int not null, [value] nvarchar(255) not null, constraint [address2_pkey] primary key ([author_id]));",
       "if exists(select * from sys.fn_listextendedproperty(N'MS_Description', N'Schema', N'custom', N'Table', N'address2', null, null))
   exec sys.sp_updateextendedproperty N'MS_Description', N'This is address table', N'Schema', N'custom', N'Table', N'address2'
 else
@@ -344,7 +344,7 @@ else
       "",
       "create table [custom].[publisher2_tests] ([id] int identity(1,1) not null constraint [publisher2_tests_pkey] primary key, [publisher2_id] int not null, [test2_id] int not null);",
       "",
-      "create table [custom].[configuration2] ([property] nvarchar(255) not null, [test_id] int not null, [value] nvarchar(255) not null, primary key ([property], [test_id]));",
+      "create table [custom].[configuration2] ([property] nvarchar(255) not null, [test_id] int not null, [value] nvarchar(255) not null, constraint [configuration2_pkey] primary key ([property], [test_id]));",
       "",
       "alter table [custom].[foo_bar2] add constraint [foo_bar2_baz_id_foreign] foreign key ([baz_id]) references [custom].[foo_baz2] ([id]) on delete set null;",
       "alter table [custom].[foo_bar2] add constraint [foo_bar2_foo_bar_id_foreign] foreign key ([foo_bar_id]) references [custom].[foo_bar2] ([id]);",

--- a/tests/features/naming/custom-naming-strategy.mssql.test.ts
+++ b/tests/features/naming/custom-naming-strategy.mssql.test.ts
@@ -11,12 +11,16 @@ class KeyNamingStrategy extends EntityCaseNamingStrategy {
   }
 
   private inferRefTable(columns: string[]): string | null {
-    if (columns.length !== 1) {return null;}
+    if (columns.length !== 1) {
+      return null;
+    }
 
     const col = columns[0] ?? '';
     const match = /^(.+?)Id$/.exec(col);
 
-    if (!match) {return null;}
+    if (!match) {
+      return null;
+    }
 
     const base = match[1] ?? '';
     const singular = base.charAt(0).toUpperCase() + base.slice(1);
@@ -37,7 +41,7 @@ class KeyNamingStrategy extends EntityCaseNamingStrategy {
       case 'primary':
         return `PK__${t}`;
       case 'foreign':
-        return ref ? `FK__${t}__${ref}` : (c ? `FK__${t}__${c}` : `FK__${t}`);
+        return ref ? `FK__${t}__${ref}` : c ? `FK__${t}__${c}` : `FK__${t}`;
       case 'unique':
         return c ? `UK__${t}__${c}` : `UK__${t}`;
       case 'index':
@@ -57,9 +61,12 @@ describe('custom constraint naming [mssql]', () => {
   const namingStrategy = new KeyNamingStrategy();
 
   beforeAll(async () => {
-    orm = await initORMMsSql({
-      namingStrategy: KeyNamingStrategy,
-    }, false);
+    orm = await initORMMsSql(
+      {
+        namingStrategy: KeyNamingStrategy,
+      },
+      false,
+    );
   });
 
   afterAll(async () => {
@@ -79,11 +86,13 @@ describe('custom constraint naming [mssql]', () => {
   test('uses KeyNamingStrategy names in generated MSSQL schema SQL', async () => {
     const sql = await orm.schema.getCreateSchemaSQL({ wrap: false });
     expect(sql).toContain('constraint [PK__Author2] primary key');
-    expect(sql).toContain('create table [FooParam2] ([bar] int not null, [baz] int not null, [value] nvarchar(255) not null, primary key ([bar], [baz]));');
+    expect(sql).toContain(
+      'create table [FooParam2] ([bar] int not null, [baz] int not null, [value] nvarchar(255) not null, primary key ([bar], [baz]));',
+    );
     expect(sql).not.toContain('constraint [PK__FooParam2] primary key');
     expect(sql).toContain('constraint [FK__FooParam2__bar] foreign key ([bar])');
     expect(sql).toContain('create unique index [UK__Author2__name_email] on [Author2] ([name], [email]);');
     expect(sql).toContain('create index [IX__Author2__termsAccepted] on [Author2] ([termsAccepted]);');
-    expect(sql).toContain('constraint [CK__Publisher2__type] check ([type] in (\'local\', \'global\'))');
+    expect(sql).toContain("constraint [CK__Publisher2__type] check ([type] in ('local', 'global'))");
   });
 });

--- a/tests/features/naming/custom-naming-strategy.mssql.test.ts
+++ b/tests/features/naming/custom-naming-strategy.mssql.test.ts
@@ -2,71 +2,32 @@ import { EntityCaseNamingStrategy } from '@mikro-orm/core';
 import { initORMMsSql } from '../../bootstrap.js';
 
 class KeyNamingStrategy extends EntityCaseNamingStrategy {
-  private normalize(value: string): string {
-    return value.replace(/[^A-Za-z0-9_]/g, '');
-  }
-
-  private cols(columns: string[]): string {
-    return columns.map(c => this.normalize(c)).join('_');
-  }
-
-  private inferRefTable(columns: string[]): string | null {
-    if (columns.length !== 1) {
-      return null;
-    }
-
-    const col = columns[0] ?? '';
-    const match = /^(.+?)Id$/.exec(col);
-
-    if (!match) {
-      return null;
-    }
-
-    const base = match[1] ?? '';
-    const singular = base.charAt(0).toUpperCase() + base.slice(1);
-
-    return this.normalize(singular);
-  }
-
   override indexName(
     tableName: string,
     columns: string[],
-    type: 'primary' | 'foreign' | 'unique' | 'index' | 'sequence' | 'check',
+    type: 'primary' | 'foreign' | 'unique' | 'index' | 'sequence' | 'check' | 'default' | 'trigger',
   ): string {
-    const t = this.normalize(tableName);
-    const c = this.cols(columns);
-    const ref = this.inferRefTable(columns);
+    const prefix = { primary: 'PK', foreign: 'FK', unique: 'UK', index: 'IX', sequence: 'SQ', check: 'CK' }[
+      type as string
+    ];
 
-    switch (type) {
-      case 'primary':
-        return `PK__${t}`;
-      case 'foreign':
-        return ref ? `FK__${t}__${ref}` : c ? `FK__${t}__${c}` : `FK__${t}`;
-      case 'unique':
-        return c ? `UK__${t}__${c}` : `UK__${t}`;
-      case 'index':
-        return c ? `IX__${t}__${c}` : `IX__${t}`;
-      case 'sequence':
-        return c ? `SQ__${t}__${c}` : `SQ__${t}`;
-      case 'check':
-        return c ? `CK__${t}__${c}` : `CK__${t}`;
-      default:
-        return super.indexName(tableName, columns, type);
+    if (!prefix) {
+      return super.indexName(tableName, columns, type);
     }
+
+    if (type === 'primary' || columns.length === 0) {
+      return `${prefix}__${tableName}`;
+    }
+
+    return `${prefix}__${tableName}__${columns.join('_')}`;
   }
 }
 
 describe('custom constraint naming [mssql]', () => {
   let orm: Awaited<ReturnType<typeof initORMMsSql>>;
-  const namingStrategy = new KeyNamingStrategy();
 
   beforeAll(async () => {
-    orm = await initORMMsSql(
-      {
-        namingStrategy: KeyNamingStrategy,
-      },
-      false,
-    );
+    orm = await initORMMsSql({ namingStrategy: KeyNamingStrategy }, false);
   });
 
   afterAll(async () => {
@@ -74,22 +35,10 @@ describe('custom constraint naming [mssql]', () => {
     await orm.close(true);
   });
 
-  test('KeyNamingStrategy returns names for all index types', () => {
-    expect(namingStrategy.indexName('author2', ['id'], 'primary')).toBe('PK__author2');
-    expect(namingStrategy.indexName('author2', ['favouriteBookId'], 'foreign')).toBe('FK__author2__FavouriteBook');
-    expect(namingStrategy.indexName('author2', ['email'], 'unique')).toBe('UK__author2__email');
-    expect(namingStrategy.indexName('author2', ['name'], 'index')).toBe('IX__author2__name');
-    expect(namingStrategy.indexName('author2', ['name'], 'check')).toBe('CK__author2__name');
-    expect(namingStrategy.indexName('author2', ['id'], 'sequence')).toBe('SQ__author2__id');
-  });
-
   test('uses KeyNamingStrategy names in generated MSSQL schema SQL', async () => {
     const sql = await orm.schema.getCreateSchemaSQL({ wrap: false });
-    expect(sql).toContain('constraint [PK__Author2] primary key');
-    expect(sql).toContain(
-      'create table [FooParam2] ([bar] int not null, [baz] int not null, [value] nvarchar(255) not null, primary key ([bar], [baz]));',
-    );
-    expect(sql).not.toContain('constraint [PK__FooParam2] primary key');
+    expect(sql).toContain('identity(1,1) not null constraint [PK__Author2] primary key');
+    expect(sql).toContain('constraint [PK__FooParam2] primary key ([bar], [baz])');
     expect(sql).toContain('constraint [FK__FooParam2__bar] foreign key ([bar])');
     expect(sql).toContain('create unique index [UK__Author2__name_email] on [Author2] ([name], [email]);');
     expect(sql).toContain('create index [IX__Author2__termsAccepted] on [Author2] ([termsAccepted]);');

--- a/tests/features/naming/custom-naming-strategy.mssql.test.ts
+++ b/tests/features/naming/custom-naming-strategy.mssql.test.ts
@@ -1,0 +1,89 @@
+import { EntityCaseNamingStrategy } from '@mikro-orm/core';
+import { initORMMsSql } from '../../bootstrap.js';
+
+class KeyNamingStrategy extends EntityCaseNamingStrategy {
+  private normalize(value: string): string {
+    return value.replace(/[^A-Za-z0-9_]/g, '');
+  }
+
+  private cols(columns: string[]): string {
+    return columns.map(c => this.normalize(c)).join('_');
+  }
+
+  private inferRefTable(columns: string[]): string | null {
+    if (columns.length !== 1) {return null;}
+
+    const col = columns[0] ?? '';
+    const match = /^(.+?)Id$/.exec(col);
+
+    if (!match) {return null;}
+
+    const base = match[1] ?? '';
+    const singular = base.charAt(0).toUpperCase() + base.slice(1);
+
+    return this.normalize(singular);
+  }
+
+  override indexName(
+    tableName: string,
+    columns: string[],
+    type: 'primary' | 'foreign' | 'unique' | 'index' | 'sequence' | 'check',
+  ): string {
+    const t = this.normalize(tableName);
+    const c = this.cols(columns);
+    const ref = this.inferRefTable(columns);
+
+    switch (type) {
+      case 'primary':
+        return `PK__${t}`;
+      case 'foreign':
+        return ref ? `FK__${t}__${ref}` : (c ? `FK__${t}__${c}` : `FK__${t}`);
+      case 'unique':
+        return c ? `UK__${t}__${c}` : `UK__${t}`;
+      case 'index':
+        return c ? `IX__${t}__${c}` : `IX__${t}`;
+      case 'sequence':
+        return c ? `SQ__${t}__${c}` : `SQ__${t}`;
+      case 'check':
+        return c ? `CK__${t}__${c}` : `CK__${t}`;
+      default:
+        return super.indexName(tableName, columns, type);
+    }
+  }
+}
+
+describe('custom constraint naming [mssql]', () => {
+  let orm: Awaited<ReturnType<typeof initORMMsSql>>;
+  const namingStrategy = new KeyNamingStrategy();
+
+  beforeAll(async () => {
+    orm = await initORMMsSql({
+      namingStrategy: KeyNamingStrategy,
+    }, false);
+  });
+
+  afterAll(async () => {
+    await orm.schema.dropDatabase();
+    await orm.close(true);
+  });
+
+  test('KeyNamingStrategy returns names for all index types', () => {
+    expect(namingStrategy.indexName('author2', ['id'], 'primary')).toBe('PK__author2');
+    expect(namingStrategy.indexName('author2', ['favouriteBookId'], 'foreign')).toBe('FK__author2__FavouriteBook');
+    expect(namingStrategy.indexName('author2', ['email'], 'unique')).toBe('UK__author2__email');
+    expect(namingStrategy.indexName('author2', ['name'], 'index')).toBe('IX__author2__name');
+    expect(namingStrategy.indexName('author2', ['name'], 'check')).toBe('CK__author2__name');
+    expect(namingStrategy.indexName('author2', ['id'], 'sequence')).toBe('SQ__author2__id');
+  });
+
+  test('uses KeyNamingStrategy names in generated MSSQL schema SQL', async () => {
+    const sql = await orm.schema.getCreateSchemaSQL({ wrap: false });
+    expect(sql).toContain('constraint [PK__Author2] primary key');
+    expect(sql).toContain('create table [FooParam2] ([bar] int not null, [baz] int not null, [value] nvarchar(255) not null, primary key ([bar], [baz]));');
+    expect(sql).not.toContain('constraint [PK__FooParam2] primary key');
+    expect(sql).toContain('constraint [FK__FooParam2__bar] foreign key ([bar])');
+    expect(sql).toContain('create unique index [UK__Author2__name_email] on [Author2] ([name], [email]);');
+    expect(sql).toContain('create index [IX__Author2__termsAccepted] on [Author2] ([termsAccepted]);');
+    expect(sql).toContain('constraint [CK__Publisher2__type] check ([type] in (\'local\', \'global\'))');
+  });
+});

--- a/tests/features/schema-generator/SchemaGenerator.mssql.test.ts
+++ b/tests/features/schema-generator/SchemaGenerator.mssql.test.ts
@@ -160,7 +160,7 @@ describe('SchemaGenerator', () => {
     newTableMeta.removeProperty('updatedAt');
     authorMeta.removeProperty('favouriteBook');
     diff = await orm.schema.getUpdateSchemaSQL({ wrap: false });
-    expect(diff.replace(/PK__new_tabl__\w+/, 'PK__new_tabl__123')).toMatchSnapshot('mssql-update-schema-drop-column');
+    expect(diff).toMatchSnapshot('mssql-update-schema-drop-column');
     await orm.schema.execute(diff);
 
     newTableMeta.addProperty(idProp);

--- a/tests/features/schema-generator/__snapshots__/SchemaGenerator.mssql.test.ts.snap
+++ b/tests/features/schema-generator/__snapshots__/SchemaGenerator.mssql.test.ts.snap
@@ -8,7 +8,7 @@ alter table [base_user2] add constraint [base_user2_type_check] check ([type] in
 
 create table [book_tag2] ([id] bigint identity(1,1) not null constraint [book_tag2_pkey] primary key, [name] nvarchar(50) not null);
 
-create table [car2] ([name] nvarchar(100) not null, [year] int not null, [price] int not null, primary key ([name], [year]));
+create table [car2] ([name] nvarchar(100) not null, [year] int not null, [price] int not null, constraint [car2_pkey] primary key ([name], [year]));
 create index [car2_name_index] on [car2] ([name]);
 create index [car2_year_index] on [car2] ([year]);
 
@@ -23,7 +23,7 @@ create table [foo_bar2] ([id] int identity(1,1) not null constraint [foo_bar2_pk
 create unique index [foo_bar2_baz_id_unique] on [foo_bar2] ([baz_id]) where [baz_id] is not null;
 create unique index [foo_bar2_foo_bar_id_unique] on [foo_bar2] ([foo_bar_id]) where [foo_bar_id] is not null;
 
-create table [foo_param2] ([bar_id] int not null, [baz_id] int not null, [value] nvarchar(255) not null, primary key ([bar_id], [baz_id]));
+create table [foo_param2] ([bar_id] int not null, [baz_id] int not null, [value] nvarchar(255) not null, constraint [foo_param2_pkey] primary key ([bar_id], [baz_id]));
 
 create table [publisher2] ([id] int identity(1,1) not null constraint [publisher2_pkey] primary key, [name] nvarchar(255) not null constraint [publisher2_name_default] default 'asd', [type] nvarchar(100) not null constraint [publisher2_type_default] default 'local', [type2] nvarchar(100) not null constraint [publisher2_type2_default] default 'LOCAL', [enum1] tinyint null, [enum2] tinyint null, [enum3] tinyint null, [enum4] nvarchar(100) null);
 alter table [publisher2] add constraint [publisher2_type_check] check ([type] in ('local', 'global'));
@@ -40,18 +40,18 @@ create index [custom_idx_name_123] on [author2] ([name]);
 create index [author2_name_age_index] on [author2] ([name], [age]);
 create unique index [author2_name_email_unique] on [author2] ([name], [email]);
 
-create table [book2] ([uuid_pk] uniqueidentifier not null, [created_at] datetime2(3) not null constraint [book2_created_at_default] default current_timestamp, [isbn] nchar(13) null, [title] nvarchar(255) null constraint [book2_title_default] default '', [perex] text null, [price] numeric(8,2) null, [float] float(24) null, [float36] float(36) null, [double] float(53) null, [meta] nvarchar(max) null, [author_id] int not null, [publisher_id] int null, primary key ([uuid_pk]));
+create table [book2] ([uuid_pk] uniqueidentifier not null, [created_at] datetime2(3) not null constraint [book2_created_at_default] default current_timestamp, [isbn] nchar(13) null, [title] nvarchar(255) null constraint [book2_title_default] default '', [perex] text null, [price] numeric(8,2) null, [float] float(24) null, [float36] float(36) null, [double] float(53) null, [meta] nvarchar(max) null, [author_id] int not null, [publisher_id] int null, constraint [book2_pkey] primary key ([uuid_pk]));
 create unique index [book2_isbn_unique] on [book2] ([isbn]) where [isbn] is not null;
 
 create table [book2_tags] ([order] int identity(1,1) not null constraint [book2_tags_pkey] primary key, [book2_uuid_pk] uniqueidentifier not null, [book_tag2_id] bigint not null);
 
-create table [book_to_tag_unordered] ([book2_uuid_pk] uniqueidentifier not null, [book_tag2_id] bigint not null, primary key ([book2_uuid_pk], [book_tag2_id]));
+create table [book_to_tag_unordered] ([book2_uuid_pk] uniqueidentifier not null, [book_tag2_id] bigint not null, constraint [book_to_tag_unordered_pkey] primary key ([book2_uuid_pk], [book_tag2_id]));
 
-create table [author2_following] ([author2_1_id] int not null, [author2_2_id] int not null, primary key ([author2_1_id], [author2_2_id]));
+create table [author2_following] ([author2_1_id] int not null, [author2_2_id] int not null, constraint [author2_following_pkey] primary key ([author2_1_id], [author2_2_id]));
 
-create table [author_to_friend] ([author2_1_id] int not null, [author2_2_id] int not null, primary key ([author2_1_id], [author2_2_id]));
+create table [author_to_friend] ([author2_1_id] int not null, [author2_2_id] int not null, constraint [author_to_friend_pkey] primary key ([author2_1_id], [author2_2_id]));
 
-create table [address2] ([author_id] int not null, [value] nvarchar(255) not null, primary key ([author_id]));
+create table [address2] ([author_id] int not null, [value] nvarchar(255) not null, constraint [address2_pkey] primary key ([author_id]));
 if exists(select * from sys.fn_listextendedproperty(N'MS_Description', N'Schema', N'dbo', N'Table', N'address2', null, null))
   exec sys.sp_updateextendedproperty N'MS_Description', N'This is address table', N'Schema', N'dbo', N'Table', N'address2'
 else
@@ -68,14 +68,14 @@ create unique index [test2_book_uuid_pk_unique] on [test2] ([book_uuid_pk]) wher
 
 create table [publisher2_tests] ([id] int identity(1,1) not null constraint [publisher2_tests_pkey] primary key, [publisher2_id] int not null, [test2_id] int not null);
 
-create table [configuration2] ([property] nvarchar(255) not null, [test_id] int not null, [value] nvarchar(255) not null, primary key ([property], [test_id]));
+create table [configuration2] ([property] nvarchar(255) not null, [test_id] int not null, [value] nvarchar(255) not null, constraint [configuration2_pkey] primary key ([property], [test_id]));
 
-create table [user2] ([first_name] nvarchar(100) not null, [last_name] nvarchar(100) not null, [foo] int null, [favourite_car_name] nvarchar(100) null, [favourite_car_year] int null, primary key ([first_name], [last_name]));
+create table [user2] ([first_name] nvarchar(100) not null, [last_name] nvarchar(100) not null, [foo] int null, [favourite_car_name] nvarchar(100) null, [favourite_car_year] int null, constraint [user2_pkey] primary key ([first_name], [last_name]));
 create unique index [user2_favourite_car_name_favourite_car_year_unique] on [user2] ([favourite_car_name], [favourite_car_year]) where [favourite_car_name] is not null and [favourite_car_year] is not null;
 
-create table [user2_cars] ([user2_first_name] nvarchar(100) not null, [user2_last_name] nvarchar(100) not null, [car2_name] nvarchar(100) not null, [car2_year] int not null, primary key ([user2_first_name], [user2_last_name], [car2_name], [car2_year]));
+create table [user2_cars] ([user2_first_name] nvarchar(100) not null, [user2_last_name] nvarchar(100) not null, [car2_name] nvarchar(100) not null, [car2_year] int not null, constraint [user2_cars_pkey] primary key ([user2_first_name], [user2_last_name], [car2_name], [car2_year]));
 
-create table [user2_sandwiches] ([user2_first_name] nvarchar(100) not null, [user2_last_name] nvarchar(100) not null, [sandwich_id] int not null, primary key ([user2_first_name], [user2_last_name], [sandwich_id]));
+create table [user2_sandwiches] ([user2_first_name] nvarchar(100) not null, [user2_last_name] nvarchar(100) not null, [sandwich_id] int not null, constraint [user2_sandwiches_pkey] primary key ([user2_first_name], [user2_last_name], [sandwich_id]));
 
 alter table [base_user2] add constraint [base_user2_favourite_employee_id_foreign] foreign key ([favourite_employee_id]) references [base_user2] ([id]);
 alter table [base_user2] add constraint [base_user2_favourite_manager_id_foreign] foreign key ([favourite_manager_id]) references [base_user2] ([id]);

--- a/tests/features/schema-generator/__snapshots__/SchemaGenerator.mssql.test.ts.snap
+++ b/tests/features/schema-generator/__snapshots__/SchemaGenerator.mssql.test.ts.snap
@@ -1,36 +1,36 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`SchemaGenerator > read-only schema tests > generate schema from metadata [mssql] > mssql-create-schema-dump 1`] = `
-"create table [base_user2] ([id] int identity(1,1) not null primary key, [first_name] nvarchar(100) not null, [last_name] nvarchar(100) not null, [type] nvarchar(100) not null, [owner_prop] nvarchar(255) null, [favourite_employee_id] int null, [favourite_manager_id] int null, [employee_prop] int null, [manager_prop] nvarchar(255) null);
+"create table [base_user2] ([id] int identity(1,1) not null constraint [base_user2_pkey] primary key, [first_name] nvarchar(100) not null, [last_name] nvarchar(100) not null, [type] nvarchar(100) not null, [owner_prop] nvarchar(255) null, [favourite_employee_id] int null, [favourite_manager_id] int null, [employee_prop] int null, [manager_prop] nvarchar(255) null);
 create index [base_user2_type_index] on [base_user2] ([type]);
 create unique index [base_user2_favourite_manager_id_unique] on [base_user2] ([favourite_manager_id]) where [favourite_manager_id] is not null;
 alter table [base_user2] add constraint [base_user2_type_check] check ([type] in ('employee', 'manager', 'owner'));
 
-create table [book_tag2] ([id] bigint identity(1,1) not null primary key, [name] nvarchar(50) not null);
+create table [book_tag2] ([id] bigint identity(1,1) not null constraint [book_tag2_pkey] primary key, [name] nvarchar(50) not null);
 
 create table [car2] ([name] nvarchar(100) not null, [year] int not null, [price] int not null, primary key ([name], [year]));
 create index [car2_name_index] on [car2] ([name]);
 create index [car2_year_index] on [car2] ([year]);
 
-create table [car_owner2] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) not null, [car_name] nvarchar(100) not null, [car_year] int not null);
+create table [car_owner2] ([id] int identity(1,1) not null constraint [car_owner2_pkey] primary key, [name] nvarchar(255) not null, [car_name] nvarchar(100) not null, [car_year] int not null);
 create index [car_owner2_car_name_car_year_index] on [car_owner2] ([car_name], [car_year]);
 
-create table [dummy2] ([id] int identity(1,1) not null primary key);
+create table [dummy2] ([id] int identity(1,1) not null constraint [dummy2_pkey] primary key);
 
-create table [foo_baz2] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) not null, [code] varchar(255) not null, [version] datetime2(3) not null constraint [foo_baz2_version_default] default current_timestamp);
+create table [foo_baz2] ([id] int identity(1,1) not null constraint [foo_baz2_pkey] primary key, [name] nvarchar(255) not null, [code] varchar(255) not null, [version] datetime2(3) not null constraint [foo_baz2_version_default] default current_timestamp);
 
-create table [foo_bar2] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) not null, [baz_id] int null, [foo_bar_id] int null, [version] datetime2(0) not null constraint [foo_bar2_version_default] default current_timestamp, [blob] varbinary(max) null, [array] text null, [object] nvarchar(max) null);
+create table [foo_bar2] ([id] int identity(1,1) not null constraint [foo_bar2_pkey] primary key, [name] nvarchar(255) not null, [baz_id] int null, [foo_bar_id] int null, [version] datetime2(0) not null constraint [foo_bar2_version_default] default current_timestamp, [blob] varbinary(max) null, [array] text null, [object] nvarchar(max) null);
 create unique index [foo_bar2_baz_id_unique] on [foo_bar2] ([baz_id]) where [baz_id] is not null;
 create unique index [foo_bar2_foo_bar_id_unique] on [foo_bar2] ([foo_bar_id]) where [foo_bar_id] is not null;
 
 create table [foo_param2] ([bar_id] int not null, [baz_id] int not null, [value] nvarchar(255) not null, primary key ([bar_id], [baz_id]));
 
-create table [publisher2] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) not null constraint [publisher2_name_default] default 'asd', [type] nvarchar(100) not null constraint [publisher2_type_default] default 'local', [type2] nvarchar(100) not null constraint [publisher2_type2_default] default 'LOCAL', [enum1] tinyint null, [enum2] tinyint null, [enum3] tinyint null, [enum4] nvarchar(100) null);
+create table [publisher2] ([id] int identity(1,1) not null constraint [publisher2_pkey] primary key, [name] nvarchar(255) not null constraint [publisher2_name_default] default 'asd', [type] nvarchar(100) not null constraint [publisher2_type_default] default 'local', [type2] nvarchar(100) not null constraint [publisher2_type2_default] default 'LOCAL', [enum1] tinyint null, [enum2] tinyint null, [enum3] tinyint null, [enum4] nvarchar(100) null);
 alter table [publisher2] add constraint [publisher2_type_check] check ([type] in ('local', 'global'));
 alter table [publisher2] add constraint [publisher2_type2_check] check ([type2] in ('LOCAL', 'GLOBAL'));
 alter table [publisher2] add constraint [publisher2_enum4_check] check ([enum4] in ('a', 'b', 'c'));
 
-create table [author2] ([id] int identity(1,1) not null primary key, [created_at] datetime2(3) not null constraint [author2_created_at_default] default current_timestamp, [updated_at] datetime2(3) not null constraint [author2_updated_at_default] default current_timestamp, [name] nvarchar(255) not null, [email] nvarchar(255) not null, [age] int null, [terms_accepted] bit not null constraint [author2_terms_accepted_default] default 0, [optional] bit null, [identities] text null, [born] date null, [born_time] time null, [favourite_book_uuid_pk] uniqueidentifier null, [favourite_author_id] int null);
+create table [author2] ([id] int identity(1,1) not null constraint [author2_pkey] primary key, [created_at] datetime2(3) not null constraint [author2_created_at_default] default current_timestamp, [updated_at] datetime2(3) not null constraint [author2_updated_at_default] default current_timestamp, [name] nvarchar(255) not null, [email] nvarchar(255) not null, [age] int null, [terms_accepted] bit not null constraint [author2_terms_accepted_default] default 0, [optional] bit null, [identities] text null, [born] date null, [born_time] time null, [favourite_book_uuid_pk] uniqueidentifier null, [favourite_author_id] int null);
 create index [custom_email_index_name] on [author2] ([email]);
 create unique index [custom_email_unique_name] on [author2] ([email]);
 create index [author2_terms_accepted_index] on [author2] ([terms_accepted]);
@@ -43,7 +43,7 @@ create unique index [author2_name_email_unique] on [author2] ([name], [email]);
 create table [book2] ([uuid_pk] uniqueidentifier not null, [created_at] datetime2(3) not null constraint [book2_created_at_default] default current_timestamp, [isbn] nchar(13) null, [title] nvarchar(255) null constraint [book2_title_default] default '', [perex] text null, [price] numeric(8,2) null, [float] float(24) null, [float36] float(36) null, [double] float(53) null, [meta] nvarchar(max) null, [author_id] int not null, [publisher_id] int null, primary key ([uuid_pk]));
 create unique index [book2_isbn_unique] on [book2] ([isbn]) where [isbn] is not null;
 
-create table [book2_tags] ([order] int identity(1,1) not null primary key, [book2_uuid_pk] uniqueidentifier not null, [book_tag2_id] bigint not null);
+create table [book2_tags] ([order] int identity(1,1) not null constraint [book2_tags_pkey] primary key, [book2_uuid_pk] uniqueidentifier not null, [book_tag2_id] bigint not null);
 
 create table [book_to_tag_unordered] ([book2_uuid_pk] uniqueidentifier not null, [book_tag2_id] bigint not null, primary key ([book2_uuid_pk], [book_tag2_id]));
 
@@ -61,12 +61,12 @@ if exists(select * from sys.fn_listextendedproperty(N'MS_Description', N'Schema'
 else
   exec sys.sp_addextendedproperty N'MS_Description', N'This is address property', N'Schema', N'dbo', N'Table', N'address2', N'Column', N'value';
 
-create table [sandwich] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) not null, [price] int not null);
+create table [sandwich] ([id] int identity(1,1) not null constraint [sandwich_pkey] primary key, [name] nvarchar(255) not null, [price] int not null);
 
-create table [test2] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) null, [book_uuid_pk] uniqueidentifier null, [version] int not null constraint [test2_version_default] default 1);
+create table [test2] ([id] int identity(1,1) not null constraint [test2_pkey] primary key, [name] nvarchar(255) null, [book_uuid_pk] uniqueidentifier null, [version] int not null constraint [test2_version_default] default 1);
 create unique index [test2_book_uuid_pk_unique] on [test2] ([book_uuid_pk]) where [book_uuid_pk] is not null;
 
-create table [publisher2_tests] ([id] int identity(1,1) not null primary key, [publisher2_id] int not null, [test2_id] int not null);
+create table [publisher2_tests] ([id] int identity(1,1) not null constraint [publisher2_tests_pkey] primary key, [publisher2_id] int not null, [test2_id] int not null);
 
 create table [configuration2] ([property] nvarchar(255) not null, [test_id] int not null, [value] nvarchar(255) not null, primary key ([property], [test_id]));
 
@@ -195,7 +195,7 @@ create index [author2_name_age_in_years_index] on [author2] ([name], [age_in_yea
 `;
 
 exports[`SchemaGenerator > update schema [mssql] > mssql-update-schema-add-column 1`] = `
-"alter table [new_table] add [id] int identity(1,1) not null primary key, [updated_at] datetime2(3) not null constraint [new_table_updated_at_default] default current_timestamp;
+"alter table [new_table] add [id] int identity(1,1) not null constraint [new_table_pkey] primary key, [updated_at] datetime2(3) not null constraint [new_table_updated_at_default] default current_timestamp;
 
 alter table [author2] add [favourite_book_uuid_pk] uniqueidentifier null;
 alter table [author2] add constraint [author2_favourite_book_uuid_pk_foreign] foreign key ([favourite_book_uuid_pk]) references [book2] ([uuid_pk]) on update no action on delete cascade;
@@ -231,7 +231,7 @@ create index [author2_born_index] on [author2] ([born]);
 `;
 
 exports[`SchemaGenerator > update schema [mssql] > mssql-update-schema-create-table 1`] = `
-"create table [new_table] ([id] int identity(1,1) not null primary key, [created_at] datetime2(3) not null constraint [new_table_created_at_default] default current_timestamp, [updated_at] datetime2(3) not null constraint [new_table_updated_at_default] default current_timestamp, [name] varchar(255) not null);
+"create table [new_table] ([id] int identity(1,1) not null constraint [new_table_pkey] primary key, [created_at] datetime2(3) not null constraint [new_table_created_at_default] default current_timestamp, [updated_at] datetime2(3) not null constraint [new_table_updated_at_default] default current_timestamp, [name] varchar(255) not null);
 "
 `;
 
@@ -247,7 +247,7 @@ alter table [foo_bar2] drop column [baz_id];
 exports[`SchemaGenerator > update schema [mssql] > mssql-update-schema-drop-column 1`] = `
 "alter table [author2] drop constraint [author2_favourite_book_uuid_pk_foreign];
 
-alter table [new_table] drop constraint [PK__new_tabl__123];
+alter table [new_table] drop constraint [new_table_pkey];
 declare @constraint0 varchar(100) = (select default_constraints.name from sys.all_columns join sys.tables on all_columns.object_id = tables.object_id join sys.schemas on tables.schema_id = schemas.schema_id join sys.default_constraints on all_columns.default_object_id = default_constraints.object_id where schemas.name = 'dbo' and tables.name = 'new_table' and all_columns.name = 'id') if @constraint0 is not null exec('alter table [new_table] drop constraint ' + @constraint0);
 alter table [new_table] drop constraint [new_table_updated_at_default];
 alter table [new_table] drop column [id], [updated_at];
@@ -293,7 +293,7 @@ exports[`SchemaGenerator > update schema [mssql] > mssql-update-schema-drop-uniq
 `;
 
 exports[`SchemaGenerator > update schema enums [mssql] > mssql-update-schema-enums-1 1`] = `
-"create table [new_table] ([id] int identity(1,1) not null primary key, [enum_test] nvarchar(100) not null);
+"create table [new_table] ([id] int identity(1,1) not null constraint [new_table_pkey] primary key, [enum_test] nvarchar(100) not null);
 "
 `;
 

--- a/tests/features/schema-generator/__snapshots__/advanced-index-features.mssql.test.ts.snap
+++ b/tests/features/schema-generator/__snapshots__/advanced-index-features.mssql.test.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`advanced index features in mssql > schema generator creates indexes with sort order, include, fill factor, and disabled > create schema 1`] = `
-"create table [adv_idx_mssql_entity] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) not null, [email] nvarchar(255) not null, [created_at] datetime2 not null);
+"create table [adv_idx_mssql_entity] ([id] int identity(1,1) not null constraint [adv_idx_mssql_entity_pkey] primary key, [name] nvarchar(255) not null, [email] nvarchar(255) not null, [created_at] datetime2 not null);
 create index [adv_idx_mssql_entity_created_at_name_index] on [adv_idx_mssql_entity] ([created_at] DESC, [name] ASC);
 create index [covering_idx] on [adv_idx_mssql_entity] ([email]) include ([name], [created_at]);
 create index [fill_factor_idx] on [adv_idx_mssql_entity] ([name]) with (fillfactor = 70);

--- a/tests/features/schema-generator/__snapshots__/collation-diffing.mssql.test.ts.snap
+++ b/tests/features/schema-generator/__snapshots__/collation-diffing.mssql.test.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`collation diffing [mssql] > create schema emits column-level collate clause 1`] = `
-"create table [book] ([id] int identity(1,1) not null primary key, [code] nvarchar(26) collate Latin1_General_BIN not null, [name] nvarchar(255) not null);
+"create table [book] ([id] int identity(1,1) not null constraint [book_pkey] primary key, [code] nvarchar(26) collate Latin1_General_BIN not null, [name] nvarchar(255) not null);
 "
 `;
 

--- a/tests/features/schema-generator/__snapshots__/index-diffing.mssql.test.ts.snap
+++ b/tests/features/schema-generator/__snapshots__/index-diffing.mssql.test.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`indexes on FKs in mssql (GH 1518) > schema generator respect indexes on FKs on column update 1`] = `
-"create table [book] ([id] int identity(1,1) not null primary key, [author1_id] int not null, [author2_id] int not null, [author3_id] int not null, [author4_id] int not null, [author5_id] int not null, [title] nvarchar(255) not null, [isbn] nvarchar(255) not null);
+"create table [book] ([id] int identity(1,1) not null constraint [book_pkey] primary key, [author1_id] int not null, [author2_id] int not null, [author3_id] int not null, [author4_id] int not null, [author5_id] int not null, [title] nvarchar(255) not null, [isbn] nvarchar(255) not null);
 create unique index [book_isbn_unique] on [book] ([isbn]);
 
 alter table [book] add constraint [book_author1_id_foreign] foreign key ([author1_id]) references [author] ([id]);

--- a/tests/features/schema-generator/__snapshots__/partial-index.mssql.test.ts.snap
+++ b/tests/features/schema-generator/__snapshots__/partial-index.mssql.test.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`partial index [mssql] > end-to-end create / no-op / change predicate > 1-create-with-where 1`] = `
-"create table [partial_user] ([id] int identity(1,1) not null primary key, [email] varchar(255) not null, [deleted_at] datetime2 null);
+"create table [partial_user] ([id] int identity(1,1) not null constraint [partial_user_pkey] primary key, [email] varchar(255) not null, [deleted_at] datetime2 null);
 create unique index [partial_user_email_uniq] on [partial_user] ([email]) where [deleted_at] is null;
 "
 `;

--- a/tests/features/schema-generator/__snapshots__/trigger.mssql.test.ts.snap
+++ b/tests/features/schema-generator/__snapshots__/trigger.mssql.test.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`trigger [mssql] > trigger is generated for decorator [mssql] > mssql-trigger-decorator 1`] = `
-"create table [trigger_entity] ([id] int identity(1,1) not null primary key, [price] int not null);
+"create table [trigger_entity] ([id] int identity(1,1) not null constraint [trigger_entity_pkey] primary key, [price] int not null);
 create trigger [trg_price] on [trigger_entity] AFTER INSERT as begin PRINT 'trigger fired'; end;
 "
 `;

--- a/tests/features/view-entities/__snapshots__/view-entities.mssql.test.ts.snap
+++ b/tests/features/view-entities/__snapshots__/view-entities.mssql.test.ts.snap
@@ -24,18 +24,18 @@ create index [custom_idx_name_123] on [author2] ([name]);
 create index [author2_name_age_index] on [author2] ([name], [age]);
 create unique index [author2_name_email_unique] on [author2] ([name], [email]);
 
-create table [book2] ([uuid_pk] uniqueidentifier not null, [created_at] datetime2(3) not null constraint [book2_created_at_default] default current_timestamp, [isbn] nchar(13) null, [title] nvarchar(255) null constraint [book2_title_default] default '', [perex] text null, [price] numeric(8,2) null, [float] float(24) null, [float36] float(36) null, [double] float(53) null, [meta] nvarchar(max) null, [author_id] int not null, [publisher_id] int null, primary key ([uuid_pk]));
+create table [book2] ([uuid_pk] uniqueidentifier not null, [created_at] datetime2(3) not null constraint [book2_created_at_default] default current_timestamp, [isbn] nchar(13) null, [title] nvarchar(255) null constraint [book2_title_default] default '', [perex] text null, [price] numeric(8,2) null, [float] float(24) null, [float36] float(36) null, [double] float(53) null, [meta] nvarchar(max) null, [author_id] int not null, [publisher_id] int null, constraint [book2_pkey] primary key ([uuid_pk]));
 create unique index [book2_isbn_unique] on [book2] ([isbn]) where [isbn] is not null;
 
 create table [book2_tags] ([order] int identity(1,1) not null constraint [book2_tags_pkey] primary key, [book2_uuid_pk] uniqueidentifier not null, [book_tag2_id] bigint not null);
 
-create table [book_to_tag_unordered] ([book2_uuid_pk] uniqueidentifier not null, [book_tag2_id] bigint not null, primary key ([book2_uuid_pk], [book_tag2_id]));
+create table [book_to_tag_unordered] ([book2_uuid_pk] uniqueidentifier not null, [book_tag2_id] bigint not null, constraint [book_to_tag_unordered_pkey] primary key ([book2_uuid_pk], [book_tag2_id]));
 
-create table [author2_following] ([author2_1_id] int not null, [author2_2_id] int not null, primary key ([author2_1_id], [author2_2_id]));
+create table [author2_following] ([author2_1_id] int not null, [author2_2_id] int not null, constraint [author2_following_pkey] primary key ([author2_1_id], [author2_2_id]));
 
-create table [author_to_friend] ([author2_1_id] int not null, [author2_2_id] int not null, primary key ([author2_1_id], [author2_2_id]));
+create table [author_to_friend] ([author2_1_id] int not null, [author2_2_id] int not null, constraint [author_to_friend_pkey] primary key ([author2_1_id], [author2_2_id]));
 
-create table [address2] ([author_id] int not null, [value] nvarchar(255) not null, primary key ([author_id]));
+create table [address2] ([author_id] int not null, [value] nvarchar(255) not null, constraint [address2_pkey] primary key ([author_id]));
 if exists(select * from sys.fn_listextendedproperty(N'MS_Description', N'Schema', N'dbo', N'Table', N'address2', null, null))
   exec sys.sp_updateextendedproperty N'MS_Description', N'This is address table', N'Schema', N'dbo', N'Table', N'address2'
 else
@@ -50,7 +50,7 @@ create unique index [test2_book_uuid_pk_unique] on [test2] ([book_uuid_pk]) wher
 
 create table [publisher2_tests] ([id] int identity(1,1) not null constraint [publisher2_tests_pkey] primary key, [publisher2_id] int not null, [test2_id] int not null);
 
-create table [configuration2] ([property] nvarchar(255) not null, [test_id] int not null, [value] nvarchar(255) not null, primary key ([property], [test_id]));
+create table [configuration2] ([property] nvarchar(255) not null, [test_id] int not null, [value] nvarchar(255) not null, constraint [configuration2_pkey] primary key ([property], [test_id]));
 
 alter table [foo_bar2] add constraint [foo_bar2_baz_id_foreign] foreign key ([baz_id]) references [foo_baz2] ([id]) on delete set null;
 alter table [foo_bar2] add constraint [foo_bar2_foo_bar_id_foreign] foreign key ([foo_bar_id]) references [foo_bar2] ([id]);

--- a/tests/features/view-entities/__snapshots__/view-entities.mssql.test.ts.snap
+++ b/tests/features/view-entities/__snapshots__/view-entities.mssql.test.ts.snap
@@ -1,20 +1,20 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`View entities (mssql) > schema generator should create views 1`] = `
-"create table [book_tag2] ([id] bigint identity(1,1) not null primary key, [name] nvarchar(50) not null);
+"create table [book_tag2] ([id] bigint identity(1,1) not null constraint [book_tag2_pkey] primary key, [name] nvarchar(50) not null);
 
-create table [foo_baz2] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) not null, [code] varchar(255) not null, [version] datetime2(3) not null constraint [foo_baz2_version_default] default current_timestamp);
+create table [foo_baz2] ([id] int identity(1,1) not null constraint [foo_baz2_pkey] primary key, [name] nvarchar(255) not null, [code] varchar(255) not null, [version] datetime2(3) not null constraint [foo_baz2_version_default] default current_timestamp);
 
-create table [foo_bar2] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) not null, [baz_id] int null, [foo_bar_id] int null, [version] datetime2(0) not null constraint [foo_bar2_version_default] default current_timestamp, [blob] varbinary(max) null, [array] text null, [object] nvarchar(max) null);
+create table [foo_bar2] ([id] int identity(1,1) not null constraint [foo_bar2_pkey] primary key, [name] nvarchar(255) not null, [baz_id] int null, [foo_bar_id] int null, [version] datetime2(0) not null constraint [foo_bar2_version_default] default current_timestamp, [blob] varbinary(max) null, [array] text null, [object] nvarchar(max) null);
 create unique index [foo_bar2_baz_id_unique] on [foo_bar2] ([baz_id]) where [baz_id] is not null;
 create unique index [foo_bar2_foo_bar_id_unique] on [foo_bar2] ([foo_bar_id]) where [foo_bar_id] is not null;
 
-create table [publisher2] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) not null constraint [publisher2_name_default] default 'asd', [type] nvarchar(100) not null constraint [publisher2_type_default] default 'local', [type2] nvarchar(100) not null constraint [publisher2_type2_default] default 'LOCAL', [enum1] tinyint null, [enum2] tinyint null, [enum3] tinyint null, [enum4] nvarchar(100) null);
+create table [publisher2] ([id] int identity(1,1) not null constraint [publisher2_pkey] primary key, [name] nvarchar(255) not null constraint [publisher2_name_default] default 'asd', [type] nvarchar(100) not null constraint [publisher2_type_default] default 'local', [type2] nvarchar(100) not null constraint [publisher2_type2_default] default 'LOCAL', [enum1] tinyint null, [enum2] tinyint null, [enum3] tinyint null, [enum4] nvarchar(100) null);
 alter table [publisher2] add constraint [publisher2_type_check] check ([type] in ('local', 'global'));
 alter table [publisher2] add constraint [publisher2_type2_check] check ([type2] in ('LOCAL', 'GLOBAL'));
 alter table [publisher2] add constraint [publisher2_enum4_check] check ([enum4] in ('a', 'b', 'c'));
 
-create table [author2] ([id] int identity(1,1) not null primary key, [created_at] datetime2(3) not null constraint [author2_created_at_default] default current_timestamp, [updated_at] datetime2(3) not null constraint [author2_updated_at_default] default current_timestamp, [name] nvarchar(255) not null, [email] nvarchar(255) not null, [age] int null, [terms_accepted] bit not null constraint [author2_terms_accepted_default] default 0, [optional] bit null, [identities] text null, [born] date null, [born_time] time null, [favourite_book_uuid_pk] uniqueidentifier null, [favourite_author_id] int null);
+create table [author2] ([id] int identity(1,1) not null constraint [author2_pkey] primary key, [created_at] datetime2(3) not null constraint [author2_created_at_default] default current_timestamp, [updated_at] datetime2(3) not null constraint [author2_updated_at_default] default current_timestamp, [name] nvarchar(255) not null, [email] nvarchar(255) not null, [age] int null, [terms_accepted] bit not null constraint [author2_terms_accepted_default] default 0, [optional] bit null, [identities] text null, [born] date null, [born_time] time null, [favourite_book_uuid_pk] uniqueidentifier null, [favourite_author_id] int null);
 create index [custom_email_index_name] on [author2] ([email]);
 create unique index [custom_email_unique_name] on [author2] ([email]);
 create index [author2_terms_accepted_index] on [author2] ([terms_accepted]);
@@ -27,7 +27,7 @@ create unique index [author2_name_email_unique] on [author2] ([name], [email]);
 create table [book2] ([uuid_pk] uniqueidentifier not null, [created_at] datetime2(3) not null constraint [book2_created_at_default] default current_timestamp, [isbn] nchar(13) null, [title] nvarchar(255) null constraint [book2_title_default] default '', [perex] text null, [price] numeric(8,2) null, [float] float(24) null, [float36] float(36) null, [double] float(53) null, [meta] nvarchar(max) null, [author_id] int not null, [publisher_id] int null, primary key ([uuid_pk]));
 create unique index [book2_isbn_unique] on [book2] ([isbn]) where [isbn] is not null;
 
-create table [book2_tags] ([order] int identity(1,1) not null primary key, [book2_uuid_pk] uniqueidentifier not null, [book_tag2_id] bigint not null);
+create table [book2_tags] ([order] int identity(1,1) not null constraint [book2_tags_pkey] primary key, [book2_uuid_pk] uniqueidentifier not null, [book_tag2_id] bigint not null);
 
 create table [book_to_tag_unordered] ([book2_uuid_pk] uniqueidentifier not null, [book_tag2_id] bigint not null, primary key ([book2_uuid_pk], [book_tag2_id]));
 
@@ -45,10 +45,10 @@ if exists(select * from sys.fn_listextendedproperty(N'MS_Description', N'Schema'
 else
   exec sys.sp_addextendedproperty N'MS_Description', N'This is address property', N'Schema', N'dbo', N'Table', N'address2', N'Column', N'value';
 
-create table [test2] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) null, [book_uuid_pk] uniqueidentifier null, [version] int not null constraint [test2_version_default] default 1);
+create table [test2] ([id] int identity(1,1) not null constraint [test2_pkey] primary key, [name] nvarchar(255) null, [book_uuid_pk] uniqueidentifier null, [version] int not null constraint [test2_version_default] default 1);
 create unique index [test2_book_uuid_pk_unique] on [test2] ([book_uuid_pk]) where [book_uuid_pk] is not null;
 
-create table [publisher2_tests] ([id] int identity(1,1) not null primary key, [publisher2_id] int not null, [test2_id] int not null);
+create table [publisher2_tests] ([id] int identity(1,1) not null constraint [publisher2_tests_pkey] primary key, [publisher2_id] int not null, [test2_id] int not null);
 
 create table [configuration2] ([property] nvarchar(255) not null, [test_id] int not null, [value] nvarchar(255) not null, primary key ([property], [test_id]));
 

--- a/tests/features/wilcardSchemaIndex/__snapshots__/wilcardSchemaIndex.mssql.test.ts.snap
+++ b/tests/features/wilcardSchemaIndex/__snapshots__/wilcardSchemaIndex.mssql.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`wilcardSchemaIndex > create SQL schema > createSchemaSQL-dump 1`] = `
 "if (schema_id('library1') is null) begin exec ('create schema [library1] authorization [dbo]') end;
-create table [library1].[author] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) not null, [email] nvarchar(255) not null, [country] nvarchar(255) not null);
+create table [library1].[author] ([id] int identity(1,1) not null constraint [author_pkey] primary key, [name] nvarchar(255) not null, [email] nvarchar(255) not null, [country] nvarchar(255) not null);
 create index [custom_idx_on_country] on [library1].[author] ([country]);
 create index custom_idx_on_name on [library1].[author] ([name]);
 create unique index [custom_unique_on_email] on [library1].[author] ([email]) where [email] is not null;
@@ -11,7 +11,7 @@ create unique index [custom_unique_on_email] on [library1].[author] ([email]) wh
 
 exports[`wilcardSchemaIndex > create SQL schema > createSchemaSQL-dump 2`] = `
 "if (schema_id('library2') is null) begin exec ('create schema [library2] authorization [dbo]') end;
-create table [library2].[author] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) not null, [email] nvarchar(255) not null, [country] nvarchar(255) not null);
+create table [library2].[author] ([id] int identity(1,1) not null constraint [author_pkey] primary key, [name] nvarchar(255) not null, [email] nvarchar(255) not null, [country] nvarchar(255) not null);
 create index [custom_idx_on_country] on [library2].[author] ([country]);
 create index custom_idx_on_name on [library2].[author] ([name]);
 create unique index [custom_unique_on_email] on [library2].[author] ([email]) where [email] is not null;
@@ -19,7 +19,7 @@ create unique index [custom_unique_on_email] on [library2].[author] ([email]) wh
 `;
 
 exports[`wilcardSchemaIndex > create SQL schema > createSchemaSQL-dump 3`] = `
-"create table [author2] ([id] int identity(1,1) not null primary key, [name] nvarchar(255) not null);
+"create table [author2] ([id] int identity(1,1) not null constraint [author2_pkey] primary key, [name] nvarchar(255) not null);
 create index custom_idx_on_name on [dbo.author2] ([name]);
 "
 `;

--- a/tests/issues/GH8061.test.ts
+++ b/tests/issues/GH8061.test.ts
@@ -120,7 +120,7 @@ describe('GH #8061 — multi statement trigger bodies stay a single DDL statemen
     });
 
     expect(await orm.schema.getCreateSchemaSQL({ wrap: false })).toMatchInlineSnapshot(`
-      "create table [items] ([id] int identity(1,1) not null primary key, [value] int not null);
+      "create table [items] ([id] int identity(1,1) not null constraint [items_pkey] primary key, [value] int not null);
       create trigger [items_increment_after_insert] on [items] AFTER INSERT as begin update items set value = value + 1 where id = NEW.id; set @sum = 1; end;
       "
     `);

--- a/tests/issues/__snapshots__/GH6688.test.ts.snap
+++ b/tests/issues/__snapshots__/GH6688.test.ts.snap
@@ -8,7 +8,7 @@ create table \`a\` (\`id\` int unsigned not null auto_increment primary key, \`l
 `;
 
 exports[`default array values [mssql] > database default when using arrays 1`] = `
-"create table [a] ([id] int identity(1,1) not null primary key, [languages] text not null constraint [a_languages_default] default 'en', [accounts] nvarchar(max) not null constraint [a_accounts_default] default '[]', [items] text not null constraint [a_items_default] default '');
+"create table [a] ([id] int identity(1,1) not null constraint [a_pkey] primary key, [languages] text not null constraint [a_languages_default] default 'en', [accounts] nvarchar(max) not null constraint [a_accounts_default] default '[]', [items] text not null constraint [a_items_default] default '');
 "
 `;
 


### PR DESCRIPTION
SQL Server assigns a random name (e.g. `PK__author__3213E83F...`) to any primary key constraint created without an explicit name. That makes schema dumps and snapshot files churn on every run, previously worked around in tests with things like:

```ts
expect(diff.replace(/PK__new_tabl__\w+/, 'PK__new_tabl__123')).toMatchSnapshot('mssql-update-schema-drop-column');
```

This PR makes MSSQL name every primary key constraint explicitly, using the same convention PostgreSQL gets from its server-side defaults (`<table>_pkey`, derived from `NamingStrategy.indexName(..., 'primary')` and hash-truncated at the 128 character identifier limit):

- identity columns emit the name inline: `[id] int identity(1,1) not null constraint [author_pkey] primary key`
- composite and non-identity PKs get a named table-level clause: `constraint [car2_pkey] primary key ([name], [year])`
- the `alter table ... add primary key` path names (and now quotes) the constraint as well
- `supportsCustomPrimaryKeyNames()` is now enabled for MSSQL, so custom PK constraint names from metadata are respected, same as on PostgreSQL

Existing databases keep their random names without generating any schema diff: the comparator matches primary keys structurally, never by name (verified against databases created with the old unnamed DDL).
