### PR TITLE
fix(sqlite): fix enum introspection for enums with more than two values

### DIFF
--- a/packages/knex/src/dialects/sqlite/BaseSqliteSchemaHelper.ts
+++ b/packages/knex/src/dialects/sqlite/BaseSqliteSchemaHelper.ts
@@ -114,9 +114,9 @@ export abstract class BaseSqliteSchemaHelper extends SchemaHelper {
 
       /* istanbul ignore else */
       if (match) {
-        o[match[1]] = match[2]
-          .split(/,(?=\s*'(?:[^']|'')*'(?:\s*\)|$))/)
-          .map((item: string) => item.trim().match(/^\(?'((?:[^']|'')*)'/)![1].replace(/''/g, "'"));
+        // Match each SQL string literal so commas inside enum values are preserved.
+        o[match[1]] = [...match[2].matchAll(/'((?:[^']|'')*)'/g)]
+          .map(item => item[1].replace(/''/g, "'"));
       }
 
       return o;

--- a/tests/features/schema-generator/GH7395.test.ts
+++ b/tests/features/schema-generator/GH7395.test.ts
@@ -5,6 +5,7 @@ import { MikroORM as MsSqlMikroORM } from '@mikro-orm/mssql';
 
 enum Status {
   ItsComplicated = "it's complicated",
+  Pending = 'pending',
   Active = 'active',
 }
 
@@ -29,7 +30,7 @@ describe('GH #7395 - enum CHECK constraint with single quotes', () => {
     await orm.schema.refreshDatabase();
 
     const createSQL = await orm.schema.getCreateSchemaSQL({ wrap: false });
-    expect(createSQL).toContain(`check ("status" in ('it''s complicated', 'active'))`);
+    expect(createSQL).toContain(`check ("status" in ('it''s complicated', 'pending', 'active'))`);
 
     const diff = await orm.schema.getUpdateSchemaSQL({ wrap: false });
     expect(diff).toBe('');
@@ -46,7 +47,7 @@ describe('GH #7395 - enum CHECK constraint with single quotes', () => {
     await orm.schema.refreshDatabase();
 
     const createSQL = await orm.schema.getCreateSchemaSQL({ wrap: false });
-    expect(createSQL).toContain(`check (\`status\` in ('it''s complicated', 'active'))`);
+    expect(createSQL).toContain(`check (\`status\` in ('it''s complicated', 'pending', 'active'))`);
 
     const diff = await orm.schema.getUpdateSchemaSQL({ wrap: false });
     expect(diff).toBe('');
@@ -63,7 +64,7 @@ describe('GH #7395 - enum CHECK constraint with single quotes', () => {
     await orm.schema.refreshDatabase();
 
     const createSQL = await orm.schema.getCreateSchemaSQL({ wrap: false });
-    expect(createSQL).toContain(`check ([status] in ('it''s complicated', 'active'))`);
+    expect(createSQL).toContain(`check ([status] in ('it''s complicated', 'pending', 'active'))`);
 
     const diff = await orm.schema.getUpdateSchemaSQL({ wrap: false });
     expect(diff).toBe('');


### PR DESCRIPTION
## Summary

- backport MikroORM 7's SQLite enum string-literal parsing to the 6.x branch
- capture every quoted enum value while preserving commas and escaped single quotes inside values
- extend the existing escaped-quote regression test from two to three values

## Problem

MikroORM 6.6.16 only recognizes the comma before the final SQLite enum value while introspecting the generated `TEXT CHECK (... IN (...))` constraint. A two-value enum is read correctly, but with three or more values the middle entries are lost. Schema diffing then proposes a redundant table rebuild immediately after creating or migrating the schema.

Minimal reproduction: https://github.com/kennethteh90/mikro-orm-sqlite-enum-repro

This regressed in the 6.x backport for escaped enum quotes. MikroORM 7.1.11 is unaffected because its SQLite helper already uses the string-literal matching strategy applied here.

## Release

This PR targets `6.x` only. If accepted, could it be included in the next 6.x patch release (presumably 6.6.17)?

## Verification

- `yarn jest tests/features/schema-generator/GH7395.test.ts --runInBand --no-watchman -t sqlite`
- `yarn jest tests/features/schema-generator/enum-diffing.sqlite.test.ts --runInBand --no-watchman`
- `yarn eslint packages/knex/src/dialects/sqlite/BaseSqliteSchemaHelper.ts tests/features/schema-generator/GH7395.test.ts`
