### PR TITLE
fix(sql): convert custom type values in kysely where clauses

### DIFF
--- a/packages/sql/src/plugin/transformer.ts
+++ b/packages/sql/src/plugin/transformer.ts
@@ -631,22 +631,13 @@ export class MikroTransformer extends OperationNodeTransformer {
 
   /** Resolve the entity property a comparison's left operand refers to, so its value operand can be converted. */
   resolveOperandProperty(operand: OperationNode): { prop: EntityProperty; fieldName: string } | undefined {
-    let column: ColumnNode | undefined;
-    let tableName: string | undefined;
-
-    if (ReferenceNode.is(operand) && ColumnNode.is(operand.column)) {
-      column = operand.column;
-      tableName = operand.table ? this.getTableName(operand.table) : undefined;
-    } else if (ColumnNode.is(operand)) {
-      column = operand;
-    }
-
-    if (!column) {
+    if (!ReferenceNode.is(operand) || !ColumnNode.is(operand.column)) {
       return undefined;
     }
 
+    const tableName = operand.table ? this.getTableName(operand.table) : undefined;
     const meta = this.findOwnerMeta(tableName);
-    const fieldName = this.normalizeColumnName(column.column);
+    const fieldName = this.normalizeColumnName(operand.column.column);
     const prop = this.findProperty(meta, fieldName);
 
     return prop ? { prop, fieldName } : undefined;

--- a/packages/sql/src/plugin/transformer.ts
+++ b/packages/sql/src/plugin/transformer.ts
@@ -8,6 +8,7 @@ import {
   isRaw,
 } from '@mikro-orm/core';
 import {
+  type BinaryOperationNode,
   type CommonTableExpressionNameNode,
   type DeleteQueryNode,
   type InsertQueryNode,
@@ -575,6 +576,82 @@ export class MikroTransformer extends OperationNodeTransformer {
     };
   }
 
+  override transformBinaryOperation(node: BinaryOperationNode, queryId: QueryId): BinaryOperationNode {
+    const transformed = super.transformBinaryOperation(node, queryId);
+
+    if (!this.#options.convertValues) {
+      return transformed;
+    }
+
+    const resolved = this.resolveOperandProperty(transformed.leftOperand);
+
+    if (!resolved) {
+      return transformed;
+    }
+
+    const { prop, fieldName } = resolved;
+    const right = transformed.rightOperand;
+
+    if (ValueNode.is(right)) {
+      const converted = this.processInputValueNode(prop, fieldName, right);
+      return converted === right ? transformed : { ...transformed, rightOperand: converted };
+    }
+
+    if (PrimitiveValueListNode.is(right)) {
+      // upgrade to ValueListNode when the type needs SQL-side wrapping, since
+      // PrimitiveValueListNode can only hold primitives
+      if (prop.hasConvertToDatabaseValueSQL) {
+        const values = right.values.map(value => this.processInputValueNode(prop, fieldName, ValueNode.create(value)));
+        return { ...transformed, rightOperand: ValueListNode.create(values) };
+      }
+
+      const values = right.values.map(value => this.prepareInputValue(prop, value, true));
+      return values.every((value, idx) => value === right.values[idx])
+        ? transformed
+        : { ...transformed, rightOperand: PrimitiveValueListNode.create(values) };
+    }
+
+    if (ValueListNode.is(right)) {
+      let changed = false;
+      const values = right.values.map(valueNode => {
+        if (!ValueNode.is(valueNode)) {
+          return valueNode;
+        }
+        const converted = this.processInputValueNode(prop, fieldName, valueNode);
+        if (converted !== valueNode) {
+          changed = true;
+        }
+        return converted;
+      });
+      return changed ? { ...transformed, rightOperand: ValueListNode.create(values) } : transformed;
+    }
+
+    return transformed;
+  }
+
+  /** Resolve the entity property a comparison's left operand refers to, so its value operand can be converted. */
+  resolveOperandProperty(operand: OperationNode): { prop: EntityProperty; fieldName: string } | undefined {
+    let column: ColumnNode | undefined;
+    let tableName: string | undefined;
+
+    if (ReferenceNode.is(operand) && ColumnNode.is(operand.column)) {
+      column = operand.column;
+      tableName = operand.table ? this.getTableName(operand.table) : undefined;
+    } else if (ColumnNode.is(operand)) {
+      column = operand;
+    }
+
+    if (!column) {
+      return undefined;
+    }
+
+    const meta = this.findOwnerMeta(tableName);
+    const fieldName = this.normalizeColumnName(column.column);
+    const prop = this.findProperty(meta, fieldName);
+
+    return prop ? { prop, fieldName } : undefined;
+  }
+
   processInputValueNode(
     prop: EntityProperty | undefined,
     fieldName: string | undefined,
@@ -692,8 +769,15 @@ export class MikroTransformer extends OperationNodeTransformer {
     if (name) {
       return this.lookupInContextStack(name) ?? this.#subqueryAliasMap.get(name) ?? this.findEntityMetadata(name);
     }
+    // the stack can be empty when transforming a raw root node with embedded expressions
+    const context = this.#contextStack[this.#contextStack.length - 1];
+
+    if (!context) {
+      return undefined;
+    }
+
     let single: EntityMetadata | undefined;
-    for (const meta of this.#contextStack[this.#contextStack.length - 1].values()) {
+    for (const meta of context.values()) {
       if (!meta) {
         continue;
       }

--- a/tests/features/kysely-convert-values-where-clause.test.ts
+++ b/tests/features/kysely-convert-values-where-clause.test.ts
@@ -1,6 +1,6 @@
 import { defineEntity, p, Type } from '@mikro-orm/core';
 import { MikroORM } from '@mikro-orm/sqlite';
-import { sql } from 'kysely';
+import { expressionBuilder, sql } from 'kysely';
 
 class Email {
   constructor(readonly value: string) {}
@@ -154,6 +154,41 @@ test('where clause values on aliased tables are converted', async () => {
 test('raw root query with embedded comparison does not crash', async () => {
   const res = await sql`select * from user where ${sql.ref('email')} = ${'nobody@example.com'}`.execute(getKysely());
   expect(res.rows).toEqual([]);
+
+  // embedded binary operation reaches the transformer with an empty context stack
+  const eb = expressionBuilder<{ User: UserTable }, 'User'>();
+  const res2 = await sql`select * from user where ${eb('name', '=', 'Nobody')}`.execute(getKysely());
+  expect(res2.rows).toEqual([]);
+});
+
+test('non-column left operands are left alone', async () => {
+  const user = await getKysely()
+    .selectFrom('User')
+    .select(['name'])
+    .where(sql<string>`lower(email)`, '=', 'foo@example.com')
+    .executeTakeFirstOrThrow();
+
+  expect(user.name).toBe('Foo');
+});
+
+test('`in` list values are wrapped with convertToDatabaseValueSQL', async () => {
+  const query = getKysely().selectFrom('User').select(['name']).where('secret', 'in', ['foo secret', 'bar secret']);
+
+  expect(query.compile().sql).toBe('select "name" from "user" where "secret" in (unhex(?), unhex(?))');
+
+  const users = await query.execute();
+  expect(users.map(u => u.name).sort()).toEqual(['Bar', 'Foo']);
+});
+
+test('`in` list mixing values and expressions converts only the values', async () => {
+  const users = await getKysely()
+    .selectFrom('User')
+    .select(['name'])
+    .where('email', 'in', [new Email('foo@example.com'), sql<Email>`${'bar@example.com'}`])
+    .orderBy('id')
+    .execute();
+
+  expect(users.map(u => u.name)).toEqual(['Foo', 'Bar']);
 });
 
 test('where clause values are wrapped with convertToDatabaseValueSQL', async () => {

--- a/tests/features/kysely-convert-values-where-clause.test.ts
+++ b/tests/features/kysely-convert-values-where-clause.test.ts
@@ -1,0 +1,166 @@
+import { defineEntity, p, Type } from '@mikro-orm/core';
+import { MikroORM } from '@mikro-orm/sqlite';
+import { sql } from 'kysely';
+
+class Email {
+  constructor(readonly value: string) {}
+
+  toString(): string {
+    return this.value;
+  }
+}
+
+class EmailType extends Type<Email, string> {
+  override convertToDatabaseValue(value: Email | string): string {
+    return value instanceof Email ? value.value : value;
+  }
+
+  override convertToJSValue(value: string): Email {
+    return new Email(value);
+  }
+
+  override getColumnType(): string {
+    return 'varchar(255)';
+  }
+}
+
+class HexEncodedType extends Type<string | null, string | null> {
+  override convertToJSValueSQL(key: string): string {
+    return `hex(${key})`;
+  }
+
+  override convertToJSValue(value: string | null): string | null {
+    return value == null ? value : Buffer.from(value, 'hex').toString('utf8');
+  }
+
+  override convertToDatabaseValueSQL(key: string): string {
+    return `unhex(${key})`;
+  }
+
+  override convertToDatabaseValue(value: string | null): string | null {
+    return value == null ? value : Buffer.from(value, 'utf8').toString('hex');
+  }
+}
+
+const User = defineEntity({
+  name: 'User',
+  properties: {
+    id: p.integer().primary().autoincrement(),
+    name: p.string(),
+    email: p.type(EmailType),
+    secret: p.type(HexEncodedType).nullable(),
+  },
+});
+
+interface UserTable {
+  id: number;
+  name: string;
+  email: Email;
+  secret: string | null;
+}
+
+let orm: MikroORM;
+
+const options = {
+  tableNamingStrategy: 'entity',
+  convertValues: true,
+} as const;
+
+function getKysely() {
+  return orm.em.getKysely<{ User: UserTable }>(options);
+}
+
+beforeAll(async () => {
+  orm = new MikroORM({
+    entities: [User],
+    dbName: ':memory:',
+  });
+  await orm.schema.refresh();
+
+  await getKysely()
+    .insertInto('User')
+    .values([
+      { id: 1, name: 'Foo', email: new Email('foo@example.com'), secret: 'foo secret' },
+      { id: 2, name: 'Bar', email: new Email('bar@example.com'), secret: 'bar secret' },
+    ])
+    .execute();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+test('custom type values in where clause are converted to database values', async () => {
+  const user = await getKysely()
+    .selectFrom('User')
+    .selectAll()
+    .where('email', '=', new Email('foo@example.com'))
+    .executeTakeFirstOrThrow();
+
+  expect(user.name).toBe('Foo');
+  expect(user.email).toBeInstanceOf(Email);
+  expect(user.email.value).toBe('foo@example.com');
+});
+
+test('custom type values in `in` list are converted to database values', async () => {
+  const users = await getKysely()
+    .selectFrom('User')
+    .selectAll()
+    .where('email', 'in', [new Email('foo@example.com'), new Email('bar@example.com')])
+    .orderBy('id')
+    .execute();
+
+  expect(users.map(u => u.name)).toEqual(['Foo', 'Bar']);
+});
+
+test('custom type values in update/delete where clauses are converted', async () => {
+  await getKysely()
+    .insertInto('User')
+    .values([{ id: 3, name: 'Baz', email: new Email('baz@example.com'), secret: null }])
+    .execute();
+
+  await getKysely()
+    .updateTable('User')
+    .set({ name: 'Baz 2' })
+    .where('email', '=', new Email('baz@example.com'))
+    .execute();
+
+  const user = await getKysely()
+    .selectFrom('User')
+    .select(['name'])
+    .where('email', '=', new Email('baz@example.com'))
+    .executeTakeFirstOrThrow();
+  expect(user.name).toBe('Baz 2');
+
+  await getKysely().deleteFrom('User').where('email', '=', new Email('baz@example.com')).execute();
+
+  const count = await getKysely()
+    .selectFrom('User')
+    .select(eb => eb.fn.countAll().as('count'))
+    .executeTakeFirstOrThrow();
+  expect(Number(count.count)).toBe(2);
+});
+
+test('where clause values on aliased tables are converted', async () => {
+  const user = await getKysely()
+    .selectFrom('User as u')
+    .selectAll()
+    .where('u.email', '=', new Email('foo@example.com'))
+    .executeTakeFirstOrThrow();
+
+  expect(user.name).toBe('Foo');
+});
+
+test('raw root query with embedded comparison does not crash', async () => {
+  const res = await sql`select * from user where ${sql.ref('email')} = ${'nobody@example.com'}`.execute(getKysely());
+  expect(res.rows).toEqual([]);
+});
+
+test('where clause values are wrapped with convertToDatabaseValueSQL', async () => {
+  const query = getKysely().selectFrom('User').select(['name']).where('secret', '=', 'foo secret');
+
+  expect(query.compile().sql).toBe('select "name" from "user" where "secret" = unhex(?)');
+
+  const user = await query.executeTakeFirstOrThrow();
+  expect(user.name).toBe('Foo');
+});


### PR DESCRIPTION
With `convertValues: true`, the kysely plugin converted custom type values in `insertInto().values()` and `updateTable().set()`, but not in where clauses. Passing a custom type's runtime value (e.g. a value object) to `.where()` failed when the driver tried to bind it, even though the types allow it.

The transformer now converts comparison operands too: it resolves the entity property from the left operand (a plain or table-qualified column) and runs the right operand through the same conversion as insert/update values, including `convertToDatabaseValueSQL` wrapping and `in` lists.

Reproduction: https://github.com/mificot/kysely-cutom-types-where-clause
