### PR TITLE
fix(migrations): allow stable migration names when class names are minified

### DIFF
--- a/docs/docs/migrations.md
+++ b/docs/docs/migrations.md
@@ -432,6 +432,18 @@ await MikroORM.init({
 });
 ```
 
+For migration classes passed directly (without an explicit name), the name is resolved from the `name` property of the migration instance, falling back to the class name. Newly generated migrations set the `name` property automatically, since minifiers can mangle class names (the migration would then be recorded in the migrations table under a different name in minified and unminified builds of the same app). If your migration files predate this and you bundle your app with a minifier, add the property manually:
+
+```ts
+export class Migration20191019195930 extends Migration {
+
+  override name = 'Migration20191019195930';
+
+  // ...
+
+}
+```
+
 With the help of [webpack's context module api](https://webpack.js.org/guides/dependency-management/#context-module-api) you can dynamically import the migrations making it possible to import all files in a folder.
 
 ```ts

--- a/docs/versioned_docs/version-7.0/migrations.md
+++ b/docs/versioned_docs/version-7.0/migrations.md
@@ -348,6 +348,18 @@ await MikroORM.init({
 });
 ```
 
+For migration classes passed directly (without an explicit name), the name is resolved from the `name` property of the migration instance, falling back to the class name. Newly generated migrations set the `name` property automatically, since minifiers can mangle class names (the migration would then be recorded in the migrations table under a different name in minified and unminified builds of the same app). If your migration files predate this and you bundle your app with a minifier, add the property manually:
+
+```ts
+export class Migration20191019195930 extends Migration {
+
+  override name = 'Migration20191019195930';
+
+  // ...
+
+}
+```
+
 With the help of [webpack's context module api](https://webpack.js.org/guides/dependency-management/#context-module-api) you can dynamically import the migrations making it possible to import all files in a folder.
 
 ```ts

--- a/docs/versioned_docs/version-7.1/migrations.md
+++ b/docs/versioned_docs/version-7.1/migrations.md
@@ -432,6 +432,18 @@ await MikroORM.init({
 });
 ```
 
+For migration classes passed directly (without an explicit name), the name is resolved from the `name` property of the migration instance, falling back to the class name. Newly generated migrations set the `name` property automatically, since minifiers can mangle class names (the migration would then be recorded in the migrations table under a different name in minified and unminified builds of the same app). If your migration files predate this and you bundle your app with a minifier, add the property manually:
+
+```ts
+export class Migration20191019195930 extends Migration {
+
+  override name = 'Migration20191019195930';
+
+  // ...
+
+}
+```
+
 With the help of [webpack's context module api](https://webpack.js.org/guides/dependency-management/#context-module-api) you can dynamically import the migrations making it possible to import all files in a folder.
 
 ```ts

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -2318,6 +2318,8 @@ export interface IMigrationGenerator {
 
 /** Interface that all migration classes must implement. */
 export interface Migration {
+  /** Stable migration name, used instead of the class name (which minifiers can mangle). */
+  name?: string;
   up(): Promise<void> | void;
   down(): Promise<void> | void;
   isTransactional(): boolean;

--- a/packages/core/src/utils/AbstractMigrator.ts
+++ b/packages/core/src/utils/AbstractMigrator.ts
@@ -483,11 +483,12 @@ export abstract class AbstractMigrator<D extends IDatabaseDriver> implements IMi
     };
   }
 
-  protected initialize(MigrationClass: Constructor<Migration>, name: string): RunnableMigration {
+  protected initialize(MigrationClass: Constructor<Migration>, name?: string): RunnableMigration {
     const instance = new MigrationClass(this.driver, this.config);
 
     return {
-      name: this.storage.getMigrationName(name),
+      // the constructor name is the last resort, minifiers can mangle it (e.g. when bundling)
+      name: this.storage.getMigrationName(name ?? instance.name ?? MigrationClass.name),
       up: afterRun => this.runner.run(instance, 'up', afterRun),
       down: afterRun => this.runner.run(instance, 'down', afterRun),
     };
@@ -545,7 +546,7 @@ export abstract class AbstractMigrator<D extends IDatabaseDriver> implements IMi
     if (this.options.migrationsList) {
       return this.options.migrationsList.map(migration => {
         if (typeof migration === 'function') {
-          return this.initialize(migration, migration.name);
+          return this.initialize(migration);
         }
 
         return this.initialize(migration.class, migration.name);

--- a/packages/migrations-mongodb/src/JSMigrationGenerator.ts
+++ b/packages/migrations-mongodb/src/JSMigrationGenerator.ts
@@ -10,6 +10,7 @@ export class JSMigrationGenerator extends MigrationGenerator {
     ret += `Object.defineProperty(exports, '__esModule', { value: true });\n`;
     ret += `const { Migration } = require('@mikro-orm/migrations-mongodb');\n\n`;
     ret += `class ${className} extends Migration {\n\n`;
+    ret += `  name = '${className}';\n\n`;
     ret += `  async up() {\n`;
     /* v8 ignore next */
     diff.up.forEach(sql => (ret += this.createStatement(sql, 4)));

--- a/packages/migrations-mongodb/src/Migration.ts
+++ b/packages/migrations-mongodb/src/Migration.ts
@@ -4,6 +4,9 @@ import type { Collection, ClientSession, Document, Db } from 'mongodb';
 
 /** Base class for MongoDB migrations. Extend this class and implement `up()` (and optionally `down()`). */
 export abstract class Migration {
+  /** Stable migration name, used instead of the class name (which minifiers can mangle). */
+  name?: string;
+
   protected ctx?: Transaction<ClientSession>;
 
   constructor(

--- a/packages/migrations-mongodb/src/TSMigrationGenerator.ts
+++ b/packages/migrations-mongodb/src/TSMigrationGenerator.ts
@@ -8,6 +8,7 @@ export class TSMigrationGenerator extends MigrationGenerator {
   generateMigrationFile(className: string, diff: { up: string[]; down: string[] }): string {
     let ret = `import { Migration } from '@mikro-orm/migrations-mongodb';\n\n`;
     ret += `export class ${className} extends Migration {\n\n`;
+    ret += `  override name = '${className}';\n\n`;
     ret += `  async up(): Promise<void> {\n`;
     /* v8 ignore next */
     diff.up.forEach(sql => (ret += this.createStatement(sql, 4)));

--- a/packages/migrations/src/JSMigrationGenerator.ts
+++ b/packages/migrations/src/JSMigrationGenerator.ts
@@ -10,6 +10,7 @@ export class JSMigrationGenerator extends MigrationGenerator {
     ret += `Object.defineProperty(exports, '__esModule', { value: true });\n`;
     ret += `const { Migration } = require('@mikro-orm/migrations');\n\n`;
     ret += `class ${className} extends Migration {\n\n`;
+    ret += `  name = '${className}';\n\n`;
     ret += `  async up() {\n`;
     diff.up.forEach(sql => (ret += this.createStatement(sql, 4)));
     ret += `  }\n\n`;

--- a/packages/migrations/src/Migration.ts
+++ b/packages/migrations/src/Migration.ts
@@ -12,6 +12,9 @@ export type Query = string | NativeQueryBuilder | RawQueryFragment;
 
 /** Base class for SQL database migrations. Extend this class and implement `up()` (and optionally `down()`). */
 export abstract class Migration {
+  /** Stable migration name, used instead of the class name (which minifiers can mangle). */
+  name?: string;
+
   readonly #queries: Query[] = [];
   protected ctx?: Transaction;
   #em?: EntityManager;

--- a/packages/migrations/src/TSMigrationGenerator.ts
+++ b/packages/migrations/src/TSMigrationGenerator.ts
@@ -8,6 +8,7 @@ export class TSMigrationGenerator extends MigrationGenerator {
   generateMigrationFile(className: string, diff: { up: string[]; down: string[] }): string {
     let ret = `import { Migration } from '@mikro-orm/migrations';\n\n`;
     ret += `export class ${className} extends Migration {\n\n`;
+    ret += `  override name = '${className}';\n\n`;
     ret += `  override up(): void | Promise<void> {\n`;
     diff.up.forEach(sql => (ret += this.createStatement(sql, 4)));
     ret += `  }\n\n`;

--- a/tests/features/migrations/__snapshots__/GH7185.test.ts.snap
+++ b/tests/features/migrations/__snapshots__/GH7185.test.ts.snap
@@ -5,6 +5,8 @@ exports[`GH7185 [mariadb] > multiline comments are not split in migration SQL 1`
 
 export class Migration20250101000000 extends Migration {
 
+  override name = 'Migration20250101000000';
+
   override up(): void | Promise<void> {
     this.addSql(\`create table \\\`test_entity\\\` (\\\`id\\\` int unsigned not null auto_increment primary key comment 'line1;\\\\nline2;\\\\nline3', \\\`name\\\` varchar(255) not null comment 'line1;\\\\nline2;\\\\nline3') default character set utf8mb4 engine = InnoDB comment = 'line1;\\\\nline2;\\\\nline3';\`);
   }
@@ -21,6 +23,8 @@ exports[`GH7185 [mssql] > multiline comments are not split in migration SQL 1`] 
 "import { Migration } from '@mikro-orm/migrations';
 
 export class Migration20250101000000 extends Migration {
+
+  override name = 'Migration20250101000000';
 
   override up(): void | Promise<void> {
     this.addSql(\`create table [test_entity] ([id] int identity(1,1) not null constraint [test_entity_pkey] primary key, [name] nvarchar(255) not null);\`);
@@ -63,6 +67,8 @@ exports[`GH7185 [mysql] > multiline comments are not split in migration SQL 1`] 
 
 export class Migration20250101000000 extends Migration {
 
+  override name = 'Migration20250101000000';
+
   override up(): void | Promise<void> {
     this.addSql(\`create table \\\`test_entity\\\` (\\\`id\\\` int unsigned not null auto_increment primary key comment 'line1;\\\\nline2;\\\\nline3', \\\`name\\\` varchar(255) not null comment 'line1;\\\\nline2;\\\\nline3') default character set utf8mb4 engine = InnoDB comment = 'line1;\\\\nline2;\\\\nline3';\`);
   }
@@ -79,6 +85,8 @@ exports[`GH7185 [postgresql] > multiline comments are not split in migration SQL
 "import { Migration } from '@mikro-orm/migrations';
 
 export class Migration20250101000000 extends Migration {
+
+  override name = 'Migration20250101000000';
 
   override up(): void | Promise<void> {
     this.addSql(\`create table "test_entity" ("id" serial primary key, "name" varchar(255) not null);\`);

--- a/tests/features/migrations/__snapshots__/Migrator.mongo.test.ts.snap
+++ b/tests/features/migrations/__snapshots__/Migrator.mongo.test.ts.snap
@@ -6,6 +6,8 @@ exports[`Migrator (mongo) > generate blank migration > migration-dump 1`] = `
 
 export class Migration20191013214813 extends Migration {
 
+  override name = 'Migration20191013214813';
+
   async up(): Promise<void> {
   }
 
@@ -27,6 +29,8 @@ const { Migration } = require('@mikro-orm/migrations-mongodb');
 
 class Migration20191013214813 extends Migration {
 
+  name = 'Migration20191013214813';
+
   async up() {
   }
 
@@ -47,6 +51,8 @@ exports[`Migrator (mongo) > generate migration with custom name > migration-dump
 
 export class Migration20191013214813 extends Migration {
 
+  override name = 'Migration20191013214813';
+
   async up(): Promise<void> {
   }
 
@@ -65,6 +71,8 @@ exports[`Migrator (mongo) > generate migration with custom name with name option
   "code": "import { Migration } from '@mikro-orm/migrations-mongodb';
 
 export class Migration20191013214813_custom_name extends Migration {
+
+  override name = 'Migration20191013214813_custom_name';
 
   async up(): Promise<void> {
   }

--- a/tests/features/migrations/__snapshots__/Migrator.mssql.test.ts.snap
+++ b/tests/features/migrations/__snapshots__/Migrator.mssql.test.ts.snap
@@ -6,6 +6,8 @@ exports[`Migrator (mssql) > generate initial migration > initial-migration-dump 
 
 export class Migration20191013214813 extends Migration {
 
+  override name = 'Migration20191013214813';
+
   override up(): void | Promise<void> {
     this.addSql(\`if (schema_id('custom') is null) begin exec ('create schema [custom] authorization [dbo]') end;\`);
     this.addSql(\`create table [custom].[book_tag2] ([id] bigint identity(1,1) not null constraint [book_tag2_pkey] primary key, [name] nvarchar(50) not null);\`);
@@ -197,6 +199,8 @@ exports[`Migrator (mssql) > generate initial migration > initial-migration-dump 
   "code": "import { Migration } from '@mikro-orm/migrations';
 
 export class Migration20191013214813 extends Migration {
+
+  override name = 'Migration20191013214813';
 
   override up(): void | Promise<void> {
     this.addSql(\`if (schema_id('custom') is null) begin exec ('create schema [custom] authorization [dbo]') end;\`);
@@ -392,6 +396,8 @@ const { Migration } = require('@mikro-orm/migrations');
 
 class Migration20191013214813 extends Migration {
 
+  name = 'Migration20191013214813';
+
   async up() {
     this.addSql(\`alter table [custom].[book2] alter column [double] nvarchar(max);\`);
 
@@ -447,6 +453,8 @@ import { Migration } from '@mikro-orm/migrations';
 
 export class Migration20191013214813 extends Migration {
 
+  override name = 'Migration20191013214813';
+
   override up(): void | Promise<void> {
     this.addSql(\`alter table [custom].[book2] alter column [double] nvarchar(max);\`);
 
@@ -498,6 +506,8 @@ exports[`Migrator (mssql) > generate migration with custom name > migration-dump
   "code": "import { Migration } from '@mikro-orm/migrations';
 
 export class Migration20191013214813 extends Migration {
+
+  override name = 'Migration20191013214813';
 
   override up(): void | Promise<void> {
     this.addSql(\`alter table [custom].[book2] alter column [double] nvarchar(max);\`);
@@ -551,6 +561,8 @@ exports[`Migrator (mssql) > generate migration with custom name with name option
 
 export class Migration20191013214813_custom_name extends Migration {
 
+  override name = 'Migration20191013214813_custom_name';
+
   override up(): void | Promise<void> {
     this.addSql(\`alter table [custom].[book2] alter column [double] nvarchar(max);\`);
 
@@ -602,6 +614,8 @@ exports[`Migrator (mssql) > generate migration with snapshot > migration-snapsho
   "code": "import { Migration } from '@mikro-orm/migrations';
 
 export class Migration20191013214813 extends Migration {
+
+  override name = 'Migration20191013214813';
 
   override up(): void | Promise<void> {
     this.addSql(\`alter table [custom].[book2] alter column [double] nvarchar(max);\`);
@@ -665,6 +679,8 @@ exports[`Migrator (mssql) > generate schema migration > migration-dump 1`] = `
   "code": "import { Migration } from '@mikro-orm/migrations';
 
 export class Migration20191013214813 extends Migration {
+
+  override name = 'Migration20191013214813';
 
   override up(): void | Promise<void> {
     this.addSql(\`alter table [custom].[book2] alter column [double] nvarchar(max);\`);

--- a/tests/features/migrations/__snapshots__/Migrator.postgres.test.ts.snap
+++ b/tests/features/migrations/__snapshots__/Migrator.postgres.test.ts.snap
@@ -6,6 +6,8 @@ exports[`Migrator (postgres) > generate initial migration > initial-migration-du
 
 export class Migration20191013214813 extends Migration {
 
+  override name = 'Migration20191013214813';
+
   override up(): void | Promise<void> {
     this.addSql(\`create schema if not exists "custom";\`);
     this.addSql(\`create table "custom"."book_tag2" ("id" bigserial primary key, "name" varchar(50) not null);\`);
@@ -201,6 +203,8 @@ exports[`Migrator (postgres) > generate initial migration > initial-migration-du
   "code": "import { Migration } from '@mikro-orm/migrations';
 
 export class Migration20191013214813 extends Migration {
+
+  override name = 'Migration20191013214813';
 
   override up(): void | Promise<void> {
     this.addSql(\`create schema if not exists "custom";\`);
@@ -400,6 +404,8 @@ const { Migration } = require('@mikro-orm/migrations');
 
 class Migration20191013214813 extends Migration {
 
+  name = 'Migration20191013214813';
+
   async up() {
     this.addSql(\`alter table "custom"."book2" drop column "foo";\`);
     this.addSql(\`alter table "custom"."book2" alter column "double" type double precision using ("double"::double precision);\`);
@@ -443,6 +449,8 @@ import { Migration } from '@mikro-orm/migrations';
 
 export class Migration20191013214813 extends Migration {
 
+  override name = 'Migration20191013214813';
+
   override up(): void | Promise<void> {
     this.addSql(\`alter table "custom"."book2" drop column "foo";\`);
     this.addSql(\`alter table "custom"."book2" alter column "double" type double precision using ("double"::double precision);\`);
@@ -482,6 +490,8 @@ exports[`Migrator (postgres) > generate migration with custom name > migration-d
   "code": "import { Migration } from '@mikro-orm/migrations';
 
 export class Migration20191013214813 extends Migration {
+
+  override name = 'Migration20191013214813';
 
   override up(): void | Promise<void> {
     this.addSql(\`alter table "custom"."book2" drop column "foo";\`);
@@ -523,6 +533,8 @@ exports[`Migrator (postgres) > generate migration with custom name with name opt
 
 export class Migration20191013214813_custom_name extends Migration {
 
+  override name = 'Migration20191013214813_custom_name';
+
   override up(): void | Promise<void> {
     this.addSql(\`alter table "custom"."book2" drop column "foo";\`);
     this.addSql(\`alter table "custom"."book2" alter column "double" type double precision using ("double"::double precision);\`);
@@ -562,6 +574,8 @@ exports[`Migrator (postgres) > generate migration with snapshot > migration-snap
   "code": "import { Migration } from '@mikro-orm/migrations';
 
 export class Migration20191013214813 extends Migration {
+
+  override name = 'Migration20191013214813';
 
   override up(): void | Promise<void> {
     this.addSql(\`alter table "custom"."book2" drop column "foo";\`);
@@ -613,6 +627,8 @@ exports[`Migrator (postgres) > generate schema migration > migration-dump 1`] = 
   "code": "import { Migration } from '@mikro-orm/migrations';
 
 export class Migration20191013214813 extends Migration {
+
+  override name = 'Migration20191013214813';
 
   override up(): void | Promise<void> {
     this.addSql(\`alter table "custom"."book2" drop column "foo";\`);
@@ -814,6 +830,8 @@ exports[`respects the skipTables option when diffing schemas > migration-dump-wi
   "code": "import { Migration } from '@mikro-orm/migrations';
 
 export class Migration20191013214813 extends Migration {
+
+  override name = 'Migration20191013214813';
 
   override up(): void | Promise<void> {
     this.addSql(\`alter table "custom"."test2" drop column "path";\`);

--- a/tests/features/migrations/__snapshots__/Migrator.sqlite.test.ts.snap
+++ b/tests/features/migrations/__snapshots__/Migrator.sqlite.test.ts.snap
@@ -6,6 +6,8 @@ exports[`Migrator (sqlite) > generate initial migration > initial-migration-dump
 
 export class Migration20191013214813 extends Migration {
 
+  override name = 'Migration20191013214813';
+
   override up(): void | Promise<void> {
     this.addSql(\`create table \\\`book_tag4\\\` (\\\`id\\\` integer not null primary key autoincrement, \\\`created_at\\\` datetime null, \\\`updated_at\\\` datetime null, \\\`name\\\` text not null, \\\`version\\\` datetime not null default (strftime('%s', 'now') * 1000));\`);
 
@@ -87,6 +89,8 @@ exports[`Migrator (sqlite) > generate initial migration > initial-migration-dump
   "code": "import { Migration } from '@mikro-orm/migrations';
 
 export class Migration20191013214813 extends Migration {
+
+  override name = 'Migration20191013214813';
 
   override up(): void | Promise<void> {
     this.addSql(\`create table \\\`book_tag4\\\` (\\\`id\\\` integer not null primary key autoincrement, \\\`created_at\\\` datetime null, \\\`updated_at\\\` datetime null, \\\`name\\\` text not null, \\\`version\\\` datetime not null default (strftime('%s', 'now') * 1000));\`);

--- a/tests/features/migrations/__snapshots__/Migrator.test.ts.snap
+++ b/tests/features/migrations/__snapshots__/Migrator.test.ts.snap
@@ -6,6 +6,8 @@ exports[`Migrator > blank initial migration can be created if no entity metadata
 
 export class Migration20191013214813 extends Migration {
 
+  override name = 'Migration20191013214813';
+
   override up(): void | Promise<void> {
     this.addSql(\`select 1\`);
   }
@@ -33,6 +35,8 @@ exports[`Migrator > do not log a migration if the schema does not exist yet > in
   "code": "import { Migration } from '@mikro-orm/migrations';
 
 export class Migration20191013214813 extends Migration {
+
+  override name = 'Migration20191013214813';
 
   override up(): void | Promise<void> {
     this.addSql(\`create table \\\`base_user2\\\` (\\\`id\\\` int unsigned not null auto_increment primary key, \\\`first_name\\\` varchar(100) not null, \\\`last_name\\\` varchar(100) not null, \\\`type\\\` enum('employee','manager','owner') not null, \\\`owner_prop\\\` varchar(255) null, \\\`favourite_employee_id\\\` int unsigned null, \\\`favourite_manager_id\\\` int unsigned null, \\\`employee_prop\\\` int null, \\\`manager_prop\\\` varchar(255) null) default character set utf8mb4 engine = InnoDB;\`);
@@ -340,6 +344,8 @@ const { Migration } = require('@mikro-orm/migrations');
 
 class Migration20191013214813 extends Migration {
 
+  name = 'Migration20191013214813';
+
   async up() {
     this.addSql(\`alter table \\\`foo_param2\\\` drop foreign key \\\`foo_param2_bar_id_foreign\\\`;\`);
     this.addSql(\`alter table \\\`foo_param2\\\` drop foreign key \\\`foo_param2_baz_id_foreign\\\`;\`);
@@ -441,6 +447,8 @@ const { Migration } = require('@mikro-orm/migrations');
 
 class Migration20191013214813 extends Migration {
 
+  name = 'Migration20191013214813';
+
   async up() {
     this.addSql(\`alter table \\\`foo_param2\\\` drop foreign key \\\`foo_param2_bar_id_foreign\\\`;\`);
     this.addSql(\`alter table \\\`foo_param2\\\` drop foreign key \\\`foo_param2_baz_id_foreign\\\`;\`);
@@ -540,6 +548,8 @@ exports[`Migrator > generate migration with custom name > migration-dump 1`] = `
 
 export class Migration20191013214813 extends Migration {
 
+  override name = 'Migration20191013214813';
+
   override up(): void | Promise<void> {
     this.addSql(\`alter table \\\`foo_param2\\\` drop foreign key \\\`foo_param2_bar_id_foreign\\\`;\`);
     this.addSql(\`alter table \\\`foo_param2\\\` drop foreign key \\\`foo_param2_baz_id_foreign\\\`;\`);
@@ -638,6 +648,8 @@ exports[`Migrator > generate schema migration > migration-dump 1`] = `
 
 export class Migration20191013214813 extends Migration {
 
+  override name = 'Migration20191013214813';
+
   override up(): void | Promise<void> {
     this.addSql(\`alter table \\\`foo_param2\\\` drop foreign key \\\`foo_param2_bar_id_foreign\\\`;\`);
     this.addSql(\`alter table \\\`foo_param2\\\` drop foreign key \\\`foo_param2_baz_id_foreign\\\`;\`);
@@ -735,6 +747,8 @@ exports[`Migrator > log a migration when the schema already exists > initial-mig
   "code": "import { Migration } from '@mikro-orm/migrations';
 
 export class Migration20191013214813 extends Migration {
+
+  override name = 'Migration20191013214813';
 
   override up(): void | Promise<void> {
     this.addSql(\`create table \\\`base_user2\\\` (\\\`id\\\` int unsigned not null auto_increment primary key, \\\`first_name\\\` varchar(100) not null, \\\`last_name\\\` varchar(100) not null, \\\`type\\\` enum('employee','manager','owner') not null, \\\`owner_prop\\\` varchar(255) null, \\\`favourite_employee_id\\\` int unsigned null, \\\`favourite_manager_id\\\` int unsigned null, \\\`employee_prop\\\` int null, \\\`manager_prop\\\` varchar(255) null) default character set utf8mb4 engine = InnoDB;\`);
@@ -1039,6 +1053,8 @@ exports[`Migrator > snapshot should not be updated when custom migration fileNam
   "code": "import { Migration } from '@mikro-orm/migrations';
 
 export class Migration20191013214813_with_custom_name extends Migration {
+
+  override name = 'Migration20191013214813_with_custom_name';
 
   override up(): void | Promise<void> {
     this.addSql(\`alter table \\\`foo_param2\\\` drop foreign key \\\`foo_param2_bar_id_foreign\\\`;\`);

--- a/tests/features/migrations/migrations-list-stable-names.sqlite.test.ts
+++ b/tests/features/migrations/migrations-list-stable-names.sqlite.test.ts
@@ -1,0 +1,99 @@
+import { defineEntity, MikroORM, p } from '@mikro-orm/sqlite';
+import { Migration, Migrator } from '@mikro-orm/migrations';
+import type { Constructor, MigrationObject } from '@mikro-orm/core';
+
+const Foo = defineEntity({
+  name: 'Foo',
+  tableName: 'foo',
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+  },
+});
+
+function renameClass(cls: Constructor<Migration>, name: string): void {
+  Object.defineProperty(cls, 'name', { value: name, configurable: true });
+}
+
+async function createORM(migrationsList: (MigrationObject | Constructor<Migration>)[]) {
+  return MikroORM.init({
+    entities: [Foo],
+    dbName: ':memory:',
+    extensions: [Migrator],
+    migrations: {
+      migrationsList,
+      snapshot: false,
+      silent: true,
+    },
+  });
+}
+
+describe('migrationsList stable names (sqlite)', () => {
+  test('bare class entries derive the stored name from the `name` property, not the constructor name', async () => {
+    // a minifier (e.g. Turbopack production build) mangles class names, so the constructor
+    // name is not a stable identity — the `name` property survives minification
+    class Migration20250101000000 extends Migration {
+      override name = 'Migration20250101000000';
+
+      override async up(): Promise<void> {
+        this.addSql('create table stable_name_test (id integer not null primary key)');
+      }
+    }
+
+    const orm = await createORM([Migration20250101000000]);
+
+    try {
+      // simulate the minified production build executing the migration first
+      renameClass(Migration20250101000000, 'g');
+      await orm.migrator.up();
+      const executed = await orm.migrator.getExecuted();
+      expect(executed.map(row => row.name)).toEqual(['Migration20250101000000']);
+
+      // simulate the unminified dev build running against the same database — without a stable
+      // name, the migration is considered pending again and fails with a TableExistsException
+      renameClass(Migration20250101000000, 'Migration20250101000000');
+      await expect(orm.migrator.up()).resolves.toEqual([]);
+      await expect(orm.migrator.getPending()).resolves.toEqual([]);
+    } finally {
+      await orm.close(true);
+    }
+  });
+
+  test('explicit name of a `MigrationObject` entry wins over the `name` property', async () => {
+    class MigrationWithBothNames extends Migration {
+      override name = 'instance-name';
+
+      override async up(): Promise<void> {
+        this.addSql('select 1');
+      }
+    }
+
+    const orm = await createORM([{ name: 'explicit-name', class: MigrationWithBothNames }]);
+
+    try {
+      await orm.migrator.up();
+      const executed = await orm.migrator.getExecuted();
+      expect(executed.map(row => row.name)).toEqual(['explicit-name']);
+    } finally {
+      await orm.close(true);
+    }
+  });
+
+  test('bare class entries without a `name` property keep using the constructor name', async () => {
+    class Migration20250102000000 extends Migration {
+      override async up(): Promise<void> {
+        this.addSql('select 1');
+      }
+    }
+
+    const orm = await createORM([Migration20250102000000]);
+
+    try {
+      await orm.migrator.up();
+      const executed = await orm.migrator.getExecuted();
+      expect(executed.map(row => row.name)).toEqual(['Migration20250102000000']);
+    } finally {
+      await orm.close(true);
+    }
+  });
+});


### PR DESCRIPTION
Migrations provided via `migrations.migrationsList` as bare class references were recorded in the migrations table under their constructor name. Minifiers (e.g. Turbopack in Next.js 16 production builds) mangle class names, so the same migration got recorded under a different name in minified and unminified builds of the same app. Running the dev build against a database migrated by the production build then re-executed the migration and failed, e.g. with a `TableExistsException`.

The migration name is now resolved from the `name` property of the migration instance before falling back to the constructor name (an explicit `MigrationObject.name` still wins). Generated migration files set the property automatically, so new migrations survive minification out of the box. Existing migration files can add the property manually (documented), or keep using the object form with an explicit name.
