### PR TITLE
feat(core): support configurable string normalization

### DIFF
--- a/docs/docs/custom-types.md
+++ b/docs/docs/custom-types.md
@@ -69,43 +69,40 @@ For most custom types, you only need the runtime conversion methods. The SQL-lev
 
 ## Normalizing string properties
 
-The built-in `StringType` can trim and change the casing of string values. With `defineEntity`, pass the options to
-`p.string()`:
+The built-in `StringType` and `TextType` can trim and change the casing of string values. With `defineEntity`, use the string-specific builder methods:
 
 ```ts
 const Customer = defineEntity({
   name: 'Customer',
   properties: {
     id: p.integer().primary().autoincrement(),
-    currency: p.string({ trim: true, case: 'upper' }),
-    email: p.string({ trim: true, case: 'lower' }).unique(),
+    currency: p.string().trim().uppercase(),
+    email: p.string().trim().lowercase().unique(),
+    biography: p.text().trim(),
+    aliases: p.string().trim().lowercase().array(),
   },
 });
 ```
 
-Decorator and `EntitySchema` definitions can use a configured type instance directly:
+Decorator and `EntitySchema` definitions can configure the mapped type directly with an options object:
 
 ```ts
 @Entity()
 class Customer {
-
   @PrimaryKey()
   id!: number;
 
   @Property({ type: new StringType({ trim: true, case: 'upper' }) })
   currency!: string;
 
+  @Property({ type: new TextType({ trim: true }) })
+  biography!: string;
 }
 ```
 
-When both options are enabled, trimming runs before casing. The same normalization is applied when values are written
-to the database, used as query parameters, and hydrated from database results. `null` and `undefined` are preserved.
-The casing conversion uses `toUpperCase()` or `toLowerCase()` and is not locale-specific.
+When both operations are enabled, trimming runs before casing. Normalization is applied when values are written to the database or used as ORM query parameters. `null` and `undefined` are preserved. The casing conversion uses `toUpperCase()` or `toLowerCase()` and is not locale-specific.
 
-Like other custom type conversions, normalization does not act as a property setter. Direct assignment, `em.create()`,
-and `em.assign()` keep the assigned value in memory. A flush writes its normalized form without changing the entity
-property; reloading or refreshing the entity hydrates the normalized value. These options only affect runtime values
-and do not change the SQL column type or generated schema.
+Normalization does not act as a property setter. Direct assignment, `em.create()`, and `em.assign()` keep the assigned value in memory, while a flush writes its normalized form without changing the entity property. Values read from the database are not normalized again, as values written through the mapped type are already normalized. Existing columns containing non-normalized data should be updated with a migration before enabling these options. The options do not change the SQL column type or generated schema.
 
 ### Handling null and undefined
 

--- a/docs/docs/custom-types.md
+++ b/docs/docs/custom-types.md
@@ -67,6 +67,46 @@ For most custom types, you only need the runtime conversion methods. The SQL-lev
 - The database stores values in a binary or internal format that requires SQL functions to convert (e.g., PostGIS geometry, MySQL spatial types)
 - You want to leverage database-specific functions for encoding/decoding
 
+## Normalizing string properties
+
+The built-in `StringType` can trim and change the casing of string values. With `defineEntity`, pass the options to
+`p.string()`:
+
+```ts
+const Customer = defineEntity({
+  name: 'Customer',
+  properties: {
+    id: p.integer().primary().autoincrement(),
+    currency: p.string({ trim: true, case: 'upper' }),
+    email: p.string({ trim: true, case: 'lower' }).unique(),
+  },
+});
+```
+
+Decorator and `EntitySchema` definitions can use a configured type instance directly:
+
+```ts
+@Entity()
+class Customer {
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ type: new StringType({ trim: true, case: 'upper' }) })
+  currency!: string;
+
+}
+```
+
+When both options are enabled, trimming runs before casing. The same normalization is applied when values are written
+to the database, used as query parameters, and hydrated from database results. `null` and `undefined` are preserved.
+The casing conversion uses `toUpperCase()` or `toLowerCase()` and is not locale-specific.
+
+Like other custom type conversions, normalization does not act as a property setter. Direct assignment, `em.create()`,
+and `em.assign()` keep the assigned value in memory. A flush writes its normalized form without changing the entity
+property; reloading or refreshing the entity hydrates the normalized value. These options only affect runtime values
+and do not change the SQL column type or generated schema.
+
 ### Handling null and undefined
 
 **Important:** The ORM handles `null` values from the database automatically - they will **not** be passed to your custom type's `convertToJSValue` method. However, `null` or `undefined` values **can** be passed to `convertToDatabaseValue` when using `em.create()` or when setting property values directly.

--- a/packages/core/src/entity/defineEntity.ts
+++ b/packages/core/src/entity/defineEntity.ts
@@ -57,7 +57,7 @@ import type {
 } from '../enums.js';
 import type { EventSubscriber } from '../events/EventSubscriber.js';
 import type { IType, Type } from '../types/Type.js';
-import { types } from '../types/index.js';
+import { type StringTypeOptions, types } from '../types/index.js';
 import { EntitySchema } from '../metadata/EntitySchema.js';
 import type { Collection } from './Collection.js';
 import type { FilterOptions, FindOptions, FindOneOptions } from '../drivers/IDatabaseDriver.js';
@@ -1115,6 +1115,13 @@ const propertyBuilders: PropertyBuilders = {
 
   json: <T>() => new UniversalPropertyOptionsBuilder<T, EmptyOptions, IncludeKeysForProperty>({ type: types.json }),
 
+  string: (options?: StringTypeOptions) =>
+    new UniversalPropertyOptionsBuilder<
+      InferPropertyValueType<typeof types.string>,
+      EmptyOptions,
+      IncludeKeysForProperty
+    >({ type: options?.trim === true || options?.case != null ? new types.string(options) : types.string }),
+
   formula: <T>(formula: string | FormulaCallback<any>) =>
     new UniversalPropertyOptionsBuilder<T, EmptyOptions, IncludeKeysForProperty>({ formula }),
 
@@ -1182,7 +1189,7 @@ const propertyBuilders: PropertyBuilders = {
     }) as any,
 } as PropertyBuilders;
 
-type PropertyBuildersOverrideKeys = 'bigint' | 'array' | 'decimal' | 'json' | 'datetime' | 'time' | 'enum';
+type PropertyBuildersOverrideKeys = 'bigint' | 'array' | 'decimal' | 'json' | 'string' | 'datetime' | 'time' | 'enum';
 
 /** Map of factory functions for creating type-safe property builders (scalars, enums, embeddables, and relations). */
 export type PropertyBuilders = {
@@ -1215,6 +1222,13 @@ export type PropertyBuilders = {
     IncludeKeysForProperty
   >;
   json: <T>() => UniversalPropertyOptionsBuilder<T, EmptyOptions, IncludeKeysForProperty>;
+  string: (
+    options?: StringTypeOptions,
+  ) => UniversalPropertyOptionsBuilder<
+    InferPropertyValueType<typeof types.string>,
+    EmptyOptions,
+    IncludeKeysForProperty
+  >;
   formula: <T>(
     formula: string | FormulaCallback<any>,
   ) => UniversalPropertyOptionsBuilder<T, EmptyOptions, IncludeKeysForProperty>;

--- a/packages/core/src/entity/defineEntity.ts
+++ b/packages/core/src/entity/defineEntity.ts
@@ -1056,6 +1056,36 @@ export class UniversalPropertyOptionsBuilder<Value, Options, IncludeKeys extends
 export interface EmptyOptions extends Partial<Record<UniversalPropertyKeys, unknown>> {}
 
 /** @internal */
+export class StringPropertyOptionsBuilder<Value, Options> extends UniversalPropertyOptionsBuilder<
+  Value,
+  Options,
+  IncludeKeysForProperty
+> {
+  trim(): StringPropertyOptionsBuilder<Value, Options> {
+    return this.withOptions({ trim: true });
+  }
+
+  lowercase(): StringPropertyOptionsBuilder<Value, Options> {
+    return this.withOptions({ case: 'lower' });
+  }
+
+  uppercase(): StringPropertyOptionsBuilder<Value, Options> {
+    return this.withOptions({ case: 'upper' });
+  }
+
+  private withOptions(options: StringTypeOptions): StringPropertyOptionsBuilder<Value, Options> {
+    const type = (this['~options'] as Dictionary).type;
+    const TypeClass = typeof type === 'function' ? type : type.constructor;
+    const currentOptions = typeof type === 'function' ? {} : type.options;
+
+    return new StringPropertyOptionsBuilder({
+      ...this['~options'],
+      type: new TypeClass({ ...currentOptions, ...options }),
+    });
+  }
+}
+
+/** @internal */
 export class OneToManyOptionsBuilderOnlyMappedBy<Value extends object> extends UniversalPropertyOptionsBuilder<
   Value,
   EmptyOptions & { kind: '1:m' },
@@ -1115,12 +1145,15 @@ const propertyBuilders: PropertyBuilders = {
 
   json: <T>() => new UniversalPropertyOptionsBuilder<T, EmptyOptions, IncludeKeysForProperty>({ type: types.json }),
 
-  string: (options?: StringTypeOptions) =>
-    new UniversalPropertyOptionsBuilder<
-      InferPropertyValueType<typeof types.string>,
-      EmptyOptions,
-      IncludeKeysForProperty
-    >({ type: options?.trim === true || options?.case != null ? new types.string(options) : types.string }),
+  string: () =>
+    new StringPropertyOptionsBuilder<InferPropertyValueType<typeof types.string>, EmptyOptions>({
+      type: types.string,
+    }),
+
+  text: () =>
+    new StringPropertyOptionsBuilder<InferPropertyValueType<typeof types.text>, EmptyOptions>({
+      type: types.text,
+    }),
 
   formula: <T>(formula: string | FormulaCallback<any>) =>
     new UniversalPropertyOptionsBuilder<T, EmptyOptions, IncludeKeysForProperty>({ formula }),
@@ -1189,7 +1222,16 @@ const propertyBuilders: PropertyBuilders = {
     }) as any,
 } as PropertyBuilders;
 
-type PropertyBuildersOverrideKeys = 'bigint' | 'array' | 'decimal' | 'json' | 'string' | 'datetime' | 'time' | 'enum';
+type PropertyBuildersOverrideKeys =
+  | 'bigint'
+  | 'array'
+  | 'decimal'
+  | 'json'
+  | 'string'
+  | 'text'
+  | 'datetime'
+  | 'time'
+  | 'enum';
 
 /** Map of factory functions for creating type-safe property builders (scalars, enums, embeddables, and relations). */
 export type PropertyBuilders = {
@@ -1222,13 +1264,8 @@ export type PropertyBuilders = {
     IncludeKeysForProperty
   >;
   json: <T>() => UniversalPropertyOptionsBuilder<T, EmptyOptions, IncludeKeysForProperty>;
-  string: (
-    options?: StringTypeOptions,
-  ) => UniversalPropertyOptionsBuilder<
-    InferPropertyValueType<typeof types.string>,
-    EmptyOptions,
-    IncludeKeysForProperty
-  >;
+  string: () => StringPropertyOptionsBuilder<InferPropertyValueType<typeof types.string>, EmptyOptions>;
+  text: () => StringPropertyOptionsBuilder<InferPropertyValueType<typeof types.text>, EmptyOptions>;
   formula: <T>(
     formula: string | FormulaCallback<any>,
   ) => UniversalPropertyOptionsBuilder<T, EmptyOptions, IncludeKeysForProperty>;

--- a/packages/core/src/types/StringType.ts
+++ b/packages/core/src/types/StringType.ts
@@ -1,9 +1,34 @@
-import { Type } from './Type.js';
+import { type TransformContext, Type } from './Type.js';
 import type { Platform } from '../platforms/Platform.js';
 import type { EntityProperty } from '../typings.js';
 
+export interface StringTypeOptions {
+  trim?: boolean;
+  case?: 'upper' | 'lower';
+}
+
 /** Maps a database VARCHAR column to a JS `string`. */
 export class StringType extends Type<string | null | undefined, string | null | undefined> {
+  constructor(private readonly options: StringTypeOptions = {}) {
+    super();
+  }
+
+  override convertToDatabaseValue(
+    value: string | null | undefined,
+    _platform: Platform,
+    _context?: TransformContext,
+  ): string | null | undefined {
+    return this.normalize(value);
+  }
+
+  override convertToJSValue(
+    value: string | null | undefined,
+    _platform: Platform,
+    _context?: TransformContext,
+  ): string | null | undefined {
+    return this.normalize(value);
+  }
+
   override getColumnType(prop: EntityProperty, platform: Platform): string {
     return platform.getVarcharTypeDeclarationSQL(prop);
   }
@@ -13,10 +38,30 @@ export class StringType extends Type<string | null | undefined, string | null | 
   }
 
   override ensureComparable(): boolean {
-    return false;
+    return this.options.trim === true || this.options.case != null;
   }
 
   override getDefaultLength(platform: Platform): number {
     return platform.getDefaultVarcharLength();
+  }
+
+  private normalize(value: string | null | undefined): string | null | undefined {
+    if (value == null) {
+      return value;
+    }
+
+    if (this.options.trim) {
+      value = value.trim();
+    }
+
+    if (this.options.case === 'upper') {
+      return value.toUpperCase();
+    }
+
+    if (this.options.case === 'lower') {
+      return value.toLowerCase();
+    }
+
+    return value;
   }
 }

--- a/packages/core/src/types/StringType.ts
+++ b/packages/core/src/types/StringType.ts
@@ -11,14 +11,15 @@ export interface StringTypeOptions {
 export abstract class BaseStringType extends Type<string | null | undefined, string | null | undefined> {
   constructor(readonly options: StringTypeOptions = {}) {
     super();
+
+    // a defined `compareValues` replaces the inline `!==` comparator, so only provide it when normalization is configured
+    if (options.trim || options.case) {
+      this.compareValues = (a, b) => this.normalize(a) === this.normalize(b);
+    }
   }
 
   override convertToDatabaseValue(value: string | null | undefined): string | null | undefined {
     return this.normalize(value);
-  }
-
-  override compareValues(a: string | null | undefined, b: string | null | undefined): boolean {
-    return this.normalize(a) === this.normalize(b);
   }
 
   override compareAsType(): string {

--- a/packages/core/src/types/StringType.ts
+++ b/packages/core/src/types/StringType.ts
@@ -1,4 +1,4 @@
-import { type TransformContext, Type } from './Type.js';
+import { Type } from './Type.js';
 import type { Platform } from '../platforms/Platform.js';
 import type { EntityProperty } from '../typings.js';
 
@@ -7,35 +7,18 @@ export interface StringTypeOptions {
   case?: 'upper' | 'lower';
 }
 
-const stringTypeOptions = Symbol('StringTypeOptions');
-
-/** Maps a database VARCHAR column to a JS `string`. */
-export class StringType extends Type<string | null | undefined, string | null | undefined> {
-  declare private readonly [stringTypeOptions]: StringTypeOptions;
-
-  constructor(options: StringTypeOptions = {}) {
+/** @internal */
+export abstract class BaseStringType extends Type<string | null | undefined, string | null | undefined> {
+  constructor(readonly options: StringTypeOptions = {}) {
     super();
-    Object.defineProperty(this, stringTypeOptions, { value: options, enumerable: false });
   }
 
-  override convertToDatabaseValue(
-    value: string | null | undefined,
-    _platform: Platform,
-    _context?: TransformContext,
-  ): string | null | undefined {
+  override convertToDatabaseValue(value: string | null | undefined): string | null | undefined {
     return this.normalize(value);
   }
 
-  override convertToJSValue(
-    value: string | null | undefined,
-    _platform: Platform,
-    _context?: TransformContext,
-  ): string | null | undefined {
-    return this.normalize(value);
-  }
-
-  override getColumnType(prop: EntityProperty, platform: Platform): string {
-    return platform.getVarcharTypeDeclarationSQL(prop);
+  override compareValues(a: string | null | undefined, b: string | null | undefined): boolean {
+    return this.normalize(a) === this.normalize(b);
   }
 
   override compareAsType(): string {
@@ -43,11 +26,7 @@ export class StringType extends Type<string | null | undefined, string | null | 
   }
 
   override ensureComparable(): boolean {
-    return this[stringTypeOptions].trim === true || this[stringTypeOptions].case != null;
-  }
-
-  override getDefaultLength(platform: Platform): number {
-    return platform.getDefaultVarcharLength();
+    return false;
   }
 
   private normalize(value: string | null | undefined): string | null | undefined {
@@ -55,20 +34,29 @@ export class StringType extends Type<string | null | undefined, string | null | 
       return value;
     }
 
-    const options = this[stringTypeOptions];
-
-    if (options.trim) {
+    if (this.options.trim) {
       value = value.trim();
     }
 
-    if (options.case === 'upper') {
+    if (this.options.case === 'upper') {
       return value.toUpperCase();
     }
 
-    if (options.case === 'lower') {
+    if (this.options.case === 'lower') {
       return value.toLowerCase();
     }
 
     return value;
+  }
+}
+
+/** Maps a database VARCHAR column to a JS `string`. */
+export class StringType extends BaseStringType {
+  override getColumnType(prop: EntityProperty, platform: Platform): string {
+    return platform.getVarcharTypeDeclarationSQL(prop);
+  }
+
+  override getDefaultLength(platform: Platform): number {
+    return platform.getDefaultVarcharLength();
   }
 }

--- a/packages/core/src/types/StringType.ts
+++ b/packages/core/src/types/StringType.ts
@@ -55,15 +55,17 @@ export class StringType extends Type<string | null | undefined, string | null | 
       return value;
     }
 
-    if (this[stringTypeOptions].trim) {
+    const options = this[stringTypeOptions];
+
+    if (options.trim) {
       value = value.trim();
     }
 
-    if (this[stringTypeOptions].case === 'upper') {
+    if (options.case === 'upper') {
       return value.toUpperCase();
     }
 
-    if (this[stringTypeOptions].case === 'lower') {
+    if (options.case === 'lower') {
       return value.toLowerCase();
     }
 

--- a/packages/core/src/types/StringType.ts
+++ b/packages/core/src/types/StringType.ts
@@ -9,8 +9,11 @@ export interface StringTypeOptions {
 
 /** Maps a database VARCHAR column to a JS `string`. */
 export class StringType extends Type<string | null | undefined, string | null | undefined> {
-  constructor(private readonly options: StringTypeOptions = {}) {
+  readonly #options: StringTypeOptions;
+
+  constructor(options: StringTypeOptions = {}) {
     super();
+    this.#options = options;
   }
 
   override convertToDatabaseValue(
@@ -38,7 +41,7 @@ export class StringType extends Type<string | null | undefined, string | null | 
   }
 
   override ensureComparable(): boolean {
-    return this.options.trim === true || this.options.case != null;
+    return this.#options.trim === true || this.#options.case != null;
   }
 
   override getDefaultLength(platform: Platform): number {
@@ -50,15 +53,15 @@ export class StringType extends Type<string | null | undefined, string | null | 
       return value;
     }
 
-    if (this.options.trim) {
+    if (this.#options.trim) {
       value = value.trim();
     }
 
-    if (this.options.case === 'upper') {
+    if (this.#options.case === 'upper') {
       return value.toUpperCase();
     }
 
-    if (this.options.case === 'lower') {
+    if (this.#options.case === 'lower') {
       return value.toLowerCase();
     }
 

--- a/packages/core/src/types/StringType.ts
+++ b/packages/core/src/types/StringType.ts
@@ -7,13 +7,15 @@ export interface StringTypeOptions {
   case?: 'upper' | 'lower';
 }
 
+const stringTypeOptions = Symbol('StringTypeOptions');
+
 /** Maps a database VARCHAR column to a JS `string`. */
 export class StringType extends Type<string | null | undefined, string | null | undefined> {
-  readonly #options: StringTypeOptions;
+  declare private readonly [stringTypeOptions]: StringTypeOptions;
 
   constructor(options: StringTypeOptions = {}) {
     super();
-    this.#options = options;
+    Object.defineProperty(this, stringTypeOptions, { value: options, enumerable: false });
   }
 
   override convertToDatabaseValue(
@@ -41,7 +43,7 @@ export class StringType extends Type<string | null | undefined, string | null | 
   }
 
   override ensureComparable(): boolean {
-    return this.#options.trim === true || this.#options.case != null;
+    return this[stringTypeOptions].trim === true || this[stringTypeOptions].case != null;
   }
 
   override getDefaultLength(platform: Platform): number {
@@ -53,15 +55,15 @@ export class StringType extends Type<string | null | undefined, string | null | 
       return value;
     }
 
-    if (this.#options.trim) {
+    if (this[stringTypeOptions].trim) {
       value = value.trim();
     }
 
-    if (this.#options.case === 'upper') {
+    if (this[stringTypeOptions].case === 'upper') {
       return value.toUpperCase();
     }
 
-    if (this.#options.case === 'lower') {
+    if (this[stringTypeOptions].case === 'lower') {
       return value.toLowerCase();
     }
 

--- a/packages/core/src/types/TextType.ts
+++ b/packages/core/src/types/TextType.ts
@@ -1,18 +1,10 @@
-import { Type } from './Type.js';
+import { BaseStringType } from './StringType.js';
 import type { Platform } from '../platforms/Platform.js';
 import type { EntityProperty } from '../typings.js';
 
 /** Maps a database TEXT column (unbounded length) to a JS `string`. */
-export class TextType extends Type<string | null | undefined, string | null | undefined> {
+export class TextType extends BaseStringType {
   override getColumnType(prop: EntityProperty, platform: Platform): string {
     return platform.getTextTypeDeclarationSQL(prop);
-  }
-
-  override compareAsType(): string {
-    return 'string';
-  }
-
-  override ensureComparable(): boolean {
-    return false;
   }
 }

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -15,7 +15,7 @@ import { IntervalType } from './IntervalType.js';
 import { JsonType } from './JsonType.js';
 import { MediumIntType } from './MediumIntType.js';
 import { SmallIntType } from './SmallIntType.js';
-import { StringType } from './StringType.js';
+import { type StringTypeOptions, StringType } from './StringType.js';
 import { TextType } from './TextType.js';
 import { TimeType } from './TimeType.js';
 import { TinyIntType } from './TinyIntType.js';
@@ -24,7 +24,7 @@ import { Uint8ArrayType } from './Uint8ArrayType.js';
 import { UnknownType } from './UnknownType.js';
 import { UuidType } from './UuidType.js';
 
-export type { TransformContext, IType };
+export type { TransformContext, IType, StringTypeOptions };
 export {
   Type,
   DateType,

--- a/tests/defineEntity.test.ts
+++ b/tests/defineEntity.test.ts
@@ -111,7 +111,7 @@ describe('defineEntity', () => {
     expect((Foo.meta.properties.nullable.type as unknown as TextType).options).toEqual({ case: 'lower' });
     expect(Foo.meta.properties.aliases.array).toBe(true);
 
-    // @ts-expect-error p.string() no longer accepts an options object
+    // @ts-expect-error p.string() does not accept an options object
     expect(p.string({ trim: true, case: 'lower' })).toBeDefined();
     // @ts-expect-error non-string property factories do not accept normalization options
     expect(p.integer({ trim: true })).toBeDefined();

--- a/tests/defineEntity.test.ts
+++ b/tests/defineEntity.test.ts
@@ -24,6 +24,7 @@ import {
   RequiredEntityData,
   ScalarReference,
   StringType,
+  TextType,
   Type,
   types,
   p,
@@ -74,9 +75,13 @@ describe('defineEntity', () => {
       name: 'Foo',
       properties: {
         plain: p.string(),
-        normalized: p.string({ trim: true, case: 'upper' }).length(50),
-        nullable: p.string({ case: 'lower' }).nullable(),
-        optional: p.string({ trim: true }).onCreate(() => ''),
+        normalized: p.string().trim().uppercase().length(50),
+        nullable: p.text().lowercase().nullable(),
+        optional: p
+          .string()
+          .trim()
+          .onCreate(() => ''),
+        aliases: p.string().trim().lowercase().array(),
       },
     });
 
@@ -89,6 +94,7 @@ describe('defineEntity', () => {
           normalized: string;
           nullable: string | null | undefined;
           optional: Opt<string>;
+          aliases: string[];
           [PrimaryKeyProp]?: undefined;
         }
       >
@@ -96,11 +102,18 @@ describe('defineEntity', () => {
 
     expect(Foo.meta.properties.plain.type).toBe(types.string);
     expect(Foo.meta.properties.normalized.type).toBeInstanceOf(StringType);
+    expect((Foo.meta.properties.normalized.type as unknown as StringType).options).toEqual({
+      trim: true,
+      case: 'upper',
+    });
     expect(Foo.meta.properties.normalized.length).toBe(50);
+    expect(Foo.meta.properties.nullable.type).toBeInstanceOf(TextType);
+    expect((Foo.meta.properties.nullable.type as unknown as TextType).options).toEqual({ case: 'lower' });
+    expect(Foo.meta.properties.aliases.array).toBe(true);
 
-    // @ts-expect-error invalid casing option
-    expect(p.string({ case: 'title' })).toBeDefined();
-    // @ts-expect-error options are specialized to p.string()
+    // @ts-expect-error p.string() no longer accepts an options object
+    expect(p.string({ trim: true, case: 'lower' })).toBeDefined();
+    // @ts-expect-error non-string property factories do not accept normalization options
     expect(p.integer({ trim: true })).toBeDefined();
     // @ts-expect-error string normalizers are not universal builder methods
     expect(p.integer().trim).toBeUndefined();

--- a/tests/defineEntity.test.ts
+++ b/tests/defineEntity.test.ts
@@ -23,6 +23,7 @@ import {
   Reference,
   RequiredEntityData,
   ScalarReference,
+  StringType,
   Type,
   types,
   p,
@@ -68,6 +69,43 @@ type _AssertParamsInSync = _ParamsMatch<keyof _TestPC> extends true ? true : nev
 const _paramsInSync: _AssertParamsInSync = true as any;
 
 describe('defineEntity', () => {
+  it('should configure string normalization without changing builder inference', () => {
+    const Foo = defineEntity({
+      name: 'Foo',
+      properties: {
+        plain: p.string(),
+        normalized: p.string({ trim: true, case: 'upper' }).length(50),
+        nullable: p.string({ case: 'lower' }).nullable(),
+        optional: p.string({ trim: true }).onCreate(() => ''),
+      },
+    });
+
+    type IFoo = InferEntity<typeof Foo>;
+    assert<
+      IsExact<
+        Omit<IFoo, typeof IndexHints>,
+        {
+          plain: string;
+          normalized: string;
+          nullable: string | null | undefined;
+          optional: Opt<string>;
+          [PrimaryKeyProp]?: undefined;
+        }
+      >
+    >(true);
+
+    expect(Foo.meta.properties.plain.type).toBe(types.string);
+    expect(Foo.meta.properties.normalized.type).toBeInstanceOf(StringType);
+    expect(Foo.meta.properties.normalized.length).toBe(50);
+
+    // @ts-expect-error invalid casing option
+    expect(p.string({ case: 'title' })).toBeDefined();
+    // @ts-expect-error options are specialized to p.string()
+    expect(p.integer({ trim: true })).toBeDefined();
+    // @ts-expect-error string normalizers are not universal builder methods
+    expect(p.integer().trim).toBeUndefined();
+  });
+
   it('should define entity', () => {
     const Foo = defineEntity({
       name: 'Foo',

--- a/tests/features/custom-types/StringType.test.ts
+++ b/tests/features/custom-types/StringType.test.ts
@@ -1,26 +1,27 @@
 import { inspect } from 'node:util';
-import { type StringTypeOptions, StringType, Utils } from '@mikro-orm/core';
+import { type StringTypeOptions, StringType, TextType, Utils } from '@mikro-orm/core';
 import { MongoPlatform } from '@mikro-orm/mongodb';
 
 describe('StringType', () => {
   const platform = new MongoPlatform();
 
-  test('preserves values and the fast comparison path without options', () => {
+  test('preserves values and the fast hydration path without options', () => {
     const type = new StringType();
 
-    expect(inspect(type)).toBe('StringType {}');
-    expect(type.convertToDatabaseValue('  Foo Bar  ', platform)).toBe('  Foo Bar  ');
+    expect(inspect(type)).toBe('StringType { options: {} }');
+    expect(type.convertToDatabaseValue('  Foo Bar  ')).toBe('  Foo Bar  ');
     expect(type.convertToJSValue('  Foo Bar  ', platform)).toBe('  Foo Bar  ');
     expect(type.ensureComparable()).toBe(false);
+    expect(type.getDefaultLength(platform)).toBe(platform.getDefaultVarcharLength());
     expect(new StringType({ trim: false }).ensureComparable()).toBe(false);
   });
 
-  test('preserves hidden options when cloned with metadata', () => {
+  test('preserves options when cloned with metadata', () => {
     const type = Utils.copy(new StringType({ trim: true, case: 'upper' }), false);
 
-    expect(inspect(type)).toBe('StringType {}');
-    expect(type.convertToDatabaseValue('  Foo Bar  ', platform)).toBe('FOO BAR');
-    expect(type.ensureComparable()).toBe(true);
+    expect(type.options).toEqual({ trim: true, case: 'upper' });
+    expect(type.convertToDatabaseValue('  Foo Bar  ')).toBe('FOO BAR');
+    expect(type.ensureComparable()).toBe(false);
   });
 
   test.each<[StringTypeOptions, string, string]>([
@@ -29,12 +30,19 @@ describe('StringType', () => {
     [{ case: 'lower' }, ' Foo Bar ', ' foo bar '],
     [{ trim: true, case: 'upper' }, '  Foo Bar  ', 'FOO BAR'],
     [{ trim: true, case: 'lower' }, '  Foo Bar  ', 'foo bar'],
-  ])('normalizes database and JS values with %o', (options, value, expected) => {
+  ])('normalizes database values with %o', (options, value, expected) => {
     const type = new StringType(options);
 
-    expect(type.convertToDatabaseValue(value, platform)).toBe(expected);
-    expect(type.convertToJSValue(value, platform)).toBe(expected);
-    expect(type.ensureComparable()).toBe(true);
+    expect(type.convertToDatabaseValue(value)).toBe(expected);
+    expect(type.convertToJSValue(value, platform)).toBe(value);
+    expect(type.ensureComparable()).toBe(false);
+  });
+
+  test('compares values by their normalized database representation', () => {
+    const type = new StringType({ trim: true, case: 'lower' });
+
+    expect(type.compareValues('  Foo Bar  ', 'foo bar')).toBe(true);
+    expect(type.compareValues('  Foo Bar  ', 'other')).toBe(false);
   });
 
   test('applies trim before casing', () => {
@@ -42,14 +50,23 @@ describe('StringType', () => {
     const trim = vi.fn(() => ({ toUpperCase: upper }));
     const value = { trim } as unknown as string;
 
-    expect(new StringType({ trim: true, case: 'upper' }).convertToDatabaseValue(value, platform)).toBe('VALUE');
+    expect(new StringType({ trim: true, case: 'upper' }).convertToDatabaseValue(value)).toBe('VALUE');
     expect(trim.mock.invocationCallOrder[0]).toBeLessThan(upper.mock.invocationCallOrder[0]);
   });
 
   test.each([null, undefined])('preserves %s', value => {
     const type = new StringType({ trim: true, case: 'upper' });
 
-    expect(type.convertToDatabaseValue(value, platform)).toBe(value);
+    expect(type.convertToDatabaseValue(value)).toBe(value);
     expect(type.convertToJSValue(value, platform)).toBe(value);
+  });
+
+  test('supports the same normalization options on TextType', () => {
+    const type = new TextType({ trim: true, case: 'lower' });
+
+    expect(type.convertToDatabaseValue('  Foo Bar  ')).toBe('foo bar');
+    expect(type.convertToJSValue('  Foo Bar  ', platform)).toBe('  Foo Bar  ');
+    expect(type.compareValues('  Foo Bar  ', 'foo bar')).toBe(true);
+    expect(type.getDefaultLength).toBeUndefined();
   });
 });

--- a/tests/features/custom-types/StringType.test.ts
+++ b/tests/features/custom-types/StringType.test.ts
@@ -1,3 +1,4 @@
+import { inspect } from 'node:util';
 import { type StringTypeOptions, StringType } from '@mikro-orm/core';
 import { MongoPlatform } from '@mikro-orm/mongodb';
 
@@ -7,6 +8,7 @@ describe('StringType', () => {
   test('preserves values and the fast comparison path without options', () => {
     const type = new StringType();
 
+    expect(inspect(type)).toBe('StringType {}');
     expect(type.convertToDatabaseValue('  Foo Bar  ', platform)).toBe('  Foo Bar  ');
     expect(type.convertToJSValue('  Foo Bar  ', platform)).toBe('  Foo Bar  ');
     expect(type.ensureComparable()).toBe(false);

--- a/tests/features/custom-types/StringType.test.ts
+++ b/tests/features/custom-types/StringType.test.ts
@@ -1,0 +1,45 @@
+import { type StringTypeOptions, StringType } from '@mikro-orm/core';
+import { MongoPlatform } from '@mikro-orm/mongodb';
+
+describe('StringType', () => {
+  const platform = new MongoPlatform();
+
+  test('preserves values and the fast comparison path without options', () => {
+    const type = new StringType();
+
+    expect(type.convertToDatabaseValue('  Foo Bar  ', platform)).toBe('  Foo Bar  ');
+    expect(type.convertToJSValue('  Foo Bar  ', platform)).toBe('  Foo Bar  ');
+    expect(type.ensureComparable()).toBe(false);
+    expect(new StringType({ trim: false }).ensureComparable()).toBe(false);
+  });
+
+  test.each<[StringTypeOptions, string, string]>([
+    [{ trim: true }, '  Foo Bar  ', 'Foo Bar'],
+    [{ case: 'upper' }, ' Foo Bar ', ' FOO BAR '],
+    [{ case: 'lower' }, ' Foo Bar ', ' foo bar '],
+    [{ trim: true, case: 'upper' }, '  Foo Bar  ', 'FOO BAR'],
+    [{ trim: true, case: 'lower' }, '  Foo Bar  ', 'foo bar'],
+  ])('normalizes database and JS values with %o', (options, value, expected) => {
+    const type = new StringType(options);
+
+    expect(type.convertToDatabaseValue(value, platform)).toBe(expected);
+    expect(type.convertToJSValue(value, platform)).toBe(expected);
+    expect(type.ensureComparable()).toBe(true);
+  });
+
+  test('applies trim before casing', () => {
+    const upper = vi.fn(() => 'VALUE');
+    const trim = vi.fn(() => ({ toUpperCase: upper }));
+    const value = { trim } as unknown as string;
+
+    expect(new StringType({ trim: true, case: 'upper' }).convertToDatabaseValue(value, platform)).toBe('VALUE');
+    expect(trim.mock.invocationCallOrder[0]).toBeLessThan(upper.mock.invocationCallOrder[0]);
+  });
+
+  test.each([null, undefined])('preserves %s', value => {
+    const type = new StringType({ trim: true, case: 'upper' });
+
+    expect(type.convertToDatabaseValue(value, platform)).toBe(value);
+    expect(type.convertToJSValue(value, platform)).toBe(value);
+  });
+});

--- a/tests/features/custom-types/StringType.test.ts
+++ b/tests/features/custom-types/StringType.test.ts
@@ -41,8 +41,10 @@ describe('StringType', () => {
   test('compares values by their normalized database representation', () => {
     const type = new StringType({ trim: true, case: 'lower' });
 
-    expect(type.compareValues('  Foo Bar  ', 'foo bar')).toBe(true);
-    expect(type.compareValues('  Foo Bar  ', 'other')).toBe(false);
+    expect(type.compareValues!('  Foo Bar  ', 'foo bar')).toBe(true);
+    expect(type.compareValues!('  Foo Bar  ', 'other')).toBe(false);
+    // without normalization options the default inline comparator is kept
+    expect(new StringType().compareValues).toBeUndefined();
   });
 
   test('applies trim before casing', () => {
@@ -66,7 +68,7 @@ describe('StringType', () => {
 
     expect(type.convertToDatabaseValue('  Foo Bar  ')).toBe('foo bar');
     expect(type.convertToJSValue('  Foo Bar  ', platform)).toBe('  Foo Bar  ');
-    expect(type.compareValues('  Foo Bar  ', 'foo bar')).toBe(true);
+    expect(type.compareValues!('  Foo Bar  ', 'foo bar')).toBe(true);
     expect(type.getDefaultLength).toBeUndefined();
   });
 });

--- a/tests/features/custom-types/StringType.test.ts
+++ b/tests/features/custom-types/StringType.test.ts
@@ -1,5 +1,5 @@
 import { inspect } from 'node:util';
-import { type StringTypeOptions, StringType } from '@mikro-orm/core';
+import { type StringTypeOptions, StringType, Utils } from '@mikro-orm/core';
 import { MongoPlatform } from '@mikro-orm/mongodb';
 
 describe('StringType', () => {
@@ -13,6 +13,14 @@ describe('StringType', () => {
     expect(type.convertToJSValue('  Foo Bar  ', platform)).toBe('  Foo Bar  ');
     expect(type.ensureComparable()).toBe(false);
     expect(new StringType({ trim: false }).ensureComparable()).toBe(false);
+  });
+
+  test('preserves hidden options when cloned with metadata', () => {
+    const type = Utils.copy(new StringType({ trim: true, case: 'upper' }), false);
+
+    expect(inspect(type)).toBe('StringType {}');
+    expect(type.convertToDatabaseValue('  Foo Bar  ', platform)).toBe('FOO BAR');
+    expect(type.ensureComparable()).toBe(true);
   });
 
   test.each<[StringTypeOptions, string, string]>([

--- a/tests/features/custom-types/string-normalization.sqlite.test.ts
+++ b/tests/features/custom-types/string-normalization.sqlite.test.ts
@@ -6,7 +6,9 @@ const NormalizedStringUser = defineEntity({
   name: 'NormalizedStringUser',
   properties: {
     id: p.integer().primary().autoincrement(),
-    name: p.string({ trim: true, case: 'upper' }),
+    name: p.string().trim().uppercase(),
+    description: p.text().trim().lowercase(),
+    aliases: p.string().trim().lowercase().array(),
   },
 });
 
@@ -35,8 +37,14 @@ describe('string normalization', () => {
   beforeEach(() => orm.schema.clear());
 
   test('normalizes persistence, query parameters, assignment, and refresh', async () => {
-    const user = orm.em.create(NormalizedStringUser, { name: '  Alice  ' });
+    const user = orm.em.create(NormalizedStringUser, {
+      name: '  Alice  ',
+      description: '  DESCRIPTION  ',
+      aliases: ['  Alice  ', '  A. SMITH  '],
+    });
     expect(user.name).toBe('  Alice  ');
+    expect(user.description).toBe('  DESCRIPTION  ');
+    expect(user.aliases).toEqual(['  Alice  ', '  A. SMITH  ']);
 
     orm.em.assign(user, { name: '  Alice Smith  ' });
     expect(user.name).toBe('  Alice Smith  ');
@@ -44,13 +52,19 @@ describe('string normalization', () => {
 
     const [inserted] = await orm.em
       .getConnection()
-      .execute<{ name: string }[]>('select "name" from "normalized_string_user" where "id" = ?', [user.id]);
+      .execute<{ name: string; description: string }[]>(
+        'select "name", "description" from "normalized_string_user" where "id" = ?',
+        [user.id],
+      );
     expect(inserted.name).toBe('ALICE SMITH');
+    expect(inserted.description).toBe('description');
     expect(user.name).toBe('  Alice Smith  ');
 
     orm.em.clear();
     const loaded = await orm.em.findOneOrFail(NormalizedStringUser, { name: '  alice smith  ' });
     expect(loaded.name).toBe('ALICE SMITH');
+    expect(loaded.description).toBe('description');
+    expect(loaded.aliases).toEqual(['alice', 'a. smith']);
 
     loaded.name = '  Bob  ';
     await orm.em.flush();
@@ -65,13 +79,41 @@ describe('string normalization', () => {
     expect(loaded.name).toBe('BOB');
   });
 
-  test('normalizes externally inserted values during hydration without a phantom update', async () => {
+  test('compares assigned values by their normalized representation', async () => {
+    const user = orm.em.create(NormalizedStringUser, {
+      name: 'Alice',
+      description: 'Description',
+      aliases: ['Alias'],
+    });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const loaded = await orm.em.findOneOrFail(NormalizedStringUser, user.id);
+    loaded.name = '  alice  ';
+
+    const logger = mockLogger(orm);
+    logger.mockClear();
+    await orm.em.flush();
+
+    expect(loaded.name).toBe('  alice  ');
+    expect(logger.mock.calls.filter(([message]) => /update/i.test(String(message)))).toHaveLength(0);
+  });
+
+  test('does not normalize externally inserted values during hydration', async () => {
+    const aliases = orm.em.getPlatform().marshallArray(['  Alias  ']);
     await orm.em
       .getConnection()
-      .execute('insert into "normalized_string_user" ("id", "name") values (?, ?)', [100, '  External  ']);
+      .execute('insert into "normalized_string_user" ("id", "name", "description", "aliases") values (?, ?, ?, ?)', [
+        100,
+        '  External  ',
+        '  DESCRIPTION  ',
+        aliases,
+      ]);
 
     const user = await orm.em.findOneOrFail(NormalizedStringUser, 100);
-    expect(user.name).toBe('EXTERNAL');
+    expect(user.name).toBe('  External  ');
+    expect(user.description).toBe('  DESCRIPTION  ');
+    expect(user.aliases).toEqual(['  Alias  ']);
 
     const logger = mockLogger(orm);
     logger.mockClear();

--- a/tests/features/custom-types/string-normalization.sqlite.test.ts
+++ b/tests/features/custom-types/string-normalization.sqlite.test.ts
@@ -1,0 +1,98 @@
+import { defineEntity, MikroORM, p, StringType } from '@mikro-orm/sqlite';
+import { Entity, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+import { mockLogger } from '../../helpers.js';
+
+const NormalizedStringUser = defineEntity({
+  name: 'NormalizedStringUser',
+  properties: {
+    id: p.integer().primary().autoincrement(),
+    name: p.string({ trim: true, case: 'upper' }),
+  },
+});
+
+@Entity()
+class DirectStringUser {
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ type: new StringType({ trim: true, case: 'lower' }) })
+  name!: string;
+}
+
+describe('string normalization', () => {
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      entities: [NormalizedStringUser, DirectStringUser],
+      dbName: ':memory:',
+    });
+    await orm.schema.create();
+  });
+
+  afterAll(() => orm.close(true));
+  beforeEach(() => orm.schema.clear());
+
+  test('normalizes persistence, query parameters, assignment, and refresh', async () => {
+    const user = orm.em.create(NormalizedStringUser, { name: '  Alice  ' });
+    expect(user.name).toBe('  Alice  ');
+
+    orm.em.assign(user, { name: '  Alice Smith  ' });
+    expect(user.name).toBe('  Alice Smith  ');
+    await orm.em.flush();
+
+    const [inserted] = await orm.em
+      .getConnection()
+      .execute<{ name: string }[]>('select "name" from "normalized_string_user" where "id" = ?', [user.id]);
+    expect(inserted.name).toBe('ALICE SMITH');
+    expect(user.name).toBe('  Alice Smith  ');
+
+    orm.em.clear();
+    const loaded = await orm.em.findOneOrFail(NormalizedStringUser, { name: '  alice smith  ' });
+    expect(loaded.name).toBe('ALICE SMITH');
+
+    loaded.name = '  Bob  ';
+    await orm.em.flush();
+    expect(loaded.name).toBe('  Bob  ');
+
+    const [updated] = await orm.em
+      .getConnection()
+      .execute<{ name: string }[]>('select "name" from "normalized_string_user" where "id" = ?', [loaded.id]);
+    expect(updated.name).toBe('BOB');
+
+    await orm.em.refresh(loaded);
+    expect(loaded.name).toBe('BOB');
+  });
+
+  test('normalizes externally inserted values during hydration without a phantom update', async () => {
+    await orm.em
+      .getConnection()
+      .execute('insert into "normalized_string_user" ("id", "name") values (?, ?)', [100, '  External  ']);
+
+    const user = await orm.em.findOneOrFail(NormalizedStringUser, 100);
+    expect(user.name).toBe('EXTERNAL');
+
+    const logger = mockLogger(orm);
+    logger.mockClear();
+    await orm.em.flush();
+
+    expect(logger.mock.calls.filter(([message]) => /update/i.test(String(message)))).toHaveLength(0);
+  });
+
+  test('supports direct configured StringType metadata', async () => {
+    const user = orm.em.create(DirectStringUser, { name: '  Mixed Case  ' });
+    await orm.em.flush();
+    expect(user.name).toBe('  Mixed Case  ');
+
+    const [inserted] = await orm.em
+      .getConnection()
+      .execute<{ name: string }[]>('select "name" from "direct_string_user" where "id" = ?', [user.id]);
+    expect(inserted.name).toBe('mixed case');
+
+    orm.em.clear();
+    const loaded = await orm.em.findOneOrFail(DirectStringUser, { name: '  MIXED CASE  ' });
+    expect(loaded.name).toBe('mixed case');
+    await expect(orm.schema.getUpdateSchemaSQL({ wrap: false })).resolves.toBe('');
+  });
+});

--- a/tests/features/schema-generator/serial-property.postgres.test.ts
+++ b/tests/features/schema-generator/serial-property.postgres.test.ts
@@ -141,7 +141,7 @@ test('schema generator works with non-pk autoincrement columns (serial)', async 
     `'type' changed for column something.id { fromColumnType: 'int', toColumnType: 'varchar(255)' }`,
   );
   expect(mock.mock.calls[8][0]).toMatch(
-    `'autoincrement' changed for column something.id { fromColumn: { name: 'id', type: 'int4', mappedType: IntegerType {}, length: null, precision: 32, scale: 0, nullable: false, default: null, unsigned: true, autoincrement: true, comment: null, primary: true, unique: false, enumItems: [] }, toColumn: { name: 'id', type: 'varchar(255)', mappedType: StringType {}, unsigned: false, autoincrement: false, primary: true, nullable: false, length: 255 }}`,
+    `'autoincrement' changed for column something.id { fromColumn: { name: 'id', type: 'int4', mappedType: IntegerType {}, length: null, precision: 32, scale: 0, nullable: false, default: null, unsigned: true, autoincrement: true, comment: null, primary: true, unique: false, enumItems: [] }, toColumn: { name: 'id', type: 'varchar(255)', mappedType: StringType { options: {} }, unsigned: false, autoincrement: false, primary: true, nullable: false, length: 255 }}`,
   );
   expect(mock.mock.calls[9][0]).toMatch(
     `column something.id changed { changedProperties: Set(2) { 'type', 'autoincrement' } }`,


### PR DESCRIPTION
Follow-up to discussion #8165.

Adds opt-in string normalization through `StringTypeOptions`, available via both
`p.string(options)` and configured `StringType` instances.

Normalization is applied consistently during database conversion, hydration,
and query parameter conversion. Direct assignment, `em.create()`, and
`em.assign()` retain their existing in-memory semantics.

`p.string()` without options keeps the existing fast path, no universal
property-builder methods are added, and the type benchmarks show no regression.