### PR TITLE
fix(sql): support joining a table or CTE by name via sql.ref()

### DIFF
--- a/packages/sql/src/query/QueryBuilder.ts
+++ b/packages/sql/src/query/QueryBuilder.ts
@@ -1018,7 +1018,7 @@ export class QueryBuilder<
   >;
 
   /**
-   * Adds a JOIN clause to the query for a subquery.
+   * Adds a JOIN clause to the query for a subquery. Use `sql.ref('...')` to join a table or CTE by name.
    */
   join<Alias extends string>(
     field: RawQueryFragment | QueryBuilder<any>,
@@ -1076,7 +1076,7 @@ export class QueryBuilder<
   >;
 
   /**
-   * Adds an INNER JOIN clause to the query for a subquery.
+   * Adds an INNER JOIN clause to the query for a subquery. Use `sql.ref('...')` to join a table or CTE by name.
    */
   innerJoin<Alias extends string>(
     field: RawQueryFragment | QueryBuilder<any>,
@@ -1147,7 +1147,7 @@ export class QueryBuilder<
   >;
 
   /**
-   * Adds a LEFT JOIN clause to the query for a subquery.
+   * Adds a LEFT JOIN clause to the query for a subquery. Use `sql.ref('...')` to join a table or CTE by name.
    */
   leftJoin<Alias extends string>(
     field: RawQueryFragment | QueryBuilder<any>,
@@ -3117,20 +3117,21 @@ export class QueryBuilder<
         field = field.getNativeQuery();
       }
 
-      if (isRaw(field)) {
-        field = this.platform.formatQuery(field.sql, field.params);
+      const key = `${this.alias}.${prop.name}#${alias}`;
+      const join = { prop, alias, type, cond, schema, ownerAlias: this.alias } as unknown as JoinOptions;
+
+      // `sql.ref('...')` is a bare table/CTE reference, join it by name instead of wrapping it as a sub-query
+      if (isRaw(field) && field.sql === '??' && field.params.length === 1) {
+        join.table = String(field.params[0]);
+      } else {
+        if (isRaw(field)) {
+          field = this.platform.formatQuery(field.sql, field.params);
+        }
+
+        join.subquery = field.toString();
       }
 
-      const key = `${this.alias}.${prop.name}#${alias}`;
-      this.#state.joins[key] = {
-        prop,
-        alias,
-        type,
-        cond,
-        schema,
-        subquery: field.toString(),
-        ownerAlias: this.alias,
-      } as any;
+      this.#state.joins[key] = join;
 
       return { prop, key };
     }

--- a/packages/sql/src/query/QueryBuilderHelper.ts
+++ b/packages/sql/src/query/QueryBuilderHelper.ts
@@ -394,7 +394,12 @@ export class QueryBuilderHelper {
       }[join.type] ?? join.type;
     const conditions: string[] = [];
     const params: unknown[] = [];
-    schema = join.schema === '*' ? schema : (join.schema ?? schemaOverride);
+    if (join.prop.name === '__subquery__') {
+      // bare table/CTE references (`sql.ref()` joins) keep their literal name, only an explicit schema applies
+      schema = join.schema === '*' ? undefined : join.schema;
+    } else {
+      schema = join.schema === '*' ? schema : (join.schema ?? schemaOverride);
+    }
 
     if (schema && schema !== this.#platform.getDefaultSchemaName()) {
       table = `${schema}.${table}`;

--- a/tests/features/query-builder/query-builder-cte.test.ts
+++ b/tests/features/query-builder/query-builder-cte.test.ts
@@ -1,4 +1,4 @@
-import { type Ref, raw, Utils } from '@mikro-orm/core';
+import { type Ref, raw, sql, Utils } from '@mikro-orm/core';
 import { MikroORM, type AbstractSqlDriver, type SelectQueryBuilder } from '@mikro-orm/sql';
 import { Entity, PrimaryKey, Property, ManyToOne, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
 import { PLATFORMS } from '../../bootstrap.js';
@@ -132,6 +132,35 @@ describe.each(Utils.keys(options))('CTE [%s]', type => {
     const rows = await qb.execute<{ name: string }[]>();
     expect(rows).toHaveLength(1);
     expect(rows[0].name).toBe('Bob');
+  });
+
+  test('join() can reference a CTE by name via sql.ref (#8157)', async () => {
+    const sub = orm.em
+      .createQueryBuilder(Author, 'a')
+      .select(['a.id', 'a.name'])
+      .where({ age: { $gte: 45 } });
+    const qb = orm.em
+      .createQueryBuilder(Book, 'b')
+      .with('older', sub)
+      .select(['b.title'])
+      .join(sql.ref('older'), 'o', { 'o.id': sql.ref('b.author_id') });
+
+    // the CTE name must be joined as a bare identifier, not wrapped as a sub-query
+    expect(qb.getFormattedQuery()).not.toMatch(/join \(/);
+
+    const rows = await qb.execute<{ title: string }[]>();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].title).toBe('Bob Book');
+
+    // an active schema override must not qualify the CTE name
+    const qb2 = orm.em
+      .createQueryBuilder(Book, 'b')
+      .withSchema('custom')
+      .with('older', sub.clone())
+      .select(['b.title'])
+      .join(sql.ref('older'), 'o', { 'o.id': sql.ref('b.author_id') });
+    const quotedCte = orm.em.getPlatform().quoteIdentifier('older');
+    expect(qb2.getFormattedQuery()).toContain(`join ${quotedCte} `);
   });
 
   test('duplicate CTE name throws', () => {


### PR DESCRIPTION
`join()` routed every raw fragment into the sub-query branch, so `join(sql.ref('employee_tree'), 'tree', ...)` rendered `inner join ("employee_tree") as "tree"`, which is a syntax error. There was no way to reference a CTE from a recursive term, since the CTE registry is not visible there.

`joinReference()` now detects the pure identifier form (`sql.ref(name)`, i.e. `raw('??', [name])`) and stores it as a plain table join, so it renders as `inner join "employee_tree" as "tree"`. Schema overrides from `withSchema()`/`em.schema` don't qualify the name, since CTEs cannot be schema-qualified. This matches how `from()` treats CTE names; an explicit `schema` argument still applies.

Closes #8157
