### PR TITLE
fix(core): keep `$or` conditions intact when populating to-one relations

### DIFF
--- a/packages/core/src/entity/EntityLoader.ts
+++ b/packages/core/src/entity/EntityLoader.ts
@@ -706,7 +706,12 @@ export class EntityLoader {
       }
     }
 
-    if ([ReferenceKind.ONE_TO_ONE, ReferenceKind.MANY_TO_ONE].includes(prop.kind) && items.length !== children.length) {
+    // a missing target row means an orphaned reference, unless the query was narrowed by a populate condition
+    if (
+      [ReferenceKind.ONE_TO_ONE, ReferenceKind.MANY_TO_ONE].includes(prop.kind) &&
+      items.length !== children.length &&
+      Utils.isEmpty(options.where)
+    ) {
       const nullVal = this.#em.config.get('forceUndefined') ? undefined : null;
       const itemsMap = new Set<string>();
       const childrenMap = new Set<string>();
@@ -1005,7 +1010,10 @@ export class EntityLoader {
             return cond;
           });
 
-        if (child.length > 0) {
+        // partial extraction from `$or` is unsound for to-one relations — the parent may have matched via a dropped branch
+        const toOne = [ReferenceKind.ONE_TO_ONE, ReferenceKind.MANY_TO_ONE].includes(prop.kind);
+
+        if (child.length > 0 && (op === '$and' || !toOne || child.length === where[op].length)) {
           subCond[op] = child;
         }
       }

--- a/packages/sql/src/query/QueryBuilder.ts
+++ b/packages/sql/src/query/QueryBuilder.ts
@@ -3938,6 +3938,11 @@ export class QueryBuilder<
     for (const k of Object.keys(cond)) {
       if (Utils.isOperator(k)) {
         if (Array.isArray(cond[k])) {
+          // distributing a partial `$or` to a to-one join would drop rows that match a sibling branch
+          if (k === '$or' && !this.canDistributeOrBranches(cond[k], joins)) {
+            continue;
+          }
+
           cond[k].forEach((c: Dictionary) => this.mergeOnConditions(joins, c, filter, k));
         }
 
@@ -3973,6 +3978,32 @@ export class QueryBuilder<
         }
       }
     }
+  }
+
+  /**
+   * `$or` branches can be moved to a to-one join's `on` clause only when they all target that same
+   * join — a partial `$or` in the `on` clause would drop rows matching a sibling branch. To-many
+   * joins keep receiving partial branches, as that is how `PopulateHint.INFER` narrows collections.
+   */
+  private canDistributeOrBranches(branches: Dictionary[], joins: JoinOptions[]): boolean {
+    const aliases = new Set<string>();
+    const collectAliases = (cond: Dictionary) => {
+      for (const k of Object.keys(cond)) {
+        if (Utils.isOperator(k)) {
+          Utils.asArray(cond[k]).forEach((c: Dictionary) => collectAliases(c));
+        } else {
+          aliases.add(this.helper.splitField(k as EntityKey<Entity>)[0]);
+        }
+      }
+    };
+    branches.forEach(collectAliases);
+    const targeted = joins.filter(j => aliases.has(j.alias));
+
+    if (aliases.size === 1 && targeted.length === 1) {
+      return true;
+    }
+
+    return !targeted.some(j => [ReferenceKind.ONE_TO_ONE, ReferenceKind.MANY_TO_ONE].includes(j.prop.kind));
   }
 
   /**

--- a/packages/sql/src/query/QueryBuilder.ts
+++ b/packages/sql/src/query/QueryBuilder.ts
@@ -3938,8 +3938,8 @@ export class QueryBuilder<
     for (const k of Object.keys(cond)) {
       if (Utils.isOperator(k)) {
         if (Array.isArray(cond[k])) {
-          // distributing a partial `$or` to a to-one join would drop rows that match a sibling branch
-          if (k === '$or' && !this.canDistributeOrBranches(cond[k], joins)) {
+          // a partial `$or` on a to-one join drops rows matching a sibling branch, but entity filters have no other sink, so they must pass
+          if (k === '$or' && !filter && !this.canDistributeOrBranches(cond[k], joins)) {
             continue;
           }
 
@@ -3982,8 +3982,9 @@ export class QueryBuilder<
 
   /**
    * `$or` branches can be moved to a to-one join's `on` clause only when they all target that same
-   * join — a partial `$or` in the `on` clause would drop rows matching a sibling branch. To-many
-   * joins keep receiving partial branches, as that is how `PopulateHint.INFER` narrows collections.
+   * join and stay flat — a partial `$or` in the `on` clause would drop rows matching a sibling
+   * branch. A `$or` targeting only to-many joins keeps the partial distribution, as that is how
+   * `PopulateHint.INFER` narrows collections.
    */
   private canDistributeOrBranches(branches: Dictionary[], joins: JoinOptions[]): boolean {
     const aliases = new Set<string>();
@@ -3998,8 +3999,10 @@ export class QueryBuilder<
     };
     branches.forEach(collectAliases);
     const targeted = joins.filter(j => aliases.has(j.alias));
+    // nested operators cannot be preserved inside a distributed disjunction, `mergeOnConditions` would flatten them into `and` conjuncts
+    const flat = branches.every(branch => Object.keys(branch).every(k => !Utils.isOperator(k)));
 
-    if (aliases.size === 1 && targeted.length === 1) {
+    if (aliases.size === 1 && targeted.length === 1 && flat) {
       return true;
     }
 

--- a/tests/features/filters/filter-or-condition-on-populated-relation.test.ts
+++ b/tests/features/filters/filter-or-condition-on-populated-relation.test.ts
@@ -1,0 +1,87 @@
+import { Collection, MikroORM, Ref } from '@mikro-orm/sqlite';
+import {
+  Entity,
+  Filter,
+  ManyToOne,
+  OneToMany,
+  PrimaryKey,
+  Property,
+  ReflectMetadataProvider,
+} from '@mikro-orm/decorators/legacy';
+
+@Entity()
+class Author {
+  @PrimaryKey()
+  id!: number;
+
+  @OneToMany(() => Book, b => b.author)
+  books = new Collection<Book>(this);
+}
+
+@Entity()
+class Publisher {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  open!: boolean;
+}
+
+@Entity()
+@Filter({ name: 'visible', cond: { $or: [{ title: 'keep' }, { publisher: { open: true } }] }, default: true })
+class Book {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  title!: string;
+
+  @ManyToOne(() => Author, { ref: true, nullable: true })
+  author?: Ref<Author>;
+
+  @ManyToOne(() => Publisher, { ref: true })
+  publisher!: Ref<Publisher>;
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    entities: [Author, Publisher, Book],
+    dbName: ':memory:',
+    metadataProvider: ReflectMetadataProvider,
+  });
+  await orm.schema.refresh();
+
+  const em = orm.em.fork();
+  await em.insertMany(Author, [{ id: 1 }]);
+  await em.insertMany(Publisher, [
+    { id: 10, open: true },
+    { id: 11, open: false },
+  ]);
+  await em.insertMany(Book, [
+    { id: 100, title: 'keep', author: 1, publisher: 11 }, // matches the `title` branch only
+    { id: 101, title: 'drop', author: 1, publisher: 10 }, // matches the `publisher` branch only
+    { id: 102, title: 'drop', author: 1, publisher: 11 }, // matches neither branch
+  ]);
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+test('filter with `$or` spanning a to-one relation is not bypassed on joined populate', async () => {
+  const em = orm.em.fork();
+  const authors = await em.find(Author, {}, { populate: ['books'], strategy: 'joined' });
+  const ids = authors[0].books.getIdentifiers();
+
+  // joined strategy splits the branches into separate `on` clauses and drops books 100/101 too (pre-existing), so only the safety property holds: 102 matches no branch
+  expect(ids).not.toContain(102);
+});
+
+test('filter with `$or` spanning a to-one relation applies on select-in populate', async () => {
+  const em = orm.em.fork();
+  const authors = await em.find(Author, {}, { populate: ['books'], strategy: 'select-in' });
+
+  expect(authors[0].books.getIdentifiers().sort()).toEqual([100, 101]);
+});

--- a/tests/issues/GH8175.test.ts
+++ b/tests/issues/GH8175.test.ts
@@ -1,0 +1,167 @@
+import { Collection, MikroORM, Ref } from '@mikro-orm/sqlite';
+import {
+  Entity,
+  ManyToOne,
+  OneToMany,
+  PrimaryKey,
+  Property,
+  ReflectMetadataProvider,
+} from '@mikro-orm/decorators/legacy';
+import { mockLogger } from '../helpers.js';
+
+@Entity()
+class Author {
+  @PrimaryKey()
+  id!: number;
+
+  @OneToMany(() => Book, b => b.author)
+  books = new Collection<Book>(this);
+}
+
+@Entity()
+class Publisher {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  open!: boolean;
+}
+
+@Entity()
+class Book {
+  @PrimaryKey()
+  id!: number;
+
+  @ManyToOne(() => Author, { ref: true, nullable: true })
+  author?: Ref<Author>;
+
+  @ManyToOne(() => Publisher, { ref: true })
+  publisher!: Ref<Publisher>;
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    entities: [Author, Publisher, Book],
+    dbName: ':memory:',
+    metadataProvider: ReflectMetadataProvider,
+  });
+  await orm.schema.refresh();
+
+  const em = orm.em.fork();
+  await em.insertMany(Author, [{ id: 1 }, { id: 2 }, { id: 3 }]);
+  await em.insertMany(Publisher, [
+    { id: 10, open: true },
+    { id: 11, open: false },
+  ]);
+  // book 100 is matched by the `open` branch only, book 101 by the `author` branch only
+  await em.insertMany(Book, [
+    { id: 100, author: 3, publisher: 10 },
+    { id: 101, author: 2, publisher: 11 },
+  ]);
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+test('populate where with `$or` keeps the disjunction when loading nested relations', async () => {
+  const em = orm.em.fork();
+  const authors = await em.find(Author, {}, { orderBy: { id: 'asc' } });
+  const mock = mockLogger(orm);
+
+  await em.populate(authors, ['books.publisher'], {
+    strategy: 'select-in',
+    where: {
+      books: {
+        $or: [{ publisher: { open: true } }, { author: { $in: [2] } }],
+      },
+    },
+  });
+
+  const queries: string[] = mock.mock.calls.map(call => call[0]);
+  const bookQuery = queries.find(query => query.includes('from `book`'))!;
+  const publisherQuery = queries.find(query => query.includes('from `publisher`'))!;
+
+  // the collection query keeps both branches of the disjunction
+  expect(bookQuery).toMatch(/`p1`\.`open` = true or `b0`\.`author_id` in \(2\)/);
+  expect(authors.map(author => author.books.getIdentifiers())).toEqual([[], [101], [100]]);
+
+  // the nested populate must not apply one branch of the `$or` on its own
+  const books = authors.flatMap(author => author.books.getItems());
+  expect(books.map(book => [book.id, book.publisher?.id])).toEqual([
+    [101, 11],
+    [100, 10],
+  ]);
+
+  expect(publisherQuery).not.toMatch(/`open` = true/);
+});
+
+test('populate where without `$or` loads the nested relation of every matched row', async () => {
+  const em = orm.em.fork();
+  const authors = await em.find(Author, {}, { orderBy: { id: 'asc' } });
+  const mock = mockLogger(orm);
+
+  await em.populate(authors, ['books.publisher'], {
+    strategy: 'select-in',
+    where: {
+      books: {
+        author: { $in: [2] },
+      },
+    },
+  });
+
+  const queries: string[] = mock.mock.calls.map(call => call[0]);
+  const publisherQuery = queries.find(query => query.includes('from `publisher`'))!;
+
+  expect(publisherQuery).not.toMatch(/`open` = true/);
+  expect(authors.map(author => author.books.getIdentifiers())).toEqual([[], [101], []]);
+
+  const books = authors.flatMap(author => author.books.getItems());
+  expect(books.map(book => [book.id, book.publisher?.id])).toEqual([[101, 11]]);
+});
+
+test('populate where with `$or` does not turn one branch into a join condition', async () => {
+  const em = orm.em.fork();
+  const authors = await em.find(Author, {}, { orderBy: { id: 'asc' } });
+  const mock = mockLogger(orm);
+
+  // no `strategy`, so the nested to-one is loaded by the default `balanced` strategy, which joins it
+  await em.populate(authors, ['books.publisher'], {
+    where: {
+      books: {
+        $or: [{ publisher: { open: true } }, { author: { $in: [2] } }],
+      },
+    },
+  });
+
+  const queries: string[] = mock.mock.calls.map(call => call[0]);
+  const bookQuery = queries.find(query => query.includes('from `book`'))!;
+
+  expect(authors.map(author => author.books.getIdentifiers())).toEqual([[], [101], [100]]);
+
+  // the where keeps the disjunction, and the join `on` clause must not repeat one branch as a filter
+  expect(bookQuery).toMatch(/`p1`\.`open` = true or `b0`\.`author_id` in \(2\)/);
+  expect(bookQuery).not.toMatch(/on `b0`\.`publisher_id` = `p1`\.`id` and `p1`\.`open` = true/);
+});
+
+test('populate where without `$or` does not turn the condition into a join condition', async () => {
+  const em = orm.em.fork();
+  const authors = await em.find(Author, {}, { orderBy: { id: 'asc' } });
+  const mock = mockLogger(orm);
+
+  await em.populate(authors, ['books.publisher'], {
+    where: {
+      books: {
+        author: { $in: [2] },
+      },
+    },
+  });
+
+  const queries: string[] = mock.mock.calls.map(call => call[0]);
+  const bookQuery = queries.find(query => query.includes('from `book`'))!;
+
+  expect(authors.map(author => author.books.getIdentifiers())).toEqual([[], [101], []]);
+  expect(bookQuery).not.toMatch(/on `b0`\.`publisher_id` = `p1`\.`id` and /);
+});

--- a/tests/issues/GH8175.test.ts
+++ b/tests/issues/GH8175.test.ts
@@ -146,6 +146,23 @@ test('populate where with `$or` does not turn one branch into a join condition',
   expect(bookQuery).not.toMatch(/on `b0`\.`publisher_id` = `p1`\.`id` and `p1`\.`open` = true/);
 });
 
+test('`$or` with an explicit `$and` branch on a to-one relation is not distributed to the join', async () => {
+  const em = orm.em.fork();
+  const books = await em.find(
+    Book,
+    {
+      $or: [{ publisher: { open: true } }, { $and: [{ publisher: { open: false } }, { publisher: { id: 11 } }] }],
+    },
+    { populate: ['publisher'], strategy: 'joined', populateWhere: 'infer', orderBy: { id: 'asc' } },
+  );
+
+  // each book matches one branch, distributing the `$and` branch would flatten it into the join `on` clause
+  expect(books.map(book => [book.id, book.publisher?.id])).toEqual([
+    [100, 10],
+    [101, 11],
+  ]);
+});
+
 test('populate where without `$or` does not turn the condition into a join condition', async () => {
   const em = orm.em.fork();
   const authors = await em.find(Author, {}, { orderBy: { id: 'asc' } });


### PR DESCRIPTION
When a populate condition contained a `$or` where only some branches named a to-one relation, the surviving branches were extracted and applied on their own, either as a filter on the nested query (`select-in`) or in the join `on` clause (`joined`/`balanced`). A row that matched through a dropped branch then had its non-nullable reference nulled, since the loader read the filtered-out target as a missing row, or never reached its parent collection at all.

Both extraction sites (`EntityLoader.extractChildCondition` and `QueryBuilder.mergeOnConditions`) now require every `$or` branch to name the relation before applying anything to a to-one relation. To-many relations keep the partial extraction, since that is how `PopulateHint.INFER` narrows collections, so #1882 and #6658 behavior is unchanged.

The null-out block in `EntityLoader.findChildren` is also guarded now: when the child query was narrowed by a populate condition, a missing item no longer implies an orphaned reference.

Closes #8175
