### PR TITLE
chore(deps): use unscoped resolutions so Renovate can update them

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,8 +167,8 @@
     "vitest": "4.1.10"
   },
   "resolutions": {
-    "lerna/js-yaml": "4.3.0",
-    "lerna/tar": "7.5.22"
+    "js-yaml": "4.3.0",
+    "tar": "7.5.22"
   },
   "packageManager": "yarn@4.18.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6103,7 +6103,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:4.3.0, js-yaml@npm:^4.1.0":
+"js-yaml@npm:4.3.0":
   version: 4.3.0
   resolution: "js-yaml@npm:4.3.0"
   dependencies:
@@ -9301,7 +9301,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:7.5.22, tar@npm:^7.4.3, tar@npm:^7.5.4":
+"tar@npm:7.5.22":
   version: 7.5.22
   resolution: "tar@npm:7.5.22"
   dependencies:


### PR DESCRIPTION
Renovate can't regenerate `yarn.lock` for `resolutions` keys that contain a slash (renovatebot/renovate#25853): the dep-level `managerData` clobbers the `hasPackageManager` flag, so it falls back to yarn v1, which then refuses to run because of the `packageManager` field. That's why #8130 and #8033 got the "Artifact update problem" comment.

Unscoping the two keys avoids the bug and is equivalent with the current tree: every `js-yaml`/`tar` descriptor in the root lockfile already resolves to the pinned version, so the lockfile diff only merges descriptors and no versions change. Once this lands, Renovate should rebase #8130 and finish the js-yaml 4.3.1 bump on its own.
