### PR TITLE
fix(mongo): support cursor pagination ordered by date inside object embeddable

### DIFF
--- a/packages/core/src/drivers/DatabaseDriver.ts
+++ b/packages/core/src/drivers/DatabaseDriver.ts
@@ -371,7 +371,8 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
   /**
    * Restores the JS value of a single cursor offset: ISO strings become `Date` instances based on the
    * property type (never based on the string shape alone), and custom types are restored via
-   * `convertToJSValue`. Values compared against a JSON document keep their serialized form instead.
+   * `convertToJSValue`. Values compared against a JSON document keep their serialized form instead,
+   * unless the platform preserves native date types inside JSON documents (mongo).
    */
   private mapCursorOffset(prop: EntityProperty | undefined, value: unknown, insideJson: boolean): unknown {
     if (Utils.isScalarReference(value)) {
@@ -387,7 +388,7 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
       return value;
     }
 
-    if (insideJson) {
+    if (insideJson && !this.platform.preservesDatesInsideJson()) {
       // compared against the JSON document, which holds the serialized form
       if (value instanceof Date) {
         return value.toISOString();

--- a/packages/core/src/platforms/Platform.ts
+++ b/packages/core/src/platforms/Platform.ts
@@ -623,6 +623,11 @@ export abstract class Platform {
     return true;
   }
 
+  /** Whether date values inside JSON documents keep their native type (e.g. BSON dates), instead of being serialized to ISO strings. */
+  preservesDatesInsideJson(): boolean {
+    return false;
+  }
+
   /** Converts a JS value to its JSON database representation (typically JSON.stringify). */
   convertJsonToDatabaseValue(value: unknown, context?: TransformContext): unknown {
     return JSON.stringify(value);

--- a/packages/mongodb/src/MongoDriver.ts
+++ b/packages/mongodb/src/MongoDriver.ts
@@ -119,6 +119,7 @@ export class MongoDriver extends DatabaseDriver<MongoConnection> {
       };
       const meta = this.metadata.find<T>(entityName)!;
       const { orderBy: newOrderBy, where: newWhere } = this.processCursorOptions(meta, options, options.orderBy!);
+      this.convertCursorDates(newWhere as Dictionary);
       const newWhereConverted = this.renameFields(entityName, newWhere as T, true);
       const orderBy = Utils.asArray(newOrderBy).map(order => this.renameFields(entityName, order as T, true));
       const res = await this.rethrow(
@@ -735,6 +736,22 @@ export class MongoDriver extends DatabaseDriver<MongoConnection> {
     }
 
     return data;
+  }
+
+  /**
+   * `Cursor.decode` revives ISO date strings only at the top level of the offsets array, but object
+   * embeddables are stored as documents with real BSON dates, so we need to revive the nested values too.
+   */
+  private convertCursorDates(data: Dictionary): void {
+    Object.keys(data).forEach(k => {
+      if (Array.isArray(data[k])) {
+        data[k].forEach((item: unknown) => Utils.isPlainObject(item) && this.convertCursorDates(item));
+      } else if (Utils.isPlainObject(data[k])) {
+        this.convertCursorDates(data[k]);
+      } else if (typeof data[k] === 'string' && /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}/.exec(data[k])) {
+        data[k] = new Date(data[k]);
+      }
+    });
   }
 
   private buildFilterById<T extends { _id: any }>(entityName: EntityName, id: string): FilterQuery<T> {

--- a/packages/mongodb/src/MongoDriver.ts
+++ b/packages/mongodb/src/MongoDriver.ts
@@ -119,7 +119,6 @@ export class MongoDriver extends DatabaseDriver<MongoConnection> {
       };
       const meta = this.metadata.find<T>(entityName)!;
       const { orderBy: newOrderBy, where: newWhere } = this.processCursorOptions(meta, options, options.orderBy!);
-      this.convertCursorDates(newWhere as Dictionary);
       const newWhereConverted = this.renameFields(entityName, newWhere as T, true);
       const orderBy = Utils.asArray(newOrderBy).map(order => this.renameFields(entityName, order as T, true));
       const res = await this.rethrow(
@@ -736,22 +735,6 @@ export class MongoDriver extends DatabaseDriver<MongoConnection> {
     }
 
     return data;
-  }
-
-  /**
-   * `Cursor.decode` revives ISO date strings only at the top level of the offsets array, but object
-   * embeddables are stored as documents with real BSON dates, so we need to revive the nested values too.
-   */
-  private convertCursorDates(data: Dictionary): void {
-    Object.keys(data).forEach(k => {
-      if (Array.isArray(data[k])) {
-        data[k].forEach((item: unknown) => Utils.isPlainObject(item) && this.convertCursorDates(item));
-      } else if (Utils.isPlainObject(data[k])) {
-        this.convertCursorDates(data[k]);
-      } else if (typeof data[k] === 'string' && /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}/.exec(data[k])) {
-        data[k] = new Date(data[k]);
-      }
-    });
   }
 
   private buildFilterById<T extends { _id: any }>(entityName: EntityName, id: string): FilterQuery<T> {

--- a/packages/mongodb/src/MongoPlatform.ts
+++ b/packages/mongodb/src/MongoPlatform.ts
@@ -88,6 +88,10 @@ export class MongoPlatform extends Platform {
     return true;
   }
 
+  override preservesDatesInsideJson(): boolean {
+    return true;
+  }
+
   override convertJsonToDatabaseValue(value: unknown): unknown {
     return Utils.copy(value);
   }

--- a/tests/features/cursor-based-pagination/cursor-object-embeddable-date.mongo.test.ts
+++ b/tests/features/cursor-based-pagination/cursor-object-embeddable-date.mongo.test.ts
@@ -1,0 +1,78 @@
+import { Cursor } from '@mikro-orm/core';
+import {
+  Embeddable,
+  Embedded,
+  Entity,
+  PrimaryKey,
+  Property,
+  ReflectMetadataProvider,
+} from '@mikro-orm/decorators/legacy';
+import { MikroORM, ObjectId } from '@mikro-orm/mongodb';
+
+@Embeddable()
+class Audit {
+  @Property()
+  changedAt!: Date;
+}
+
+@Entity()
+class Job {
+  @PrimaryKey()
+  _id!: ObjectId;
+
+  @Property()
+  seq!: number;
+
+  @Embedded(() => Audit, { object: true })
+  audit!: Audit;
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    metadataProvider: ReflectMetadataProvider,
+    entities: [Job],
+    dbName: 'mikro_orm_cursor_embedded_date',
+  });
+  await orm.schema.clear();
+
+  for (let i = 1; i <= 9; i++) {
+    orm.em.create(Job, {
+      seq: i,
+      audit: { changedAt: new Date(Date.UTC(2023, 0, i)) },
+    });
+  }
+
+  await orm.em.flush();
+  orm.em.clear();
+});
+
+afterAll(() => orm.close(true));
+
+test('cursor pagination ordered by date inside object embeddable (string cursor)', async () => {
+  const orderBy = { audit: { changedAt: 'asc' }, seq: 'asc' } as const;
+  const page1 = await orm.em.findByCursor(Job, { first: 3, orderBy });
+  expect(page1).toBeInstanceOf(Cursor);
+  expect(page1.items.map(j => j.seq)).toEqual([1, 2, 3]);
+  expect(page1.hasNextPage).toBe(true);
+  orm.em.clear();
+
+  const page2 = await orm.em.findByCursor(Job, { first: 3, after: page1.endCursor!, orderBy });
+  expect(page2.items.map(j => j.seq)).toEqual([4, 5, 6]);
+  expect(page2.hasNextPage).toBe(true);
+  orm.em.clear();
+
+  const page3 = await orm.em.findByCursor(Job, { first: 3, after: page2.endCursor!, orderBy });
+  expect(page3.items.map(j => j.seq)).toEqual([7, 8, 9]);
+  expect(page3.hasNextPage).toBe(false);
+});
+
+test('cursor pagination ordered by date inside object embeddable (POJO cursor)', async () => {
+  const cursor = await orm.em.findByCursor(Job, {
+    first: 3,
+    after: { audit: { changedAt: new Date(Date.UTC(2023, 0, 3)) }, seq: 3 },
+    orderBy: { audit: { changedAt: 'asc' }, seq: 'asc' },
+  });
+  expect(cursor.items.map(j => j.seq)).toEqual([4, 5, 6]);
+});


### PR DESCRIPTION
`em.findByCursor` on mongo returned empty pages when ordering by a `Date` property inside an object embeddable, both with a string cursor and with a POJO `after`.

`mapCursorOffset` (#8097) treats values compared against a JSON document as their serialized form: string offsets stay strings, and `Date` offsets from POJO cursors are serialized to ISO strings. That is the correct comparand for SQL JSON columns, but object embeddables in mongo are stored as documents with real BSON dates, and BSON comparisons between a string and a date never match, hence the empty pages.

This adds a `Platform.preservesDatesInsideJson()` predicate (mongo returns `true`) and gates the serialized-form branch of `mapCursorOffset` on it. For mongo, embedded date offsets fall through to the regular property-type based restoration, so they reach the query as real dates. SQL platforms keep the default and are unaffected.
