### PR TITLE
fix(sql): keep row-value tuples in `$in` on a `raw()` key

### DIFF
--- a/packages/sql/src/query/QueryBuilderHelper.ts
+++ b/packages/sql/src/query/QueryBuilderHelper.ts
@@ -782,6 +782,13 @@ export class QueryBuilderHelper {
     const replacement = this.getOperatorReplacement(op, value);
     const rawField = Raw.isKnownFragmentSymbol(key);
     const fields = rawField ? [key as unknown as string] : Utils.splitPrimaryKeys(key);
+    // a raw key can hold a column tuple like `(a, b)`, but its arity is opaque, so we detect the
+    // row-value form from the payload instead: an `$in`/`$nin` list where every item is an array
+    const rowValues =
+      rawField &&
+      ['$in', '$nin'].includes(op) &&
+      Array.isArray(value[op]) &&
+      value[op].every((v: unknown) => Array.isArray(v));
 
     if (fields.length > 1 && Array.isArray(value[op])) {
       const singleTuple = !value[op].every((v: unknown) => Array.isArray(v));
@@ -861,7 +868,7 @@ export class QueryBuilderHelper {
         params.push(...query.params);
       } else {
         const mappedKey = this.mapper(key, type, opValue, null);
-        const val = this.getValueReplacement(fields, opValue, params, op, prop);
+        const val = this.getValueReplacement(fields, opValue, params, op, prop, rowValues);
 
         parts.push(`${this.#platform.quoteIdentifier(mappedKey)} ${replacement} ${val}`);
       }
@@ -876,9 +883,10 @@ export class QueryBuilderHelper {
     params: unknown[],
     key?: string,
     prop?: EntityProperty,
+    rowValues = false,
   ): string {
     if (Array.isArray(value)) {
-      if (fields.length > 1) {
+      if (fields.length > 1 || rowValues) {
         const tmp = [];
 
         for (const field of value) {

--- a/packages/sql/src/query/QueryBuilderHelper.ts
+++ b/packages/sql/src/query/QueryBuilderHelper.ts
@@ -782,8 +782,7 @@ export class QueryBuilderHelper {
     const replacement = this.getOperatorReplacement(op, value);
     const rawField = Raw.isKnownFragmentSymbol(key);
     const fields = rawField ? [key as unknown as string] : Utils.splitPrimaryKeys(key);
-    // a raw key can hold a column tuple like `(a, b)`, but its arity is opaque, so we detect the
-    // row-value form from the payload instead: an `$in`/`$nin` list where every item is an array
+    // a raw key's arity is opaque, so the row-value form is detected from the payload instead
     const rowValues =
       rawField &&
       ['$in', '$nin'].includes(op) &&

--- a/tests/features/raw-queries/raw-tuple-in.mssql.test.ts
+++ b/tests/features/raw-queries/raw-tuple-in.mssql.test.ts
@@ -43,12 +43,8 @@ afterAll(async () => {
 
 const tupleKey = () => raw('([tool].[class_id], [tool].[role_id])');
 
-// SQL Server has no row value constructor. `MsSqlPlatform.allowsComparingTuples()` returns false
-// so that the ORM can decompose a composite key it renders itself into `(a = ? and b = ?) or ...`,
-// but that rewrite needs the individual column names and a raw fragment does not expose them --
-// it is an opaque SQL string. So the row-value form is emitted as written and mssql rejects it,
-// exactly as it did in v6 where knex rendered the same shape for a raw key. Grouping the tuples
-// is still the right output; it is just not something mssql can run. Use `$or` over the columns.
+// SQL Server has no row value constructor, and a raw key cannot be decomposed into per-column
+// comparisons (its column names are not recoverable), so the row-value form is emitted and rejected
 test('a raw column tuple is emitted as a row value and rejected by the driver', async () => {
   const qb = orm.em
     .createQueryBuilder(Tool, 'tool')

--- a/tests/features/raw-queries/raw-tuple-in.mssql.test.ts
+++ b/tests/features/raw-queries/raw-tuple-in.mssql.test.ts
@@ -1,0 +1,96 @@
+import { MikroORM, raw } from '@mikro-orm/mssql';
+import { Entity, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+
+@Entity()
+class Tool {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  classId: number;
+
+  @Property()
+  roleId: number;
+
+  constructor(classId: number, roleId: number) {
+    this.classId = classId;
+    this.roleId = roleId;
+  }
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    metadataProvider: ReflectMetadataProvider,
+    entities: [Tool],
+    dbName: 'mikro_orm_test_raw_tuple_in',
+    password: 'Root.Root',
+  });
+  await orm.schema.refresh();
+
+  orm.em.create(Tool, { classId: 1, roleId: 1 });
+  orm.em.create(Tool, { classId: 1, roleId: 2 });
+  orm.em.create(Tool, { classId: 2, roleId: 1 });
+  orm.em.create(Tool, { classId: 2, roleId: 2 });
+  await orm.em.flush();
+  orm.em.clear();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+const tupleKey = () => raw('([tool].[class_id], [tool].[role_id])');
+
+// SQL Server has no row value constructor. `MsSqlPlatform.allowsComparingTuples()` returns false
+// so that the ORM can decompose a composite key it renders itself into `(a = ? and b = ?) or ...`,
+// but that rewrite needs the individual column names and a raw fragment does not expose them --
+// it is an opaque SQL string. So the row-value form is emitted as written and mssql rejects it,
+// exactly as it did in v6 where knex rendered the same shape for a raw key. Grouping the tuples
+// is still the right output; it is just not something mssql can run. Use `$or` over the columns.
+test('a raw column tuple is emitted as a row value and rejected by the driver', async () => {
+  const qb = orm.em
+    .createQueryBuilder(Tool, 'tool')
+    .select(['id', 'classId', 'roleId'])
+    .where({
+      [tupleKey()]: {
+        $in: [
+          [1, 1],
+          [2, 2],
+        ],
+      },
+    });
+
+  expect(qb.getFormattedQuery()).toBe(
+    'select [tool].[id], [tool].[class_id], [tool].[role_id] from [tool] as [tool] ' +
+      'where ([tool].[class_id], [tool].[role_id]) in ((1, 1), (2, 2))',
+  );
+
+  // the parser fails at the comma inside the tuple, before arity is even considered -- the
+  // pre-fix output `in (1, 1, 2, 2)` is rejected with this very same error
+  await expect(qb.getResult()).rejects.toThrow(
+    'An expression of non-boolean type specified in a context where a condition is expected',
+  );
+});
+
+// The rest of the raw-key handling is unaffected: only the row-value form is out of reach here.
+test('a flat array on a raw key stays a scalar list', async () => {
+  const qb = orm.em
+    .createQueryBuilder(Tool, 'tool')
+    .select(['id'])
+    .where({ [raw('[tool].[class_id]')]: { $in: [1, 2] } });
+
+  expect(qb.getFormattedQuery()).toBe('select [tool].[id] from [tool] as [tool] where [tool].[class_id] in (1, 2)');
+  await expect(qb.getResult()).resolves.toHaveLength(4);
+});
+
+test('an empty tuple list is still a contradiction', async () => {
+  const qb = orm.em
+    .createQueryBuilder(Tool, 'tool')
+    .select(['id'])
+    .where({ [tupleKey()]: { $in: [] } });
+
+  expect(qb.getFormattedQuery()).toBe('select [tool].[id] from [tool] as [tool] where 1 = 0');
+  await expect(qb.getResult()).resolves.toHaveLength(0);
+});

--- a/tests/features/raw-queries/raw-tuple-in.oracle.test.ts
+++ b/tests/features/raw-queries/raw-tuple-in.oracle.test.ts
@@ -42,13 +42,8 @@ afterAll(async () => {
   await orm.close(true);
 });
 
-// A raw key can hold a column tuple, and the pairs are meaningful together --
-// `classId in (1, 2) and roleId in (1, 2)` is a different, wider condition.
-//
-// `OraclePlatform.allowsComparingTuples()` returns false, so the ORM avoids row values when it
-// renders a composite key itself. That opt-out is more conservative than the database requires:
-// Oracle does accept row-value comparisons, and a raw fragment gets them either way, since its
-// column names are not recoverable from the SQL string and cannot be compared one by one.
+// Oracle accepts row-value comparisons even though `allowsComparingTuples()` returns false,
+// and a raw key cannot be decomposed anyway, so the row-value form is emitted and runs fine
 const tupleKey = () => raw('("tool"."class_id", "tool"."role_id")');
 
 test('tuple $in on a raw key renders a row-value comparison', async () => {

--- a/tests/features/raw-queries/raw-tuple-in.oracle.test.ts
+++ b/tests/features/raw-queries/raw-tuple-in.oracle.test.ts
@@ -1,0 +1,119 @@
+import { MikroORM, raw } from '@mikro-orm/oracledb';
+import { Entity, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+
+@Entity()
+class Tool {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  classId: number;
+
+  @Property()
+  roleId: number;
+
+  constructor(classId: number, roleId: number) {
+    this.classId = classId;
+    this.roleId = roleId;
+  }
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    metadataProvider: ReflectMetadataProvider,
+    entities: [Tool],
+    dbName: 'mikro_orm_test_raw_tuple_in',
+    password: 'oracle123',
+    schemaGenerator: { managementDbName: 'system', tableSpace: 'mikro_orm' },
+  });
+  await orm.schema.refresh();
+
+  orm.em.create(Tool, { classId: 1, roleId: 1 });
+  orm.em.create(Tool, { classId: 1, roleId: 2 });
+  orm.em.create(Tool, { classId: 2, roleId: 1 });
+  orm.em.create(Tool, { classId: 2, roleId: 2 });
+  await orm.em.flush();
+  orm.em.clear();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+// A raw key can hold a column tuple, and the pairs are meaningful together --
+// `classId in (1, 2) and roleId in (1, 2)` is a different, wider condition.
+//
+// `OraclePlatform.allowsComparingTuples()` returns false, so the ORM avoids row values when it
+// renders a composite key itself. That opt-out is more conservative than the database requires:
+// Oracle does accept row-value comparisons, and a raw fragment gets them either way, since its
+// column names are not recoverable from the SQL string and cannot be compared one by one.
+const tupleKey = () => raw('("tool"."class_id", "tool"."role_id")');
+
+test('tuple $in on a raw key renders a row-value comparison', async () => {
+  const qb = orm.em
+    .createQueryBuilder(Tool, 'tool')
+    .select(['id', 'classId', 'roleId'])
+    .where({
+      [tupleKey()]: {
+        $in: [
+          [-1, -1],
+          [1, 1],
+          [2, 2],
+        ],
+      },
+    })
+    .orderBy({ classId: 'asc' });
+
+  expect(qb.getFormattedQuery()).toBe(
+    'select "tool"."id", "tool"."class_id", "tool"."role_id" from "tool" "tool" ' +
+      'where ("tool"."class_id", "tool"."role_id") in ((-1, -1), (1, 1), (2, 2)) ' +
+      'order by "tool"."class_id" asc',
+  );
+
+  const rows = await qb.getResult();
+  expect(rows.map(r => [r.classId, r.roleId])).toEqual([
+    [1, 1],
+    [2, 2],
+  ]);
+});
+
+test('tuple $nin on a raw key renders a row-value comparison', async () => {
+  const qb = orm.em
+    .createQueryBuilder(Tool, 'tool')
+    .select(['id', 'classId', 'roleId'])
+    .where({
+      [tupleKey()]: {
+        $nin: [
+          [1, 1],
+          [2, 2],
+        ],
+      },
+    })
+    .orderBy({ classId: 'asc', roleId: 'asc' });
+
+  expect(qb.getFormattedQuery()).toBe(
+    'select "tool"."id", "tool"."class_id", "tool"."role_id" from "tool" "tool" ' +
+      'where ("tool"."class_id", "tool"."role_id") not in ((1, 1), (2, 2)) ' +
+      'order by "tool"."class_id" asc, "tool"."role_id" asc',
+  );
+
+  const rows = await qb.getResult();
+  expect(rows.map(r => [r.classId, r.roleId])).toEqual([
+    [1, 2],
+    [2, 1],
+  ]);
+});
+
+test('a single tuple is still wrapped as a row value', async () => {
+  const qb = orm.em
+    .createQueryBuilder(Tool, 'tool')
+    .select(['id'])
+    .where({ [tupleKey()]: { $in: [[1, 2]] } });
+
+  expect(qb.getFormattedQuery()).toBe(
+    'select "tool"."id" from "tool" "tool" where ("tool"."class_id", "tool"."role_id") in ((1, 2))',
+  );
+  await expect(qb.getResult()).resolves.toHaveLength(1);
+});

--- a/tests/features/raw-queries/raw-tuple-in.test.ts
+++ b/tests/features/raw-queries/raw-tuple-in.test.ts
@@ -1,0 +1,132 @@
+import { MikroORM, raw } from '@mikro-orm/sqlite';
+import { Entity, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+
+@Entity()
+class Tool {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  classId: number;
+
+  @Property()
+  roleId: number;
+
+  constructor(classId: number, roleId: number) {
+    this.classId = classId;
+    this.roleId = roleId;
+  }
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    metadataProvider: ReflectMetadataProvider,
+    dbName: ':memory:',
+    entities: [Tool],
+  });
+  await orm.schema.create();
+
+  orm.em.create(Tool, { classId: 1, roleId: 1 });
+  orm.em.create(Tool, { classId: 1, roleId: 2 });
+  orm.em.create(Tool, { classId: 2, roleId: 1 });
+  orm.em.create(Tool, { classId: 2, roleId: 2 });
+  await orm.em.flush();
+  orm.em.clear();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+// A raw key can hold a column tuple, and the pairs are meaningful together --
+// `classId in (1, 2) and roleId in (1, 2)` is a different, wider condition.
+const tupleKey = () => raw('(`tool`.`class_id`, `tool`.`role_id`)');
+
+test('tuple $in on a raw key renders a row-value comparison', async () => {
+  const qb = orm.em
+    .createQueryBuilder(Tool, 'tool')
+    .select(['id', 'classId', 'roleId'])
+    .where({
+      [tupleKey()]: {
+        $in: [
+          [-1, -1],
+          [1, 1],
+          [2, 2],
+        ],
+      },
+    });
+
+  expect(qb.getFormattedQuery()).toBe(
+    'select `tool`.`id`, `tool`.`class_id`, `tool`.`role_id` from `tool` as `tool` ' +
+      'where (`tool`.`class_id`, `tool`.`role_id`) in ((-1, -1), (1, 1), (2, 2))',
+  );
+
+  const rows = await qb.getResult();
+  expect(rows.map(r => [r.classId, r.roleId])).toEqual([
+    [1, 1],
+    [2, 2],
+  ]);
+});
+
+test('tuple $nin on a raw key renders a row-value comparison', async () => {
+  const qb = orm.em
+    .createQueryBuilder(Tool, 'tool')
+    .select(['id', 'classId', 'roleId'])
+    .where({
+      [tupleKey()]: {
+        $nin: [
+          [1, 1],
+          [2, 2],
+        ],
+      },
+    })
+    .orderBy({ classId: 'asc', roleId: 'asc' });
+
+  expect(qb.getFormattedQuery()).toBe(
+    'select `tool`.`id`, `tool`.`class_id`, `tool`.`role_id` from `tool` as `tool` ' +
+      'where (`tool`.`class_id`, `tool`.`role_id`) not in ((1, 1), (2, 2)) ' +
+      'order by `tool`.`class_id` asc, `tool`.`role_id` asc',
+  );
+
+  const rows = await qb.getResult();
+  expect(rows.map(r => [r.classId, r.roleId])).toEqual([
+    [1, 2],
+    [2, 1],
+  ]);
+});
+
+test('a single tuple is still wrapped as a row value', async () => {
+  const qb = orm.em
+    .createQueryBuilder(Tool, 'tool')
+    .select(['id'])
+    .where({ [tupleKey()]: { $in: [[1, 2]] } });
+
+  expect(qb.getFormattedQuery()).toBe(
+    'select `tool`.`id` from `tool` as `tool` where (`tool`.`class_id`, `tool`.`role_id`) in ((1, 2))',
+  );
+  await expect(qb.getResult()).resolves.toHaveLength(1);
+});
+
+test('a flat array on a raw key stays a scalar list', async () => {
+  // the arity of a raw key is opaque, so a flat array keeps its scalar meaning;
+  // pass `[[1, 1]]` to ask for a single tuple
+  const qb = orm.em
+    .createQueryBuilder(Tool, 'tool')
+    .select(['id'])
+    .where({ [raw('`tool`.`class_id`')]: { $in: [1, 2] } });
+
+  expect(qb.getFormattedQuery()).toBe('select `tool`.`id` from `tool` as `tool` where `tool`.`class_id` in (1, 2)');
+  await expect(qb.getResult()).resolves.toHaveLength(4);
+});
+
+test('an empty tuple list is still a contradiction', async () => {
+  const qb = orm.em
+    .createQueryBuilder(Tool, 'tool')
+    .select(['id'])
+    .where({ [tupleKey()]: { $in: [] } });
+
+  expect(qb.getFormattedQuery()).toBe('select `tool`.`id` from `tool` as `tool` where 1 = 0');
+  await expect(qb.getResult()).resolves.toHaveLength(0);
+});


### PR DESCRIPTION
## Problem

A `raw()` key can hold a column tuple, and `$in` with an array of tuples rendered a real row-value comparison in v6, where knex did the rendering. The native query builder in v7 flattens it one level:

```ts
qb.where({
  [raw('(`tool`.`class_id`, `tool`.`role_id`)')]: { $in: [[-1, -1], [1, 1], [2, 2]] },
});
```

```sql
-- v6
where (`tool`.`class_id`, `tool`.`role_id`) in ( values (-1, -1), (1, 1), (2, 2))
-- v7
where (`tool`.`class_id`, `tool`.`role_id`) in (-1, -1, 1, 1, 2, 2)
```

Not cosmetic — the driver rejects the flattened SQL. sqlite reports `IN(...) element has 1 term - expected 2`, mysql `Operand should contain 2 column(s)`. And the pairs are meaningful together: `classId in (1, 2) and roleId in (1, 2)` is a wider, different condition.

## Cause

`QueryBuilderHelper` already renders row values, but gates it on `fields.length > 1`. A raw key is opaque, so `fields` is just `[key]` and the payload falls through to the scalar branch, which binds each tuple as a single param; `Platform.formatQuery` then flattens each array into `-1, -1`.

## Fix

The arity of a raw key can't be inferred from the key, so the row-value form is detected from the payload instead — an `$in`/`$nin` list where every item is an array — and reuses the existing tuple rendering.

The output is the portable `((-1, -1), (1, 1), (2, 2))` form rather than knex's `values` spelling. That is what v7 already emits for composite non-raw keys, and unlike `values` it also works on MySQL before 8.0.19.

Deliberately unchanged:

- A flat array on a raw key keeps its scalar meaning, so `[[1, 1]]` is how to ask for a single tuple.
- `$in: []` still renders `1 = 0`.
- MSSQL and Oracle both report `allowsComparingTuples() === false`, so a *composite key* is decomposed into `(a = ? and b = ?) or ...` there. A `raw()` fragment can't be decomposed -- the column names aren't recoverable from it -- so it gets the row-value form on every platform. Oracle accepts that and raw tuple keys work; SQL Server has no row value constructor and rejects it, exactly as it did in v6, where knex rendered the same `(a, b) in ((1, 1), (2, 2))` shape for a raw key on every dialect. So no regression on either, and Oracle gains a working case.

The first commit is the failing test, the second is the fix. Coverage is sqlite plus the two platforms that report `allowsComparingTuples() === false`; seven of the eleven cases fail on the first commit.

Reproduction: https://github.com/lamkashingpaul/reproduction/tree/raw-tuple-in
