### PR TITLE
fix(postgres): flatten dollar-quoted bodies in raw trigger and routine DDL

### DIFF
--- a/packages/sql/src/dialects/postgresql/PostgreSqlSchemaHelper.ts
+++ b/packages/sql/src/dialects/postgresql/PostgreSqlSchemaHelper.ts
@@ -28,6 +28,9 @@ import { normalizePartitionBound, normalizePartitionDefinition } from '../../sch
 /** PostGIS system views that should be automatically ignored */
 const POSTGIS_VIEWS = ['geography_columns', 'geometry_columns'];
 
+/** Dollar-quote delimiter, e.g. `$$` or `$body$`, captured so `split` keeps it. */
+const DOLLAR_QUOTE_TAG = /(\$(?:[A-Za-z_]\w*)?\$)/;
+
 export class PostgreSqlSchemaHelper extends SchemaHelper {
   static readonly DEFAULT_VALUES = {
     'now()': ['now()', 'current_timestamp'],
@@ -711,7 +714,7 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
   /** Generates SQL to create a PostgreSQL trigger and its associated function. */
   override createTrigger(table: DatabaseTable, trigger: SqlTriggerDef): string {
     if (trigger.expression) {
-      return trigger.expression;
+      return this.flattenDollarQuotedBodies(trigger.expression);
     }
 
     const timing = trigger.timing.toUpperCase();
@@ -734,9 +737,27 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
     return `drop trigger if exists ${triggerName} on ${table.getQuotedName()};\ndrop function if exists ${fnName}()`;
   }
 
+  /** Flattens `;\n` inside the dollar-quoted blocks of a raw DDL expression, which are not statement boundaries. */
+  private flattenDollarQuotedBodies(ddl: string): string {
+    let openTag = '';
+
+    return ddl
+      .split(DOLLAR_QUOTE_TAG)
+      .map((part, i) => {
+        // the capture group puts the delimiters on the odd indexes
+        if (i % 2 === 1) {
+          openTag = openTag === part ? '' : openTag || part;
+          return part;
+        }
+
+        return openTag ? stripStatementNewlines(part) : part;
+      })
+      .join('');
+  }
+
   override createRoutine(routine: SqlRoutineDef): string {
     if (routine.expression) {
-      return routine.expression;
+      return this.flattenDollarQuotedBodies(routine.expression);
     }
 
     const qualifiedName = this.qualifiedRoutineName(routine);

--- a/tests/issues/GH8140.test.ts
+++ b/tests/issues/GH8140.test.ts
@@ -1,0 +1,97 @@
+import { rm } from 'node:fs/promises';
+import { EntitySchema } from '@mikro-orm/core';
+import { MikroORM, Routine } from '@mikro-orm/postgresql';
+import { Migrator } from '@mikro-orm/migrations';
+import { TEMP_DIR } from '../helpers.js';
+
+const migrationPath = TEMP_DIR + '/migrations-8140';
+
+class Item {
+  id!: number;
+  value!: number;
+}
+
+// raw DDL escape hatches whose dollar-quoted bodies span several lines, so they carry the `;\n`
+// sequence the statement splitter takes for a statement boundary
+const triggerExpression = `create or replace function "items_bump_fn"() returns trigger as $$
+begin
+  update "items" set "value" = new."value" + 1 where "id" = new."id";
+  return new;
+end;
+$$ language plpgsql;
+create trigger "items_bump" AFTER INSERT on "items" for each ROW execute function "items_bump_fn"()`;
+
+const routineExpression = `create or replace function "items_label"("n" int) returns text as $label$
+begin
+  return 'item ' || "n";
+end;
+$label$ language plpgsql`;
+
+const schema = new EntitySchema({
+  class: Item,
+  tableName: 'items',
+  properties: {
+    id: { type: 'number', primary: true },
+    value: { type: 'number' },
+  },
+  triggers: [
+    {
+      name: 'items_bump',
+      timing: 'after',
+      events: ['insert'],
+      expression: triggerExpression,
+    },
+  ],
+});
+
+const routine = new Routine({
+  name: 'items_label',
+  type: 'function',
+  params: { n: { type: 'integer' } },
+  returns: { runtimeType: 'string', columnType: 'text' },
+  expression: routineExpression,
+});
+
+describe('GH #8140 — dollar-quoted raw DDL stays a single statement', () => {
+  beforeAll(async () => {
+    await rm(migrationPath, { recursive: true, force: true });
+  });
+
+  afterAll(async () => {
+    await rm(migrationPath, { recursive: true, force: true });
+  });
+
+  test('postgres', async () => {
+    const orm = await MikroORM.init({
+      dbName: 'mikro_orm_test_gh8140',
+      entities: [schema],
+      routines: [routine],
+      extensions: [Migrator],
+      migrations: { path: migrationPath, snapshot: false, emit: 'ts' },
+    });
+
+    await orm.schema.refresh();
+    await orm.schema.drop();
+
+    const { diff } = await orm.migrator.createInitial(migrationPath);
+    expect(diff.up).toMatchInlineSnapshot(`
+      [
+        "create table "items" ("id" serial primary key, "value" int not null);",
+        "create or replace function "items_bump_fn"() returns trigger as $$begin
+        update "items" set "value" = new."value" + 1 where "id" = new."id";   return new; end;$$ language plpgsql;",
+        "create trigger "items_bump" AFTER INSERT on "items" for each ROW execute function "items_bump_fn"();",
+        "",
+        "create or replace function "items_label"("n" int) returns text as $label$begin
+        return 'item ' || "n"; end;$label$ language plpgsql;",
+      ]
+    `);
+
+    // used to fail with `42601 unterminated dollar-quoted string`, as the function bodies were
+    // spread over several `addSql()` calls
+    await orm.migrator.up();
+    expect(await orm.schema.getUpdateSchemaSQL({ wrap: false })).toBe('');
+
+    await orm.schema.dropDatabase();
+    await orm.close(true);
+  });
+});


### PR DESCRIPTION
`createTrigger` and `createRoutine` return the `expression` escape hatch verbatim, so a raw `create function ... $$ ... $$` whose body spans several lines keeps a `;\n` inside the dollar-quoted block. Both the migration statement splitter and `SqlSchemaGenerator.execute` read that as a statement boundary, so the generated migration spreads the function over four `addSql()` calls and `migration:up` fails with `unterminated dollar-quoted string`.

Same treatment as #8063, applied to the raw form: only the `;\n` inside dollar-quoted blocks gets flattened, the ones between statements stay, so `create function ...;\ncreate trigger ...` still emits two statements. Doing it here rather than in the splitter (#8062) covers both consumers.

Fixes #8140