### PR TITLE
fix(sql): prevent forward join alias references from earlier joined paths

### DIFF
--- a/packages/sql/src/query/QueryBuilder.ts
+++ b/packages/sql/src/query/QueryBuilder.ts
@@ -1530,6 +1530,8 @@ export class QueryBuilder<
           join.cond = { ...cond };
         }
 
+        this.nestReferencedJoins(join);
+
         // For polymorphic LEFT JOIN filters, add a WHERE condition to enforce the filter
         // only for rows matching this target's discriminator value. This ensures rows pointing
         // to other polymorphic targets are not excluded.
@@ -1584,6 +1586,44 @@ export class QueryBuilder<
       j.type = j.type === JoinType.innerJoin ? JoinType.nestedInnerJoin : JoinType.nestedLeftJoin;
       nested.add(j);
     }
+  }
+
+  /**
+   * A joined filter can resolve to an alias created by an earlier joined path that renders after
+   * `condJoin`, so its `on` clause forward-references that alias. Such joins are owned by `condJoin`
+   * but predate its pass, so `nestNewJoins` skips them. Fold the referenced ones into `condJoin`, so
+   * they render inside its parenthesized group and share the scope of the outer `on` clause.
+   */
+  private nestReferencedJoins(condJoin: JoinOptions): void {
+    for (const j of Object.values(this.#state.joins)) {
+      if (j === condJoin || j.ownerAlias !== condJoin.alias || condJoin.nested?.has(j)) {
+        continue;
+      }
+
+      if (!this.condReferencesAlias(condJoin.cond, j.alias)) {
+        continue;
+      }
+
+      const nested = (condJoin.nested ??= new Set());
+      j.type = j.type === JoinType.innerJoin ? JoinType.nestedInnerJoin : JoinType.nestedLeftJoin;
+      nested.add(j);
+    }
+  }
+
+  private condReferencesAlias(cond: Dictionary, alias: string): boolean {
+    const check = (value: unknown): boolean => {
+      if (Array.isArray(value)) {
+        return value.some(check);
+      }
+
+      if (Utils.isPlainObject(value)) {
+        return Object.entries(value).some(([key, val]) => key.startsWith(`${alias}.`) || check(val));
+      }
+
+      return false;
+    };
+
+    return check(cond);
   }
 
   withSubQuery(subQuery: RawQueryFragment | NativeQueryBuilder, alias: string): this {

--- a/tests/issues/GH8099.test.ts
+++ b/tests/issues/GH8099.test.ts
@@ -1,0 +1,86 @@
+import type { Rel } from '@mikro-orm/postgresql';
+import { MikroORM } from '@mikro-orm/postgresql';
+import { Entity, Filter, ManyToOne, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+
+@Entity()
+class Company {
+  @PrimaryKey({ autoincrement: true })
+  id!: number;
+
+  @Property()
+  code!: string;
+}
+
+@Entity()
+@Filter({ name: 'auth', cond: ({ company }) => ({ company }), default: true })
+class Location {
+  @PrimaryKey({ autoincrement: true })
+  id!: number;
+
+  @ManyToOne(() => Company)
+  company!: Rel<Company>;
+}
+
+@Entity()
+@Filter({
+  name: 'auth',
+  cond: ({ company }) => ({ location: { company } }),
+  default: true,
+})
+class User {
+  @PrimaryKey({ autoincrement: true })
+  id!: number;
+
+  @ManyToOne(() => Location)
+  location!: Rel<Location>;
+}
+
+@Entity()
+@Filter({
+  name: 'auth',
+  cond: ({ company }) => ({ user: { location: { company } } }),
+  default: true,
+})
+class Grant {
+  @PrimaryKey({ autoincrement: true })
+  id!: number;
+
+  @ManyToOne(() => User)
+  user!: Rel<User>;
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    dbName: 'mikro_orm_test_gh_8099',
+    entities: [Company, Location, User, Grant],
+    metadataProvider: ReflectMetadataProvider,
+  });
+  await orm.schema.refresh();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+test('nested filter referencing an alias created by an earlier joined path', async () => {
+  const em = orm.em.fork();
+
+  const company1 = em.create(Company, { code: 'ACME' });
+  const company2 = em.create(Company, { code: 'OTHER' });
+  const location1 = em.create(Location, { company: company1 });
+  const location2 = em.create(Location, { company: company2 });
+  const user1 = em.create(User, { location: location1 });
+  const user2 = em.create(User, { location: location2 });
+  const grant1 = em.create(Grant, { user: user1 });
+  em.create(Grant, { user: user2 });
+  await em.flush();
+  em.clear();
+
+  const em2 = orm.em.fork();
+  em2.setFilterParams('auth', { company: company1.id });
+
+  const grants = await em2.find(Grant, {}, { fields: ['id'] });
+  expect(grants.map(g => g.id)).toEqual([grant1.id]);
+});


### PR DESCRIPTION
When a joined entity's `@Filter` resolves to a relation whose alias was already created by an earlier joined path, `applyJoinedFilters` puts the condition in that join's `on` clause even though the referenced alias is joined on a later line, so PostgreSQL reports `missing FROM-clause entry for table "l2"`.

This is the sibling of #8090. The fold added in #8091 only nests joins created during the current pass, so an alias created earlier is skipped. Nest those referenced joins into the filtered join as well, so they render inside its parenthesized group and share the scope of the outer `on` clause.

Closes #8099