### PR TITLE
fix(sql): nest joins referenced by `on` conditions instead of only newly added ones

### DIFF
--- a/packages/sql/src/query/QueryBuilder.ts
+++ b/packages/sql/src/query/QueryBuilder.ts
@@ -1500,7 +1500,6 @@ export class QueryBuilder<
       filterOptions = QueryHelper.mergePropertyFilters(join.prop.filters, filterOptions);
       let cond = await em.applyFilters(join.prop.targetMeta!.class, join.cond, filterOptions, 'read');
       const criteriaNode = CriteriaNodeFactory.createNode<Entity>(this.metadata, join.prop.targetMeta!.class, cond);
-      const joinCountBefore = Object.keys(this.#state.joins).length;
       cond = criteriaNode.process(this as IQueryBuilder<Entity>, {
         matchPopulateJoins: true,
         filter: true,
@@ -1508,7 +1507,6 @@ export class QueryBuilder<
         ignoreBranching: true,
         parentPath: join.path,
       });
-      this.nestNewJoins(join, joinCountBefore);
 
       if (Utils.hasObjectKeys(cond) || RawQueryFragment.hasObjectFragments(cond)) {
         // remove nested filters, we only care about scalars here, nesting would require another join branch
@@ -1529,6 +1527,8 @@ export class QueryBuilder<
         } else {
           join.cond = { ...cond };
         }
+
+        this.nestReferencedJoins(join);
 
         // For polymorphic LEFT JOIN filters, add a WHERE condition to enforce the filter
         // only for rows matching this target's discriminator value. This ensures rows pointing
@@ -1561,29 +1561,53 @@ export class QueryBuilder<
   }
 
   /**
-   * Auto-joins added while processing a condition of `condJoin` would render after it and produce a
-   * forward alias reference in its `on` clause. Fold them into `condJoin`, so they render as a single
-   * parenthesized join group and share the scope of the outer `on` clause (issue #7681).
+   * The `on` clause of `condJoin` — its explicit join condition or a filter condition merged into
+   * it — can reference the alias of any join in its subtree, both auto-joins created while
+   * processing the condition and pre-existing joined paths, all of which render after `condJoin`
+   * and would be forward alias references (issues #7681, #8090, #8099). When that happens, fold the
+   * subtree into `condJoin`, so it renders as a single parenthesized join group and every alias
+   * shares the scope of the outer `on` clause.
    */
-  private nestNewJoins(condJoin: JoinOptions | undefined, joinCountBefore: number): void {
+  private nestReferencedJoins(condJoin: JoinOptions | undefined): void {
     // m:n pivot joins might not have the target join entry created
     if (!condJoin) {
       return;
     }
 
-    const joinKeys = Object.keys(this.#state.joins);
+    const subtree = this.getJoinSubtree(condJoin);
 
-    for (let i = joinCountBefore; i < joinKeys.length; i++) {
-      const j = this.#state.joins[joinKeys[i]];
-
-      if (j === condJoin || j.ownerAlias !== condJoin.alias) {
-        continue;
-      }
-
-      const nested = (condJoin.nested ??= new Set());
-      j.type = j.type === JoinType.innerJoin ? JoinType.nestedInnerJoin : JoinType.nestedLeftJoin;
-      nested.add(j);
+    if (!subtree.some(j => this.condReferencesAlias(condJoin.cond, j.alias))) {
+      return;
     }
+
+    for (const j of subtree) {
+      const parent = j.ownerAlias === condJoin.alias ? condJoin : subtree.find(p => p.alias === j.ownerAlias)!;
+
+      if (!parent.nested?.has(j)) {
+        const nested = (parent.nested ??= new Set());
+        j.type = j.type === JoinType.innerJoin ? JoinType.nestedInnerJoin : JoinType.nestedLeftJoin;
+        nested.add(j);
+      }
+    }
+  }
+
+  private getJoinSubtree(join: JoinOptions): JoinOptions[] {
+    const children = Object.values(this.#state.joins).filter(j => j !== join && j.ownerAlias === join.alias);
+    return children.flatMap(j => [j, ...this.getJoinSubtree(j)]);
+  }
+
+  private condReferencesAlias(cond: unknown, alias: string): boolean {
+    if (Array.isArray(cond)) {
+      return cond.some(c => this.condReferencesAlias(c, alias));
+    }
+
+    if (Utils.isPlainObject(cond)) {
+      return Object.entries(cond).some(
+        ([key, value]) => key.startsWith(`${alias}.`) || this.condReferencesAlias(value, alias),
+      );
+    }
+
+    return false;
   }
 
   withSubQuery(subQuery: RawQueryFragment | NativeQueryBuilder, alias: string): this {
@@ -3164,7 +3188,6 @@ export class QueryBuilder<
       aliased: [QueryType.SELECT, QueryType.COUNT].includes(this.type),
     })!;
     const criteriaNode = CriteriaNodeFactory.createNode<Entity>(this.metadata, prop.targetMeta!.class, cond);
-    const joinCountBefore = Object.keys(this.#state.joins).length;
     cond = criteriaNode.process(this as IQueryBuilder<Entity>, { ignoreBranching: true, alias });
     let aliasedName = `${fromAlias}.${prop.name}#${alias}`;
     path ??= `${Object.values(this.#state.joins).find(j => j.alias === fromAlias)?.path ?? Utils.className(entityName)}.${prop.name}`;
@@ -3196,7 +3219,7 @@ export class QueryBuilder<
       this.#state.joins[aliasedName].path ??= path;
     }
 
-    this.nestNewJoins(this.#state.joins[aliasedName], joinCountBefore);
+    this.nestReferencedJoins(this.#state.joins[aliasedName]);
 
     return { prop, key: aliasedName };
   }

--- a/tests/issues/GH8099.test.ts
+++ b/tests/issues/GH8099.test.ts
@@ -1,0 +1,103 @@
+import type { Rel } from '@mikro-orm/postgresql';
+import { MikroORM } from '@mikro-orm/postgresql';
+import { Entity, Filter, ManyToOne, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+
+@Entity()
+class Company {
+  @PrimaryKey({ autoincrement: true })
+  id!: number;
+
+  @Property()
+  code!: string;
+}
+
+@Entity()
+@Filter({ name: 'auth', cond: ({ company }) => ({ company }), default: true })
+class Location {
+  @PrimaryKey({ autoincrement: true })
+  id!: number;
+
+  @ManyToOne(() => Company)
+  company!: Rel<Company>;
+}
+
+@Entity()
+@Filter({
+  name: 'auth',
+  cond: ({ company }) => ({ location: { company } }),
+  default: true,
+})
+@Filter({
+  name: 'deep',
+  cond: () => ({ location: { company: { code: 'ACME' } } }),
+})
+class User {
+  @PrimaryKey({ autoincrement: true })
+  id!: number;
+
+  @ManyToOne(() => Location)
+  location!: Rel<Location>;
+}
+
+@Entity()
+@Filter({
+  name: 'auth',
+  cond: ({ company }) => ({ user: { location: { company } } }),
+  default: true,
+})
+class Grant {
+  @PrimaryKey({ autoincrement: true })
+  id!: number;
+
+  @ManyToOne(() => User)
+  user!: Rel<User>;
+}
+
+let orm: MikroORM;
+let companyId: number;
+let grantId: number;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    dbName: 'mikro_orm_test_gh_8099',
+    entities: [Company, Location, User, Grant],
+    metadataProvider: ReflectMetadataProvider,
+  });
+  await orm.schema.refresh();
+
+  const em = orm.em.fork();
+  const company1 = em.create(Company, { code: 'ACME' });
+  const company2 = em.create(Company, { code: 'OTHER' });
+  const location1 = em.create(Location, { company: company1 });
+  const location2 = em.create(Location, { company: company2 });
+  const user1 = em.create(User, { location: location1 });
+  const user2 = em.create(User, { location: location2 });
+  const grant1 = em.create(Grant, { user: user1 });
+  em.create(Grant, { user: user2 });
+  await em.flush();
+  companyId = company1.id;
+  grantId = grant1.id;
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+test('nested filter referencing an alias created by an earlier joined path', async () => {
+  const em = orm.em.fork();
+  em.setFilterParams('auth', { company: companyId });
+
+  const grants = await em.find(Grant, {}, { fields: ['id'] });
+  expect(grants.map(g => g.id)).toEqual([grantId]);
+});
+
+test('nested filter referencing an alias two levels below the joined path', async () => {
+  const em = orm.em.fork();
+
+  const grants = await em.find(
+    Grant,
+    { user: { location: { company: companyId } } },
+    { fields: ['id'], filters: { auth: false, deep: true } },
+  );
+  expect(grants.map(g => g.id)).toEqual([grantId]);
+});


### PR DESCRIPTION
Supersedes #8100, same root cause as #8090 but fixed by generalizing the existing mechanism instead of adding another special case.

When a joined entity's `@Filter` resolves to a relation whose alias was created by an earlier joined path, the condition lands in that join's `on` clause while the referenced alias renders on a later line, so the database rejects the query (`missing FROM-clause entry for table "l2"`). #8100 nested the referenced direct children, but the same failure remains one level deeper: a filter like `{ location: { company: { code } } }` still produces a forward reference to the grandchild alias.

The `nestNewJoins` helper from #7681/#8091 used "joins created while processing the condition" as a proxy for the joins an `on` clause can reference. This PR replaces the proxy with the actual invariant: when a join's `on` condition references any alias in its join subtree, the whole subtree is folded into the join's parenthesized group, so every referenced alias shares the scope of the outer `on` clause. The `joinCountBefore` bookkeeping is gone from both call sites. The fold only triggers for queries that would otherwise be invalid SQL, so join shapes of working queries are unchanged.

Includes the test from #8100 plus a second case for the deeper chain.

Closes #8099