### PR TITLE
fix(entity-generator): keep index column order when columns map to relations

### DIFF
--- a/packages/sql/src/schema/DatabaseTable.ts
+++ b/packages/sql/src/schema/DatabaseTable.ts
@@ -706,13 +706,24 @@ export class DatabaseTable {
     fksOnStandaloneProps: Map<string, { fkIndex?: IndexDef; currentFk: ForeignKey }>,
     namingStrategy: NamingStrategy,
   ) {
-    const propBaseNames = new Set<string>();
+    const propBaseNames = new Map<string, { first: number; last: number }>();
     const columnNames = index.columnNames;
     const l = columnNames.length;
 
     if (columnNames.some(col => !col)) {
       return;
     }
+
+    const addPropBaseName = (baseName: string, position: number) => {
+      const positions = propBaseNames.get(baseName);
+
+      if (positions) {
+        positions.last = position;
+        return;
+      }
+
+      propBaseNames.set(baseName, { first: position, last: position });
+    };
 
     for (let i = 0; i < l; ++i) {
       const columnName = columnNames[i];
@@ -725,7 +736,7 @@ export class DatabaseTable {
         }
         // It has a prop named after it.
         // Add it and move on.
-        propBaseNames.add(columnName);
+        addPropBaseName(columnName, i);
         continue;
       }
 
@@ -733,7 +744,7 @@ export class DatabaseTable {
       // include this prop and move on.
       const columnPropFk = fksOnColumnProps.get(columnName);
       if (columnPropFk && !columnPropFk.columnNames.some(fkColumnName => !columnNames.includes(fkColumnName))) {
-        propBaseNames.add(columnName);
+        addPropBaseName(columnName, i);
         continue;
       }
 
@@ -747,7 +758,7 @@ export class DatabaseTable {
         }
 
         if (!fk.columnNames.some(fkColumnName => !columnNames.includes(fkColumnName))) {
-          propBaseNames.add(propName);
+          addPropBaseName(propName, i);
           propAdded = true;
         }
       }
@@ -761,9 +772,10 @@ export class DatabaseTable {
       return;
     }
 
-    return Array.from(propBaseNames).map(baseName =>
-      this.getPropertyName(namingStrategy, baseName, fksOnColumnProps.get(baseName)),
-    );
+    // Props sharing their first column would otherwise follow FK discovery order, so break ties on the last one.
+    return Array.from(propBaseNames)
+      .sort(([, a], [, b]) => a.first - b.first || a.last - b.last)
+      .map(([baseName]) => this.getPropertyName(namingStrategy, baseName, fksOnColumnProps.get(baseName)));
   }
 
   private getSafeBaseNameForFkProp(

--- a/tests/features/entity-generator/GH8116.postgresql.test.ts
+++ b/tests/features/entity-generator/GH8116.postgresql.test.ts
@@ -39,6 +39,23 @@ const schema = `
     on "public"."role_grants" ("tenant_id", "user_id", "role_id", "org_node_id", "coverage");
 `;
 
+const nestedSchema = `
+  create table "public"."p1" ("c1" int4 not null, "c2" int4 not null, primary key ("c1", "c2"));
+  create table "public"."p2" ("d1" int4 not null, "d2" int4 not null, primary key ("d1", "d2"));
+  create table "public"."child" (
+    "id" serial4 not null,
+    "p_a" int4 not null,
+    "q_a" int4 not null,
+    "q_b" int4 not null,
+    "filler" int4 not null,
+    "p_b" int4 not null,
+    primary key ("id"),
+    constraint "fk_p" foreign key ("p_a", "p_b") references "public"."p1" ("c1", "c2"),
+    constraint "fk_q" foreign key ("q_a", "q_b") references "public"."p2" ("d1", "d2")
+  );
+  create unique index "uq_child" on "public"."child" ("p_a", "q_a", "q_b", "filler", "p_b");
+`;
+
 test('GH8116: index column order is kept when columns are shared between relations', async () => {
   const orm = await MikroORM.init({
     metadataProvider: ReflectMetadataProvider,
@@ -62,6 +79,31 @@ test('GH8116: index column order is kept when columns are shared between relatio
 
   const roleGrants = dump.find(file => file.includes('class RoleGrants'))!;
   expect(roleGrants).toContain(`properties: ['tenantId', 'userId', 'roleId', 'orgNodeId', 'coverage']`);
+
+  await orm.close(true);
+});
+
+test('GH8116: a relation spanning other index columns keeps the position of its first column', async () => {
+  const orm = await MikroORM.init({
+    metadataProvider: ReflectMetadataProvider,
+    dbName: '8116_nested',
+    discovery: {
+      warnWhenNoEntities: false,
+    },
+    ensureDatabase: false,
+    extensions: [EntityGenerator],
+    entityGenerator: {
+      scalarPropertiesForRelations: 'always',
+    },
+  });
+
+  if (await orm.schema.ensureDatabase({ create: true })) {
+    await orm.schema.execute(nestedSchema);
+  }
+
+  const dump = await orm.entityGenerator.generate();
+  const child = dump.find(file => file.includes('class Child'))!;
+  expect(child).toContain(`properties: ['p1', 'p2', 'filler']`);
 
   await orm.close(true);
 });

--- a/tests/features/entity-generator/GH8116.postgresql.test.ts
+++ b/tests/features/entity-generator/GH8116.postgresql.test.ts
@@ -1,0 +1,67 @@
+import { MikroORM } from '@mikro-orm/postgresql';
+import { ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+import { EntityGenerator } from '@mikro-orm/entity-generator';
+
+const schema = `
+  create table "public"."tenants" (
+    "id" int4 not null,
+    primary key ("id")
+  );
+  create table "public"."users" (
+    "tenant_id" int4 not null,
+    "id" int4 not null,
+    primary key ("tenant_id", "id")
+  );
+  create table "public"."roles" (
+    "tenant_id" int4 not null,
+    "id" int4 not null,
+    primary key ("tenant_id", "id")
+  );
+  create table "public"."org_nodes" (
+    "tenant_id" int4 not null,
+    "id" int4 not null,
+    primary key ("tenant_id", "id")
+  );
+  create table "public"."role_grants" (
+    "id" serial4 not null,
+    "tenant_id" int4 not null,
+    "user_id" int4 not null,
+    "role_id" int4 not null,
+    "org_node_id" int4 not null,
+    "coverage" varchar(64) not null,
+    primary key ("id"),
+    constraint "fk_org" foreign key ("tenant_id", "org_node_id") references "public"."org_nodes" ("tenant_id", "id"),
+    constraint "fk_role" foreign key ("tenant_id", "role_id") references "public"."roles" ("tenant_id", "id"),
+    constraint "fk_tenant" foreign key ("tenant_id") references "public"."tenants" ("id"),
+    constraint "fk_user" foreign key ("tenant_id", "user_id") references "public"."users" ("tenant_id", "id")
+  );
+  create unique index "uq_role_grants_anchored"
+    on "public"."role_grants" ("tenant_id", "user_id", "role_id", "org_node_id", "coverage");
+`;
+
+test('GH8116: index column order is kept when columns are shared between relations', async () => {
+  const orm = await MikroORM.init({
+    metadataProvider: ReflectMetadataProvider,
+    dbName: '8116',
+    discovery: {
+      warnWhenNoEntities: false,
+    },
+    ensureDatabase: false,
+    extensions: [EntityGenerator],
+    entityGenerator: {
+      scalarPropertiesForRelations: 'always',
+    },
+  });
+
+  if (await orm.schema.ensureDatabase({ create: true })) {
+    await orm.schema.execute(schema);
+  }
+
+  const dump = await orm.entityGenerator.generate();
+  expect(dump).toMatchSnapshot();
+
+  const roleGrants = dump.find(file => file.includes('class RoleGrants'))!;
+  expect(roleGrants).toContain(`properties: ['tenantId', 'userId', 'roleId', 'orgNodeId', 'coverage']`);
+
+  await orm.close(true);
+});

--- a/tests/features/entity-generator/__snapshots__/GH8116.postgresql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/GH8116.postgresql.test.ts.snap
@@ -1,0 +1,120 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`GH8116: index column order is kept when columns are shared between relations 1`] = `
+[
+  "import { Collection, PrimaryKeyProp, defineEntity, p } from '@mikro-orm/core';
+import { RoleGrants } from './RoleGrants';
+
+export class OrgNodes {
+  [PrimaryKeyProp]?: ['tenantId', 'id'];
+  tenantId!: number;
+  id!: number;
+  roleGrantsCollection = new Collection<RoleGrants>(this);
+}
+
+export const OrgNodesSchema = defineEntity({
+  class: OrgNodes,
+  properties: {
+    tenantId: p.integer().primary(),
+    id: p.integer().primary(),
+    roleGrantsCollection: () => p.oneToMany(RoleGrants).mappedBy('orgNode'),
+  },
+});
+",
+  "import { type Ref, defineEntity, p } from '@mikro-orm/core';
+import { OrgNodes } from './OrgNodes';
+import { Roles } from './Roles';
+import { Tenants } from './Tenants';
+import { Users } from './Users';
+
+export class RoleGrants {
+  id!: number;
+  tenant!: Ref<Tenants>;
+  tenantId!: number;
+  user!: Ref<Users>;
+  userId!: number;
+  role!: Ref<Roles>;
+  roleId!: number;
+  orgNode!: Ref<OrgNodes>;
+  orgNodeId!: number;
+  coverage!: string;
+}
+
+export const RoleGrantsSchema = defineEntity({
+  class: RoleGrants,
+  uniques: [
+    {
+      name: 'uq_role_grants_anchored',
+      properties: ['tenantId', 'userId', 'roleId', 'orgNodeId', 'coverage'],
+    },
+  ],
+  properties: {
+    id: p.integer().primary(),
+    tenant: () => p.manyToOne(Tenants).ref().updateRule('no action').deleteRule('no action'),
+    tenantId: p.integer().persist(false),
+    user: () => p.manyToOne(Users).ref().fieldNames('tenant_id','user_id').updateRule('no action').deleteRule('no action'),
+    userId: p.integer().persist(false),
+    role: () => p.manyToOne(Roles).ref().fieldNames('tenant_id','role_id').updateRule('no action').deleteRule('no action'),
+    roleId: p.integer().persist(false),
+    orgNode: () => p.manyToOne(OrgNodes).ref().fieldNames('tenant_id','org_node_id').updateRule('no action').deleteRule('no action'),
+    orgNodeId: p.integer().persist(false),
+    coverage: p.string().length(64),
+  },
+});
+",
+  "import { Collection, PrimaryKeyProp, defineEntity, p } from '@mikro-orm/core';
+import { RoleGrants } from './RoleGrants';
+
+export class Roles {
+  [PrimaryKeyProp]?: ['tenantId', 'id'];
+  tenantId!: number;
+  id!: number;
+  roleGrantsCollection = new Collection<RoleGrants>(this);
+}
+
+export const RolesSchema = defineEntity({
+  class: Roles,
+  properties: {
+    tenantId: p.integer().primary(),
+    id: p.integer().primary(),
+    roleGrantsCollection: () => p.oneToMany(RoleGrants).mappedBy('role'),
+  },
+});
+",
+  "import { Collection, defineEntity, p } from '@mikro-orm/core';
+import { RoleGrants } from './RoleGrants';
+
+export class Tenants {
+  id!: number;
+  roleGrantsCollection = new Collection<RoleGrants>(this);
+}
+
+export const TenantsSchema = defineEntity({
+  class: Tenants,
+  properties: {
+    id: p.integer().primary().autoincrement(false),
+    roleGrantsCollection: () => p.oneToMany(RoleGrants).mappedBy('tenant'),
+  },
+});
+",
+  "import { Collection, PrimaryKeyProp, defineEntity, p } from '@mikro-orm/core';
+import { RoleGrants } from './RoleGrants';
+
+export class Users {
+  [PrimaryKeyProp]?: ['tenantId', 'id'];
+  tenantId!: number;
+  id!: number;
+  roleGrantsCollection = new Collection<RoleGrants>(this);
+}
+
+export const UsersSchema = defineEntity({
+  class: Users,
+  properties: {
+    tenantId: p.integer().primary(),
+    id: p.integer().primary(),
+    roleGrantsCollection: () => p.oneToMany(RoleGrants).mappedBy('user'),
+  },
+});
+",
+]
+`;


### PR DESCRIPTION
`getIndexProperties()` collected property names of a composite index into a `Set`, so a property covering several columns landed at the position of the first index column it touches. With `scalarPropertiesForRelations: 'always'`, all foreign keys of the reported table start with the shared `tenant_id`, so every one of them got collected while processing the leading column and the result came out in foreign key discovery order instead of the index order. A unique index on `(tenant_id, user_id, role_id, org_node_id, coverage)` was generated as `['orgNodeId', 'roleId', 'tenantId', 'userId', 'coverage']`.

The collected names now remember the first and last index position they were seen at, and ties on the first position are broken by the last one, so the generated order follows the columns again.

Fixes #8116