### PR TITLE
fix(sql): keep relation filters within their own join branch

### DIFF
--- a/packages/sql/src/query/QueryBuilder.ts
+++ b/packages/sql/src/query/QueryBuilder.ts
@@ -2475,13 +2475,16 @@ export class QueryBuilder<
 
     if (!join && options?.ignoreBranching) {
       join = joins.find(j => {
-        return j.path?.replace(/\[\d+]/g, '') === path.replace(/\[\d+]/g, '');
+        return j.path?.replace(/\[\d+]/g, '') === path.replace(/\[\d+]/g, '') && !this.branchesConflict(j.path!, path);
       });
     }
 
     if (!join && options?.matchPopulateJoins && options?.ignoreBranching) {
       join = joins.find(j => {
-        return j.path?.replace(/\[\d+]|\[populate]/g, '') === path.replace(/\[\d+]|\[populate]/g, '');
+        return (
+          j.path?.replace(/\[\d+]|\[populate]/g, '') === path.replace(/\[\d+]|\[populate]/g, '') &&
+          !this.branchesConflict(j.path!, path)
+        );
       });
     }
 
@@ -2492,6 +2495,13 @@ export class QueryBuilder<
     }
 
     return join;
+  }
+
+  /** Branch-insensitive path matching still must not cross branches — segments with different explicit branch markers (e.g. `Mobile[0]` vs `Mobile[1]`) belong to sibling joins. */
+  private branchesConflict(path1: string, path2: string): boolean {
+    const markers = (path: string) => path.split('.').map(segment => /\[(\d+)]/.exec(segment)?.[1]);
+    const markers2 = markers(path2);
+    return markers(path1).some((m, idx) => m != null && markers2[idx] != null && m !== markers2[idx]);
   }
 
   /**

--- a/tests/issues/GH8210.test.ts
+++ b/tests/issues/GH8210.test.ts
@@ -1,0 +1,108 @@
+import type { Rel } from '@mikro-orm/sqlite';
+import { BaseEntity, Collection, MikroORM } from '@mikro-orm/sqlite';
+import {
+  Entity,
+  Filter,
+  ManyToOne,
+  OneToMany,
+  PrimaryKey,
+  Property,
+  ReflectMetadataProvider,
+} from '@mikro-orm/decorators/legacy';
+
+@Entity()
+class Location extends BaseEntity {
+  @PrimaryKey({ autoincrement: true })
+  readonly id!: number;
+
+  @Property()
+  name!: string;
+}
+
+@Entity()
+class User extends BaseEntity {
+  @PrimaryKey({ autoincrement: true })
+  readonly id!: number;
+
+  @Property()
+  name!: string;
+
+  @ManyToOne(() => Location)
+  location!: Rel<Location>;
+}
+
+@Entity()
+@Filter({
+  name: 'location',
+  cond: ({ location }) => ({ user: { location } }),
+  default: true,
+})
+class ManagementObject extends BaseEntity {
+  @PrimaryKey({ autoincrement: true })
+  readonly id!: number;
+
+  @Property()
+  status!: string;
+
+  @ManyToOne(() => Mobile)
+  mobile!: Rel<Mobile>;
+
+  @ManyToOne(() => User, { nullable: true })
+  user?: Rel<User>;
+}
+
+@Entity()
+@Filter({
+  name: 'auth',
+  cond: ({ location }) => ({ managementObjects: { user: { location } } }),
+  default: true,
+})
+@Filter({
+  name: 'status',
+  cond: { managementObjects: { status: { $in: ['active', 'pending'] } } },
+  default: true,
+})
+class Mobile extends BaseEntity {
+  @PrimaryKey({ autoincrement: true })
+  readonly id!: number;
+
+  @Property()
+  name!: string;
+
+  @OneToMany(() => ManagementObject, mo => mo.mobile)
+  managementObjects = new Collection<ManagementObject>(this);
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    dbName: ':memory:',
+    entities: [Location, User, Mobile, ManagementObject],
+    metadataProvider: ReflectMetadataProvider,
+  });
+  await orm.schema.create();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+test('filter on auto-joined entity binds nested relation to its own join branch (GH #8210)', async () => {
+  const location = orm.em.create(Location, { name: 'Location 1' });
+  const user = orm.em.create(User, { name: 'User 1', location });
+  const mobile = orm.em.create(Mobile, { name: 'Mobile 1' });
+  orm.em.create(ManagementObject, { mobile, user, status: 'active' });
+  const location2 = orm.em.create(Location, { name: 'Location 2' });
+  const user2 = orm.em.create(User, { name: 'User 2', location: location2 });
+  const mobile2 = orm.em.create(Mobile, { name: 'Mobile 2' });
+  orm.em.create(ManagementObject, { mobile: mobile2, user: user2, status: 'active' });
+  await orm.em.flush();
+  orm.em.clear();
+
+  orm.em.setFilterParams('location', { location: location.id });
+  orm.em.setFilterParams('auth', { location: location.id });
+
+  const mobiles = await orm.em.find(Mobile, {});
+  expect(mobiles.map(m => m.name)).toEqual(['Mobile 1']);
+});


### PR DESCRIPTION
When two default filters on an entity each traverse the same to-many relation, the relation is auto-joined twice, in two branches. A filter on the target entity is merged into the `on` clause of both joins, but a nested relation path inside it was resolved with branch-insensitive matching in `getJoinForPath()`, which could bind it to a join created under the sibling branch. That alias renders later, so the database rejects the query (`ON clause references tables to its right` / `missing FROM-clause entry`), and even when the ordering happens to be accepted, the condition points at the wrong row.

The branch-insensitive lookups now skip candidates whose explicit branch markers conflict (e.g. `Mobile[0].managementObjects.user` vs `Mobile[1].managementObjects.user`), so the filter auto-joins the relation under its own branch instead.

Closes #8210
