### PR TITLE
fix(core): derive FK field names from `targetKey` instead of composite PKs

### DIFF
--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -591,8 +591,9 @@ export class MetadataDiscovery {
   private initManyToOneFieldName(prop: EntityProperty, name: string): string[] {
     const meta2 = prop.targetMeta!;
     const ret: string[] = [];
-    // with `targetKey`, the FK references that property instead of the target's PKs
-    const referencedKeys = prop.targetKey ? [prop.targetKey] : meta2.primaryKeys;
+    // with `targetKey` on a composite PK target, derive the FK field name from that property
+    // instead of the PKs (simple PK targets keep the PK based naming for backwards compatibility)
+    const referencedKeys = prop.targetKey && meta2.compositePK ? [prop.targetKey] : meta2.primaryKeys;
 
     for (const referencedKey of referencedKeys) {
       this.initFieldName(meta2.properties[referencedKey]);

--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -591,12 +591,14 @@ export class MetadataDiscovery {
   private initManyToOneFieldName(prop: EntityProperty, name: string): string[] {
     const meta2 = prop.targetMeta!;
     const ret: string[] = [];
+    // with `targetKey`, the FK references that property instead of the target's PKs
+    const referencedKeys = prop.targetKey ? [prop.targetKey] : meta2.primaryKeys;
 
-    for (const primaryKey of meta2.primaryKeys) {
-      this.initFieldName(meta2.properties[primaryKey]);
+    for (const referencedKey of referencedKeys) {
+      this.initFieldName(meta2.properties[referencedKey]);
 
-      for (const fieldName of meta2.properties[primaryKey].fieldNames) {
-        ret.push(this.#namingStrategy.joinKeyColumnName(name, fieldName, meta2.compositePK));
+      for (const fieldName of meta2.properties[referencedKey].fieldNames) {
+        ret.push(this.#namingStrategy.joinKeyColumnName(name, fieldName, !prop.targetKey && meta2.compositePK));
       }
     }
 

--- a/tests/features/non-pk-relation-target/non-pk-relation-target-composite-pk.sqlite.test.ts
+++ b/tests/features/non-pk-relation-target/non-pk-relation-target-composite-pk.sqlite.test.ts
@@ -1,0 +1,64 @@
+import { MikroORM, Ref } from '@mikro-orm/sqlite';
+import { Entity, PrimaryKey, Property, ManyToOne, Unique, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+
+@Entity()
+class CompositeUser {
+  @PrimaryKey()
+  tenant!: string;
+
+  @PrimaryKey()
+  code!: string;
+
+  @Property()
+  @Unique()
+  slug!: string;
+
+  @Property()
+  name!: string;
+}
+
+@Entity()
+class CompositeSession {
+  @PrimaryKey()
+  id!: number;
+
+  // References CompositeUser by its unique `slug`, not its composite PK
+  @ManyToOne(() => CompositeUser, { ref: true, targetKey: 'slug' })
+  owner!: Ref<CompositeUser>;
+}
+
+describe('targetKey pointing at composite-PK entity', () => {
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      entities: [CompositeUser, CompositeSession],
+      dbName: ':memory:',
+    });
+  });
+
+  afterAll(() => orm.close(true));
+
+  test('relation metadata follows targetKey, not the composite PK', () => {
+    const prop = orm.getMetadata(CompositeSession).properties.owner;
+    expect(prop.fieldNames).toEqual(['owner_slug']);
+    expect(prop.joinColumns).toEqual(['owner_slug']);
+    expect(prop.referencedColumnNames).toEqual(['slug']);
+    expect(prop.columnTypes).toHaveLength(1);
+  });
+
+  test('schema generation and persistence work', async () => {
+    const sql = await orm.schema.getCreateSchemaSQL();
+    expect(sql).toMatch(/`owner_slug` text not null/);
+    await orm.schema.create();
+
+    const user = orm.em.create(CompositeUser, { tenant: 't1', code: 'c1', slug: 'u-1', name: 'John' });
+    orm.em.create(CompositeSession, { owner: user });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const session = await orm.em.findOneOrFail(CompositeSession, { owner: { slug: 'u-1' } }, { populate: ['owner'] });
+    expect(session.owner.$.name).toBe('John');
+  });
+});


### PR DESCRIPTION
When a `@ManyToOne`/`@OneToOne` relation uses `targetKey` pointing at a unique non-PK property of an entity with a composite primary key, `initManyToOneFieldName` still derived `prop.fieldNames` from the composite PK (e.g. `['owner_tenant', 'owner_code']`), while `joinColumns`, `referencedColumnNames` and `columnTypes` followed the `targetKey` property and had a single entry. The mismatch then crashed schema generation in `DatabaseTable.addColumnFromProperty` with `Cannot read properties of undefined (reading 'toLowerCase')`.

The field name initialization now derives the FK field name from the `targetKey` property when the target has a composite PK, so all the relation metadata stays consistent. Simple PK targets keep the current PK based naming (e.g. `owner_id` even with `targetKey: 'slug'`), since renaming those columns would break existing schemas.
