### PR TITLE
fix(core): apply TPT version property only to the table that declares it

### DIFF
--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -1602,6 +1602,15 @@ export class EntityMetadata<Entity = any, Class extends EntityCtor<Entity> = Ent
     }
   }
 
+  /** For TPT entities, the version column exists only on the table of the entity that declares it. */
+  ownsVersionProperty(): boolean {
+    if (!this.versionProperty) {
+      return false;
+    }
+
+    return this.inheritanceType !== 'tpt' || !this.ownProps || this.ownProps.some(p => p.name === this.versionProperty);
+  }
+
   getPrimaryProps(flatten = false): EntityProperty<Entity>[] {
     const pks = this.primaryKeys.map(pk => this.properties[pk]);
 

--- a/packages/core/src/unit-of-work/ChangeSetPersister.ts
+++ b/packages/core/src/unit-of-work/ChangeSetPersister.ts
@@ -459,12 +459,12 @@ export class ChangeSetPersister {
 
     if (
       meta.concurrencyCheckKeys.size === 0 &&
-      (!meta.versionProperty || changeSet.entity[meta.versionProperty] == null)
+      (!meta.ownsVersionProperty() || changeSet.entity[meta.versionProperty] == null)
     ) {
       return this.#driver.nativeUpdate(changeSet.meta.class, cond as FilterQuery<T>, changeSet.payload, options);
     }
 
-    if (meta.versionProperty) {
+    if (meta.ownsVersionProperty()) {
       cond[meta.versionProperty] = this.#platform.convertVersionValue(
         changeSet.entity[meta.versionProperty] as unknown as Date,
         meta.properties[meta.versionProperty],
@@ -483,7 +483,7 @@ export class ChangeSetPersister {
   ): Promise<void> {
     if (
       meta.concurrencyCheckKeys.size === 0 &&
-      (!meta.versionProperty || changeSets.every(cs => cs.entity[meta.versionProperty] == null))
+      (!meta.ownsVersionProperty() || changeSets.every(cs => cs.entity[meta.versionProperty] == null))
     ) {
       return;
     }
@@ -497,7 +497,7 @@ export class ChangeSetPersister {
         meta.primaryKeys.concat(...meta.concurrencyCheckKeys),
       ) as FilterQuery<T>;
 
-      if (meta.versionProperty) {
+      if (meta.ownsVersionProperty()) {
         // @ts-ignore
         cond[meta.versionProperty] = this.#platform.convertVersionValue(
           cs.entity[meta.versionProperty] as unknown as Date,
@@ -516,7 +516,9 @@ export class ChangeSetPersister {
         return o;
       }, {} as Dictionary),
     });
-    const res = await this.#driver.find<T>(meta.root.class, { $or } as FilterQuery<T>, options);
+    // TPT tables query their own metadata, as the version column might not live on the root table
+    const target = meta.inheritanceType === 'tpt' ? meta : meta.root;
+    const res = await this.#driver.find<T>(target.class, { $or } as FilterQuery<T>, options);
 
     if (res.length !== changeSets.length) {
       // a FK pointing to a composite PK is an array, so the values need to be compared deeply
@@ -548,7 +550,7 @@ export class ChangeSetPersister {
     options?: DriverMethodOptions,
   ) {
     const reloadProps =
-      meta.versionProperty && !this.#usesReturningStatement ? [meta.properties[meta.versionProperty]] : [];
+      meta.ownsVersionProperty() && !this.#usesReturningStatement ? [meta.properties[meta.versionProperty]] : [];
 
     if (changeSets[0].type === ChangeSetType.CREATE) {
       for (const prop of meta.props) {

--- a/packages/core/src/unit-of-work/UnitOfWork.ts
+++ b/packages/core/src/unit-of-work/UnitOfWork.ts
@@ -468,6 +468,7 @@ export class UnitOfWork {
 
           if (!parentCs) {
             parentCs = new ChangeSet(entity, changeSet.type, {} as EntityDictionary<T>, current as EntityMetadata<T>);
+            parentCs.originalEntity = changeSet.originalEntity;
             changeSet.tptChangeSets.splice(idx, 0, parentCs);
           }
 
@@ -938,7 +939,8 @@ export class UnitOfWork {
         }
       }
 
-      if (!isCreate && Object.keys(payload).length === 0) {
+      // the table declaring the version property still needs its bump and lock check
+      if (!isCreate && Object.keys(payload).length === 0 && !current.ownsVersionProperty()) {
         current = current.tptParent;
         continue;
       }
@@ -949,9 +951,9 @@ export class UnitOfWork {
         payload as EntityDictionary<T>,
         current as EntityMetadata<T>,
       );
+      cs.originalEntity = originalChangeSet.originalEntity;
 
       if (current === meta) {
-        cs.originalEntity = originalChangeSet.originalEntity;
         leafCs = cs;
       } else {
         parentChangeSets.push(cs);
@@ -1624,7 +1626,8 @@ export class UnitOfWork {
       // Skip stub TPT changesets with empty payload (e.g. leaf with no own-property changes on UPDATE)
       if (
         (cs.type === ChangeSetType.UPDATE || cs.type === ChangeSetType.UPDATE_EARLY) &&
-        !Utils.hasObjectKeys(cs.payload)
+        !Utils.hasObjectKeys(cs.payload) &&
+        !cs.meta.ownsVersionProperty()
       ) {
         return;
       }

--- a/packages/sql/src/AbstractSqlDriver.ts
+++ b/packages/sql/src/AbstractSqlDriver.ts
@@ -1388,7 +1388,8 @@ export abstract class AbstractSqlDriver<
       where = (await this.applyUnionWhere(meta, where as ObjectQuery<T>, options, true)) as FilterQuery<T>;
     }
 
-    if (Utils.hasObjectKeys(data)) {
+    // a TPT table declaring the version property is bumped even when only other tables of the hierarchy changed
+    if (Utils.hasObjectKeys(data) || (meta.inheritanceType === 'tpt' && meta.ownsVersionProperty())) {
       const qb = this.createQueryBuilder<T>(
         entityName,
         options.ctx,
@@ -1425,7 +1426,7 @@ export abstract class AbstractSqlDriver<
 
         // reload generated columns and version fields
         const returning: string[] = [];
-        meta.props
+        this.getTableProps(meta)
           .filter(prop => (prop.generated && !prop.primary) || prop.version)
           .forEach(prop => returning.push(prop.name));
 
@@ -1503,7 +1504,10 @@ export abstract class AbstractSqlDriver<
     }
 
     // reload generated columns and version fields
-    meta.props.filter(prop => prop.generated || prop.version || prop.primary).forEach(prop => returning.add(prop.name));
+    meta.getPrimaryProps().forEach(prop => returning.add(prop.name));
+    this.getTableProps(meta)
+      .filter(prop => prop.generated || prop.version)
+      .forEach(prop => returning.add(prop.name));
 
     const pkCond = Utils.flatten(meta.primaryKeys.map(pk => meta.properties[pk].fieldNames))
       .map(pk => `${this.platform.quoteIdentifier(pk)} = ?`)
@@ -1574,7 +1578,7 @@ export abstract class AbstractSqlDriver<
       });
     }
 
-    if (meta.versionProperty) {
+    if (meta.ownsVersionProperty()) {
       const versionProperty = meta.properties[meta.versionProperty];
       const quotedFieldName = this.platform.quoteIdentifier(versionProperty.fieldNames[0]);
       sql += `${quotedFieldName} = `;

--- a/packages/sql/src/query/QueryBuilderHelper.ts
+++ b/packages/sql/src/query/QueryBuilderHelper.ts
@@ -1097,7 +1097,7 @@ export class QueryBuilderHelper {
   updateVersionProperty(qb: NativeQueryBuilder, data: Dictionary): void {
     const meta = this.#metadata.find(this.#entityName);
 
-    if (!meta?.versionProperty || meta.versionProperty in data) {
+    if (!meta?.ownsVersionProperty() || meta.versionProperty in data) {
       return;
     }
 

--- a/tests/features/table-per-type-inheritance/tpt-version-property.mysql.test.ts
+++ b/tests/features/table-per-type-inheritance/tpt-version-property.mysql.test.ts
@@ -1,0 +1,126 @@
+import { MikroORM, OptimisticLockError, OptionalProps } from '@mikro-orm/mysql';
+import { Entity, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+
+@Entity({ inheritance: 'tpt' })
+abstract class Animal {
+  [OptionalProps]?: 'version';
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @Property({ version: true })
+  version!: number;
+}
+
+@Entity()
+class Dog extends Animal {
+  @Property()
+  breed!: string;
+}
+
+@Entity({ inheritance: 'tpt' })
+abstract class Bird {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+}
+
+@Entity()
+class Parrot extends Bird {
+  [OptionalProps]?: 'version';
+
+  @Property({ version: true })
+  version!: number;
+
+  @Property()
+  wingspan!: number;
+}
+
+// covers the version reload path of drivers without `returning`
+describe('TPT inheritance with a version property (mysql)', () => {
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      dbName: 'mikro_orm_test_tpt_version',
+      port: 3308,
+      entities: [Animal, Dog, Bird, Parrot],
+    });
+    await orm.schema.refresh();
+  });
+
+  afterAll(async () => {
+    await orm.schema.drop();
+    await orm.close(true);
+  });
+
+  beforeEach(async () => {
+    await orm.schema.clear();
+    orm.em.clear();
+  });
+
+  test('updating a child-owned column bumps the version on the declaring table', async () => {
+    const dog = orm.em.create(Dog, { name: 'Rex', breed: 'poodle' });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const found = await orm.em.findOneOrFail(Dog, dog.id);
+    found.breed = 'labrador';
+    await orm.em.flush();
+    expect(found.version).toBe(2);
+    orm.em.clear();
+
+    const reloaded = await orm.em.findOneOrFail(Dog, dog.id);
+    expect(reloaded.breed).toBe('labrador');
+    expect(reloaded.version).toBe(2);
+  });
+
+  test('batched update of a child-owned column bumps the version on the declaring table', async () => {
+    orm.em.create(Dog, { name: 'Rex', breed: 'poodle' });
+    orm.em.create(Dog, { name: 'Fido', breed: 'poodle' });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const all = await orm.em.find(Dog, {});
+    all.forEach(dog => (dog.breed = 'labrador'));
+    await orm.em.flush();
+    expect(all.map(dog => dog.version)).toEqual([2, 2]);
+    orm.em.clear();
+
+    const reloaded = await orm.em.find(Dog, {}, { orderBy: { id: 'asc' } });
+    expect(reloaded.map(dog => dog.version)).toEqual([2, 2]);
+  });
+
+  test('updating a root-owned column bumps the version when it is declared below the root', async () => {
+    const parrot = orm.em.create(Parrot, { name: 'Polly', wingspan: 30 });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const found = await orm.em.findOneOrFail(Parrot, parrot.id);
+    found.name = 'Hector';
+    await orm.em.flush();
+    expect(found.version).toBe(2);
+    orm.em.clear();
+
+    const reloaded = await orm.em.findOneOrFail(Parrot, parrot.id);
+    expect(reloaded.name).toBe('Hector');
+    expect(reloaded.version).toBe(2);
+  });
+
+  test('stale version is rejected when it is declared below the root', async () => {
+    const parrot = orm.em.create(Parrot, { name: 'Polly', wingspan: 30 });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const found = await orm.em.findOneOrFail(Parrot, parrot.id);
+    await orm.em.nativeUpdate(Parrot, parrot.id, { wingspan: 31 });
+    found.name = 'Hector';
+    await expect(orm.em.flush()).rejects.toThrow(OptimisticLockError);
+  });
+});

--- a/tests/features/table-per-type-inheritance/tpt-version-property.test.ts
+++ b/tests/features/table-per-type-inheritance/tpt-version-property.test.ts
@@ -1,0 +1,228 @@
+import { MikroORM, OptimisticLockError, OptionalProps } from '@mikro-orm/sqlite';
+import { Entity, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+import { mockLogger } from '../../bootstrap.js';
+
+// version property on the root
+@Entity({ inheritance: 'tpt' })
+abstract class Animal {
+  [OptionalProps]?: 'version';
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @Property({ version: true })
+  version!: number;
+}
+
+@Entity()
+class Dog extends Animal {
+  @Property()
+  breed!: string;
+}
+
+// version property declared below the root
+@Entity({ inheritance: 'tpt' })
+abstract class Bird {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+}
+
+@Entity()
+class Parrot extends Bird {
+  [OptionalProps]?: 'version';
+
+  @Property({ version: true })
+  version!: number;
+
+  @Property()
+  wingspan!: number;
+}
+
+describe('TPT inheritance with a version property', () => {
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      dbName: ':memory:',
+      entities: [Animal, Dog, Bird, Parrot],
+    });
+    await orm.schema.create();
+  });
+
+  afterAll(async () => {
+    await orm.close(true);
+  });
+
+  beforeEach(async () => {
+    await orm.schema.clear();
+    orm.em.clear();
+  });
+
+  test('updating a root-owned column bumps the version', async () => {
+    const dog = orm.em.create(Dog, { name: 'Rex', breed: 'poodle' });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const found = await orm.em.findOneOrFail(Dog, dog.id);
+    found.name = 'Rexy';
+    await orm.em.flush();
+    expect(found.version).toBe(2);
+    orm.em.clear();
+
+    const reloaded = await orm.em.findOneOrFail(Dog, dog.id);
+    expect(reloaded.name).toBe('Rexy');
+    expect(reloaded.version).toBe(2);
+  });
+
+  test('updating a child-owned column bumps the version on the declaring table', async () => {
+    const dog = orm.em.create(Dog, { name: 'Rex', breed: 'poodle' });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const found = await orm.em.findOneOrFail(Dog, dog.id);
+    found.breed = 'labrador';
+    const mock = mockLogger(orm);
+    await orm.em.flush();
+    expect(mock.mock.calls[1][0]).toMatch(
+      `update \`animal\` set \`version\` = \`version\` + 1 where \`id\` = ${dog.id} and \`version\` = 1 returning \`version\``,
+    );
+    expect(mock.mock.calls[2][0]).toMatch(`update \`dog\` set \`breed\` = 'labrador' where \`id\` = ${dog.id}`);
+    expect(found.version).toBe(2);
+    orm.em.clear();
+
+    const reloaded = await orm.em.findOneOrFail(Dog, dog.id);
+    expect(reloaded.breed).toBe('labrador');
+    expect(reloaded.version).toBe(2);
+  });
+
+  test('updating root-owned and child-owned columns in one flush bumps the version once', async () => {
+    const dog = orm.em.create(Dog, { name: 'Rex', breed: 'poodle' });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const found = await orm.em.findOneOrFail(Dog, dog.id);
+    found.name = 'Rexy';
+    found.breed = 'labrador';
+    const mock = mockLogger(orm);
+    await orm.em.flush();
+    expect(mock.mock.calls[1][0]).toMatch(
+      `update \`animal\` set \`name\` = 'Rexy', \`version\` = \`version\` + 1 where \`id\` = ${dog.id} and \`version\` = 1 returning \`version\``,
+    );
+    expect(mock.mock.calls[2][0]).toMatch(`update \`dog\` set \`breed\` = 'labrador' where \`id\` = ${dog.id}`);
+    expect(found.version).toBe(2);
+    orm.em.clear();
+
+    const reloaded = await orm.em.findOneOrFail(Dog, dog.id);
+    expect(reloaded.name).toBe('Rexy');
+    expect(reloaded.breed).toBe('labrador');
+    expect(reloaded.version).toBe(2);
+  });
+
+  test('updating a child-owned column still enforces the optimistic lock', async () => {
+    const dog = orm.em.create(Dog, { name: 'Rex', breed: 'poodle' });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const found = await orm.em.findOneOrFail(Dog, dog.id);
+    await orm.em.nativeUpdate(Animal, dog.id, { name: 'Rover' });
+    found.breed = 'labrador';
+    await expect(orm.em.flush()).rejects.toThrow(OptimisticLockError);
+  });
+
+  test('batched update of a child-owned column bumps the version on the declaring table', async () => {
+    orm.em.create(Dog, { name: 'Rex', breed: 'poodle' });
+    orm.em.create(Dog, { name: 'Fido', breed: 'poodle' });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const all = await orm.em.find(Dog, {}, { orderBy: { id: 'asc' } });
+    all.forEach(dog => (dog.breed = 'labrador'));
+    const [id1, id2] = all.map(dog => dog.id);
+    const mock = mockLogger(orm);
+    await orm.em.flush();
+    expect(mock.mock.calls[1][0]).toMatch('select `a0`.`id` from `animal` as `a0` where');
+    expect(mock.mock.calls[2][0]).toMatch(
+      `update \`animal\` set \`version\` = \`version\` + 1 where \`id\` in (${id1}, ${id2}) returning \`id\`, \`version\``,
+    );
+    expect(mock.mock.calls[3][0]).toMatch(
+      `update \`dog\` set \`breed\` = case when (\`id\` = ${id1}) then 'labrador' when (\`id\` = ${id2}) then 'labrador' else \`breed\` end where \`id\` in (${id1}, ${id2}) returning \`id\``,
+    );
+    expect(all.map(dog => dog.version)).toEqual([2, 2]);
+    orm.em.clear();
+
+    const reloaded = await orm.em.find(Dog, {}, { orderBy: { id: 'asc' } });
+    expect(reloaded.map(dog => dog.breed)).toEqual(['labrador', 'labrador']);
+    expect(reloaded.map(dog => dog.version)).toEqual([2, 2]);
+  });
+
+  test('batched update of a root-owned column bumps the version', async () => {
+    orm.em.create(Dog, { name: 'Rex', breed: 'poodle' });
+    orm.em.create(Dog, { name: 'Fido', breed: 'poodle' });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const all = await orm.em.find(Dog, {});
+    all.forEach(dog => (dog.name = 'Rover'));
+    await orm.em.flush();
+    expect(all.map(dog => dog.version)).toEqual([2, 2]);
+    orm.em.clear();
+
+    const reloaded = await orm.em.find(Dog, {}, { orderBy: { id: 'asc' } });
+    expect(reloaded.map(dog => dog.version)).toEqual([2, 2]);
+  });
+
+  test('batched update bumps the version when it is declared below the root', async () => {
+    orm.em.create(Parrot, { name: 'Polly', wingspan: 30 });
+    orm.em.create(Parrot, { name: 'Hector', wingspan: 32 });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const all = await orm.em.find(Parrot, {});
+    all.forEach(parrot => (parrot.wingspan = 35));
+    await orm.em.flush();
+    expect(all.map(parrot => parrot.version)).toEqual([2, 2]);
+    orm.em.clear();
+
+    const reloaded = await orm.em.find(Parrot, {}, { orderBy: { id: 'asc' } });
+    expect(reloaded.map(parrot => parrot.version)).toEqual([2, 2]);
+  });
+
+  test('updating a root-owned column bumps the version when it is declared below the root', async () => {
+    const parrot = orm.em.create(Parrot, { name: 'Polly', wingspan: 30 });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const found = await orm.em.findOneOrFail(Parrot, parrot.id);
+    found.name = 'Hector';
+    const mock = mockLogger(orm);
+    await orm.em.flush();
+    expect(mock.mock.calls[1][0]).toMatch(`update \`bird\` set \`name\` = 'Hector' where \`id\` = ${parrot.id}`);
+    expect(mock.mock.calls[2][0]).toMatch(
+      `update \`parrot\` set \`version\` = \`version\` + 1 where \`id\` = ${parrot.id} and \`version\` = 1 returning \`version\``,
+    );
+    expect(found.version).toBe(2);
+    orm.em.clear();
+
+    const reloaded = await orm.em.findOneOrFail(Parrot, parrot.id);
+    expect(reloaded.name).toBe('Hector');
+    expect(reloaded.version).toBe(2);
+  });
+
+  test('stale version is rejected when it is declared below the root', async () => {
+    const parrot = orm.em.create(Parrot, { name: 'Polly', wingspan: 30 });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const found = await orm.em.findOneOrFail(Parrot, parrot.id);
+    await orm.em.nativeUpdate(Parrot, parrot.id, { wingspan: 31 });
+    found.name = 'Hector';
+    await expect(orm.em.flush()).rejects.toThrow(OptimisticLockError);
+  });
+});


### PR DESCRIPTION
With TPT inheritance the version column exists only on the table of the entity that declares it, but `meta.versionProperty` is set on every metadata in the hierarchy. The update path did not tell the two apart, so it added the version bump, the lock predicate and the `returning` clause to every table. Changing a child-owned column failed with `no such column: version`. With the version declared below the root, the batched lock check queried the root table for a column it does not have, and a single-row update of a root-owned column skipped the version handling altogether, so a stale entity could overwrite a concurrent write with no error at all.

The fix adds `EntityMetadata.ownsVersionProperty()` and checks it in `ChangeSetPersister`, `QueryBuilderHelper.updateVersionProperty`, `nativeUpdate` and `nativeUpdateMany`. The bump, the lock predicate and the version reload now target only the declaring table. The `returning` lists use the table's own props, which also stops a child update from asking for a parent's generated columns. The declaring table's change set stays alive when none of its own columns changed, so the version is still bumped and the lock still checked. TPT parent change sets now get `originalEntity`, which fixes a `TypeError` in the batched lock check.

Closes #8226
