### PR TITLE
feat(core): support `await using` via `Symbol.asyncDispose`

### DIFF
--- a/docs/docs/quick-start.md
+++ b/docs/docs/quick-start.md
@@ -99,6 +99,17 @@ This method has some limitations:
 - ORM extensions are not auto-loaded
 - when metadata cache is enabled, `FileCacheAdapter` needs to be explicitly set in the config
 
+## Closing the ORM
+
+To close the database connection, call `orm.close()`. The ORM instance also implements the async disposable protocol via `Symbol.asyncDispose`, so you can use [explicit resource management](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Resource_management) to close it automatically:
+
+```ts
+await using orm = await MikroORM.init({ ... });
+// `orm.close()` is called automatically at the end of the enclosing scope
+```
+
+> The `await using` syntax requires node 24+, or a transpiler that downlevels it (TypeScript does so for any compilation target below `ESNext`).
+
 ## RequestContext helper
 
 Now you will need to fork entity manager for each request so their [identity maps](https://mikro-orm.io/identity-map/)

--- a/packages/core/src/MikroORM.ts
+++ b/packages/core/src/MikroORM.ts
@@ -214,6 +214,13 @@ export class MikroORM<
   }
 
   /**
+   * Closes the database connection, allows using the ORM instance with `await using`.
+   */
+  async [Symbol.asyncDispose](): Promise<void> {
+    await this.close();
+  }
+
+  /**
    * Gets the `MetadataStorage`.
    */
   getMetadata(): MetadataStorage;

--- a/tests/features/resource-management/async-dispose.test.ts
+++ b/tests/features/resource-management/async-dispose.test.ts
@@ -1,0 +1,23 @@
+import { MikroORM } from '@mikro-orm/sqlite';
+import { Entity, PrimaryKey } from '@mikro-orm/decorators/legacy';
+
+@Entity()
+class User {
+  @PrimaryKey({ type: 'number' })
+  id!: number;
+}
+
+test('MikroORM instance implements Symbol.asyncDispose', async () => {
+  const orm = await MikroORM.init({
+    entities: [User],
+    dbName: ':memory:',
+  });
+  await orm.connect();
+
+  await expect(orm.isConnected()).resolves.toBe(true);
+
+  // node 22 lacks native `await using` syntax, so we call the dispose method explicitly
+  await orm[Symbol.asyncDispose]();
+
+  await expect(orm.isConnected()).resolves.toBe(false);
+});

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "module": "Node20",
     "target": "ES2023",
-    "lib": ["ES2023", "ESNext.Temporal"],
+    "lib": ["ES2023", "ESNext.Temporal", "ESNext.Disposable"],
     "incremental": true,
     "declaration": true,
     "sourceMap": false,


### PR DESCRIPTION
The `MikroORM` instance now implements the async disposable protocol, so the connection is closed automatically when used with explicit resource management:

```ts
await using orm = await MikroORM.init(config);
```

`Symbol.asyncDispose` exists at runtime since node 18.18, so this works on node 22 without a polyfill. Only the `await using` syntax itself needs node 24+ or a transpiler. Also adds `ESNext.Disposable` to the compiler `lib` for the typings.

Closes #8158
