### PR TITLE
fix(core): infer primary key from plain class base in `defineEntity`

### DIFF
--- a/packages/core/src/entity/defineEntity.ts
+++ b/packages/core/src/entity/defineEntity.ts
@@ -1699,8 +1699,20 @@ type InferCombinedPrimaryKey<Properties extends Record<string, any>, PK, Base> =
   ? CombinePrimaryKeys<InferPrimaryKey<Properties>, ExtractBasePrimaryKey<Base>>
   : PK;
 
-// Extract primary key from base entity type
-type ExtractBasePrimaryKey<Base> = Base extends { [PrimaryKeyProp]?: infer BasePK } ? BasePK : never;
+// Extract primary key from base entity type, falling back to `_id`/`id`/`uuid` detection (as in `Primary`) for plain classes without `[PrimaryKeyProp]`
+type ExtractBasePrimaryKey<Base> = typeof PrimaryKeyProp extends keyof Base
+  ? Base extends { [PrimaryKeyProp]?: infer BasePK }
+    ? BasePK
+    : never
+  : [keyof Base] extends [never] // a structurally empty base would falsely match the weak `{ _id?: any }` check below
+    ? never
+    : Base extends { _id?: any }
+      ? '_id'
+      : Base extends { id?: any }
+        ? 'id'
+        : Base extends { uuid?: any }
+          ? 'uuid'
+          : never;
 
 // Combine child and base primary keys into a union
 type CombinePrimaryKeys<ChildPK, BasePK> = [ChildPK] extends [never]

--- a/tests/defineEntity.test.ts
+++ b/tests/defineEntity.test.ts
@@ -410,6 +410,25 @@ describe('defineEntity', () => {
     expect(UserSchema.meta.className).toBe('User');
   });
 
+  it('should keep primary key optional in em.create() when extending a plain class', () => {
+    abstract class BaseEntity {
+      id!: number;
+    }
+
+    const TagSchema = defineEntity({
+      name: 'Tag',
+      extends: BaseEntity,
+      properties: {
+        name: p.string(),
+      },
+    });
+
+    type ITag = InferEntity<typeof TagSchema>;
+    assert<IsExact<Primary<ITag>, number>>(true);
+    const data: RequiredEntityData<ITag> = { name: 'ts' };
+    expect(data.name).toBe('ts');
+  });
+
   it('should inherit property initializers from parent class via extends', () => {
     const BaseSchema = defineEntity({
       name: 'BaseWithInit',


### PR DESCRIPTION
When `defineEntity({ extends: SomeClass })` is used with a plain class that does not declare `[PrimaryKeyProp]`, the inferred entity type ended up with `[PrimaryKeyProp]?: unknown`: every type matches the optional `{ [PrimaryKeyProp]?: infer PK }` constraint, so `ExtractBasePrimaryKey` inferred `unknown` instead of bailing out. `PrimaryProperty<T>` then resolved to `never`, and `em.create()` wrongly required the primary key:

```ts
abstract class BaseEntity {
  id!: number;
}

const TagSchema = defineEntity({
  name: 'Tag',
  extends: BaseEntity,
  properties: { name: p.string() },
});

em.create(TagSchema, { name: 'ts' }); // TS2345: Property 'id' is missing
```

`ExtractBasePrimaryKey` now only uses the declared symbol when it actually exists on the base, and otherwise falls back to the conventional `_id`/`id`/`uuid` detection, same as `Primary`/`PrimaryProperty` do for regular classes.
