### PR TITLE
fix(query-builder): allow alias-prefixed keys in nested `$and`/`$or` groups

### DIFF
--- a/packages/sql/src/query/QueryBuilder.ts
+++ b/packages/sql/src/query/QueryBuilder.ts
@@ -488,18 +488,13 @@ type ContextFieldType<Context, K extends string> = Context[keyof Context] extend
 type ContextFilterKeys<Context> = { [K in ContextFieldKeys<Context>]?: ContextFieldType<Context, K> };
 type RawFilterKeys<RawAliases extends string> = { [K in RawAliases]?: AliasedFilterValue };
 
-// Internal type for nested filter conditions in group operators ($and, $or, $not)
-// Uses intersection to ensure unknown aliased keys are caught by excess property checking
-type NestedFilterCondition<Entity, RootAlias extends string, Context, RawAliases extends string> = ObjectQuery<Entity> &
-  (IsNever<RootAlias> extends true ? {} : string extends RootAlias ? {} : RootAliasFilterKeys<RootAlias, Entity>) &
-  ([Context] extends [never] ? {} : ContextFilterKeys<Context>) &
-  (IsNever<RawAliases> extends true ? {} : string extends RawAliases ? {} : RawFilterKeys<RawAliases>);
-
 // Group operators type that accepts both plain entity keys and aliased keys
+// Nested conditions reuse `QBFilterQuery` so aliases keep validating at any depth; going through
+// `ObjectQuery` instead would widen the element type to `FilterQuery` and disable excess property checking
 type GroupOperators<RootAlias extends string, Context, Entity, RawAliases extends string> = {
-  $and?: NestedFilterCondition<Entity, RootAlias, Context, RawAliases>[];
-  $or?: NestedFilterCondition<Entity, RootAlias, Context, RawAliases>[];
-  $not?: NestedFilterCondition<Entity, RootAlias, Context, RawAliases>;
+  $and?: QBFilterQuery<Entity, RootAlias, Context, RawAliases>[];
+  $or?: QBFilterQuery<Entity, RootAlias, Context, RawAliases>[];
+  $not?: QBFilterQuery<Entity, RootAlias, Context, RawAliases>;
 };
 
 // Aliased keys filter condition - split into separate intersected parts for better caching

--- a/tests/bench/types/querybuilder.ts
+++ b/tests/bench/types/querybuilder.ts
@@ -164,7 +164,13 @@ bench('QBFilterQuery<Author, "a", SimpleContext> - with $and', () => {
   useFilter<Author, 'a', SimpleContext>({
     $and: [{ 'b.title': 'test' }, { name: 'foo' }],
   });
-}).types([423, 'instantiations']);
+}).types([413, 'instantiations']);
+
+bench('QBFilterQuery<Author, "a", SimpleContext> - with nested $or in $and', () => {
+  useFilter<Author, 'a', SimpleContext>({
+    $and: [{ $or: [{ 'b.title': 'test' }, { name: 'foo' }] }],
+  });
+}).types([437, 'instantiations']);
 
 // ============================================
 // ModifyFields benchmarks (Fields tracking)

--- a/tests/features/query-builder/query-builder-type-safety.test.ts
+++ b/tests/features/query-builder/query-builder-type-safety.test.ts
@@ -251,5 +251,32 @@ describe('QueryBuilder type safety', () => {
         qb.where({ $or: [{ 'a.name': { $badOp: 'test' } }] });
       }
     });
+
+    test('should accept aliased keys in nested $and/$or groups', async () => {
+      const qb = orm.em.createQueryBuilder(Author2, 'a').select('*').leftJoin('a.books', 'b');
+
+      qb.where({ $or: [{ $and: [{ 'a.name': 'x' }] }, { $and: [{ 'b.title': 'y' }] }] });
+
+      expect(qb.getFormattedQuery()).toBe(
+        'select `a`.* from `author2` as `a` ' +
+          'left join `book2` as `b` on `a`.`id` = `b`.`author_id` ' +
+          "where ((`a`.`name` = 'x') or (`b`.`title` = 'y'))",
+      );
+
+      // Type-only checks - nested groups keep validating aliases, properties and value types
+      if (false as boolean) {
+        qb.where({ $and: [{ $or: [{ $and: [{ 'b.title': { $like: '%y%' } }] }] }] });
+        qb.where({ $not: { $or: [{ 'a.name': 'x' }] } });
+
+        // @ts-expect-error - 'unknown' is not a valid alias
+        qb.where({ $or: [{ $and: [{ 'unknown.name': 'x' }] }] });
+
+        // @ts-expect-error - 'a.invalidProp' does not exist on Author2
+        qb.where({ $or: [{ $and: [{ 'a.invalidProp': 'x' }] }] });
+
+        // @ts-expect-error - 'a.name' is a string property
+        qb.where({ $or: [{ $and: [{ 'a.name': 123 }] }] });
+      }
+    });
   });
 });


### PR DESCRIPTION
`QBFilterQuery` accepted alias-prefixed keys at the top level of `where()` and inside a single group operator, but rejected them one level deeper. The same condition built the expected SQL at runtime, so this was types-only.

`GroupOperators` typed its elements as `NestedFilterCondition`, a hand-rolled near-copy of `QBFilterQuery` that left out the group operators themselves. A nested `$and`/`$or` could therefore only resolve through `ObjectQuery<Entity>`, which takes non-prefixed entity keys.

Pointing the group operators at `QBFilterQuery` and deleting `NestedFilterCondition` fixes it. The detour through `ObjectQuery` is what broke it in the first place: it pulls in `OperatorMap`, whose own `$and`/`$or`/`$not` widen the element type to `FilterQuery`, which is permissive enough to switch off excess property checking for everything nested inside. Adding `GroupOperators` to the old type instead would have compiled the valid cases but silently stopped flagging unknown aliases, unknown properties and wrong value types at depth two.

Ends up cheaper than what it replaces: the existing `$and` type benchmark goes from 423 to 413 instantiations. Added a nested-group benchmark alongside it.

Closes #8145
