### PR TITLE
fix(sql): skip trigger diff when only one side uses `expression`

### DIFF
--- a/packages/sql/src/schema/SchemaComparator.ts
+++ b/packages/sql/src/schema/SchemaComparator.ts
@@ -1220,14 +1220,14 @@ export class SchemaComparator {
 
   private diffTrigger(from: SqlTriggerDef, to: SqlTriggerDef): boolean {
     // Raw DDL expression cannot be meaningfully compared to introspected
-    // trigger metadata, so skip diffing when the metadata side uses it.
-    if (to.expression) {
+    // trigger metadata, so skip diffing when either side uses it.
+    if (from.expression || to.expression) {
       // Both sides have expression — compare the raw DDL directly
-      if (from.expression) {
+      if (from.expression && to.expression) {
         return this.diffExpression(from.expression, to.expression);
       }
 
-      // Only metadata side has expression — the raw DDL cannot be compared to
+      // Only one side has expression — the raw DDL cannot be compared to
       // introspected metadata. Changes to the expression value won't be detected;
       // drop and recreate the trigger manually to apply expression changes.
       return false;

--- a/packages/sql/src/schema/SchemaComparator.ts
+++ b/packages/sql/src/schema/SchemaComparator.ts
@@ -1220,7 +1220,7 @@ export class SchemaComparator {
 
   private diffTrigger(from: SqlTriggerDef, to: SqlTriggerDef): boolean {
     // Raw DDL expression cannot be meaningfully compared to introspected
-    // trigger metadata, so skip diffing when either side uses it.
+    // trigger metadata, so it needs special handling when either side uses it.
     if (from.expression || to.expression) {
       // Both sides have expression — compare the raw DDL directly
       if (from.expression && to.expression) {

--- a/tests/features/schema-generator/trigger.postgres.test.ts
+++ b/tests/features/schema-generator/trigger.postgres.test.ts
@@ -265,6 +265,7 @@ execute function "trg_custom_fn"()`,
       },
       name: 'ExprDownTriggerTable',
       tableName: 'expr_down_trigger_table',
+      // fn name follows the `{table}_{trigger}_fn` convention, so introspection reports a body to diff against
       triggers: [
         {
           name: 'trg_custom',

--- a/tests/features/schema-generator/trigger.postgres.test.ts
+++ b/tests/features/schema-generator/trigger.postgres.test.ts
@@ -247,4 +247,50 @@ execute function "trg_custom_fn"()`,
     await orm.schema.dropDatabase();
     await orm.close();
   });
+
+  test('trigger with expression escape hatch is not diffed in the reverse direction [postgres]', async () => {
+    const orm = await initORMPostgreSql();
+    const meta = orm.getMetadata();
+    await orm.schema.update();
+
+    const newTableMeta = new EntitySchema({
+      properties: {
+        id: {
+          primary: true,
+          name: 'id',
+          type: 'number',
+          fieldName: 'id',
+          columnType: 'int',
+        },
+      },
+      name: 'ExprDownTriggerTable',
+      tableName: 'expr_down_trigger_table',
+      triggers: [
+        {
+          name: 'trg_custom',
+          timing: 'after' as const,
+          events: ['insert' as const],
+          expression: `create or replace function "expr_down_trigger_table_trg_custom_fn"() returns trigger as $$
+begin
+  RETURN NEW;
+end;
+$$ language plpgsql;
+create trigger "trg_custom"
+AFTER INSERT on "expr_down_trigger_table"
+for each ROW
+execute function "expr_down_trigger_table_trg_custom_fn"()`,
+        },
+      ],
+    }).init().meta;
+    meta.set(newTableMeta.class, newTableMeta);
+
+    await orm.schema.execute(await orm.schema.getUpdateSchemaSQL({ wrap: false }));
+
+    const migration = await orm.schema.getUpdateSchemaMigrationSQL({ wrap: false });
+    expect(migration.up).toBe('');
+    expect(migration.down).toBe('');
+
+    await orm.schema.dropDatabase();
+    await orm.close();
+  });
 });


### PR DESCRIPTION
`diffTrigger()` only skipped the expression-vs-introspected comparison when the `to` side carried `expression`. Down migrations diff in the reverse direction, so `to` is then the introspected side, which never has `expression`, and the compare fell through to `diffExpression(from.body, to.body)` with `from.body` empty. Every migration generated while an `expression`-form `@Trigger` existed picked up a bogus drop and recreate of that trigger in `down()`, built from introspected metadata that isn't equivalent to the original DDL.

The guard now skips the comparison whenever only one side uses `expression`, in either direction. Routine and index diffing already check both sides, triggers were the one place that didn't.

Closes #8190
