### PR TITLE
fix(core): do not mutate the options object provided by the caller

### DIFF
--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -233,7 +233,7 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
     }
 
     const em = this.getContext();
-    em.prepareOptions(options);
+    options = em.prepareOptions(options);
     const meta = this.metadata.get<Entity>(entityName);
     em.validateIndexUsage(meta, where, options);
     await em.tryFlush(entityName, options);
@@ -346,7 +346,7 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
     > = {} as any,
   ): AsyncIterableIterator<Loaded<Entity, Hint, Fields, Excludes>> {
     const em = this.getContext();
-    em.prepareOptions(options);
+    options = em.prepareOptions(options);
     (options as Dictionary).strategy = 'joined';
     await em.tryFlush(entityName, options);
     const where = (await em.processWhere(entityName, options.where ?? {}, options, 'read')) as FilterQuery<Entity>;
@@ -840,7 +840,7 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
   ): Promise<[Loaded<Entity, Hint, Fields, Excludes>[], number]> {
     const em = this.getContext(false);
     await em.tryFlush(entityName, options);
-    options.flushMode = 'commit'; // do not try to auto flush again
+    options = { ...options, flushMode: 'commit' }; // do not try to auto flush again
 
     return Promise.all([
       em.find(entityName, where as any, options),
@@ -920,6 +920,7 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
     >,
   ): Promise<Cursor<Entity, Hint, Fields, Excludes, IncludeCount>> {
     const em = this.getContext(false);
+    options = { ...options };
     options.overfetch ??= true;
     (options as any).where ??= {};
 
@@ -1058,7 +1059,7 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
     }
 
     const em = this.getContext();
-    em.prepareOptions(options);
+    options = em.prepareOptions(options);
     let entity = em.#unitOfWork.tryGetById(entityName, where, options.schema);
 
     // query for a not managed entity which is already in the identity map as it
@@ -1234,7 +1235,7 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
     }
 
     const em = this.getContext(false);
-    em.prepareOptions(options);
+    options = em.prepareOptions(options);
 
     let entityName: EntityName<Entity>;
     let where: FilterQuery<Entity>;
@@ -1407,7 +1408,7 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
     }
 
     const em = this.getContext(false);
-    em.prepareOptions(options);
+    options = em.prepareOptions(options);
 
     let entityName: EntityName<Entity>;
     let propIndex: number | false;
@@ -1758,7 +1759,7 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
     options: LockOptions | number | Date = {},
   ): Promise<void> {
     options = Utils.isPlainObject(options) ? (options as LockOptions) : { lockVersion: options };
-    this.getContext(false).prepareOptions(options as FindOptions<any, any, any, any>);
+    options = this.getContext(false).prepareOptions(options as FindOptions<any, any, any, any>);
     await this.getUnitOfWork().lock(entity, { lockMode, ...options });
   }
 
@@ -1771,7 +1772,7 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
     options: NativeInsertUpdateOptions<Entity> = {},
   ): Promise<Primary<Entity>> {
     const em = this.getContext(false);
-    em.prepareOptions(options);
+    options = em.prepareOptions(options);
 
     let entityName: EntityName<Entity>;
 
@@ -1852,7 +1853,7 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
     }
 
     options ??= {};
-    em.prepareOptions(options);
+    options = em.prepareOptions(options);
 
     const meta = em.metadata.get<Entity>(entityName);
     const res = await em.driver.nativeClone<Entity>(entityName, where, overrides, {
@@ -1876,7 +1877,7 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
     options: NativeInsertUpdateOptions<Entity> = {},
   ): Promise<Primary<Entity>[]> {
     const em = this.getContext(false);
-    em.prepareOptions(options);
+    options = em.prepareOptions(options);
 
     let entityName: EntityName<Entity>;
 
@@ -1934,7 +1935,7 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
     options: UpdateOptions<Entity> = {},
   ): Promise<number> {
     const em = this.getContext(false);
-    em.prepareOptions(options);
+    options = em.prepareOptions(options);
 
     await em.processUnionWhere(entityName, options, 'update');
 
@@ -1999,7 +2000,7 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
     options: DeleteOptions<Entity> = {},
   ): Promise<number> {
     const em = this.getContext(false);
-    em.prepareOptions(options);
+    options = em.prepareOptions(options);
 
     await em.processUnionWhere(entityName, options, 'delete');
 
@@ -2309,9 +2310,7 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
   ): Promise<number> {
     const em = this.getContext(false);
 
-    // Shallow copy options since the object will be modified when deleting orderBy
-    options = { ...options };
-    em.prepareOptions(options);
+    options = em.prepareOptions(options);
 
     await em.tryFlush(entityName, options);
     where = await em.processWhere(entityName, where, options as FindOptions<Entity, Hint>, 'read');
@@ -2515,7 +2514,7 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
     }
 
     const em = this.getContext();
-    em.prepareOptions(options);
+    options = em.prepareOptions(options);
     const entityName = arr[0].constructor;
     const preparedPopulate = await em.preparePopulate<Entity>(
       entityName,
@@ -3088,28 +3087,32 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
     return !!options.populate;
   }
 
-  protected prepareOptions(
-    options: (
+  protected prepareOptions<
+    Options extends (
       | FindOptions<any, any, any, any>
       | FindOneOptions<any, any, any, any>
       | CountOptions<any, any>
       | CountByOptions<any>
     ) &
       AbortQueryOptions,
-  ): void {
+  >(options: Options): Options {
     if (!Utils.isEmpty((options as FindOptions<any>).fields) && !Utils.isEmpty((options as FindOptions<any>).exclude)) {
       throw new ValidationError(`Cannot combine 'fields' and 'exclude' option.`);
     }
 
-    options.schema ??= this.#schema;
-    options.signal ??= this.signal;
-    options.inflightQueryAbortStrategy ??= this.inflightQueryAbortStrategy;
-    options.logging = options.loggerContext = Utils.merge(
+    // the options object belongs to the caller, everything below works on our own copy
+    const opts = { ...options };
+    opts.schema ??= this.#schema;
+    opts.signal ??= this.signal;
+    opts.inflightQueryAbortStrategy ??= this.inflightQueryAbortStrategy;
+    opts.logging = opts.loggerContext = Utils.merge(
       { id: this.id },
       this.loggerContext,
-      options.loggerContext,
-      options.logging,
+      opts.loggerContext,
+      opts.logging,
     );
+
+    return opts;
   }
 
   /**

--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -958,10 +958,10 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
     const ret = await this.refresh(entity, options);
 
     if (!ret) {
-      options.failHandler ??= this.config.get('findOneOrFailHandler');
+      const failHandler = options.failHandler ?? this.config.get('findOneOrFailHandler');
       const wrapped = helper(entity);
       const where = wrapped.getPrimaryKey();
-      throw options.failHandler(wrapped.__meta.className, where);
+      throw failHandler(wrapped.__meta.className, where);
     }
 
     return ret as any;
@@ -1188,11 +1188,11 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
 
     if (!entity || isStrictViolation) {
       const key = options.strict ? 'findExactlyOneOrFailHandler' : 'findOneOrFailHandler';
-      options.failHandler ??= this.config.get(key);
+      const failHandler = options.failHandler ?? this.config.get(key);
       const name = Utils.className(entityName);
       /* v8 ignore next */
       where = Utils.isEntity(where) ? (helper(where).getPrimaryKey() as any) : where;
-      throw options.failHandler(name, where);
+      throw failHandler(name, where);
     }
 
     return entity;
@@ -2315,7 +2315,6 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
     await em.tryFlush(entityName, options);
     where = await em.processWhere(entityName, where, options as FindOptions<Entity, Hint>, 'read');
     options.populate = (await em.preparePopulate(entityName, options as FindOptions<Entity, Hint>)) as any;
-    options = { ...options };
     // save the original hint value so we know it was infer/all
     const meta = em.metadata.find(entityName)!;
     (options as Dictionary)._populateWhere = options.populateWhere ?? this.config.get('populateWhere');

--- a/packages/mongodb/src/MongoEntityManager.ts
+++ b/packages/mongodb/src/MongoEntityManager.ts
@@ -72,8 +72,7 @@ export class MongoEntityManager<Driver extends MongoDriver = MongoDriver> extend
     options: CountByOptions<Entity> = {},
   ): Promise<Dictionary<number>> {
     const em = this.getContext(false) as MongoEntityManager;
-    options = { ...options };
-    em.prepareOptions(options);
+    options = em.prepareOptions(options);
     const meta = em.getMetadata().find(entityName)!;
     const fields = Utils.asArray(groupBy);
 

--- a/packages/sql/src/SqlEntityManager.ts
+++ b/packages/sql/src/SqlEntityManager.ts
@@ -184,8 +184,7 @@ export class SqlEntityManager<Driver extends AbstractSqlDriver = AbstractSqlDriv
     options: CountByOptions<Entity> = {},
   ): Promise<Dictionary<number>> {
     const em = this.getContext(false) as SqlEntityManager;
-    options = { ...options };
-    em.prepareOptions(options);
+    options = em.prepareOptions(options);
     const meta = em.getMetadata().find(entityName)!;
     const fields = Utils.asArray(groupBy);
     const { where: rawWhere, ...countOptions } = options;

--- a/tests/issues/GH8143.test.ts
+++ b/tests/issues/GH8143.test.ts
@@ -1,0 +1,63 @@
+import { defineEntity, MikroORM, p } from '@mikro-orm/sqlite';
+
+const User = defineEntity({
+  name: 'User',
+  properties: () => ({
+    id: p.integer().primary().autoincrement(),
+    name: p.string(),
+  }),
+});
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    dbName: ':memory:',
+    entities: [User],
+  });
+  await orm.schema.create();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+test('em.find() does not mutate the options object', async () => {
+  const options = Object.freeze({ filters: false });
+  await orm.em.find(User, {}, options);
+  expect(options).toEqual({ filters: false });
+});
+
+test('em.findOne() does not mutate the options object', async () => {
+  const options = Object.freeze({ filters: false });
+  await orm.em.findOne(User, { id: 1 }, options);
+  expect(options).toEqual({ filters: false });
+});
+
+test('em.findAndCount() does not mutate the options object', async () => {
+  const options = Object.freeze({ filters: false });
+  await orm.em.findAndCount(User, {}, options);
+  expect(options).toEqual({ filters: false });
+});
+
+test('em.findByCursor() does not mutate the options object', async () => {
+  const options = Object.freeze({ first: 1, orderBy: { id: 'asc' } } as const);
+  await orm.em.findByCursor(User, options);
+  expect(options).toEqual({ first: 1, orderBy: { id: 'asc' } });
+});
+
+test('em.count() does not mutate the options object', async () => {
+  const options = Object.freeze({ filters: false });
+  await orm.em.count(User, {}, options);
+  expect(options).toEqual({ filters: false });
+});
+
+test('em.stream() does not mutate the options object', async () => {
+  const options = Object.freeze({ filters: false });
+
+  for await (const user of orm.em.stream(User, options)) {
+    expect(user).toBeDefined();
+  }
+
+  expect(options).toEqual({ filters: false });
+});

--- a/tests/issues/GH8143.test.ts
+++ b/tests/issues/GH8143.test.ts
@@ -46,6 +46,23 @@ test('em.findByCursor() does not mutate the options object', async () => {
   expect(options).toEqual({ first: 1, orderBy: { id: 'asc' } });
 });
 
+test('em.findOneOrFail() does not mutate the options object on the failure path', async () => {
+  const options = Object.freeze({ filters: false });
+  await expect(orm.em.findOneOrFail(User, { id: 123 }, options)).rejects.toThrow('User not found ({ id: 123 })');
+  expect(options).toEqual({ filters: false });
+});
+
+test('em.refreshOrFail() does not mutate the options object on the failure path', async () => {
+  const em = orm.em.fork();
+  const user = em.create(User, { name: 'u1' });
+  await em.flush();
+  await em.nativeDelete(User, { id: user.id });
+
+  const options = Object.freeze({ filters: false });
+  await expect(em.refreshOrFail(user, options)).rejects.toThrow(`User not found (${user.id})`);
+  expect(options).toEqual({ filters: false });
+});
+
 test('em.count() does not mutate the options object', async () => {
   const options = Object.freeze({ filters: false });
   await orm.em.count(User, {}, options);


### PR DESCRIPTION
`prepareOptions()` assigned `schema`, `signal`, the abort strategy and the logger context straight onto the options object it received, and `em.find()`, `em.findOne()` and `em.stream()` then wrote the normalized `populate` hint onto it too. All of that happens before the local `options = { ...options }` copy, so the object the caller owns comes back changed. A module level base config like `const BASE_OPTIONS = { filters: false }` picks up `populate: []` from the first query that runs without a populate hint, and every later query spreading that base loses its own hint. Nothing resets it, so in a long running app the leak survives across requests.

`prepareOptions()` now returns a copy instead of writing into its argument, and every caller reassigns the result, which covers `upsert()`, `insert()`, `nativeUpdate()`, `nativeDelete()`, `lock()` and `em.populate()` as well. `findAndCount()` and `findByCursor()` set `flushMode` and `overfetch` before that call, so they copy first too. The manual copies in `em.count()` and in both `countBy()` implementations are no longer needed.

Fixes #8143