### PR TITLE
fix(sql): prevent endless loop when entity filters form a relation cycle

### DIFF
--- a/packages/sql/src/query/QueryBuilder.ts
+++ b/packages/sql/src/query/QueryBuilder.ts
@@ -1470,7 +1470,10 @@ export class QueryBuilder<
    * @internal
    */
   scheduleFilterCheck(path: string): void {
-    this.#state.autoJoinedPaths.push(path);
+    // deduplicate so filters forming a relation cycle cannot reschedule an already visited path forever
+    if (!this.#state.autoJoinedPaths.includes(path)) {
+      this.#state.autoJoinedPaths.push(path);
+    }
   }
 
   /**

--- a/tests/issues/GH8211.test.ts
+++ b/tests/issues/GH8211.test.ts
@@ -1,0 +1,85 @@
+import type { Rel } from '@mikro-orm/sqlite';
+import { BaseEntity, Collection, MikroORM } from '@mikro-orm/sqlite';
+import {
+  Entity,
+  Filter,
+  ManyToOne,
+  OneToMany,
+  PrimaryKey,
+  Property,
+  ReflectMetadataProvider,
+} from '@mikro-orm/decorators/legacy';
+
+@Entity()
+@Filter({
+  name: 'auth',
+  cond: ({ company }) => ({ $or: [{ company }, { deviations: { type: { identifier: company } } }] }),
+  default: true,
+})
+class ManagementObject extends BaseEntity {
+  @PrimaryKey({ autoincrement: true })
+  readonly id!: number;
+
+  @Property()
+  company!: string;
+
+  @OneToMany(() => Deviation, d => d.managementObject)
+  deviations = new Collection<Deviation>(this);
+}
+
+@Entity()
+@Filter({
+  name: 'auth',
+  cond: ({ company }) => ({ deviations: { managementObject: { company } } }),
+  default: true,
+})
+class DeviationType extends BaseEntity {
+  @PrimaryKey({ autoincrement: true })
+  readonly id!: number;
+
+  @Property()
+  identifier!: string;
+
+  @OneToMany(() => Deviation, d => d.type)
+  deviations = new Collection<Deviation>(this);
+}
+
+@Entity()
+class Deviation extends BaseEntity {
+  @PrimaryKey({ autoincrement: true })
+  readonly id!: number;
+
+  @ManyToOne(() => ManagementObject)
+  managementObject!: Rel<ManagementObject>;
+
+  @ManyToOne(() => DeviationType)
+  type!: Rel<DeviationType>;
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    dbName: ':memory:',
+    entities: [ManagementObject, DeviationType, Deviation],
+    metadataProvider: ReflectMetadataProvider,
+  });
+  await orm.schema.create();
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+test('filters forming a relation cycle terminate (GH #8211)', async () => {
+  const mo = orm.em.create(ManagementObject, { company: 'x' });
+  const type = orm.em.create(DeviationType, { identifier: 'x' });
+  orm.em.create(Deviation, { managementObject: mo, type });
+  await orm.em.flush();
+  orm.em.clear();
+
+  orm.em.setFilterParams('auth', { company: 'x' });
+
+  const res = await orm.em.find(ManagementObject, { deviations: { type: { identifier: 'x' } } });
+  expect(res).toHaveLength(1);
+});


### PR DESCRIPTION
`applyJoinedFilters()` iterates `autoJoinedPaths` with `for…of` while `CriteriaNode.process()`, called inside the loop, appends new paths to the same array via `scheduleFilterCheck()`. Array iterators are live, so when two entity filters reference each other through relations, each lap schedules the next lap's joins, the same paths get re-pushed forever, and the process dies with a heap OOM.

Deduplicating the scheduled paths at the push site bounds the loop to unique paths: the cycle unrolls to a finite depth and the query completes with correct results. It also stops an already visited path from having its filter conditions merged into the join a second time.

Closes #8211
