### PR TITLE
feat(core): add `getNativeClient()` to access the underlying database client

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -203,6 +203,28 @@ MikroORM.init({
 });
 ```
 
+### Accessing the native client
+
+`getNativeClient()` returns the client the connection drives, for vendor APIs MikroORM does not wrap. Each driver narrows the return type to its own client:
+
+```ts
+const pool = await orm.em.getConnection().getNativeClient(); // pg Pool on postgresql
+```
+
+| Driver                   | Returns                                     |
+| ------------------------ | ------------------------------------------- |
+| `postgresql`             | `Pool` from `pg`                            |
+| `mysql`, `mariadb`       | `Pool` from `mysql2`                        |
+| `sqlite`                 | `Database` from `better-sqlite3`            |
+| `libsql`                 | `Database` from `libsql`                    |
+| `pglite`                 | `PGlite` from `@electric-sql/pglite`        |
+| `oracledb`               | `Pool` from `oracledb`                      |
+| `mongodb`                | `MongoClient` (same as `getClient()`)       |
+
+It throws on `mssql`, which has no long-lived native client — use the `onCreateConnection`/`onReserveConnection` hooks to reach `tedious` connections. It also throws when you supplied a ready-made Kysely instance or dialect via `driverOptions`, since the driver never creates a client of its own in that case.
+
+The client's lifecycle belongs to the ORM, so leave closing it to `orm.close()` unless you provided it yourself. For the Kysely query builder rather than the vendor client, use [`getClient()`](./kysely.md).
+
 > You can also set the timezone directly in the ORM configuration:
 >
 > ```ts

--- a/docs/docs/usage-with-pglite.md
+++ b/docs/docs/usage-with-pglite.md
@@ -92,6 +92,19 @@ const orm = await MikroORM.init({
 });
 ```
 
+### Accessing the PGlite instance
+
+[`getNativeClient()`](./configuration.md#accessing-the-native-client) returns the `PGlite` instance the connection is using, whether MikroORM created it or you passed it in. Use it for PGlite APIs that have no ORM equivalent, such as [`pgDump`](https://pglite.dev/docs/pglite-tools#pgdump) or `dumpDataDir`:
+
+```ts
+import { pgDump } from '@electric-sql/pglite-tools/pg_dump';
+
+const pglite = await orm.em.getConnection().getNativeClient();
+const dump = await pgDump({ pg: pglite });
+```
+
+Unless you supplied the instance yourself, its lifecycle stays with the ORM — let `orm.close()` close it rather than calling `close()` on it directly.
+
 ## Schema, migrations, and queries
 
 PGlite implements standard PostgreSQL features, so the [Schema Generator](./schema-generator.md), [Migrations](./migrations.md), [QueryBuilder](./query-builder.md), and [Kysely integration](./kysely.md) all work the same way as with `@mikro-orm/postgresql`.

--- a/packages/core/src/connections/Connection.ts
+++ b/packages/core/src/connections/Connection.ts
@@ -103,6 +103,16 @@ export abstract class Connection {
     throw new Error(`Executing SQL dumps is not supported by current driver`);
   }
 
+  /**
+   * Returns the underlying database client the connection drives — e.g. the `pg` pool, the
+   * `better-sqlite3` database, or the `PGlite` instance — for vendor APIs MikroORM does not wrap.
+   * Each driver narrows the return type to its own client. Its lifecycle belongs to the ORM, so
+   * leave closing it to `orm.close()` unless you supplied the client yourself via `driverOptions`.
+   */
+  async getNativeClient(): Promise<unknown> {
+    throw new Error(`Accessing the native client is not supported by current driver`);
+  }
+
   protected async onConnect(): Promise<void> {
     const schemaGenerator = this.config.getExtension<ISchemaGenerator>('@mikro-orm/schema-generator');
 

--- a/packages/libsql/src/LibSqlConnection.ts
+++ b/packages/libsql/src/LibSqlConnection.ts
@@ -47,6 +47,15 @@ export class LibSqlConnection extends BaseSqliteConnection {
     this.database.exec(source);
   }
 
+  /**
+   * Returns the `libsql` database backing this connection. Remote/replica connections are
+   * recycled, so re-read it rather than holding on to the returned handle.
+   */
+  override async getNativeClient(): Promise<Database.Database> {
+    await this.ensureConnection();
+    return this.requireNativeClient(this.database);
+  }
+
   private validateAttachSupport(): void {
     const attachDatabases = this.config.get('attachDatabases');
     if (!attachDatabases?.length) {

--- a/packages/mongodb/src/MongoConnection.ts
+++ b/packages/mongodb/src/MongoConnection.ts
@@ -136,6 +136,12 @@ export class MongoConnection extends Connection {
     return this.#client!;
   }
 
+  /** Returns the `MongoClient` backing this connection, the async counterpart of `getClient()`. */
+  override async getNativeClient(): Promise<MongoClient> {
+    await this.ensureConnection();
+    return this.getClient();
+  }
+
   getCollection<T extends object>(name: EntityName<T> | string): Collection<T> {
     return this.getDb().collection<T>(this.getCollectionName(name));
   }

--- a/packages/mssql/src/MsSqlConnection.ts
+++ b/packages/mssql/src/MsSqlConnection.ts
@@ -51,7 +51,13 @@ class MsSqlReserveDialect extends MssqlDialect {
   }
 }
 
-/** Microsoft SQL Server database connection using the `tedious` driver. */
+/**
+ * Microsoft SQL Server database connection using the `tedious` driver.
+ *
+ * There is no `getNativeClient()` here: tedious has no long-lived client object, and the pool
+ * kysely builds holds its own connection wrappers rather than tedious ones. Reach individual
+ * `Tedious.Connection`s through the `onCreateConnection`/`onReserveConnection` hooks instead.
+ */
 export class MsSqlConnection extends AbstractSqlConnection {
   override createKyselyDialect(overrides: ConnectionConfiguration): MssqlDialect {
     const options = this.mapOptions(overrides);

--- a/packages/mysql/src/MySqlConnection.ts
+++ b/packages/mysql/src/MySqlConnection.ts
@@ -22,6 +22,8 @@ export class MySqlConnection extends AbstractSqlConnection {
   // query it is meant to cancel. Postgres gets one from its pool by default, mysql2 does not.
   static readonly #controlConnection = createConnection as unknown as MysqlDialectConfig['controlConnection'];
 
+  #pool?: Pool;
+
   override async createKyselyDialect(overrides: PoolOptions): Promise<MysqlDialect> {
     const options = this.mapOptions(overrides);
     const password = options.password as ConnectionConfig['password'];
@@ -29,6 +31,8 @@ export class MySqlConnection extends AbstractSqlConnection {
     if (typeof password === 'function') {
       const initialPassword = await password();
       const innerPool = createPool({ ...options, password: initialPassword });
+      // the wrapper below is a kysely-shaped shim, so expose the real mysql2 pool
+      this.#pool = innerPool;
 
       // mysql2 reads pool.config.connectionConfig.password when creating new physical
       // connections, so updating it before getConnection() ensures fresh tokens are used.
@@ -61,12 +65,20 @@ export class MySqlConnection extends AbstractSqlConnection {
       });
     }
 
+    this.#pool = createPool(options);
+
     return new MysqlDialect({
-      pool: createPool(options) as any,
+      pool: this.#pool as any,
       controlConnection: MySqlConnection.#controlConnection,
       onCreateConnection: this.options.onCreateConnection ?? this.config.get('onCreateConnection'),
       onReserveConnection: this.options.onReserveConnection ?? this.config.get('onReserveConnection'),
     });
+  }
+
+  /** Returns the `mysql2` connection pool backing this connection. */
+  override async getNativeClient(): Promise<Pool> {
+    await this.ensureConnection();
+    return this.requireNativeClient(this.#pool);
   }
 
   mapOptions(overrides: PoolOptions): PoolOptions {

--- a/packages/oracledb/src/OracleConnection.ts
+++ b/packages/oracledb/src/OracleConnection.ts
@@ -243,6 +243,12 @@ export class OracleConnection extends AbstractSqlConnection {
     }
   }
 
+  /** Returns the `oracledb` connection pool backing this connection. */
+  override async getNativeClient(): Promise<oracledb.Pool> {
+    await this.ensureConnection();
+    return this.requireNativeClient(this.oraclePool);
+  }
+
   /**
    * Oracle routines acquire their own pool connection with `autoCommit: true` (refcursor binds
    * and DML need to resolve in one round-trip), so they cannot share the EM's transaction. Wrapping

--- a/packages/pglite/src/PgliteConnection.ts
+++ b/packages/pglite/src/PgliteConnection.ts
@@ -12,9 +12,8 @@ import { AbstractSqlConnection, type Dictionary, createPostgreSqlTypeParsers } f
  * you're responsible for configuring them yourself, and `dataDir` from
  * `dbName` is ignored — your instance keeps whatever it was constructed with).
  *
- * @internal — kept module-local so `@electric-sql/pglite`'s d.ts (which
- * references DOM/Emscripten/WebAssembly ambient globals) doesn't leak into
- * downstream type graphs.
+ * @internal — kept module-local; `driverOptions` is untyped at the config level
+ * anyway, so exporting this would only widen the API surface.
  */
 type PgliteDriverOptions = Partial<PGliteOptions> & {
   pglite?: PGlite | (() => PGlite | Promise<PGlite>);
@@ -128,10 +127,19 @@ export class PgliteConnection extends AbstractSqlConnection {
     }
   }
 
+  /**
+   * Returns the underlying `PGlite` instance, for APIs we don't wrap (e.g. `pgDump`
+   * from `@electric-sql/pglite-tools`, extensions, or `dumpDataDir`). Closing it is
+   * still `orm.close()`'s job unless you supplied it via `driverOptions.pglite`.
+   */
+  override async getNativeClient(): Promise<PGlite> {
+    await this.ensureConnection();
+    return this.#pglite!;
+  }
+
   /** PGlite supports multi-statement scripts via `exec()`, which is what schema dumps need. */
   override async executeDump(source: string): Promise<void> {
-    await this.ensureConnection();
-    const pglite = await this.#pglite!;
+    const pglite = await this.getNativeClient();
     await pglite.exec(source);
   }
 }

--- a/packages/postgresql/src/PostgreSqlConnection.ts
+++ b/packages/postgresql/src/PostgreSqlConnection.ts
@@ -7,12 +7,15 @@ import { AbstractSqlConnection, createPostgreSqlTypeParsers, Utils } from '@mikr
 
 /** PostgreSQL database connection using the `pg` driver. */
 export class PostgreSqlConnection extends AbstractSqlConnection {
+  #pool?: Pool;
+
   override createKyselyDialect(overrides: PoolConfig): PostgresDialect {
     const { onPoolCreated, ...poolOverrides } = (overrides ?? {}) as PoolConfig & {
       onPoolCreated?: (pool: Pool) => unknown;
     };
     const options = this.mapOptions(poolOverrides);
     const pool = new Pool(options);
+    this.#pool = pool;
     this.handlePoolErrors(pool);
     void onPoolCreated?.(pool);
     return new PostgresDialect({
@@ -21,6 +24,12 @@ export class PostgreSqlConnection extends AbstractSqlConnection {
       onCreateConnection: this.options.onCreateConnection ?? this.config.get('onCreateConnection'),
       onReserveConnection: this.options.onReserveConnection ?? this.config.get('onReserveConnection'),
     });
+  }
+
+  /** Returns the `pg` connection pool backing this connection. */
+  override async getNativeClient(): Promise<Pool> {
+    await this.ensureConnection();
+    return this.requireNativeClient(this.#pool);
   }
 
   /**

--- a/packages/sql/src/AbstractSqlConnection.ts
+++ b/packages/sql/src/AbstractSqlConnection.ts
@@ -143,6 +143,22 @@ export abstract class AbstractSqlConnection extends Connection {
     }
   }
 
+  /**
+   * Guards `getNativeClient()` overrides — drivers only capture their client while building their
+   * own dialect, which `driverOptions` carrying a ready-made Kysely instance or dialect skips.
+   *
+   * @internal
+   */
+  protected requireNativeClient<T>(client: T | undefined | null): T {
+    if (client == null) {
+      throw new Error(
+        'The native client is not available, as it is owned by the Kysely instance or dialect passed via `driverOptions`. Access it through the object you provided there instead.',
+      );
+    }
+
+    return client;
+  }
+
   /** Executes a callback within a transaction, committing on success and rolling back on error. */
   override async transactional<T>(
     cb: (trx: Transaction<ControlledTransaction<any, any>>) => Promise<T>,

--- a/packages/sqlite/src/SqliteConnection.ts
+++ b/packages/sqlite/src/SqliteConnection.ts
@@ -26,6 +26,12 @@ export class SqliteConnection extends BaseSqliteConnection {
     this.database.exec(dump);
   }
 
+  /** Returns the `better-sqlite3` database backing this connection. */
+  override async getNativeClient(): Promise<Database.Database> {
+    await this.ensureConnection();
+    return this.requireNativeClient(this.database);
+  }
+
   /** SQLite has no procedures; functions bridge via `bodyJs` registered as a UDF. */
   override async callRoutine<T>(routine: Routine, args: Record<string, unknown> = {}, ctx?: Transaction): Promise<T> {
     if (routine.type === 'procedure') {

--- a/tests/Connection.test.ts
+++ b/tests/Connection.test.ts
@@ -37,6 +37,9 @@ describe('Connection', () => {
     await expect(conn.commit({} as any)).rejects.toThrow('Transactions are not supported by current driver');
     await expect(conn.rollback({} as any)).rejects.toThrow('Transactions are not supported by current driver');
     await expect(conn.executeDump('...')).rejects.toThrow('Executing SQL dumps is not supported by current driver');
+    await expect(conn.getNativeClient()).rejects.toThrow(
+      'Accessing the native client is not supported by current driver',
+    );
   });
 
   test('special characters in username and password', async () => {

--- a/tests/features/entity-manager/EntityManager.pglite.test.ts
+++ b/tests/features/entity-manager/EntityManager.pglite.test.ts
@@ -3115,6 +3115,32 @@ describe('EntityManagerPglite', () => {
     expect(existsSync('whatever')).toBe(false);
   });
 
+  test('getNativeClient() exposes the underlying PGlite instance', async () => {
+    const { PGlite } = await import('@electric-sql/pglite');
+    const connection = orm.em.getConnection();
+    const pglite = await connection.getNativeClient();
+    expect(pglite).toBeInstanceOf(PGlite);
+
+    // PGlite-only APIs we don't wrap (multi-statement `exec`, `dumpDataDir`) are now reachable
+    const res = await pglite.exec('select 1 as a; select 2 as b');
+    expect(res.map(r => r.rows[0])).toEqual([{ a: 1 }, { b: 2 }]);
+    expect(await connection.getNativeClient()).toBe(pglite);
+  });
+
+  test('getNativeClient() returns the instance passed via driverOptions', async () => {
+    const { defineEntity, p } = await import('@mikro-orm/core');
+    const { PGlite } = await import('@electric-sql/pglite');
+    const Mini = defineEntity({
+      name: 'Mini',
+      properties: { id: p.integer().primary().autoincrement(), name: p.string() },
+    });
+    const pglite = await PGlite.create();
+    const child = await MikroORM.init({ entities: [Mini], driverOptions: { pglite } });
+    await expect(child.em.getConnection().getNativeClient()).resolves.toBe(pglite);
+    await child.close(true);
+    await pglite.close();
+  });
+
   test('MikroORM.init resolves with PgliteDriver and accepts a PGlite instance', async () => {
     const { defineEntity, p } = await import('@mikro-orm/core');
     const { PGlite } = await import('@electric-sql/pglite');

--- a/tests/features/native-client.test.ts
+++ b/tests/features/native-client.test.ts
@@ -1,0 +1,134 @@
+import { Pool } from 'pg';
+import { MongoClient } from 'mongodb';
+import BetterSqlite3 from 'better-sqlite3';
+import LibSqlDatabase from 'libsql';
+import { SqliteDialect } from 'kysely';
+import { MikroORM } from '@mikro-orm/core';
+import { SqliteDriver } from '@mikro-orm/sqlite';
+import { LibSqlDriver } from '@mikro-orm/libsql';
+import { Author4 } from '../entities-schema/index.js';
+import {
+  initORMMongo,
+  initORMMsSql,
+  initORMMySql,
+  initORMOracleDb,
+  initORMPostgreSql,
+  initORMSqlite,
+} from '../bootstrap.js';
+
+describe('getNativeClient', () => {
+  test('sqlite returns the better-sqlite3 database', async () => {
+    const orm = await initORMSqlite<SqliteDriver>('sqlite');
+    const db = await orm.em.getConnection().getNativeClient();
+
+    expect(db).toBeInstanceOf(BetterSqlite3);
+    // a better-sqlite3-only API — synchronous prepared statements have no ORM equivalent
+    expect(db.prepare('select 1 as a').get()).toEqual({ a: 1 });
+
+    await orm.close(true);
+  });
+
+  test('libsql returns the libsql database', async () => {
+    const orm = await initORMSqlite<LibSqlDriver>('libsql');
+    const db = await orm.em.getConnection().getNativeClient();
+
+    expect(db).toBeInstanceOf(LibSqlDatabase);
+    // libsql tacks `_metadata` onto rows, hence the loose match
+    expect(db.prepare('select 1 as a').get()).toMatchObject({ a: 1 });
+
+    await orm.close(true);
+  });
+
+  test('throws when the driver builds no client of its own', async () => {
+    // `node-sqlite` hands MikroORM a ready-made kysely dialect and its connection never
+    // captures a client, so the base implementation stands
+    const orm = await initORMSqlite('node-sqlite');
+
+    await expect(orm.em.getConnection().getNativeClient()).rejects.toThrow(
+      'Accessing the native client is not supported by current driver',
+    );
+
+    await orm.close(true);
+  });
+
+  test('throws when a driver that has a client was handed a dialect via driverOptions', async () => {
+    const orm = await MikroORM.init<SqliteDriver>({
+      entities: [Author4],
+      dbName: ':memory:',
+      driver: SqliteDriver,
+      driverOptions: new SqliteDialect({ database: new BetterSqlite3(':memory:') }),
+    });
+
+    // `createKyselyDialect()` is skipped, so `SqliteConnection` never gets hold of a database
+    await expect(orm.em.getConnection().getNativeClient()).rejects.toThrow(
+      'The native client is not available, as it is owned by the Kysely instance or dialect passed via `driverOptions`',
+    );
+
+    await orm.close(true);
+  });
+
+  test('postgres returns the pg pool', async () => {
+    const orm = await initORMPostgreSql();
+    const pool = await orm.em.getConnection().getNativeClient();
+
+    expect(pool).toBeInstanceOf(Pool);
+    const res = await pool.query('select 1 as a');
+    expect(res.rows).toEqual([{ a: 1 }]);
+
+    await orm.close(true);
+  });
+
+  test('mysql returns the mysql2 pool', async () => {
+    const orm = await initORMMySql('mysql', {}, true);
+    const pool = await orm.em.getConnection().getNativeClient();
+
+    const [rows] = await pool.promise().query('select 1 as a');
+    expect(rows).toEqual([{ a: 1 }]);
+
+    await orm.close(true);
+  });
+
+  test('mariadb returns the mysql2 pool', async () => {
+    const orm = await initORMMySql('mariadb', {}, true);
+    const pool = await orm.em.getConnection().getNativeClient();
+
+    const [rows] = await pool.promise().query('select 1 as a');
+    expect(rows).toEqual([{ a: 1 }]);
+
+    await orm.close(true);
+  });
+
+  test('mssql has no native client to expose', async () => {
+    const orm = await initORMMsSql();
+
+    // tedious has no long-lived client, and kysely's pool holds its own connection wrappers
+    await expect(orm.em.getConnection().getNativeClient()).rejects.toThrow(
+      'Accessing the native client is not supported by current driver',
+    );
+
+    await orm.close(true);
+  });
+
+  test('oracle returns the oracledb pool', async () => {
+    const orm = await initORMOracleDb();
+    const pool = await orm.em.getConnection().getNativeClient();
+
+    expect(pool.poolMax).toBeGreaterThan(0);
+    const connection = await pool.getConnection();
+    const res = await connection.execute<[number]>('select 1 from dual');
+    expect(res.rows).toEqual([[1]]);
+    await connection.close();
+
+    await orm.close(true);
+  });
+
+  test('mongo returns the MongoClient', async () => {
+    const orm = await initORMMongo();
+    const client = await orm.em.getConnection().getNativeClient();
+
+    expect(client).toBeInstanceOf(MongoClient);
+    await expect(client.db().admin().ping()).resolves.toMatchObject({ ok: 1 });
+
+    await orm.close(true);
+  });
+});


### PR DESCRIPTION
Adds `Connection.getNativeClient()`, which returns the client a driver runs on, for vendor APIs the ORM does not wrap. The request was for the PGlite instance (to run `pgDump` at runtime), which was unreachable because it lives in a native private field.

Each driver narrows the return type to its own client:

| Driver | Returns |
| --- | --- |
| `postgresql` | `Pool` from `pg` |
| `mysql`, `mariadb` | `Pool` from `mysql2` |
| `sqlite` | `Database` from `better-sqlite3` |
| `libsql` | `Database` from `libsql` |
| `pglite` | `PGlite` from `@electric-sql/pglite` |
| `oracledb` | `Pool` from `oracledb` |
| `mongodb` | `MongoClient`, the async counterpart of the existing `getClient()` |

The base implementation throws, mirroring `executeDump()`, so custom drivers keep working and `mssql` inherits it. Tedious has no long-lived client, and the pool kysely builds holds its own connection wrappers rather than tedious ones, so the `onCreateConnection`/`onReserveConnection` hooks remain the way to reach connections there. Passing a ready-made Kysely instance or dialect through `driverOptions` also throws, since `createKyselyDialect()` never runs and the driver captures nothing.

`getClient()` is unchanged: the Kysely query builder on SQL drivers, the `MongoClient` on mongo.

Closes #8146
