### PR TITLE
fix(core): map cursor offsets based on property types

### DIFF
--- a/packages/core/src/drivers/DatabaseDriver.ts
+++ b/packages/core/src/drivers/DatabaseDriver.ts
@@ -41,8 +41,11 @@ import { EntityManager } from '../EntityManager.js';
 import { CursorError, ValidationError } from '../errors.js';
 import { DriverException } from '../exceptions.js';
 import { helper } from '../entity/wrap.js';
+import { Reference } from '../entity/Reference.js';
 import { PolymorphicRef } from '../entity/PolymorphicRef.js';
 import { JsonType } from '../types/JsonType.js';
+import { DateTimeType } from '../types/DateTimeType.js';
+import { QueryHelper } from '../utils/QueryHelper.js';
 import { MikroORM } from '../MikroORM.js';
 
 /** Abstract base class for all database drivers, implementing common driver logic. */
@@ -296,17 +299,27 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
       return !!val && typeof val === 'object' && key in val;
     };
     const createCursor = (val: unknown, key: 'startCursor' | 'endCursor', inverse = false) => {
-      let def = isCursor(val, key) ? val[key] : val;
+      const def: unknown = Reference.unwrapReference((isCursor(val, key) ? val[key] : val) as T);
+      let offsets: unknown[];
 
-      if (Utils.isPlainObject<FilterObject<T>>(def)) {
-        def = Cursor.for<T>(meta, def, orderBy);
+      // entity (and reference) instances are supported as cursors too, their properties are read the same way
+      if (Utils.isPlainObject<FilterObject<T>>(def) || Utils.isEntity<FilterObject<T>>(def)) {
+        // POJO values are already JS values, extract them ordered per the definition,
+        // without the JSON round trip `Cursor.for` + `Cursor.decode` would impose
+        offsets = definition.map(([key]) => {
+          if (def[key] === undefined) {
+            throw CursorError.missingValue(meta.className, key as string);
+          }
+
+          return def[key];
+        });
+      } else {
+        /* v8 ignore next */
+        offsets = def ? Cursor.decode(def as string) : [];
       }
 
-      /* v8 ignore next */
-      const offsets = def ? (Cursor.decode(def as string) as Dictionary[]) : [];
-
-      if (definition.length === offsets.length) {
-        return this.createCursorCondition<T>(definition, offsets, inverse, meta);
+      if (definition.length > 0 && definition.length === offsets.length) {
+        return this.createCursorCondition<T>(definition, offsets as Dictionary[], inverse, meta);
       }
 
       /* v8 ignore next */
@@ -339,10 +352,61 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
       return { [prop]: dir } as OrderDefinition<T>;
     };
 
+    // the cursor condition is created at the driver level, after the EM already converted custom types
+    // in the user `where`, so we need to run the same conversion over it explicitly
+    const where = QueryHelper.processWhere({
+      where: ($and.length > 1 ? { $and } : { ...$and[0] }) as FilterQuery<T>,
+      entityName: meta.class,
+      metadata: this.metadata,
+      platform: this.platform,
+      convertCustomTypes: options.convertCustomTypes,
+    });
+
     return {
       orderBy: definition.map(([prop, direction]) => createOrderBy(prop, direction)),
-      where: ($and.length > 1 ? { $and } : { ...$and[0] }) as FilterQuery<T>,
+      where,
     };
+  }
+
+  /**
+   * Restores the JS value of a single cursor offset: ISO strings become `Date` instances based on the
+   * property type (never based on the string shape alone), and custom types are restored via
+   * `convertToJSValue`. Values compared against a JSON document keep their serialized form instead.
+   */
+  private mapCursorOffset(prop: EntityProperty | undefined, value: unknown, insideJson: boolean): unknown {
+    if (Utils.isScalarReference(value)) {
+      value = value.unwrap();
+    }
+
+    // scalar direction on a relation orders by its primary key
+    if (Utils.isEntity(value, true)) {
+      value = helper(value).getPrimaryKey();
+    }
+
+    if (value == null) {
+      return value;
+    }
+
+    if (insideJson) {
+      // compared against the JSON document, which holds the serialized form
+      if (value instanceof Date) {
+        return value.toISOString();
+      }
+
+      // restore the JS value from the serialized form, `processWhere` then converts it to
+      // the database form, which is what the JSON document holds for custom typed props
+      return prop?.customType ? prop.customType.convertToJSValue(value, this.platform) : value;
+    }
+
+    if (
+      typeof value === 'string' &&
+      (prop?.runtimeType === 'Date' ||
+        (prop?.customType && this.platform.getMappedType(prop.columnTypes?.[0] ?? '') instanceof DateTimeType))
+    ) {
+      value = new Date(value);
+    }
+
+    return prop?.customType ? prop.customType.convertToJSValue(value, this.platform) : value;
   }
 
   protected createCursorCondition<T extends object>(
@@ -357,16 +421,35 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
       offset: Dictionary,
       eq = false,
       path = prop,
+      properties: Dictionary<EntityProperty> = meta.properties as Dictionary<EntityProperty>,
+      insideJson = false,
     ): Dictionary => {
+      const propMeta = properties[prop];
+
       if (Utils.isPlainObject(direction)) {
         if (offset === undefined) {
           throw CursorError.missingValue(meta.className, path);
         }
 
+        // POJO cursors can carry entity, reference or embeddable class instances, read their properties directly
+        offset = Reference.unwrapReference(offset);
+        const childProps =
+          propMeta?.kind === ReferenceKind.EMBEDDED ? propMeta.embeddedProps : propMeta?.targetMeta?.properties;
+        insideJson ||=
+          (propMeta?.kind === ReferenceKind.EMBEDDED && !!propMeta.object) || propMeta?.customType instanceof JsonType;
+
         const value = Utils.keys(direction).reduce((o, key) => {
           Object.assign(
             o,
-            createCondition(key, direction[key] as QueryOrderKeys<T>, offset?.[key], eq, `${path}.${key}`),
+            createCondition(
+              key,
+              direction[key] as QueryOrderKeys<T>,
+              offset?.[key],
+              eq,
+              `${path}.${key}`,
+              childProps ?? {},
+              insideJson,
+            ),
           );
           return o;
         }, {});
@@ -392,6 +475,8 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
       if (offset === undefined) {
         throw CursorError.missingValue(meta.className, path);
       }
+
+      offset = this.mapCursorOffset(propMeta, offset, insideJson) as Dictionary;
 
       // Handle null offset (intentional null cursor value)
       if (offset === null) {

--- a/packages/core/src/utils/Cursor.ts
+++ b/packages/core/src/utils/Cursor.ts
@@ -192,13 +192,7 @@ export class Cursor<
   }
 
   static decode(value: string): unknown[] {
-    return JSON.parse(Buffer.from(value, 'base64url').toString('utf8')).map((value: unknown) => {
-      if (typeof value === 'string' && /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}/.exec(value)) {
-        return new Date(value);
-      }
-
-      return value;
-    });
+    return JSON.parse(Buffer.from(value, 'base64url').toString('utf8'));
   }
 
   static getDefinition<Entity extends object>(

--- a/tests/features/cursor-based-pagination/__snapshots__/complex-cursor.test.ts.snap
+++ b/tests/features/cursor-based-pagination/__snapshots__/complex-cursor.test.ts.snap
@@ -24,7 +24,7 @@ exports[`simple cursor based pagination (mssql) > complex cursor based paginatio
 exports[`simple cursor based pagination (mssql) > complex cursor based pagination using \`first\` and \`after\` (id asc) 2`] = `
 [
   "[query] select count(*) as [count] from [user] as [u0] where ([u0].[terms_accepted] = 1 or [u0].[name] = N'User 1' or [u0].[age] <= 30) and [u0].[name] != N'User 2'",
-  "[query] select top (11) [u0].* from [user] as [u0] where ([u0].[terms_accepted] = 1 or [u0].[name] = N'User 1' or [u0].[age] <= 30) and [u0].[name] != N'User 2' and [u0].[name] <= 'User 1' and ([u0].[name] < 'User 1' or ([u0].[age] >= 28 and ([u0].[age] > 28 or [u0].[email] > 'email-55'))) order by [u0].[name] desc, [u0].[age] asc, [u0].[email] asc",
+  "[query] select top (11) [u0].* from [user] as [u0] where ([u0].[terms_accepted] = 1 or [u0].[name] = N'User 1' or [u0].[age] <= 30) and [u0].[name] != N'User 2' and [u0].[name] <= N'User 1' and ([u0].[name] < N'User 1' or ([u0].[age] >= 28 and ([u0].[age] > 28 or [u0].[email] > N'email-55'))) order by [u0].[name] desc, [u0].[age] asc, [u0].[email] asc",
 ]
 `;
 
@@ -38,7 +38,7 @@ exports[`simple cursor based pagination (mssql) > complex joined cursor based pa
 exports[`simple cursor based pagination (mssql) > complex joined cursor based pagination using \`last\` and \`before\` (id asc) 2`] = `
 [
   "[query] select count(*) as [count] from [user] as [u0] left join [user] as [b1] on [u0].[best_friend__id] = [b1].[_id] where [b1].[name] = N'User 3'",
-  "[query] select top (6) [u0].*, [b1].[_id] as [b1___id], [b1].[name] as [b1__name], [b1].[email] as [b1__email], [b1].[age] as [b1__age], [b1].[terms_accepted] as [b1__terms_accepted], [b1].[best_friend__id] as [b1__best_friend__id] from [user] as [u0] left join [user] as [b1] on [u0].[best_friend__id] = [b1].[_id] where [b1].[name] = N'User 3' and [b1].[email] <= 'email-96' and [b1].[name] <= 'User 3' and (([b1].[email] < 'email-96' and [b1].[name] < 'User 3') or ([u0].[name] >= 'User 3' and ([u0].[name] > 'User 3' or ([u0].[age] <= 38 and ([u0].[age] < 38 or [u0].[email] < 'email-76'))))) order by [b1].[email] desc, [b1].[name] desc, [u0].[name] asc, [u0].[age] desc, [u0].[email] desc",
+  "[query] select top (6) [u0].*, [b1].[_id] as [b1___id], [b1].[name] as [b1__name], [b1].[email] as [b1__email], [b1].[age] as [b1__age], [b1].[terms_accepted] as [b1__terms_accepted], [b1].[best_friend__id] as [b1__best_friend__id] from [user] as [u0] left join [user] as [b1] on [u0].[best_friend__id] = [b1].[_id] where [b1].[name] = N'User 3' and [b1].[email] <= N'email-96' and [b1].[name] <= N'User 3' and (([b1].[email] < N'email-96' and [b1].[name] < N'User 3') or ([u0].[name] >= N'User 3' and ([u0].[name] > N'User 3' or ([u0].[age] <= 38 and ([u0].[age] < 38 or [u0].[email] < N'email-76'))))) order by [b1].[email] desc, [b1].[name] desc, [u0].[name] asc, [u0].[age] desc, [u0].[email] desc",
 ]
 `;
 

--- a/tests/features/cursor-based-pagination/cursor-custom-types.test.ts
+++ b/tests/features/cursor-based-pagination/cursor-custom-types.test.ts
@@ -1,0 +1,828 @@
+import { Cursor, Reference, ScalarReference, Type } from '@mikro-orm/core';
+import { MikroORM } from '@mikro-orm/sqlite';
+import {
+  Embeddable,
+  Embedded,
+  Entity,
+  ManyToOne,
+  PrimaryKey,
+  Property,
+  ReflectMetadataProvider,
+} from '@mikro-orm/decorators/legacy';
+
+/**
+ * Minimal Temporal-like wrapper: JS value is not a `Date`, supports sub-millisecond
+ * precision, and serializes to an ISO-like string via `toJSON`.
+ */
+class PointInTime {
+  constructor(readonly iso: string) {}
+
+  toJSON(): string {
+    return this.iso;
+  }
+}
+
+class PointInTimeType extends Type<PointInTime | null, string | null> {
+  override convertToDatabaseValue(value: PointInTime | string | null): string | null {
+    if (value == null || typeof value === 'string') {
+      return value;
+    }
+
+    if (!(value instanceof PointInTime)) {
+      throw new Error(`Expected PointInTime, got ${(value as object).constructor.name}`);
+    }
+
+    return value.iso;
+  }
+
+  override convertToJSValue(value: PointInTime | string | null): PointInTime | null {
+    if (value == null) {
+      return null;
+    }
+
+    return value instanceof PointInTime ? value : new PointInTime(value);
+  }
+
+  override getColumnType(): string {
+    return 'varchar(255)';
+  }
+
+  override compareAsType(): string {
+    return 'string';
+  }
+}
+
+const isoToMicros = (iso: string): number => {
+  const match = /^(.+T\d{2}:\d{2}:\d{2})\.(\d{1,6})Z$/.exec(iso);
+
+  if (!match) {
+    throw new Error(`Unexpected iso value: ${iso}`);
+  }
+
+  return Date.parse(`${match[1]}Z`) * 1000 + Number(match[2].padEnd(6, '0'));
+};
+
+const microsToIso = (micros: number): string => {
+  const seconds = Math.floor(micros / 1_000_000);
+  const fraction = String(micros % 1_000_000).padStart(6, '0');
+  return new Date(seconds * 1000).toISOString().replace('.000Z', `.${fraction}Z`);
+};
+
+/** Same JS value as `PointInTimeType`, but the database form (epoch microseconds) differs from the JSON form (ISO string). */
+class PointInTimeEpochType extends Type<PointInTime | null, number | null> {
+  override convertToDatabaseValue(value: PointInTime | number | null): number | null {
+    if (value == null || typeof value === 'number') {
+      return value;
+    }
+
+    if (!(value instanceof PointInTime)) {
+      throw new Error(`Expected PointInTime, got ${(value as object).constructor.name}`);
+    }
+
+    return isoToMicros(value.iso);
+  }
+
+  override convertToJSValue(value: PointInTime | number | string | null): PointInTime | null {
+    if (value == null) {
+      return null;
+    }
+
+    if (value instanceof PointInTime) {
+      return value;
+    }
+
+    return new PointInTime(typeof value === 'string' ? value : microsToIso(value));
+  }
+
+  override getColumnType(): string {
+    return 'integer';
+  }
+
+  override compareAsType(): string {
+    return 'number';
+  }
+}
+
+/** Degenerate but valid custom type over a datetime column: both converters are the default identity. */
+class TaggedDateType extends Type<Date, Date> {
+  override getColumnType(): string {
+    return 'datetime';
+  }
+}
+
+/** Enforces the documented converter contracts: both converters only ever accept a `Date`. */
+class StrictDateType extends Type<Date | null, Date | null> {
+  override convertToDatabaseValue(value: Date | null): Date | null {
+    if (value != null && !(value instanceof Date)) {
+      throw new Error(`Expected Date, got ${typeof value}`);
+    }
+
+    return value;
+  }
+
+  override convertToJSValue(value: Date | null): Date | null {
+    if (value != null && !(value instanceof Date)) {
+      throw new Error(`Expected Date, got ${typeof value}`);
+    }
+
+    return value;
+  }
+
+  override getColumnType(): string {
+    return 'datetime';
+  }
+}
+
+/** Wrapper JS value over a datetime column: reflection stamps `runtimeType: 'Stamp'`, not `'Date'`. */
+class Stamp {
+  constructor(readonly date: Date) {}
+
+  toJSON(): string {
+    return this.date.toISOString();
+  }
+}
+
+class StampType extends Type<Stamp | null, Date | null> {
+  override convertToDatabaseValue(value: Stamp | Date | null): Date | null {
+    if (value == null || value instanceof Date) {
+      return value;
+    }
+
+    if (!(value instanceof Stamp)) {
+      throw new Error(`Expected Stamp, got ${typeof value}`);
+    }
+
+    return value.date;
+  }
+
+  override convertToJSValue(value: Stamp | Date | number | null): Stamp | null {
+    if (value == null) {
+      return null;
+    }
+
+    if (value instanceof Stamp) {
+      return value;
+    }
+
+    // a string is never the DB form of a datetime column, so reject it
+    if (!(value instanceof Date) && typeof value !== 'number') {
+      throw new Error(`Expected Date or epoch number, got ${typeof value}`);
+    }
+
+    return new Stamp(value instanceof Date ? value : new Date(value));
+  }
+
+  override getColumnType(): string {
+    return 'datetime';
+  }
+}
+
+/** Wrapper whose JSON form is a number, not a string. */
+class Ticks {
+  constructor(readonly ms: number) {}
+
+  toJSON(): number {
+    return this.ms;
+  }
+}
+
+class TicksType extends Type<Ticks | null, string | null> {
+  override convertToDatabaseValue(value: Ticks | string | null): string | null {
+    if (value == null || typeof value === 'string') {
+      return value;
+    }
+
+    if (!(value instanceof Ticks)) {
+      throw new Error(`Expected Ticks, got ${typeof value}`);
+    }
+
+    return new Date(value.ms).toISOString();
+  }
+
+  override convertToJSValue(value: Ticks | string | number | null): Ticks | null {
+    if (value == null) {
+      return null;
+    }
+
+    if (value instanceof Ticks) {
+      return value;
+    }
+
+    return new Ticks(typeof value === 'number' ? value : Date.parse(value));
+  }
+
+  override getColumnType(): string {
+    return 'varchar(64)';
+  }
+
+  override compareAsType(): string {
+    return 'string';
+  }
+}
+
+/** Validating type over a varchar column: rejects values outside its known set. */
+class CodeType extends Type<string | null, string | null> {
+  override convertToJSValue(value: string | null): string | null {
+    if (value != null && !/^c\d{2}$/.test(value)) {
+      throw new Error(`unknown code '${value}'`);
+    }
+
+    return value;
+  }
+
+  override getColumnType(): string {
+    return 'varchar(3)';
+  }
+
+  override compareAsType(): string {
+    return 'string';
+  }
+}
+
+@Embeddable()
+class Audit {
+  @Property()
+  changedAt!: Date;
+
+  @Property({ type: TaggedDateType })
+  auditedAt!: Date;
+
+  @Property({ type: PointInTimeEpochType })
+  epochAt!: PointInTime;
+}
+
+@Entity()
+class Owner {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @Property()
+  since!: Date;
+}
+
+@Entity()
+class Job {
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ type: PointInTimeType })
+  startedAt!: PointInTime;
+
+  @Property({ type: PointInTimeEpochType })
+  startedAtEpoch!: PointInTime;
+
+  @Property({ type: TaggedDateType })
+  taggedAt!: Date;
+
+  @Property({ type: StrictDateType })
+  strictAt!: Date;
+
+  @Property({ type: StampType })
+  stampedAt!: Stamp;
+
+  @Property({ type: CodeType })
+  code!: string;
+
+  @Property({ type: TicksType })
+  ticksAt!: Ticks;
+
+  @Property({ type: PointInTimeType, nullable: true })
+  finishedAt?: PointInTime | null;
+
+  @Property()
+  createdAt!: Date;
+
+  @Property()
+  label!: string;
+
+  @Property({ type: 'json' })
+  payload!: { ts: string };
+
+  @Embedded(() => Audit, { object: true })
+  audit!: Audit;
+
+  @ManyToOne(() => Owner)
+  owner!: Owner;
+}
+
+let orm: MikroORM;
+
+// jobs 2-4 share the same millisecond and differ only in sub-millisecond digits,
+// so the page boundary between jobs 3 and 4 requires full precision
+const startedAtValues = [
+  '2024-01-01T00:00:00.100000Z',
+  '2024-01-01T00:00:00.123400Z',
+  '2024-01-01T00:00:00.123450Z',
+  '2024-01-01T00:00:00.123500Z',
+  '2024-01-01T00:00:00.200000Z',
+  '2024-01-01T00:00:01.100000Z',
+  '2024-01-01T00:00:02.100000Z',
+  '2024-01-01T00:00:03.100000Z',
+  '2024-01-01T00:00:04.100000Z',
+];
+
+const day = (id: number) => String(id).padStart(2, '0');
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    metadataProvider: ReflectMetadataProvider,
+    entities: [Job, Owner, Audit],
+    dbName: ':memory:',
+  });
+  await orm.schema.refresh();
+
+  startedAtValues.forEach((iso, index) => {
+    const id = index + 1;
+    orm.em.create(Job, {
+      id,
+      startedAt: new PointInTime(iso),
+      startedAtEpoch: new PointInTime(iso),
+      taggedAt: new Date(`2024-05-${day(id)}T00:00:00.000Z`),
+      strictAt: new Date(`2024-06-${day(id)}T00:00:00.000Z`),
+      stampedAt: new Stamp(new Date(`2024-07-${day(id)}T00:00:00.000Z`)),
+      code: `c${day(id)}`,
+      finishedAt: id % 2 === 0 ? null : new PointInTime(iso),
+      createdAt: new Date(`2024-02-${day(id)}T00:00:00.500Z`),
+      label: iso,
+      payload: { ts: `2024-10-${day(id)}T00:00:00.000Z` },
+      audit: {
+        changedAt: new Date(`2024-04-${day(id)}T00:00:00.000Z`),
+        auditedAt: new Date(`2024-08-${day(id)}T00:00:00.000Z`),
+        epochAt: new PointInTime(`2024-11-${day(id)}T00:00:00.000Z`),
+      },
+      ticksAt: new Ticks(Date.parse(`2024-09-${day(id)}T00:00:00.000Z`)),
+      owner: { id, name: `Owner ${id}`, since: new Date(`2024-03-${day(id)}T00:00:00.000Z`) },
+    });
+  });
+
+  await orm.em.flush();
+  orm.em.clear();
+});
+
+afterAll(() => orm.close(true));
+
+afterEach(() => orm.em.clear());
+
+test('custom-typed cursor member with string cursor', async () => {
+  const cursor1 = await orm.em.findByCursor(Job, {
+    first: 3,
+    orderBy: { startedAt: 'asc', id: 'asc' },
+  });
+  expect(cursor1.items).toMatchObject([{ id: 1 }, { id: 2 }, { id: 3 }]);
+
+  const cursor2 = await orm.em.findByCursor(Job, {
+    first: 3,
+    after: cursor1.endCursor!,
+    orderBy: { startedAt: 'asc', id: 'asc' },
+  });
+  expect(cursor2.items).toMatchObject([{ id: 4 }, { id: 5 }, { id: 6 }]);
+  expect(cursor2.items[0].startedAt).toBeInstanceOf(PointInTime);
+  expect(cursor2.items[0].startedAt.iso).toBe('2024-01-01T00:00:00.123500Z');
+});
+
+test('custom-typed cursor member with POJO `after`', async () => {
+  const job3 = await orm.em.findOneOrFail(Job, { id: 3 });
+
+  const cursor = await orm.em.findByCursor(Job, {
+    first: 3,
+    after: { startedAt: job3.startedAt, id: job3.id },
+    orderBy: { startedAt: 'asc', id: 'asc' },
+  });
+  expect(cursor.items).toMatchObject([{ id: 4 }, { id: 5 }, { id: 6 }]);
+});
+
+test('custom type with distinct JSON and DB forms with string cursor', async () => {
+  const cursor1 = await orm.em.findByCursor(Job, {
+    first: 3,
+    orderBy: { startedAtEpoch: 'asc', id: 'asc' },
+  });
+  expect(cursor1.items).toMatchObject([{ id: 1 }, { id: 2 }, { id: 3 }]);
+
+  const cursor2 = await orm.em.findByCursor(Job, {
+    first: 3,
+    after: cursor1.endCursor!,
+    orderBy: { startedAtEpoch: 'asc', id: 'asc' },
+  });
+  expect(cursor2.items).toMatchObject([{ id: 4 }, { id: 5 }, { id: 6 }]);
+  expect(cursor2.items[0].startedAtEpoch.iso).toBe('2024-01-01T00:00:00.123500Z');
+});
+
+test('custom type with distinct JSON and DB forms with POJO `after`', async () => {
+  const job3 = await orm.em.findOneOrFail(Job, { id: 3 });
+
+  const cursor = await orm.em.findByCursor(Job, {
+    first: 3,
+    after: { startedAtEpoch: job3.startedAtEpoch, id: job3.id },
+    orderBy: { startedAtEpoch: 'asc', id: 'asc' },
+  });
+  expect(cursor.items).toMatchObject([{ id: 4 }, { id: 5 }, { id: 6 }]);
+});
+
+test('identity custom type over a datetime column with POJO `after`', async () => {
+  const job3 = await orm.em.findOneOrFail(Job, { id: 3 });
+
+  const cursor = await orm.em.findByCursor(Job, {
+    first: 3,
+    after: { taggedAt: job3.taggedAt, id: job3.id },
+    orderBy: { taggedAt: 'asc', id: 'asc' },
+  });
+  expect(cursor.items).toMatchObject([{ id: 4 }, { id: 5 }, { id: 6 }]);
+});
+
+test('contract-strict custom type over a datetime column', async () => {
+  const cursor1 = await orm.em.findByCursor(Job, {
+    first: 3,
+    orderBy: { strictAt: 'asc', id: 'asc' },
+  });
+  expect(cursor1.items).toMatchObject([{ id: 1 }, { id: 2 }, { id: 3 }]);
+
+  const cursor2 = await orm.em.findByCursor(Job, {
+    first: 3,
+    after: cursor1.endCursor!,
+    orderBy: { strictAt: 'asc', id: 'asc' },
+  });
+  expect(cursor2.items).toMatchObject([{ id: 4 }, { id: 5 }, { id: 6 }]);
+
+  const cursor3 = await orm.em.findByCursor(Job, {
+    first: 3,
+    after: { strictAt: new Date('2024-06-03T00:00:00.000Z'), id: 3 },
+    orderBy: { strictAt: 'asc', id: 'asc' },
+  });
+  expect(cursor3.items).toMatchObject([{ id: 4 }, { id: 5 }, { id: 6 }]);
+});
+
+test('wrapper-typed field over a datetime column', async () => {
+  const cursor1 = await orm.em.findByCursor(Job, {
+    first: 3,
+    orderBy: { stampedAt: 'asc', id: 'asc' },
+  });
+  expect(cursor1.items).toMatchObject([{ id: 1 }, { id: 2 }, { id: 3 }]);
+  expect(cursor1.items[0].stampedAt).toBeInstanceOf(Stamp);
+
+  const cursor2 = await orm.em.findByCursor(Job, {
+    first: 3,
+    after: cursor1.endCursor!,
+    orderBy: { stampedAt: 'asc', id: 'asc' },
+  });
+  expect(cursor2.items).toMatchObject([{ id: 4 }, { id: 5 }, { id: 6 }]);
+
+  const cursor3 = await orm.em.findByCursor(Job, {
+    first: 3,
+    after: { stampedAt: new Stamp(new Date('2024-07-03T00:00:00.000Z')), id: 3 },
+    orderBy: { stampedAt: 'asc', id: 'asc' },
+  });
+  expect(cursor3.items).toMatchObject([{ id: 4 }, { id: 5 }, { id: 6 }]);
+
+  const cursor4 = await orm.em.findByCursor(Job, {
+    first: 3,
+    after: { stampedAt: '2024-07-03T00:00:00.000Z' as unknown as Stamp, id: 3 },
+    orderBy: { stampedAt: 'asc', id: 'asc' },
+  });
+  expect(cursor4.items).toMatchObject([{ id: 4 }, { id: 5 }, { id: 6 }]);
+});
+
+test('hand-written ISO string for a custom-typed datetime cursor member heals to Date', async () => {
+  const cursor1 = await orm.em.findByCursor(Job, {
+    first: 3,
+    after: { taggedAt: '2024-05-03T00:00:00.000Z', id: 3 },
+    orderBy: { taggedAt: 'asc', id: 'asc' },
+  });
+  expect(cursor1.items).toMatchObject([{ id: 4 }, { id: 5 }, { id: 6 }]);
+
+  const cursor2 = await orm.em.findByCursor(Job, {
+    first: 3,
+    after: { strictAt: '2024-06-03T00:00:00.000Z', id: 3 },
+    orderBy: { strictAt: 'asc', id: 'asc' },
+  });
+  expect(cursor2.items).toMatchObject([{ id: 4 }, { id: 5 }, { id: 6 }]);
+});
+
+test('identity custom type over a datetime column with string cursor', async () => {
+  const cursor1 = await orm.em.findByCursor(Job, {
+    first: 3,
+    orderBy: { taggedAt: 'asc', id: 'asc' },
+  });
+  expect(cursor1.items).toMatchObject([{ id: 1 }, { id: 2 }, { id: 3 }]);
+
+  const cursor2 = await orm.em.findByCursor(Job, {
+    first: 3,
+    after: cursor1.endCursor!,
+    orderBy: { taggedAt: 'asc', id: 'asc' },
+  });
+  expect(cursor2.items).toMatchObject([{ id: 4 }, { id: 5 }, { id: 6 }]);
+});
+
+test('native Date cursor member still rehydrates', async () => {
+  const cursor1 = await orm.em.findByCursor(Job, {
+    first: 3,
+    orderBy: { createdAt: 'asc', id: 'asc' },
+  });
+  expect(cursor1.items).toMatchObject([{ id: 1 }, { id: 2 }, { id: 3 }]);
+
+  const cursor2 = await orm.em.findByCursor(Job, {
+    first: 3,
+    after: cursor1.endCursor!,
+    orderBy: { createdAt: 'asc', id: 'asc' },
+  });
+  expect(cursor2.items).toMatchObject([{ id: 4 }, { id: 5 }, { id: 6 }]);
+});
+
+test('hand-written ISO string for a native Date cursor member heals to Date', async () => {
+  const cursor = await orm.em.findByCursor(Job, {
+    first: 3,
+    after: { createdAt: '2024-02-03T00:00:00.500Z', id: 3 },
+    orderBy: { createdAt: 'asc', id: 'asc' },
+  });
+  expect(cursor.items).toMatchObject([{ id: 4 }, { id: 5 }, { id: 6 }]);
+});
+
+test('nested relation cursor member', async () => {
+  const cursor1 = await orm.em.findByCursor(Job, {
+    first: 3,
+    orderBy: { owner: { since: 'asc' }, id: 'asc' },
+    populate: ['owner'],
+  });
+  expect(cursor1.items).toMatchObject([{ id: 1 }, { id: 2 }, { id: 3 }]);
+
+  const cursor2 = await orm.em.findByCursor(Job, {
+    first: 3,
+    after: cursor1.endCursor!,
+    orderBy: { owner: { since: 'asc' }, id: 'asc' },
+    populate: ['owner'],
+  });
+  expect(cursor2.items).toMatchObject([{ id: 4 }, { id: 5 }, { id: 6 }]);
+
+  const cursor3 = await orm.em.findByCursor(Job, {
+    first: 3,
+    after: { owner: { since: new Date('2024-03-03T00:00:00.000Z') }, id: 3 },
+    orderBy: { owner: { since: 'asc' }, id: 'asc' },
+    populate: ['owner'],
+  });
+  expect(cursor3.items).toMatchObject([{ id: 4 }, { id: 5 }, { id: 6 }]);
+
+  // an entity instance instead of a plain object must work the same way
+  const owner3 = await orm.em.findOneOrFail(Owner, { id: 3 });
+  const cursor4 = await orm.em.findByCursor(Job, {
+    first: 3,
+    after: { owner: owner3, id: 3 },
+    orderBy: { owner: { since: 'asc' }, id: 'asc' },
+    populate: ['owner'],
+  });
+  expect(cursor4.items).toMatchObject([{ id: 4 }, { id: 5 }, { id: 6 }]);
+
+  // same for a Reference wrapper
+  const cursor5 = await orm.em.findByCursor(Job, {
+    first: 3,
+    after: { owner: Reference.create(owner3), id: 3 },
+    orderBy: { owner: { since: 'asc' }, id: 'asc' },
+    populate: ['owner'],
+  });
+  expect(cursor5.items).toMatchObject([{ id: 4 }, { id: 5 }, { id: 6 }]);
+});
+
+test('Date inside object-mode embeddable stays in JSON space', async () => {
+  const cursor1 = await orm.em.findByCursor(Job, {
+    first: 3,
+    orderBy: { audit: { changedAt: 'asc' }, id: 'asc' },
+  });
+  expect(cursor1.items).toMatchObject([{ id: 1 }, { id: 2 }, { id: 3 }]);
+
+  const cursor2 = await orm.em.findByCursor(Job, {
+    first: 3,
+    after: cursor1.endCursor!,
+    orderBy: { audit: { changedAt: 'asc' }, id: 'asc' },
+  });
+  expect(cursor2.items).toMatchObject([{ id: 4 }, { id: 5 }, { id: 6 }]);
+
+  const cursor3 = await orm.em.findByCursor(Job, {
+    first: 3,
+    after: { audit: { changedAt: new Date('2024-04-03T00:00:00.000Z') }, id: 3 },
+    orderBy: { audit: { changedAt: 'asc' }, id: 'asc' },
+  });
+  expect(cursor3.items).toMatchObject([{ id: 4 }, { id: 5 }, { id: 6 }]);
+
+  // an embeddable class instance instead of a plain object must work the same way
+  const job3 = await orm.em.findOneOrFail(Job, { id: 3 });
+  expect(job3.audit).toBeInstanceOf(Audit);
+  const cursor4 = await orm.em.findByCursor(Job, {
+    first: 3,
+    after: { audit: job3.audit, id: 3 },
+    orderBy: { audit: { changedAt: 'asc' }, id: 'asc' },
+  });
+  expect(cursor4.items).toMatchObject([{ id: 4 }, { id: 5 }, { id: 6 }]);
+});
+
+test('string property with timestamp-shaped values stays a string', async () => {
+  const cursor1 = await orm.em.findByCursor(Job, {
+    first: 3,
+    orderBy: { label: 'asc', id: 'asc' },
+  });
+  expect(cursor1.items).toMatchObject([{ id: 1 }, { id: 2 }, { id: 3 }]);
+
+  const cursor2 = await orm.em.findByCursor(Job, {
+    first: 3,
+    after: cursor1.endCursor!,
+    orderBy: { label: 'asc', id: 'asc' },
+  });
+  expect(cursor2.items).toMatchObject([{ id: 4 }, { id: 5 }, { id: 6 }]);
+});
+
+test('nullable custom-typed cursor member', async () => {
+  const cursor = await orm.em.findByCursor(Job, {
+    first: 2,
+    after: { finishedAt: null, id: 2 },
+    orderBy: { finishedAt: 'asc', id: 'asc' },
+  });
+  expect(cursor.items).toMatchObject([{ id: 4 }, { id: 6 }]);
+});
+
+test('MANY_TO_ONE cursor member is unaffected', async () => {
+  const cursor1 = await orm.em.findByCursor(Job, {
+    first: 3,
+    orderBy: { owner: 'asc', id: 'asc' },
+  });
+  expect(cursor1.items).toMatchObject([{ id: 1 }, { id: 2 }, { id: 3 }]);
+
+  const cursor2 = await orm.em.findByCursor(Job, {
+    first: 3,
+    after: cursor1.endCursor!,
+    orderBy: { owner: 'asc', id: 'asc' },
+  });
+  expect(cursor2.items).toMatchObject([{ id: 4 }, { id: 5 }, { id: 6 }]);
+
+  // an entity instance as the relation value must resolve to its primary key
+  const owner3 = await orm.em.findOneOrFail(Owner, { id: 3 });
+  const cursor3 = await orm.em.findByCursor(Job, {
+    first: 3,
+    after: { owner: owner3, id: 3 },
+    orderBy: { owner: 'asc', id: 'asc' },
+  });
+  expect(cursor3.items).toMatchObject([{ id: 4 }, { id: 5 }, { id: 6 }]);
+});
+
+test('custom type whose JSON form is not a string', async () => {
+  const cursor1 = await orm.em.findByCursor(Job, {
+    first: 3,
+    orderBy: { ticksAt: 'asc', id: 'asc' },
+  });
+  expect(cursor1.items).toMatchObject([{ id: 1 }, { id: 2 }, { id: 3 }]);
+  expect(cursor1.items[0].ticksAt).toBeInstanceOf(Ticks);
+
+  const cursor2 = await orm.em.findByCursor(Job, {
+    first: 3,
+    after: cursor1.endCursor!,
+    orderBy: { ticksAt: 'asc', id: 'asc' },
+  });
+  expect(cursor2.items).toMatchObject([{ id: 4 }, { id: 5 }, { id: 6 }]);
+});
+
+test('custom-typed Date inside object-mode embeddable stays in JSON space', async () => {
+  const cursor1 = await orm.em.findByCursor(Job, {
+    first: 3,
+    orderBy: { audit: { auditedAt: 'asc' }, id: 'asc' },
+  });
+  expect(cursor1.items).toMatchObject([{ id: 1 }, { id: 2 }, { id: 3 }]);
+
+  const cursor2 = await orm.em.findByCursor(Job, {
+    first: 3,
+    after: cursor1.endCursor!,
+    orderBy: { audit: { auditedAt: 'asc' }, id: 'asc' },
+  });
+  expect(cursor2.items).toMatchObject([{ id: 4 }, { id: 5 }, { id: 6 }]);
+
+  const cursor3 = await orm.em.findByCursor(Job, {
+    first: 3,
+    after: { audit: { auditedAt: new Date('2024-08-03T00:00:00.000Z') }, id: 3 },
+    orderBy: { audit: { auditedAt: 'asc' }, id: 'asc' },
+  });
+  expect(cursor3.items).toMatchObject([{ id: 4 }, { id: 5 }, { id: 6 }]);
+});
+
+test('custom type with distinct JSON and DB forms inside object-mode embeddable', async () => {
+  const cursor1 = await orm.em.findByCursor(Job, {
+    first: 3,
+    orderBy: { audit: { epochAt: 'asc' }, id: 'asc' },
+  });
+  expect(cursor1.items).toMatchObject([{ id: 1 }, { id: 2 }, { id: 3 }]);
+
+  // the string cursor carries the serialized ISO form, which must be restored to the JS value
+  // first, so it can be converted to the epoch number the JSON document holds
+  const cursor2 = await orm.em.findByCursor(Job, {
+    first: 3,
+    after: cursor1.endCursor!,
+    orderBy: { audit: { epochAt: 'asc' }, id: 'asc' },
+  });
+  expect(cursor2.items).toMatchObject([{ id: 4 }, { id: 5 }, { id: 6 }]);
+
+  const cursor3 = await orm.em.findByCursor(Job, {
+    first: 3,
+    after: { audit: { epochAt: new PointInTime('2024-11-03T00:00:00.000Z') }, id: 3 },
+    orderBy: { audit: { epochAt: 'asc' }, id: 'asc' },
+  });
+  expect(cursor3.items).toMatchObject([{ id: 4 }, { id: 5 }, { id: 6 }]);
+});
+
+test('validating custom type keeps its own error message', async () => {
+  const cursor1 = await orm.em.findByCursor(Job, {
+    first: 3,
+    orderBy: { code: 'asc', id: 'asc' },
+  });
+  expect(cursor1.items).toMatchObject([{ id: 1 }, { id: 2 }, { id: 3 }]);
+
+  const cursor2 = await orm.em.findByCursor(Job, {
+    first: 3,
+    after: cursor1.endCursor!,
+    orderBy: { code: 'asc', id: 'asc' },
+  });
+  expect(cursor2.items).toMatchObject([{ id: 4 }, { id: 5 }, { id: 6 }]);
+
+  // '2024' is Date.parse-able but not ISO-shaped, so the type's own error must survive
+  await expect(
+    orm.em.findByCursor(Job, {
+      first: 3,
+      after: { code: '2024', id: 3 },
+      orderBy: { code: 'asc', id: 'asc' },
+    }),
+  ).rejects.toThrow("unknown code '2024'");
+
+  // an ISO-shaped value must not be coerced to a Date for a non-datetime column,
+  // and the type's error referencing the caller's string must survive
+  await expect(
+    orm.em.findByCursor(Job, {
+      first: 3,
+      after: { code: '2024-01-05T00:00:00.000Z', id: 3 },
+      orderBy: { code: 'asc', id: 'asc' },
+    }),
+  ).rejects.toThrow("unknown code '2024-01-05T00:00:00.000Z'");
+});
+
+test('Date under a plain JSON property stays in JSON space', async () => {
+  const cursor1 = await orm.em.findByCursor(Job, {
+    first: 3,
+    after: { payload: { ts: '2024-10-03T00:00:00.000Z' }, id: 3 },
+    orderBy: { payload: { ts: 'asc' }, id: 'asc' },
+  });
+  expect(cursor1.items).toMatchObject([{ id: 4 }, { id: 5 }, { id: 6 }]);
+
+  // a Date instance for the same JSON path must serialize instead of hitting the query as a Date
+  const cursor2 = await orm.em.findByCursor(Job, {
+    first: 3,
+    after: { payload: { ts: new Date('2024-10-03T00:00:00.000Z') }, id: 3 } as never,
+    orderBy: { payload: { ts: 'asc' }, id: 'asc' },
+  });
+  expect(cursor2.items).toMatchObject([{ id: 4 }, { id: 5 }, { id: 6 }]);
+
+  const cursor3 = await orm.em.findByCursor(Job, {
+    first: 3,
+    after: cursor1.endCursor!,
+    orderBy: { payload: { ts: 'asc' }, id: 'asc' },
+  });
+  expect(cursor3.items).toMatchObject([{ id: 7 }, { id: 8 }, { id: 9 }]);
+});
+
+test('entity or reference instance as the cursor itself', async () => {
+  const job3 = await orm.em.findOneOrFail(Job, { id: 3 });
+
+  const cursor1 = await orm.em.findByCursor(Job, {
+    first: 3,
+    after: job3,
+    orderBy: { startedAt: 'asc', id: 'asc' },
+  });
+  expect(cursor1.items).toMatchObject([{ id: 4 }, { id: 5 }, { id: 6 }]);
+
+  const cursor2 = await orm.em.findByCursor(Job, {
+    first: 3,
+    after: Reference.create(job3) as never,
+    orderBy: { startedAt: 'asc', id: 'asc' },
+  });
+  expect(cursor2.items).toMatchObject([{ id: 4 }, { id: 5 }, { id: 6 }]);
+});
+
+test('scalar reference as cursor value unwraps', async () => {
+  const job3 = await orm.em.findOneOrFail(Job, { id: 3 });
+
+  const cursor = await orm.em.findByCursor(Job, {
+    first: 3,
+    after: { startedAt: new ScalarReference(job3.startedAt), id: 3 } as never,
+    orderBy: { startedAt: 'asc', id: 'asc' },
+  });
+  expect(cursor.items).toMatchObject([{ id: 4 }, { id: 5 }, { id: 6 }]);
+});
+
+test('scalar value where a nested cursor object is expected', async () => {
+  await expect(
+    orm.em.findByCursor(Job, {
+      first: 3,
+      after: { owner: 5, id: 3 } as never,
+      orderBy: { owner: { since: 'asc' }, id: 'asc' },
+    }),
+  ).rejects.toThrow("value for 'Job.owner.since' is missing");
+});
+
+test('`Cursor.decode` returns raw JSON values', () => {
+  const encoded = Cursor.encode(['2024-01-01T00:00:00.123Z', 42, null]);
+  expect(Cursor.decode(encoded)).toEqual(['2024-01-01T00:00:00.123Z', 42, null]);
+});


### PR DESCRIPTION
## Summary

`Cursor.decode` restored types by sniffing the string shape: any timestamp-looking string became a JS `Date`, regardless of the target property. Custom types received a `Date` their converters reject (found with a Temporal `Instant` wrapper type, where every paged request failed on postgres), sub-millisecond precision was silently truncated, and plain string properties holding timestamp-shaped values were coerced into dates, returning wrong pages. On top of that, the cursor condition is built at the driver level, after the EM has already run custom type conversion on the user `where`, so cursor offsets never went through `convertToDatabaseValue` at all.

`Cursor.decode` now returns raw JSON values, and the offsets are mapped per property inside the existing `createCursorCondition` recursion:

- ISO strings become `Date` instances only when the property maps to a datetime column (checked via the platform's mapped type), never based on the string shape.
- Custom types are restored via `convertToJSValue`. On the string-cursor path, a type is expected to accept its own `toJSON` output there, same as the serialization round trip already requires for `Date` values.
- The finished condition then runs through `QueryHelper.processWhere` with custom type conversion enabled, so it is processed exactly like a user-provided `where` (nested relations, embeddables and operators all go through the standard pipeline).
- Values compared against JSON documents (object-mode embeddables, `JsonType` properties) keep their serialized form, with custom types restored first so distinct DB/JSON forms convert correctly.
- POJO `after`/`before` values skip the JSON round trip. Entity instances, `Reference`/`ScalarReference` wrappers and embeddable class instances are accepted as cursor values, and an entity or reference can be passed as the cursor argument itself.

Behavior notes:

- Cursor offsets a custom type cannot convert now raise the type's own error. Previously such values were coerced or passed through and silently returned wrong pages.
- Some offsets now bind in their `convertToDatabaseValue` form, e.g. bigint in number mode binds `'1003'` instead of `1003`; the returned rows are identical. On mssql, string offsets now bind as `N'...'` unicode literals like any other where condition.
- `Cursor.decode` is public API and no longer revives ISO-shaped strings into `Date` instances; callers relying on that get the raw JSON values back.
- The cursor wire format is unchanged, existing cursors keep working.
