### PR TITLE
fix(core): don't double-wrap `orderBy` in M:N dataloader batch load

### DIFF
--- a/packages/core/src/utils/DataloaderUtils.ts
+++ b/packages/core/src/utils/DataloaderUtils.ts
@@ -237,7 +237,8 @@ export class DataloaderUtils {
         const prop = group[0][0].property;
         const options = {} as Dictionary;
         const wrap = (cond: unknown) => ({ [prop.name]: cond });
-        const orderBy = Utils.asArray(group[0][1]?.orderBy).map(o => wrap(o));
+        // `findChildrenFromPivotTable` expects the `orderBy` relative to the target entity, so no wrapping here
+        const orderBy = Utils.asArray(group[0][1]?.orderBy);
         const populate = wrap(group[0][1]?.populate);
         const owners = group.map(c => c[0].owner);
         const $or: Dictionary[] = [];

--- a/tests/issues/GH8193.test.ts
+++ b/tests/issues/GH8193.test.ts
@@ -1,0 +1,71 @@
+import { DataloaderType, defineEntity, MikroORM, QueryOrder } from '@mikro-orm/sqlite';
+
+const Competency = defineEntity({
+  name: 'Competency',
+  properties: p => ({
+    id: p.integer().primary(),
+    name: p.string(),
+  }),
+  orderBy: {
+    name: QueryOrder.ASC,
+    id: QueryOrder.ASC,
+  },
+});
+
+const Step = defineEntity({
+  name: 'Step',
+  properties: p => ({
+    id: p.integer().primary(),
+    competencies: () => p.manyToMany(Competency).pivotEntity(() => StepCompetency),
+  }),
+});
+
+const StepCompetency = defineEntity({
+  name: 'StepCompetency',
+  properties: p => ({
+    step: () => p.manyToOne(Step).primary(),
+    competency: () => p.manyToOne(Competency).primary(),
+  }),
+});
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    entities: [Step, Competency, StepCompetency],
+    dbName: ':memory:',
+    dataloader: DataloaderType.ALL,
+  });
+  await orm.schema.refresh();
+
+  const em = orm.em.fork();
+  await em.insertMany(Competency, [
+    { id: 1, name: 'b' },
+    { id: 2, name: 'a' },
+    { id: 3, name: 'c' },
+  ]);
+  await em.insert(Step, { id: 1 });
+  await em.insertMany(StepCompetency, [
+    { step: 1, competency: 1 },
+    { step: 1, competency: 2 },
+    { step: 1, competency: 3 },
+  ]);
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+test('M:N loadItems with dataloader respects target entity default orderBy', async () => {
+  const em = orm.em.fork();
+  const step = await em.findOneOrFail(Step, 1);
+  const items = await step.competencies.loadItems();
+  expect(items.map(c => c.id)).toEqual([2, 1, 3]);
+});
+
+test('M:N loadItems with dataloader respects explicit orderBy option', async () => {
+  const em = orm.em.fork();
+  const step = await em.findOneOrFail(Step, 1);
+  const items = await step.competencies.loadItems({ orderBy: { id: QueryOrder.DESC } });
+  expect(items.map(c => c.id)).toEqual([3, 2, 1]);
+});


### PR DESCRIPTION
Loading an uninitialized M:N collection through the dataloader failed with `Trying to order by not existing property` whenever an `orderBy` was in play (target entity default `orderBy`, relation `orderBy`, or the `loadItems()` option).

`Collection.init()` merges those into `options.orderBy` relative to the target entity, but the M:N batch load fn wrapped each entry with the collection property name before passing it to `findChildrenFromPivotTable`, which expects it target-relative (the non-dataloader path passes it unwrapped). `getPivotOrderBy` then wrapped it again with the pivot relation name, so the pivot query tried to order by a path like `competency.competencies.name`, which fails the metadata lookup.

The fix drops the extra wrapping so the dataloader path matches the non-dataloader one.

Closes #8193
