### PR TITLE
fix(core): accept plain arrays for enum array properties in EntityData

### DIFF
--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -335,7 +335,7 @@ export type EntityDataProp<T, C extends boolean> = T extends Date
           : T extends Collection<infer U, any>
             ? U | U[] | EntityDataNested<U, C> | EntityDataNested<U, C>[]
             : T extends readonly (infer U)[]
-              ? U extends NonArrayObject
+              ? [U] extends [NonArrayObject]
                 ? U | U[] | EntityDataNested<U, C> | EntityDataNested<U, C>[]
                 : U[] | EntityDataNested<U, C>[]
               : EntityDataNested<T, C>;
@@ -355,7 +355,7 @@ export type RequiredEntityDataProp<T, O, C extends boolean> = T extends Date
             : T extends Collection<infer U, any>
               ? U | U[] | RequiredEntityDataNested<U, O, C> | RequiredEntityDataNested<U, O, C>[]
               : T extends readonly (infer U)[]
-                ? U extends NonArrayObject
+                ? [U] extends [NonArrayObject]
                   ? U | U[] | RequiredEntityDataNested<U, O, C> | RequiredEntityDataNested<U, O, C>[]
                   : U[] | RequiredEntityDataNested<U, O, C>[]
                 : RequiredEntityDataNested<T, O, C>;

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -16,6 +16,7 @@ import type { ObjectId } from 'bson';
 import type {
   AutoPath,
   EntityData,
+  EntityDataProp,
   EntityDTO,
   FilterQuery,
   FilterValue,
@@ -24,6 +25,7 @@ import type {
   Primary,
   PrimaryKeyProp,
   ExpandQuery,
+  RequiredEntityDataProp,
   RequiredNullable,
 } from '../packages/core/src/typings';
 import type { Author2, Book2, BookTag2, Car2, FooBar2, FooParam2, Publisher2, User2 } from './entities-sql';
@@ -1104,4 +1106,31 @@ describe('check typings', () => {
     const s2: string | null = user.requiredNullableString;
     void s2; // so no unused variable error for `s`
   });
+
+  test('enum array property accepts a plain array regardless of convertCustomTypes (GH #8166)', async () => {
+    enum Colour {
+      Red = 'Red',
+      Green = 'Green',
+      Blue = 'Blue',
+    }
+
+    class Thing {
+
+      id!: number;
+      colours: Colour[] | null = null;
+
+    }
+
+    // the array branch must not distribute over enum members (`Colour.Red[] | Colour.Green[] | ...`)
+    assert<IsAssignable<EntityDataProp<Colour[], true>, Colour[]>>(true);
+    assert<IsAssignable<EntityDataProp<Colour[], false>, Colour[]>>(true);
+    assert<IsAssignable<RequiredEntityDataProp<Colour[], Thing, true>, Colour[]>>(true);
+    assert<IsAssignable<RequiredEntityDataProp<Colour[], Thing, false>, Colour[]>>(true);
+
+    const dto = {} as { colours?: Colour[] | null };
+    const d1: EntityData<Thing, false> = dto;
+    const d2: EntityData<Thing, true> = dto;
+    const d3: RequiredEntityData<Thing, never, true> = { id: 1, colours: [Colour.Red, Colour.Green] };
+  });
+
 });


### PR DESCRIPTION
Port of the master fix for #8166 (#8167) to 6.x. `EntityData<T, true>` rejected a plain array for `@Enum({ array: true })` properties: the array branch of `EntityDataProp`/`RequiredEntityDataProp` used `U extends NonArrayObject`, a distributive conditional, so a string enum element type produced `Colour.Red[] | Colour.Green[] | Colour.Blue[]` instead of accepting `Colour[]`. Wrapping both sides in tuples makes the check non-distributive. As a side effect, mixed arrays of union object types are now assignable too.

Closes #8166