### PR TITLE
fix(postgres): strip array-typed casts cleanly when recovering check constraints

### DIFF
--- a/packages/sql/src/dialects/postgresql/PostgreSqlSchemaHelper.ts
+++ b/packages/sql/src/dialects/postgresql/PostgreSqlSchemaHelper.ts
@@ -699,7 +699,7 @@ export class PostgreSqlSchemaHelper extends SchemaHelper {
       // SchemaHelper.createCheck).
       const m = /^check \(\((.*)\)\)$/is.exec(check.expression);
       const single = m ? null : /^check \((.*)\)$/is.exec(check.expression);
-      const def = m ? m[1].replace(/\(([^()]*)\)::\w+/g, '$1') : single ? single[1] : check.expression;
+      const def = m ? m[1].replace(/\(([^()]*)\)::\w+(?:\[\])?/g, '$1') : single ? single[1] : check.expression;
       ret[key].push({
         name: check.name,
         columnName: check.column_name,

--- a/tests/features/schema-generator/check-constraint.postgres.test.ts
+++ b/tests/features/schema-generator/check-constraint.postgres.test.ts
@@ -452,4 +452,48 @@ describe('check constraint [postgres]', () => {
     await orm.schema.dropDatabase();
     await orm.close();
   });
+
+  test('array-typed cast in a non-enum check keeps brackets balanced on introspection [postgres]', async () => {
+    const orm = await initORMPostgreSql();
+    const meta = orm.getMetadata();
+    await orm.schema.update();
+
+    // pg stores `mode in ('a', 'b')` on a varchar column as
+    // `CHECK (((mode IS NULL) OR ((mode)::text = ANY ((ARRAY['a'::character varying, 'b'::character varying])::text[]))))`
+    // — the array literal is cast as a whole, so the cast strip must consume the array-type suffix
+    // too, otherwise the recovered expression keeps an orphaned `[]` and re-emitting it as DDL is a
+    // syntax error. The `is null` disjunct keeps the check out of the enum-as-check detection, which
+    // would otherwise rebuild the expression from the parsed items and mask the recovery.
+    const newTableMeta = new EntitySchema({
+      properties: {
+        id: { primary: true, name: 'id', type: 'number', fieldName: 'id', columnType: 'int' },
+        mode: { type: 'string', name: 'mode', fieldName: 'mode', columnType: 'varchar(16)', nullable: true },
+      },
+      name: 'ArrayCastCheckTable',
+      tableName: 'array_cast_check_table',
+      checks: [{ name: 'chk_mode', expression: `mode is null or mode in ('a', 'b')` }],
+    }).init().meta;
+    meta.set(newTableMeta.class, newTableMeta);
+
+    const diff = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    await orm.schema.execute(diff);
+
+    const schema = await DatabaseSchema.create(orm.em.getConnection(), orm.em.getPlatform(), orm.config);
+    const check = schema
+      .getTable('array_cast_check_table')!
+      .getChecks()
+      .find(c => c.name === 'chk_mode');
+    expect(check?.expression).toBe(
+      `(mode IS NULL) OR (mode = ANY (ARRAY['a'::character varying, 'b'::character varying]))`,
+    );
+
+    // the recovered expression must be valid SQL again — re-adding the constraint from it must work
+    await orm.schema.execute(`alter table "array_cast_check_table" drop constraint "chk_mode";`);
+    await orm.schema.execute(
+      `alter table "array_cast_check_table" add constraint "chk_mode" check (${check!.expression});`,
+    );
+
+    await orm.schema.dropDatabase();
+    await orm.close();
+  });
 });


### PR DESCRIPTION
Postgres stores an `IN` list on a varchar column with the whole array cast, e.g. `(ARRAY['a', 'b'])::text[]`. The cast strip in `getAllChecks()` matched the type with `::\w+`, which cannot cover an array type name, so it consumed `(ARRAY[...])::text` and left the trailing `[]` orphaned. The recovered expression is no longer valid SQL, and re-adding it as DDL fails with a syntax error:

```
recovered: (mode IS NULL) OR (mode = ANY (ARRAY['a'::character varying, 'b'::character varying][]))
expected:  (mode IS NULL) OR (mode = ANY (ARRAY['a'::character varying, 'b'::character varying]))
```

Bare `IN`-list checks never surface this: the enum-as-check detection rebuilds their expression from the parsed items. It bites on any check not shaped like a pure enum membership, e.g. one with an `is null` disjunct.

The regression test sits next to the existing check-recovery tests and asserts both the recovered expression and that re-adding the constraint from the recovered text executes.

Closes #8197
