### PR TITLE
fix(postgres): keep parens balanced when stripping casts from introspected checks

### DIFF
--- a/packages/sql/src/dialects/postgresql/PostgreSqlSchemaHelper.ts
+++ b/packages/sql/src/dialects/postgresql/PostgreSqlSchemaHelper.ts
@@ -696,7 +696,7 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
       // SchemaHelper.createCheck).
       const m = /^check \(\((.*)\)\)$/is.exec(check.expression);
       const single = m ? null : /^check \((.*)\)$/is.exec(check.expression);
-      const def = m ? m[1].replace(/\((.*?)\)::\w+/g, '$1') : single ? single[1] : check.expression;
+      const def = m ? m[1].replace(/\(([^()]*)\)::\w+/g, '$1') : single ? single[1] : check.expression;
       ret[key].push({
         name: check.name,
         columnName: check.column_name,

--- a/tests/features/schema-generator/check-constraint.postgres.test.ts
+++ b/tests/features/schema-generator/check-constraint.postgres.test.ts
@@ -415,4 +415,41 @@ describe('check constraint [postgres]', () => {
     await orm.schema.dropDatabase();
     await orm.close();
   });
+
+  test('multi-term check on a castable column keeps parentheses balanced on introspection [postgres]', async () => {
+    const orm = await initORMPostgreSql();
+    const meta = orm.getMetadata();
+    await orm.schema.update();
+
+    // pg stores this check as `CHECK (((code IS NULL) OR ((code)::text ~ '^[a-z]+$'::text)))` — the
+    // cast-stripping in getAllChecks() must not pair parens across term boundaries, otherwise the
+    // recovered expression is unbalanced and re-emitting it as DDL is a syntax error.
+    const newTableMeta = new EntitySchema({
+      properties: {
+        id: { primary: true, name: 'id', type: 'number', fieldName: 'id', columnType: 'int' },
+        code: { type: 'string', name: 'code', fieldName: 'code', columnType: 'varchar(255)', nullable: true },
+      },
+      name: 'MultiTermCheckTable',
+      tableName: 'multi_term_check_table',
+      checks: [{ name: 'chk_code', expression: `code IS NULL OR code ~ '^[a-z]+$'` }],
+    }).init().meta;
+    meta.set(newTableMeta.class, newTableMeta);
+
+    let diff = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    await orm.schema.execute(diff);
+
+    const schema = await DatabaseSchema.create(orm.em.getConnection(), orm.em.getPlatform(), orm.config);
+    const check = schema
+      .getTable('multi_term_check_table')!
+      .getChecks()
+      .find(c => c.name === 'chk_code');
+    expect(check?.expression).toBe(`(code IS NULL) OR (code ~ '^[a-z]+$'::text)`);
+
+    // the recovered expression must also round-trip through the comparator without drift
+    diff = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(diff).toBe('');
+
+    await orm.schema.dropDatabase();
+    await orm.close();
+  });
 });


### PR DESCRIPTION
The cast-stripping regex in `getAllChecks()` used a lazy group (`/\((.*?)\)::\w+/g`) that could pair an opening parenthesis with a closing one from a different term. A multi-term check on a castable column, e.g. `code IS NULL OR code ~ '^[a-z]+$'` on a `varchar`, is stored by PostgreSQL as `CHECK (((code IS NULL) OR ((code)::text ~ '^[a-z]+$'::text)))` and came back from introspection as the unbalanced `code IS NULL) OR ((code ~ '^[a-z]+$'::text)`. Re-emitting that expression as DDL (via the entity generator's `@Check` output, for example) fails with a syntax error.

The fix restricts the cast operand to `[^()]*`, so the regex only strips innermost `(col)::type` casts and parentheses stay balanced. Introspected expressions covered by existing tests are unchanged.

Closes #8123
