### PR TITLE
chore(ci): bump mssql docker image to 2025-CU8 and simplify startup

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -184,29 +184,18 @@ jobs:
           # Start everything so all services boot in parallel.
           docker compose up -d
           rc=0
-          # Wait for the reliable services to become healthy; a failure here is a
-          # real problem, but route it through the diagnostics dump below.
-          docker compose up -d --wait mongo mysql9 mariadb postgre postgis cockroachdb oracledb || rc=1
+          # Wait for all services to become healthy; route a failure through the
+          # diagnostics dump below.
+          docker compose up -d --wait || rc=1
 
-          # mssql 2025-CU3 intermittently crashes during early startup
-          # (SQLPAL/lsass.exe segfault) and is recovered by `restart: always`.
-          # `docker compose up --wait` aborts the moment it observes the restart
-          # cycle, so poll the probe ourselves until mssql is *stably* reachable;
-          # several consecutive successes rule out a pending crash-restart.
-          ok=0
-          for i in $(seq 1 72); do
-            if docker compose exec -T mssql /opt/mssql-tools18/bin/sqlcmd -b -C -S tcp:localhost -U sa -P 'Root.Root' -Q 'select 1' >/dev/null 2>&1; then
-              ok=$((ok + 1))
-              [ "$ok" -ge 5 ] && break
-            else
-              [ "$ok" -gt 0 ] && echo "::warning::mssql probe failed after $ok consecutive successes; tolerating restart cycle"
-              ok=0
-            fi
-            sleep 5
-          done
-          if [ "$ok" -lt 5 ]; then
-            echo "::error::mssql did not stabilise within the startup window"
-            rc=1
+          # mssql sometimes segfaults during early startup (SQLPAL lsass.exe crash, see
+          # microsoft/mssql-docker#947); `restart: always` never recovers from it, so give
+          # it one clean container before failing the job.
+          if [ "$rc" -ne 0 ]; then
+            echo "::warning::services did not become healthy, recreating mssql and retrying"
+            docker compose rm -fsv mssql
+            rc=0
+            docker compose up -d --wait || rc=1
           fi
 
           if [ "$rc" -eq 0 ]; then

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,7 +74,7 @@ services:
       test: cockroach sql --insecure -e 'select 1'
 
   mssql:
-    image: mcr.microsoft.com/mssql/server:2025-CU3-ubuntu-24.04
+    image: mcr.microsoft.com/mssql/server:2025-CU8-ubuntu-24.04
     platform: linux/amd64
     restart: always
     ports:


### PR DESCRIPTION
The mssql container keeps failing the `Init docker` step. Every failed run shows the same crash rather than a slow start: `sqlservr` faults through `samsrv.dll`, `lsasrv.dll` and `lsass.exe`, dumps core, and `restart: always` loops it until the step gives up about 7 minutes later. Upstream tracks this as microsoft/mssql-docker#947 for 2025 images on CI runners.

We have patched around it four times (#7623, #7741, #7812, #7856) without ever moving off the image, and we are still on CU3 while CU8 is out. So this bumps the image and drops the workaround that never worked anyway.

The polling loop tolerated restart cycles, but the crash never self-heals, so all it bought was six extra minutes before the same failure. mssql goes back into `docker compose up -d --wait`, with a single clean recreate as a retry. A genuinely one-off bad start now costs a minute, and a real crash surfaces in one minute instead of seven.

Verified locally on CU8: the full mssql suite and everything else touching `MsSqlDriver` passes, with no snapshot drift.

Only CI can tell us whether CU8 actually fixes the crash. If it does not, the next step is measuring which tags crash across parallel runners instead of guessing one CU at a time.
