### PR TITLE
fix(postgres): emit and diff the index access method

### DIFF
--- a/packages/sql/src/dialects/postgresql/PostgreSqlSchemaHelper.ts
+++ b/packages/sql/src/dialects/postgresql/PostgreSqlSchemaHelper.ts
@@ -1540,6 +1540,16 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
       .join(', ');
   }
 
+  /** Non-default index access methods (gin, gist, brin, hash, ...), normalized to lower case. */
+  override getIndexAccessMethod(index: IndexDef): string {
+    // `fulltext` is a cross-dialect alias handled via `getFullTextIndexExpression`, not a pg access method
+    if (typeof index.type !== 'string' || ['', 'btree', 'fulltext'].includes(index.type.toLowerCase())) {
+      return '';
+    }
+
+    return index.type.toLowerCase();
+  }
+
   /**
    * PostgreSQL-specific index options like fill factor.
    */

--- a/packages/sql/src/schema/SchemaComparator.ts
+++ b/packages/sql/src/schema/SchemaComparator.ts
@@ -1049,6 +1049,11 @@ export class SchemaComparator {
       return false;
     }
 
+    // Compare the index access method (e.g. `using gin` on PostgreSQL); unset means the platform default
+    if (this.#helper.getIndexAccessMethod(index1) !== this.#helper.getIndexAccessMethod(index2)) {
+      return false;
+    }
+
     // Compare WHERE predicate of partial indexes structurally (whitespace/quoting/casing
     // are normalized via the same helper used for check constraints).
     if (this.diffExpression(index1.where ?? '', index2.where ?? '')) {

--- a/packages/sql/src/schema/SchemaHelper.ts
+++ b/packages/sql/src/schema/SchemaHelper.ts
@@ -255,7 +255,8 @@ export abstract class SchemaHelper {
     tableName = this.quote(tableName);
     const keyName = this.quote(index.keyName);
     const defer = index.deferMode ? ` deferrable initially ${index.deferMode}` : '';
-    let sql = `create ${index.unique ? 'unique ' : ''}index ${keyName} on ${tableName}`;
+    const using = this.getIndexAccessMethodClause(index);
+    let sql = `create ${index.unique ? 'unique ' : ''}index ${keyName} on ${tableName}${using}`;
 
     if (index.unique && index.constraint) {
       sql = `alter table ${tableName} add constraint ${keyName} unique`;
@@ -263,7 +264,7 @@ export abstract class SchemaHelper {
 
     if (index.columnNames.some(column => column.includes('.'))) {
       // JSON columns can have unique index but not unique constraint, and we need to distinguish those, so we can properly drop them
-      sql = `create ${index.unique ? 'unique ' : ''}index ${keyName} on ${tableName}`;
+      sql = `create ${index.unique ? 'unique ' : ''}index ${keyName} on ${tableName}${using}`;
       const columns = this.platform.getJsonIndexDefinition(index);
       return `${sql} (${columns.join(', ')})${this.getCreateIndexSuffix(index)}${this.getIndexWhereClause(index)}${defer}`;
     }
@@ -285,6 +286,20 @@ export abstract class SchemaHelper {
    */
   protected getCreateIndexSuffix(_index: IndexDef): string {
     return '';
+  }
+
+  /**
+   * Normalized index access method (e.g. `gin` on PostgreSQL), empty string when the
+   * platform default applies. Used for both DDL emission and index diffing.
+   */
+  getIndexAccessMethod(_index: IndexDef): string {
+    return '';
+  }
+
+  /** Emits the access method between the table name and the column list (e.g. ` using gin`). */
+  protected getIndexAccessMethodClause(index: IndexDef): string {
+    const method = this.getIndexAccessMethod(index);
+    return method ? ` using ${method}` : '';
   }
 
   /**

--- a/tests/features/schema-generator/advanced-index-features.postgres.test.ts
+++ b/tests/features/schema-generator/advanced-index-features.postgres.test.ts
@@ -1,4 +1,4 @@
-import { DeferMode, defineEntity, MikroORM, p, type Options } from '@mikro-orm/postgresql';
+import { DatabaseSchema, DeferMode, defineEntity, MikroORM, p, type Options } from '@mikro-orm/postgresql';
 
 class TestEntity {
   id!: number;
@@ -396,6 +396,40 @@ const ColumnsMismatchSchema = defineEntity({
   },
 });
 
+class AccessMethodTestEntity {
+  id!: number;
+  data!: unknown;
+  createdAt!: Date;
+}
+
+const AccessMethodSchema = defineEntity({
+  class: AccessMethodTestEntity,
+  tableName: 'index_access_method_test',
+  indexes: [
+    { name: 'data_gin_idx', properties: ['data'], type: 'gin' },
+    { name: 'created_at_brin_idx', properties: ['createdAt'], type: 'brin' },
+  ],
+  properties: {
+    id: p.integer().primary(),
+    data: p.json(),
+    createdAt: p.datetime(),
+  },
+});
+
+const AccessMethodSchema2 = defineEntity({
+  class: AccessMethodTestEntity,
+  tableName: 'index_access_method_test',
+  indexes: [
+    { name: 'data_gin_idx', properties: ['data'], type: 'gist' },
+    { name: 'created_at_brin_idx', properties: ['createdAt'], type: 'btree' },
+  ],
+  properties: {
+    id: p.integer().primary(),
+    data: p.json(),
+    createdAt: p.datetime(),
+  },
+});
+
 describe('advanced index features in postgres', () => {
   let orm: MikroORM;
 
@@ -613,5 +647,37 @@ describe('advanced index features in postgres', () => {
         fillFactor: 200,
       }),
     ).toThrow('fillFactor must be between 0 and 100, got 200');
+  });
+
+  test('schema generator emits the index access method and round-trips without drift', async () => {
+    const orm2 = await MikroORM.init({
+      entities: [AccessMethodSchema],
+      dbName: `mikro_orm_test_adv_idx_am`,
+    });
+    await orm2.schema.refresh();
+
+    const sql = await orm2.schema.getCreateSchemaSQL({ wrap: false });
+    expect(sql).toMatch(/create index "data_gin_idx" on "index_access_method_test" using gin \("data"\)/);
+    expect(sql).toMatch(/create index "created_at_brin_idx" on "index_access_method_test" using brin \("created_at"\)/);
+
+    // the indexes in the DB must actually use the declared access method, not the default b-tree
+    const schema = await DatabaseSchema.create(orm2.em.getConnection(), orm2.em.getPlatform(), orm2.config);
+    const indexes = schema.getTable('index_access_method_test')!.getIndexes();
+    expect(indexes.find(i => i.keyName === 'data_gin_idx')?.type).toBe('gin');
+    expect(indexes.find(i => i.keyName === 'created_at_brin_idx')?.type).toBe('brin');
+
+    const diff = await orm2.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(diff).toBe('');
+
+    // changing the access method must be detected; explicit `btree` means the default (no `using`)
+    orm2.discoverEntity(AccessMethodSchema2, AccessMethodSchema);
+    const diff2 = await orm2.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(diff2).toMatch(/drop index "data_gin_idx"/);
+    expect(diff2).toMatch(/create index "data_gin_idx" on "index_access_method_test" using gist \("data"\)/);
+    expect(diff2).toMatch(/drop index "created_at_brin_idx"/);
+    expect(diff2).toMatch(/create index "created_at_brin_idx" on "index_access_method_test" \("created_at"\)/);
+
+    await orm2.schema.dropDatabase();
+    await orm2.close();
   });
 });


### PR DESCRIPTION
An index declaring a non-default access method (`@Index({ type: 'gin' })`, `gist`, `brin`, `hash`, ...) was silently created as a b-tree. Introspection already stores the access method on `IndexDef.type` and the entity generator round-trips it, but DDL emission never consulted it, and the schema comparator ignored it, so access-method changes never produced a diff either.

`getCreateIndexSQL()` now emits `using <method>` between the table name and the column list, and `isIndexFulfilledBy()` compares the access method. Both go through a new `getIndexAccessMethod()` normalization hook on `SchemaHelper` (base returns an empty string, so other dialects are unaffected; `fulltext` keeps flowing through `getFullTextIndexExpression`).

Behavior note: an index declared in metadata without a `type` now diffs against a manually created GIST/GIN index of the same name, and the DB index gets recreated with the default method on `schema:update`. Indexes that can't be expressed in metadata (operator classes etc.) should use the `expression` escape hatch, which keeps name-only diffing.

Closes #8124
