### PR TITLE
fix(entity-generator): preserve the where clause of partial indexes

### DIFF
--- a/packages/sql/src/schema/DatabaseTable.ts
+++ b/packages/sql/src/schema/DatabaseTable.ts
@@ -304,6 +304,7 @@ export class DatabaseTable {
           skippedColumnNames.includes(index.columnNames[0]) || // Non-composite indexes for skipped columns are to be mapped as entity decorators.
           index.deferMode ||
           index.expression ||
+          index.where ||
           !(index.columnNames[0] in columnFks)) && // Trivial non-composite indexes for scalar props are to be mapped to the column.
         // ignore indexes that don't have all column names (this can happen in sqlite where there is no way to infer this for expressions)
         !(index.columnNames.some(col => !col) && !index.expression),
@@ -680,6 +681,7 @@ export class DatabaseTable {
     const fkColumnsLength = currentFk.columnNames.length;
     const possibleIndexes = this.#indexes.filter(index => {
       return (
+        !index.where &&
         index.columnNames.length === fkColumnsLength &&
         !currentFk.columnNames.some((columnName, i) => index.columnNames[i] !== columnName)
       );
@@ -941,10 +943,14 @@ export class DatabaseTable {
     const persist = !(column.name in columnFks && typeof fk === 'undefined');
     const index =
       compositeFkIndexes[prop] ||
-      this.#indexes.find(idx => idx.columnNames[0] === column.name && !idx.composite && !idx.unique && !idx.primary);
+      this.#indexes.find(
+        idx => idx.columnNames[0] === column.name && !idx.composite && !idx.unique && !idx.primary && !idx.where,
+      );
     const unique =
       compositeFkUniques[prop] ||
-      this.#indexes.find(idx => idx.columnNames[0] === column.name && !idx.composite && idx.unique && !idx.primary);
+      this.#indexes.find(
+        idx => idx.columnNames[0] === column.name && !idx.composite && idx.unique && !idx.primary && !idx.where,
+      );
 
     const kind = this.getReferenceKind(fk, unique);
     const runtimeType = this.getPropertyTypeForColumn(namingStrategy, column, fk);

--- a/tests/features/entity-generator/__snapshots__/advanced-index-options.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/advanced-index-options.test.ts.snap
@@ -275,6 +275,105 @@ export const TestIndexTypeSchema = defineEntity({
 ]
 `;
 
+exports[`EntityGenerator advanced index options > generates entities with partial index on a foreign key column > partial index on foreign key column 1`] = `
+[
+  "import { type Ref, defineEntity, p } from '@mikro-orm/core';
+import { TestPartialTenant } from './TestPartialTenant';
+
+export class TestPartialNode {
+  id!: number;
+  tenant!: Ref<TestPartialTenant>;
+  slug?: string;
+  parentId?: number;
+}
+
+export const TestPartialNodeSchema = defineEntity({
+  class: TestPartialNode,
+  indexes: [
+    { name: 'partial_slug_idx', where: 'parent_id IS NULL', properties: ['slug'] },
+  ],
+  uniques: [
+    {
+      name: 'partial_single_root_idx',
+      where: 'parent_id IS NULL',
+      properties: ['tenant'],
+    },
+  ],
+  properties: {
+    id: p.integer().primary(),
+    tenant: () => p.manyToOne(TestPartialTenant).ref().updateRule('no action').deleteRule('no action'),
+    slug: p.string().nullable(),
+    parentId: p.integer().nullable(),
+  },
+});
+",
+  "import { Collection, defineEntity, p } from '@mikro-orm/core';
+import { TestPartialNode } from './TestPartialNode';
+
+export class TestPartialTenant {
+  id!: number;
+  testPartialNodeCollection = new Collection<TestPartialNode>(this);
+}
+
+export const TestPartialTenantSchema = defineEntity({
+  class: TestPartialTenant,
+  properties: {
+    id: p.integer().primary(),
+    testPartialNodeCollection: () => p.oneToMany(TestPartialNode).mappedBy('tenant'),
+  },
+});
+",
+]
+`;
+
+exports[`EntityGenerator advanced index options > generates entities with partial index on a foreign key column with standalone scalar properties > partial index on foreign key column with standalone scalar properties 1`] = `
+[
+  "import { type Ref, defineEntity, p } from '@mikro-orm/core';
+import { TestPartialTenant } from './TestPartialTenant';
+
+export class TestPartialNode {
+  id!: number;
+  tenant!: Ref<TestPartialTenant>;
+  tenantId!: number;
+  parentId?: number;
+}
+
+export const TestPartialNodeSchema = defineEntity({
+  class: TestPartialNode,
+  uniques: [
+    {
+      name: 'partial_single_root_idx',
+      where: 'parent_id IS NULL',
+      properties: ['tenantId'],
+    },
+  ],
+  properties: {
+    id: p.integer().primary(),
+    tenant: () => p.manyToOne(TestPartialTenant).ref().updateRule('no action').deleteRule('no action'),
+    tenantId: p.integer().persist(false),
+    parentId: p.integer().nullable(),
+  },
+});
+",
+  "import { Collection, defineEntity, p } from '@mikro-orm/core';
+import { TestPartialNode } from './TestPartialNode';
+
+export class TestPartialTenant {
+  id!: number;
+  testPartialNodeCollection = new Collection<TestPartialNode>(this);
+}
+
+export const TestPartialTenantSchema = defineEntity({
+  class: TestPartialTenant,
+  properties: {
+    id: p.integer().primary(),
+    testPartialNodeCollection: () => p.oneToMany(TestPartialNode).mappedBy('tenant'),
+  },
+});
+",
+]
+`;
+
 exports[`EntityGenerator advanced index options > generates entities with sort order and NULLS ordering > sort and nulls ordering 1`] = `
 [
   "import { defineEntity, p } from '@mikro-orm/core';

--- a/tests/features/entity-generator/advanced-index-options.test.ts
+++ b/tests/features/entity-generator/advanced-index-options.test.ts
@@ -244,6 +244,77 @@ describe('EntityGenerator advanced index options', () => {
     expect(dump).toMatchSnapshot('unique with sort order');
     await orm.close(true);
   });
+
+  test('generates entities with partial index on a foreign key column', async () => {
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      dbName: 'mikro_orm_test_entity_gen_partial_fk',
+      discovery: { warnWhenNoEntities: false },
+      ensureDatabase: false,
+      extensions: [EntityGenerator],
+    });
+
+    await orm.schema.ensureDatabase({ create: true });
+    await orm.schema.execute('DROP TABLE IF EXISTS "test_partial_node"');
+    await orm.schema.execute('DROP TABLE IF EXISTS "test_partial_tenant"');
+    await orm.schema.execute(`
+      CREATE TABLE "test_partial_tenant" (
+        "id" serial PRIMARY KEY
+      )
+    `);
+    await orm.schema.execute(`
+      CREATE TABLE "test_partial_node" (
+        "id" serial PRIMARY KEY,
+        "tenant_id" int NOT NULL REFERENCES "test_partial_tenant" ("id"),
+        "slug" varchar(255),
+        "parent_id" int
+      )
+    `);
+    await orm.schema.execute(
+      'CREATE UNIQUE INDEX "partial_single_root_idx" ON "test_partial_node" ("tenant_id") WHERE "parent_id" IS NULL',
+    );
+    await orm.schema.execute(
+      'CREATE INDEX "partial_slug_idx" ON "test_partial_node" ("slug") WHERE "parent_id" IS NULL',
+    );
+
+    const dump = await orm.entityGenerator.generate();
+    expect(dump).toMatchSnapshot('partial index on foreign key column');
+    await orm.close(true);
+  });
+
+  test('generates entities with partial index on a foreign key column with standalone scalar properties', async () => {
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      dbName: 'mikro_orm_test_entity_gen_partial_fk',
+      discovery: { warnWhenNoEntities: false },
+      ensureDatabase: false,
+      entityGenerator: { scalarPropertiesForRelations: 'always' },
+      extensions: [EntityGenerator],
+    });
+
+    await orm.schema.ensureDatabase({ create: true });
+    await orm.schema.execute('DROP TABLE IF EXISTS "test_partial_node"');
+    await orm.schema.execute('DROP TABLE IF EXISTS "test_partial_tenant"');
+    await orm.schema.execute(`
+      CREATE TABLE "test_partial_tenant" (
+        "id" serial PRIMARY KEY
+      )
+    `);
+    await orm.schema.execute(`
+      CREATE TABLE "test_partial_node" (
+        "id" serial PRIMARY KEY,
+        "tenant_id" int NOT NULL REFERENCES "test_partial_tenant" ("id"),
+        "parent_id" int
+      )
+    `);
+    await orm.schema.execute(
+      'CREATE UNIQUE INDEX "partial_single_root_idx" ON "test_partial_node" ("tenant_id") WHERE "parent_id" IS NULL',
+    );
+
+    const dump = await orm.entityGenerator.generate();
+    expect(dump).toMatchSnapshot('partial index on foreign key column with standalone scalar properties');
+    await orm.close(true);
+  });
 });
 
 describe('EntityGenerator advanced index options (MySQL)', () => {


### PR DESCRIPTION
A partial index covering a single foreign key column came out of the entity generator as a plain unique/index on the property, without its `WHERE` predicate. The prefilter in `DatabaseTable.getEntityDeclaration()` decides which indexes still need an entity level declaration, and it only looked at `deferMode` and `expression`. The `isTrivial` check further down does consider `where`, but a single-column partial index never got that far.

`where` is now part of that prefilter. The two lookups that attach a plain index to a property, `findFkIndex()` and the fallbacks in `getPropertyDeclaration()`, skip partial indexes as well. Without that, the same index would be rendered twice, once at entity level with the predicate and once on the property without it, and generating the schema back from that produces two objects sharing one name. It also keeps a partial unique index on a foreign key column from being read as a 1:1 relation, since it only constrains the rows its predicate matches.

Fixes #8115