### PR TITLE
fix(core): resolve entity metadata via class references instead of class names

### DIFF
--- a/packages/core/src/metadata/EntitySchema.ts
+++ b/packages/core/src/metadata/EntitySchema.ts
@@ -33,6 +33,9 @@ import type {
   UniqueOptions,
 } from './types.js';
 
+// mirrors `MetadataStorage.META_SYMBOL`, we can't import it here due to a module cycle
+const META_SYMBOL = Symbol.for('@mikro-orm/core/MetadataStorage.META_SYMBOL');
+
 type TypeType =
   | string
   | NumberConstructor
@@ -371,8 +374,9 @@ export class EntitySchema<Entity = any, Base = never, Class extends EntityCtor =
     // Only set extends if the parent is NOT the auto-generated class for this same entity.
     // When the user extends the auto-generated class (from defineEntity without a class option)
     // and registers their custom class via setClass, we don't want to discover the
-    // auto-generated class as a separate parent entity.
-    if (base !== BaseEntity && base.name !== this._meta.className) {
+    // auto-generated class as a separate parent entity. A parent carrying its own decorator
+    // metadata is a real base class even when a minifier mangles it to the same name as the child.
+    if (base !== BaseEntity && (base.name !== this._meta.className || Object.hasOwn(base, META_SYMBOL))) {
       this._meta.extends ??= base.name ? base : undefined;
     }
   }

--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -278,6 +278,13 @@ export class MetadataDiscovery {
         .replace(/\[]$/, '') // remove array suffix
         .replace(/\((.*)\)/, '$1'); // unwrap union types
 
+    // Names can be ambiguous when a minifier mangles two classes to the same name,
+    // so class references also need to be checked by identity.
+    const discoveredByIdentity = (target: unknown) => {
+      const cls = EntitySchema.is(target) ? target.meta.class : target;
+      return typeof cls !== 'function' || this.#discovered.some(m => m.class === cls);
+    };
+
     const missing: EntityClass[] = [];
     this.#discovered.forEach(meta =>
       Object.values(meta.properties).forEach(prop => {
@@ -288,7 +295,7 @@ export class MetadataDiscovery {
               ? (pivotEntity as () => EntityClass)()
               : pivotEntity;
 
-          if (!this.#discovered.find(m => m.className === Utils.className(target))) {
+          if (!this.#discovered.find(m => m.className === Utils.className(target)) || !discoveredByIdentity(target)) {
             missing.push(target);
           }
         }
@@ -299,7 +306,8 @@ export class MetadataDiscovery {
           if (
             !unwrap(prop.type)
               .split(/ ?\| ?/)
-              .every(type => this.#discovered.find(m => m.className === type))
+              .every(type => this.#discovered.find(m => m.className === type)) ||
+            !Utils.asArray(target as EntityClass).every(discoveredByIdentity)
           ) {
             missing.push(...Utils.asArray(target as EntityClass));
           }
@@ -399,9 +407,7 @@ export class MetadataDiscovery {
     }
   }
 
-  private getSchema<T>(
-    entity: (EntityClass<T> & { [MetadataStorage.PATH_SYMBOL]?: string }) | EntitySchema<T>,
-  ): EntitySchema<T> {
+  private getSchema<T>(entity: EntityClass<T> | EntitySchema<T>): EntitySchema<T> {
     if (EntitySchema.REGISTRY.has(entity)) {
       entity = EntitySchema.REGISTRY.get(entity)!;
     }

--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -362,10 +362,12 @@ export class MetadataDiscovery {
 
       parent = Object.getPrototypeOf(meta.class);
 
-      // Skip if parent is the auto-generated base class for the same entity (from setClass usage)
+      // Skip if parent is the auto-generated base class for the same entity (from setClass usage).
+      // A parent carrying its own decorator metadata is a real base class even when a minifier
+      // mangles it to the same name as the child.
       if (
         parent.name !== '' &&
-        parent.name !== meta.className &&
+        (parent.name !== meta.className || Object.hasOwn(parent, MetadataStorage.META_SYMBOL)) &&
         !this.#metadata.has(parent) &&
         parent !== BaseEntity
       ) {
@@ -410,11 +412,19 @@ export class MetadataDiscovery {
     }
 
     // After the EntitySchema check, entity must be an EntityClass
-    const cls = entity as EntityClass<T> & { [MetadataStorage.PATH_SYMBOL]?: string };
+    const cls = entity as EntityClass<T> & {
+      [MetadataStorage.PATH_SYMBOL]?: string;
+      [MetadataStorage.META_SYMBOL]?: EntityMetadata<T>;
+    };
     const path = cls[MetadataStorage.PATH_SYMBOL];
 
     if (path) {
-      const meta = Utils.copy(MetadataStorage.getMetadata(cls.name, path), false);
+      // Prefer the metadata stored on the class reference, the `className-path` key can
+      // collide when a minifier mangles two classes to the same name.
+      const stored = Object.hasOwn(cls, MetadataStorage.META_SYMBOL)
+        ? cls[MetadataStorage.META_SYMBOL]!
+        : MetadataStorage.getMetadata<T>(cls.name, path);
+      const meta = Utils.copy(stored, false);
       meta.path = path;
       this.#metadata.set(cls, meta);
     }
@@ -1568,7 +1578,12 @@ export class MetadataDiscovery {
     }
 
     visited.add(embeddedProp);
-    const embeddable = this.#discovered.find(m => m.name === embeddedProp.type);
+    // Prefer resolution via the class reference, the name can be ambiguous when a minifier
+    // mangles two classes to the same name. Only named metadata counts, an auto-discovered
+    // class without the `@Embeddable()` decorator should still fail as unknown below.
+    const embeddable =
+      this.#discovered.find(m => m.name && m.class === embeddedProp.target) ??
+      this.#discovered.find(m => m.name === embeddedProp.type);
 
     if (!embeddable) {
       throw MetadataError.fromUnknownEntity(embeddedProp.type, `${meta.className}.${embeddedProp.name}`);

--- a/packages/core/src/metadata/MetadataStorage.ts
+++ b/packages/core/src/metadata/MetadataStorage.ts
@@ -35,7 +35,7 @@ export class MetadataStorage {
     }
   }
 
-  /** Returns the global metadata dictionary, or a specific entry by entity name and path. */
+  /** Returns the global metadata dictionary, or a specific entry by entity name and path (keyed by the class reference when `target` is provided). */
   static getMetadata(): Dictionary<EntityMetadata>;
   static getMetadata<T = any>(entity: string, path: string, target?: EntityCtor): EntityMetadata<T>;
   static getMetadata<T = any>(
@@ -53,8 +53,10 @@ export class MetadataStorage {
           value: new EntityMetadata({ className: entity, path }),
           writable: true,
         });
-        MetadataStorage.#metadata[key] = target[MetadataStorage.META_SYMBOL]!;
       }
+
+      // Keep the name-keyed entry in sync, the class-keyed metadata survives `MetadataStorage.clear()`.
+      MetadataStorage.#metadata[key] = target[MetadataStorage.META_SYMBOL]!;
 
       return target[MetadataStorage.META_SYMBOL]!;
     }

--- a/packages/core/src/metadata/MetadataStorage.ts
+++ b/packages/core/src/metadata/MetadataStorage.ts
@@ -15,6 +15,7 @@ function getGlobalStorage(namespace: string): Dictionary {
 /** Registry that stores and provides access to entity metadata by class, name, or id. */
 export class MetadataStorage {
   static readonly PATH_SYMBOL = Symbol.for('@mikro-orm/core/MetadataStorage.PATH_SYMBOL');
+  static readonly META_SYMBOL = Symbol.for('@mikro-orm/core/MetadataStorage.META_SYMBOL');
 
   static readonly #metadata: Dictionary<EntityMetadata> = getGlobalStorage('metadata');
   readonly #metadataMap = new Map<EntityName, EntityMetadata>();
@@ -36,9 +37,27 @@ export class MetadataStorage {
 
   /** Returns the global metadata dictionary, or a specific entry by entity name and path. */
   static getMetadata(): Dictionary<EntityMetadata>;
-  static getMetadata<T = any>(entity: string, path: string): EntityMetadata<T>;
-  static getMetadata<T = any>(entity?: string, path?: string): Dictionary<EntityMetadata> | EntityMetadata<T> {
+  static getMetadata<T = any>(entity: string, path: string, target?: EntityCtor): EntityMetadata<T>;
+  static getMetadata<T = any>(
+    entity?: string,
+    path?: string,
+    target?: EntityCtor & { [MetadataStorage.META_SYMBOL]?: EntityMetadata },
+  ): Dictionary<EntityMetadata> | EntityMetadata<T> {
     const key = entity && path ? entity + '-' + Utils.hash(path) : null;
+
+    // Key the registry by the class reference when available, so two classes minified
+    // to the same mangled name don't collide on the `className-path` key.
+    if (key && target) {
+      if (!Object.hasOwn(target, MetadataStorage.META_SYMBOL)) {
+        Object.defineProperty(target, MetadataStorage.META_SYMBOL, {
+          value: new EntityMetadata({ className: entity, path }),
+          writable: true,
+        });
+        MetadataStorage.#metadata[key] = target[MetadataStorage.META_SYMBOL]!;
+      }
+
+      return target[MetadataStorage.META_SYMBOL]!;
+    }
 
     if (key && !MetadataStorage.#metadata[key]) {
       MetadataStorage.#metadata[key] = new EntityMetadata({ className: entity, path });

--- a/packages/decorators/src/utils.ts
+++ b/packages/decorators/src/utils.ts
@@ -1,5 +1,6 @@
 import {
   type Dictionary,
+  type EntityCtor,
   EntityManager,
   type EntityMetadata,
   EntityRepository,
@@ -192,5 +193,5 @@ export function getMetadataFromDecorator<T = any>(
     });
   }
 
-  return MetadataStorage.getMetadata(target.name, target[MetadataStorage.PATH_SYMBOL]!);
+  return MetadataStorage.getMetadata(target.name, target[MetadataStorage.PATH_SYMBOL]!, target as EntityCtor);
 }

--- a/tests/issues/GH8107.test.ts
+++ b/tests/issues/GH8107.test.ts
@@ -1,0 +1,86 @@
+import type { Ref } from '@mikro-orm/core';
+import { Embeddable, Embedded, Entity, ManyToOne, PrimaryKey, Property } from '@mikro-orm/decorators/legacy';
+import { MikroORM } from '@mikro-orm/sqlite';
+
+// Minifiers (e.g. Turbopack) can mangle two entity classes from different module scopes
+// to the same short name. The decorator metadata registry must not collide on class name.
+function defineBase() {
+  class d {
+    @PrimaryKey({ type: 'number' })
+    id!: number;
+  }
+
+  return d;
+}
+
+const Base = defineBase();
+
+function defineSocial() {
+  @Embeddable()
+  class d {
+    @Property({ type: 'string', nullable: true })
+    twitter?: string;
+  }
+
+  return d;
+}
+
+const Social = defineSocial();
+
+function defineAuthor(base: typeof Base, social: typeof Social) {
+  @Entity({ tableName: 'gh8107_author' })
+  class d extends base {
+    @Property({ type: 'string' })
+    name!: string;
+
+    @Embedded({ entity: () => social, object: true, nullable: true })
+    social?: InstanceType<typeof Social>;
+  }
+
+  return d;
+}
+
+const Author = defineAuthor(Base, Social);
+
+function defineBook(base: typeof Base, author: typeof Author) {
+  @Entity({ tableName: 'gh8107_book' })
+  class d extends base {
+    @Property({ type: 'string' })
+    title!: string;
+
+    @ManyToOne({ entity: () => author, ref: true })
+    author!: Ref<InstanceType<typeof Author>>;
+  }
+
+  return d;
+}
+
+const Book = defineBook(Base, Author);
+
+test('discovery works when two entity classes share a mangled class name', async () => {
+  const orm = await MikroORM.init({
+    dbName: ':memory:',
+    entities: [Author, Book, Social],
+  });
+
+  const authorMeta = orm.getMetadata().get(Author);
+  const bookMeta = orm.getMetadata().get(Book);
+  expect(authorMeta.tableName).toBe('gh8107_author');
+  expect(bookMeta.tableName).toBe('gh8107_book');
+  expect(Object.keys(authorMeta.properties)).toEqual(expect.arrayContaining(['id', 'name', 'social']));
+  expect(Object.keys(bookMeta.properties)).toEqual(['id', 'title', 'author']);
+  expect(authorMeta.properties.social.embeddable).toBe(Social);
+
+  await orm.schema.create();
+
+  const author = orm.em.create(Author, { name: 'Jon', social: { twitter: '@jon' } });
+  orm.em.create(Book, { title: 'B1', author });
+  await orm.em.flush();
+  orm.em.clear();
+
+  const book = await orm.em.findOneOrFail(Book, { title: 'B1' }, { populate: ['author'] });
+  expect(book.author.$.name).toBe('Jon');
+  expect(book.author.$.social?.twitter).toBe('@jon');
+
+  await orm.close(true);
+});

--- a/tests/issues/GH8107.test.ts
+++ b/tests/issues/GH8107.test.ts
@@ -85,6 +85,22 @@ test('discovery works when two entity classes share a mangled class name', async
   await orm.close(true);
 });
 
+test('auto-discovery of referenced entities works when class names collide', async () => {
+  // `Author` and `Social` are not listed in `entities`, they are discovered
+  // via the `Book.author` relation and the `Author.social` embedded property
+  const orm = await MikroORM.init({
+    dbName: ':memory:',
+    entities: [Book],
+  });
+
+  expect(orm.getMetadata().get(Book).tableName).toBe('gh8107_book');
+  expect(orm.getMetadata().get(Author).tableName).toBe('gh8107_author');
+  expect(orm.getMetadata().get(Book).properties.author.targetMeta?.tableName).toBe('gh8107_author');
+  expect(orm.getMetadata().get(Author).properties.social.embeddable).toBe(Social);
+
+  await orm.close(true);
+});
+
 test('discovery falls back to the name-keyed registry (older decorators versions)', async () => {
   // simulate a class decorated by an older @mikro-orm/decorators version, which registered
   // the metadata only under the `className-path` key and stored just the path on the class

--- a/tests/issues/GH8107.test.ts
+++ b/tests/issues/GH8107.test.ts
@@ -1,4 +1,4 @@
-import type { Ref } from '@mikro-orm/core';
+import { type EntityCtor, MetadataStorage, ReferenceKind, type Ref } from '@mikro-orm/core';
 import { Embeddable, Embedded, Entity, ManyToOne, PrimaryKey, Property } from '@mikro-orm/decorators/legacy';
 import { MikroORM } from '@mikro-orm/sqlite';
 
@@ -82,5 +82,29 @@ test('discovery works when two entity classes share a mangled class name', async
   expect(book.author.$.name).toBe('Jon');
   expect(book.author.$.social?.twitter).toBe('@jon');
 
+  await orm.close(true);
+});
+
+test('discovery falls back to the name-keyed registry (older decorators versions)', async () => {
+  // simulate a class decorated by an older @mikro-orm/decorators version, which registered
+  // the metadata only under the `className-path` key and stored just the path on the class
+  class OldStyle {}
+  const meta = MetadataStorage.getMetadata('OldStyle', '/gh8107/old-style');
+  meta.class = OldStyle as EntityCtor;
+  meta.name = 'OldStyle';
+  meta.properties.id = {
+    name: 'id',
+    kind: ReferenceKind.SCALAR,
+    type: 'number',
+    primary: true,
+  } as (typeof meta.properties)[string];
+  Object.defineProperty(OldStyle, MetadataStorage.PATH_SYMBOL, { value: '/gh8107/old-style', writable: true });
+
+  const orm = await MikroORM.init({
+    dbName: ':memory:',
+    entities: [OldStyle],
+  });
+
+  expect(orm.getMetadata().get<any>(OldStyle).properties.id.primary).toBe(true);
   await orm.close(true);
 });


### PR DESCRIPTION
Production bundlers that mangle class names (e.g. Turbopack in Next.js 16) could corrupt the decorator metadata registry: two classes minified to the same short name in one output file collided on the `className-path` registry key, so both wrote into a single `EntityMetadata` object. Depending on the entity graph this surfaced as `Multiple property decorators used on 'd.user'`, `Duplicate table names are not allowed`, or a crash later in discovery.

The registry key is only a bridge between decorator execution and discovery, and both sides already hold the class constructor, so the metadata can be keyed by the class itself:

- decorator-time metadata is now stored directly on the class constructor under `MetadataStorage.META_SYMBOL` (a `Symbol.for` global, same pattern as `PATH_SYMBOL`), and discovery reads it from there, falling back to the old name-keyed dictionary for compatibility
- the "skip auto-generated base class" heuristic in `EntitySchema.setClass()` and parent discovery no longer skips a real decorated base class whose mangled name equals the child's
- `initEmbeddables()` resolves the embeddable target via the class reference first, since the name lookup can hit the wrong class when names collide

Mangled class names now only affect derived names (table names default to the mangled class name, so explicit `tableName` is recommended) and error message readability, not discovery correctness.

Verified end to end against the Next.js example app converted to decorators and built with production Turbopack: the build previously crashed during prerendering when two entities were mangled to the same name, and with this change it builds and serves correctly, including inserts through server actions using entity constructors and hooks.

Closes #8107
