### PR TITLE
feat(core): inherit `collation` from referenced PK on FK columns

### DIFF
--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -2670,6 +2670,7 @@ export class MetadataDiscovery {
 
       if (!targetMeta.compositePK || prop.targetKey) {
         prop.customType = referencedProp.customType;
+        prop.collation ??= referencedProp.collation;
       }
     }
   }

--- a/tests/features/schema-generator/fk-collation-inheritance.postgres.test.ts
+++ b/tests/features/schema-generator/fk-collation-inheritance.postgres.test.ts
@@ -1,0 +1,75 @@
+import { MikroORM, type Options } from '@mikro-orm/postgresql';
+import { Entity, ManyToOne, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+import { PrimaryKeyProp, type Rel } from '@mikro-orm/core';
+
+@Entity()
+class User {
+  @PrimaryKey({ type: 'varchar', length: 26, collation: 'C' })
+  id!: string;
+
+  @Property({ type: 'varchar', length: 26, collation: 'POSIX', unique: true })
+  slug!: string;
+}
+
+@Entity()
+class Session {
+  @PrimaryKey({ type: 'varchar', length: 26, collation: 'C' })
+  id!: string;
+
+  @ManyToOne(() => User)
+  user!: Rel<User>;
+
+  @ManyToOne(() => User, { collation: 'POSIX' })
+  reviewer!: Rel<User>;
+
+  @ManyToOne(() => User, { targetKey: 'slug' })
+  owner!: Rel<User>;
+}
+
+@Entity()
+class CompositeUser {
+  @PrimaryKey({ type: 'varchar', length: 26, collation: 'C' })
+  tenant!: string;
+
+  @PrimaryKey({ type: 'varchar', length: 26, collation: 'POSIX' })
+  code!: string;
+
+  [PrimaryKeyProp]?: ['tenant', 'code'];
+}
+
+@Entity()
+class CompositeSession {
+  @PrimaryKey()
+  id!: number;
+
+  @ManyToOne(() => CompositeUser)
+  user!: Rel<CompositeUser>;
+}
+
+async function bootstrap(entities: any[]) {
+  return MikroORM.init({
+    metadataProvider: ReflectMetadataProvider,
+    entities,
+    dbName: 'mikro_orm_test_fk_collation',
+    connect: false,
+  } as Options);
+}
+
+describe('FK collation inheritance [postgres]', () => {
+  test('FK column inherits collation from referenced key unless set explicitly', async () => {
+    const orm = await bootstrap([User, Session]);
+    const sql = await orm.schema.getCreateSchemaSQL({ wrap: false });
+    expect(sql).toContain('"user_id" varchar(26) collate "C" not null');
+    expect(sql).toContain('"reviewer_id" varchar(26) collate "POSIX" not null');
+    expect(sql).toContain('"owner_id" varchar(26) collate "POSIX" not null');
+    await orm.close(true);
+  });
+
+  test('composite FK does not inherit collation', async () => {
+    const orm = await bootstrap([CompositeUser, CompositeSession]);
+    const sql = await orm.schema.getCreateSchemaSQL({ wrap: false });
+    expect(sql).toContain('"user_tenant" varchar(26) not null');
+    expect(sql).toContain('"user_code" varchar(26) not null');
+    await orm.close(true);
+  });
+});


### PR DESCRIPTION
M:1 and 1:1 relation properties inherit the referenced PK's column types, custom type and unsigned flag, but collation was left out. A `@ManyToOne` pointing at a `@PrimaryKey({ collation: 'C' })` produced an FK column with the database default collation. The FK now inherits the referenced property's `collation` unless the relation sets one explicitly. Composite FKs are excluded, since a single `collation` value cannot describe multiple referenced columns (same guard the `customType` inheritance already uses).

Note for existing schemas: `schema:update` will now emit `alter` statements for FK columns whose referenced PK has an explicit collation.

Closes #8170
