### PR TITLE
fix(core): infer `serializer` callback value from relation kind in `defineEntity`

### DIFF
--- a/packages/core/src/entity/defineEntity.ts
+++ b/packages/core/src/entity/defineEntity.ts
@@ -153,7 +153,9 @@ export interface PropertyChain<Value, Options> {
   getter(getter?: boolean): PropertyChain<Value, Options>;
   getterName(getterName: string): PropertyChain<Value, Options>;
   serializedPrimaryKey(serializedPrimaryKey?: boolean): PropertyChain<Value, Options>;
-  serializer(serializer: (value: Value, options?: SerializeOptions<any>) => any): PropertyChain<Value, Options>;
+  serializer(
+    serializer: (value: SerializerValue<Value, Options>, options?: SerializeOptions<any>) => any,
+  ): PropertyChain<Value, Options>;
   serializedName(serializedName: string): PropertyChain<Value, Options>;
   groups(...groups: string[]): PropertyChain<Value, Options>;
   customOrder(...customOrder: string[] | number[] | boolean[]): PropertyChain<Value, Options>;
@@ -760,7 +762,7 @@ export class UniversalPropertyOptionsBuilder<Value, Options, IncludeKeys extends
    * @see https://mikro-orm.io/docs/serializing#property-serializers
    */
   serializer(
-    serializer: (value: Value, options?: SerializeOptions<any>) => any,
+    serializer: (value: SerializerValue<Value, Options>, options?: SerializeOptions<any>) => any,
   ): Pick<UniversalPropertyOptionsBuilder<Value, Options, IncludeKeys>, IncludeKeys> {
     return this.assignOptions({ serializer });
   }
@@ -1064,7 +1066,7 @@ export class OneToManyOptionsBuilderOnlyMappedBy<Value extends object> extends U
     UniversalPropertyOptionsBuilder<Value, EmptyOptions & { kind: '1:m' }, IncludeKeysForOneToManyOptions>,
     IncludeKeysForOneToManyOptions
   > {
-    return new UniversalPropertyOptionsBuilder({ ...this['~options'], mappedBy });
+    return this.assignOptions({ mappedBy });
   }
 }
 
@@ -1751,6 +1753,12 @@ type InferBuilderValue<Builder> = Builder extends { '~type'?: { value: infer Val
   : never;
 
 type MaybeArray<Value, Options> = Options extends { array: true } ? Value[] : Value;
+
+/** The runtime value passed to a custom serializer — the property value as stored on the entity (e.g. `Collection`/`Ref` for relations), without the `Opt`/`Hidden` branding. */
+type SerializerValue<Value, Options> = MaybeScalarRef<
+  MaybeNullable<MaybeRelationRef<MaybeMapToPk<MaybeArray<Value, Options>, Options>, Options>, Options>,
+  Options
+>;
 
 type MaybeMapToPk<Value, Options> = Options extends { mapToPk: true } ? Primary<Value> : Value;
 

--- a/packages/core/src/entity/defineEntity.ts
+++ b/packages/core/src/entity/defineEntity.ts
@@ -762,7 +762,7 @@ export class UniversalPropertyOptionsBuilder<Value, Options, IncludeKeys extends
    * @see https://mikro-orm.io/docs/serializing#property-serializers
    */
   serializer(
-    serializer: (value: SerializerValue<Value, Options>, options?: SerializeOptions<any>) => any,
+    serializer: (value: Value, options?: SerializeOptions<any>) => any,
   ): Pick<UniversalPropertyOptionsBuilder<Value, Options, IncludeKeys>, IncludeKeys> {
     return this.assignOptions({ serializer });
   }
@@ -1754,11 +1754,8 @@ type InferBuilderValue<Builder> = Builder extends { '~type'?: { value: infer Val
 
 type MaybeArray<Value, Options> = Options extends { array: true } ? Value[] : Value;
 
-/** The runtime value passed to a custom serializer — the property value as stored on the entity (e.g. `Collection`/`Ref` for relations), without the `Opt`/`Hidden` branding. */
-type SerializerValue<Value, Options> = MaybeScalarRef<
-  MaybeNullable<MaybeRelationRef<MaybeMapToPk<MaybeArray<Value, Options>, Options>, Options>, Options>,
-  Options
->;
+/** The runtime value passed to a custom serializer — the property value as stored on the entity (e.g. `Collection`/`Ref` for relations). Skips `MaybeMapToPk`, as its `Primary<Value>` branch is too costly for the type checker. */
+type SerializerValue<Value, Options> = MaybeNullable<MaybeRelationRef<MaybeArray<Value, Options>, Options>, Options>;
 
 type MaybeMapToPk<Value, Options> = Options extends { mapToPk: true } ? Primary<Value> : Value;
 

--- a/tests/bench/types/defineEntity-extends.ts
+++ b/tests/bench/types/defineEntity-extends.ts
@@ -19,7 +19,7 @@ bench('entity extends entity', () => {
       extra: p.string(),
     },
   });
-}).types([1541, 'instantiations']);
+}).types([1549, 'instantiations']);
 
 bench('entity extends entity with discriminator', () => {
   const base = defineEntity({
@@ -40,7 +40,7 @@ bench('entity extends entity with discriminator', () => {
       extra: p.string(),
     },
   });
-}).types([1605, 'instantiations']);
+}).types([1617, 'instantiations']);
 
 bench('embeddable extends embeddable', () => {
   const base = defineEntity({
@@ -60,7 +60,7 @@ bench('embeddable extends embeddable', () => {
       bar: p.string(),
     },
   });
-}).types([986, 'instantiations']);
+}).types([992, 'instantiations']);
 
 bench('embeddable extends embeddable with discriminator', () => {
   const base = defineEntity({
@@ -83,7 +83,7 @@ bench('embeddable extends embeddable with discriminator', () => {
       bar: p.string(),
     },
   });
-}).types([1050, 'instantiations']);
+}).types([1043, 'instantiations']);
 
 bench('polymorphic embeddables', () => {
   const base = defineEntity({
@@ -198,7 +198,7 @@ bench('polymorphic embeddables', () => {
       data: () => p.embedded([documentDataAwEdCard, documentDataCoCheckMig, documentDataMvDiCard]).object(),
     },
   });
-}).types([3945, 'instantiations']);
+}).types([3919, 'instantiations']);
 
 bench('realistic entity (~20 props, relations, extends)', () => {
   const base = defineEntity({
@@ -270,7 +270,7 @@ bench('realistic entity (~20 props, relations, extends)', () => {
       tags: () => p.manyToMany(Tag),
     },
   });
-}).types([8579, 'instantiations']);
+}).types([8553, 'instantiations']);
 
 bench('realistic entity - InferEntity usage', () => {
   const base = defineEntity({
@@ -350,7 +350,7 @@ bench('realistic entity - InferEntity usage', () => {
 
   // Force evaluation of all entity types
   const _check: [IAuthor, IBook, ITag, IPublisher] = {} as any;
-}).types([8687, 'instantiations']);
+}).types([8661, 'instantiations']);
 
 bench('realistic entity - setClass pattern', () => {
   const BaseSchema = defineEntity({
@@ -436,4 +436,4 @@ bench('realistic entity - setClass pattern', () => {
   PublisherSchema.setClass(Publisher);
   AuthorSchema.setClass(Author);
   BookSchema.setClass(Book);
-}).types([8978, 'instantiations']);
+}).types([8953, 'instantiations']);

--- a/tests/bench/types/defineEntity.ts
+++ b/tests/bench/types/defineEntity.ts
@@ -19,7 +19,7 @@ bench('defineEntity with relations', () => {
       strictNullRef: () => p.oneToOne(Foo).strictNullable(),
     },
   });
-}).types([7794, 'instantiations']);
+}).types([7758, 'instantiations']);
 
 bench('defineEntity with ref and nullable', () => {
   const Foo = defineEntity({
@@ -36,7 +36,7 @@ bench('defineEntity with ref and nullable', () => {
       scalarRefNullable: p.string().ref().nullable(),
     },
   });
-}).types([7278, 'instantiations']);
+}).types([7242, 'instantiations']);
 
 bench('defineEntity only with ref and nullable', () => {
   const Foo = defineEntity({
@@ -46,7 +46,7 @@ bench('defineEntity only with ref and nullable', () => {
       toOneRefNullable: () => p.oneToOne(Foo).ref().nullable(),
     },
   });
-}).types([1901, 'instantiations']);
+}).types([1905, 'instantiations']);
 
 bench('defineEntity only with nullable and ref', () => {
   const Foo = defineEntity({
@@ -56,7 +56,7 @@ bench('defineEntity only with nullable and ref', () => {
       toOneRefNullable: () => p.oneToOne(Foo).nullable().ref(),
     },
   });
-}).types([1904, 'instantiations']);
+}).types([1908, 'instantiations']);
 
 bench('defineEntity with relations using class', () => {
   class Foo {
@@ -88,7 +88,7 @@ bench('defineEntity with relations using class', () => {
       scalarRefNullable: p.string().ref().nullable(),
     },
   });
-}).types([7795, 'instantiations']);
+}).types([7787, 'instantiations']);
 
 bench('defineEntity with ref and nullable using class', () => {
   class Foo {
@@ -120,7 +120,7 @@ bench('defineEntity with ref and nullable using class', () => {
       scalarRefNullable: p.string().ref().nullable(),
     },
   });
-}).types([7795, 'instantiations']);
+}).types([7787, 'instantiations']);
 
 bench('defineEntity only with ref and nullable using class', () => {
   class Foo {
@@ -138,7 +138,7 @@ bench('defineEntity only with ref and nullable using class', () => {
       toOneRefNullable: () => p.oneToOne(Foo).ref().nullable(),
     },
   });
-}).types([2443, 'instantiations']);
+}).types([2475, 'instantiations']);
 
 bench('defineEntity only with nullable and ref using class', () => {
   class Foo {
@@ -156,7 +156,7 @@ bench('defineEntity only with nullable and ref using class', () => {
       toOneRefNullable: () => p.oneToOne(Foo).nullable().ref(),
     },
   });
-}).types([2446, 'instantiations']);
+}).types([2478, 'instantiations']);
 
 bench('EntitySchema', () => {
   interface IFoo {
@@ -241,7 +241,7 @@ bench('defineEntity with setClass pattern (circular relations)', () => {
 
   AuthorSchema.setClass(Author);
   BookSchema.setClass(Book);
-}).types([6221, 'instantiations']);
+}).types([6187, 'instantiations']);
 
 bench('defineEntity with indexes', () => {
   const Bar = defineEntity({
@@ -255,4 +255,4 @@ bench('defineEntity with indexes', () => {
     },
     indexes: [{ name: 'idx_status_views', properties: ['status', 'views'] }],
   });
-}).types([1978, 'instantiations']);
+}).types([1982, 'instantiations']);

--- a/tests/issues/GH8214.test.ts
+++ b/tests/issues/GH8214.test.ts
@@ -1,0 +1,50 @@
+import { Collection, defineEntity, InferEntity, MikroORM, p, Ref, wrap } from '@mikro-orm/sqlite';
+
+const User = defineEntity({
+  name: 'User',
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+  },
+});
+
+type IUser = InferEntity<typeof User>;
+
+const Post = defineEntity({
+  name: 'Post',
+  properties: {
+    id: p.integer().primary(),
+    author: p
+      .manyToOne(User)
+      .ref()
+      .serializer((author: Ref<IUser>) => author.id),
+    authors: p
+      .manyToMany(User)
+      .pivotTable('post_authors')
+      .serializer((users: Collection<IUser>) => users.getIdentifiers())
+      .serializedName('userIds'),
+  },
+});
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    dbName: ':memory:',
+    entities: [User, Post],
+  });
+  await orm.schema.refresh();
+});
+
+afterAll(() => orm.close(true));
+
+test('GH #8214 (serializer callback parameter matches the runtime relation value)', async () => {
+  const author1 = orm.em.create(User, { id: 1, name: 'u1' });
+  const author2 = orm.em.create(User, { id: 2, name: 'u2' });
+  orm.em.create(Post, { id: 1, author: author1, authors: [author1, author2] });
+  await orm.em.flush();
+  orm.em.clear();
+
+  const post = await orm.em.findOneOrFail(Post, 1, { populate: ['authors'] });
+  expect(wrap(post).toObject()).toEqual({ id: 1, author: 1, userIds: [1, 2] });
+});


### PR DESCRIPTION
The `.serializer()` callback parameter in `defineEntity` property builders was typed as the raw target entity type (`User`), while at runtime the serializer receives the stored property value: a `Collection<User>` for `1:m`/`m:n`, a `Ref` for `ref()` relations, a `ScalarReference` for scalar refs, and the primary key for `mapToPk`. Code like `users.getIdentifiers()` worked at runtime but failed to compile.

The new `SerializerValue` type composes the same wrappers as the entity type inference (minus the `Opt`/`Hidden` branding), so the callback parameter now matches what the serializer actually gets. The `mappedBy` override in `OneToManyOptionsBuilderOnlyMappedBy` now goes through `assignOptions()`, since the conditional type in the new signature breaks structural assignability of the bare `new UniversalPropertyOptionsBuilder(...)` call.

Closes #8214
