### PR TITLE
fix(core): accept plain arrays for enum array properties in EntityData

### DIFF
--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -712,7 +712,7 @@ export type EntityDataProp<T, C extends boolean> = T extends Date
             : T extends CollectionShape<infer U>
               ? U | U[] | EntityDataNested<U & object, C> | EntityDataNested<U & object, C>[]
               : T extends readonly (infer U)[]
-                ? U extends NonArrayObject
+                ? [U] extends [NonArrayObject]
                   ? U | U[] | EntityDataNested<U, C> | EntityDataNested<U, C>[]
                   : U[] | EntityDataNested<U, C>[]
                 : EntityDataNested<T, C>;
@@ -737,7 +737,7 @@ export type RequiredEntityDataProp<T, O, C extends boolean> = T extends Date
               : T extends CollectionShape<infer U>
                 ? U | U[] | RequiredEntityDataNested<U & object, O, C> | RequiredEntityDataNested<U & object, O, C>[]
                 : T extends readonly (infer U)[]
-                  ? U extends NonArrayObject
+                  ? [U] extends [NonArrayObject]
                     ? U | U[] | RequiredEntityDataNested<U, O, C> | RequiredEntityDataNested<U, O, C>[]
                     : U[] | RequiredEntityDataNested<U, O, C>[]
                   : RequiredEntityDataNested<T, O, C>;

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -31,6 +31,7 @@ import type { ObjectId } from 'bson';
 import type {
   AutoPath,
   EntityData,
+  EntityDataProp,
   EntityDTO,
   FilterQuery,
   FilterValue,
@@ -40,6 +41,7 @@ import type {
   Primary,
   PrimaryKeyProp,
   ExpandQuery,
+  RequiredEntityDataProp,
   RequiredNullable,
 } from '../packages/core/src/typings.js';
 import type { Author2, Book2, BookTag2, Car2, FooBar2, FooParam2, Publisher2, User2 } from './entities-sql/index.js';
@@ -547,6 +549,30 @@ describe('check typings', () => {
     }
     // @ts-expect-error name requires a string, not a number
     const r6: RequiredEntityData<RowTyped> = { name: 123 };
+  });
+
+  test('enum array property accepts a plain array regardless of convertCustomTypes (GH #8166)', async () => {
+    enum Colour {
+      Red = 'Red',
+      Green = 'Green',
+      Blue = 'Blue',
+    }
+
+    class Thing {
+      id!: number;
+      colours: Colour[] | null = null;
+    }
+
+    // the array branch must not distribute over enum members (`Colour.Red[] | Colour.Green[] | ...`)
+    assert<IsAssignable<EntityDataProp<Colour[], true>, Colour[]>>(true);
+    assert<IsAssignable<EntityDataProp<Colour[], false>, Colour[]>>(true);
+    assert<IsAssignable<RequiredEntityDataProp<Colour[], Thing, true>, Colour[]>>(true);
+    assert<IsAssignable<RequiredEntityDataProp<Colour[], Thing, false>, Colour[]>>(true);
+
+    const dto = {} as { colours?: Colour[] | null };
+    const d1: EntityData<Thing, false> = dto;
+    const d2: EntityData<Thing, true> = dto;
+    const d3: RequiredEntityData<Thing, never, true> = { id: 1, colours: [Colour.Red, Colour.Green] };
   });
 
   test('FilterQuery ok assignments', async () => {


### PR DESCRIPTION
`EntityData<T, true>` rejected a plain array for `@Enum({ array: true })` properties. The array branch of `EntityDataProp`/`RequiredEntityDataProp` used `U extends NonArrayObject`, a distributive conditional, so a string enum element type produced `Colour.Red[] | Colour.Green[] | Colour.Blue[]` instead of accepting `Colour[]`. Wrapping both sides in tuples makes the check non-distributive. As a side effect, mixed arrays of union object types are now assignable too.

On v7 the reported top-level repro is masked by the bare `T[K]` branch in `EntityData`, but the wrong union was still produced and reachable through nested/expanded paths, and via `EntityDataProp` directly. The same fix is ported to 6.x, where the repro fails exactly as reported.

Closes #8166