### PR TITLE
fix(core): ignore metadata cache entries cached from a different source file

### DIFF
--- a/packages/core/src/cache/CacheAdapter.ts
+++ b/packages/core/src/cache/CacheAdapter.ts
@@ -1,9 +1,10 @@
 /** Interface for async-capable cache storage used by result cache and metadata cache. */
 export interface CacheAdapter {
   /**
-   * Gets the items under `name` key from the cache.
+   * Gets the items under `name` key from the cache. When `origin` is provided, adapters that
+   * track the entry origin should ignore entries cached from a different source file.
    */
-  get<T = any>(name: string): T | Promise<T | undefined> | undefined;
+  get<T = any>(name: string, origin?: string): T | Promise<T | undefined> | undefined;
 
   /**
    * Sets the item to the cache. `origin` is used for cache invalidation and should reflect the change in data.
@@ -29,9 +30,10 @@ export interface CacheAdapter {
 /** Synchronous variant of CacheAdapter, used for metadata cache where async access is not needed. */
 export interface SyncCacheAdapter extends CacheAdapter {
   /**
-   * Gets the items under `name` key from the cache.
+   * Gets the items under `name` key from the cache. When `origin` is provided, adapters that
+   * track the entry origin should ignore entries cached from a different source file.
    */
-  get<T = any>(name: string): T | undefined;
+  get<T = any>(name: string, origin?: string): T | undefined;
 
   /**
    * Sets the item to the cache. `origin` is used for cache invalidation and should reflect the change in data.

--- a/packages/core/src/cache/FileCacheAdapter.ts
+++ b/packages/core/src/cache/FileCacheAdapter.ts
@@ -22,7 +22,7 @@ export class FileCacheAdapter implements SyncCacheAdapter {
   /**
    * @inheritDoc
    */
-  get(name: string): any {
+  get(name: string, origin?: string): any {
     const path = this.path(name);
 
     if (!existsSync(path)) {
@@ -30,6 +30,13 @@ export class FileCacheAdapter implements SyncCacheAdapter {
     }
 
     const payload = fs.readJSONSync(path);
+
+    // Two classes with the same name share the cache key, ignore entries cached
+    // from a different source file.
+    if (origin && fs.absolutePath(payload.origin, this.#baseDir) !== fs.absolutePath(origin, this.#baseDir)) {
+      return null;
+    }
+
     const hash = this.getHash(payload.origin);
 
     if (!hash || payload.hash !== hash) {

--- a/packages/core/src/metadata/MetadataProvider.ts
+++ b/packages/core/src/metadata/MetadataProvider.ts
@@ -121,7 +121,7 @@ export class MetadataProvider {
       return undefined;
     }
 
-    const cache = meta.path && this.config.getMetadataCacheAdapter().get(this.getCacheKey(meta));
+    const cache = meta.path && this.config.getMetadataCacheAdapter().get(this.getCacheKey(meta), meta.path);
 
     if (cache) {
       this.loadFromCache(meta as EntityMetadata<T>, cache);

--- a/tests/features/reflection/duplicate-class-name-cache.test.ts
+++ b/tests/features/reflection/duplicate-class-name-cache.test.ts
@@ -1,0 +1,38 @@
+import { rmSync } from 'node:fs';
+import { MikroORM } from '@mikro-orm/sqlite';
+import { TsMorphMetadataProvider } from '@mikro-orm/reflection';
+import { User as User1 } from './entities-dup-name/user1/User.js';
+import { User as User2 } from './entities-dup-name/user2/User.js';
+import { TEMP_DIR } from '../../helpers.js';
+
+const cacheDir = TEMP_DIR + '/metadata-cache-dup-class-name';
+
+function createORM() {
+  return MikroORM.init({
+    dbName: ':memory:',
+    entities: [User1, User2],
+    baseDir: import.meta.dirname,
+    metadataProvider: TsMorphMetadataProvider,
+    metadataCache: { enabled: true, options: { cacheDir } },
+  });
+}
+
+afterAll(() => rmSync(cacheDir, { recursive: true, force: true }));
+
+test('metadata cache ignores entries cached from a different file (duplicate class names)', async () => {
+  rmSync(cacheDir, { recursive: true, force: true });
+
+  // cold boot populates the cache, both classes share the cache key `User.ts`
+  const orm1 = await createORM();
+  expect(Object.keys(orm1.getMetadata().get(User1).properties)).toEqual(['id', 'email']);
+  expect(Object.keys(orm1.getMetadata().get(User2).properties)).toEqual(['id', 'username']);
+  await orm1.close(true);
+
+  // warm boot must not serve one class the other's cached metadata
+  const orm2 = await createORM();
+  expect(orm2.getMetadata().get(User1).tableName).toBe('user1');
+  expect(Object.keys(orm2.getMetadata().get(User1).properties)).toEqual(['id', 'email']);
+  expect(orm2.getMetadata().get(User2).tableName).toBe('user2');
+  expect(Object.keys(orm2.getMetadata().get(User2).properties)).toEqual(['id', 'username']);
+  await orm2.close(true);
+});

--- a/tests/features/reflection/entities-dup-name/user1/User.ts
+++ b/tests/features/reflection/entities-dup-name/user1/User.ts
@@ -1,0 +1,10 @@
+import { Entity, PrimaryKey, Property } from '@mikro-orm/decorators/legacy';
+
+@Entity({ tableName: 'user1' })
+export class User {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  email!: string;
+}

--- a/tests/features/reflection/entities-dup-name/user2/User.ts
+++ b/tests/features/reflection/entities-dup-name/user2/User.ts
@@ -1,0 +1,10 @@
+import { Entity, PrimaryKey, Property } from '@mikro-orm/decorators/legacy';
+
+@Entity({ tableName: 'user2' })
+export class User {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  username!: string;
+}


### PR DESCRIPTION
The metadata cache key is derived from the class name (`getCacheKey()` returns `className` plus the file extension for the ts-morph provider), so two entities with the same class name in different files share one cache entry. `FileCacheAdapter` only validated the content hash of the recorded origin file, never that the origin matches the entity being loaded, so one class could silently load the other's cached metadata. A single cold run is enough to hit it: discovery caches the first class, then the second class finds that fresh entry (its hash is valid), gets the first one's properties and table name merged in, and discovery fails with `Duplicate table names are not allowed`.

`CacheAdapter.get()` now accepts an optional `origin` (symmetric with `set()`, which already takes one), the metadata provider passes the entity path, and `FileCacheAdapter` ignores entries cached from a different source file. Duplicate class names effectively opt out of caching (each boot re-reflects them), which trades cache hits for correct metadata. Other adapters are unaffected, and the combined/`GeneratedCacheAdapter` production flow keeps its name-based lookup, since bundled runtime paths legitimately differ from generation-time paths.

Related to #8107 (same "class name used as identity" family, found while auditing the remaining name-keyed lookups).
