### PR TITLE
fix(core): don't require the discriminator value when creating an STI entity

### DIFF
--- a/packages/core/src/entity/EntityFactory.ts
+++ b/packages/core/src/entity/EntityFactory.ts
@@ -149,6 +149,15 @@ export class EntityFactory {
     }
 
     data = { ...data };
+
+    if (options.newEntity && meta2.root.inheritanceType === 'sti' && meta2.discriminatorValue != null) {
+      const prop = meta2.properties[meta2.root.discriminatorColumn as EntityKey<T>];
+
+      if (prop && prop.userDefined !== false) {
+        data[prop.name] ??= meta2.discriminatorValue as EntityValue<T>;
+      }
+    }
+
     const entity = exists ?? this.createEntity<T>(data, meta2, options);
     wrapped = helper(entity);
     wrapped.__processing = true;

--- a/packages/core/src/entity/defineEntity.ts
+++ b/packages/core/src/entity/defineEntity.ts
@@ -1284,6 +1284,7 @@ export interface EntityMetadataWithProperties<
   TDiscriminatorColumn extends string | undefined = undefined,
   TDiscriminatorValue extends string | number | undefined = undefined,
   TBaseDiscriminatorColumn extends string | undefined = undefined,
+  TEmbeddable extends boolean = false,
 > extends Omit<
   Partial<EntityMetadata<InferEntityFromProperties<TProperties, TPK, TBase, TRepository>>>,
   | 'properties'
@@ -1334,6 +1335,9 @@ export interface EntityMetadataWithProperties<
     strict?: boolean;
   }>;
   forceObject?: TForceObject;
+  // Captured as a literal so `NarrowDiscriminator` can keep the discriminator required for
+  // polymorphic embeddables, where the ORM cannot auto-fill it (the value picks the subtype).
+  embeddable?: TEmbeddable;
 
   // Table-per-type inheritance (each entity has its own table)
   inheritance?: 'tpt';
@@ -1400,6 +1404,7 @@ export function defineEntity<
   const TDiscriminatorColumn extends string | undefined = undefined,
   const TDiscriminatorValue extends string | number | undefined = undefined,
   const TBaseDiscriminatorColumn extends string | undefined = undefined,
+  const TEmbeddable extends boolean = false,
 >(
   meta: EntityMetadataWithProperties<
     TName,
@@ -1411,7 +1416,8 @@ export function defineEntity<
     TForceObject,
     TDiscriminatorColumn,
     TDiscriminatorValue,
-    TBaseDiscriminatorColumn
+    TBaseDiscriminatorColumn,
+    TEmbeddable
   >,
 ): EntitySchemaWithMeta<
   TName,
@@ -1423,7 +1429,8 @@ export function defineEntity<
     TRepository,
     TForceObject,
     TBaseDiscriminatorColumn,
-    TDiscriminatorValue
+    TDiscriminatorValue,
+    TEmbeddable
   >,
   TBase,
   TProperties,
@@ -1435,7 +1442,8 @@ export function defineEntity<
       TRepository,
       TForceObject,
       TBaseDiscriminatorColumn,
-      TDiscriminatorValue
+      TDiscriminatorValue,
+      TEmbeddable
     >
   >,
   TDiscriminatorColumn
@@ -1613,6 +1621,7 @@ export type InferEntityFromProperties<
   ForceObject extends boolean = false,
   BaseDiscriminatorColumn extends string | undefined = undefined,
   DiscriminatorValue extends string | number | undefined = undefined,
+  Embeddable extends boolean = false,
 > = (IsNever<Base> extends true
   ? {}
   : Base extends { toObject(...args: any[]): any }
@@ -1625,7 +1634,12 @@ export type InferEntityFromProperties<
           } & (IsNever<Repository> extends true
               ? {}
               : { [EntityRepositoryType]?: Repository extends Constructor<infer R> ? R : Repository }) &
-            NarrowDiscriminator<Omit<Base, typeof PrimaryKeyProp>, BaseDiscriminatorColumn, DiscriminatorValue>
+            NarrowDiscriminator<
+              Omit<Base, typeof PrimaryKeyProp>,
+              BaseDiscriminatorColumn,
+              DiscriminatorValue,
+              Embeddable
+            >
         >,
         BaseEntityMethodKeys
       >
@@ -1638,7 +1652,7 @@ export type InferEntityFromProperties<
     : { [EntityRepositoryType]?: Repository extends Constructor<infer R> ? R : Repository }) &
   (IsNever<Base> extends true
     ? {}
-    : NarrowDiscriminator<Omit<Base, typeof PrimaryKeyProp>, BaseDiscriminatorColumn, DiscriminatorValue>) &
+    : NarrowDiscriminator<Omit<Base, typeof PrimaryKeyProp>, BaseDiscriminatorColumn, DiscriminatorValue, Embeddable>) &
   (ForceObject extends true ? { [Config]?: DefineConfig<{ forceObject: true }> } : {}) & {
     [IndexHints]?: [Omit<ExtractBaseProperties<Base>, keyof Properties> & Properties];
   };
@@ -1659,14 +1673,23 @@ type ExtractOptionalProps<Base> = Base extends { [OptionalProps]?: infer K } ? (
 
 // Narrows the inherited discriminator property on `Base` to the literal `DiscValue` so a union
 // of sibling subtypes forms a proper discriminated union (GH #7677), and marks it optional for
-// `em.create()`, as the ORM fills it in from the schema. Falls through to `Base` when either
-// marker is absent (parent without `discriminatorColumn`, or self-defined entity).
-type NarrowDiscriminator<Base, DiscColumn extends string | undefined, DiscValue> = DiscColumn extends string
+// `em.create()`, as the ORM fills it in from the schema (GH #8200). Falls through to `Base` when
+// either marker is absent (parent without `discriminatorColumn`, or self-defined entity).
+// Polymorphic embeddables keep the discriminator required — there the provided value is the only
+// thing that identifies which subtype a plain object is, so it cannot be auto-filled.
+type NarrowDiscriminator<
+  Base,
+  DiscColumn extends string | undefined,
+  DiscValue,
+  Embeddable extends boolean = false,
+> = DiscColumn extends string
   ? DiscColumn extends keyof Base
     ? DiscValue extends string | number
-      ? Omit<Base, DiscColumn | typeof OptionalProps> & { [K in DiscColumn]: DiscValue } & {
-          [OptionalProps]?: DiscColumn | ExtractOptionalProps<Base>;
-        }
+      ? Embeddable extends true
+        ? Omit<Base, DiscColumn> & { [K in DiscColumn]: DiscValue }
+        : Omit<Base, DiscColumn | typeof OptionalProps> & { [K in DiscColumn]: DiscValue } & {
+            [OptionalProps]?: DiscColumn | ExtractOptionalProps<Base>;
+          }
       : Base
     : Base
   : Base;

--- a/packages/core/src/entity/defineEntity.ts
+++ b/packages/core/src/entity/defineEntity.ts
@@ -41,6 +41,7 @@ import type {
   Config,
   MaybePromise,
   IndexHints,
+  OptionalProps,
   ExtractDefineEntityProperties,
 } from '../typings.js';
 import type { Raw } from '../utils/RawQueryFragment.js';
@@ -1652,13 +1653,20 @@ type ExtractBaseProperties<Base> = [ExtractDefineEntityProperties<Base>] extends
     : P
   : {};
 
+// Recovers the `[OptionalProps]` declaration of a base entity, so `NarrowDiscriminator` can extend
+// it instead of replacing it; `never` when there is none.
+type ExtractOptionalProps<Base> = Base extends { [OptionalProps]?: infer K } ? (K extends string ? K : never) : never;
+
 // Narrows the inherited discriminator property on `Base` to the literal `DiscValue` so a union
-// of sibling subtypes forms a proper discriminated union (GH #7677). Falls through to `Base`
-// when either marker is absent (parent without `discriminatorColumn`, or self-defined entity).
+// of sibling subtypes forms a proper discriminated union (GH #7677), and marks it optional for
+// `em.create()`, as the ORM fills it in from the schema. Falls through to `Base` when either
+// marker is absent (parent without `discriminatorColumn`, or self-defined entity).
 type NarrowDiscriminator<Base, DiscColumn extends string | undefined, DiscValue> = DiscColumn extends string
   ? DiscColumn extends keyof Base
     ? DiscValue extends string | number
-      ? Omit<Base, DiscColumn> & { [K in DiscColumn]: DiscValue }
+      ? Omit<Base, DiscColumn | typeof OptionalProps> & { [K in DiscColumn]: DiscValue } & {
+          [OptionalProps]?: DiscColumn | ExtractOptionalProps<Base>;
+        }
       : Base
     : Base
   : Base;

--- a/tests/issues/GH7677.test.ts
+++ b/tests/issues/GH7677.test.ts
@@ -98,4 +98,7 @@ test('discriminator on embedded inheritance narrows the union', async () => {
 
   expect(meows).toBe(1);
   expect(barks).toBe(1);
+
+  // @ts-expect-error unlike with STI (GH #8200), the discriminator of an embedded polymorph cannot be auto-filled — its value is what identifies the subtype
+  orm.em.create(Owner, { id: 3, name: 'Baz', pet: { name: 'Whiskers', canMeow: true } }, { persist: false });
 });

--- a/tests/issues/GH8200.test.ts
+++ b/tests/issues/GH8200.test.ts
@@ -1,0 +1,41 @@
+import { defineEntity, MikroORM, p } from '@mikro-orm/sqlite';
+
+const BasePerson = defineEntity({
+  name: 'BasePerson',
+  abstract: true,
+  discriminatorColumn: 'type',
+  properties: {
+    id: p.integer().primary(),
+    type: p.text(),
+  },
+});
+
+const Person = defineEntity({
+  name: 'Person',
+  extends: BasePerson,
+  discriminatorValue: 'person',
+  properties: {
+    name: p.text(),
+  },
+});
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    dbName: ':memory:',
+    entities: [Person],
+  });
+  await orm.schema.refresh();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+test('discriminator value is not required when creating an STI entity', async () => {
+  const person = orm.em.create(Person, { name: 'Foo' });
+  await orm.em.flush();
+
+  expect(person.type).toBe('person');
+});

--- a/tests/issues/GH8200.test.ts
+++ b/tests/issues/GH8200.test.ts
@@ -35,7 +35,18 @@ afterAll(async () => {
 
 test('discriminator value is not required when creating an STI entity', async () => {
   const person = orm.em.create(Person, { name: 'Foo' });
+  expect(person.type).toBe('person'); // assigned already at create time, not only at flush
   await orm.em.flush();
 
   expect(person.type).toBe('person');
+});
+
+test('explicitly passed discriminator value is kept', async () => {
+  const person = orm.em.create(Person, { name: 'Bar', type: 'person' });
+  expect(person.type).toBe('person');
+  await orm.em.flush();
+  orm.em.clear();
+
+  const reloaded = await orm.em.findOneOrFail(Person, { name: 'Bar' });
+  expect(reloaded.type).toBe('person');
 });


### PR DESCRIPTION
Creating an STI entity defined via `defineEntity()` required passing the discriminator value explicitly, even though the ORM already sets it from the schema on insert. The inherited discriminator property was narrowed to the child's `discriminatorValue` but stayed required, so `em.create()` rejected data without it.

It is now declared via `[OptionalProps]` instead. Branding it with `Opt` would have been shorter, but it breaks the discriminated union added in #7677, as an intersection type no longer works as a discriminant. `em.create()` also assigns the value to the entity itself now, which used to stay undefined until the entity was reloaded.

Fixes #8200
