### PR TITLE
fix(core): respect `connectionType` option in `em.countBy()`

### DIFF
--- a/packages/core/src/drivers/IDatabaseDriver.ts
+++ b/packages/core/src/drivers/IDatabaseDriver.ts
@@ -528,6 +528,7 @@ export interface CountByOptions<T extends object> {
   filters?: FilterOptions;
   having?: FilterQuery<T>;
   schema?: string;
+  connectionType?: ConnectionType;
   flushMode?: FlushMode | `${FlushMode}`;
   loggerContext?: LogContext;
   logging?: LoggingOptions;

--- a/packages/sql/src/SqlEntityManager.ts
+++ b/packages/sql/src/SqlEntityManager.ts
@@ -192,7 +192,9 @@ export class SqlEntityManager<Driver extends AbstractSqlDriver = AbstractSqlDriv
     await em.tryFlush(entityName, options);
     const where = await em.processWhere(entityName, rawWhere ?? ({} as FilterQuery<Entity>), options as any, 'read');
 
-    const qb = em.createQueryBuilder(meta.class);
+    // match `em.count()` semantics: an active transaction always wins over the requested connection type
+    const connectionType = em.getTransactionContext() ? 'write' : options.connectionType;
+    const qb = em.createQueryBuilder(meta.class, undefined, connectionType);
 
     (qb as any)
       .select([...fields, raw('count(*) as cnt')])

--- a/tests/features/read-replicas.test.ts
+++ b/tests/features/read-replicas.test.ts
@@ -136,6 +136,33 @@ describe('read-replicas', () => {
       expect(mock.mock.calls[8][0]).toMatch(/select.*via write connection '127\.0\.0\.1'/);
     });
 
+    test('can explicitly set connection type for countBy operations', async () => {
+      const mock = mockLogger(orm, ['query']);
+      const author = new Author2('Jon Snow', 'snow@wall.st');
+      author.born = '1990-03-23';
+      author.books.add(new Book2('B', author));
+      await orm.em.persist(author).flush();
+
+      // defaults to read
+      await orm.em.countBy(Author2, 'termsAccepted');
+      expect(mock.mock.calls[4][0]).toMatch(/via read connection 'read-.*'/);
+
+      // explicitly set to read
+      await orm.em.countBy(Author2, 'termsAccepted', { connectionType: 'read' });
+      expect(mock.mock.calls[5][0]).toMatch(/via read connection 'read-.*'/);
+
+      // explicitly set to write
+      await orm.em.countBy(Author2, 'termsAccepted', { connectionType: 'write' });
+      expect(mock.mock.calls[6][0]).toMatch(/via write connection '127\.0\.0\.1'/);
+
+      // when running in a transaction will always use a write connection
+      await orm.em.transactional(async em => {
+        return em.countBy(Author2, 'termsAccepted', { connectionType: 'read' });
+      });
+      expect(mock.mock.calls[7][0]).toMatch(/begin.*via write connection '127\.0\.0\.1'/);
+      expect(mock.mock.calls[8][0]).toMatch(/select.*via write connection '127\.0\.0\.1'/);
+    });
+
     test('use write connection for fetching data after upsert/upsertMany', async () => {
       const mock = mockLogger(orm, ['query']);
       await orm.em.upsert(Author2, { name: 'Jon Snow', email: 'snow@wall.st', born: '1990-03-23' });
@@ -264,6 +291,35 @@ describe('read-replicas', () => {
       // when running in a transaction will always use a write connection
       await orm.em.transactional(async em => {
         return em.count(Author2, {}, { connectionType: 'read' });
+      });
+      expect(mock.mock.calls[7][0]).toMatch(/begin.*via write connection '127\.0\.0\.1'/);
+      expect(mock.mock.calls[8][0]).toMatch(/select.*via write connection '127\.0\.0\.1'/);
+    });
+
+    test('can explicitly set connection type for countBy operations', async () => {
+      orm.config.set('preferReadReplicas', false);
+
+      const mock = mockLogger(orm, ['query']);
+      const author = new Author2('Jon Snow', 'snow@wall.st');
+      author.born = '1990-03-23';
+      author.books.add(new Book2('B', author));
+      await orm.em.persist(author).flush();
+
+      // defaults to write
+      await orm.em.countBy(Author2, 'termsAccepted');
+      expect(mock.mock.calls[4][0]).toMatch(/via write connection '127\.0\.0\.1'/);
+
+      // explicitly set to read
+      await orm.em.countBy(Author2, 'termsAccepted', { connectionType: 'read' });
+      expect(mock.mock.calls[5][0]).toMatch(/via read connection 'read-.*'/);
+
+      // explicitly set to write
+      await orm.em.countBy(Author2, 'termsAccepted', { connectionType: 'write' });
+      expect(mock.mock.calls[6][0]).toMatch(/via write connection '127\.0\.0\.1'/);
+
+      // when running in a transaction will always use a write connection
+      await orm.em.transactional(async em => {
+        return em.countBy(Author2, 'termsAccepted', { connectionType: 'read' });
       });
       expect(mock.mock.calls[7][0]).toMatch(/begin.*via write connection '127\.0\.0\.1'/);
       expect(mock.mock.calls[8][0]).toMatch(/select.*via write connection '127\.0\.0\.1'/);


### PR DESCRIPTION
`CountByOptions` was the only query-options interface without `connectionType`, and `countBy()` created its internal query builder without one, so grouped counts always used the default routing and could not opt in or out of read replicas per call.

This adds `connectionType` to `CountByOptions` and passes it through to the query builder. An active transaction still forces the write connection, same as `em.count()`. That override has to be explicit here, because a QB with an explicit `read` type would otherwise honor it even inside a transaction.

Closes #8187
