### PR TITLE
fix(core): do not mutate caller-provided options in `merge`, `create`, `getReference` and `fork`

### DIFF
--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -424,6 +424,8 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
    * Registers global filter to this entity manager. Global filters are enabled by default (unless disabled via last parameter).
    */
   addFilter<T extends EntityName | readonly EntityName[]>(options: FilterDef<T>): void {
+    options = { ...options };
+
     if (options.entity) {
       options.entity = Utils.asArray(options.entity).map(n => Utils.className(n)) as any;
     }
@@ -2086,6 +2088,7 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
     }
 
     const em = options.disableContextResolution ? this : this.getContext();
+    options = { ...options };
     options.schema ??= em.#schema;
     options.validate ??= true;
     options.cascade ??= true;
@@ -2184,6 +2187,7 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
     options: CreateOptions<Convert> = {},
   ): Entity {
     const em = this.getContext();
+    options = { ...options };
     options.schema ??= em.#schema;
     const entity = em.#entityFactory.create(entityName, data as EntityData<Entity>, {
       ...options,
@@ -2278,6 +2282,7 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
     id: Primary<Entity>,
     options: GetReferenceOptions = {},
   ): Entity | Ref<Entity> | Reference<Entity> {
+    options = { ...options };
     options.schema ??= this.schema;
     options.convertCustomTypes ??= false;
     const meta = this.metadata.get(entityName);
@@ -2532,6 +2537,7 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
    */
   fork(options: ForkOptions = {}): this {
     const em = options.disableContextResolution ? this : this.getContext(false);
+    options = { ...options };
     options.clear ??= true;
     options.useContext ??= false;
     options.freshEventManager ??= false;

--- a/tests/features/entity-manager/no-options-mutation.test.ts
+++ b/tests/features/entity-manager/no-options-mutation.test.ts
@@ -1,0 +1,57 @@
+import { defineEntity, MikroORM, p } from '@mikro-orm/sqlite';
+
+const User = defineEntity({
+  name: 'User',
+  properties: () => ({
+    id: p.integer().primary().autoincrement(),
+    name: p.string(),
+  }),
+});
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    dbName: ':memory:',
+    entities: [User],
+  });
+  await orm.schema.create();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+test('em.merge() does not mutate the options object', () => {
+  const options = Object.freeze({ refresh: true });
+  orm.em.fork().merge(User, { id: 1, name: 'n' }, options);
+  expect(options).toEqual({ refresh: true });
+});
+
+test('em.create() does not mutate the options object', () => {
+  const options = Object.freeze({ partial: true } as const);
+  orm.em.fork().create(User, { name: 'n' }, options);
+  expect(options).toEqual({ partial: true });
+});
+
+test('em.getReference() does not mutate the options object', () => {
+  const options = Object.freeze({ wrapped: false } as const);
+  orm.em.getReference(User, 1, options);
+  expect(options).toEqual({ wrapped: false });
+});
+
+test('em.fork() does not mutate the options object', () => {
+  const options = Object.freeze({ useContext: true });
+  orm.em.fork(options);
+  expect(options).toEqual({ useContext: true });
+});
+
+test('em.addFilter() does not mutate the options object', () => {
+  const options = Object.freeze({
+    name: 'frozen',
+    entity: [User],
+    cond: {},
+  });
+  orm.em.fork().addFilter(options);
+  expect(options).toEqual({ name: 'frozen', entity: [User], cond: {} });
+});


### PR DESCRIPTION
Follow-up to #8144, which stopped the find/count/stream family from mutating the caller's options object. This covers the remaining public methods that still wrote defaults into the caller-provided object: `merge`, `create`, `getReference`, `fork` and `addFilter`. Each now works on a shallow copy, so a frozen options object no longer throws and reusing one options object across calls no longer leaks defaults between them. As a side effect, `addFilter` no longer stores the caller's object by reference.

Related: #8143
