### PR TITLE
fix(core): support polymorphic relations inside embeddables

### DIFF
--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -581,8 +581,12 @@ export class MetadataDiscovery {
 
     if (prop.kind === ReferenceKind.SCALAR || prop.kind === ReferenceKind.EMBEDDED) {
       prop.fieldNames = [this.#namingStrategy.propertyToColumnName(prop.name, object)];
-    } else if ([ReferenceKind.MANY_TO_ONE, ReferenceKind.ONE_TO_ONE].includes(prop.kind) && !prop.polymorphic) {
-      prop.fieldNames = this.initManyToOneFieldName(prop, prop.name);
+    } else if ([ReferenceKind.MANY_TO_ONE, ReferenceKind.ONE_TO_ONE].includes(prop.kind)) {
+      if (prop.polymorphic && prop.polymorphTargets) {
+        this.initManyToOneFields(prop);
+      } else if (!prop.polymorphic) {
+        prop.fieldNames = this.initManyToOneFieldName(prop, prop.name);
+      }
     } else if (prop.kind === ReferenceKind.MANY_TO_MANY && prop.owner) {
       prop.fieldNames = this.initManyToManyFieldName(prop, prop.name);
     }

--- a/packages/core/src/utils/EntityComparator.ts
+++ b/packages/core/src/utils/EntityComparator.ts
@@ -840,7 +840,7 @@ export class EntityComparator {
           ret += `    ret${dataKey} = entity${entityKey};\n`;
         }
       } else if (prop.polymorphic) {
-        const discriminatorMapKey = `discriminatorMapReverse_${prop.name}`;
+        const discriminatorMapKey = `discriminatorMapReverse_${this.safeKey(prop.name)}`;
         const reverseMap = new Map<Function, string>();
 
         for (const [key, value] of Object.entries(prop.discriminatorMap!)) {

--- a/tests/issues/GH8217.test.ts
+++ b/tests/issues/GH8217.test.ts
@@ -1,0 +1,88 @@
+import { defineEntity, InferEntity, MikroORM, p } from '@mikro-orm/sqlite';
+
+const SubEntity1 = defineEntity({
+  name: 'SubEntity1',
+  properties: { id: p.integer().primary() },
+});
+
+const SubEntity2 = defineEntity({
+  name: 'SubEntity2',
+  properties: { id: p.integer().primary() },
+});
+
+const Meta = defineEntity({
+  name: 'Meta',
+  embeddable: true,
+  properties: {
+    subentity: () => p.manyToOne([SubEntity1, SubEntity2]),
+  },
+});
+
+const InlineOwner = defineEntity({
+  name: 'InlineOwner',
+  properties: {
+    id: p.integer().primary(),
+    meta: () => p.embedded(Meta),
+  },
+});
+
+const ObjectOwner = defineEntity({
+  name: 'ObjectOwner',
+  properties: {
+    id: p.integer().primary(),
+    meta: () => p.embedded(Meta).object(),
+  },
+});
+
+type ISubEntity1 = InferEntity<typeof SubEntity1>;
+type ISubEntity2 = InferEntity<typeof SubEntity2>;
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    dbName: ':memory:',
+    entities: [SubEntity1, SubEntity2, Meta, InlineOwner, ObjectOwner],
+  });
+  await orm.schema.refresh();
+});
+
+afterAll(() => orm.close(true));
+
+test('GH #8217 (polymorphic relation in an inline embeddable)', async () => {
+  const sub1 = orm.em.create(SubEntity1, { id: 1 });
+  const sub2 = orm.em.create(SubEntity2, { id: 1 });
+  orm.em.create(InlineOwner, { id: 1, meta: { subentity: sub1 } });
+  orm.em.create(InlineOwner, { id: 2, meta: { subentity: sub2 } });
+  await orm.em.flush();
+  orm.em.clear();
+
+  const owners = await orm.em.find(InlineOwner, {}, { orderBy: { id: 'asc' } });
+  expect(owners[0].meta.subentity).toBeInstanceOf(SubEntity1.meta.class);
+  expect(owners[1].meta.subentity).toBeInstanceOf(SubEntity2.meta.class);
+  expect((owners[0].meta.subentity as ISubEntity1).id).toBe(1);
+  expect((owners[1].meta.subentity as ISubEntity2).id).toBe(1);
+});
+
+test('GH #8217 (polymorphic relation in an object embeddable)', async () => {
+  const sub1 = orm.em.create(SubEntity1, { id: 2 });
+  const sub2 = orm.em.create(SubEntity2, { id: 2 });
+  orm.em.create(ObjectOwner, { id: 1, meta: { subentity: sub1 } });
+  orm.em.create(ObjectOwner, { id: 2, meta: { subentity: sub2 } });
+  await orm.em.flush();
+  orm.em.clear();
+
+  const rows = await orm.em
+    .getConnection()
+    .execute<{ id: number; meta: string }[]>('select id, meta from object_owner order by id asc');
+  expect(rows.map(row => row.meta)).toEqual([
+    '{"subentity_type":"sub_entity1","subentity_id":2}',
+    '{"subentity_type":"sub_entity2","subentity_id":2}',
+  ]);
+
+  const owners = await orm.em.find(ObjectOwner, {}, { orderBy: { id: 'asc' } });
+  expect(owners[0].meta.subentity).toBeInstanceOf(SubEntity1.meta.class);
+  expect(owners[1].meta.subentity).toBeInstanceOf(SubEntity2.meta.class);
+  expect((owners[0].meta.subentity as ISubEntity1).id).toBe(2);
+  expect((owners[1].meta.subentity as ISubEntity2).id).toBe(2);
+});


### PR DESCRIPTION
Discovering an entity whose embeddable holds a polymorphic relation crashed with `Cannot read properties of undefined (reading '0')`. `initFieldName()` skips polymorphic to-one relations, so by the time `initEmbeddables()` flattens the embeddable onto the owner, the relation still has no `fieldNames` to derive the column names from, and in object mode nothing to build the JSON path with either. It now delegates to `initManyToOneFields()`, which names the columns after the discriminator, the same way a polymorphic relation declared directly on an entity is named.

That alone is not enough for object mode. The comparator turns the property name into a variable name, and a property flattened into an object embeddable is named with a `~` glue (`meta~subentity`), which is not a valid identifier, so the generated snapshot function fails to compile. The `safeKey()` helper already covers that everywhere else, so the discriminator map key goes through it too.

Closes #8217
