### PR TITLE
feat(core): support `index` option on M:N properties for pivot table join columns

### DIFF
--- a/docs/docs/collections.md
+++ b/docs/docs/collections.md
@@ -436,6 +436,17 @@ books = new Collection<Book>(this);
 </TabItem>
 </Tabs>
 
+### Indexing pivot table join columns
+
+Whether the join columns of the generated pivot table get indexed is driven by the platform default (e.g. SQLite indexes every foreign key, PostgreSQL does not). You can override this via the `index` option on the owning side of the M:N property:
+
+```ts
+@ManyToMany({ entity: () => User, index: true })
+users = new Collection<User>(this);
+```
+
+With `index: true`, only the join columns not already covered by a leading prefix of the pivot table's composite primary key get an extra index — for the default pivot that means just the inverse join column, while with `fixedOrder` both get indexed. The owning join column keeps the platform default either way (so on platforms that index every foreign key, it stays indexed too). You can also pass a string to name the index (it applies to the inverse join column), or `index: false` to disable the platform default indexes.
+
 ### Custom pivot table entity
 
 By default, a generated pivot table entity is used under the hood to represent the pivot table. You can provide your own implementation via `pivotEntity` option.

--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -1284,6 +1284,13 @@ export class MetadataDiscovery {
     owner: boolean,
     selfReferencing: boolean,
   ): EntityProperty {
+    let index = prop.index ?? this.#platform.indexForeignKeys();
+
+    if (owner && prop.index) {
+      // owner join columns are the leading prefix of the composite PK, so an explicit `index` only applies to them with `fixedOrder`; a custom index name always belongs to the inverse side
+      index = prop.fixedOrder ? true : this.#platform.indexForeignKeys();
+    }
+
     const ret = {
       name,
       type: Utils.className(type),
@@ -1292,7 +1299,7 @@ export class MetadataDiscovery {
       cascade: [Cascade.ALL],
       fixedOrder: prop.fixedOrder,
       fixedOrderColumn: prop.fixedOrderColumn,
-      index: this.#platform.indexForeignKeys(),
+      index,
       primary: !prop.fixedOrder,
       autoincrement: false,
       updateRule: prop.updateRule,

--- a/tests/features/schema-generator/pivot-table-fk-indexes.postgres.test.ts
+++ b/tests/features/schema-generator/pivot-table-fk-indexes.postgres.test.ts
@@ -1,0 +1,114 @@
+import { Collection, MikroORM, type Options } from '@mikro-orm/postgresql';
+import { Entity, ManyToMany, PrimaryKey, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+
+@Entity()
+class User {
+  @PrimaryKey()
+  id!: number;
+}
+
+@Entity()
+class Team {
+  @PrimaryKey()
+  id!: number;
+
+  @ManyToMany({ entity: () => User, index: true })
+  users = new Collection<User>(this);
+}
+
+@Entity()
+class Playlist {
+  @PrimaryKey()
+  id!: number;
+
+  @ManyToMany({ entity: () => User, index: true, fixedOrder: true })
+  users = new Collection<User>(this);
+}
+
+@Entity()
+class Project {
+  @PrimaryKey()
+  id!: number;
+
+  @ManyToMany(() => User)
+  users = new Collection<User>(this);
+}
+
+@Entity()
+class Group {
+  @PrimaryKey()
+  id!: number;
+
+  @ManyToMany({ entity: () => User, index: 'custom_pivot_index' })
+  users = new Collection<User>(this);
+}
+
+@Entity()
+class Wiki {
+  @PrimaryKey()
+  id!: number;
+
+  @ManyToMany({ entity: () => User, index: 'wiki_users_custom', fixedOrder: true })
+  users = new Collection<User>(this);
+}
+
+describe('indexing implicit pivot table join columns (GH 8156)', () => {
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      entities: [User, Team, Playlist, Project, Group, Wiki],
+      dbName: 'mikro_orm_test_pivot_fk_indexes',
+      connect: false,
+    } as Options);
+  });
+
+  afterAll(() => orm.close(true));
+
+  test('`index: true` indexes the join columns not covered by the composite PK prefix', async () => {
+    const sql = await orm.schema.getCreateSchemaSQL();
+    // owner column `team_id` is the leading column of the composite PK, so only the inverse side gets an index
+    expect(sql).not.toContain('create index "team_users_team_id_index"');
+    expect(sql).toContain('create index "team_users_user_id_index" on "team_users" ("user_id");');
+  });
+
+  test('`index: true` with `fixedOrder` indexes both join columns', async () => {
+    const sql = await orm.schema.getCreateSchemaSQL();
+    expect(sql).toContain('create index "playlist_users_playlist_id_index" on "playlist_users" ("playlist_id");');
+    expect(sql).toContain('create index "playlist_users_user_id_index" on "playlist_users" ("user_id");');
+  });
+
+  test('platform default is kept without the `index` option', async () => {
+    const sql = await orm.schema.getCreateSchemaSQL();
+    expect(sql).not.toContain('create index "project_users_project_id_index"');
+    expect(sql).not.toContain('create index "project_users_user_id_index"');
+  });
+
+  test('`index` accepts a custom index name', async () => {
+    const sql = await orm.schema.getCreateSchemaSQL();
+    expect(sql).toContain('create index "custom_pivot_index" on "group_users" ("user_id");');
+  });
+
+  test('custom index name with `fixedOrder` names the inverse index, owner index gets a generated name', async () => {
+    const sql = await orm.schema.getCreateSchemaSQL();
+    expect(sql).toContain('create index "wiki_users_wiki_id_index" on "wiki_users" ("wiki_id");');
+    expect(sql).toContain('create index "wiki_users_custom" on "wiki_users" ("user_id");');
+  });
+
+  test('schema diffing sees the pivot indexes as up to date', async () => {
+    const orm2 = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      entities: [User, Team, Playlist, Project, Group, Wiki],
+      dbName: 'mikro_orm_test_pivot_fk_indexes',
+    });
+
+    try {
+      await orm2.schema.refresh();
+      const diff = await orm2.schema.getUpdateSchemaSQL();
+      expect(diff).toBe('');
+    } finally {
+      await orm2.close(true);
+    }
+  });
+});

--- a/tests/features/schema-generator/pivot-table-fk-indexes.sqlite.test.ts
+++ b/tests/features/schema-generator/pivot-table-fk-indexes.sqlite.test.ts
@@ -1,0 +1,53 @@
+import { Collection, MikroORM, type Options } from '@mikro-orm/sqlite';
+import { Entity, ManyToMany, PrimaryKey, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+
+@Entity()
+class User {
+  @PrimaryKey()
+  id!: number;
+}
+
+@Entity()
+class Team {
+  @PrimaryKey()
+  id!: number;
+
+  @ManyToMany({ entity: () => User, index: false })
+  users = new Collection<User>(this);
+}
+
+@Entity()
+class Project {
+  @PrimaryKey()
+  id!: number;
+
+  @ManyToMany(() => User)
+  users = new Collection<User>(this);
+}
+
+describe('disabling implicit pivot table join column indexes (GH 8156)', () => {
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      entities: [User, Team, Project],
+      dbName: ':memory:',
+      connect: false,
+    } as Options);
+  });
+
+  afterAll(() => orm.close(true));
+
+  test('`index: false` disables the platform default indexes on both join columns', async () => {
+    const sql = await orm.schema.getCreateSchemaSQL();
+    expect(sql).not.toContain('create index `team_users_team_id_index`');
+    expect(sql).not.toContain('create index `team_users_user_id_index`');
+  });
+
+  test('platform default is kept without the `index` option', async () => {
+    const sql = await orm.schema.getCreateSchemaSQL();
+    expect(sql).toContain('create index `project_users_project_id_index` on `project_users` (`project_id`);');
+    expect(sql).toContain('create index `project_users_user_id_index` on `project_users` (`user_id`);');
+  });
+});


### PR DESCRIPTION
On PostgreSQL (and other platforms where `indexForeignKeys()` is `false`), there was no way to get an index on an implicit M:N pivot table's join columns, since `definePivotProperty` hard-coded the platform default. This honors the `index` option on the owning M:N property:

- `index: true` indexes the join columns not already covered by a leading prefix of the pivot's composite PK: just the inverse join column for the default pivot, both columns with `fixedOrder`.
- `index: '<name>'` additionally names the index (the name goes to the inverse-side index; with `fixedOrder`, the owner column gets a generated name).
- `index: false` disables the platform default indexes on both join columns (e.g. on SQLite, which indexes every FK).

The owning join column keeps the platform default either way, since the composite PK already serves lookups on it.

Closes #8156
