### PR TITLE
fix(sql): compare quoted decimal defaults numerically

### DIFF
--- a/packages/sql/src/schema/DatabaseTable.ts
+++ b/packages/sql/src/schema/DatabaseTable.ts
@@ -1401,8 +1401,13 @@ export class DatabaseTable {
       // mysql stores decimal defaults padded to scale (`0` → `0.00`); collapse to canonical numeric form
       // so the metadata-side (`0`) and introspection-side (`0.00`) snapshots agree
       let defaultValue: string | null = c.default ?? null;
-      if (defaultValue != null && c.mappedType instanceof DecimalType && Number.isFinite(+defaultValue)) {
-        defaultValue = this.#platform.formatDecimal(defaultValue, c.scale).toString();
+      if (defaultValue != null && c.mappedType instanceof DecimalType) {
+        // string defaults like `default: '0.00'` are quoted in metadata, so strip the quotes first
+        const unquoted = defaultValue.replace(/^'(.*)'$/, '$1');
+
+        if (Number.isFinite(+unquoted)) {
+          defaultValue = this.#platform.formatDecimal(unquoted, c.scale).toString();
+        }
       }
       const normalized: Dictionary = {
         name: c.name,

--- a/packages/sql/src/schema/SchemaComparator.ts
+++ b/packages/sql/src/schema/SchemaComparator.ts
@@ -1259,6 +1259,12 @@ export class SchemaComparator {
     return parseJsonSafe(val);
   }
 
+  private parseDecimalDefault(defaultValue: string | number): number | null {
+    const value = +('' + defaultValue).replace(/^'(.+)'$/, '$1');
+
+    return Number.isFinite(value) ? value : null;
+  }
+
   hasSameDefaultValue(from: Column, to: Column): boolean {
     if (
       from.default == null ||
@@ -1294,12 +1300,18 @@ export class SchemaComparator {
       return defaultValueFrom === defaultValueTo;
     }
 
-    // mysql stores decimal defaults padded to scale (`0` → `0.00`); compare numerically so the
-    // entity-side raw literal and the introspected padded form don't churn the no-op migration
-    if (to.mappedType instanceof DecimalType && Number.isFinite(+from.default) && Number.isFinite(+to.default)) {
-      return (
-        this.#platform.formatDecimal(from.default, to.scale) === this.#platform.formatDecimal(to.default, to.scale)
-      );
+    // mysql pads decimal defaults to scale (`0` → `0.00`) and postgres reports them unquoted
+    // while metadata keeps them quoted; compare numerically so neither churns a no-op migration
+    if (to.mappedType instanceof DecimalType) {
+      const defaultValueFrom = this.parseDecimalDefault(from.default);
+      const defaultValueTo = this.parseDecimalDefault(to.default);
+
+      if (defaultValueFrom != null && defaultValueTo != null) {
+        return (
+          this.#platform.formatDecimal(defaultValueFrom, to.scale) ===
+          this.#platform.formatDecimal(defaultValueTo, to.scale)
+        );
+      }
     }
 
     if (from.default && to.default) {

--- a/tests/issues/GH7796.test.ts
+++ b/tests/issues/GH7796.test.ts
@@ -38,6 +38,10 @@ class Widget7796 {
   @Property({ columnType: 'decimal(10,2)', default: 0 })
   price: number = 0;
 
+  // string default gets quoted in metadata (`'0.00'`), see GH #8131
+  @Property({ columnType: 'decimal(10,2)', type: 'decimal', default: '0.00' })
+  fee: string = '0.00';
+
   @ManyToOne(() => Category7796, { deleteRule: 'cascade', updateRule: 'cascade' })
   category!: Category7796;
 }

--- a/tests/issues/GH8131.test.ts
+++ b/tests/issues/GH8131.test.ts
@@ -1,0 +1,35 @@
+import { defineEntity, MikroORM, p } from '@mikro-orm/postgresql';
+
+// Postgres reports decimal defaults unquoted while metadata keeps the quoted literal, so a
+// `default('0.00')` column diffed on every schema update, right after it was created from it.
+
+const Product = defineEntity({
+  name: 'Product',
+  properties: () => ({
+    id: p.integer().primary().autoincrement(),
+    price: p.decimal().precision(12).scale(2).default('0.00'),
+    quantity: p.decimal().precision(12).scale(2).default('0'),
+    discount: p.decimal().precision(12).scale(2).default(0),
+    tax: p.decimal().precision(12).scale(2).defaultRaw('0.00'),
+  }),
+});
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    dbName: 'mikro_orm_test_gh8131',
+    entities: [Product],
+  });
+  await orm.schema.ensureDatabase();
+  await orm.schema.refresh();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+test('schema is up to date after creating decimal columns with quoted defaults', async () => {
+  const diff = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+  expect(diff).toBe('');
+});


### PR DESCRIPTION
`SchemaComparator.hasSameDefaultValue` compares decimal defaults numerically, but metadata keeps string defaults quoted, so `+"'0.00'"` is `NaN` and that branch is skipped. The comparison falls back to strings, where the `0.00` postgres reports never matches the quoted `'0.00'`, and `getUpdateSchemaSQL()` keeps emitting the same `alter column ... set default` for a schema it just created from that metadata.

Both values are now unquoted before the numeric check, so the quoted literal compares equal to what the database reports.

The snapshot serialization in `DatabaseTable.toJSON` had the same finite-number guard, so `migration:create` (metadata side) and `migration:up` (introspection side) kept rewriting the snapshot file with `'0.00'` vs `0.00`. That spot now strips the quotes too before collapsing to the canonical numeric form.

Closes #8131
