### PR TITLE
fix(core): use own-property checks in populate hints, canPopulate, and filter options

### DIFF
--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -2484,9 +2484,10 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
 
     // For TPT inheritance, check the entity's own properties, not just the root's
     // For STI, meta.properties includes all properties anyway
-    const ret = p in meta.properties;
+    // use an own-property check so inherited `Object.prototype` members (e.g. `__proto__`, `constructor`) are not treated as populatable
+    const ret = Object.hasOwn(meta.properties, p);
 
-    if (parts.length > 0) {
+    if (ret && parts.length > 0) {
       return this.canPopulate(meta.properties[p as EntityKey<Entity>].targetMeta!.class, parts.join('.'));
     }
 

--- a/packages/core/src/entity/EntityLoader.ts
+++ b/packages/core/src/entity/EntityLoader.ts
@@ -15,7 +15,7 @@ import type {
 } from '../typings.js';
 import type { EntityManager } from '../EntityManager.js';
 import { QueryHelper } from '../utils/QueryHelper.js';
-import { Utils } from '../utils/Utils.js';
+import { DANGEROUS_PROPERTY_NAMES, Utils } from '../utils/Utils.js';
 import { ValidationError } from '../errors.js';
 import type { Collection } from './Collection.js';
 import {
@@ -245,11 +245,11 @@ export class EntityLoader {
     const tmp = populate.reduce(
       (ret, item) => {
         /* v8 ignore next */
-        if (item.field === PopulatePath.ALL) {
+        if (item.field === PopulatePath.ALL || DANGEROUS_PROPERTY_NAMES.includes(item.field as string)) {
           return ret;
         }
 
-        if (!ret[item.field]) {
+        if (!Object.hasOwn(ret, item.field)) {
           ret[item.field] = item;
           return ret;
         }

--- a/packages/core/src/utils/QueryHelper.ts
+++ b/packages/core/src/utils/QueryHelper.ts
@@ -1,5 +1,5 @@
 import { Reference } from '../entity/Reference.js';
-import { Utils } from './Utils.js';
+import { DANGEROUS_PROPERTY_NAMES, Utils } from './Utils.js';
 import type {
   Dictionary,
   EntityKey,
@@ -386,7 +386,11 @@ export class QueryHelper {
     if (Array.isArray(options)) {
       options.forEach(filter => (opts[filter] = true));
     } else if (Utils.isPlainObject(options)) {
-      Object.keys(options).forEach(filter => (opts[filter] = options[filter]));
+      Object.keys(options).forEach(filter => {
+        if (!DANGEROUS_PROPERTY_NAMES.includes(filter)) {
+          opts[filter] = options[filter];
+        }
+      });
     }
 
     return Object.keys(filters)

--- a/tests/features/special-object-keys.test.ts
+++ b/tests/features/special-object-keys.test.ts
@@ -1,0 +1,74 @@
+import { MikroORM } from '@mikro-orm/sqlite';
+import { Entity, Filter, ManyToOne, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+
+@Entity()
+class Author {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+}
+
+@Entity()
+class Book {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  title!: string;
+
+  @ManyToOne(() => Author, { nullable: true })
+  author?: Author;
+}
+
+@Filter({ name: 'notDeleted', cond: { deleted: false }, default: true })
+@Entity()
+class Article {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  title!: string;
+
+  @Property()
+  deleted: boolean = false;
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    metadataProvider: ReflectMetadataProvider,
+    entities: [Author, Book, Article],
+    dbName: ':memory:',
+  });
+  await orm.schema.refresh();
+  const em = orm.em.fork();
+  em.create(Article, { id: 1, title: 'live', deleted: false });
+  em.create(Article, { id: 2, title: 'deleted', deleted: true });
+  await em.flush();
+});
+
+afterAll(() => orm.close(true));
+
+test('object-shaped populate hint with a special key does not touch Object.prototype', async () => {
+  expect(({} as any).children).toBeUndefined();
+  await orm.em.fork().find(Book, {}, { populate: [{ field: '__proto__', children: [{ field: 'x' }] }] as any });
+  expect(({} as any).children).toBeUndefined();
+});
+
+test('canPopulate rejects special property names', () => {
+  expect(orm.em.canPopulate(Book, 'author')).toBe(true);
+  expect(orm.em.canPopulate(Book, '__proto__')).toBe(false);
+  expect(orm.em.canPopulate(Book, 'constructor')).toBe(false);
+  expect(orm.em.canPopulate(Book, 'hasOwnProperty')).toBe(false);
+  // dotted variant must not throw
+  expect(orm.em.canPopulate(Book, '__proto__.x')).toBe(false);
+});
+
+test('a special key in the filters option cannot disable a default filter', async () => {
+  const filters = JSON.parse('{"__proto__":{"notDeleted":false}}');
+  const rows = await orm.em.fork().find(Article, {}, { filters });
+  expect(rows.map(r => r.title)).toEqual(['live']);
+});


### PR DESCRIPTION
Three spots in core treated a prototype-walking read or copy as if it were an own-key check:

- `canPopulate()` did `key in meta.properties`, so it returned `true` for inherited `Object.prototype` members (`__proto__`, `constructor`, `hasOwnProperty`, ...) and threw a `TypeError` on a dotted path whose first segment was not a real property.
- `mergeNestedPopulate()` used `!ret[item.field]` to decide whether a field was already in the accumulator.
- `getActiveFilters()` copied object-form filter options key by key with no filtering.

Switched the first two to `Object.hasOwn`, and made `getActiveFilters()` skip the special property names, consistent with the `DANGEROUS_PROPERTY_NAMES` guard already used in `assign`/`merge`. `canPopulate()` also only recurses now when the first segment is a real property, which removes the dotted-path crash.
