### PR TITLE
fix(core): resolve user-class lookups by class reference instead of class name

### DIFF
--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -432,10 +432,7 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
     options = { ...options };
 
     if (options.entity) {
-      // classes are kept as references, as minifiers can mangle two classes to the same name
-      options.entity = Utils.asArray(options.entity).map(n =>
-        typeof n === 'function' ? n : Utils.className(n),
-      ) as any;
+      options.entity = Utils.asArray(options.entity).map(n => Utils.classOrName(n)) as any;
     }
 
     options.default ??= true;

--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -432,7 +432,10 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
     options = { ...options };
 
     if (options.entity) {
-      options.entity = Utils.asArray(options.entity).map(n => Utils.className(n)) as any;
+      // classes are kept as references, as minifiers can mangle two classes to the same name
+      options.entity = Utils.asArray(options.entity).map(n =>
+        typeof n === 'function' ? n : Utils.className(n),
+      ) as any;
     }
 
     options.default ??= true;

--- a/packages/core/src/EntityManager.ts
+++ b/packages/core/src/EntityManager.ts
@@ -3169,7 +3169,12 @@ export class EntityManager<Driver extends IDatabaseDriver = IDatabaseDriver> {
       delete opts[k as keyof typeof opts];
     }
 
-    return [Utils.className(entityName), method, opts, where];
+    // the table name (plus discriminator value for STI) is stable across builds and processes,
+    // unlike class names, which minifiers can mangle to the same short name for two entities
+    const meta = this.metadata.find(entityName);
+    const key = meta?.tableName ? [meta.schema, meta.tableName, meta.discriminatorValue] : Utils.className(entityName);
+
+    return [key, method, opts, where];
   }
 
   /**

--- a/packages/core/src/entity/EntityRepository.ts
+++ b/packages/core/src/entity/EntityRepository.ts
@@ -473,8 +473,12 @@ export class EntityRepository<Entity extends object> {
 
     const entityName = entities[0].constructor.name;
     const repoType = Utils.className(this.entityName);
+    // compare metadata identity where possible, as minifiers can mangle two classes to the same name
+    const entityMeta = (entities[0] as Dictionary).__meta;
+    const repoMeta = this.getEntityManager().getMetadata?.().find(this.entityName);
+    const mismatch = entityMeta && repoMeta ? entityMeta !== repoMeta : entityName && repoType !== entityName;
 
-    if (entityName && repoType !== entityName) {
+    if (mismatch) {
       throw ValidationError.fromWrongRepositoryType(entityName, repoType, method);
     }
   }

--- a/packages/core/src/entity/EntityRepository.ts
+++ b/packages/core/src/entity/EntityRepository.ts
@@ -473,10 +473,11 @@ export class EntityRepository<Entity extends object> {
 
     const entityName = entities[0].constructor.name;
     const repoType = Utils.className(this.entityName);
-    // compare metadata identity where possible, as minifiers can mangle two classes to the same name
+    // compare class identity where possible, as minifiers can mangle two classes to the same name
     const entityMeta = (entities[0] as Dictionary).__meta;
     const repoMeta = this.getEntityManager().getMetadata?.().find(this.entityName);
-    const mismatch = entityMeta && repoMeta ? entityMeta !== repoMeta : entityName && repoType !== entityName;
+    const mismatch =
+      entityMeta && repoMeta ? entityMeta.class !== repoMeta.class : entityName && repoType !== entityName;
 
     if (mismatch) {
       throw ValidationError.fromWrongRepositoryType(entityName, repoType, method);

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -343,6 +343,12 @@ export class MetadataError<T extends AnyEntity = AnyEntity> extends ValidationEr
     return new MetadataError(`Metadata for entity ${entity} not found`);
   }
 
+  static ambiguousEntityName(className: string): MetadataError {
+    return new MetadataError(
+      `Entity name '${className}' is ambiguous, multiple discovered entity classes share it (possibly due to a minifier mangling class names). Use a class reference instead of a string name.`,
+    );
+  }
+
   static invalidPrimaryKey(meta: EntityMetadata, prop: EntityProperty, requiredName: string): MetadataError {
     return this.fromMessage(meta, prop, `has wrong field name, '${requiredName}' is required in current driver`);
   }

--- a/packages/core/src/events/EventManager.ts
+++ b/packages/core/src/events/EventManager.ts
@@ -134,10 +134,7 @@ export class EventManager {
       return new Set();
     }
 
-    // classes are kept as references, as minifiers can mangle two classes to the same name
-    return new Set(
-      listener.getSubscribedEntities().map(name => (typeof name === 'function' ? name : Utils.className(name))),
-    );
+    return new Set(listener.getSubscribedEntities().map(name => Utils.classOrName(name)));
   }
 }
 

--- a/packages/core/src/events/EventManager.ts
+++ b/packages/core/src/events/EventManager.ts
@@ -1,4 +1,4 @@
-import type { AnyEntity, AsyncFunction, EntityKey, EntityMetadata } from '../typings.js';
+import type { AnyEntity, AsyncFunction, EntityClass, EntityKey, EntityMetadata } from '../typings.js';
 import type { EventArgs, EventSubscriber, FlushEventArgs, TransactionEventArgs } from './EventSubscriber.js';
 import { Utils } from '../utils/Utils.js';
 import { EventType, EventTypeMap, type TransactionEventType } from '../enums.js';
@@ -6,7 +6,7 @@ import { EventType, EventTypeMap, type TransactionEventType } from '../enums.js'
 /** Manages event subscribers and dispatches entity/flush/transaction lifecycle events. */
 export class EventManager {
   readonly #listeners: { [K in EventType]?: Set<EventSubscriber> } = {};
-  readonly #entities = new Map<EventSubscriber, Set<string>>();
+  readonly #entities = new Map<EventSubscriber, Set<string | EntityClass>>();
   readonly #cache = new Map<number, boolean>();
   readonly #subscribers = new Set<EventSubscriber>();
 
@@ -75,7 +75,12 @@ export class EventManager {
     for (const listener of this.#listeners[event] ?? new Set()) {
       const entities = this.#entities.get(listener)!;
 
-      if (entities.size === 0 || !entity || entities.has(entity.constructor.name)) {
+      if (
+        entities.size === 0 ||
+        !entity ||
+        entities.has(entity.constructor as EntityClass) ||
+        entities.has(entity.constructor.name)
+      ) {
         listeners.push(listener[event]!.bind(listener) as AsyncFunction);
       }
     }
@@ -109,7 +114,7 @@ export class EventManager {
     for (const listener of this.#listeners[event] ?? new Set()) {
       const entities = this.#entities.get(listener)!;
 
-      if (entities.size === 0 || entities.has(meta.className)) {
+      if (entities.size === 0 || entities.has(meta.class) || entities.has(meta.className)) {
         this.#cache.set(cacheKey, true);
         return true;
       }
@@ -124,12 +129,15 @@ export class EventManager {
     return new EventManager(this.#subscribers);
   }
 
-  private getSubscribedEntities(listener: EventSubscriber): Set<string> {
+  private getSubscribedEntities(listener: EventSubscriber): Set<string | EntityClass> {
     if (!listener.getSubscribedEntities) {
       return new Set();
     }
 
-    return new Set(listener.getSubscribedEntities().map(name => Utils.className(name)));
+    // classes are kept as references, as minifiers can mangle two classes to the same name
+    return new Set(
+      listener.getSubscribedEntities().map(name => (typeof name === 'function' ? name : Utils.className(name))),
+    );
   }
 }
 

--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -2749,7 +2749,9 @@ export class MetadataDiscovery {
     const forceConstructor = this.#config.get('forceEntityConstructor');
 
     if (Array.isArray(forceConstructor)) {
-      return forceConstructor.some(cls => Utils.className(cls) === meta.className);
+      return forceConstructor.some(cls =>
+        typeof cls === 'function' ? (cls as unknown) === meta.class : cls === meta.className,
+      );
     }
 
     return forceConstructor;

--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -2749,9 +2749,7 @@ export class MetadataDiscovery {
     const forceConstructor = this.#config.get('forceEntityConstructor');
 
     if (Array.isArray(forceConstructor)) {
-      return forceConstructor.some(cls =>
-        typeof cls === 'function' ? (cls as unknown) === meta.class : cls === meta.className,
-      );
+      return forceConstructor.some(cls => Utils.matchesEntity(cls, meta));
     }
 
     return forceConstructor;

--- a/packages/core/src/metadata/MetadataStorage.ts
+++ b/packages/core/src/metadata/MetadataStorage.ts
@@ -22,6 +22,7 @@ export class MetadataStorage {
   readonly #idMap: Record<number, EntityMetadata>;
   readonly #classNameMap: Record<string, EntityMetadata>;
   readonly #uniqueNameMap: Record<string, EntityMetadata>;
+  readonly #ambiguousNames = new Set<string>();
 
   constructor(metadata: Dictionary<EntityMetadata> = {}) {
     this.#idMap = {};
@@ -89,6 +90,11 @@ export class MetadataStorage {
 
   /** Returns metadata for the given entity, optionally initializing it if not found. */
   get<T = any>(entityName: EntityName<T>, init = false): EntityMetadata<T> {
+    // string lookups cannot be resolved when several classes were minified to the same name
+    if (typeof entityName === 'string' && this.#ambiguousNames.has(entityName)) {
+      throw MetadataError.ambiguousEntityName(entityName);
+    }
+
     const exists = this.find(entityName);
 
     if (exists) {
@@ -136,7 +142,15 @@ export class MetadataStorage {
     this.#metadataMap.set(entityName, meta);
     this.#idMap[meta._id] = meta;
     this.#uniqueNameMap[meta.uniqueName] = meta;
-    this.#classNameMap[Utils.className(entityName)] = meta;
+    const className = Utils.className(entityName);
+    const existing = this.#classNameMap[className];
+
+    // track name collisions caused by minifiers mangling two classes to the same name
+    if (existing && existing !== meta && existing.class !== meta.class) {
+      this.#ambiguousNames.add(className);
+    }
+
+    this.#classNameMap[className] = meta;
 
     return meta;
   }
@@ -150,6 +164,15 @@ export class MetadataStorage {
       delete this.#idMap[meta._id];
       delete this.#uniqueNameMap[meta.uniqueName];
       delete this.#classNameMap[meta.className];
+
+      // the name may still be ambiguous among the remaining metas
+      const remaining = new Set(
+        [...this.#metadataMap.values()].filter(m => m.className === meta.className).map(m => m.class),
+      );
+
+      if (remaining.size <= 1) {
+        this.#ambiguousNames.delete(meta.className);
+      }
     }
   }
 

--- a/packages/core/src/types/Type.ts
+++ b/packages/core/src/types/Type.ts
@@ -119,13 +119,12 @@ export abstract class Type<JSType = string, DBType = JSType> {
     DBType = JSType,
     TypeClass extends Constructor<Type<JSType, DBType>> = Constructor<Type<JSType, DBType>>,
   >(cls: TypeClass): InstanceType<TypeClass> {
-    const key = cls.name;
-
-    if (!Type.types.has(key)) {
-      Type.types.set(key, new cls());
+    // keyed by class reference, as minifiers can mangle two classes to the same name
+    if (!Type.types.has(cls)) {
+      Type.types.set(cls, new cls());
     }
 
-    return Type.types.get(key);
+    return Type.types.get(cls);
   }
 
   /**

--- a/packages/core/src/utils/QueryHelper.ts
+++ b/packages/core/src/utils/QueryHelper.ts
@@ -437,7 +437,10 @@ export class QueryHelper {
     filter: FilterDef,
     options: Dictionary<boolean | Dictionary>,
   ): boolean {
-    if (filter.entity && !(filter.entity as string[]).includes(meta.className)) {
+    const matches = (e: EntityName) =>
+      typeof e === 'function' ? e === meta.class : Utils.className(e) === meta.className;
+
+    if (filter.entity && !Utils.asArray(filter.entity).some(matches)) {
       return false;
     }
 

--- a/packages/core/src/utils/QueryHelper.ts
+++ b/packages/core/src/utils/QueryHelper.ts
@@ -437,10 +437,7 @@ export class QueryHelper {
     filter: FilterDef,
     options: Dictionary<boolean | Dictionary>,
   ): boolean {
-    const matches = (e: EntityName) =>
-      typeof e === 'function' ? e === meta.class : Utils.className(e) === meta.className;
-
-    if (filter.entity && !Utils.asArray(filter.entity).some(matches)) {
+    if (filter.entity && !Utils.asArray(filter.entity).some(e => Utils.matchesEntity(e, meta))) {
       return false;
     }
 

--- a/packages/core/src/utils/Utils.ts
+++ b/packages/core/src/utils/Utils.ts
@@ -2,6 +2,7 @@ import { clone } from './clone.js';
 import type {
   CompiledFunctions,
   Dictionary,
+  EntityCtor,
   EntityData,
   EntityDictionary,
   EntityKey,
@@ -742,6 +743,23 @@ export class Utils {
     }
 
     return classOrName.name as string;
+  }
+
+  /**
+   * Normalizes an entity reference for identity-safe matching: keeps class references
+   * (minifiers can mangle two classes to the same name) and falls back to the class name otherwise.
+   */
+  static classOrName<T>(classOrName: string | EntityName<T>): EntityCtor<T> | string {
+    return typeof classOrName === 'function' ? (classOrName as EntityCtor<T>) : Utils.className(classOrName);
+  }
+
+  /**
+   * Checks whether the given entity reference points at the given metadata,
+   * comparing classes by identity and strings by class name.
+   */
+  static matchesEntity<T>(classOrName: string | EntityName<T>, meta: EntityMetadata<any>): boolean {
+    const ref = Utils.classOrName(classOrName);
+    return typeof ref === 'function' ? (ref as unknown) === meta.class : ref === meta.className;
   }
 
   static extractChildElements(items: readonly string[], prefix: string, allSymbol?: string): string[] {

--- a/tests/issues/GH8208.test.ts
+++ b/tests/issues/GH8208.test.ts
@@ -123,6 +123,66 @@ test('repository type validation compares metadata identity, not class names', a
   await orm.close(true);
 });
 
+test('repository type validation works with multiple ORM instances sharing entity classes', async () => {
+  const orm1 = await MikroORM.init({ dbName: ':memory:', entities: [EntityA, EntityB] });
+  const orm2 = await MikroORM.init({ dbName: ':memory:', entities: [EntityA, EntityB] });
+  await orm1.schema.create();
+
+  // the second init overwrote `prototype.__meta`, so identity has to be compared via `meta.class`
+  const repoA = orm1.em.getRepository(EntityA);
+  const a = orm1.em.create(EntityA, { name: 'a1' });
+  const b = orm1.em.create(EntityB, { name: 'b1' });
+
+  expect(() => repoA.assign(a, { name: 'a2' })).not.toThrow();
+  expect(() => repoA.assign(b as any, { name: 'b2' })).toThrow(ValidationError);
+
+  await orm1.close(true);
+  await orm2.close(true);
+});
+
+test('result cache does not leak between entities sharing a mangled name', async () => {
+  const orm = await MikroORM.init({
+    dbName: ':memory:',
+    entities: [EntityA, EntityB],
+  });
+  await orm.schema.create();
+
+  orm.em.create(EntityA, { name: 'a1' });
+  orm.em.create(EntityB, { name: 'b1' });
+  await orm.em.flush();
+  orm.em.clear();
+
+  const as = await orm.em.find(EntityA, {}, { cache: 1000 });
+  expect(as).toHaveLength(1);
+  expect(as[0].name).toBe('a1');
+  orm.em.clear();
+
+  // same method, options and where produce the same cache key modulo the entity part
+  const bs = await orm.em.find(EntityB, {}, { cache: 1000 });
+  expect(bs).toHaveLength(1);
+  expect(bs[0].name).toBe('b1');
+
+  await orm.close(true);
+});
+
+test('string-based metadata lookup on an ambiguous class name throws', async () => {
+  const orm = await MikroORM.init({
+    dbName: ':memory:',
+    entities: [EntityA, EntityB],
+  });
+
+  // both entities minified to the same name, so a string lookup cannot be resolved
+  // string entity names are not part of the `EntityName` type anymore, but still work at runtime
+  expect(() => orm.getMetadata().get('d' as any)).toThrow(
+    `Entity name 'd' is ambiguous, multiple discovered entity classes share it (possibly due to a minifier mangling class names). Use a class reference instead of a string name.`,
+  );
+  // class reference lookups are not affected
+  expect(orm.getMetadata().get(EntityA).tableName).toBe('gh8208_a');
+  expect(orm.getMetadata().get(EntityB).tableName).toBe('gh8208_b');
+
+  await orm.close(true);
+});
+
 test('forceEntityConstructor matches entities by class reference', async () => {
   const orm = await MikroORM.init({
     dbName: ':memory:',

--- a/tests/issues/GH8208.test.ts
+++ b/tests/issues/GH8208.test.ts
@@ -1,0 +1,137 @@
+import { type EventArgs, type EventSubscriber, Type, ValidationError } from '@mikro-orm/core';
+import { Entity, PrimaryKey, Property } from '@mikro-orm/decorators/legacy';
+import { MikroORM } from '@mikro-orm/sqlite';
+
+// Minifiers (e.g. Turbopack) can mangle two entity classes from different module scopes
+// to the same short name. Lookups that resolve a user-supplied class must key by class
+// reference, not by class name.
+function defineEntityA() {
+  @Entity({ tableName: 'gh8208_a' })
+  class d {
+    @PrimaryKey({ type: 'number' })
+    id!: number;
+
+    @Property({ type: 'string' })
+    name!: string;
+  }
+
+  return d;
+}
+
+const EntityA = defineEntityA();
+
+function defineEntityB() {
+  @Entity({ tableName: 'gh8208_b' })
+  class d {
+    @PrimaryKey({ type: 'number' })
+    id!: number;
+
+    @Property({ type: 'string' })
+    name!: string;
+  }
+
+  return d;
+}
+
+const EntityB = defineEntityB();
+
+test('event subscribers match subscribed entities by class reference', async () => {
+  const calls: string[] = [];
+
+  class Subscriber implements EventSubscriber {
+    getSubscribedEntities() {
+      return [EntityA];
+    }
+
+    beforeCreate(args: EventArgs<any>) {
+      calls.push(args.entity.constructor === EntityA ? 'A' : 'B');
+    }
+  }
+
+  const orm = await MikroORM.init({
+    dbName: ':memory:',
+    entities: [EntityA, EntityB],
+    subscribers: [new Subscriber()],
+  });
+  await orm.schema.create();
+
+  orm.em.create(EntityA, { name: 'a1' });
+  orm.em.create(EntityB, { name: 'b1' });
+  await orm.em.flush();
+
+  expect(calls).toEqual(['A']);
+  await orm.close(true);
+});
+
+test('em.addFilter with entity restriction matches by class reference', async () => {
+  const orm = await MikroORM.init({
+    dbName: ':memory:',
+    entities: [EntityA, EntityB],
+  });
+  await orm.schema.create();
+
+  orm.em.create(EntityA, { name: 'match' });
+  orm.em.create(EntityA, { name: 'other' });
+  orm.em.create(EntityB, { name: 'other' });
+  await orm.em.flush();
+  orm.em.clear();
+
+  orm.em.addFilter({ name: 'named', cond: { name: 'match' }, entity: [EntityA] });
+
+  // the filter applies to `EntityA`...
+  await expect(orm.em.find(EntityA, {})).resolves.toHaveLength(1);
+  // ...but not to `EntityB`, which only shares the mangled class name
+  await expect(orm.em.find(EntityB, {})).resolves.toHaveLength(1);
+
+  await orm.close(true);
+});
+
+test('Type.getType caches instances by class reference', () => {
+  function defineType1() {
+    class a extends Type<string, string> {}
+
+    return a;
+  }
+
+  function defineType2() {
+    class a extends Type<string, string> {}
+
+    return a;
+  }
+
+  const Type1 = defineType1();
+  const Type2 = defineType2();
+
+  expect(Type.getType(Type1)).toBeInstanceOf(Type1);
+  expect(Type.getType(Type2)).toBeInstanceOf(Type2);
+});
+
+test('repository type validation compares metadata identity, not class names', async () => {
+  const orm = await MikroORM.init({
+    dbName: ':memory:',
+    entities: [EntityA, EntityB],
+  });
+  await orm.schema.create();
+
+  const repoA = orm.em.getRepository(EntityA);
+  const a = orm.em.create(EntityA, { name: 'a1' });
+  const b = orm.em.create(EntityB, { name: 'b1' });
+
+  expect(() => repoA.assign(a, { name: 'a2' })).not.toThrow();
+  expect(() => repoA.assign(b as any, { name: 'b2' })).toThrow(ValidationError);
+
+  await orm.close(true);
+});
+
+test('forceEntityConstructor matches entities by class reference', async () => {
+  const orm = await MikroORM.init({
+    dbName: ':memory:',
+    entities: [EntityA, EntityB],
+    forceEntityConstructor: [EntityA],
+  });
+
+  expect(orm.getMetadata().get(EntityA).forceConstructor).toBe(true);
+  expect(orm.getMetadata().get(EntityB).forceConstructor).toBe(false);
+
+  await orm.close(true);
+});


### PR DESCRIPTION
Minifiers can mangle two user classes to the same short name, so any lookup keyed by class name can resolve to the wrong class. This covers the actionable part of the audit in #8208: lookups where a class reference is available on both ends, plus two paths that can only fail loudly. Name matching stays as a fallback for string inputs.

- `EventManager` now matches subscribed entities by class reference. A subscriber no longer receives events for an unrelated entity that shares a mangled name, which was the confirmed failure in the report.
- `em.addFilter` keeps class references in the filter definition and `isFilterActive` compares them against `meta.class`. This also fixes class references in config-level filters, which never matched before.
- `Type.getType` caches instances per class reference instead of `cls.name`.
- `EntityRepository` type validation compares metadata identity where available.
- `forceEntityConstructor` entries match by class reference.
- The result cache key is derived from the table name (plus schema and discriminator value) instead of the class name. Table names are also stable across builds and processes, which class names under a minifier never were for external cache adapters.
- `MetadataStorage` tracks class-name collisions during discovery. Resolving a string entity name that several classes share now throws a descriptive `MetadataError` instead of silently returning whichever entity registered last. Class reference lookups resolve by identity and are not affected.

One row from the audit needed no change: the name-only "entity not discovered" check in `MetadataValidator` is unreachable for class references, because `tryDiscoverTargets` auto-discovers any class or schema target by identity before validation runs. That check only ever faces string references, where names are load-bearing by design.

Class names remain non-unique in metadata internals (`meta.className`, pivot property naming, error messages), so name-based features such as STI discriminators, string references and string subscriptions still require stable class names.

Closes #8208
