### PR TITLE
fix(core): apply TPT concurrency check only to the table that declares it

### DIFF
--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -1611,6 +1611,22 @@ export class EntityMetadata<Entity = any, Class extends EntityCtor<Entity> = Ent
     return this.inheritanceType !== 'tpt' || !this.ownProps || this.ownProps.some(p => p.name === this.versionProperty);
   }
 
+  /** For TPT entities, concurrency check columns exist only on the table of the entity that declares them. */
+  getOwnConcurrencyCheckKeys(): EntityKey<Entity>[] {
+    const keys = [...this.concurrencyCheckKeys];
+
+    if (this.inheritanceType !== 'tpt' || !this.ownProps) {
+      return keys;
+    }
+
+    return keys.filter(key => this.ownProps!.some(p => p.name === key));
+  }
+
+  /** Whether updates of this table are guarded by a version property or concurrency check columns it owns. */
+  hasOptimisticLock(): boolean {
+    return this.ownsVersionProperty() || this.getOwnConcurrencyCheckKeys().length > 0;
+  }
+
   getPrimaryProps(flatten = false): EntityProperty<Entity>[] {
     const pks = this.primaryKeys.map(pk => this.properties[pk]);
 

--- a/packages/core/src/unit-of-work/ChangeSetPersister.ts
+++ b/packages/core/src/unit-of-work/ChangeSetPersister.ts
@@ -328,8 +328,9 @@ export class ChangeSetPersister {
     cond: Dictionary,
   ): void {
     const tmp: string[] = [];
+    const keys = meta.getOwnConcurrencyCheckKeys();
 
-    for (const key of meta.concurrencyCheckKeys) {
+    for (const key of keys) {
       cond[key] = changeSet.originalEntity![key];
 
       if (changeSet.payload[key]) {
@@ -337,7 +338,7 @@ export class ChangeSetPersister {
       }
     }
 
-    if (tmp.length === 0 && meta.concurrencyCheckKeys.size > 0) {
+    if (tmp.length === 0 && keys.length > 0) {
       throw OptimisticLockError.lockFailed(changeSet.entity);
     }
   }
@@ -458,7 +459,7 @@ export class ChangeSetPersister {
     });
 
     if (
-      meta.concurrencyCheckKeys.size === 0 &&
+      meta.getOwnConcurrencyCheckKeys().length === 0 &&
       (!meta.ownsVersionProperty() || changeSet.entity[meta.versionProperty] == null)
     ) {
       return this.#driver.nativeUpdate(changeSet.meta.class, cond as FilterQuery<T>, changeSet.payload, options);
@@ -481,8 +482,10 @@ export class ChangeSetPersister {
     changeSets: ChangeSet<T>[],
     options?: DriverMethodOptions,
   ): Promise<void> {
+    const concurrencyCheckKeys = meta.getOwnConcurrencyCheckKeys();
+
     if (
-      meta.concurrencyCheckKeys.size === 0 &&
+      concurrencyCheckKeys.length === 0 &&
       (!meta.ownsVersionProperty() || changeSets.every(cs => cs.entity[meta.versionProperty] == null))
     ) {
       return;
@@ -490,12 +493,10 @@ export class ChangeSetPersister {
 
     // skip entity references as they don't have version values loaded
     changeSets = changeSets.filter(cs => helper(cs.entity).__initialized);
+    const primaryKeys = meta.primaryKeys.concat(...concurrencyCheckKeys);
 
     const $or = changeSets.map(cs => {
-      const cond = Utils.getPrimaryKeyCond<T>(
-        cs.originalEntity as T,
-        meta.primaryKeys.concat(...meta.concurrencyCheckKeys),
-      ) as FilterQuery<T>;
+      const cond = Utils.getPrimaryKeyCond<T>(cs.originalEntity as T, primaryKeys) as FilterQuery<T>;
 
       if (meta.ownsVersionProperty()) {
         // @ts-ignore
@@ -508,7 +509,6 @@ export class ChangeSetPersister {
       return cond;
     });
 
-    const primaryKeys = meta.primaryKeys.concat(...meta.concurrencyCheckKeys);
     options = this.prepareOptions(meta, options, {
       fields: primaryKeys,
       orderBy: meta.primaryKeys.reduce((o, pk) => {
@@ -535,7 +535,7 @@ export class ChangeSetPersister {
     changeSet: ChangeSet<T>,
     res?: QueryResult<T>,
   ) {
-    if ((meta.versionProperty || meta.concurrencyCheckKeys.size > 0) && res && !res.affectedRows) {
+    if ((meta.ownsVersionProperty() || meta.getOwnConcurrencyCheckKeys().length > 0) && res && !res.affectedRows) {
       throw OptimisticLockError.lockFailed(changeSet.entity);
     }
   }

--- a/packages/core/src/unit-of-work/UnitOfWork.ts
+++ b/packages/core/src/unit-of-work/UnitOfWork.ts
@@ -939,8 +939,8 @@ export class UnitOfWork {
         }
       }
 
-      // the table declaring the version property still needs its bump and lock check
-      if (!isCreate && Object.keys(payload).length === 0 && !current.ownsVersionProperty()) {
+      // the table declaring the version property or a concurrency check still needs its bump and lock check
+      if (!isCreate && Object.keys(payload).length === 0 && !current.hasOptimisticLock()) {
         current = current.tptParent;
         continue;
       }
@@ -1627,7 +1627,7 @@ export class UnitOfWork {
       if (
         (cs.type === ChangeSetType.UPDATE || cs.type === ChangeSetType.UPDATE_EARLY) &&
         !Utils.hasObjectKeys(cs.payload) &&
-        !cs.meta.ownsVersionProperty()
+        !cs.meta.hasOptimisticLock()
       ) {
         return;
       }

--- a/packages/sql/src/AbstractSqlDriver.ts
+++ b/packages/sql/src/AbstractSqlDriver.ts
@@ -1593,7 +1593,7 @@ export abstract class AbstractSqlDriver<
     }
 
     sql = sql.substring(0, sql.length - 2) + ' where ';
-    const pkProps = meta.primaryKeys.concat(...meta.concurrencyCheckKeys);
+    const pkProps = meta.primaryKeys.concat(...meta.getOwnConcurrencyCheckKeys());
     const pks = Utils.flatten(pkProps.map(pk => meta.properties[pk].fieldNames));
 
     const useTupleIn = pks.length <= 1 || this.platform.allowsComparingTuples();

--- a/tests/features/table-per-type-inheritance/tpt-concurrency-check.test.ts
+++ b/tests/features/table-per-type-inheritance/tpt-concurrency-check.test.ts
@@ -1,0 +1,202 @@
+import { MikroORM, OptimisticLockError } from '@mikro-orm/sqlite';
+import { Entity, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+import { mockLogger } from '../../bootstrap.js';
+
+// concurrency check on the root
+@Entity({ inheritance: 'tpt' })
+abstract class Animal {
+  @PrimaryKey()
+  id!: number;
+
+  @Property({ concurrencyCheck: true })
+  name!: string;
+}
+
+@Entity()
+class Dog extends Animal {
+  @Property()
+  breed!: string;
+}
+
+// concurrency check declared below the root
+@Entity({ inheritance: 'tpt' })
+abstract class Bird {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+}
+
+@Entity()
+class Parrot extends Bird {
+  @Property({ concurrencyCheck: true })
+  wingspan!: number;
+}
+
+describe('TPT inheritance with a concurrency check', () => {
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      dbName: ':memory:',
+      entities: [Animal, Dog, Bird, Parrot],
+    });
+    await orm.schema.create();
+  });
+
+  afterAll(async () => {
+    await orm.close(true);
+  });
+
+  beforeEach(async () => {
+    await orm.schema.clear();
+    orm.em.clear();
+  });
+
+  test('updating the concurrency field on the root adds the predicate only to the root table', async () => {
+    const dog = orm.em.create(Dog, { name: 'Rex', breed: 'poodle' });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const found = await orm.em.findOneOrFail(Dog, dog.id);
+    found.name = 'Rexy';
+    found.breed = 'labrador';
+    const mock = mockLogger(orm);
+    await orm.em.flush();
+    expect(mock.mock.calls[1][0]).toMatch(
+      `update \`animal\` set \`name\` = 'Rexy' where \`id\` = ${dog.id} and \`name\` = 'Rex'`,
+    );
+    expect(mock.mock.calls[2][0]).toMatch(`update \`dog\` set \`breed\` = 'labrador' where \`id\` = ${dog.id}`);
+    orm.em.clear();
+
+    const reloaded = await orm.em.findOneOrFail(Dog, dog.id);
+    expect(reloaded.name).toBe('Rexy');
+    expect(reloaded.breed).toBe('labrador');
+  });
+
+  test('updating only a child-owned column without changing the concurrency field fails', async () => {
+    const dog = orm.em.create(Dog, { name: 'Rex', breed: 'poodle' });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const found = await orm.em.findOneOrFail(Dog, dog.id);
+    found.breed = 'labrador';
+    await expect(orm.em.flush()).rejects.toThrow(OptimisticLockError);
+  });
+
+  test('stale concurrency field on the root is rejected', async () => {
+    const dog = orm.em.create(Dog, { name: 'Rex', breed: 'poodle' });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const found = await orm.em.findOneOrFail(Dog, dog.id);
+    await orm.em.nativeUpdate(Animal, dog.id, { name: 'Rover' });
+    found.name = 'Rexy';
+    found.breed = 'labrador';
+    await expect(orm.em.flush()).rejects.toThrow(OptimisticLockError);
+  });
+
+  test('batched update adds the predicate only to the root table', async () => {
+    orm.em.create(Dog, { name: 'Rex', breed: 'poodle' });
+    orm.em.create(Dog, { name: 'Fido', breed: 'poodle' });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const all = await orm.em.find(Dog, {}, { orderBy: { id: 'asc' } });
+    all.forEach(dog => {
+      dog.name += '!';
+      dog.breed = 'labrador';
+    });
+    const [id1, id2] = all.map(dog => dog.id);
+    const mock = mockLogger(orm);
+    await orm.em.flush();
+    expect(mock.mock.calls[1][0]).toMatch(
+      `select \`a0\`.\`id\`, \`a0\`.\`name\` from \`animal\` as \`a0\` where ((\`a0\`.\`id\` = ${id1} and \`a0\`.\`name\` = 'Rex') or (\`a0\`.\`id\` = ${id2} and \`a0\`.\`name\` = 'Fido'))`,
+    );
+    expect(mock.mock.calls[2][0]).toMatch(
+      `update \`animal\` set \`name\` = case when (\`id\` = ${id1}) then 'Rex!' when (\`id\` = ${id2}) then 'Fido!' else \`name\` end where (\`id\`, \`name\`) in ((${id1}, 'Rex'), (${id2}, 'Fido'))`,
+    );
+    expect(mock.mock.calls[3][0]).toMatch(
+      `update \`dog\` set \`breed\` = case when (\`id\` = ${id1}) then 'labrador' when (\`id\` = ${id2}) then 'labrador' else \`breed\` end where \`id\` in (${id1}, ${id2})`,
+    );
+    orm.em.clear();
+
+    const reloaded = await orm.em.find(Dog, {}, { orderBy: { id: 'asc' } });
+    expect(reloaded.map(dog => dog.name)).toEqual(['Rex!', 'Fido!']);
+    expect(reloaded.map(dog => dog.breed)).toEqual(['labrador', 'labrador']);
+  });
+
+  test('concurrency field declared below the root adds the predicate only to that table', async () => {
+    const parrot = orm.em.create(Parrot, { name: 'Polly', wingspan: 30 });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const found = await orm.em.findOneOrFail(Parrot, parrot.id);
+    found.name = 'Hector';
+    found.wingspan = 35;
+    const mock = mockLogger(orm);
+    await orm.em.flush();
+    expect(mock.mock.calls[1][0]).toMatch(`update \`bird\` set \`name\` = 'Hector' where \`id\` = ${parrot.id}`);
+    expect(mock.mock.calls[2][0]).toMatch(
+      `update \`parrot\` set \`wingspan\` = 35 where \`id\` = ${parrot.id} and \`wingspan\` = 30`,
+    );
+    orm.em.clear();
+
+    const reloaded = await orm.em.findOneOrFail(Parrot, parrot.id);
+    expect(reloaded.name).toBe('Hector');
+    expect(reloaded.wingspan).toBe(35);
+  });
+
+  test('batched update adds the predicate only to the table declaring the concurrency field', async () => {
+    orm.em.create(Parrot, { name: 'Polly', wingspan: 30 });
+    orm.em.create(Parrot, { name: 'Hector', wingspan: 40 });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const all = await orm.em.find(Parrot, {}, { orderBy: { id: 'asc' } });
+    all.forEach(parrot => {
+      parrot.name += '!';
+      parrot.wingspan += 1;
+    });
+    const [id1, id2] = all.map(parrot => parrot.id);
+    const mock = mockLogger(orm);
+    await orm.em.flush();
+    expect(mock.mock.calls[1][0]).toMatch(
+      `update \`bird\` set \`name\` = case when (\`id\` = ${id1}) then 'Polly!' when (\`id\` = ${id2}) then 'Hector!' else \`name\` end where \`id\` in (${id1}, ${id2})`,
+    );
+    expect(mock.mock.calls[2][0]).toMatch(
+      `select \`b1\`.\`id\`, \`p0\`.\`wingspan\` from \`parrot\` as \`p0\` inner join \`bird\` as \`b1\` on \`p0\`.\`id\` = \`b1\`.\`id\` where ((\`b1\`.\`id\` = ${id1} and \`p0\`.\`wingspan\` = 30) or (\`b1\`.\`id\` = ${id2} and \`p0\`.\`wingspan\` = 40))`,
+    );
+    expect(mock.mock.calls[3][0]).toMatch(
+      `update \`parrot\` set \`wingspan\` = case when (\`id\` = ${id1}) then 31 when (\`id\` = ${id2}) then 41 else \`wingspan\` end where (\`id\`, \`wingspan\`) in ((${id1}, 30), (${id2}, 40))`,
+    );
+    orm.em.clear();
+
+    const reloaded = await orm.em.find(Parrot, {}, { orderBy: { id: 'asc' } });
+    expect(reloaded.map(parrot => parrot.name)).toEqual(['Polly!', 'Hector!']);
+    expect(reloaded.map(parrot => parrot.wingspan)).toEqual([31, 41]);
+  });
+
+  test('updating only a root-owned column without changing the concurrency field below the root fails', async () => {
+    const parrot = orm.em.create(Parrot, { name: 'Polly', wingspan: 30 });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const found = await orm.em.findOneOrFail(Parrot, parrot.id);
+    found.name = 'Hector';
+    await expect(orm.em.flush()).rejects.toThrow(OptimisticLockError);
+  });
+
+  test('stale concurrency field below the root is rejected', async () => {
+    const parrot = orm.em.create(Parrot, { name: 'Polly', wingspan: 30 });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const found = await orm.em.findOneOrFail(Parrot, parrot.id);
+    await orm.em.nativeUpdate(Parrot, parrot.id, { wingspan: 31 });
+    found.wingspan = 35;
+    await expect(orm.em.flush()).rejects.toThrow(OptimisticLockError);
+  });
+});


### PR DESCRIPTION
Follow-up to #8227, covering the second item from #8226. With TPT inheritance every child metadata inherits `concurrencyCheckKeys`, so the persister expected the key in the payload of each table's change set and added the key column to the where condition of tables that do not have that column. Updating a child-owned column threw `OptimisticLockError` before a single query ran, and the batched path built its where condition on a column missing from the table.

`EntityMetadata.getOwnConcurrencyCheckKeys()` now returns only the keys whose columns live on the table, and the persister and `nativeUpdateMany` read the keys through it. The predicate and the rule that a concurrency field has to change on each update apply only to the table declaring the columns. That table's change set is kept even when only other tables changed, so updating the entity without touching a concurrency field still throws, as documented. `hasOptimisticLock()` combines this with `ownsVersionProperty()` in the change set checks.

Related to #8226
