### PR TITLE
fix(core): ignore own `__proto__` key when cloning objects

### DIFF
--- a/packages/core/src/utils/clone.ts
+++ b/packages/core/src/utils/clone.ts
@@ -126,6 +126,13 @@ export function clone<T>(parent: T, respectCustomCloneMethod = true): T {
     }
 
     for (const i in parent) {
+      // an own `__proto__` key (as produced by `JSON.parse`) has no own counterpart on
+      // `child` to shadow the inherited accessor, so assigning it would replace the
+      // clone's prototype instead of copying the value
+      if (i === '__proto__') {
+        continue;
+      }
+
       let attrs;
 
       if (proto) {

--- a/tests/features/clone/clone.test.ts
+++ b/tests/features/clone/clone.test.ts
@@ -1,5 +1,6 @@
 import {
   Collection,
+  Dictionary,
   EntityData,
   IDatabaseDriver,
   MikroORM,
@@ -696,6 +697,25 @@ describe('clone unit tests', () => {
     const { sql } = nqb.compile();
     expect(sql).toMatch(/insert into/i);
     expect(sql).toMatch(/select a, b from source/i);
+  });
+
+  test('does not let an own `__proto__` key replace the clone prototype', () => {
+    // `JSON.parse` creates a literal own key, unlike the `{ __proto__: x }` literal syntax
+    const copy = Utils.copy(JSON.parse('{"a":1,"__proto__":{"polluted":true}}'));
+
+    expect(Object.getPrototypeOf(copy)).toBe(Object.prototype);
+    expect((copy as Dictionary).polluted).toBeUndefined();
+    expect(({} as Dictionary).polluted).toBeUndefined();
+    expect(copy).toEqual({ a: 1 });
+  });
+
+  test('does not let a nested own `__proto__` key through `Utils.merge`', () => {
+    const target: Dictionary = {};
+    Utils.merge(target, JSON.parse('{"nested":{"__proto__":{"polluted":true}}}'));
+
+    expect(Object.getPrototypeOf(target.nested)).toBe(Object.prototype);
+    expect(target.nested.polluted).toBeUndefined();
+    expect(({} as Dictionary).polluted).toBeUndefined();
   });
 
   test('DatabaseDriver.nativeClone throws by default', async () => {


### PR DESCRIPTION
`clone()` creates the copy with `Object.create(proto)`, so the copy has no own `__proto__` data property to shadow the accessor inherited from `Object.prototype`. When the source object has an own enumerable `__proto__` key, the assignment in the copy loop reaches that inherited setter and replaces the copy's prototype instead of copying the value.

`JSON.parse()` produces that shape, unlike the `{ __proto__: x }` literal syntax which the grammar special-cases. So any object parsed from JSON and then copied is affected, including data passed to `em.upsert()` and `em.upsertMany()`.

The copy ends up with a prototype taken from the source data, and the value itself is lost, since it never becomes an own property. A JSON column round-trips `{"a":1,"__proto__":{"b":2}}` as `{"a":1}`.

It also meant `Utils.merge()` and `EntityAssigner.assign()` only guarded the top level. Both skip `DANGEROUS_PROPERTY_NAMES` per level but hand nested subtrees to `Utils.copy()`, so a nested `__proto__` slipped past a guard that a top-level one hits.

The fix skips an own `__proto__` key, and only that key. `constructor` and `prototype` assign as ordinary own data properties and are copied correctly today. Skipping those as well drops valid data, and broke an existing `MetadataValidator` test that relies on a `constructor` property surviving `Utils.copy()`.
