### PR TITLE
feat(core): support named parameters in `em.execute()`

### DIFF
--- a/docs/docs/raw-queries.md
+++ b/docs/docs/raw-queries.md
@@ -28,6 +28,26 @@ The `raw` helper supports several signatures, you can pass in a callback that re
 await em.find(User, { [raw(alias => `lower(${alias}.name)`)]: name.toLowerCase() });
 ```
 
+### Named parameters
+
+Besides positional `?` placeholders bound from an array, the `raw` helper supports named parameters bound from an object. Use `:name` for values and `:name:` for identifiers (quoted according to the database in use). Parameters can repeat, and PostgreSQL `::` casts are left untouched:
+
+```ts
+const fragment = raw('select :col: from geo_seed where city = :city or region = :city', { col: 'city', city: 'Brno' });
+```
+
+This also works with `em.execute()` and `connection.execute()`, where you can pass the object directly as the `params` argument:
+
+```ts
+await em.execute(`
+  insert into geo_seed (country, region, city)
+  values (:country, :region, :city)
+  on conflict (city)
+      do update set country = excluded.country,
+                    region  = excluded.region
+`, { country, region, city });
+```
+
 ### Raw fragments in filters
 
 When using raw query fragment inside a filter, you might have to use a callback signature to create new raw instance for every filter usage - namely when you use the fragment as an object key, which requires its serialization.

--- a/packages/core/src/utils/RawQueryFragment.ts
+++ b/packages/core/src/utils/RawQueryFragment.ts
@@ -186,6 +186,12 @@ export const ALIAS_REPLACEMENT_RE = '\\[::alias::\\]';
  * await em.find(User, { [raw(alias => `lower(${alias}.name)`)]: name.toLowerCase() });
  * ```
  *
+ * Named parameters are supported via an object of parameters, use `:name` for values and `:name:` for identifiers:
+ *
+ * ```ts
+ * raw('select :col: from geo where city = :city or region = :city', { col: 'city', city: 'Brno' });
+ * ```
+ *
  * You can also use the `sql` tagged template function, which works the same, but supports only the simple string signature:
  *
  * ```ts
@@ -238,14 +244,19 @@ export function raw<R = RawQueryFragment & symbol, T extends object = any>(
   }
 
   if (typeof params === 'object' && !Array.isArray(params)) {
-    const pairs = Object.entries(params);
-    const objectParams = [];
+    const dict = params as Dictionary<unknown>;
+    const objectParams: unknown[] = [];
 
-    for (const [key, value] of pairs) {
-      sql = sql.replace(`:${key}:`, '??');
-      sql = sql.replace(`:${key}`, '?');
-      objectParams.push(value);
-    }
+    // single left-to-right scan keeps values in SQL-placeholder order while `::` casts and unknown tokens stay untouched
+    sql = sql.replace(/(?<!:):([$\w]+)(:(?!:))?/g, (match, key: string, identifier?: string) => {
+      if (!Object.hasOwn(dict, key)) {
+        return match;
+      }
+
+      objectParams.push(dict[key]);
+
+      return identifier ? '??' : '?';
+    });
 
     return new RawQueryFragment(sql, objectParams) as R;
   }

--- a/packages/sql/src/AbstractSqlConnection.ts
+++ b/packages/sql/src/AbstractSqlConnection.ts
@@ -12,6 +12,7 @@ import {
   type LoggingOptions,
   type MaybePromise,
   type QueryResult,
+  raw,
   type RawQueryFragment,
   type Transaction,
   type TransactionEventBroadcaster,
@@ -295,10 +296,15 @@ export abstract class AbstractSqlConnection extends Connection {
 
   private prepareQuery(
     query: string | NativeQueryBuilder | RawQueryFragment,
-    params: readonly unknown[] = [],
+    params: readonly unknown[] | Dictionary<unknown> = [],
   ): { query: string; params: readonly unknown[]; formatted: string } {
     if (query instanceof NativeQueryBuilder) {
       query = query.toRaw();
+    }
+
+    if (typeof query === 'string' && !Array.isArray(params)) {
+      // plain object params hold named parameters, translate them via the `raw()` helper
+      query = raw<RawQueryFragment>(query, params);
     }
 
     if (isRaw(query)) {
@@ -306,16 +312,16 @@ export abstract class AbstractSqlConnection extends Connection {
       query = query.sql;
     }
 
-    query = this.config.get('onQuery')(query, params);
-    const formatted = this.platform.formatQuery(query, params);
+    query = this.config.get('onQuery')(query as string, params as readonly unknown[]);
+    const formatted = this.platform.formatQuery(query, params as readonly unknown[]);
 
-    return { query, params, formatted };
+    return { query, params: params as readonly unknown[], formatted };
   }
 
   /** Executes a SQL query and returns the result based on the method: `'all'` for rows, `'get'` for single row, `'run'` for affected count. */
   async execute<T extends QueryResult | EntityData<AnyEntity> | EntityData<AnyEntity>[] = EntityData<AnyEntity>[]>(
     query: string | NativeQueryBuilder | RawQueryFragment,
-    params: readonly unknown[] = [],
+    params: readonly unknown[] | Dictionary<unknown> = [],
     method: 'all' | 'get' | 'run' = 'all',
     ctx?: Transaction,
     loggerContext?: LoggingOptions,
@@ -339,7 +345,7 @@ export abstract class AbstractSqlConnection extends Connection {
   /** Executes a SQL query and returns an async iterable that yields results row by row. */
   async *stream<T extends EntityData<AnyEntity>>(
     query: string | NativeQueryBuilder | RawQueryFragment,
-    params: readonly unknown[] = [],
+    params: readonly unknown[] | Dictionary<unknown> = [],
     ctx?: Transaction<Kysely<any>>,
     loggerContext?: LoggingOptions,
     chunkSize?: number,
@@ -365,7 +371,7 @@ export abstract class AbstractSqlConnection extends Connection {
 
       this.logQuery(sql, {
         sql,
-        params,
+        params: q.params,
         ...cleanCtx,
         affected: Utils.isPlainObject<QueryResult>(res) ? res.affectedRows : undefined,
       });
@@ -376,7 +382,7 @@ export abstract class AbstractSqlConnection extends Connection {
         }
       }
     } catch (e) {
-      this.logQuery(sql, { sql, params, ...cleanCtx, level: 'error' });
+      this.logQuery(sql, { sql, params: q.params, ...cleanCtx, level: 'error' });
       throw e;
     }
   }

--- a/packages/sql/src/AbstractSqlDriver.ts
+++ b/packages/sql/src/AbstractSqlDriver.ts
@@ -2310,7 +2310,7 @@ export abstract class AbstractSqlDriver<
 
   async execute<T extends QueryResult | EntityData<AnyEntity> | EntityData<AnyEntity>[] = EntityData<AnyEntity>[]>(
     query: string | NativeQueryBuilder | RawQueryFragment,
-    params: any[] = [],
+    params: any[] | Dictionary = [],
     method: 'all' | 'get' | 'run' = 'all',
     ctx?: Transaction,
     loggerContext?: LoggingOptions,

--- a/packages/sql/src/SqlEntityManager.ts
+++ b/packages/sql/src/SqlEntityManager.ts
@@ -132,7 +132,7 @@ export class SqlEntityManager<Driver extends AbstractSqlDriver = AbstractSqlDriv
    */
   async execute<T extends QueryResult | EntityData<AnyEntity> | EntityData<AnyEntity>[] = EntityData<AnyEntity>[]>(
     query: string | NativeQueryBuilder | RawQueryFragment,
-    params?: any[],
+    params?: any[] | Dictionary,
     method?: 'all' | 'get' | 'run',
     loggerContext?: LoggingOptions,
   ): Promise<T>;
@@ -144,12 +144,12 @@ export class SqlEntityManager<Driver extends AbstractSqlDriver = AbstractSqlDriv
    */
   async execute<T extends QueryResult | EntityData<AnyEntity> | EntityData<AnyEntity>[] = EntityData<AnyEntity>[]>(
     query: string | NativeQueryBuilder | RawQueryFragment,
-    params: any[],
+    params: any[] | Dictionary,
     options: EmExecuteOptions,
   ): Promise<T>;
   async execute<T extends QueryResult | EntityData<AnyEntity> | EntityData<AnyEntity>[] = EntityData<AnyEntity>[]>(
     query: string | NativeQueryBuilder | RawQueryFragment,
-    params: any[] = [],
+    params: any[] | Dictionary = [],
     methodOrOptions: 'all' | 'get' | 'run' | EmExecuteOptions = 'all',
     loggerContext?: LoggingOptions,
   ): Promise<T> {

--- a/tests/features/raw-queries/raw-named-parameters.test.ts
+++ b/tests/features/raw-queries/raw-named-parameters.test.ts
@@ -1,0 +1,81 @@
+import { raw } from '@mikro-orm/core';
+import { MikroORM } from '@mikro-orm/sqlite';
+
+describe('named parameters in raw() helper', () => {
+  test('binds values in SQL-placeholder order, not object-key order', () => {
+    const fragment = raw('select :b as b, :a as a', { a: 1, b: 2 });
+    expect(fragment.sql).toBe('select ? as b, ? as a');
+    expect(fragment.params).toEqual([2, 1]);
+  });
+
+  test('supports repeated named parameters', () => {
+    const fragment = raw('select * from geo where city = :city or country = :city', { city: 'Brno' });
+    expect(fragment.sql).toBe('select * from geo where city = ? or country = ?');
+    expect(fragment.params).toEqual(['Brno', 'Brno']);
+  });
+
+  test('does not corrupt parameters sharing a prefix', () => {
+    const fragment = raw('select :cityCode as code, :city as city', { city: 'Brno', cityCode: 'BRQ' });
+    expect(fragment.sql).toBe('select ? as code, ? as city');
+    expect(fragment.params).toEqual(['BRQ', 'Brno']);
+  });
+
+  test('supports keys containing $', () => {
+    const fragment = raw('select :$price as p, :price$net as n', { $price: 100, price$net: 80 });
+    expect(fragment.sql).toBe('select ? as p, ? as n');
+    expect(fragment.params).toEqual([100, 80]);
+  });
+
+  test('quotes identifiers via :name: syntax', () => {
+    const fragment = raw('select :col: from :tbl: where :col: = :val', { col: 'name', tbl: 'user', val: 'x' });
+    expect(fragment.sql).toBe('select ?? from ?? where ?? = ?');
+    expect(fragment.params).toEqual(['name', 'user', 'name', 'x']);
+  });
+
+  test('ignores postgres :: casts', () => {
+    const fragment = raw(`select '[1]'::jsonb, :val::text`, { val: 'x' });
+    expect(fragment.sql).toBe(`select '[1]'::jsonb, ?::text`);
+    expect(fragment.params).toEqual(['x']);
+  });
+
+  test('leaves tokens without a matching key untouched', () => {
+    const fragment = raw('select :known, :unknown', { known: 1 });
+    expect(fragment.sql).toBe('select ?, :unknown');
+    expect(fragment.params).toEqual([1]);
+  });
+
+  test('works end to end via em.execute (GH #8093)', async () => {
+    const orm = await MikroORM.init({ dbName: ':memory:', discovery: { warnWhenNoEntities: false } });
+    await orm.em.execute('create table geo_seed (country text, region text, city text)');
+
+    const [country, region, city] = ['CZ', 'South Moravia', 'Brno'];
+    await orm.em.execute(
+      raw('insert into geo_seed (country, region, city) values (:country, :region, :city)', { country, region, city }),
+    );
+
+    const res = await orm.em.execute(raw('select * from geo_seed where city = :city or region = :city', { city }));
+    expect(res).toEqual([{ country: 'CZ', region: 'South Moravia', city: 'Brno' }]);
+
+    await orm.close(true);
+  });
+
+  test('named parameters work directly in em.execute and connection.execute (GH #8093)', async () => {
+    const orm = await MikroORM.init({ dbName: ':memory:', discovery: { warnWhenNoEntities: false } });
+    await orm.em.execute('create table geo_seed (country text, region text, city text)');
+
+    const [country, region, city] = ['CZ', 'South Moravia', 'Brno'];
+    await orm.em.execute('insert into geo_seed (country, region, city) values (:country, :region, :city)', {
+      country,
+      region,
+      city,
+    });
+
+    const res = await orm.em.execute('select * from geo_seed where city = :city or region = :city', { city });
+    expect(res).toEqual([{ country: 'CZ', region: 'South Moravia', city: 'Brno' }]);
+
+    const res2 = await orm.em.getConnection().execute('select * from geo_seed where city = :city', { city }, 'get');
+    expect(res2).toEqual({ country: 'CZ', region: 'South Moravia', city: 'Brno' });
+
+    await orm.close(true);
+  });
+});


### PR DESCRIPTION
`em.execute()` and `connection.execute()` now accept a plain object of named parameters (`:name` for values, `:name:` for identifiers) as an alternative to the positional array. The object is translated via the `raw()` helper once, before formatting, so the platform query formatter stays untouched.

This also fixes the named parameter translation in the `raw()` helper itself: it used to bind values in object-key order rather than SQL-placeholder order, replace only the first occurrence of a repeated token, and corrupt SQL when one key was a prefix of another (`:city` vs `:cityCode`). The translation is now a single left-to-right scan that also leaves `::` casts and unmatched tokens alone.

Closes #8093
