### PR TITLE
fix(core): escape entity property names in generated hydration/comparison code

### DIFF
--- a/packages/core/src/hydration/ObjectHydrator.ts
+++ b/packages/core/src/hydration/ObjectHydrator.ts
@@ -163,7 +163,7 @@ export class ObjectHydrator extends Hydrator {
       ret.push(`  if (data${dataKey} === null) {`);
       if (prop.ref) {
         ret.push(`    entity${entityKey} = new ScalarReference();`);
-        ret.push(`    entity${entityKey}.bind(entity, '${prop.name}');`);
+        ret.push(`    entity${entityKey}.bind(entity, ${JSON.stringify(prop.name)});`);
         ret.push(`    entity${entityKey}.set(${nullVal});`);
       } else {
         ret.push(`    entity${entityKey} = ${nullVal};`);
@@ -217,7 +217,7 @@ export class ObjectHydrator extends Hydrator {
           `    const value = isScalarReference(entity${entityKey}) ? entity${entityKey}.unwrap() : entity${entityKey};`,
         );
         ret.push(`    entity${entityKey} = oldValue_${idx} ?? new ScalarReference(value);`);
-        ret.push(`    entity${entityKey}.bind(entity, '${prop.name}');`);
+        ret.push(`    entity${entityKey}.bind(entity, ${JSON.stringify(prop.name)});`);
         ret.push(`    entity${entityKey}.set(value);`);
       }
 
@@ -226,7 +226,7 @@ export class ObjectHydrator extends Hydrator {
       if (prop.ref) {
         ret.push(`  if (!entity${entityKey}) {`);
         ret.push(`    entity${entityKey} = new ScalarReference();`);
-        ret.push(`    entity${entityKey}.bind(entity, '${prop.name}');`);
+        ret.push(`    entity${entityKey}.bind(entity, ${JSON.stringify(prop.name)});`);
         ret.push(`  }`);
       }
 
@@ -256,7 +256,7 @@ export class ObjectHydrator extends Hydrator {
         context.set(discriminatorMapKey, prop.discriminatorMap);
         ret.push(`      const targetClass = ${discriminatorMapKey}[data${dataKey}.discriminator];`);
         ret.push(
-          `      if (!targetClass) throw new ValidationError(\`Unknown discriminator value '\${data${dataKey}.discriminator}' for polymorphic relation '${prop.name}'. Valid values: \${Object.keys(${discriminatorMapKey}).join(', ')}\`);`,
+          `      if (!targetClass) throw new ValidationError(\`Unknown discriminator value '\${data${dataKey}.discriminator}' for polymorphic relation ${JSON.stringify(prop.name)}. Valid values: \${Object.keys(${discriminatorMapKey}).join(', ')}\`);`,
         );
         if (prop.ref) {
           ret.push(
@@ -344,7 +344,7 @@ export class ObjectHydrator extends Hydrator {
       ret.push(
         `    const items = data${dataKey}.map(value => createCollectionItem_${this.safeKey(prop.name)}(value, entity));`,
       );
-      ret.push(`    const coll = Collection.create(entity, '${prop.name}', items, newEntity);`);
+      ret.push(`    const coll = Collection.create(entity, ${JSON.stringify(prop.name)}, items, newEntity);`);
       ret.push(`    if (newEntity) {`);
       ret.push(`      coll.setDirty();`);
       ret.push(`    } else {`);
@@ -357,13 +357,13 @@ export class ObjectHydrator extends Hydrator {
         ret.push(`  } else if (!entity${entityKey} && Array.isArray(data${dataKey})) {`);
         const items = this.platform.usesPivotTable() || !prop.owner ? 'undefined' : '[]';
         ret.push(
-          `    const coll = Collection.create(entity, '${prop.name}', ${items}, !!data${dataKey} || newEntity);`,
+          `    const coll = Collection.create(entity, ${JSON.stringify(prop.name)}, ${items}, !!data${dataKey} || newEntity);`,
         );
         ret.push(`    coll.setDirty(false);`);
       }
 
       ret.push(`  } else if (!entity${entityKey}) {`);
-      ret.push(`    const coll = Collection.create(entity, '${prop.name}', undefined, newEntity);`);
+      ret.push(`    const coll = Collection.create(entity, ${JSON.stringify(prop.name)}, undefined, newEntity);`);
       ret.push(`    coll.setDirty(false);`);
       ret.push(`  }`);
 
@@ -616,11 +616,11 @@ export class ObjectHydrator extends Hydrator {
   }
 
   private wrap(key: string): string {
-    if (/^\[.*]$/.exec(key)) {
+    if (/^\[idx_\d+]$/.exec(key)) {
       return key;
     }
 
-    return /^\w+$/.exec(key) ? `.${key}` : `['${key}']`;
+    return /^\w+$/.exec(key) ? `.${key}` : `[${JSON.stringify(key)}]`;
   }
 
   private safeKey(key: string): string {

--- a/packages/core/src/hydration/ObjectHydrator.ts
+++ b/packages/core/src/hydration/ObjectHydrator.ts
@@ -163,7 +163,7 @@ export class ObjectHydrator extends Hydrator {
       ret.push(`  if (data${dataKey} === null) {`);
       if (prop.ref) {
         ret.push(`    entity${entityKey} = new ScalarReference();`);
-        ret.push(`    entity${entityKey}.bind(entity, ${JSON.stringify(prop.name)});`);
+        ret.push(`    entity${entityKey}.bind(entity, ${this.quote(prop.name)});`);
         ret.push(`    entity${entityKey}.set(${nullVal});`);
       } else {
         ret.push(`    entity${entityKey} = ${nullVal};`);
@@ -217,7 +217,7 @@ export class ObjectHydrator extends Hydrator {
           `    const value = isScalarReference(entity${entityKey}) ? entity${entityKey}.unwrap() : entity${entityKey};`,
         );
         ret.push(`    entity${entityKey} = oldValue_${idx} ?? new ScalarReference(value);`);
-        ret.push(`    entity${entityKey}.bind(entity, ${JSON.stringify(prop.name)});`);
+        ret.push(`    entity${entityKey}.bind(entity, ${this.quote(prop.name)});`);
         ret.push(`    entity${entityKey}.set(value);`);
       }
 
@@ -226,7 +226,7 @@ export class ObjectHydrator extends Hydrator {
       if (prop.ref) {
         ret.push(`  if (!entity${entityKey}) {`);
         ret.push(`    entity${entityKey} = new ScalarReference();`);
-        ret.push(`    entity${entityKey}.bind(entity, ${JSON.stringify(prop.name)});`);
+        ret.push(`    entity${entityKey}.bind(entity, ${this.quote(prop.name)});`);
         ret.push(`  }`);
       }
 
@@ -256,7 +256,7 @@ export class ObjectHydrator extends Hydrator {
         context.set(discriminatorMapKey, prop.discriminatorMap);
         ret.push(`      const targetClass = ${discriminatorMapKey}[data${dataKey}.discriminator];`);
         ret.push(
-          `      if (!targetClass) throw new ValidationError(\`Unknown discriminator value '\${data${dataKey}.discriminator}' for polymorphic relation ${JSON.stringify(prop.name)}. Valid values: \${Object.keys(${discriminatorMapKey}).join(', ')}\`);`,
+          `      if (!targetClass) throw new ValidationError(\`Unknown discriminator value '\${data${dataKey}.discriminator}' for polymorphic relation '${prop.name}'. Valid values: \${Object.keys(${discriminatorMapKey}).join(', ')}\`);`,
         );
         if (prop.ref) {
           ret.push(
@@ -344,7 +344,7 @@ export class ObjectHydrator extends Hydrator {
       ret.push(
         `    const items = data${dataKey}.map(value => createCollectionItem_${this.safeKey(prop.name)}(value, entity));`,
       );
-      ret.push(`    const coll = Collection.create(entity, ${JSON.stringify(prop.name)}, items, newEntity);`);
+      ret.push(`    const coll = Collection.create(entity, ${this.quote(prop.name)}, items, newEntity);`);
       ret.push(`    if (newEntity) {`);
       ret.push(`      coll.setDirty();`);
       ret.push(`    } else {`);
@@ -357,13 +357,13 @@ export class ObjectHydrator extends Hydrator {
         ret.push(`  } else if (!entity${entityKey} && Array.isArray(data${dataKey})) {`);
         const items = this.platform.usesPivotTable() || !prop.owner ? 'undefined' : '[]';
         ret.push(
-          `    const coll = Collection.create(entity, ${JSON.stringify(prop.name)}, ${items}, !!data${dataKey} || newEntity);`,
+          `    const coll = Collection.create(entity, ${this.quote(prop.name)}, ${items}, !!data${dataKey} || newEntity);`,
         );
         ret.push(`    coll.setDirty(false);`);
       }
 
       ret.push(`  } else if (!entity${entityKey}) {`);
-      ret.push(`    const coll = Collection.create(entity, ${JSON.stringify(prop.name)}, undefined, newEntity);`);
+      ret.push(`    const coll = Collection.create(entity, ${this.quote(prop.name)}, undefined, newEntity);`);
       ret.push(`    coll.setDirty(false);`);
       ret.push(`  }`);
 
@@ -620,7 +620,12 @@ export class ObjectHydrator extends Hydrator {
       return key;
     }
 
-    return /^\w+$/.exec(key) ? `.${key}` : `[${JSON.stringify(key)}]`;
+    return /^\w+$/.exec(key) ? `.${key}` : `[${this.quote(key)}]`;
+  }
+
+  /** Renders a key as a single-quoted JS string literal, safe to embed in generated code. */
+  private quote(key: string): string {
+    return `'${key.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
   }
 
   private safeKey(key: string): string {

--- a/packages/core/src/utils/EntityComparator.ts
+++ b/packages/core/src/utils/EntityComparator.ts
@@ -1068,11 +1068,11 @@ export class EntityComparator {
   }
 
   private wrap(key: string): string {
-    if (/^\[.*]$/.exec(key)) {
+    if (/^\[idx_\d+]$/.exec(key)) {
       return key;
     }
 
-    return /^\w+$/.exec(key) ? `.${key}` : `['${key}']`;
+    return /^\w+$/.exec(key) ? `.${key}` : `[${JSON.stringify(key)}]`;
   }
 
   private safeKey(key: string): string {

--- a/packages/core/src/utils/EntityComparator.ts
+++ b/packages/core/src/utils/EntityComparator.ts
@@ -1072,7 +1072,12 @@ export class EntityComparator {
       return key;
     }
 
-    return /^\w+$/.exec(key) ? `.${key}` : `[${JSON.stringify(key)}]`;
+    return /^\w+$/.exec(key) ? `.${key}` : `[${this.quote(key)}]`;
+  }
+
+  /** Renders a key as a single-quoted JS string literal, safe to embed in generated code. */
+  private quote(key: string): string {
+    return `'${key.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
   }
 
   private safeKey(key: string): string {

--- a/tests/features/embeddables/__snapshots__/polymorphic-embedded-entities.sqlite.test.ts.snap
+++ b/tests/features/embeddables/__snapshots__/polymorphic-embedded-entities.sqlite.test.ts.snap
@@ -313,25 +313,25 @@ exports[`polymorphic embeddables in sqlite > diffing 1`] = `
       } else if (typeof data.pet2.canBark !== 'undefined') {
         entity.pet2.canBark = !!data.pet2.canBark;
       }
-      if (data["pet2~foodcats"] != null || data["pet2~foodmice"] != null) {
+      if (data['pet2~foodcats'] != null || data['pet2~foodmice'] != null) {
         const embeddedData = {
-          cats: data["pet2~foodcats"],
-          mice: data["pet2~foodmice"],
+          cats: data['pet2~foodcats'],
+          mice: data['pet2~foodmice'],
         };
         if (entity.pet2.food == null) {
           entity.pet2.food = factory.createEmbeddable(dog_food_43, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
         }
-        if (data["pet2~foodcats"] === null) {
+        if (data['pet2~foodcats'] === null) {
           entity.pet2.food.cats = null;
-        } else if (typeof data["pet2~foodcats"] !== 'undefined') {
-          entity.pet2.food.cats = data["pet2~foodcats"];
+        } else if (typeof data['pet2~foodcats'] !== 'undefined') {
+          entity.pet2.food.cats = data['pet2~foodcats'];
         }
-        if (data["pet2~foodmice"] === null) {
+        if (data['pet2~foodmice'] === null) {
           entity.pet2.food.mice = null;
-        } else if (typeof data["pet2~foodmice"] !== 'undefined') {
-          entity.pet2.food.mice = data["pet2~foodmice"];
+        } else if (typeof data['pet2~foodmice'] !== 'undefined') {
+          entity.pet2.food.mice = data['pet2~foodmice'];
         }
-      } else if (data["pet2~foodcats"] === null && data["pet2~foodmice"] === null) {
+      } else if (data['pet2~foodcats'] === null && data['pet2~foodmice'] === null) {
         entity.pet2.food = null;
       }
       if (typeof data.pet2.food === 'string') {
@@ -380,25 +380,25 @@ exports[`polymorphic embeddables in sqlite > diffing 1`] = `
       } else if (typeof data.pet2.canBark !== 'undefined') {
         entity.pet2.canBark = data.pet2.canBark;
       }
-      if (data["pet2~foodcats"] != null || data["pet2~foodmice"] != null) {
+      if (data['pet2~foodcats'] != null || data['pet2~foodmice'] != null) {
         const embeddedData = {
-          cats: data["pet2~foodcats"],
-          mice: data["pet2~foodmice"],
+          cats: data['pet2~foodcats'],
+          mice: data['pet2~foodmice'],
         };
         if (entity.pet2.food == null) {
           entity.pet2.food = factory.createEmbeddable(cat_food_53, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
         }
-        if (data["pet2~foodcats"] === null) {
+        if (data['pet2~foodcats'] === null) {
           entity.pet2.food.cats = null;
-        } else if (typeof data["pet2~foodcats"] !== 'undefined') {
-          entity.pet2.food.cats = data["pet2~foodcats"];
+        } else if (typeof data['pet2~foodcats'] !== 'undefined') {
+          entity.pet2.food.cats = data['pet2~foodcats'];
         }
-        if (data["pet2~foodmice"] === null) {
+        if (data['pet2~foodmice'] === null) {
           entity.pet2.food.mice = null;
-        } else if (typeof data["pet2~foodmice"] !== 'undefined') {
-          entity.pet2.food.mice = data["pet2~foodmice"];
+        } else if (typeof data['pet2~foodmice'] !== 'undefined') {
+          entity.pet2.food.mice = data['pet2~foodmice'];
         }
-      } else if (data["pet2~foodcats"] === null && data["pet2~foodmice"] === null) {
+      } else if (data['pet2~foodcats'] === null && data['pet2~foodmice'] === null) {
         entity.pet2.food = null;
       }
       if (typeof data.pet2.food === 'string') {
@@ -461,25 +461,25 @@ exports[`polymorphic embeddables in sqlite > diffing 1`] = `
           } else if (typeof data.pets[idx_62].canBark !== 'undefined') {
             entity.pets[idx_62].canBark = !!data.pets[idx_62].canBark;
           }
-          if (data["pets~foodcats"] != null || data["pets~foodmice"] != null) {
+          if (data['pets~foodcats'] != null || data['pets~foodmice'] != null) {
             const embeddedData = {
-              cats: data["pets~foodcats"],
-              mice: data["pets~foodmice"],
+              cats: data['pets~foodcats'],
+              mice: data['pets~foodmice'],
             };
             if (entity.pets[idx_62].food == null) {
               entity.pets[idx_62].food = factory.createEmbeddable(dog_food_64, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
             }
-            if (data["pets~foodcats"] === null) {
+            if (data['pets~foodcats'] === null) {
               entity.pets[idx_62].food.cats = null;
-            } else if (typeof data["pets~foodcats"] !== 'undefined') {
-              entity.pets[idx_62].food.cats = data["pets~foodcats"];
+            } else if (typeof data['pets~foodcats'] !== 'undefined') {
+              entity.pets[idx_62].food.cats = data['pets~foodcats'];
             }
-            if (data["pets~foodmice"] === null) {
+            if (data['pets~foodmice'] === null) {
               entity.pets[idx_62].food.mice = null;
-            } else if (typeof data["pets~foodmice"] !== 'undefined') {
-              entity.pets[idx_62].food.mice = data["pets~foodmice"];
+            } else if (typeof data['pets~foodmice'] !== 'undefined') {
+              entity.pets[idx_62].food.mice = data['pets~foodmice'];
             }
-          } else if (data["pets~foodcats"] === null && data["pets~foodmice"] === null) {
+          } else if (data['pets~foodcats'] === null && data['pets~foodmice'] === null) {
             entity.pets[idx_62].food = null;
           }
           if (typeof data.pets[idx_62].food === 'string') {
@@ -528,25 +528,25 @@ exports[`polymorphic embeddables in sqlite > diffing 1`] = `
           } else if (typeof data.pets[idx_62].canBark !== 'undefined') {
             entity.pets[idx_62].canBark = data.pets[idx_62].canBark;
           }
-          if (data["pets~foodcats"] != null || data["pets~foodmice"] != null) {
+          if (data['pets~foodcats'] != null || data['pets~foodmice'] != null) {
             const embeddedData = {
-              cats: data["pets~foodcats"],
-              mice: data["pets~foodmice"],
+              cats: data['pets~foodcats'],
+              mice: data['pets~foodmice'],
             };
             if (entity.pets[idx_62].food == null) {
               entity.pets[idx_62].food = factory.createEmbeddable(cat_food_74, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
             }
-            if (data["pets~foodcats"] === null) {
+            if (data['pets~foodcats'] === null) {
               entity.pets[idx_62].food.cats = null;
-            } else if (typeof data["pets~foodcats"] !== 'undefined') {
-              entity.pets[idx_62].food.cats = data["pets~foodcats"];
+            } else if (typeof data['pets~foodcats'] !== 'undefined') {
+              entity.pets[idx_62].food.cats = data['pets~foodcats'];
             }
-            if (data["pets~foodmice"] === null) {
+            if (data['pets~foodmice'] === null) {
               entity.pets[idx_62].food.mice = null;
-            } else if (typeof data["pets~foodmice"] !== 'undefined') {
-              entity.pets[idx_62].food.mice = data["pets~foodmice"];
+            } else if (typeof data['pets~foodmice'] !== 'undefined') {
+              entity.pets[idx_62].food.mice = data['pets~foodmice'];
             }
-          } else if (data["pets~foodcats"] === null && data["pets~foodmice"] === null) {
+          } else if (data['pets~foodcats'] === null && data['pets~foodmice'] === null) {
             entity.pets[idx_62].food = null;
           }
           if (typeof data.pets[idx_62].food === 'string') {

--- a/tests/features/embeddables/__snapshots__/polymorphic-embedded-entities.sqlite.test.ts.snap
+++ b/tests/features/embeddables/__snapshots__/polymorphic-embedded-entities.sqlite.test.ts.snap
@@ -313,25 +313,25 @@ exports[`polymorphic embeddables in sqlite > diffing 1`] = `
       } else if (typeof data.pet2.canBark !== 'undefined') {
         entity.pet2.canBark = !!data.pet2.canBark;
       }
-      if (data['pet2~foodcats'] != null || data['pet2~foodmice'] != null) {
+      if (data["pet2~foodcats"] != null || data["pet2~foodmice"] != null) {
         const embeddedData = {
-          cats: data['pet2~foodcats'],
-          mice: data['pet2~foodmice'],
+          cats: data["pet2~foodcats"],
+          mice: data["pet2~foodmice"],
         };
         if (entity.pet2.food == null) {
           entity.pet2.food = factory.createEmbeddable(dog_food_43, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
         }
-        if (data['pet2~foodcats'] === null) {
+        if (data["pet2~foodcats"] === null) {
           entity.pet2.food.cats = null;
-        } else if (typeof data['pet2~foodcats'] !== 'undefined') {
-          entity.pet2.food.cats = data['pet2~foodcats'];
+        } else if (typeof data["pet2~foodcats"] !== 'undefined') {
+          entity.pet2.food.cats = data["pet2~foodcats"];
         }
-        if (data['pet2~foodmice'] === null) {
+        if (data["pet2~foodmice"] === null) {
           entity.pet2.food.mice = null;
-        } else if (typeof data['pet2~foodmice'] !== 'undefined') {
-          entity.pet2.food.mice = data['pet2~foodmice'];
+        } else if (typeof data["pet2~foodmice"] !== 'undefined') {
+          entity.pet2.food.mice = data["pet2~foodmice"];
         }
-      } else if (data['pet2~foodcats'] === null && data['pet2~foodmice'] === null) {
+      } else if (data["pet2~foodcats"] === null && data["pet2~foodmice"] === null) {
         entity.pet2.food = null;
       }
       if (typeof data.pet2.food === 'string') {
@@ -380,25 +380,25 @@ exports[`polymorphic embeddables in sqlite > diffing 1`] = `
       } else if (typeof data.pet2.canBark !== 'undefined') {
         entity.pet2.canBark = data.pet2.canBark;
       }
-      if (data['pet2~foodcats'] != null || data['pet2~foodmice'] != null) {
+      if (data["pet2~foodcats"] != null || data["pet2~foodmice"] != null) {
         const embeddedData = {
-          cats: data['pet2~foodcats'],
-          mice: data['pet2~foodmice'],
+          cats: data["pet2~foodcats"],
+          mice: data["pet2~foodmice"],
         };
         if (entity.pet2.food == null) {
           entity.pet2.food = factory.createEmbeddable(cat_food_53, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
         }
-        if (data['pet2~foodcats'] === null) {
+        if (data["pet2~foodcats"] === null) {
           entity.pet2.food.cats = null;
-        } else if (typeof data['pet2~foodcats'] !== 'undefined') {
-          entity.pet2.food.cats = data['pet2~foodcats'];
+        } else if (typeof data["pet2~foodcats"] !== 'undefined') {
+          entity.pet2.food.cats = data["pet2~foodcats"];
         }
-        if (data['pet2~foodmice'] === null) {
+        if (data["pet2~foodmice"] === null) {
           entity.pet2.food.mice = null;
-        } else if (typeof data['pet2~foodmice'] !== 'undefined') {
-          entity.pet2.food.mice = data['pet2~foodmice'];
+        } else if (typeof data["pet2~foodmice"] !== 'undefined') {
+          entity.pet2.food.mice = data["pet2~foodmice"];
         }
-      } else if (data['pet2~foodcats'] === null && data['pet2~foodmice'] === null) {
+      } else if (data["pet2~foodcats"] === null && data["pet2~foodmice"] === null) {
         entity.pet2.food = null;
       }
       if (typeof data.pet2.food === 'string') {
@@ -461,25 +461,25 @@ exports[`polymorphic embeddables in sqlite > diffing 1`] = `
           } else if (typeof data.pets[idx_62].canBark !== 'undefined') {
             entity.pets[idx_62].canBark = !!data.pets[idx_62].canBark;
           }
-          if (data['pets~foodcats'] != null || data['pets~foodmice'] != null) {
+          if (data["pets~foodcats"] != null || data["pets~foodmice"] != null) {
             const embeddedData = {
-              cats: data['pets~foodcats'],
-              mice: data['pets~foodmice'],
+              cats: data["pets~foodcats"],
+              mice: data["pets~foodmice"],
             };
             if (entity.pets[idx_62].food == null) {
               entity.pets[idx_62].food = factory.createEmbeddable(dog_food_64, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
             }
-            if (data['pets~foodcats'] === null) {
+            if (data["pets~foodcats"] === null) {
               entity.pets[idx_62].food.cats = null;
-            } else if (typeof data['pets~foodcats'] !== 'undefined') {
-              entity.pets[idx_62].food.cats = data['pets~foodcats'];
+            } else if (typeof data["pets~foodcats"] !== 'undefined') {
+              entity.pets[idx_62].food.cats = data["pets~foodcats"];
             }
-            if (data['pets~foodmice'] === null) {
+            if (data["pets~foodmice"] === null) {
               entity.pets[idx_62].food.mice = null;
-            } else if (typeof data['pets~foodmice'] !== 'undefined') {
-              entity.pets[idx_62].food.mice = data['pets~foodmice'];
+            } else if (typeof data["pets~foodmice"] !== 'undefined') {
+              entity.pets[idx_62].food.mice = data["pets~foodmice"];
             }
-          } else if (data['pets~foodcats'] === null && data['pets~foodmice'] === null) {
+          } else if (data["pets~foodcats"] === null && data["pets~foodmice"] === null) {
             entity.pets[idx_62].food = null;
           }
           if (typeof data.pets[idx_62].food === 'string') {
@@ -528,25 +528,25 @@ exports[`polymorphic embeddables in sqlite > diffing 1`] = `
           } else if (typeof data.pets[idx_62].canBark !== 'undefined') {
             entity.pets[idx_62].canBark = data.pets[idx_62].canBark;
           }
-          if (data['pets~foodcats'] != null || data['pets~foodmice'] != null) {
+          if (data["pets~foodcats"] != null || data["pets~foodmice"] != null) {
             const embeddedData = {
-              cats: data['pets~foodcats'],
-              mice: data['pets~foodmice'],
+              cats: data["pets~foodcats"],
+              mice: data["pets~foodmice"],
             };
             if (entity.pets[idx_62].food == null) {
               entity.pets[idx_62].food = factory.createEmbeddable(cat_food_74, embeddedData, { newEntity, convertCustomTypes, normalizeAccessors });
             }
-            if (data['pets~foodcats'] === null) {
+            if (data["pets~foodcats"] === null) {
               entity.pets[idx_62].food.cats = null;
-            } else if (typeof data['pets~foodcats'] !== 'undefined') {
-              entity.pets[idx_62].food.cats = data['pets~foodcats'];
+            } else if (typeof data["pets~foodcats"] !== 'undefined') {
+              entity.pets[idx_62].food.cats = data["pets~foodcats"];
             }
-            if (data['pets~foodmice'] === null) {
+            if (data["pets~foodmice"] === null) {
               entity.pets[idx_62].food.mice = null;
-            } else if (typeof data['pets~foodmice'] !== 'undefined') {
-              entity.pets[idx_62].food.mice = data['pets~foodmice'];
+            } else if (typeof data["pets~foodmice"] !== 'undefined') {
+              entity.pets[idx_62].food.mice = data["pets~foodmice"];
             }
-          } else if (data['pets~foodcats'] === null && data['pets~foodmice'] === null) {
+          } else if (data["pets~foodcats"] === null && data["pets~foodmice"] === null) {
             entity.pets[idx_62].food = null;
           }
           if (typeof data.pets[idx_62].food === 'string') {

--- a/tests/features/hydration/special-property-names.test.ts
+++ b/tests/features/hydration/special-property-names.test.ts
@@ -8,7 +8,7 @@ interface IFoo {
 // Property names are embedded into the JIT-compiled hydrator/comparator source. Names that are not
 // plain identifiers (quotes, brackets, dots, whitespace) must be emitted as data, not as raw code,
 // otherwise they break the generated function or change its behaviour.
-const weirdNames = [`weird'quote`, '[bracket]', 'has.dot', 'has space', 'back`tick', 'dollar${x}'];
+const weirdNames = [`weird'quote`, '[bracket]', 'has.dot', 'has space', 'back`tick', 'dollar${x}', 'back\\slash'];
 
 function buildSchema() {
   const schema = new EntitySchema<IFoo>({

--- a/tests/features/hydration/special-property-names.test.ts
+++ b/tests/features/hydration/special-property-names.test.ts
@@ -1,0 +1,51 @@
+import { EntitySchema, MikroORM } from '@mikro-orm/sqlite';
+
+interface IFoo {
+  id: number;
+  name: string;
+}
+
+// Property names are embedded into the JIT-compiled hydrator/comparator source. Names that are not
+// plain identifiers (quotes, brackets, dots, whitespace) must be emitted as data, not as raw code,
+// otherwise they break the generated function or change its behaviour.
+const weirdNames = [`weird'quote`, '[bracket]', 'has.dot', 'has space', 'back`tick', 'dollar${x}'];
+
+function buildSchema() {
+  const schema = new EntitySchema<IFoo>({
+    name: 'Foo',
+    properties: {
+      id: { primary: true, type: 'number' },
+      name: { type: 'string' },
+    },
+  });
+
+  // non-persisted so the odd name never needs to map to a real column
+  for (const n of weirdNames) {
+    (schema as EntitySchema<any>).addProperty(n, 'string', { persist: false, nullable: true });
+  }
+
+  return schema;
+}
+
+test('property names with special characters do not corrupt generated hydrator code', async () => {
+  const schema = buildSchema();
+  const orm = await MikroORM.init({ dbName: ':memory:', entities: [schema] });
+  await orm.schema.create();
+
+  const em = orm.em.fork();
+  await em.insert(schema, { name: 'bar' } as IFoo);
+
+  // first hydration compiles the hydrator; a badly escaped name would throw a SyntaxError here
+  const found = await em.find(schema, {});
+  expect(found).toHaveLength(1);
+  expect(found[0].name).toBe('bar');
+
+  // changes are computed via the comparator (also JIT-compiled from the same names)
+  found[0].name = 'baz';
+  await em.flush();
+
+  const reloaded = await orm.em.fork().findOneOrFail(schema, { id: found[0].id });
+  expect(reloaded.name).toBe('baz');
+
+  await orm.close(true);
+});


### PR DESCRIPTION
Property names are interpolated into the JIT-compiled hydrator and comparator source. Two positions were not escaped: single-quoted string literals (`bind(entity, '<name>')`, `Collection.create(entity, '<name>', ...)`) and the `['<name>']` branch of `wrap()`. A property name that is not a plain identifier, such as one containing a quote or a bracket, produced uncompilable or incorrect generated code.

The names are now emitted as data: string literals go through `JSON.stringify`, and the passthrough branch of `wrap()` is restricted to the internal `[idx_N]` marker so every other key is escaped. This lines the string and bracket positions up with the `safeKey` handling that the identifier positions already had. Same change in both `ObjectHydrator` and `EntityComparator`.

The one snapshot change is the quote style of generated embedded-key access (`'a~b'` becomes `"a~b"`); the generated code is otherwise identical.
