### PR TITLE
fix(sql): infer columns with a default value as kysely `Generated`

### DIFF
--- a/packages/sql/src/typings.ts
+++ b/packages/sql/src/typings.ts
@@ -456,9 +456,9 @@ type MaybeGenerated<TValue, TOptions, TProcessOnCreate extends boolean> = TOptio
   ? TValue | null
   : TOptions extends { autoincrement: true }
     ? Generated<TValue>
-    : TOptions extends { default: true }
+    : TOptions extends { default: unknown }
       ? Generated<TValue>
-      : TOptions extends { defaultRaw: true }
+      : TOptions extends { defaultRaw: unknown }
         ? Generated<TValue>
         : TProcessOnCreate extends false
           ? TValue

--- a/tests/features/get-kysely.test.ts
+++ b/tests/features/get-kysely.test.ts
@@ -670,7 +670,8 @@ describe('InferKyselyDB', () => {
       name: string;
     }>();
 
-    orm.em.getKysely().insertInto('probe').values({ name: 'foo' });
+    const kysely = orm.em.getKysely();
+    kysely.insertInto('probe').values({ name: 'foo' });
   });
 });
 

--- a/tests/features/get-kysely.test.ts
+++ b/tests/features/get-kysely.test.ts
@@ -639,6 +639,39 @@ describe('InferKyselyDB', () => {
       lives: number;
     }>();
   });
+
+  test('infer columns with a default value as Generated (GH #8113)', () => {
+    const Probe = defineEntity({
+      name: 'Probe8113',
+      tableName: 'probe',
+      properties: {
+        id: p.uuid().primary().defaultRaw('uuidv7()'),
+        createdAt: p.datetime().defaultRaw('now()'),
+        enabled: p.boolean().default(true),
+        disabled: p.boolean().default(false),
+        count: p.integer().default(0),
+        name: p.string(),
+      },
+    });
+
+    const orm = new MikroORM({
+      entities: [Probe],
+      dbName: ':memory:',
+    });
+
+    type DB = InferKyselyDB<typeof Probe, {}>;
+
+    expectTypeOf<DB['probe']>().toEqualTypeOf<{
+      id: Generated<string>;
+      created_at: Generated<Date>;
+      enabled: Generated<boolean>;
+      disabled: Generated<boolean>;
+      count: Generated<number>;
+      name: string;
+    }>();
+
+    orm.em.getKysely().insertInto('probe').values({ name: 'foo' });
+  });
 });
 
 describe('InferClassEntityDB', () => {


### PR DESCRIPTION
`MaybeGenerated` tested the options for `{ default: true }` and `{ defaultRaw: true }`, but the property builders keep the actual value, so the options end up as `{ default: false }`, `{ default: 0 }` or `{ defaultRaw: string }`. Only a literal `true` default ever matched and the `defaultRaw` branch was unreachable, so those columns were still required in a typed Kysely insert. Now both branches check that the option is present instead.

Fixes #8113