### PR TITLE
fix(core): evict referrers holding a removed entity in their primary key

### DIFF
--- a/packages/core/src/unit-of-work/UnitOfWork.ts
+++ b/packages/core/src/unit-of-work/UnitOfWork.ts
@@ -710,6 +710,9 @@ export class UnitOfWork {
         ) {
           if (prop.formula) {
             delete referrer[prop.name];
+          } else if (prop.primary) {
+            // the referrer's primary key contains the removed entity, so its identity cannot survive the removal
+            this.unsetIdentity(referrer);
           } else {
             delete helper(referrer).__data[prop.name];
           }

--- a/tests/issues/GH8203.test.ts
+++ b/tests/issues/GH8203.test.ts
@@ -1,0 +1,47 @@
+import { defineEntity, MikroORM } from '@mikro-orm/sqlite';
+
+const Foo = defineEntity({
+  name: 'Foo',
+  properties: p => ({
+    id: p.integer().primary(),
+    label: p.string(),
+  }),
+});
+
+const Referrer = defineEntity({
+  name: 'Referrer',
+  properties: p => ({
+    foo: () => p.manyToOne(Foo).primary(),
+  }),
+});
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    entities: [Foo, Referrer],
+    dbName: ':memory:',
+  });
+  await orm.schema.refresh();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+test('GH #8203: removed entity is not re-inserted by a resident referrer holding it in its primary key', async () => {
+  const em = orm.em.fork();
+  const foo = em.create(Foo, { id: 1, label: 'foo' });
+  em.create(Referrer, { foo });
+  await em.flush();
+
+  // the referrer row is deleted outside the ORM, so it stays resident in the identity map
+  await em.nativeDelete(Referrer, { foo: foo.id });
+
+  await em.remove(foo).flush();
+  await expect(orm.em.fork().count(Foo)).resolves.toBe(0);
+
+  // any later flush on the same EntityManager must not resurrect the removed entity
+  await em.flush();
+  await expect(orm.em.fork().count(Foo)).resolves.toBe(0);
+});


### PR DESCRIPTION
When a managed entity holds a removed entity in its primary key and stays resident in the identity map (e.g. its own row was deleted outside the ORM), any later `flush()` re-inserted the removed entity with its original PK.

`unsetIdentity()` scrubs referring relations via `delete helper(referrer).__data[prop.name]`, but primary key relations get no accessor (`EntityHelper.decorate()` skips them), so the value lives as a plain own property and the `delete` is a no-op. The referrer keeps a live reference, `findNewEntities()` reaches the removed entity through it on the next flush, and because `__originalEntityData` was already cleared, the comparator classifies it as new and re-inserts it.

A PK component cannot be unset, and the referrer's identity cannot survive the removal of its target, so we now evict the referrer from the identity map as well (recursively). Cycles terminate because the entity is deleted from the identity map before its referrers are scanned.

Closes #8203
