### PR TITLE
fix(query-builder): keep filter `$or` intact when it spans joined to-one relations

### DIFF
--- a/packages/sql/src/query/QueryBuilder.ts
+++ b/packages/sql/src/query/QueryBuilder.ts
@@ -3938,8 +3938,12 @@ export class QueryBuilder<
     for (const k of Object.keys(cond)) {
       if (Utils.isOperator(k)) {
         if (Array.isArray(cond[k])) {
-          // a partial `$or` on a join drops rows matching a sibling branch, but entity filters have no other sink, so they must pass
-          if (k === '$or' && !filter && !this.canDistributeOrBranches(cond[k], joins)) {
+          if (k === '$or' && !this.canDistributeOrBranches(cond[k], joins)) {
+            // entity filters have no other sink, so their `$or` is kept intact on the outermost targeted join instead
+            if (filter) {
+              this.mergeFilterOrCondition(cond[k], joins);
+            }
+
             continue;
           }
 
@@ -3987,6 +3991,14 @@ export class QueryBuilder<
    * would flatten them into `and` conjuncts.
    */
   private canDistributeOrBranches(branches: Dictionary[], joins: JoinOptions[]): boolean {
+    const aliases = this.getOrBranchAliases(branches);
+    const targeted = joins.filter(j => aliases.has(j.alias));
+    const flat = branches.every(branch => Object.keys(branch).every(k => !Utils.isOperator(k)));
+
+    return aliases.size === 1 && targeted.length === 1 && flat;
+  }
+
+  private getOrBranchAliases(branches: Dictionary[]): Set<string> {
     const aliases = new Set<string>();
     const collectAliases = (cond: Dictionary) => {
       for (const k of Object.keys(cond)) {
@@ -3998,10 +4010,43 @@ export class QueryBuilder<
       }
     };
     branches.forEach(collectAliases);
-    const targeted = joins.filter(j => aliases.has(j.alias));
-    const flat = branches.every(branch => Object.keys(branch).every(k => !Utils.isOperator(k)));
 
-    return aliases.size === 1 && targeted.length === 1 && flat;
+    return aliases;
+  }
+
+  /**
+   * An entity filter's `$or` that cannot be distributed is applied intact to the `on` clause of the
+   * outermost join common to all targeted joins, nesting the targeted joins under it so the clause
+   * can reference their aliases.
+   */
+  private mergeFilterOrCondition(branches: Dictionary[], joins: JoinOptions[]): void {
+    const aliases = this.getOrBranchAliases(branches);
+    const chainOf = (join: JoinOptions): JoinOptions[] => {
+      const parent = joins.find(j => j.alias === join.ownerAlias);
+      return parent ? [join, ...chainOf(parent)] : [join];
+    };
+    // chains go from each targeted join up to its root, so the first join present in all of them is the outermost common one
+    const chains = joins.filter(j => aliases.has(j.alias)).map(chainOf);
+    const anchor = chains[0]?.find(a => chains.every(chain => chain.includes(a)));
+
+    /* v8 ignore next 3 */
+    if (!anchor) {
+      return;
+    }
+
+    for (const chain of chains) {
+      // nest the chain below the anchor, so the anchor's `on` clause can reference the nested aliases
+      for (let i = 0; chain[i] !== anchor; i++) {
+        const nested = (chain[i + 1].nested ??= new Set());
+
+        if (!nested.has(chain[i])) {
+          chain[i].type = chain[i].type === JoinType.innerJoin ? JoinType.nestedInnerJoin : JoinType.nestedLeftJoin;
+          nested.add(chain[i]);
+        }
+      }
+    }
+
+    anchor.cond = anchor.cond.$or ? { $and: [anchor.cond, { $or: branches }] } : { ...anchor.cond, $or: branches };
   }
 
   /**

--- a/tests/features/filters/filter-or-condition-on-populated-relation.test.ts
+++ b/tests/features/filters/filter-or-condition-on-populated-relation.test.ts
@@ -73,10 +73,7 @@ afterAll(async () => {
 test('filter with `$or` spanning a to-one relation is not bypassed on joined populate', async () => {
   const em = orm.em.fork();
   const authors = await em.find(Author, {}, { populate: ['books'], strategy: 'joined' });
-  const ids = authors[0].books.getIdentifiers();
-
-  // joined strategy splits the branches into separate `on` clauses and drops books 100/101 too (pre-existing), so only the safety property holds: 102 matches no branch
-  expect(ids).not.toContain(102);
+  expect(authors[0].books.getIdentifiers().sort()).toEqual([100, 101]);
 });
 
 test('filter with `$or` spanning a to-one relation applies on select-in populate', async () => {

--- a/tests/features/filters/filter-or-condition-spanning-join-aliases.test.ts
+++ b/tests/features/filters/filter-or-condition-spanning-join-aliases.test.ts
@@ -1,0 +1,118 @@
+import { MikroORM, Ref } from '@mikro-orm/sqlite';
+import { Entity, Filter, ManyToOne, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+
+@Entity()
+class Country {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  code!: string;
+}
+
+@Entity()
+class Owner {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+}
+
+// `sibling` spans two to-one relations, so the disjunction anchors on their common parent join;
+// the first `$or` of `stacked` targets only the publisher alias and is distributed into its `on`
+// clause, the second spans the country join and must be attached intact on top of it
+@Entity()
+@Filter({ name: 'sibling', cond: { $or: [{ country: { code: 'DE' } }, { owner: { name: 'boss' } }] } })
+@Filter({
+  name: 'stacked',
+  cond: {
+    $and: [{ $or: [{ open: true }, { active: true }] }, { $or: [{ open: true }, { country: { code: 'DE' } }] }],
+  },
+})
+class Publisher {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  open!: boolean;
+
+  @Property()
+  active!: boolean;
+
+  @ManyToOne(() => Country, { ref: true, nullable: true })
+  country?: Ref<Country>;
+
+  @ManyToOne(() => Owner, { ref: true })
+  owner!: Ref<Owner>;
+}
+
+@Entity()
+class Book {
+  @PrimaryKey()
+  id!: number;
+
+  @ManyToOne(() => Publisher, { ref: true })
+  publisher!: Ref<Publisher>;
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    entities: [Country, Owner, Publisher, Book],
+    dbName: ':memory:',
+    metadataProvider: ReflectMetadataProvider,
+  });
+  await orm.schema.refresh();
+
+  const em = orm.em.fork();
+  await em.insertMany(Country, [
+    { id: 1, code: 'DE' },
+    { id: 2, code: 'FR' },
+  ]);
+  await em.insertMany(Owner, [
+    { id: 1, name: 'boss' },
+    { id: 2, name: 'other' },
+  ]);
+  await em.insertMany(Publisher, [
+    { id: 10, open: false, active: true, country: 1, owner: 2 },
+    { id: 11, open: true, active: false, country: 2, owner: 1 },
+    { id: 12, open: false, active: true, country: null, owner: 1 },
+    { id: 13, open: false, active: false, country: 2, owner: 2 },
+  ]);
+  await em.insertMany(Book, [
+    { id: 100, publisher: 10 },
+    { id: 101, publisher: 11 },
+    { id: 102, publisher: 12 },
+    { id: 103, publisher: 13 },
+  ]);
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+test('filter `$or` spanning two sibling to-one relations stays a disjunction on joined populate', async () => {
+  const em = orm.em.fork();
+  const books = await em.find(
+    Book,
+    {},
+    { populate: ['publisher'], strategy: 'joined', filters: ['sibling'], orderBy: { id: 'asc' } },
+  );
+
+  // 10 passes via `country.code`, 11 via `owner.name`, 12 via `owner.name` despite missing country
+  expect(books.map(b => b.id)).toEqual([100, 101, 102]);
+});
+
+test('both `$or` conditions of a filter apply on joined populate', async () => {
+  const em = orm.em.fork();
+  const books = await em.find(
+    Book,
+    {},
+    { populate: ['publisher'], strategy: 'joined', filters: ['stacked'], orderBy: { id: 'asc' } },
+  );
+
+  // 10 passes via `active` + `country.code`, 11 via `open`, 12 fails the second `$or`, 13 the first
+  expect(books.map(b => b.id)).toEqual([100, 101]);
+});

--- a/tests/issues/GH8179.test.ts
+++ b/tests/issues/GH8179.test.ts
@@ -1,0 +1,71 @@
+import { MikroORM, Ref } from '@mikro-orm/sqlite';
+import { Entity, Filter, ManyToOne, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+
+@Entity()
+class Country {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  code!: string;
+}
+
+@Entity()
+@Filter({ name: 'visible', cond: { $or: [{ open: true }, { country: { code: 'DE' } }] }, default: true })
+class Publisher {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  open!: boolean;
+
+  @ManyToOne(() => Country, { ref: true })
+  country!: Ref<Country>;
+}
+
+@Entity()
+class Book {
+  @PrimaryKey()
+  id!: number;
+
+  @ManyToOne(() => Publisher, { ref: true })
+  publisher!: Ref<Publisher>;
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    entities: [Country, Publisher, Book],
+    dbName: ':memory:',
+    metadataProvider: ReflectMetadataProvider,
+  });
+  await orm.schema.refresh();
+
+  const em = orm.em.fork();
+  await em.insertMany(Country, [
+    { id: 1, code: 'DE' },
+    { id: 2, code: 'FR' },
+  ]);
+  await em.insertMany(Publisher, [
+    { id: 10, open: true, country: 2 }, // passes via `open`
+    { id: 11, open: false, country: 1 }, // passes via `country.code`
+    { id: 12, open: false, country: 2 }, // passes neither
+  ]);
+  await em.insertMany(Book, [
+    { id: 100, publisher: 10 },
+    { id: 101, publisher: 11 },
+    { id: 102, publisher: 12 },
+  ]);
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+test('filter `$or` spanning a joined to-one stays a disjunction (GH #8179)', async () => {
+  const em = orm.em.fork();
+  const books = await em.find(Book, {}, { populate: ['publisher'], strategy: 'joined', orderBy: { id: 'asc' } });
+
+  expect(books.map(b => b.id)).toEqual([100, 101]);
+});


### PR DESCRIPTION
An entity filter whose `cond` contains a `$or` with branches targeting different join aliases had each branch merged into its own join's `on` clause. Separate `on` clauses are ANDed by the query, so the disjunction became a conjunction and only rows matching every branch survived. The reproduction in the issue returned no rows at all.

Such a `$or` is now applied intact to the `on` clause of the outermost join common to all targeted joins, and the other targeted joins are nested under it so the clause can reference their aliases (the same nested-join mechanism #8176 uses). This also lifts the joined-strategy limitation documented in the test added by #8176.

Closes #8179
