### PR TITLE
test: increase timeout of the oracle schema updating test

### DIFF
--- a/tests/features/schema-generator/SchemaGenerator.oracle.test.ts
+++ b/tests/features/schema-generator/SchemaGenerator.oracle.test.ts
@@ -266,5 +266,5 @@ describe('SchemaGenerator [oracle]', () => {
     diff = await orm.schema.getUpdateSchemaSQL({ wrap: false });
     expect(diff).toMatchSnapshot('oracle-update-schema-drop-table');
     await orm.schema.execute(diff, { wrap: true });
-  });
+  }, 120_000);
 });


### PR DESCRIPTION
The `update schema [oracle]` test runs dozens of DDL statements and can blow past the 60s global timeout on a slow CI runner ([example failure](https://github.com/mikro-orm/mikro-orm/actions/runs/32956688962/job/98139784577)). When that happens, the CI retry runs against the half-mutated shared metadata and fails on snapshot mismatches. This bumps the per-test timeout to 120s.
