### PR TITLE
fix(entity-generator): emit check constraints in generated entities

### DIFF
--- a/packages/entity-generator/src/DefineEntitySourceFile.ts
+++ b/packages/entity-generator/src/DefineEntitySourceFile.ts
@@ -61,6 +61,10 @@ export class DefineEntitySourceFile extends EntitySchemaSourceFile {
       entitySchemaOptions.uniques = this.meta.uniques.map(index => this.getUniqueOptions(index));
     }
 
+    if (this.meta.checks.length > 0) {
+      entitySchemaOptions.checks = this.meta.checks.map(check => this.getCheckOptions(check));
+    }
+
     entitySchemaOptions.properties = Object.fromEntries(
       Object.entries(this.meta.properties).map(([name, prop]) => [name, this.getPropertyBuilder(prop)]),
     );

--- a/packages/entity-generator/src/EntitySchemaSourceFile.ts
+++ b/packages/entity-generator/src/EntitySchemaSourceFile.ts
@@ -50,6 +50,10 @@ export class EntitySchemaSourceFile extends SourceFile {
       entitySchemaOptions.uniques = this.meta.uniques.map(index => this.getUniqueOptions(index));
     }
 
+    if (this.meta.checks.length > 0) {
+      entitySchemaOptions.checks = this.meta.checks.map(check => this.getCheckOptions(check));
+    }
+
     entitySchemaOptions.properties = Object.fromEntries(
       Object.entries(this.meta.properties).map(([name, prop]) => [name, this.getPropertyOptions(prop)]),
     );

--- a/packages/entity-generator/src/SourceFile.ts
+++ b/packages/entity-generator/src/SourceFile.ts
@@ -1,5 +1,6 @@
 import {
   Cascade,
+  type CheckConstraint,
   Config,
   DecimalType,
   type DeferMode,
@@ -69,6 +70,10 @@ export class SourceFile {
         continue;
       }
       ret += `@${this.referenceDecoratorImport('Unique')}(${this.serializeObject(this.getUniqueOptions(index))})\n`;
+    }
+
+    for (const check of this.meta.checks) {
+      ret += `@${this.referenceDecoratorImport('Check')}(${this.serializeObject(this.getCheckOptions(check))})\n`;
     }
 
     let classHead = '';
@@ -261,6 +266,18 @@ export class SourceFile {
     }
 
     return uniqueOpt;
+  }
+
+  protected getCheckOptions(check: EntityMetadata['checks'][number]) {
+    const checkOpt = {} as CheckConstraint<Dictionary>;
+
+    if (typeof check.name === 'string') {
+      checkOpt.name = this.quote(check.name);
+    }
+
+    checkOpt.expression = this.quote(check.expression as string);
+
+    return checkOpt;
   }
 
   protected generateImports() {

--- a/packages/sql/src/schema/DatabaseTable.ts
+++ b/packages/sql/src/schema/DatabaseTable.ts
@@ -398,6 +398,23 @@ export class DatabaseTable {
       schema.addIndex(ret);
     }
 
+    for (const check of this.getChecks()) {
+      // skip checks that were consumed by enum conversion — the enum property recreates an
+      // equivalent check under the conventional name during discovery (only on platforms that
+      // emulate enums via check constraints; mysql/mariadb enums are native and recreate nothing)
+      const enumItems = check.columnName ? this.getColumn(check.columnName)?.enumItems : undefined;
+      if (
+        this.#platform.usesEnumCheckConstraints() &&
+        enumItems?.length &&
+        (check.expression === this.#platform.getEnumCheckConstraintExpression(check.columnName!, enumItems) ||
+          check.name === this.#platform.getIndexName(this.name, [check.columnName!], 'check'))
+      ) {
+        continue;
+      }
+
+      schema.meta.checks.push({ name: check.name, expression: check.expression as string });
+    }
+
     const addedStandaloneFkPropsBasedOnColumn = new Set<string>();
     const nonSkippedColumns = this.getColumns().filter(column => !skippedColumnNames.includes(column.name));
 

--- a/tests/features/entity-generator/CheckConstraints.postgres.test.ts
+++ b/tests/features/entity-generator/CheckConstraints.postgres.test.ts
@@ -1,0 +1,36 @@
+import { MikroORM } from '@mikro-orm/postgresql';
+import { EntityGenerator } from '@mikro-orm/entity-generator';
+
+const schema = `
+  create table "probe" (
+    "id" uuid primary key default gen_random_uuid(),
+    "code" varchar(63) not null,
+    "mode" varchar(16) not null,
+    "system_key" varchar(63),
+    constraint "chk_probe_code_format" check ("code" ~ '^[a-z0-9]+(?:-[a-z0-9]+)*$'),
+    constraint "chk_probe_mode" check ("mode" in ('explicit', 'all-active')),
+    constraint "chk_probe_shape" check ("mode" <> 'all-active' or "system_key" is not null)
+  );
+`;
+
+test('check constraints are emitted in generated entities', async () => {
+  const orm = await MikroORM.init({
+    dbName: 'mikro_orm_test_entity_gen_checks',
+    discovery: { warnWhenNoEntities: false },
+    ensureDatabase: false,
+    extensions: [EntityGenerator],
+  });
+
+  if (await orm.schema.ensureDatabase({ create: true })) {
+    await orm.schema.execute(schema);
+  }
+
+  const dump = (await orm.entityGenerator.generate()).join('\n');
+  expect(dump).toContain('chk_probe_code_format');
+  expect(dump).toContain('chk_probe_shape');
+  // the `mode in (...)` check is represented by the enum property instead
+  expect(dump).not.toContain('chk_probe_mode');
+  expect(dump).toMatchSnapshot();
+
+  await orm.close(true);
+});

--- a/tests/features/entity-generator/CheckConstraints.test.ts
+++ b/tests/features/entity-generator/CheckConstraints.test.ts
@@ -1,0 +1,34 @@
+import { MikroORM } from '@mikro-orm/sqlite';
+import { EntityGenerator } from '@mikro-orm/entity-generator';
+
+describe('check constraints in generated entities', () => {
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      dbName: ':memory:',
+      discovery: { warnWhenNoEntities: false },
+      extensions: [EntityGenerator],
+    });
+    await orm.em
+      .getConnection()
+      .execute(
+        `create table probe (id integer primary key, code text not null, mode text not null check (mode in ('explicit', 'all-active')), system_key text, price integer not null check (price >= 0), constraint chk_probe_code_format check (code like 'x%'), constraint chk_probe_shape check (mode <> 'all-active' or system_key is not null))`,
+      );
+  });
+
+  afterAll(async () => {
+    await orm.close(true);
+  });
+
+  test.each(['decorators', 'entitySchema', 'defineEntity'] as const)('%s', async entityDefinition => {
+    const dump = (await orm.entityGenerator.generate({ entityDefinition })).join('\n');
+    expect(dump).toContain('chk_probe_code_format');
+    expect(dump).toContain('chk_probe_shape');
+    expect(dump).toContain('probe_price_check');
+    // the `mode in (...)` check is represented by the enum property, the ORM
+    // recreates an equivalent check under the same conventional name
+    expect(dump).not.toContain('probe_mode_check');
+    expect(dump).toMatchSnapshot();
+  });
+});

--- a/tests/features/entity-generator/__snapshots__/CheckConstraints.postgres.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/CheckConstraints.postgres.test.ts.snap
@@ -1,0 +1,40 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`check constraints are emitted in generated entities 1`] = `
+"import { type Opt, defineEntity, p } from '@mikro-orm/core';
+
+export class Probe {
+  id!: string & Opt;
+  code!: string;
+  mode!: TProbeMode;
+  systemKey?: string;
+}
+
+export const ProbeMode = {
+  EXPLICIT: 'explicit',
+  'ALL-ACTIVE': 'all-active',
+} as const;
+
+export type TProbeMode = (typeof ProbeMode)[keyof typeof ProbeMode];
+
+export const ProbeSchema = defineEntity({
+  class: Probe,
+  checks: [
+    {
+      name: 'chk_probe_code_format',
+      expression: 'code ~ \\'^[a-z0-9]+(?:-[a-z0-9]+)*$\\'::text',
+    },
+    {
+      name: 'chk_probe_shape',
+      expression: '(mode <> \\'all-active\\'::text) OR (system_key IS NOT NULL)',
+    },
+  ],
+  properties: {
+    id: p.uuid().primary().defaultRaw(\`gen_random_uuid()\`),
+    code: p.string().length(63),
+    mode: p.enum(() => ProbeMode),
+    systemKey: p.string().length(63).nullable(),
+  },
+});
+"
+`;

--- a/tests/features/entity-generator/__snapshots__/CheckConstraints.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/CheckConstraints.test.ts.snap
@@ -1,0 +1,114 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`check constraints in generated entities > decorators 1`] = `
+"import { Check, Entity, Enum, PrimaryKey, Property } from '@mikro-orm/decorators/legacy';
+
+export const ProbeMode = {
+  EXPLICIT: 'explicit',
+  'ALL-ACTIVE': 'all-active',
+} as const;
+
+export type TProbeMode = (typeof ProbeMode)[keyof typeof ProbeMode];
+
+@Entity()
+@Check({ name: 'probe_price_check', expression: 'price >= 0' })
+@Check({ name: 'chk_probe_code_format', expression: 'code like \\'x%\\'' })
+@Check({ name: 'chk_probe_shape', expression: 'mode <> \\'all-active\\' or system_key is not null' })
+export class Probe {
+
+  @PrimaryKey({ autoincrement: false, nullable: true })
+  id?: number;
+
+  @Property({ type: 'text' })
+  code!: string;
+
+  @Enum({ items: () => ProbeMode })
+  mode!: TProbeMode;
+
+  @Property({ type: 'text', nullable: true })
+  systemKey?: string;
+
+  @Property()
+  price!: number;
+
+}
+"
+`;
+
+exports[`check constraints in generated entities > defineEntity 1`] = `
+"import { defineEntity, p } from '@mikro-orm/core';
+
+export class Probe {
+  id?: number;
+  code!: string;
+  mode!: TProbeMode;
+  systemKey?: string;
+  price!: number;
+}
+
+export const ProbeMode = {
+  EXPLICIT: 'explicit',
+  'ALL-ACTIVE': 'all-active',
+} as const;
+
+export type TProbeMode = (typeof ProbeMode)[keyof typeof ProbeMode];
+
+export const ProbeSchema = defineEntity({
+  class: Probe,
+  checks: [
+    { name: 'probe_price_check', expression: 'price >= 0' },
+    { name: 'chk_probe_code_format', expression: 'code like \\'x%\\'' },
+    {
+      name: 'chk_probe_shape',
+      expression: 'mode <> \\'all-active\\' or system_key is not null',
+    },
+  ],
+  properties: {
+    id: p.integer().primary().autoincrement(false).nullable(),
+    code: p.text(),
+    mode: p.enum(() => ProbeMode),
+    systemKey: p.text().nullable(),
+    price: p.integer(),
+  },
+});
+"
+`;
+
+exports[`check constraints in generated entities > entitySchema 1`] = `
+"import { EntitySchema } from '@mikro-orm/core';
+
+export class Probe {
+  id?: number;
+  code!: string;
+  mode!: TProbeMode;
+  systemKey?: string;
+  price!: number;
+}
+
+export const ProbeMode = {
+  EXPLICIT: 'explicit',
+  'ALL-ACTIVE': 'all-active',
+} as const;
+
+export type TProbeMode = (typeof ProbeMode)[keyof typeof ProbeMode];
+
+export const ProbeSchema = new EntitySchema({
+  class: Probe,
+  checks: [
+    { name: 'probe_price_check', expression: 'price >= 0' },
+    { name: 'chk_probe_code_format', expression: 'code like \\'x%\\'' },
+    {
+      name: 'chk_probe_shape',
+      expression: 'mode <> \\'all-active\\' or system_key is not null',
+    },
+  ],
+  properties: {
+    id: { primary: true, type: 'integer', autoincrement: false, nullable: true },
+    code: { type: 'text' },
+    mode: { enum: true, items: () => ProbeMode },
+    systemKey: { type: 'text', nullable: true },
+    price: { type: 'integer' },
+  },
+});
+"
+`;

--- a/tests/features/entity-generator/__snapshots__/index-expressions.mysql.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/index-expressions.mysql.test.ts.snap
@@ -50,6 +50,10 @@ export const DcimDeviceSchema = defineEntity({
       properties: ['virtualChassisId', 'vcPosition'],
     },
   ],
+  checks: [
+    { name: 'dcim_device_chk_1', expression: '\`vc_position\` >= 0' },
+    { name: 'dcim_device_chk_2', expression: '\`vc_priority\` >= 0' },
+  ],
   properties: {
     created: p.datetime().columnType('timestamp').nullable(),
     id: p.bigint().primary().unsigned(false).autoincrement(false),

--- a/tests/features/entity-generator/__snapshots__/index-expressions.postgres.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/index-expressions.postgres.test.ts.snap
@@ -51,6 +51,10 @@ export const DcimDeviceSchema = defineEntity({
       properties: ['virtualChassisId', 'vcPosition'],
     },
   ],
+  checks: [
+    { name: 'dcim_device_vc_position_check', expression: 'vc_position >= 0' },
+    { name: 'dcim_device_vc_priority_check', expression: 'vc_priority >= 0' },
+  ],
   properties: {
     created: p.datetime().nullable(),
     id: p.bigint().primary().autoincrement(false),

--- a/tests/features/entity-generator/__snapshots__/index-expressions.sqlite.test.ts.snap
+++ b/tests/features/entity-generator/__snapshots__/index-expressions.sqlite.test.ts.snap
@@ -42,6 +42,10 @@ export const DcimDeviceSchema = defineEntity({
       properties: ['virtualChassisId', 'vcPosition'],
     },
   ],
+  checks: [
+    { name: 'dcim_device_vc_priority_check', expression: 'vc_priority >= 0' },
+    { name: 'dcim_device_vc_position_check', expression: 'vc_position >= 0' },
+  ],
   properties: {
     created: p.unknown().columnType('timestamptz').nullable(),
     id: p.unknown().primary().columnType('int8'),


### PR DESCRIPTION
Introspection reads check constraints into `DatabaseTable`, but `getEntityDeclaration()` never copied them over to the entity metadata, so generated entities lost every check. Single-column `IN (...)` checks survived only indirectly, by being converted to an enum property. Everything else vanished.

`getEntityDeclaration()` now copies the introspected checks into the metadata, and all three output formats render them: `@Check()` decorators, and the `checks` option for `EntitySchema` and `defineEntity`. Checks consumed by the enum conversion are still skipped, because the enum property recreates an equivalent constraint under the conventional name during discovery, so emitting the original as well would duplicate it on the next schema sync. The skip only applies on platforms that emulate enums via check constraints (postgres, sqlite, mssql). On mysql/mariadb enums are native, so no check is ever skipped there.

Closes #8114
