### PR TITLE
fix(postgres): emit the index access method when creating indexes

### DIFF
--- a/packages/sql/src/dialects/postgresql/PostgreSqlSchemaHelper.ts
+++ b/packages/sql/src/dialects/postgresql/PostgreSqlSchemaHelper.ts
@@ -1557,6 +1557,18 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
     return super.getCreateIndexSuffix(index);
   }
 
+  /**
+   * PostgreSQL index access method, e.g. `gist`, `gin` or `brin`. Full-text indexes are emitted
+   * via `getFullTextIndexExpression()`, which already spells out the access method.
+   */
+  protected override getIndexTypeClause(index: IndexDef): string {
+    if (typeof index.type === 'string' && index.type !== 'fulltext') {
+      return ` using ${index.type}`;
+    }
+
+    return super.getIndexTypeClause(index);
+  }
+
   private getIndexesSQL(tables: Table[]): string {
     return `select indrelid::regclass as table_name, ns.nspname as schema_name, relname as constraint_name, idx.indisunique as unique, idx.indisprimary as primary, contype, condeferrable, condeferred,
       array(

--- a/packages/sql/src/schema/SchemaHelper.ts
+++ b/packages/sql/src/schema/SchemaHelper.ts
@@ -255,7 +255,8 @@ export abstract class SchemaHelper {
     tableName = this.quote(tableName);
     const keyName = this.quote(index.keyName);
     const defer = index.deferMode ? ` deferrable initially ${index.deferMode}` : '';
-    let sql = `create ${index.unique ? 'unique ' : ''}index ${keyName} on ${tableName}`;
+    const type = this.getIndexTypeClause(index);
+    let sql = `create ${index.unique ? 'unique ' : ''}index ${keyName} on ${tableName}${type}`;
 
     if (index.unique && index.constraint) {
       sql = `alter table ${tableName} add constraint ${keyName} unique`;
@@ -263,7 +264,7 @@ export abstract class SchemaHelper {
 
     if (index.columnNames.some(column => column.includes('.'))) {
       // JSON columns can have unique index but not unique constraint, and we need to distinguish those, so we can properly drop them
-      sql = `create ${index.unique ? 'unique ' : ''}index ${keyName} on ${tableName}`;
+      sql = `create ${index.unique ? 'unique ' : ''}index ${keyName} on ${tableName}${type}`;
       const columns = this.platform.getJsonIndexDefinition(index);
       return `${sql} (${columns.join(', ')})${this.getCreateIndexSuffix(index)}${this.getIndexWhereClause(index)}${defer}`;
     }
@@ -284,6 +285,13 @@ export abstract class SchemaHelper {
    * Hook for adding driver-specific index options (e.g., fill factor for PostgreSQL).
    */
   protected getCreateIndexSuffix(_index: IndexDef): string {
+    return '';
+  }
+
+  /**
+   * Hook for the index access method (e.g., ` using gist` for PostgreSQL).
+   */
+  protected getIndexTypeClause(_index: IndexDef): string {
     return '';
   }
 

--- a/tests/features/schema-generator/index-access-method.postgres.test.ts
+++ b/tests/features/schema-generator/index-access-method.postgres.test.ts
@@ -1,0 +1,47 @@
+import { DatabaseSchema, MikroORM } from '@mikro-orm/postgresql';
+import { Entity, Index, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+
+@Entity({ tableName: 'measurement' })
+@Index({ name: 'measurement_payload_gin', properties: ['payload'], type: 'gin' })
+@Index({ name: 'measurement_recorded_at_brin', properties: ['recordedAt'], type: 'brin' })
+class Measurement {
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ type: 'json' })
+  payload!: unknown;
+
+  @Property({ type: 'Date' })
+  recordedAt!: Date;
+}
+
+describe('index access method [postgres]', () => {
+  test('index type is emitted as the access method and survives a round trip [postgres]', async () => {
+    const orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      entities: [Measurement],
+      dbName: 'mikro_orm_test_index_access_method',
+    });
+
+    await orm.schema.ensureDatabase();
+
+    const createSql = await orm.schema.getCreateSchemaSQL({ wrap: false });
+    expect(createSql).toContain(`create index "measurement_payload_gin" on "measurement" using gin ("payload")`);
+    expect(createSql).toContain(
+      `create index "measurement_recorded_at_brin" on "measurement" using brin ("recorded_at")`,
+    );
+
+    await orm.schema.execute(createSql);
+
+    const diff = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(diff).toBe('');
+
+    const schema = await DatabaseSchema.create(orm.em.getConnection(), orm.em.getPlatform(), orm.config);
+    const indexes = schema.getTable('measurement')!.getIndexes();
+    expect(indexes.find(i => i.keyName === 'measurement_payload_gin')!.type).toBe('gin');
+    expect(indexes.find(i => i.keyName === 'measurement_recorded_at_brin')!.type).toBe('brin');
+
+    await orm.schema.dropDatabase();
+    await orm.close();
+  });
+});


### PR DESCRIPTION
Introspection already records the access method of a PostgreSQL index on `IndexDef.type`, but `getCreateIndexSQL()` never emitted it, so every index came back out as a B-tree. An entity declaring `@Index({ properties: ['payload'], type: 'gin' })` generated `create index "..." on "..." ("payload")`, and the same applies to the `type` that the entity generator writes out for an introspected gist, gin or brin index. PostgreSQL accepts the DDL without complaint, which is what makes it easy to miss: the index exists, it just cannot answer the queries it was created for.

`getCreateIndexSQL()` now asks a `getIndexTypeClause()` hook for the access method and places it after the table name. The hook returns an empty string everywhere except PostgreSQL, where it emits `using <type>`. Full-text indexes keep going through `getFullTextIndexExpression()`, which already spells out `using gin`.

Closes #8124