### PR TITLE
fix(core): keep `$or` conditions intact when populating to-many relations

### DIFF
--- a/packages/core/src/entity/EntityLoader.ts
+++ b/packages/core/src/entity/EntityLoader.ts
@@ -1010,10 +1010,8 @@ export class EntityLoader {
             return cond;
           });
 
-        // partial extraction from `$or` is unsound for to-one relations — the parent may have matched via a dropped branch
-        const toOne = [ReferenceKind.ONE_TO_ONE, ReferenceKind.MANY_TO_ONE].includes(prop.kind);
-
-        if (child.length > 0 && (op === '$and' || !toOne || child.length === where[op].length)) {
+        // partial extraction from `$or` is unsound — the parent may have matched via a dropped branch
+        if (child.length > 0 && (op === '$and' || child.length === where[op].length)) {
           subCond[op] = child;
         }
       }

--- a/packages/sql/src/query/QueryBuilder.ts
+++ b/packages/sql/src/query/QueryBuilder.ts
@@ -3938,7 +3938,7 @@ export class QueryBuilder<
     for (const k of Object.keys(cond)) {
       if (Utils.isOperator(k)) {
         if (Array.isArray(cond[k])) {
-          // a partial `$or` on a to-one join drops rows matching a sibling branch, but entity filters have no other sink, so they must pass
+          // a partial `$or` on a join drops rows matching a sibling branch, but entity filters have no other sink, so they must pass
           if (k === '$or' && !filter && !this.canDistributeOrBranches(cond[k], joins)) {
             continue;
           }
@@ -3981,10 +3981,10 @@ export class QueryBuilder<
   }
 
   /**
-   * `$or` branches can be moved to a to-one join's `on` clause only when they all target that same
-   * join and stay flat — a partial `$or` in the `on` clause would drop rows matching a sibling
-   * branch. A `$or` targeting only to-many joins keeps the partial distribution, as that is how
-   * `PopulateHint.INFER` narrows collections.
+   * `$or` branches can be moved to a join's `on` clause only when they all target that same join
+   * and stay flat — a partial `$or` in the `on` clause would drop rows matching a sibling branch,
+   * and nested operators cannot be preserved inside a distributed disjunction, as `mergeOnConditions`
+   * would flatten them into `and` conjuncts.
    */
   private canDistributeOrBranches(branches: Dictionary[], joins: JoinOptions[]): boolean {
     const aliases = new Set<string>();
@@ -3999,14 +3999,9 @@ export class QueryBuilder<
     };
     branches.forEach(collectAliases);
     const targeted = joins.filter(j => aliases.has(j.alias));
-    // nested operators cannot be preserved inside a distributed disjunction, `mergeOnConditions` would flatten them into `and` conjuncts
     const flat = branches.every(branch => Object.keys(branch).every(k => !Utils.isOperator(k)));
 
-    if (aliases.size === 1 && targeted.length === 1 && flat) {
-      return true;
-    }
-
-    return !targeted.some(j => [ReferenceKind.ONE_TO_ONE, ReferenceKind.MANY_TO_ONE].includes(j.prop.kind));
+    return aliases.size === 1 && targeted.length === 1 && flat;
   }
 
   /**

--- a/tests/issues/GH1882.test.ts
+++ b/tests/issues/GH1882.test.ts
@@ -69,9 +69,8 @@ describe('GH issue 1882', () => {
     expect(mock.mock.calls[0][0]).toMatch(
       'select `f0`.* from `foo` as `f0` left join `bar` as `b1` on `f0`.`id` = `b1`.`foo_id` where (`b1`.`id` = ? or `f0`.`name` = ?)',
     );
-    expect(mock.mock.calls[1][0]).toMatch(
-      'select `b0`.* from `bar` as `b0` where `b0`.`foo_id` in (?) and `b0`.`id` = ?',
-    );
+    // one branch of the `$or` names a root property, so the collection cannot be narrowed by the other branch
+    expect(mock.mock.calls[1][0]).toMatch('select `b0`.* from `bar` as `b0` where `b0`.`foo_id` in (?)');
     mock.mockReset();
 
     await orm.em.fork().find(Foo, cond, { populate: ['barItems'], strategy: 'select-in' });
@@ -136,11 +135,12 @@ describe('GH issue 1882', () => {
     await orm.em
       .fork()
       .find(Foo, cond, { populate: ['barItems'], populateWhere: PopulateHint.INFER, strategy: 'joined' });
+    // one branch of the `$or` names a root property, so it must not be repeated in the join `on` clause
     expect(mock.mock.calls[0][0]).toMatch(
       'select `f0`.*, ' +
         '`b1`.`id` as `b1__id`, `b1`.`foo_id` as `b1__foo_id`, `b1`.`name` as `b1__name` ' +
         'from `foo` as `f0` ' +
-        'left join `bar` as `b1` on `f0`.`id` = `b1`.`foo_id` and `b1`.`id` = ? ' +
+        'left join `bar` as `b1` on `f0`.`id` = `b1`.`foo_id` ' +
         'where (`b1`.`id` = ? or `f0`.`name` = ?)',
     );
     mock.mockReset();

--- a/tests/issues/GH8180.test.ts
+++ b/tests/issues/GH8180.test.ts
@@ -1,0 +1,135 @@
+import { Collection, MikroORM, PopulateHint, Ref } from '@mikro-orm/sqlite';
+import {
+  Entity,
+  ManyToOne,
+  OneToMany,
+  PrimaryKey,
+  Property,
+  ReflectMetadataProvider,
+} from '@mikro-orm/decorators/legacy';
+import { mockLogger } from '../helpers.js';
+
+@Entity()
+class Author {
+  @PrimaryKey()
+  id!: number;
+
+  @OneToMany(() => Book, b => b.author)
+  books = new Collection<Book>(this);
+}
+
+@Entity()
+class Book {
+  @PrimaryKey()
+  id!: number;
+
+  @ManyToOne(() => Author, { ref: true, nullable: true })
+  author?: Ref<Author>;
+
+  @OneToMany(() => Review, r => r.book)
+  reviews = new Collection<Review>(this);
+}
+
+@Entity()
+class Review {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  rating!: number;
+
+  @ManyToOne(() => Book, { ref: true })
+  book!: Ref<Book>;
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    entities: [Author, Book, Review],
+    dbName: ':memory:',
+    metadataProvider: ReflectMetadataProvider,
+  });
+  await orm.schema.refresh();
+
+  const em = orm.em.fork();
+  await em.insertMany(Author, [{ id: 1 }, { id: 2 }, { id: 3 }]);
+  await em.insertMany(Book, [
+    { id: 100, author: 3 },
+    { id: 101, author: 2 },
+  ]);
+  // book 100 is matched by the `reviews` branch, book 101 by the `author` branch only
+  await em.insertMany(Review, [
+    { id: 1000, rating: 5, book: 100 },
+    { id: 1002, rating: 1, book: 101 },
+  ]);
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+test('populate where with `$or` keeps the disjunction when loading a nested to-many relation', async () => {
+  const em = orm.em.fork();
+  const authors = await em.find(Author, {}, { orderBy: { id: 'asc' } });
+  const mock = mockLogger(orm);
+
+  await em.populate(authors, ['books.reviews'], {
+    strategy: 'select-in',
+    where: {
+      books: {
+        $or: [{ reviews: { rating: 5 } }, { author: { $in: [2] } }],
+      },
+    },
+  });
+
+  const queries: string[] = mock.mock.calls.map(call => call[0]);
+  const bookQuery = queries.find(query => query.includes('from `book`'))!;
+  const reviewQuery = queries.find(query => query.includes('from `review`'))!;
+
+  // the collection query keeps both branches of the disjunction
+  expect(bookQuery).toMatch(/`r1`\.`rating` = 5 or `b0`\.`author_id` in \(2\)/);
+  expect(authors.map(author => author.books.getIdentifiers())).toEqual([[], [101], [100]]);
+
+  // the nested populate must not apply one branch of the `$or` on its own
+  expect(reviewQuery).not.toMatch(/`rating` = 5/);
+  const books = authors.flatMap(author => author.books.getItems());
+  expect(books.map(book => [book.id, book.reviews.getIdentifiers()])).toEqual([
+    [101, [1002]],
+    [100, [1000]],
+  ]);
+});
+
+test('find with an inferred `$or` on a to-many relation does not narrow the collection by one branch', async () => {
+  const em = orm.em.fork();
+  const mock = mockLogger(orm);
+
+  const authors = await em.find(
+    Author,
+    { $or: [{ books: { author: { $in: [2] } } }, { id: 3 }] },
+    { populate: ['books'], populateWhere: PopulateHint.INFER, strategy: 'select-in', orderBy: { id: 'asc' } },
+  );
+
+  // author 3 matched via the `id` branch only, its collection must stay complete
+  expect(authors.map(author => author.books.getIdentifiers())).toEqual([[101], [100]]);
+
+  const queries: string[] = mock.mock.calls.map(call => call[0]);
+  const bookQuery = queries.find(query => query.includes('from `book` as `b0`'))!;
+  expect(bookQuery).not.toMatch(/`author_id` in \(2\)/);
+});
+
+test('joined strategy with an inferred `$or` on a to-many relation does not narrow the collection by one branch', async () => {
+  const em = orm.em.fork();
+  const mock = mockLogger(orm);
+
+  const authors = await em.find(
+    Author,
+    { $or: [{ books: { author: { $in: [2] } } }, { id: 3 }] },
+    { populate: ['books'], populateWhere: PopulateHint.INFER, strategy: 'joined', orderBy: { id: 'asc' } },
+  );
+
+  expect(authors.map(author => author.books.getIdentifiers())).toEqual([[101], [100]]);
+
+  const queries: string[] = mock.mock.calls.map(call => call[0]);
+  expect(queries[0]).not.toMatch(/on `a0`\.`id` = `b1`\.`author_id` and /);
+});


### PR DESCRIPTION
#8176 stopped partial `$or` extraction for to-one relations, but to-many relations kept the old behavior: `EntityLoader.extractChildCondition` extracted only the branches naming the relation and applied them to the nested query, and `QueryBuilder.canDistributeOrBranches` still allowed partial distribution into a to-many join's `on` clause. A parent row that matched the `$or` through a sibling branch then had its collection narrowed, or emptied, by a branch it never matched.

Both sites now apply the same rule regardless of relation kind: an `$or` is only extracted/distributed when every branch names the relation. The `GH1882` expectations for a mixed `$or` under `PopulateHint.INFER` change accordingly, since narrowing the collection by the single surviving branch was unsound.

Closes #8180
