### PR TITLE
fix(core): support polymorphic relations inside embeddables

### DIFF
--- a/packages/core/src/entity/EntityLoader.ts
+++ b/packages/core/src/entity/EntityLoader.ts
@@ -407,9 +407,10 @@ export class EntityLoader {
           continue;
         }
         toPopulate.push(entity);
-      } else if (refValue == null && !helper(entity).__loadedProperties.has(prop.name)) {
+      } else if (refValue == null && !prop.object && !helper(entity).__loadedProperties.has(prop.name)) {
         // FK columns weren't loaded (partial loading) — need to re-fetch them.
         // If the property IS in __loadedProperties, the FK was loaded and is genuinely null.
+        // Object-embedded virtual props are skipped — they are populated via the embeddable instance.
         needsFkLoad.push(entity);
       }
     }

--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -581,7 +581,19 @@ export class MetadataDiscovery {
 
     if (prop.kind === ReferenceKind.SCALAR || prop.kind === ReferenceKind.EMBEDDED) {
       prop.fieldNames = [this.#namingStrategy.propertyToColumnName(prop.name, object)];
-    } else if ([ReferenceKind.MANY_TO_ONE, ReferenceKind.ONE_TO_ONE].includes(prop.kind) && !prop.polymorphic) {
+    } else if ([ReferenceKind.MANY_TO_ONE, ReferenceKind.ONE_TO_ONE].includes(prop.kind) && prop.polymorphic) {
+      if (prop.targetMeta) {
+        // same layout as `initManyToOneFields` builds later: `[discriminatorColumn, ...fkIdColumns]`
+        const pkFields = prop.targetMeta.getPrimaryProps().flatMap(pk => {
+          this.initFieldName(pk);
+          return pk.fieldNames;
+        });
+        const idColumns = pkFields.map(fieldName =>
+          this.#namingStrategy.joinKeyColumnName(prop.discriminator!, fieldName, pkFields.length > 1),
+        );
+        prop.fieldNames = [prop.discriminatorColumn!, ...idColumns];
+      }
+    } else if ([ReferenceKind.MANY_TO_ONE, ReferenceKind.ONE_TO_ONE].includes(prop.kind)) {
       prop.fieldNames = this.initManyToOneFieldName(prop, prop.name);
     } else if (prop.kind === ReferenceKind.MANY_TO_MANY && prop.owner) {
       prop.fieldNames = this.initManyToManyFieldName(prop, prop.name);
@@ -1645,8 +1657,18 @@ export class MetadataDiscovery {
         meta.properties[name].nullable = true;
       }
 
+      // polymorphic relations derive their column names from the discriminator, so prefix it too
+      if (meta.properties[name].polymorphic && !object) {
+        meta.properties[name].discriminator = prefix + meta.properties[name].discriminator;
+        meta.properties[name].discriminatorColumn = prefix + meta.properties[name].discriminatorColumn;
+      }
+
       if (meta.properties[name].fieldNames) {
-        meta.properties[name].fieldNames[0] = prefix + meta.properties[name].fieldNames[0];
+        const { fieldNames, polymorphic } = meta.properties[name];
+        // polymorphic `fieldNames` hold `[discriminatorColumn, ...fkIdColumns]`, so prefix all of them
+        for (let i = 0; i < (polymorphic ? fieldNames.length : 1); i++) {
+          fieldNames[i] = prefix + fieldNames[i];
+        }
       } else {
         const name2 = meta.properties[name].name;
         meta.properties[name].name = prefix + prop.name;

--- a/packages/core/src/utils/EntityComparator.ts
+++ b/packages/core/src/utils/EntityComparator.ts
@@ -840,7 +840,7 @@ export class EntityComparator {
           ret += `    ret${dataKey} = entity${entityKey};\n`;
         }
       } else if (prop.polymorphic) {
-        const discriminatorMapKey = `discriminatorMapReverse_${prop.name}`;
+        const discriminatorMapKey = `discriminatorMapReverse_${this.safeKey(prop.name)}`;
         const reverseMap = new Map<Function, string>();
 
         for (const [key, value] of Object.entries(prop.discriminatorMap!)) {

--- a/packages/sql/src/AbstractSqlDriver.ts
+++ b/packages/sql/src/AbstractSqlDriver.ts
@@ -2402,6 +2402,12 @@ export abstract class AbstractSqlDriver<
         return false;
       }
 
+      // Polymorphic to-one flattened from an object embeddable lives inside a JSON column, so the join
+      // conditions would need JSON extraction for both the discriminator and the FK; fall back to SELECT_IN.
+      if (prop.polymorphic && prop.object && prop.embedded) {
+        return false;
+      }
+
       if (strategy !== LoadStrategy.JOINED) {
         // force joined strategy for explicit 1:1 owner populate hint as it would require a join anyway
         return prop.kind === ReferenceKind.ONE_TO_ONE && !prop.owner;

--- a/tests/issues/GH8217.test.ts
+++ b/tests/issues/GH8217.test.ts
@@ -1,0 +1,65 @@
+import { defineEntity, MikroORM, p } from '@mikro-orm/sqlite';
+
+const SubEntity1 = defineEntity({
+  name: 'SubEntity1',
+  properties: { id: p.integer().primary() },
+});
+
+const SubEntity2 = defineEntity({
+  name: 'SubEntity2',
+  properties: { id: p.integer().primary() },
+});
+
+const NestedEmbeddable = defineEntity({
+  name: 'NestedEmbeddable',
+  embeddable: true,
+  properties: {
+    subentity: () => p.manyToOne([SubEntity1, SubEntity2]),
+  },
+});
+
+const ObjectOwner = defineEntity({
+  name: 'ObjectOwner',
+  properties: {
+    id: p.integer().primary(),
+    embeddable: () => p.embedded(NestedEmbeddable).object(),
+  },
+});
+
+const InlineOwner = defineEntity({
+  name: 'InlineOwner',
+  properties: {
+    id: p.integer().primary(),
+    embeddable: () => p.embedded(NestedEmbeddable),
+  },
+});
+
+test('GH #8217 polymorphic relation inside an embeddable', async () => {
+  const orm = await MikroORM.init({
+    dbName: ':memory:',
+    entities: [NestedEmbeddable, ObjectOwner, InlineOwner, SubEntity1, SubEntity2],
+  });
+  const sql = await orm.schema.getCreateSchemaSQL();
+  expect(sql).toMatchSnapshot();
+  await orm.schema.create();
+
+  const sub1 = orm.em.create(SubEntity1, { id: 1 });
+  const sub2 = orm.em.create(SubEntity2, { id: 2 });
+  orm.em.create(InlineOwner, { id: 1, embeddable: { subentity: sub1 } });
+  orm.em.create(InlineOwner, { id: 2, embeddable: { subentity: sub2 } });
+  await orm.em.flush();
+  orm.em.clear();
+
+  const owners = await orm.em.find(InlineOwner, {}, { orderBy: { id: 'asc' }, populate: ['embeddable.subentity'] });
+  expect(owners[0].embeddable.subentity).toBeInstanceOf(SubEntity1.class);
+  expect(owners[1].embeddable.subentity).toBeInstanceOf(SubEntity2.class);
+
+  orm.em.create(ObjectOwner, { id: 1, embeddable: { subentity: orm.em.getReference(SubEntity1, 1) } });
+  await orm.em.flush();
+  orm.em.clear();
+
+  const objectOwner = await orm.em.findOneOrFail(ObjectOwner, 1, { populate: ['embeddable.subentity'] });
+  expect(objectOwner.embeddable.subentity).toBeInstanceOf(SubEntity1.class);
+
+  await orm.close(true);
+});

--- a/tests/issues/__snapshots__/GH8217.test.ts.snap
+++ b/tests/issues/__snapshots__/GH8217.test.ts.snap
@@ -1,0 +1,14 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`GH #8217 polymorphic relation inside an embeddable 1`] = `
+"create table \`sub_entity1\` (\`id\` integer not null primary key autoincrement);
+
+create table \`object_owner\` (\`id\` integer not null primary key autoincrement, \`embeddable\` json not null);
+create index \`object_owner_embeddable_subentity_type_index\` on \`object_owner\` ((json_extract(embeddable, '$.subentity_type')));
+
+create table \`inline_owner\` (\`id\` integer not null primary key autoincrement, \`embeddable_subentity_type\` text not null, \`embeddable_subentity_id\` integer not null);
+create index \`inline_owner_embeddable_subentity_type_embeddable_subentity_id_index\` on \`inline_owner\` (\`embeddable_subentity_type\`, \`embeddable_subentity_id\`);
+
+create table \`sub_entity2\` (\`id\` integer not null primary key autoincrement);
+"
+`;


### PR DESCRIPTION
Discovering an entity whose embeddable holds a polymorphic to-one relation crashed in `initEmbeddables()` with `Cannot read properties of undefined (reading '0')`. `initFieldName()` skipped polymorphic relations, so the flattened property never had `fieldNames` to derive column names or the JSON path from.

Fixing the crash alone is not enough, a few adjacent paths were broken too:

- `initFieldName()` now derives polymorphic to-one `fieldNames` the same way `initManyToOneFields()` builds them later (`[discriminatorColumn, ...fkIdColumns]`).
- `initEmbeddables()` prefixes the flattened copy's discriminator and all of its `fieldNames`, not just the first one. Without this, inline embedding produced columns like `subentity_type` + `subentity_id` that were unprefixed (or partially prefixed, depending on discovery order) and collide when the same embeddable is embedded twice.
- `EntityComparator` runs the discriminator map identifier through `safeKey()`, since properties flattened from object embeddables contain `~` in their names and the generated snapshot function failed to compile.
- `populate` on an object-embedded polymorphic relation failed with `no such column` under both strategies. The joined strategy now excludes such properties (the join conditions would need JSON extraction for both the discriminator and the FK), and `populatePolymorphic()` no longer tries to re-fetch the virtual flattened property as if it were real columns. The relation is populated through the embeddable instance, same as regular relations.

Supersedes #8218, which covered the first and third points but kept the unprefixed inline columns and left `populate` broken.

Closes #8217
