### PR TITLE
chore: sync type benchmark baselines

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "test:sqlite": "vitest run **/*.sqlite.test.ts **/*.win.test.ts",
     "test:fast": "vitest run --exclude='tests/features/schema-generator'",
     "bench": "tsx tests/bench/basic.bench.ts",
-    "bench:types": "bash -c 'for f in tests/bench/types/*.ts; do node --import=tsx \"$f\" || exit 1; done'",
+    "bench:types": "bash -c 'for f in tests/bench/types/*.ts; do node --import=tsx \"$f\" --benchPercentThreshold 10 || exit 1; done'",
     "clean-tests": "rimraf temp tests/generated-entities",
     "coverage": "yarn clean-tests && yarn test --coverage",
     "lint": "oxlint packages tests --tsconfig=tsconfig.json --type-aware --type-check",

--- a/tests/bench/types/defineEntity-extends.ts
+++ b/tests/bench/types/defineEntity-extends.ts
@@ -19,7 +19,7 @@ bench('entity extends entity', () => {
       extra: p.string(),
     },
   });
-}).types([1479, 'instantiations']);
+}).types([1541, 'instantiations']);
 
 bench('entity extends entity with discriminator', () => {
   const base = defineEntity({
@@ -40,7 +40,7 @@ bench('entity extends entity with discriminator', () => {
       extra: p.string(),
     },
   });
-}).types([1500, 'instantiations']);
+}).types([1605, 'instantiations']);
 
 bench('embeddable extends embeddable', () => {
   const base = defineEntity({
@@ -60,7 +60,7 @@ bench('embeddable extends embeddable', () => {
       bar: p.string(),
     },
   });
-}).types([930, 'instantiations']);
+}).types([986, 'instantiations']);
 
 bench('embeddable extends embeddable with discriminator', () => {
   const base = defineEntity({
@@ -83,7 +83,7 @@ bench('embeddable extends embeddable with discriminator', () => {
       bar: p.string(),
     },
   });
-}).types([951, 'instantiations']);
+}).types([1050, 'instantiations']);
 
 bench('polymorphic embeddables', () => {
   const base = defineEntity({
@@ -198,7 +198,7 @@ bench('polymorphic embeddables', () => {
       data: () => p.embedded([documentDataAwEdCard, documentDataCoCheckMig, documentDataMvDiCard]).object(),
     },
   });
-}).types([3657, 'instantiations']);
+}).types([3945, 'instantiations']);
 
 bench('realistic entity (~20 props, relations, extends)', () => {
   const base = defineEntity({
@@ -270,7 +270,7 @@ bench('realistic entity (~20 props, relations, extends)', () => {
       tags: () => p.manyToMany(Tag),
     },
   });
-}).types([8120, 'instantiations']);
+}).types([8579, 'instantiations']);
 
 bench('realistic entity - InferEntity usage', () => {
   const base = defineEntity({
@@ -350,7 +350,7 @@ bench('realistic entity - InferEntity usage', () => {
 
   // Force evaluation of all entity types
   const _check: [IAuthor, IBook, ITag, IPublisher] = {} as any;
-}).types([8228, 'instantiations']);
+}).types([8687, 'instantiations']);
 
 bench('realistic entity - setClass pattern', () => {
   const BaseSchema = defineEntity({
@@ -436,4 +436,4 @@ bench('realistic entity - setClass pattern', () => {
   PublisherSchema.setClass(Publisher);
   AuthorSchema.setClass(Author);
   BookSchema.setClass(Book);
-}).types([8289, 'instantiations']);
+}).types([8978, 'instantiations']);

--- a/tests/bench/types/defineEntity.ts
+++ b/tests/bench/types/defineEntity.ts
@@ -19,7 +19,7 @@ bench('defineEntity with relations', () => {
       strictNullRef: () => p.oneToOne(Foo).strictNullable(),
     },
   });
-}).types([7590, 'instantiations']);
+}).types([7794, 'instantiations']);
 
 bench('defineEntity with ref and nullable', () => {
   const Foo = defineEntity({
@@ -36,7 +36,7 @@ bench('defineEntity with ref and nullable', () => {
       scalarRefNullable: p.string().ref().nullable(),
     },
   });
-}).types([7080, 'instantiations']);
+}).types([7278, 'instantiations']);
 
 bench('defineEntity only with ref and nullable', () => {
   const Foo = defineEntity({
@@ -46,7 +46,7 @@ bench('defineEntity only with ref and nullable', () => {
       toOneRefNullable: () => p.oneToOne(Foo).ref().nullable(),
     },
   });
-}).types([1861, 'instantiations']);
+}).types([1901, 'instantiations']);
 
 bench('defineEntity only with nullable and ref', () => {
   const Foo = defineEntity({
@@ -56,7 +56,7 @@ bench('defineEntity only with nullable and ref', () => {
       toOneRefNullable: () => p.oneToOne(Foo).nullable().ref(),
     },
   });
-}).types([1864, 'instantiations']);
+}).types([1904, 'instantiations']);
 
 bench('defineEntity with relations using class', () => {
   class Foo {
@@ -88,7 +88,7 @@ bench('defineEntity with relations using class', () => {
       scalarRefNullable: p.string().ref().nullable(),
     },
   });
-}).types([7573, 'instantiations']);
+}).types([7795, 'instantiations']);
 
 bench('defineEntity with ref and nullable using class', () => {
   class Foo {
@@ -120,7 +120,7 @@ bench('defineEntity with ref and nullable using class', () => {
       scalarRefNullable: p.string().ref().nullable(),
     },
   });
-}).types([7573, 'instantiations']);
+}).types([7795, 'instantiations']);
 
 bench('defineEntity only with ref and nullable using class', () => {
   class Foo {
@@ -138,7 +138,7 @@ bench('defineEntity only with ref and nullable using class', () => {
       toOneRefNullable: () => p.oneToOne(Foo).ref().nullable(),
     },
   });
-}).types([2379, 'instantiations']);
+}).types([2443, 'instantiations']);
 
 bench('defineEntity only with nullable and ref using class', () => {
   class Foo {
@@ -156,7 +156,7 @@ bench('defineEntity only with nullable and ref using class', () => {
       toOneRefNullable: () => p.oneToOne(Foo).nullable().ref(),
     },
   });
-}).types([2382, 'instantiations']);
+}).types([2446, 'instantiations']);
 
 bench('EntitySchema', () => {
   interface IFoo {
@@ -205,7 +205,7 @@ bench('EntitySchema', () => {
       },
     } as any,
   });
-}).types([344, 'instantiations']);
+}).types([365, 'instantiations']);
 
 bench('defineEntity with setClass pattern (circular relations)', () => {
   const AuthorSchema = defineEntity({
@@ -241,7 +241,7 @@ bench('defineEntity with setClass pattern (circular relations)', () => {
 
   AuthorSchema.setClass(Author);
   BookSchema.setClass(Book);
-}).types([6036, 'instantiations']);
+}).types([6221, 'instantiations']);
 
 bench('defineEntity with indexes', () => {
   const Bar = defineEntity({
@@ -255,4 +255,4 @@ bench('defineEntity with indexes', () => {
     },
     indexes: [{ name: 'idx_status_views', properties: ['status', 'views'] }],
   });
-}).types([1938, 'instantiations']);
+}).types([1978, 'instantiations']);

--- a/tests/bench/types/querybuilder.ts
+++ b/tests/bench/types/querybuilder.ts
@@ -76,22 +76,22 @@ function useField<E, R extends string, C>(_field: Field<E, R, C>): void {}
 
 bench('Field<Author, "a", never> - no context', () => {
   useField<Author, 'a', never>('name');
-}).types([137, 'instantiations']);
+}).types([136, 'instantiations']);
 
 bench('Field<Author, "a", never> - wildcard', () => {
   useField<Author, 'a', never>('*');
-}).types([137, 'instantiations']);
+}).types([136, 'instantiations']);
 
 bench('Field<Author, "a", never> - alias wildcard', () => {
   useField<Author, 'a', never>('a.*');
-}).types([137, 'instantiations']);
+}).types([136, 'instantiations']);
 
 // Context uses tuple format: [Path, Alias, Type, Select]
 type SimpleContext = { b: ['books', 'b', Book, false] };
 
 bench('Field<Author, "a", SimpleContext> - with one join', () => {
   useField<Author, 'a', SimpleContext>('b.title');
-}).types([201, 'instantiations']);
+}).types([200, 'instantiations']);
 
 type TwoJoinContext = {
   b: ['books', 'b', Book, false];
@@ -100,7 +100,7 @@ type TwoJoinContext = {
 
 bench('Field<Author, "a", TwoJoinContext> - with two joins', () => {
   useField<Author, 'a', TwoJoinContext>('t.name');
-}).types([246, 'instantiations']);
+}).types([245, 'instantiations']);
 
 // ============================================
 // ModifyHint benchmarks
@@ -390,7 +390,7 @@ bench('with() - single CTE type accumulation', () => {
   const sub = {} as QueryBuilder<Book>;
   const r = withCte(qb, 'cte', sub);
   void r;
-}).types([15, 'instantiations']);
+}).types([18, 'instantiations']);
 
 // Measure the cost of chaining two .with() calls (intersecting CTEs records)
 bench('with() - two chained CTEs', () => {
@@ -399,7 +399,7 @@ bench('with() - two chained CTEs', () => {
   const sub2 = {} as QueryBuilder<Tag>;
   const r = qb.with('books_cte', sub1).with('tags_cte', sub2);
   void r;
-}).types([73, 'instantiations']);
+}).types([83, 'instantiations']);
 
 // Measure the cost of from() resolving a CTE name to its entity type
 bench('from() - CTE name resolution', () => {
@@ -414,7 +414,7 @@ bench('with().from() - full CTE chain', () => {
   const sub = {} as QueryBuilder<Book>;
   const r = qb.with('cte', sub).from('cte');
   void r;
-}).types([84, 'instantiations']);
+}).types([88, 'instantiations']);
 
 // Verify from() preserves the alias as a literal type
 bench('from() - CTE alias preserved as literal', () => {
@@ -431,4 +431,4 @@ bench('with().from() then select() - type-safe field access', () => {
   // After from(), select should accept 'c.title' as a valid field for Book
   fromQb.select('c.title');
   void fromQb;
-}).types([2455, 'instantiations']);
+}).types([2457, 'instantiations']);


### PR DESCRIPTION
28 type benchmarks had drifted from their recorded baselines on master, mostly upward: entity inheritance and `defineEntity` between +2% and +10%, the CTE benches between +4% and +20%, and five `Field` ones down by a single instantiation.

None of them were failing. `@ark/attest` defaults `benchPercentThreshold` to 20 and the repo didn't override it, so drift stayed invisible until a bench moved more than a fifth in one step. `with() - single CTE type accumulation` had reached exactly +20.00% (15 to 18), and since the check is `delta > threshold`, it passed by one instantiation. Any later commit nudging it further would have failed CI without being the cause.

The drift comes from ordinary source changes rather than a compiler bump, since the bench workspace pins `typescript: 6.0.3` and hasn't moved since #7980.

The second commit drops the threshold to 10% via `--benchPercentThreshold` in the `bench:types` script, since these are exact instantiation counts and 20% leaves a lot of room to hide in. I checked that the flag is honored rather than ignored: a synthetic +15.25% drift now exits 1, where it passed at the old default.

Note for anyone re-recording these later. `ATTEST_updateSnapshots=true yarn bench:types` also rewrites the quote style of every untouched baseline, because it shells out to prettier, which isn't on PATH here. Running `yarn format` afterwards reverts that noise and leaves only the changed numbers.
