### PR TITLE
fix(schema): create foreign keys of new tables after altering existing ones

### DIFF
--- a/packages/sql/src/schema/SqlSchemaGenerator.ts
+++ b/packages/sql/src/schema/SqlSchemaGenerator.ts
@@ -434,27 +434,6 @@ export class SqlSchemaGenerator extends AbstractSchemaGenerator<AbstractSqlDrive
       this.append(ret, this.helper.createTable(newTable, true), true);
     }
 
-    if (this.helper.supportsSchemaConstraints()) {
-      for (const newTable of Object.values(schemaDiff.newTables)) {
-        const sql: string[] = [];
-
-        if (this.options.createForeignKeyConstraints) {
-          const fks = Object.values(newTable.getForeignKeys()).map(fk => this.helper.createForeignKey(newTable, fk));
-          this.append(sql, fks);
-        }
-
-        for (const check of newTable.getChecks()) {
-          this.append(sql, this.helper.createCheck(newTable, check));
-        }
-
-        for (const trigger of newTable.getTriggers()) {
-          this.append(sql, this.helper.createTrigger(newTable, trigger));
-        }
-
-        this.append(ret, sql, true);
-      }
-    }
-
     if (options.dropTables && !options.safe) {
       for (const table of Object.values(schemaDiff.removedTables)) {
         // Drop triggers before the table so driver-specific cleanup runs (e.g. PostgreSQL function removal)
@@ -490,6 +469,28 @@ export class SqlSchemaGenerator extends AbstractSchemaGenerator<AbstractSqlDrive
 
     for (const changedTable of alteredTables) {
       this.append(ret, this.helper.getPostAlterTable(changedTable, options.safe!), true);
+    }
+
+    // after the alters, so a new table's FK can reference a unique constraint an existing table gains in the same diff
+    if (this.helper.supportsSchemaConstraints()) {
+      for (const newTable of Object.values(schemaDiff.newTables)) {
+        const sql: string[] = [];
+
+        if (this.options.createForeignKeyConstraints) {
+          const fks = Object.values(newTable.getForeignKeys()).map(fk => this.helper.createForeignKey(newTable, fk));
+          this.append(sql, fks);
+        }
+
+        for (const check of newTable.getChecks()) {
+          this.append(sql, this.helper.createCheck(newTable, check));
+        }
+
+        for (const trigger of newTable.getTriggers()) {
+          this.append(sql, this.helper.createTrigger(newTable, trigger));
+        }
+
+        this.append(ret, sql, true);
+      }
     }
 
     if (!options.safe && this.platform.supportsNativeEnums()) {

--- a/tests/features/schema-generator/__snapshots__/new-table-fk-ordering.postgres.test.ts.snap
+++ b/tests/features/schema-generator/__snapshots__/new-table-fk-ordering.postgres.test.ts.snap
@@ -1,0 +1,16 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`constraints of new tables are created after altering existing tables (GH 8141) > new table FK can reference a unique constraint added to an existing table in the same diff 1`] = `
+{
+  "down": "drop table if exists "book" cascade;
+
+alter table "author" drop constraint "author_id_tenant_id_unique";
+",
+  "up": "create table "book" ("id" serial primary key, "author_id" int not null, "author_tenant_id" int not null);
+
+alter table "author" add constraint "author_id_tenant_id_unique" unique ("id", "tenant_id");
+
+alter table "book" add constraint "book_author_id_author_tenant_id_foreign" foreign key ("author_id", "author_tenant_id") references "author" ("id", "tenant_id");
+",
+}
+`;

--- a/tests/features/schema-generator/new-table-fk-ordering.postgres.test.ts
+++ b/tests/features/schema-generator/new-table-fk-ordering.postgres.test.ts
@@ -1,0 +1,68 @@
+import { MikroORM } from '@mikro-orm/postgresql';
+import { Entity, ManyToOne, PrimaryKey, Property, ReflectMetadataProvider, Unique } from '@mikro-orm/decorators/legacy';
+
+@Entity({ tableName: 'tenant' })
+class Tenant {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+}
+
+@Entity({ tableName: 'author' })
+class Author {
+  @PrimaryKey()
+  id!: number;
+
+  @ManyToOne(() => Tenant)
+  tenant!: Tenant;
+}
+
+@Entity({ tableName: 'author' })
+@Unique({ properties: ['id', 'tenant'] })
+class Author1 {
+  @PrimaryKey()
+  id!: number;
+
+  @ManyToOne(() => Tenant)
+  tenant!: Tenant;
+}
+
+@Entity({ tableName: 'book' })
+class Book {
+  @PrimaryKey()
+  id!: number;
+
+  @ManyToOne(() => Author1, {
+    fieldNames: ['author_id', 'author_tenant_id'],
+    referencedColumnNames: ['id', 'tenant_id'],
+  })
+  author!: Author1;
+}
+
+describe('constraints of new tables are created after altering existing tables (GH 8141)', () => {
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      entities: [Tenant, Author],
+      dbName: 'mikro_orm_test_new_table_fk_ordering',
+    });
+    await orm.schema.ensureDatabase();
+    await orm.schema.refresh();
+  });
+
+  afterAll(() => orm.close(true));
+
+  test('new table FK can reference a unique constraint added to an existing table in the same diff', async () => {
+    orm.discoverEntity([Author1, Book], [Author]);
+
+    const diff = await orm.schema.getUpdateSchemaMigrationSQL({ wrap: false });
+    expect(diff).toMatchSnapshot();
+
+    await orm.schema.execute(diff.up);
+    await orm.schema.execute(diff.down);
+  });
+});


### PR DESCRIPTION
`diffToSQL()` emitted the FK/check/trigger block for new tables right after creating them, before the alter passes on existing tables. So if a new table has a composite FK pointing at columns that only gain their matching unique constraint in the same diff, the FK is created first and Postgres rejects it with `42830 there is no unique constraint matching given keys for referenced table`. This hits both `schema:update` and generated migrations, and regenerating gives the same order.

Moved that block after the alter passes. New tables are still created earlier in the same function and their own indexes and unique constraints are inline in `createTable`, so an altered table's FK pointing at a new table still resolves.

No dialect snapshots changed.

Closes #8141
