### PR TITLE
fix(core): respect explicit join alias in JSON property conditions

### DIFF
--- a/packages/core/src/platforms/Platform.ts
+++ b/packages/core/src/platforms/Platform.ts
@@ -546,7 +546,8 @@ export abstract class Platform {
     return path;
   }
 
-  getSearchJsonPropertyKey(path: string[], type: string, aliased: boolean, value?: unknown): string | Raw {
+  /** When `aliased` is a string, it holds an explicit alias the key was prefixed with. */
+  getSearchJsonPropertyKey(path: string[], type: string, aliased: boolean | string, value?: unknown): string | Raw {
     return path.join('.');
   }
 
@@ -554,7 +555,7 @@ export abstract class Platform {
     o: FilterQuery<T>,
     value: EntityValue<T>,
     path: EntityKey<T>[],
-    alias: boolean,
+    alias: boolean | string,
   ): FilterQuery<T> {
     if (Utils.isPlainObject<T>(value) && !Object.keys(value).some(k => Utils.isOperator(k))) {
       Utils.keys(value).forEach(k => {
@@ -565,7 +566,8 @@ export abstract class Platform {
     }
 
     if (path.length === 1) {
-      o[path[0] as FilterKey<T>] = value as any;
+      const key = typeof alias === 'string' ? `${alias}.${path[0]}` : path[0];
+      o[key as FilterKey<T>] = value as any;
       return o;
     }
 

--- a/packages/core/src/utils/QueryHelper.ts
+++ b/packages/core/src/utils/QueryHelper.ts
@@ -339,12 +339,17 @@ export class QueryHelper {
       const isJsonProperty = prop?.customType instanceof JsonType && !isRaw(value) && (Utils.isPlainObject(value) ? !['$eq', '$elemMatch'].includes(Object.keys(value)[0]) : !Array.isArray(value));
 
       if (isJsonProperty && prop?.kind !== ReferenceKind.EMBEDDED) {
+        // an explicit alias prefix (e.g. `a.meta`) has to survive, otherwise the condition falls back to the root alias
+        const explicitAlias = (key as string).includes('.')
+          ? (key as string).split('.').slice(0, -1).join('.')
+          : undefined;
+
         return this.processJsonCondition<T>(
           o as FilterQuery<T>,
           value as EntityValue<T>,
           [prop.fieldNames[0]] as EntityKey<T>[],
           platform,
-          aliased,
+          aliased && explicitAlias != null ? explicitAlias : aliased,
         );
       }
 
@@ -516,7 +521,7 @@ export class QueryHelper {
     value: EntityValue<T>,
     path: EntityKey<T>[],
     platform: Platform,
-    alias: boolean,
+    alias: boolean | string,
   ) {
     return platform.processJsonCondition(o, value, path, alias);
   }

--- a/packages/mssql/src/MsSqlPlatform.ts
+++ b/packages/mssql/src/MsSqlPlatform.ts
@@ -234,12 +234,13 @@ export class MsSqlPlatform extends AbstractSqlPlatform {
   override getSearchJsonPropertyKey(
     path: string[],
     type: string,
-    aliased: boolean,
+    aliased: boolean | string,
     value?: unknown,
   ): string | RawQueryFragment {
     const [a, ...b] = path;
+    const alias = typeof aliased === 'string' ? this.quoteIdentifier(aliased) : `[${ALIAS_REPLACEMENT}]`;
     /* v8 ignore next */
-    const root = aliased ? `[${ALIAS_REPLACEMENT}].${this.quoteIdentifier(a)}` : this.quoteIdentifier(a);
+    const root = aliased ? `${alias}.${this.quoteIdentifier(a)}` : this.quoteIdentifier(a);
     const types = {
       boolean: 'bit',
     } as Dictionary;

--- a/packages/oracledb/src/OraclePlatform.ts
+++ b/packages/oracledb/src/OraclePlatform.ts
@@ -312,9 +312,10 @@ export class OraclePlatform extends AbstractSqlPlatform {
     return true;
   }
 
-  override getSearchJsonPropertyKey(path: string[], type: string, aliased: boolean, value?: unknown): string {
+  override getSearchJsonPropertyKey(path: string[], type: string, aliased: boolean | string, value?: unknown): string {
     const [a, ...b] = path;
-    const root = this.quoteIdentifier(aliased ? `${ALIAS_REPLACEMENT}.${a}` : a);
+    const alias = typeof aliased === 'string' ? aliased : ALIAS_REPLACEMENT;
+    const root = this.quoteIdentifier(aliased ? `${alias}.${a}` : a);
 
     if (b.length === 0) {
       return raw(`json_equal(${root}, json(?))`, [value]);
@@ -327,7 +328,7 @@ export class OraclePlatform extends AbstractSqlPlatform {
     o: FilterQuery<T>,
     value: EntityValue<T>,
     path: EntityKey<T>[],
-    alias: boolean,
+    alias: boolean | string,
   ): FilterQuery<T> {
     if (Utils.isPlainObject<Dictionary>(value) && !Object.keys(value).some(k => Utils.isOperator(k))) {
       Utils.keys(value).forEach(k => {

--- a/packages/sql/src/AbstractSqlPlatform.ts
+++ b/packages/sql/src/AbstractSqlPlatform.ts
@@ -111,11 +111,15 @@ export abstract class AbstractSqlPlatform extends Platform {
   override getSearchJsonPropertyKey(
     path: string[],
     type: string,
-    aliased: boolean,
+    aliased: boolean | string,
     value?: unknown,
   ): string | RawQueryFragment {
     const [a, ...b] = path;
     const jsonPath = this.quoteValue(`$.${b.map(this.quoteJsonKey).join('.')}`);
+
+    if (typeof aliased === 'string') {
+      return raw(`json_extract(${this.quoteIdentifier(`${aliased}.${a}`)}, ${jsonPath})`);
+    }
 
     if (aliased) {
       return raw(alias => `json_extract(${this.quoteIdentifier(`${alias}.${a}`)}, ${jsonPath})`);

--- a/packages/sql/src/dialects/postgresql/BasePostgreSqlPlatform.ts
+++ b/packages/sql/src/dialects/postgresql/BasePostgreSqlPlatform.ts
@@ -401,12 +401,13 @@ export class BasePostgreSqlPlatform extends AbstractSqlPlatform {
   override getSearchJsonPropertyKey(
     path: string[],
     type: string | undefined | Type,
-    aliased: boolean,
+    aliased: boolean | string,
     value?: unknown,
   ): string | RawQueryFragment {
     const first = path.shift();
     const last = path.pop();
-    const root = this.quoteIdentifier(aliased ? `${ALIAS_REPLACEMENT}.${first}` : first!);
+    const alias = typeof aliased === 'string' ? aliased : ALIAS_REPLACEMENT;
+    const root = this.quoteIdentifier(aliased ? `${alias}.${first}` : first!);
     type = typeof type === 'string' ? this.getMappedType(type).runtimeType : String(type);
     const cast = (key: string) =>
       raw(type in this.#jsonTypeCasts ? `(${key})::${this.#jsonTypeCasts[type as string]}` : key);

--- a/packages/sql/src/query/CriteriaNodeFactory.ts
+++ b/packages/sql/src/query/CriteriaNodeFactory.ts
@@ -133,6 +133,11 @@ export class CriteriaNodeFactory {
       return this.createScalarNode(metadata, childEntity, val, node, key, validate);
     }
 
+    // operator payloads under an unresolvable alias-prefixed key (e.g. `a.meta`) are opaque values, not entity criteria
+    if (!prop && !rawField && Utils.isOperator(key, false) && String(node.key).includes('.')) {
+      return this.createScalarNode(metadata, entityName, val, node, key, validate);
+    }
+
     if (prop?.kind === ReferenceKind.SCALAR && val != null && Object.keys(val).some(f => f in GroupOperator)) {
       throw ValidationError.cannotUseGroupOperatorsInsideScalars(entityName, prop.name, payload);
     }

--- a/tests/issues/GH8192.test.ts
+++ b/tests/issues/GH8192.test.ts
@@ -1,0 +1,138 @@
+import type { Rel } from '@mikro-orm/postgresql';
+import { MikroORM } from '@mikro-orm/postgresql';
+import { Entity, ManyToOne, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+import { type AbstractSqlDriver, MikroORM as SqlMikroORM } from '@mikro-orm/sql';
+import { PLATFORMS } from '../bootstrap.js';
+
+@Entity()
+class Author {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  active!: boolean;
+
+  @Property({ type: 'json', nullable: true })
+  meta?: { tag?: string; nested?: { deep?: string } };
+
+  @Property({ type: 'json', nullable: true })
+  items?: { tag: string }[];
+}
+
+@Entity()
+class Book {
+  @PrimaryKey()
+  id!: number;
+
+  @ManyToOne(() => Author)
+  author!: Rel<Author>;
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    metadataProvider: ReflectMetadataProvider,
+    dbName: 'mikro_orm_test_gh_8192',
+    entities: [Author, Book],
+  });
+  await orm.schema.refresh();
+
+  await orm.em.insert(Author, {
+    id: 1,
+    active: true,
+    meta: { tag: 'x', nested: { deep: 'd' } },
+    items: [{ tag: 'x' }],
+  });
+  await orm.em.insert(Author, { id: 2, active: true, meta: { tag: 'y' }, items: [{ tag: 'y' }] });
+  await orm.em.insert(Book, { id: 1, author: 1 });
+  await orm.em.insert(Book, { id: 2, author: 2 });
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+const createQb = () => orm.em.fork().createQueryBuilder(Book, 'b').select('b.*').leftJoin('b.author', 'a');
+
+test('where condition on a JSON property of a joined entity uses the join alias', async () => {
+  const qb = createQb().where({ 'a.meta': { tag: 'x' } });
+  expect(qb.getFormattedQuery()).toBe(
+    `select "b".* from "book" as "b" left join "author" as "a" on "b"."author_id" = "a"."id" where "a"."meta"->>'tag' = 'x'`,
+  );
+  await expect(qb.getResultList()).resolves.toMatchObject([{ id: 1 }]);
+});
+
+test('nested JSON path on a joined entity uses the join alias', async () => {
+  const qb = createQb().where({ 'a.meta': { nested: { deep: 'd' } } });
+  expect(qb.getFormattedQuery()).toBe(
+    `select "b".* from "book" as "b" left join "author" as "a" on "b"."author_id" = "a"."id" where "a"."meta"->'nested'->>'deep' = 'd'`,
+  );
+  await expect(qb.getResultList()).resolves.toMatchObject([{ id: 1 }]);
+});
+
+test('$contains on a JSON property of a joined entity', async () => {
+  const qb = createQb().where({ 'a.meta': { $contains: { tag: 'x' } } });
+  expect(qb.getFormattedQuery()).toBe(
+    `select "b".* from "book" as "b" left join "author" as "a" on "b"."author_id" = "a"."id" where "a"."meta" @> '{"tag":"x"}'`,
+  );
+  await expect(qb.getResultList()).resolves.toMatchObject([{ id: 1 }]);
+});
+
+test('$elemMatch on a JSON array property of a joined entity', async () => {
+  const qb = createQb().where({ 'a.items': { $elemMatch: { tag: 'x' } } as never });
+  expect(qb.getFormattedQuery()).toBe(
+    `select "b".* from "book" as "b" left join "author" as "a" on "b"."author_id" = "a"."id" where exists (select 1 from jsonb_array_elements("a"."items") as "__je0" where "__je0"->>'tag' = 'x')`,
+  );
+  await expect(qb.getResultList()).resolves.toMatchObject([{ id: 1 }]);
+});
+
+test('scalar property of a joined entity keeps working', async () => {
+  const qb = createQb().where({ 'a.active': true });
+  expect(qb.getFormattedQuery()).toBe(
+    `select "b".* from "book" as "b" left join "author" as "a" on "b"."author_id" = "a"."id" where "a"."active" = true`,
+  );
+  await expect(qb.getResultList()).resolves.toMatchObject([{ id: 1 }, { id: 2 }]);
+});
+
+test.each([
+  ['sqlite', 'json_extract(`a`.`meta`, '] as const,
+  ['mysql', 'json_extract(`a`.`meta`, '] as const,
+  ['mariadb', 'json_extract(`a`.`meta`, '] as const,
+  ['mssql', 'json_value([a].[meta], '] as const,
+  ['oracledb', 'json_value("a"."meta", '] as const,
+])('JSON condition uses the explicit join alias [%s]', async (type, fragment) => {
+  const orm2 = await SqlMikroORM.init<AbstractSqlDriver>({
+    metadataProvider: ReflectMetadataProvider,
+    entities: [Author, Book],
+    driver: PLATFORMS[type],
+    dbName: 'mikro_orm_test_gh_8192',
+  });
+
+  try {
+    const qb1 = orm2.em
+      .fork()
+      .createQueryBuilder(Book, 'b')
+      .leftJoin('b.author', 'a')
+      .where({ 'a.meta': { tag: 'x' } });
+    expect(qb1.getFormattedQuery()).toContain(`${fragment}'$.tag') = 'x'`);
+
+    const qb2 = orm2.em
+      .fork()
+      .createQueryBuilder(Book, 'b')
+      .leftJoin('b.author', 'a')
+      .where({ 'a.meta': { nested: { deep: 'd' } } });
+    expect(qb2.getFormattedQuery()).toContain(`${fragment}'$.nested.deep') = 'd'`);
+  } finally {
+    await orm2.close(true);
+  }
+});
+
+test('JSON property condition without explicit alias keeps using the root alias', async () => {
+  const qb = orm.em
+    .fork()
+    .createQueryBuilder(Author, 'a0')
+    .where({ meta: { tag: 'x' } });
+  expect(qb.getFormattedQuery()).toBe(`select "a0".* from "author" as "a0" where "a0"."meta"->>'tag' = 'x'`);
+  await expect(qb.getResultList()).resolves.toMatchObject([{ id: 1 }]);
+});


### PR DESCRIPTION
A `where` condition keyed by an explicit join alias (`{ 'a.meta': { tag: 'x' } }`) dropped the alias segment for JSON properties, so the rendered SQL used the root alias of the query builder (`"b"."meta"->>'tag'`), which is invalid when the column only exists on the joined entity. The `$contains` and `$elemMatch` variants failed even earlier with `Trying to query by not existing property ...`, because the unqualified key got resolved against the root entity.

The alias segment of the key is now passed through `processJsonCondition()` to `getSearchJsonPropertyKey()` (as `boolean | string`) and used in place of the alias replacement placeholder, in all SQL dialects. The criteria node factory also no longer descends into operator payloads of such alias-prefixed keys, since those are opaque JSON values rather than entity criteria.

Closes #8192
