### PR TITLE
feat(core): rework cursor pagination for custom types and nullable columns

### DIFF
--- a/docs/docs/custom-types.md
+++ b/docs/docs/custom-types.md
@@ -19,6 +19,10 @@ You can define custom types by extending `Type` abstract class. It has several o
 
   Converts a value from its JS representation to its serialized JSON form of this type. By default, uses the runtime value.
 
+- `fromJSON(value: unknown, platform: Platform): any` (optional)
+
+  Converts a value from its serialized JSON form (what `toJSON` produced, after a `JSON.parse` round trip) back to its JS representation. Implementing it makes the type own its cursor wire format: cursor encoding then uses `toJSON`, and decoding passes the value back to `fromJSON`. Cursor values are client supplied, so implementations should validate the input and throw for values they cannot restore — the failure surfaces as a `CursorError`. Without it, cursors carry the raw JS value and decoding falls back to `convertToJSValue`.
+
 - `getColumnType(prop: EntityProperty, platform: Platform): string`
 
   Gets the SQL declaration snippet for a field of this type. By default, returns `columnType` of given property.

--- a/packages/core/src/drivers/DatabaseDriver.ts
+++ b/packages/core/src/drivers/DatabaseDriver.ts
@@ -44,7 +44,6 @@ import { helper } from '../entity/wrap.js';
 import { Reference } from '../entity/Reference.js';
 import { PolymorphicRef } from '../entity/PolymorphicRef.js';
 import { JsonType } from '../types/JsonType.js';
-import { DateTimeType } from '../types/DateTimeType.js';
 import { QueryHelper } from '../utils/QueryHelper.js';
 import { MikroORM } from '../MikroORM.js';
 
@@ -301,6 +300,7 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
     const createCursor = (val: unknown, key: 'startCursor' | 'endCursor', inverse = false) => {
       const def: unknown = Reference.unwrapReference((isCursor(val, key) ? val[key] : val) as T);
       let offsets: unknown[];
+      let fromJson = false;
 
       // entity (and reference) instances are supported as cursors too, their properties are read the same way
       if (Utils.isPlainObject<FilterObject<T>>(def) || Utils.isEntity<FilterObject<T>>(def)) {
@@ -316,10 +316,11 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
       } else {
         /* v8 ignore next */
         offsets = def ? Cursor.decode(def as string) : [];
+        fromJson = true;
       }
 
       if (definition.length > 0 && definition.length === offsets.length) {
-        return this.createCursorCondition<T>(definition, offsets as Dictionary[], inverse, meta);
+        return this.createCursorCondition<T>(definition, offsets as Dictionary[], inverse, meta, fromJson);
       }
 
       /* v8 ignore next */
@@ -374,7 +375,12 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
    * `convertToJSValue`. Values compared against a JSON document keep their serialized form instead,
    * unless the platform preserves native date types inside JSON documents (mongo).
    */
-  private mapCursorOffset(prop: EntityProperty | undefined, value: unknown, insideJson: boolean): unknown {
+  private mapCursorOffset(
+    prop: EntityProperty | undefined,
+    value: unknown,
+    insideJson: boolean,
+    fromJson: boolean,
+  ): unknown {
     if (Utils.isScalarReference(value)) {
       value = value.unwrap();
     }
@@ -388,26 +394,71 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
       return value;
     }
 
+    // mongo preserves native date types inside JSON documents, restored JS values compare directly
     if (insideJson && !this.platform.preservesDatesInsideJson()) {
-      // compared against the JSON document, which holds the serialized form
+      // compared against the JSON document, which holds the JSON form of the database value
       if (value instanceof Date) {
         return value.toISOString();
       }
 
-      // restore the JS value from the serialized form, `processWhere` then converts it to
-      // the database form, which is what the JSON document holds for custom typed props
-      return prop?.customType ? prop.customType.convertToJSValue(value, this.platform) : value;
+      if (prop?.customType && fromJson) {
+        const restored = prop.customType.fromJSON
+          ? prop.customType.fromJSON(value, this.platform)
+          : prop.customType.convertToJSValue(value, this.platform);
+
+        // a restored `Date` compares against its ISO string in the document, everything else
+        // keeps the JS value and gets its single `convertToDatabaseValue` in `processWhere`
+        if (restored instanceof Date) {
+          const converted = prop.customType.convertToDatabaseValue(restored, this.platform, {
+            fromQuery: true,
+            key: prop.name,
+            mode: 'query',
+          });
+
+          if (converted instanceof Date) {
+            return converted.toISOString();
+          }
+        }
+
+        return restored;
+      }
+
+      return value;
     }
 
-    if (
-      typeof value === 'string' &&
-      (prop?.runtimeType === 'Date' ||
-        (prop?.customType && this.platform.getMappedType(prop.columnTypes?.[0] ?? '') instanceof DateTimeType))
-    ) {
-      value = new Date(value);
+    if (prop?.customType) {
+      if (fromJson && prop.customType.fromJSON) {
+        // the type owns its JSON round trip
+        return prop.customType.fromJSON(value, this.platform);
+      }
+
+      // A string is either a serialized form (string cursor) or a hand-written one (POJO).
+      // Types whose JS value is a `Date` must receive one. The rest get the string first,
+      // so any sub-millisecond precision survives.
+      if (
+        typeof value === 'string' &&
+        (prop.runtimeType === 'Date' || this.platform.getMappedType(prop.columnTypes?.[0] ?? '').runtimeType === 'Date')
+      ) {
+        if (prop.runtimeType !== 'Date') {
+          try {
+            return prop.customType.convertToJSValue(value, this.platform);
+          } catch {
+            // the type cannot read the serialized string, fall back to the `Date` form
+          }
+        }
+
+        return prop.customType.convertToJSValue(new Date(value), this.platform);
+      }
+
+      // serialized non-string values still need restoring; POJO values are already JS values
+      return fromJson ? prop.customType.convertToJSValue(value, this.platform) : value;
     }
 
-    return prop?.customType ? prop.customType.convertToJSValue(value, this.platform) : value;
+    if (typeof value === 'string' && prop?.runtimeType === 'Date') {
+      return new Date(value);
+    }
+
+    return value;
   }
 
   protected createCursorCondition<T extends object>(
@@ -415,6 +466,7 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
     offsets: Dictionary[],
     inverse: boolean,
     meta: EntityMetadata<T>,
+    fromJson = false,
   ): FilterQuery<T> {
     const createCondition = (
       prop: string,
@@ -477,7 +529,7 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
         throw CursorError.missingValue(meta.className, path);
       }
 
-      offset = this.mapCursorOffset(propMeta, offset, insideJson) as Dictionary;
+      offset = this.mapCursorOffset(propMeta, offset, insideJson, fromJson) as Dictionary;
 
       // Handle null offset (intentional null cursor value)
       if (offset === null) {
@@ -513,7 +565,7 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
       ...createCondition(prop, direction, offset, true),
       $or: [
         createCondition(prop, direction, offset),
-        this.createCursorCondition(otherOrders, otherOffsets, inverse, meta),
+        this.createCursorCondition(otherOrders, otherOffsets, inverse, meta, fromJson),
       ],
     } as FilterQuery<T>;
   }

--- a/packages/core/src/drivers/DatabaseDriver.ts
+++ b/packages/core/src/drivers/DatabaseDriver.ts
@@ -314,13 +314,28 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
           return def[key];
         });
       } else {
-        /* v8 ignore next */
-        offsets = def ? Cursor.decode(def as string) : [];
+        try {
+          /* v8 ignore next */
+          offsets = def ? Cursor.decode(def as string) : [];
+        } catch (error) {
+          throw CursorError.invalidCursor(meta.className, error as Error);
+        }
+
         fromJson = true;
       }
 
       if (definition.length > 0 && definition.length === offsets.length) {
-        return this.createCursorCondition<T>(definition, offsets as Dictionary[], inverse, meta, fromJson);
+        // a string cursor is client supplied, so everything failing to restore from it is an
+        // invalid cursor, letting callers map `CursorError` to a client error response
+        try {
+          return this.createCursorCondition<T>(definition, offsets as Dictionary[], inverse, meta, fromJson);
+        } catch (error) {
+          if (!fromJson || error instanceof CursorError) {
+            throw error;
+          }
+
+          throw CursorError.invalidCursor(meta.className, error as Error);
+        }
       }
 
       /* v8 ignore next */

--- a/packages/core/src/drivers/DatabaseDriver.ts
+++ b/packages/core/src/drivers/DatabaseDriver.ts
@@ -325,17 +325,7 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
       }
 
       if (definition.length > 0 && definition.length === offsets.length) {
-        // a string cursor is client supplied, so everything failing to restore from it is an
-        // invalid cursor, letting callers map `CursorError` to a client error response
-        try {
-          return this.createCursorCondition<T>(definition, offsets as Dictionary[], inverse, meta, fromJson);
-        } catch (error) {
-          if (!fromJson || error instanceof CursorError) {
-            throw error;
-          }
-
-          throw CursorError.invalidCursor(meta.className, error as Error);
-        }
+        return this.createCursorCondition<T>(definition, offsets as Dictionary[], inverse, meta, fromJson);
       }
 
       /* v8 ignore next */
@@ -544,7 +534,17 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
         throw CursorError.missingValue(meta.className, path);
       }
 
-      offset = this.mapCursorOffset(propMeta, offset, insideJson, fromJson) as Dictionary;
+      // string-cursor values are client supplied, so a value the type cannot restore is an
+      // invalid cursor, letting callers map `CursorError` to a client error response
+      try {
+        offset = this.mapCursorOffset(propMeta, offset, insideJson, fromJson) as Dictionary;
+      } catch (error) {
+        if (!fromJson || error instanceof CursorError) {
+          throw error;
+        }
+
+        throw CursorError.invalidCursor(meta.className, error as Error);
+      }
 
       // Handle null offset (intentional null cursor value)
       if (offset === null) {

--- a/packages/core/src/drivers/DatabaseDriver.ts
+++ b/packages/core/src/drivers/DatabaseDriver.ts
@@ -44,7 +44,6 @@ import { helper } from '../entity/wrap.js';
 import { Reference } from '../entity/Reference.js';
 import { PolymorphicRef } from '../entity/PolymorphicRef.js';
 import { JsonType } from '../types/JsonType.js';
-import { DateTimeType } from '../types/DateTimeType.js';
 import { QueryHelper } from '../utils/QueryHelper.js';
 import { MikroORM } from '../MikroORM.js';
 
@@ -301,6 +300,7 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
     const createCursor = (val: unknown, key: 'startCursor' | 'endCursor', inverse = false) => {
       const def: unknown = Reference.unwrapReference((isCursor(val, key) ? val[key] : val) as T);
       let offsets: unknown[];
+      let fromJson = false;
 
       // entity (and reference) instances are supported as cursors too, their properties are read the same way
       if (Utils.isPlainObject<FilterObject<T>>(def) || Utils.isEntity<FilterObject<T>>(def)) {
@@ -316,10 +316,11 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
       } else {
         /* v8 ignore next */
         offsets = def ? Cursor.decode(def as string) : [];
+        fromJson = true;
       }
 
       if (definition.length > 0 && definition.length === offsets.length) {
-        return this.createCursorCondition<T>(definition, offsets as Dictionary[], inverse, meta);
+        return this.createCursorCondition<T>(definition, offsets as Dictionary[], inverse, meta, fromJson);
       }
 
       /* v8 ignore next */
@@ -373,7 +374,12 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
    * property type (never based on the string shape alone), and custom types are restored via
    * `convertToJSValue`. Values compared against a JSON document keep their serialized form instead.
    */
-  private mapCursorOffset(prop: EntityProperty | undefined, value: unknown, insideJson: boolean): unknown {
+  private mapCursorOffset(
+    prop: EntityProperty | undefined,
+    value: unknown,
+    insideJson: boolean,
+    fromJson: boolean,
+  ): unknown {
     if (Utils.isScalarReference(value)) {
       value = value.unwrap();
     }
@@ -388,25 +394,69 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
     }
 
     if (insideJson) {
-      // compared against the JSON document, which holds the serialized form
+      // compared against the JSON document, which holds the JSON form of the database value
       if (value instanceof Date) {
         return value.toISOString();
       }
 
-      // restore the JS value from the serialized form, `processWhere` then converts it to
-      // the database form, which is what the JSON document holds for custom typed props
-      return prop?.customType ? prop.customType.convertToJSValue(value, this.platform) : value;
+      if (prop?.customType && fromJson) {
+        const restored = prop.customType.fromJSON
+          ? prop.customType.fromJSON(value, this.platform)
+          : prop.customType.convertToJSValue(value, this.platform);
+
+        // a restored `Date` compares against its ISO string in the document, everything else
+        // keeps the JS value and gets its single `convertToDatabaseValue` in `processWhere`
+        if (restored instanceof Date) {
+          const converted = prop.customType.convertToDatabaseValue(restored, this.platform, {
+            fromQuery: true,
+            key: prop.name,
+            mode: 'query',
+          });
+
+          if (converted instanceof Date) {
+            return converted.toISOString();
+          }
+        }
+
+        return restored;
+      }
+
+      return value;
     }
 
-    if (
-      typeof value === 'string' &&
-      (prop?.runtimeType === 'Date' ||
-        (prop?.customType && this.platform.getMappedType(prop.columnTypes?.[0] ?? '') instanceof DateTimeType))
-    ) {
-      value = new Date(value);
+    if (prop?.customType) {
+      if (fromJson && prop.customType.fromJSON) {
+        // the type owns its JSON round trip
+        return prop.customType.fromJSON(value, this.platform);
+      }
+
+      // A string is either a serialized form (string cursor) or a hand-written one (POJO).
+      // Types whose JS value is a `Date` must receive one. The rest get the string first,
+      // so any sub-millisecond precision survives.
+      if (
+        typeof value === 'string' &&
+        (prop.runtimeType === 'Date' || this.platform.getMappedType(prop.columnTypes?.[0] ?? '').runtimeType === 'Date')
+      ) {
+        if (prop.runtimeType !== 'Date') {
+          try {
+            return prop.customType.convertToJSValue(value, this.platform);
+          } catch {
+            // the type cannot read the serialized string, fall back to the `Date` form
+          }
+        }
+
+        return prop.customType.convertToJSValue(new Date(value), this.platform);
+      }
+
+      // serialized non-string values still need restoring; POJO values are already JS values
+      return fromJson ? prop.customType.convertToJSValue(value, this.platform) : value;
     }
 
-    return prop?.customType ? prop.customType.convertToJSValue(value, this.platform) : value;
+    if (typeof value === 'string' && prop?.runtimeType === 'Date') {
+      return new Date(value);
+    }
+
+    return value;
   }
 
   protected createCursorCondition<T extends object>(
@@ -414,6 +464,7 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
     offsets: Dictionary[],
     inverse: boolean,
     meta: EntityMetadata<T>,
+    fromJson = false,
   ): FilterQuery<T> {
     const createCondition = (
       prop: string,
@@ -476,7 +527,7 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
         throw CursorError.missingValue(meta.className, path);
       }
 
-      offset = this.mapCursorOffset(propMeta, offset, insideJson) as Dictionary;
+      offset = this.mapCursorOffset(propMeta, offset, insideJson, fromJson) as Dictionary;
 
       // Handle null offset (intentional null cursor value)
       if (offset === null) {
@@ -512,7 +563,7 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
       ...createCondition(prop, direction, offset, true),
       $or: [
         createCondition(prop, direction, offset),
-        this.createCursorCondition(otherOrders, otherOffsets, inverse, meta),
+        this.createCursorCondition(otherOrders, otherOffsets, inverse, meta, fromJson),
       ],
     } as FilterQuery<T>;
   }

--- a/packages/core/src/drivers/DatabaseDriver.ts
+++ b/packages/core/src/drivers/DatabaseDriver.ts
@@ -344,17 +344,38 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
       options.limit = limit + (overfetch ? 1 : 0);
     }
 
-    const createOrderBy = (prop: string, direction: QueryOrderKeys<T>): OrderDefinition<T> => {
+    const createOrderBy = (
+      prop: string,
+      direction: QueryOrderKeys<T>,
+      properties: Dictionary<EntityProperty> = meta.properties as Dictionary<EntityProperty>,
+      nullable = false,
+    ): OrderDefinition<T> => {
+      const propMeta = properties[prop];
+      // a nullable relation or embeddable makes its joined columns null too
+      nullable ||= !!propMeta?.nullable;
+
       if (Utils.isPlainObject(direction)) {
+        const childProps =
+          propMeta?.kind === ReferenceKind.EMBEDDED ? propMeta.embeddedProps : propMeta?.targetMeta?.properties;
         const value = Utils.getObjectQueryKeys(direction).reduce((o, key) => {
-          Object.assign(o, createOrderBy(key as string, direction[key] as unknown as QueryOrderKeys<T>));
+          Object.assign(
+            o,
+            createOrderBy(key as string, direction[key] as unknown as QueryOrderKeys<T>, childProps ?? {}, nullable),
+          );
           return o;
         }, {});
         return { [prop]: value } as OrderDefinition<T>;
       }
 
-      const desc = (direction as unknown) === QueryOrderNumeric.DESC || direction.toString().toLowerCase() === 'desc';
+      const { desc, nullsFirst } = this.parseCursorDirection(direction);
       const dir = Utils.xor(desc, isLast) ? 'desc' : 'asc';
+
+      // the condition assumes a placement, spell it out instead of taking the database default
+      if (nullable && this.platform.supportsNullsOrdering()) {
+        const nulls = Utils.xor(nullsFirst, isLast) ? 'first' : 'last';
+        return { [prop]: `${dir} nulls ${nulls}` } as OrderDefinition<T>;
+      }
+
       return { [prop]: dir } as OrderDefinition<T>;
     };
 
@@ -375,10 +396,37 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
   }
 
   /**
-   * Restores the JS value of a single cursor offset: ISO strings become `Date` instances based on the
-   * property type (never based on the string shape alone), and custom types are restored via
-   * `convertToJSValue`. Values compared against a JSON document keep their serialized form instead,
-   * unless the platform preserves native date types inside JSON documents (mongo).
+   * Resolves a leaf `orderBy` direction into the two flags the rewritten `orderBy` and the cursor
+   * condition have to agree on, or pagination skips rows at the null boundary. Platforms that cannot
+   * order nulls explicitly sort them as the lowest value, elsewhere the requested placement wins,
+   * defaulting to nulls last for `asc` and nulls first for `desc`.
+   */
+  private parseCursorDirection(direction: unknown): { desc: boolean; nullsFirst: boolean } {
+    const dir = ('' + direction).toLowerCase();
+    const desc = direction === QueryOrderNumeric.DESC || dir.startsWith('desc');
+
+    if (!this.platform.supportsNullsOrdering()) {
+      return { desc, nullsFirst: !desc };
+    }
+
+    if (dir.includes('nulls first')) {
+      return { desc, nullsFirst: true };
+    }
+
+    if (dir.includes('nulls last')) {
+      return { desc, nullsFirst: false };
+    }
+
+    return { desc, nullsFirst: desc };
+  }
+
+  /**
+   * Restores the JS value of a single cursor offset. String-cursor values (`fromJson`) are decoded
+   * JSON: types implementing `fromJSON` own the round trip, other custom types restore via
+   * `convertToJSValue`, with `Date` healing for date-like columns based on the property type (never
+   * based on the string shape alone). POJO values are already JS values and only date-like strings
+   * are healed. Values compared against a JSON document keep their serialized form instead, unless
+   * the platform preserves native date types inside JSON documents (mongo).
    */
   private mapCursorOffset(
     prop: EntityProperty | undefined,
@@ -481,8 +529,11 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
       path = prop,
       properties: Dictionary<EntityProperty> = meta.properties as Dictionary<EntityProperty>,
       insideJson = false,
+      nullable = false,
     ): Dictionary => {
       const propMeta = properties[prop];
+      // a nullable relation or embeddable makes its joined columns null too
+      nullable ||= !!propMeta?.nullable;
 
       if (Utils.isPlainObject(direction)) {
         if (offset === undefined) {
@@ -496,37 +547,33 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
         insideJson ||=
           (propMeta?.kind === ReferenceKind.EMBEDDED && !!propMeta.object) || propMeta?.customType instanceof JsonType;
 
-        const value = Utils.keys(direction).reduce((o, key) => {
-          Object.assign(
-            o,
+        const children = Utils.keys(direction)
+          .map(key =>
             createCondition(
               key,
               direction[key] as QueryOrderKeys<T>,
-              offset?.[key],
+              // a null relation offset means the whole sort key is null, propagate it to the leaves
+              offset === null ? null : offset[key],
               eq,
               `${path}.${key}`,
               childProps ?? {},
               insideJson,
+              nullable,
             ),
-          );
-          return o;
-        }, {});
-        return { [prop]: value };
+          )
+          .filter(child => Utils.hasObjectKeys(child));
+
+        // children comparing against nulls are group conditions, those cannot be merged into one object
+        const value =
+          children.length > 1 && children.some(child => '$or' in child)
+            ? { $and: children }
+            : children.reduce((o, child) => Object.assign(o, child), {} as Dictionary);
+
+        // an unconstrained child condition must not degrade to `{ [prop]: {} }`
+        return children.length > 0 ? { [prop]: value } : {};
       }
 
-      const isDesc = (direction as unknown) === QueryOrderNumeric.DESC || direction.toString().toLowerCase() === 'desc';
-      const dirStr = direction.toString().toLowerCase();
-      let nullsFirst: boolean;
-
-      if (dirStr.includes('nulls first')) {
-        nullsFirst = true;
-      } else if (dirStr.includes('nulls last')) {
-        nullsFirst = false;
-      } else {
-        // Default: NULLS LAST for ASC, NULLS FIRST for DESC (matches most databases)
-        nullsFirst = isDesc;
-      }
-
+      const { desc: isDesc, nullsFirst } = this.parseCursorDirection(direction);
       const operator = Utils.xor(isDesc, inverse) ? '$lt' : '$gt';
 
       // For leaf-level properties, undefined means missing value
@@ -548,14 +595,16 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
 
       // Handle null offset (intentional null cursor value)
       if (offset === null) {
+        // hasItemsAfterNull: forward + nullsFirst, or backward + nullsLast
+        const hasItemsAfterNull = Utils.xor(nullsFirst, inverse);
+
         if (eq) {
-          // Equal to null
-          return { [prop]: null };
+          // at-or-after a null sort key means every row when non-null rows follow the null block,
+          // so the tie-breaker in the `$or` sibling can reach past it
+          return hasItemsAfterNull ? {} : { [prop]: null };
         }
 
         // Strict comparison with null cursor value
-        // hasItemsAfterNull: forward + nullsFirst, or backward + nullsLast
-        const hasItemsAfterNull = Utils.xor(nullsFirst, inverse);
         if (hasItemsAfterNull) {
           return { [prop]: { $ne: null } };
         }
@@ -565,7 +614,14 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
       }
 
       // Non-null offset
-      return { [prop]: { [operator + (eq ? 'e' : '')]: offset } };
+      const condition = { [prop]: { [operator + (eq ? 'e' : '')]: offset } };
+
+      // null sort keys lie past the offset here, and no comparison ever matches them
+      if (nullable && !Utils.xor(nullsFirst, inverse)) {
+        return { $or: [condition, { [prop]: null }] };
+      }
+
+      return condition;
     };
 
     const [order, ...otherOrders] = definition;
@@ -576,13 +632,20 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
       return createCondition(prop, direction, offset) as FilterQuery<T>;
     }
 
-    return {
-      ...createCondition(prop, direction, offset, true),
+    const atOrPast = createCondition(prop, direction, offset, true);
+    const past = {
       $or: [
         createCondition(prop, direction, offset),
         this.createCursorCondition(otherOrders, otherOffsets, inverse, meta, fromJson),
       ],
-    } as FilterQuery<T>;
+    };
+
+    // the `at or past` prefix is itself a group condition when it compares against nulls
+    if ('$or' in atOrPast) {
+      return { $and: [atOrPast, past] } as FilterQuery<T>;
+    }
+
+    return { ...atOrPast, ...past } as FilterQuery<T>;
   }
 
   /** @internal */

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -200,6 +200,12 @@ export class CursorError<T extends AnyEntity = AnyEntity> extends ValidationErro
   static missingValue(entityName: string, prop: string): ValidationError {
     return new CursorError(`Invalid cursor condition, value for '${entityName}.${prop}' is missing.`);
   }
+
+  static invalidCursor(entityName: string, cause: Error): CursorError {
+    const error = new CursorError(`Invalid cursor for entity ${entityName}: ${cause.message}`);
+    error.cause = cause;
+    return error;
+  }
 }
 
 /** Error thrown when an optimistic lock conflict is detected during entity persistence. */

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -247,6 +247,12 @@ export class CursorError<T extends AnyEntity = AnyEntity> extends ValidationErro
   static missingValue(entityName: string, prop: string): ValidationError {
     return new CursorError(`Invalid cursor condition, value for '${entityName}.${prop}' is missing.`);
   }
+
+  static invalidCursor(entityName: string, cause: Error): CursorError {
+    const error = new CursorError(`Invalid cursor for entity ${entityName}: ${cause.message}`);
+    error.cause = cause;
+    return error;
+  }
 }
 
 /** Error thrown when an optimistic lock conflict is detected during entity persistence. */

--- a/packages/core/src/platforms/Platform.ts
+++ b/packages/core/src/platforms/Platform.ts
@@ -631,6 +631,11 @@ export abstract class Platform {
     return false;
   }
 
+  /** Whether `nulls first`/`nulls last` can be requested in an `orderBy`. Platforms returning `false` always sort nulls as the lowest value. */
+  supportsNullsOrdering(): boolean {
+    return true;
+  }
+
   /** Converts a JS value to its JSON database representation (typically JSON.stringify). */
   convertJsonToDatabaseValue(value: unknown, context?: TransformContext): unknown {
     return JSON.stringify(value);

--- a/packages/core/src/types/BigIntType.ts
+++ b/packages/core/src/types/BigIntType.ts
@@ -1,6 +1,7 @@
 import { Type } from './Type.js';
 import type { Platform } from '../platforms/Platform.js';
 import type { EntityProperty } from '../typings.js';
+import { ValidationError } from '../errors.js';
 
 /**
  * This type will automatically convert string values returned from the database to native JS bigints (default)
@@ -45,6 +46,26 @@ export class BigIntType<Mode extends 'bigint' | 'number' | 'string' = 'bigint'> 
     }
 
     return this.convertToDatabaseValue(value) as JSTypeByMode<Mode> | null | undefined;
+  }
+
+  override fromJSON(value: unknown): JSTypeByMode<Mode> | null | undefined {
+    // the serialized form is a decimal string, or a plain number in `number` mode
+    const valid =
+      (typeof value === 'string' && /^-?\d+$/.test(value)) || (typeof value === 'number' && Number.isInteger(value));
+
+    if (!valid) {
+      throw ValidationError.invalidType(BigIntType, value, 'JSON');
+    }
+
+    switch (this.mode) {
+      case 'number':
+        return Number(value) as JSTypeByMode<Mode>;
+      case 'string':
+        return String(value) as JSTypeByMode<Mode>;
+      case 'bigint':
+      default:
+        return BigInt(value) as JSTypeByMode<Mode>;
+    }
   }
 
   override getColumnType(prop: EntityProperty, platform: Platform): string {

--- a/packages/core/src/types/BigIntType.ts
+++ b/packages/core/src/types/BigIntType.ts
@@ -58,8 +58,16 @@ export class BigIntType<Mode extends 'bigint' | 'number' | 'string' = 'bigint'> 
     }
 
     switch (this.mode) {
-      case 'number':
-        return Number(value) as JSTypeByMode<Mode>;
+      case 'number': {
+        // `Number` silently rounds past `MAX_SAFE_INTEGER`, tampered cursors must fail loudly
+        const num = Number(value);
+
+        if (!Number.isSafeInteger(num)) {
+          throw ValidationError.invalidType(BigIntType, value, 'JSON');
+        }
+
+        return num as JSTypeByMode<Mode>;
+      }
       case 'string':
         return String(value) as JSTypeByMode<Mode>;
       case 'bigint':

--- a/packages/core/src/types/DateTimeType.ts
+++ b/packages/core/src/types/DateTimeType.ts
@@ -1,6 +1,7 @@
 import { Type } from './Type.js';
 import type { Platform } from '../platforms/Platform.js';
 import type { EntityProperty } from '../typings.js';
+import { ValidationError } from '../errors.js';
 
 /** Maps a database DATETIME/TIMESTAMP column to a JS `Date` object. */
 export class DateTimeType extends Type<Date, string> {
@@ -10,6 +11,16 @@ export class DateTimeType extends Type<Date, string> {
 
   override compareAsType(): string {
     return 'Date';
+  }
+
+  override fromJSON(value: unknown): Date {
+    const date = new Date(value as string);
+
+    if (typeof value !== 'string' || Number.isNaN(date.getTime())) {
+      throw ValidationError.invalidType(DateTimeType, value, 'JSON');
+    }
+
+    return date;
   }
 
   override get runtimeType(): string {

--- a/packages/core/src/types/Type.ts
+++ b/packages/core/src/types/Type.ts
@@ -92,6 +92,17 @@ export abstract class Type<JSType = string, DBType = JSType> {
   }
 
   /**
+   * Converts a value from its serialized JSON form back to its JS representation. Used when
+   * decoding cursor values. The input is what `toJSON` produced, after a `JSON.parse` round
+   * trip, and never an already restored JS value. Cursors are client supplied, so the value
+   * can be any JSON shape: validate it and throw for values the type cannot restore.
+   * Implementing this method also makes cursor encoding use `toJSON`. Without it, cursors
+   * carry the raw JS value, and decoding falls back to `convertToJSValue`, with shape based
+   * `Date` restoration for date-like columns.
+   */
+  fromJSON?(value: unknown, platform: Platform): JSType;
+
+  /**
    * Gets the SQL declaration snippet for a field of this type.
    */
   getColumnType(prop: EntityProperty, platform: Platform): string {

--- a/packages/core/src/types/Type.ts
+++ b/packages/core/src/types/Type.ts
@@ -95,7 +95,8 @@ export abstract class Type<JSType = string, DBType = JSType> {
    * Converts a value from its serialized JSON form back to its JS representation. Used when
    * decoding cursor values. The input is what `toJSON` produced, after a `JSON.parse` round
    * trip, and never an already restored JS value. Cursors are client supplied, so the value
-   * can be any JSON shape: validate it and throw for values the type cannot restore.
+   * can be any JSON shape: validate it and throw for values the type cannot restore, and
+   * `findByCursor` surfaces the failure as a `CursorError`.
    * Implementing this method also makes cursor encoding use `toJSON`. Without it, cursors
    * carry the raw JS value, and decoding falls back to `convertToJSValue`, with shape based
    * `Date` restoration for date-like columns.

--- a/packages/core/src/types/Type.ts
+++ b/packages/core/src/types/Type.ts
@@ -98,7 +98,7 @@ export abstract class Type<JSType = string, DBType = JSType> {
    * can be any JSON shape: validate it and throw for values the type cannot restore, and
    * `findByCursor` surfaces the failure as a `CursorError`.
    * Implementing this method also makes cursor encoding use `toJSON`. Without it, cursors
-   * carry the raw JS value, and decoding falls back to `convertToJSValue`, with shape based
+   * carry the raw JS value, and decoding falls back to `convertToJSValue`, with type-based
    * `Date` restoration for date-like columns.
    */
   fromJSON?(value: unknown, platform: Platform): JSType;

--- a/packages/core/src/utils/Cursor.ts
+++ b/packages/core/src/utils/Cursor.ts
@@ -1,4 +1,4 @@
-import type { Dictionary, EntityKey, EntityMetadata, FilterObject, Loaded } from '../typings.js';
+import type { Dictionary, EntityKey, EntityMetadata, EntityProperty, FilterObject, Loaded } from '../typings.js';
 import type { FindByCursorOptions, OrderDefinition } from '../drivers/IDatabaseDriver.js';
 import { Utils } from './Utils.js';
 import { ReferenceKind, type QueryOrder, type QueryOrderKeys } from '../enums.js';
@@ -66,6 +66,7 @@ export class Cursor<
   readonly hasNextPage: boolean;
 
   readonly #definition: (readonly [EntityKey<Entity>, QueryOrder])[];
+  readonly #meta: EntityMetadata<Entity>;
 
   constructor(
     readonly items: Loaded<Entity, Hint, Fields, Excludes>[],
@@ -89,6 +90,7 @@ export class Cursor<
     }
 
     this.#definition = Cursor.getDefinition(meta, orderBy!);
+    this.#meta = meta;
   }
 
   get startCursor(): string | null {
@@ -111,50 +113,69 @@ export class Cursor<
    * Computes the cursor value for a given entity.
    */
   from(entity: Entity | Loaded<Entity, Hint, Fields, Excludes>): string {
-    const processEntity = <T extends object>(
-      entity: T,
-      prop: EntityKey<T>,
-      direction: QueryOrderKeys<T>,
-      object = false,
-    ) => {
-      if (Utils.isPlainObject(direction)) {
-        const unwrapped = Reference.unwrapReference(entity[prop] as T);
-
-        // Check if the relation is loaded - for nested properties, undefined means not populated
-        if (Utils.isEntity(unwrapped) && !helper(unwrapped).isInitialized()) {
-          throw CursorError.entityNotPopulated(entity, prop);
-        }
-
-        return Utils.keys(direction).reduce((o, key) => {
-          Object.assign(o, processEntity(unwrapped, key, direction[key] as QueryOrderKeys<T>, true));
-          return o;
-        }, {} as Dictionary);
-      }
-
-      let value: unknown = entity[prop];
-
-      // Allow null/undefined values in cursor - they will be handled in createCursorCondition
-      // undefined can occur with forceUndefined config option which converts null to undefined
-      if (value == null) {
-        return object ? { [prop]: null } : null;
-      }
-
-      if (Utils.isEntity(value, true)) {
-        value = helper(value).getPrimaryKey();
-      }
-
-      if (Utils.isScalarReference(value)) {
-        value = value.unwrap();
-      }
-
-      if (object) {
-        return { [prop]: value };
-      }
-
-      return value;
-    };
-    const value = this.#definition.map(([key, direction]) => processEntity(entity as Entity, key, direction));
+    const value = this.#definition.map(([key, direction]) =>
+      Cursor.serialize(this.#meta.properties as Dictionary<EntityProperty>, entity as Entity, key, direction),
+    );
     return Cursor.encode(value);
+  }
+
+  /** Serializes a single cursor value, walking nested directions and reading the owner's properties. */
+  private static serialize<T extends object>(
+    properties: Dictionary<EntityProperty>,
+    owner: T,
+    key: EntityKey<T>,
+    direction: unknown,
+  ): unknown {
+    const prop = properties[key as string];
+    let value: unknown = owner[key];
+
+    if (Utils.isPlainObject(direction)) {
+      const unwrapped: unknown = Reference.unwrapReference(value as object);
+
+      // for nested properties, an uninitialized relation means not populated
+      if (Utils.isEntity(unwrapped) && !helper(unwrapped).isInitialized()) {
+        throw CursorError.entityNotPopulated(owner, key as string);
+      }
+
+      if (unwrapped == null || typeof unwrapped !== 'object') {
+        return unwrapped;
+      }
+
+      const childProps = prop?.kind === ReferenceKind.EMBEDDED ? prop.embeddedProps : prop?.targetMeta?.properties;
+
+      return Utils.keys(direction).reduce((o, childKey) => {
+        o[childKey as string] = Cursor.serialize(
+          childProps ?? {},
+          unwrapped as Dictionary,
+          childKey as string,
+          (direction as Dictionary)[childKey as string],
+        );
+        return o;
+      }, {} as Dictionary);
+    }
+
+    // allow null/undefined values in cursor - they will be handled in createCursorCondition
+    // undefined can occur with forceUndefined config option which converts null to undefined
+    if (value == null) {
+      return null;
+    }
+
+    if (Utils.isEntity(value, true)) {
+      value = helper(value).getPrimaryKey();
+    }
+
+    if (Utils.isScalarReference(value)) {
+      value = value.unwrap();
+    }
+
+    // only types implementing `fromJSON` own their wire format, others keep the raw JS value,
+    // so their cursors stay decodable by the `convertToJSValue` fallback
+    if (prop?.customType?.fromJSON) {
+      // the platform is assigned to the type instance during discovery
+      return prop.customType.toJSON(value as never, prop.customType.platform!);
+    }
+
+    return value;
   }
 
   *[Symbol.iterator](): IterableIterator<Loaded<Entity, Hint, Fields, Excludes>> {
@@ -176,13 +197,14 @@ export class Cursor<
     orderBy: OrderDefinition<Entity>,
   ): string {
     const definition = this.getDefinition(meta, orderBy);
+
     return Cursor.encode(
-      definition.map(([key]) => {
-        const value = entity[key];
-        if (value === undefined) {
+      definition.map(([key, direction]) => {
+        if (entity[key] === undefined) {
           throw CursorError.missingValue(meta.className, key as string);
         }
-        return value;
+
+        return this.serialize(meta.properties as Dictionary<EntityProperty>, entity as object, key as never, direction);
       }),
     );
   }

--- a/packages/core/src/utils/Cursor.ts
+++ b/packages/core/src/utils/Cursor.ts
@@ -1,7 +1,7 @@
 import type { Dictionary, EntityKey, EntityMetadata, EntityProperty, FilterObject, Loaded } from '../typings.js';
 import type { FindByCursorOptions, OrderDefinition } from '../drivers/IDatabaseDriver.js';
 import { Utils } from './Utils.js';
-import { ReferenceKind, type QueryOrder, type QueryOrderKeys } from '../enums.js';
+import { ReferenceKind, type QueryOrder } from '../enums.js';
 import { Reference } from '../entity/Reference.js';
 import { helper } from '../entity/wrap.js';
 import { Raw } from '../utils/RawQueryFragment.js';

--- a/packages/mongodb/src/MongoPlatform.ts
+++ b/packages/mongodb/src/MongoPlatform.ts
@@ -92,6 +92,10 @@ export class MongoPlatform extends Platform {
     return true;
   }
 
+  override supportsNullsOrdering(): boolean {
+    return false;
+  }
+
   override convertJsonToDatabaseValue(value: unknown): unknown {
     return Utils.copy(value);
   }

--- a/tests/features/cursor-based-pagination/__snapshots__/complex-cursor.test.ts.snap
+++ b/tests/features/cursor-based-pagination/__snapshots__/complex-cursor.test.ts.snap
@@ -31,14 +31,14 @@ exports[`simple cursor based pagination (mssql) > complex cursor based paginatio
 exports[`simple cursor based pagination (mssql) > complex joined cursor based pagination using \`last\` and \`before\` (id asc) 1`] = `
 [
   "[query] select count(*) as [count] from [user] as [u0] left join [user] as [b1] on [u0].[best_friend__id] = [b1].[_id] where [b1].[name] = N'User 3'",
-  "[query] select top (6) [u0].*, [b1].[_id] as [b1___id], [b1].[name] as [b1__name], [b1].[email] as [b1__email], [b1].[age] as [b1__age], [b1].[terms_accepted] as [b1__terms_accepted], [b1].[best_friend__id] as [b1__best_friend__id] from [user] as [u0] left join [user] as [b1] on [u0].[best_friend__id] = [b1].[_id] where [b1].[name] = N'User 3' order by [b1].[email] desc, [b1].[name] desc, [u0].[name] asc, [u0].[age] desc, [u0].[email] desc",
+  "[query] select top (6) [u0].*, [b1].[_id] as [b1___id], [b1].[name] as [b1__name], [b1].[email] as [b1__email], [b1].[age] as [b1__age], [b1].[terms_accepted] as [b1__terms_accepted], [b1].[best_friend__id] as [b1__best_friend__id] from [user] as [u0] left join [user] as [b1] on [u0].[best_friend__id] = [b1].[_id] where [b1].[name] = N'User 3' order by case when [b1].[email] is null then 0 else 1 end, [b1].[email] desc, case when [b1].[name] is null then 0 else 1 end, [b1].[name] desc, [u0].[name] asc, [u0].[age] desc, [u0].[email] desc",
 ]
 `;
 
 exports[`simple cursor based pagination (mssql) > complex joined cursor based pagination using \`last\` and \`before\` (id asc) 2`] = `
 [
   "[query] select count(*) as [count] from [user] as [u0] left join [user] as [b1] on [u0].[best_friend__id] = [b1].[_id] where [b1].[name] = N'User 3'",
-  "[query] select top (6) [u0].*, [b1].[_id] as [b1___id], [b1].[name] as [b1__name], [b1].[email] as [b1__email], [b1].[age] as [b1__age], [b1].[terms_accepted] as [b1__terms_accepted], [b1].[best_friend__id] as [b1__best_friend__id] from [user] as [u0] left join [user] as [b1] on [u0].[best_friend__id] = [b1].[_id] where [b1].[name] = N'User 3' and [b1].[email] <= N'email-96' and [b1].[name] <= N'User 3' and (([b1].[email] < N'email-96' and [b1].[name] < N'User 3') or ([u0].[name] >= N'User 3' and ([u0].[name] > N'User 3' or ([u0].[age] <= 38 and ([u0].[age] < 38 or [u0].[email] < N'email-76'))))) order by [b1].[email] desc, [b1].[name] desc, [u0].[name] asc, [u0].[age] desc, [u0].[email] desc",
+  "[query] select top (6) [u0].*, [b1].[_id] as [b1___id], [b1].[name] as [b1__name], [b1].[email] as [b1__email], [b1].[age] as [b1__age], [b1].[terms_accepted] as [b1__terms_accepted], [b1].[best_friend__id] as [b1__best_friend__id] from [user] as [u0] left join [user] as [b1] on [u0].[best_friend__id] = [b1].[_id] where [b1].[name] = N'User 3' and [b1].[email] <= N'email-96' and [b1].[name] <= N'User 3' and (([b1].[email] < N'email-96' and [b1].[name] < N'User 3') or ([u0].[name] >= N'User 3' and ([u0].[name] > N'User 3' or ([u0].[age] <= 38 and ([u0].[age] < 38 or [u0].[email] < N'email-76'))))) order by case when [b1].[email] is null then 0 else 1 end, [b1].[email] desc, case when [b1].[name] is null then 0 else 1 end, [b1].[name] desc, [u0].[name] asc, [u0].[age] desc, [u0].[email] desc",
 ]
 `;
 
@@ -58,14 +58,14 @@ exports[`simple cursor based pagination (mysql) > complex cursor based paginatio
 
 exports[`simple cursor based pagination (mysql) > complex joined cursor based pagination using \`last\` and \`before\` (id asc) 1`] = `
 [
-  "[query] select \`u0\`.*, \`b1\`.\`_id\` as \`b1___id\`, \`b1\`.\`name\` as \`b1__name\`, \`b1\`.\`email\` as \`b1__email\`, \`b1\`.\`age\` as \`b1__age\`, \`b1\`.\`terms_accepted\` as \`b1__terms_accepted\`, \`b1\`.\`best_friend__id\` as \`b1__best_friend__id\` from \`user\` as \`u0\` left join \`user\` as \`b1\` on \`u0\`.\`best_friend__id\` = \`b1\`.\`_id\` where \`b1\`.\`name\` = 'User 3' order by \`b1\`.\`email\` desc, \`b1\`.\`name\` desc, \`u0\`.\`name\` asc, \`u0\`.\`age\` desc, \`u0\`.\`email\` desc limit 6",
+  "[query] select \`u0\`.*, \`b1\`.\`_id\` as \`b1___id\`, \`b1\`.\`name\` as \`b1__name\`, \`b1\`.\`email\` as \`b1__email\`, \`b1\`.\`age\` as \`b1__age\`, \`b1\`.\`terms_accepted\` as \`b1__terms_accepted\`, \`b1\`.\`best_friend__id\` as \`b1__best_friend__id\` from \`user\` as \`u0\` left join \`user\` as \`b1\` on \`u0\`.\`best_friend__id\` = \`b1\`.\`_id\` where \`b1\`.\`name\` = 'User 3' order by \`b1\`.\`email\` is not null, \`b1\`.\`email\` desc, \`b1\`.\`name\` is not null, \`b1\`.\`name\` desc, \`u0\`.\`name\` asc, \`u0\`.\`age\` desc, \`u0\`.\`email\` desc limit 6",
   "[query] select count(*) as \`count\` from \`user\` as \`u0\` left join \`user\` as \`b1\` on \`u0\`.\`best_friend__id\` = \`b1\`.\`_id\` where \`b1\`.\`name\` = 'User 3'",
 ]
 `;
 
 exports[`simple cursor based pagination (mysql) > complex joined cursor based pagination using \`last\` and \`before\` (id asc) 2`] = `
 [
-  "[query] select \`u0\`.*, \`b1\`.\`_id\` as \`b1___id\`, \`b1\`.\`name\` as \`b1__name\`, \`b1\`.\`email\` as \`b1__email\`, \`b1\`.\`age\` as \`b1__age\`, \`b1\`.\`terms_accepted\` as \`b1__terms_accepted\`, \`b1\`.\`best_friend__id\` as \`b1__best_friend__id\` from \`user\` as \`u0\` left join \`user\` as \`b1\` on \`u0\`.\`best_friend__id\` = \`b1\`.\`_id\` where \`b1\`.\`name\` = 'User 3' and \`b1\`.\`email\` <= 'email-96' and \`b1\`.\`name\` <= 'User 3' and ((\`b1\`.\`email\` < 'email-96' and \`b1\`.\`name\` < 'User 3') or (\`u0\`.\`name\` >= 'User 3' and (\`u0\`.\`name\` > 'User 3' or (\`u0\`.\`age\` <= 38 and (\`u0\`.\`age\` < 38 or \`u0\`.\`email\` < 'email-76'))))) order by \`b1\`.\`email\` desc, \`b1\`.\`name\` desc, \`u0\`.\`name\` asc, \`u0\`.\`age\` desc, \`u0\`.\`email\` desc limit 6",
+  "[query] select \`u0\`.*, \`b1\`.\`_id\` as \`b1___id\`, \`b1\`.\`name\` as \`b1__name\`, \`b1\`.\`email\` as \`b1__email\`, \`b1\`.\`age\` as \`b1__age\`, \`b1\`.\`terms_accepted\` as \`b1__terms_accepted\`, \`b1\`.\`best_friend__id\` as \`b1__best_friend__id\` from \`user\` as \`u0\` left join \`user\` as \`b1\` on \`u0\`.\`best_friend__id\` = \`b1\`.\`_id\` where \`b1\`.\`name\` = 'User 3' and \`b1\`.\`email\` <= 'email-96' and \`b1\`.\`name\` <= 'User 3' and ((\`b1\`.\`email\` < 'email-96' and \`b1\`.\`name\` < 'User 3') or (\`u0\`.\`name\` >= 'User 3' and (\`u0\`.\`name\` > 'User 3' or (\`u0\`.\`age\` <= 38 and (\`u0\`.\`age\` < 38 or \`u0\`.\`email\` < 'email-76'))))) order by \`b1\`.\`email\` is not null, \`b1\`.\`email\` desc, \`b1\`.\`name\` is not null, \`b1\`.\`name\` desc, \`u0\`.\`name\` asc, \`u0\`.\`age\` desc, \`u0\`.\`email\` desc limit 6",
   "[query] select count(*) as \`count\` from \`user\` as \`u0\` left join \`user\` as \`b1\` on \`u0\`.\`best_friend__id\` = \`b1\`.\`_id\` where \`b1\`.\`name\` = 'User 3'",
 ]
 `;
@@ -86,14 +86,14 @@ exports[`simple cursor based pagination (postgresql) > complex cursor based pagi
 
 exports[`simple cursor based pagination (postgresql) > complex joined cursor based pagination using \`last\` and \`before\` (id asc) 1`] = `
 [
-  "[query] select "u0".*, "b1"."_id" as "b1___id", "b1"."name" as "b1__name", "b1"."email" as "b1__email", "b1"."age" as "b1__age", "b1"."terms_accepted" as "b1__terms_accepted", "b1"."best_friend__id" as "b1__best_friend__id" from "user" as "u0" left join "user" as "b1" on "u0"."best_friend__id" = "b1"."_id" where "b1"."name" = 'User 3' order by "b1"."email" desc, "b1"."name" desc, "u0"."name" asc, "u0"."age" desc, "u0"."email" desc limit 6",
+  "[query] select "u0".*, "b1"."_id" as "b1___id", "b1"."name" as "b1__name", "b1"."email" as "b1__email", "b1"."age" as "b1__age", "b1"."terms_accepted" as "b1__terms_accepted", "b1"."best_friend__id" as "b1__best_friend__id" from "user" as "u0" left join "user" as "b1" on "u0"."best_friend__id" = "b1"."_id" where "b1"."name" = 'User 3' order by "b1"."email" desc nulls first, "b1"."name" desc nulls first, "u0"."name" asc, "u0"."age" desc, "u0"."email" desc limit 6",
   "[query] select count(*) as "count" from "user" as "u0" left join "user" as "b1" on "u0"."best_friend__id" = "b1"."_id" where "b1"."name" = 'User 3'",
 ]
 `;
 
 exports[`simple cursor based pagination (postgresql) > complex joined cursor based pagination using \`last\` and \`before\` (id asc) 2`] = `
 [
-  "[query] select "u0".*, "b1"."_id" as "b1___id", "b1"."name" as "b1__name", "b1"."email" as "b1__email", "b1"."age" as "b1__age", "b1"."terms_accepted" as "b1__terms_accepted", "b1"."best_friend__id" as "b1__best_friend__id" from "user" as "u0" left join "user" as "b1" on "u0"."best_friend__id" = "b1"."_id" where "b1"."name" = 'User 3' and "b1"."email" <= 'email-96' and "b1"."name" <= 'User 3' and (("b1"."email" < 'email-96' and "b1"."name" < 'User 3') or ("u0"."name" >= 'User 3' and ("u0"."name" > 'User 3' or ("u0"."age" <= 38 and ("u0"."age" < 38 or "u0"."email" < 'email-76'))))) order by "b1"."email" desc, "b1"."name" desc, "u0"."name" asc, "u0"."age" desc, "u0"."email" desc limit 6",
+  "[query] select "u0".*, "b1"."_id" as "b1___id", "b1"."name" as "b1__name", "b1"."email" as "b1__email", "b1"."age" as "b1__age", "b1"."terms_accepted" as "b1__terms_accepted", "b1"."best_friend__id" as "b1__best_friend__id" from "user" as "u0" left join "user" as "b1" on "u0"."best_friend__id" = "b1"."_id" where "b1"."name" = 'User 3' and "b1"."email" <= 'email-96' and "b1"."name" <= 'User 3' and (("b1"."email" < 'email-96' and "b1"."name" < 'User 3') or ("u0"."name" >= 'User 3' and ("u0"."name" > 'User 3' or ("u0"."age" <= 38 and ("u0"."age" < 38 or "u0"."email" < 'email-76'))))) order by "b1"."email" desc nulls first, "b1"."name" desc nulls first, "u0"."name" asc, "u0"."age" desc, "u0"."email" desc limit 6",
   "[query] select count(*) as "count" from "user" as "u0" left join "user" as "b1" on "u0"."best_friend__id" = "b1"."_id" where "b1"."name" = 'User 3'",
 ]
 `;
@@ -114,14 +114,14 @@ exports[`simple cursor based pagination (sqlite) > complex cursor based paginati
 
 exports[`simple cursor based pagination (sqlite) > complex joined cursor based pagination using \`last\` and \`before\` (id asc) 1`] = `
 [
-  "[query] select \`u0\`.*, \`b1\`.\`_id\` as \`b1___id\`, \`b1\`.\`name\` as \`b1__name\`, \`b1\`.\`email\` as \`b1__email\`, \`b1\`.\`age\` as \`b1__age\`, \`b1\`.\`terms_accepted\` as \`b1__terms_accepted\`, \`b1\`.\`best_friend__id\` as \`b1__best_friend__id\` from \`user\` as \`u0\` left join \`user\` as \`b1\` on \`u0\`.\`best_friend__id\` = \`b1\`.\`_id\` where \`b1\`.\`name\` = 'User 3' order by \`b1\`.\`email\` desc, \`b1\`.\`name\` desc, \`u0\`.\`name\` asc, \`u0\`.\`age\` desc, \`u0\`.\`email\` desc limit 6",
+  "[query] select \`u0\`.*, \`b1\`.\`_id\` as \`b1___id\`, \`b1\`.\`name\` as \`b1__name\`, \`b1\`.\`email\` as \`b1__email\`, \`b1\`.\`age\` as \`b1__age\`, \`b1\`.\`terms_accepted\` as \`b1__terms_accepted\`, \`b1\`.\`best_friend__id\` as \`b1__best_friend__id\` from \`user\` as \`u0\` left join \`user\` as \`b1\` on \`u0\`.\`best_friend__id\` = \`b1\`.\`_id\` where \`b1\`.\`name\` = 'User 3' order by \`b1\`.\`email\` desc nulls first, \`b1\`.\`name\` desc nulls first, \`u0\`.\`name\` asc, \`u0\`.\`age\` desc, \`u0\`.\`email\` desc limit 6",
   "[query] select count(*) as \`count\` from \`user\` as \`u0\` left join \`user\` as \`b1\` on \`u0\`.\`best_friend__id\` = \`b1\`.\`_id\` where \`b1\`.\`name\` = 'User 3'",
 ]
 `;
 
 exports[`simple cursor based pagination (sqlite) > complex joined cursor based pagination using \`last\` and \`before\` (id asc) 2`] = `
 [
-  "[query] select \`u0\`.*, \`b1\`.\`_id\` as \`b1___id\`, \`b1\`.\`name\` as \`b1__name\`, \`b1\`.\`email\` as \`b1__email\`, \`b1\`.\`age\` as \`b1__age\`, \`b1\`.\`terms_accepted\` as \`b1__terms_accepted\`, \`b1\`.\`best_friend__id\` as \`b1__best_friend__id\` from \`user\` as \`u0\` left join \`user\` as \`b1\` on \`u0\`.\`best_friend__id\` = \`b1\`.\`_id\` where \`b1\`.\`name\` = 'User 3' and \`b1\`.\`email\` <= 'email-96' and \`b1\`.\`name\` <= 'User 3' and ((\`b1\`.\`email\` < 'email-96' and \`b1\`.\`name\` < 'User 3') or (\`u0\`.\`name\` >= 'User 3' and (\`u0\`.\`name\` > 'User 3' or (\`u0\`.\`age\` <= 38 and (\`u0\`.\`age\` < 38 or \`u0\`.\`email\` < 'email-76'))))) order by \`b1\`.\`email\` desc, \`b1\`.\`name\` desc, \`u0\`.\`name\` asc, \`u0\`.\`age\` desc, \`u0\`.\`email\` desc limit 6",
+  "[query] select \`u0\`.*, \`b1\`.\`_id\` as \`b1___id\`, \`b1\`.\`name\` as \`b1__name\`, \`b1\`.\`email\` as \`b1__email\`, \`b1\`.\`age\` as \`b1__age\`, \`b1\`.\`terms_accepted\` as \`b1__terms_accepted\`, \`b1\`.\`best_friend__id\` as \`b1__best_friend__id\` from \`user\` as \`u0\` left join \`user\` as \`b1\` on \`u0\`.\`best_friend__id\` = \`b1\`.\`_id\` where \`b1\`.\`name\` = 'User 3' and \`b1\`.\`email\` <= 'email-96' and \`b1\`.\`name\` <= 'User 3' and ((\`b1\`.\`email\` < 'email-96' and \`b1\`.\`name\` < 'User 3') or (\`u0\`.\`name\` >= 'User 3' and (\`u0\`.\`name\` > 'User 3' or (\`u0\`.\`age\` <= 38 and (\`u0\`.\`age\` < 38 or \`u0\`.\`email\` < 'email-76'))))) order by \`b1\`.\`email\` desc nulls first, \`b1\`.\`name\` desc nulls first, \`u0\`.\`name\` asc, \`u0\`.\`age\` desc, \`u0\`.\`email\` desc limit 6",
   "[query] select count(*) as \`count\` from \`user\` as \`u0\` left join \`user\` as \`b1\` on \`u0\`.\`best_friend__id\` = \`b1\`.\`_id\` where \`b1\`.\`name\` = 'User 3'",
 ]
 `;

--- a/tests/features/cursor-based-pagination/cursor-custom-types.test.ts
+++ b/tests/features/cursor-based-pagination/cursor-custom-types.test.ts
@@ -1,4 +1,4 @@
-import { BigIntType, Cursor, DateTimeType, Reference, ScalarReference, Type } from '@mikro-orm/core';
+import { BigIntType, Cursor, CursorError, DateTimeType, Reference, ScalarReference, Type } from '@mikro-orm/core';
 import { MikroORM } from '@mikro-orm/sqlite';
 import {
   Embeddable,
@@ -994,6 +994,40 @@ test('scalar value where a nested cursor object is expected', async () => {
       orderBy: { owner: { since: 'asc' }, id: 'asc' },
     }),
   ).rejects.toThrow("value for 'Job.owner.since' is missing");
+});
+
+test('invalid string cursors surface as CursorError', async () => {
+  // undecodable payload
+  await expect(
+    orm.em.findByCursor(Job, {
+      first: 3,
+      after: '!!not a cursor!!',
+      orderBy: { id: 'asc' },
+    }),
+  ).rejects.toThrow(CursorError);
+
+  // decodable payload the type cannot restore, original error kept on the cause chain
+  const tampered = orm.em.findByCursor(Job, {
+    first: 3,
+    after: Cursor.encode(['nope', 3]),
+    orderBy: { loggedAt: 'asc', id: 'asc' },
+  });
+  await expect(tampered).rejects.toThrow(CursorError);
+  await expect(tampered).rejects.toThrow(
+    "Invalid cursor for entity Job: Could not convert JSON value 'nope' of type 'string' to type DateTimeType",
+  );
+});
+
+test('`BigIntType.fromJSON` restores all three modes', () => {
+  expect(new BigIntType().fromJSON('1003')).toBe(BigInt(1003));
+  expect(new BigIntType('number').fromJSON(2003)).toBe(2003);
+  expect(new BigIntType('string').fromJSON('3003')).toBe('3003');
+});
+
+test('`Cursor.for` keeps non-object values under a nested direction', () => {
+  const meta = orm.getMetadata().get(Job);
+  const encoded = Cursor.for(meta, { owner: null, id: 3 } as never, { owner: { since: 'asc' }, id: 'asc' });
+  expect(Cursor.decode(encoded)).toEqual([null, 3]);
 });
 
 test('`Cursor.decode` returns raw JSON values', () => {

--- a/tests/features/cursor-based-pagination/cursor-custom-types.test.ts
+++ b/tests/features/cursor-based-pagination/cursor-custom-types.test.ts
@@ -165,8 +165,9 @@ class SealedPointInTimeType extends Type<PointInTime | null, string | null> {
   }
 
   override fromJSON(value: string): PointInTime {
+    // a type may reject client input with a `CursorError` of its own
     if (!value.startsWith('sealed:')) {
-      throw new Error(`Expected sealed value, got '${value}'`);
+      throw CursorError.invalidCursor('Job', new Error(`Expected sealed value, got '${value}'`));
     }
 
     return new PointInTime(value.slice('sealed:'.length));
@@ -188,7 +189,22 @@ class TaggedDateType extends Type<Date, Date> {
   }
 }
 
-/** Enforces the documented converter contracts: both converters only ever accept a `Date`. */
+/** JS value is a `Date`, but the database form is an ISO string rather than a `Date`. */
+class IsoDateType extends Type<Date, string> {
+  override convertToDatabaseValue(value: Date | string): string {
+    return value instanceof Date ? value.toISOString() : value;
+  }
+
+  override convertToJSValue(value: Date | string): Date {
+    return value instanceof Date ? value : new Date(value);
+  }
+
+  override getColumnType(): string {
+    return 'datetime';
+  }
+}
+
+/** Enforces the documented converter contracts: both converters only ever accept a valid `Date`. */
 class StrictDateType extends Type<Date | null, Date | null> {
   override convertToDatabaseValue(value: Date | null): Date | null {
     if (value != null && !(value instanceof Date)) {
@@ -201,6 +217,10 @@ class StrictDateType extends Type<Date | null, Date | null> {
   override convertToJSValue(value: Date | null): Date | null {
     if (value != null && !(value instanceof Date)) {
       throw new Error(`Expected Date, got ${typeof value}`);
+    }
+
+    if (value != null && Number.isNaN(value.getTime())) {
+      throw new Error('Expected a valid Date');
     }
 
     return value;
@@ -330,6 +350,9 @@ class Audit {
 
   @Property({ type: new DateTimeType() })
   loggedIn!: Date;
+
+  @Property({ type: IsoDateType })
+  isoAt!: Date;
 }
 
 @Entity()
@@ -446,6 +469,7 @@ beforeAll(async () => {
         auditedAt: new Date(`2024-08-${day(id)}T00:00:00.000Z`),
         epochAt: new PointInTime(`2024-11-${day(id)}T00:00:00.000Z`),
         loggedIn: new Date(`2025-01-${day(id)}T00:00:00.000Z`),
+        isoAt: new Date(`2025-02-${day(id)}T00:00:00.000Z`),
       },
       ticksAt: new Ticks(Date.parse(`2024-09-${day(id)}T00:00:00.000Z`)),
       owner: { id, name: `Owner ${id}`, since: new Date(`2024-03-${day(id)}T00:00:00.000Z`) },
@@ -897,6 +921,43 @@ test('custom type with distinct JSON and DB forms inside object-mode embeddable'
     orderBy: { audit: { epochAt: 'asc' }, id: 'asc' },
   });
   expect(cursor3.items).toMatchObject([{ id: 4 }, { id: 5 }, { id: 6 }]);
+});
+
+test('custom type with a string database form inside object-mode embeddable', async () => {
+  const cursor1 = await orm.em.findByCursor(Job, {
+    first: 3,
+    orderBy: { audit: { isoAt: 'asc' }, id: 'asc' },
+  });
+  expect(cursor1.items).toMatchObject([{ id: 1 }, { id: 2 }, { id: 3 }]);
+
+  // the restored `Date` is not the database form, so it stays a JS value for `processWhere`
+  const cursor2 = await orm.em.findByCursor(Job, {
+    first: 3,
+    after: cursor1.endCursor!,
+    orderBy: { audit: { isoAt: 'asc' }, id: 'asc' },
+  });
+  expect(cursor2.items).toMatchObject([{ id: 4 }, { id: 5 }, { id: 6 }]);
+});
+
+test('POJO cursor value the type rejects keeps the raw error', async () => {
+  // POJO values are not client supplied, so the type's own error is not wrapped as a `CursorError`
+  const failing = orm.em.findByCursor(Job, {
+    first: 3,
+    after: { strictAt: 'not a date', id: 3 },
+    orderBy: { strictAt: 'asc', id: 'asc' },
+  });
+  await expect(failing).rejects.toThrow('Expected a valid Date');
+  await expect(failing).rejects.not.toBeInstanceOf(CursorError);
+});
+
+test('a `CursorError` from the type is not wrapped again', async () => {
+  await expect(
+    orm.em.findByCursor(Job, {
+      first: 3,
+      after: Cursor.encode(['nope', 3]),
+      orderBy: { sealedAt: 'asc', id: 'asc' },
+    }),
+  ).rejects.toThrow("Invalid cursor for entity Job: Expected sealed value, got 'nope'");
 });
 
 test('validating custom type keeps its own error message', async () => {

--- a/tests/features/cursor-based-pagination/cursor-custom-types.test.ts
+++ b/tests/features/cursor-based-pagination/cursor-custom-types.test.ts
@@ -1022,6 +1022,12 @@ test('`BigIntType.fromJSON` restores all three modes', () => {
   expect(new BigIntType().fromJSON('1003')).toBe(BigInt(1003));
   expect(new BigIntType('number').fromJSON(2003)).toBe(2003);
   expect(new BigIntType('string').fromJSON('3003')).toBe('3003');
+
+  // `number` mode cannot represent values past `MAX_SAFE_INTEGER` without rounding
+  expect(() => new BigIntType('number').fromJSON('9007199254740993')).toThrow(
+    "Could not convert JSON value '9007199254740993' of type 'string' to type BigIntType",
+  );
+  expect(new BigIntType().fromJSON('9007199254740993')).toBe(9007199254740993n);
 });
 
 test('`Cursor.for` keeps non-object values under a nested direction', () => {

--- a/tests/features/cursor-based-pagination/cursor-custom-types.test.ts
+++ b/tests/features/cursor-based-pagination/cursor-custom-types.test.ts
@@ -1,4 +1,4 @@
-import { Cursor, Reference, ScalarReference, Type } from '@mikro-orm/core';
+import { BigIntType, Cursor, DateTimeType, Reference, ScalarReference, Type } from '@mikro-orm/core';
 import { MikroORM } from '@mikro-orm/sqlite';
 import {
   Embeddable,
@@ -100,6 +100,84 @@ class PointInTimeEpochType extends Type<PointInTime | null, number | null> {
 
   override compareAsType(): string {
     return 'number';
+  }
+}
+
+/**
+ * Temporal-style wrapper over a datetime column: the DB form is the ISO string with full
+ * sub-millisecond precision, while a `Date` input can only carry millisecond precision.
+ */
+class PointInTimeDateTimeType extends Type<PointInTime | null, string | null> {
+  override convertToDatabaseValue(value: PointInTime | string | null): string | null {
+    if (value == null || typeof value === 'string') {
+      return value;
+    }
+
+    if (!(value instanceof PointInTime)) {
+      throw new Error(`Expected PointInTime, got ${typeof value}`);
+    }
+
+    return value.iso;
+  }
+
+  override convertToJSValue(value: PointInTime | Date | string | null): PointInTime | null {
+    if (value == null) {
+      return null;
+    }
+
+    if (value instanceof PointInTime) {
+      return value;
+    }
+
+    // like `Temporal.Instant.fromEpochMilliseconds`, a `Date` only carries ms precision
+    return new PointInTime(value instanceof Date ? value.toISOString() : value);
+  }
+
+  override getColumnType(): string {
+    return 'datetime';
+  }
+
+  override compareAsType(): string {
+    return 'date';
+  }
+}
+
+/** Owns its cursor JSON round trip: `toJSON` seals the value and only `fromJSON` can unseal it. */
+class SealedPointInTimeType extends Type<PointInTime | null, string | null> {
+  override convertToDatabaseValue(value: PointInTime | string | null): string | null {
+    if (value == null || typeof value === 'string') {
+      return value;
+    }
+
+    return value.iso;
+  }
+
+  override convertToJSValue(value: PointInTime | string | null): PointInTime | null {
+    if (value == null) {
+      return null;
+    }
+
+    return value instanceof PointInTime ? value : new PointInTime(value);
+  }
+
+  override toJSON(value: PointInTime | null): string | null {
+    return value == null ? null : `sealed:${value.iso}`;
+  }
+
+  override fromJSON(value: string): PointInTime {
+    if (!value.startsWith('sealed:')) {
+      throw new Error(`Expected sealed value, got '${value}'`);
+    }
+
+    return new PointInTime(value.slice('sealed:'.length));
+  }
+
+  override getColumnType(): string {
+    return 'varchar(255)';
+  }
+
+  override compareAsType(): string {
+    return 'string';
   }
 }
 
@@ -249,6 +327,9 @@ class Audit {
 
   @Property({ type: PointInTimeEpochType })
   epochAt!: PointInTime;
+
+  @Property({ type: new DateTimeType() })
+  loggedIn!: Date;
 }
 
 @Entity()
@@ -274,8 +355,17 @@ class Job {
   @Property({ type: PointInTimeEpochType })
   startedAtEpoch!: PointInTime;
 
-  @Property({ type: TaggedDateType })
-  taggedAt!: Date;
+  @Property({ type: PointInTimeDateTimeType })
+  recordedAt!: PointInTime;
+
+  @Property({ type: SealedPointInTimeType })
+  sealedAt!: PointInTime;
+
+  @Property({ type: new BigIntType() })
+  serial!: bigint;
+
+  @Property({ type: new DateTimeType() })
+  loggedAt!: Date;
 
   @Property({ type: StrictDateType })
   strictAt!: Date;
@@ -340,7 +430,10 @@ beforeAll(async () => {
       id,
       startedAt: new PointInTime(iso),
       startedAtEpoch: new PointInTime(iso),
-      taggedAt: new Date(`2024-05-${day(id)}T00:00:00.000Z`),
+      recordedAt: new PointInTime(iso),
+      sealedAt: new PointInTime(iso),
+      serial: BigInt(1000 + id),
+      loggedAt: new Date(`2024-12-${day(id)}T00:00:00.000Z`),
       strictAt: new Date(`2024-06-${day(id)}T00:00:00.000Z`),
       stampedAt: new Stamp(new Date(`2024-07-${day(id)}T00:00:00.000Z`)),
       code: `c${day(id)}`,
@@ -352,6 +445,7 @@ beforeAll(async () => {
         changedAt: new Date(`2024-04-${day(id)}T00:00:00.000Z`),
         auditedAt: new Date(`2024-08-${day(id)}T00:00:00.000Z`),
         epochAt: new PointInTime(`2024-11-${day(id)}T00:00:00.000Z`),
+        loggedIn: new Date(`2025-01-${day(id)}T00:00:00.000Z`),
       },
       ticksAt: new Ticks(Date.parse(`2024-09-${day(id)}T00:00:00.000Z`)),
       owner: { id, name: `Owner ${id}`, since: new Date(`2024-03-${day(id)}T00:00:00.000Z`) },
@@ -410,26 +504,105 @@ test('custom type with distinct JSON and DB forms with string cursor', async () 
   expect(cursor2.items[0].startedAtEpoch.iso).toBe('2024-01-01T00:00:00.123500Z');
 });
 
-test('custom type with distinct JSON and DB forms with POJO `after`', async () => {
-  const job3 = await orm.em.findOneOrFail(Job, { id: 3 });
-
-  const cursor = await orm.em.findByCursor(Job, {
+test('sub-millisecond precision survives a string cursor on a datetime column', async () => {
+  const cursor1 = await orm.em.findByCursor(Job, {
     first: 3,
-    after: { startedAtEpoch: job3.startedAtEpoch, id: job3.id },
-    orderBy: { startedAtEpoch: 'asc', id: 'asc' },
+    orderBy: { recordedAt: 'asc', id: 'asc' },
   });
-  expect(cursor.items).toMatchObject([{ id: 4 }, { id: 5 }, { id: 6 }]);
+  expect(cursor1.items).toMatchObject([{ id: 1 }, { id: 2 }, { id: 3 }]);
+
+  // jobs 2-4 share the same millisecond, so healing the offset through `Date` would skip job 4
+  const cursor2 = await orm.em.findByCursor(Job, {
+    first: 3,
+    after: cursor1.endCursor!,
+    orderBy: { recordedAt: 'asc', id: 'asc' },
+  });
+  expect(cursor2.items).toMatchObject([{ id: 4 }, { id: 5 }, { id: 6 }]);
+  expect(cursor2.items[0].recordedAt.iso).toBe('2024-01-01T00:00:00.123500Z');
 });
 
-test('identity custom type over a datetime column with POJO `after`', async () => {
-  const job3 = await orm.em.findOneOrFail(Job, { id: 3 });
-
-  const cursor = await orm.em.findByCursor(Job, {
+test('custom type owning its cursor JSON round trip via toJSON/fromJSON', async () => {
+  const cursor1 = await orm.em.findByCursor(Job, {
     first: 3,
-    after: { taggedAt: job3.taggedAt, id: job3.id },
-    orderBy: { taggedAt: 'asc', id: 'asc' },
+    orderBy: { sealedAt: 'asc', id: 'asc' },
   });
-  expect(cursor.items).toMatchObject([{ id: 4 }, { id: 5 }, { id: 6 }]);
+  expect(cursor1.items).toMatchObject([{ id: 1 }, { id: 2 }, { id: 3 }]);
+
+  // the cursor payload carries the type's own serialized form
+  expect(Cursor.decode(cursor1.endCursor!)).toEqual(['sealed:2024-01-01T00:00:00.123450Z', 3]);
+
+  const cursor2 = await orm.em.findByCursor(Job, {
+    first: 3,
+    after: cursor1.endCursor!,
+    orderBy: { sealedAt: 'asc', id: 'asc' },
+  });
+  expect(cursor2.items).toMatchObject([{ id: 4 }, { id: 5 }, { id: 6 }]);
+
+  // POJO values are JS values and never reach `fromJSON`
+  const cursor3 = await orm.em.findByCursor(Job, {
+    first: 3,
+    after: { sealedAt: new PointInTime('2024-01-01T00:00:00.123450Z'), id: 3 },
+    orderBy: { sealedAt: 'asc', id: 'asc' },
+  });
+  expect(cursor3.items).toMatchObject([{ id: 4 }, { id: 5 }, { id: 6 }]);
+});
+
+test('bigint cursor member survives the JSON round trip', async () => {
+  const cursor1 = await orm.em.findByCursor(Job, {
+    first: 3,
+    orderBy: { serial: 'asc', id: 'asc' },
+  });
+  expect(cursor1.items).toMatchObject([{ id: 1 }, { id: 2 }, { id: 3 }]);
+
+  // `JSON.stringify` cannot serialize a bigint, `BigIntType.toJSON` makes it JSON-safe
+  expect(Cursor.decode(cursor1.endCursor!)).toEqual(['1003', 3]);
+
+  const cursor2 = await orm.em.findByCursor(Job, {
+    first: 3,
+    after: cursor1.endCursor!,
+    orderBy: { serial: 'asc', id: 'asc' },
+  });
+  expect(cursor2.items).toMatchObject([{ id: 4 }, { id: 5 }, { id: 6 }]);
+
+  const cursor3 = await orm.em.findByCursor(Job, {
+    first: 3,
+    after: { serial: BigInt(1003), id: 3 },
+    orderBy: { serial: 'asc', id: 'asc' },
+  });
+  expect(cursor3.items).toMatchObject([{ id: 4 }, { id: 5 }, { id: 6 }]);
+
+  // tampered cursors fail loudly instead of restoring garbage
+  await expect(
+    orm.em.findByCursor(Job, {
+      first: 3,
+      after: Cursor.encode([{ nested: true }, 3]),
+      orderBy: { serial: 'asc', id: 'asc' },
+    }),
+  ).rejects.toThrow("Could not convert JSON value '[object Object]' of type 'object' to type BigIntType");
+});
+
+test('explicit datetime type instance restores dates via its own fromJSON', async () => {
+  const cursor1 = await orm.em.findByCursor(Job, {
+    first: 3,
+    orderBy: { loggedAt: 'asc', id: 'asc' },
+  });
+  expect(cursor1.items).toMatchObject([{ id: 1 }, { id: 2 }, { id: 3 }]);
+
+  const cursor2 = await orm.em.findByCursor(Job, {
+    first: 3,
+    after: cursor1.endCursor!,
+    orderBy: { loggedAt: 'asc', id: 'asc' },
+  });
+  expect(cursor2.items).toMatchObject([{ id: 4 }, { id: 5 }, { id: 6 }]);
+
+  // tampered cursors fail loudly instead of restoring an invalid date
+  await expect(
+    orm.em.findByCursor(Job, {
+      first: 3,
+      after: Cursor.encode(['not a date', 3]),
+      orderBy: { loggedAt: 'asc', id: 'asc' },
+    }),
+  ).rejects.toThrow("Could not convert JSON value 'not a date' of type 'string' to type DateTimeType");
 });
 
 test('contract-strict custom type over a datetime column', async () => {
@@ -485,34 +658,12 @@ test('wrapper-typed field over a datetime column', async () => {
 });
 
 test('hand-written ISO string for a custom-typed datetime cursor member heals to Date', async () => {
-  const cursor1 = await orm.em.findByCursor(Job, {
-    first: 3,
-    after: { taggedAt: '2024-05-03T00:00:00.000Z', id: 3 },
-    orderBy: { taggedAt: 'asc', id: 'asc' },
-  });
-  expect(cursor1.items).toMatchObject([{ id: 4 }, { id: 5 }, { id: 6 }]);
-
-  const cursor2 = await orm.em.findByCursor(Job, {
+  const cursor = await orm.em.findByCursor(Job, {
     first: 3,
     after: { strictAt: '2024-06-03T00:00:00.000Z', id: 3 },
     orderBy: { strictAt: 'asc', id: 'asc' },
   });
-  expect(cursor2.items).toMatchObject([{ id: 4 }, { id: 5 }, { id: 6 }]);
-});
-
-test('identity custom type over a datetime column with string cursor', async () => {
-  const cursor1 = await orm.em.findByCursor(Job, {
-    first: 3,
-    orderBy: { taggedAt: 'asc', id: 'asc' },
-  });
-  expect(cursor1.items).toMatchObject([{ id: 1 }, { id: 2 }, { id: 3 }]);
-
-  const cursor2 = await orm.em.findByCursor(Job, {
-    first: 3,
-    after: cursor1.endCursor!,
-    orderBy: { taggedAt: 'asc', id: 'asc' },
-  });
-  expect(cursor2.items).toMatchObject([{ id: 4 }, { id: 5 }, { id: 6 }]);
+  expect(cursor.items).toMatchObject([{ id: 4 }, { id: 5 }, { id: 6 }]);
 });
 
 test('native Date cursor member still rehydrates', async () => {
@@ -679,6 +830,29 @@ test('custom type whose JSON form is not a string', async () => {
   expect(cursor2.items).toMatchObject([{ id: 4 }, { id: 5 }, { id: 6 }]);
 });
 
+test('fromJSON type inside object-mode embeddable stays in JSON space', async () => {
+  const cursor1 = await orm.em.findByCursor(Job, {
+    first: 3,
+    orderBy: { audit: { loggedIn: 'asc' }, id: 'asc' },
+  });
+  expect(cursor1.items).toMatchObject([{ id: 1 }, { id: 2 }, { id: 3 }]);
+
+  // the restored `Date` must be compared in its JSON form, matching the stored document
+  const cursor2 = await orm.em.findByCursor(Job, {
+    first: 3,
+    after: cursor1.endCursor!,
+    orderBy: { audit: { loggedIn: 'asc' }, id: 'asc' },
+  });
+  expect(cursor2.items).toMatchObject([{ id: 4 }, { id: 5 }, { id: 6 }]);
+
+  const cursor3 = await orm.em.findByCursor(Job, {
+    first: 3,
+    after: cursor2.endCursor!,
+    orderBy: { audit: { loggedIn: 'asc' }, id: 'asc' },
+  });
+  expect(cursor3.items).toMatchObject([{ id: 7 }, { id: 8 }, { id: 9 }]);
+});
+
 test('custom-typed Date inside object-mode embeddable stays in JSON space', async () => {
   const cursor1 = await orm.em.findByCursor(Job, {
     first: 3,
@@ -743,7 +917,7 @@ test('validating custom type keeps its own error message', async () => {
   await expect(
     orm.em.findByCursor(Job, {
       first: 3,
-      after: { code: '2024', id: 3 },
+      after: Cursor.encode(['2024', 3]),
       orderBy: { code: 'asc', id: 'asc' },
     }),
   ).rejects.toThrow("unknown code '2024'");
@@ -753,7 +927,7 @@ test('validating custom type keeps its own error message', async () => {
   await expect(
     orm.em.findByCursor(Job, {
       first: 3,
-      after: { code: '2024-01-05T00:00:00.000Z', id: 3 },
+      after: Cursor.encode(['2024-01-05T00:00:00.000Z', 3]),
       orderBy: { code: 'asc', id: 'asc' },
     }),
   ).rejects.toThrow("unknown code '2024-01-05T00:00:00.000Z'");

--- a/tests/features/cursor-based-pagination/cursor-nested-nullable.test.ts
+++ b/tests/features/cursor-based-pagination/cursor-nested-nullable.test.ts
@@ -52,6 +52,8 @@ describe('cursor pagination with nested null values', () => {
 
   afterAll(() => orm.close(true));
 
+  afterEach(() => orm.em.clear());
+
   test('cursor can be created from entity with nested null value', async () => {
     // Book with author that has null rating
     const book = await orm.em.findOneOrFail(Book, { id: 2 }, { populate: ['author'] });
@@ -122,8 +124,39 @@ describe('cursor pagination with nested null values', () => {
       populate: ['author'],
     });
 
-    // Should get books with non-null author ratings
-    expect(result.items.length).toBeGreaterThanOrEqual(0);
+    // the remaining row with a null sort key comes first, then the non-null rows
+    expect(result.items.map(b => b.id)).toEqual([3, 1]);
+  });
+
+  test('cursor produced for a null relation under a nested direction is consumable', async () => {
+    // books 2 (author with null rating) and 3 (null author) share a null sort key
+    const cursor1 = await orm.em.findByCursor(Book, {
+      first: 1,
+      orderBy: { author: { rating: 'asc nulls first' }, id: 'asc' },
+      populate: ['author'],
+    });
+    expect(cursor1.items.map(b => b.id)).toEqual([2]);
+    orm.em.clear();
+
+    const cursor2 = await orm.em.findByCursor(Book, {
+      first: 1,
+      after: cursor1.endCursor!,
+      orderBy: { author: { rating: 'asc nulls first' }, id: 'asc' },
+      populate: ['author'],
+    });
+    expect(cursor2.items.map(b => b.id)).toEqual([3]);
+    // the boundary row has no author, its cursor carries a null in place of the nested object
+    expect(Cursor.decode(cursor2.endCursor!)).toEqual([null, 3]);
+    orm.em.clear();
+
+    const cursor3 = await orm.em.findByCursor(Book, {
+      first: 1,
+      after: cursor2.endCursor!,
+      orderBy: { author: { rating: 'asc nulls first' }, id: 'asc' },
+      populate: ['author'],
+    });
+    expect(cursor3.items.map(b => b.id)).toEqual([1]);
+    expect(cursor3.hasNextPage).toBe(false);
   });
 
   test('throws error for missing nested property when relation not populated', async () => {

--- a/tests/features/cursor-based-pagination/cursor-nullable-columns.test.ts
+++ b/tests/features/cursor-based-pagination/cursor-nullable-columns.test.ts
@@ -377,8 +377,8 @@ describe('cursor pagination - null cursor condition branches', () => {
       orderBy: { age: 'asc nulls first', id: 'asc' },
     });
 
-    // Result count depends on database NULLS ordering support
-    expect(result.items.length).toBeGreaterThanOrEqual(0);
+    // the null block comes first, so every non-null row follows it
+    expect(result.items.map(u => u.id)).toEqual([1, 2, 4]);
   });
 
   test('cursor condition with null value and nulls last (forward)', async () => {
@@ -458,7 +458,7 @@ describe('cursor pagination - null cursor condition branches', () => {
       orderBy: { age: 'asc nulls last', id: 'asc' },
     });
 
-    // Result count depends on database NULLS ordering support
-    expect(result.items.length).toBeGreaterThanOrEqual(0);
+    // the null block comes last, so every non-null row precedes it
+    expect(result.items.map(u => u.id)).toEqual([1, 2, 4]);
   });
 });

--- a/tests/features/cursor-based-pagination/cursor-nulls-ordering.test.ts
+++ b/tests/features/cursor-based-pagination/cursor-nulls-ordering.test.ts
@@ -1,0 +1,140 @@
+import { MikroORM, QueryOrder, QueryOrderMap, ref, Ref } from '@mikro-orm/sqlite';
+import { Entity, ManyToOne, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+
+@Entity()
+class User {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @Property({ nullable: true, type: 'integer' })
+  age?: number | null;
+}
+
+@Entity()
+class Author {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @Property({ nullable: true, type: 'integer' })
+  rating?: number | null;
+}
+
+@Entity()
+class Book {
+  @PrimaryKey()
+  id!: number;
+
+  @ManyToOne(() => Author, { ref: true, nullable: true })
+  author?: Ref<Author> | null;
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    metadataProvider: ReflectMetadataProvider,
+    entities: [User, Author, Book],
+    dbName: ':memory:',
+  });
+  await orm.schema.refresh();
+
+  orm.em.create(User, { id: 1, name: 'User 1', age: 10 });
+  orm.em.create(User, { id: 2, name: 'User 2', age: 20 });
+  orm.em.create(User, { id: 3, name: 'User 3', age: null });
+  orm.em.create(User, { id: 4, name: 'User 4', age: null });
+
+  const author1 = orm.em.create(Author, { id: 1, name: 'Author A', rating: 5 });
+  const author2 = orm.em.create(Author, { id: 2, name: 'Author B', rating: null });
+
+  orm.em.create(Book, { id: 1, author: ref(author1) });
+  orm.em.create(Book, { id: 2, author: ref(author2) });
+  // an unset relation makes every joined column null, even the non-nullable ones
+  orm.em.create(Book, { id: 3, author: null });
+
+  await orm.em.flush();
+  orm.em.clear();
+});
+
+afterAll(() => orm.close(true));
+
+afterEach(() => orm.em.clear());
+
+/** Walks the whole result set one row per page, so every page boundary is a cursor round trip. */
+const walk = async <T extends User | Book>(
+  entity: { new (): T },
+  orderBy: QueryOrderMap<T>,
+  backwards = false,
+): Promise<number[]> => {
+  const ids: number[] = [];
+  let cursor: string | undefined;
+
+  // the data sets have at most 4 rows, a higher bound only guards against a broken cursor looping
+  for (let i = 0; i < 8; i++) {
+    const page = await orm.em.findByCursor(entity, {
+      ...(backwards ? { last: 1, before: cursor } : { first: 1, after: cursor }),
+      orderBy: orderBy as QueryOrderMap<T>,
+      populate: ['*'],
+    });
+
+    if (page.items.length === 0) {
+      break;
+    }
+
+    ids.push(...page.items.map(item => item.id));
+    cursor = backwards ? page.startCursor! : page.endCursor!;
+    orm.em.clear();
+
+    if (backwards ? !page.hasPrevPage : !page.hasNextPage) {
+      break;
+    }
+  }
+
+  return ids;
+};
+
+describe.each([
+  [QueryOrder.ASC_NULLS_LAST, [1, 2, 3, 4]],
+  [QueryOrder.ASC_NULLS_FIRST, [3, 4, 1, 2]],
+  [QueryOrder.DESC_NULLS_LAST, [2, 1, 3, 4]],
+  [QueryOrder.DESC_NULLS_FIRST, [3, 4, 2, 1]],
+] as const)('cursor pagination over a nullable column ordered by %s', (direction, expected) => {
+  const orderBy = { age: direction, id: QueryOrder.ASC } as QueryOrderMap<User>;
+
+  test('the requested nulls placement is honored', async () => {
+    const { items } = await orm.em.findByCursor(User, { first: 10, orderBy });
+    expect(items.map(u => u.id)).toEqual(expected);
+  });
+
+  test('paginating forward crosses the null boundary', async () => {
+    expect(await walk(User, orderBy)).toEqual(expected);
+  });
+
+  test('paginating backward crosses the null boundary', async () => {
+    expect(await walk(User, orderBy, true)).toEqual([...expected].reverse());
+  });
+});
+
+describe('cursor pagination ordered by a nullable relation', () => {
+  test('a missing relation sorts as null even for a non-nullable column', async () => {
+    const orderBy = { author: { name: QueryOrder.ASC }, id: QueryOrder.ASC } as QueryOrderMap<Book>;
+
+    expect(await walk(Book, orderBy)).toEqual([1, 2, 3]);
+    expect(await walk(Book, orderBy, true)).toEqual([3, 2, 1]);
+  });
+
+  test('several nullable columns of the same relation', async () => {
+    const orderBy = {
+      author: { rating: QueryOrder.ASC, name: QueryOrder.ASC },
+      id: QueryOrder.ASC,
+    } as QueryOrderMap<Book>;
+
+    expect(await walk(Book, orderBy)).toEqual([1, 2, 3]);
+    expect(await walk(Book, orderBy, true)).toEqual([3, 2, 1]);
+  });
+});


### PR DESCRIPTION
Follow-up to #8097, covering the two halves of cursor pagination that still produced wrong pages: custom types over datetime columns, and nullable sort keys.

## Custom types own their cursor wire format

The sub-millisecond half of the original bug survived for custom types over datetime columns: the decode fallback healed every string offset through `new Date()`, and the precision test sat on a varchar column, so nothing caught the truncation. Boundary rows were silently skipped on the string cursor path for Temporal-style wrapper types.

Instead of widening the shape heuristics, this makes the type the authority over its cursor wire format:

- New optional `Type.fromJSON(value, platform)`, paired with the existing `toJSON`. Implementing it routes cursor encoding through `toJSON` and passes the decoded value back to `fromJSON`. Cursors are client supplied, so implementations validate and throw for values they cannot restore, and `findByCursor` surfaces the failure as a `CursorError`.
- `DateTimeType` and `BigIntType` ship implementations. The bigint one also fixes encoding: a bigint cursor member previously crashed in `JSON.stringify`.
- Types without `fromJSON` keep the previous wire format and decode via the `convertToJSValue` fallback, which now tries the type's own string parsing before healing to a `Date`, so sub-millisecond precision survives for any type that can parse its own serialized form.
- POJO `after`/`before` values count as JS values and get a single conversion in `processWhere`, like any user `where` condition. Values compared against JSON documents stay in JSON space, restored through the type's database form when it is a `Date`.

## Cursor conditions follow the actual NULLS ordering

Keyset pagination over a nullable sort key needs the condition and the emitted `orderBy` to agree on where nulls sit. They disagreed in three ways, each of which could return a wrong page:

- The rewritten `orderBy` dropped the `nulls first`/`nulls last` qualifier, so the placement was the database default while the condition assumed the requested one. Only PostgreSQL matched the assumption.
- `desc nulls first`/`desc nulls last` were treated as ascending, as the direction was compared to `desc` for equality.
- A non-null offset compared with `$gt`/`$lt` never matches a null sort key, so pagination could not enter the null block from the non-null side.

Nullable sort keys now carry an explicit placement into the emitted `orderBy`, and both sides resolve the direction through one parser. A comparison against a nullable key gets a null arm when the null block lies ahead. Keys that cannot be null keep their previous SQL.

New `Platform.supportsNullsOrdering()` reports whether the placement can be requested. Every SQL dialect honors it, natively on PostgreSQL, SQLite and Oracle, emulated on MySQL and MSSQL. MongoDB cannot, and always sorts nulls lowest, so its conditions follow that instead.

## Behavior notes

- Unusable POJO cursor values on validating types now bind like `em.find` values and return an empty page, instead of throwing a converter error. Tampered string cursors keep failing loudly with the type's own error, now a `ValidationError` for the built-in types.
- `Cursor.for` payloads changed shape for inputs it previously mishandled: nested directions emit only the ordered keys, and a scalar-direction relation emits the bare primary key. Payloads produced by older versions still decode.
- Ordering by a nullable key emits an explicit nulls placement, which adds an `order by` term on MySQL and MSSQL, where that placement is emulated.
- On MongoDB, pagination over a nullable key changes: the condition now follows the nulls-lowest ordering mongo actually produces, instead of assuming nulls last.
- Two known limitations, both unchanged: a validating `Type<Date, Date>` inside an object-mode embeddable, and string-typed `EntitySchema` props over datetime columns.
