### PR TITLE
fix(sql): support upsert for TPT entities

### DIFF
--- a/packages/core/src/utils/upsert-utils.ts
+++ b/packages/core/src/utils/upsert-utils.ts
@@ -195,7 +195,16 @@ export function getWhereCondition<T extends object>(
   data: EntityData<T>,
   where: FilterQuery<T>,
 ): { where: FilterQuery<T>; propIndex: number | false } {
-  const unique = (onConflictFields as string[]) ?? meta.props.filter(p => p.unique).map(p => p.name);
+  // TPT children do not inherit the unique flags and indexes of their parent tables
+  const uniqueProps = new Set<string>();
+  const uniques: typeof meta.uniques = [];
+
+  for (let current: EntityMetadata<T> | undefined = meta; current; current = current.tptParent) {
+    current.props.filter(p => p.unique).forEach(p => uniqueProps.add(p.name));
+    uniques.push(...current.uniques);
+  }
+
+  const unique = (onConflictFields as string[]) ?? [...uniqueProps];
   const propIndex =
     !isRaw(unique) &&
     unique.findIndex(p => (data as Dictionary)[p] ?? (data as Dictionary)[p.substring(0, p.indexOf('.'))] != null);
@@ -213,8 +222,8 @@ export function getWhereCondition<T extends object>(
       }
 
       where = { [key]: getPropertyValue(data as Dictionary, unique[propIndex]) } as FilterQuery<T>;
-    } else if (meta.uniques.length > 0) {
-      for (const u of meta.uniques) {
+    } else {
+      for (const u of uniques) {
         if (Utils.asArray<EntityKey<T>>(u.properties).every(p => data[p] != null)) {
           where = Utils.asArray<EntityKey<T>>(u.properties).reduce((o, key) => {
             o[key] = data[key];

--- a/packages/sql/src/AbstractSqlDriver.ts
+++ b/packages/sql/src/AbstractSqlDriver.ts
@@ -1388,8 +1388,10 @@ export abstract class AbstractSqlDriver<
       where = (await this.applyUnionWhere(meta, where as ObjectQuery<T>, options, true)) as FilterQuery<T>;
     }
 
-    // a TPT table declaring the version property is bumped even when only other tables of the hierarchy changed
-    if (Utils.hasObjectKeys(data) || (meta.inheritanceType === 'tpt' && meta.ownsVersionProperty())) {
+    if (options.upsert && meta.tptParent) {
+      res = await this.upsertTPT(meta, [where], [data], options);
+    } else if (Utils.hasObjectKeys(data) || (meta.inheritanceType === 'tpt' && meta.ownsVersionProperty())) {
+      // a TPT table declaring the version property is bumped even when only other tables of the hierarchy changed
       const qb = this.createQueryBuilder<T>(
         entityName,
         options.ctx,
@@ -1442,6 +1444,188 @@ export abstract class AbstractSqlDriver<
     return res;
   }
 
+  private async upsertRows<T extends object>(
+    meta: EntityMetadata<T>,
+    where: FilterQuery<T>[],
+    data: EntityDictionary<T>[],
+    options: NativeInsertUpdateManyOptions<T> & UpsertManyOptions<T>,
+  ): Promise<QueryResult<T>> {
+    const uniqueFields =
+      options.onConflictFields ??
+      ((Utils.isPlainObject(where[0])
+        ? Object.keys(where[0]).flatMap(key => Utils.splitPrimaryKeys(key))
+        : meta.primaryKeys) as (keyof T)[]);
+    const qb = this.createQueryBuilder<T>(
+      meta.class,
+      options.ctx,
+      'write',
+      options.convertCustomTypes,
+      options.loggerContext,
+    ).withSchema(this.getSchemaName(meta, options));
+    qb.setAbortOptions(pickAbortOptions(options));
+    let returning = getOnConflictReturningFields(meta, data[0], uniqueFields, options);
+
+    // a TPT table can only return its own columns
+    if (meta.inheritanceType === 'tpt' && Array.isArray(returning)) {
+      const tableProps = this.getTableProps(meta);
+      returning = returning.filter(
+        field => meta.primaryKeys.includes(field as EntityKey<T>) || tableProps.some(prop => prop.name === field),
+      );
+    }
+
+    qb.insert(data as T[])
+      .onConflict(uniqueFields as any)
+      .returning(returning as any);
+
+    if (!options.onConflictAction || options.onConflictAction === 'merge') {
+      const fields = getOnConflictFields(meta, data[0], uniqueFields, options);
+      qb.merge(fields as any);
+    }
+
+    if (options.onConflictAction === 'ignore') {
+      qb.ignore();
+    }
+
+    if (options.onConflictWhere) {
+      qb.where(options.onConflictWhere as any);
+    }
+
+    return this.rethrow(qb.execute('run', false));
+  }
+
+  /**
+   * A TPT row spans several tables, so the upsert runs once per table starting from the root,
+   * and the primary key resolved by the root table is used as the conflict target of the child tables.
+   */
+  private async upsertTPT<T extends object>(
+    meta: EntityMetadata<T>,
+    where: FilterQuery<T>[],
+    data: EntityDictionary<T>[],
+    options: NativeInsertUpdateManyOptions<T> & UpsertManyOptions<T>,
+  ): Promise<QueryResult<T>> {
+    const tables: EntityMetadata<T>[] = [];
+
+    for (let current: EntityMetadata<T> | undefined = meta; current; current = current.tptParent) {
+      tables.unshift(current);
+    }
+
+    const root = tables[0];
+    const pks = meta.primaryKeys;
+    const hasPrimaryKey = (row: Dictionary) => pks.every(pk => row[pk] != null);
+    const resolvePrimaryKey = async (target: EntityMetadata<T>, i: number) => {
+      const found = await this.findOne(target.class, where[i] as ObjectQuery<T>, {
+        fields: pks as any[],
+        ctx: options.ctx,
+        convertCustomTypes: true,
+        connectionType: 'write',
+        schema: options.schema,
+      });
+
+      if (found) {
+        pks.forEach(pk => (data[i][pk] = found[pk] as never));
+      }
+    };
+    let uniqueFields =
+      options.onConflictFields ??
+      ((Utils.isPlainObject(where[0])
+        ? Object.keys(where[0]).flatMap(key => Utils.splitPrimaryKeys(key))
+        : pks) as (keyof T)[]);
+
+    // a conflict target on a child table cannot drive the root insert, so the PK is looked up first
+    if (isRaw(uniqueFields) || !uniqueFields.every(field => root.ownProps!.some(prop => prop.name === field))) {
+      for (let i = 0; i < data.length; i++) {
+        if (!hasPrimaryKey(data[i])) {
+          await resolvePrimaryKey(meta, i);
+        }
+      }
+
+      uniqueFields = pks;
+    }
+
+    // without `returning`, the PKs of a batched insert cannot be mapped back to the rows
+    if (!this.platform.usesReturningStatement() && data.length > 1 && !data.every(hasPrimaryKey)) {
+      const results: QueryResult<T>[] = [];
+
+      for (let i = 0; i < data.length; i++) {
+        results.push(await this.upsertTPT(meta, [where[i]], [data[i]], options));
+      }
+
+      const affectedRows = results.reduce((sum, res) => sum + res.affectedRows, 0);
+      const rows = results.every(res => res.row) ? results.map(res => res.row!) : [];
+      return { ...results[0], affectedRows, rows };
+    }
+
+    const rows: Dictionary[] = data.map(() => ({}));
+    let complete = true;
+    const pick = (fields: (keyof T)[] | undefined, table: EntityMetadata<T>) =>
+      fields?.filter(field => {
+        const name = (field as string).split('.')[0];
+        return pks.includes(name as EntityKey<T>) || table.ownProps!.some(prop => prop.name === name);
+      });
+    let res!: QueryResult<T>;
+
+    for (const table of tables) {
+      const isRoot = table === root;
+      const tableData = data.map(row => {
+        const tableRow: Dictionary = {};
+
+        for (const key of Utils.keys(row)) {
+          if (pks.includes(key) || table.ownProps!.some(prop => prop.name === key)) {
+            tableRow[key] = row[key];
+          }
+        }
+
+        return tableRow as EntityDictionary<T>;
+      });
+      const tableOptions = {
+        ...options,
+        onConflictFields: isRoot ? uniqueFields : pks,
+        onConflictMergeFields: pick(options.onConflictMergeFields as (keyof T)[], table),
+        onConflictExcludeFields: pick(options.onConflictExcludeFields as (keyof T)[], table),
+        onConflictWhere: isRoot ? options.onConflictWhere : undefined,
+      } as NativeInsertUpdateManyOptions<T> & UpsertManyOptions<T>;
+      const tableRes = await this.upsertRows(table, where, tableData, tableOptions);
+      // the returned rows align with the input only when every row came back (`do nothing` skips existing ones)
+      const returned = tableRes.rows?.length === data.length ? tableRes.rows : undefined;
+      returned?.forEach((row, i) => Object.assign(rows[i], row));
+      complete &&= !!returned;
+
+      if (!isRoot) {
+        continue;
+      }
+
+      res = tableRes;
+
+      for (let i = 0; i < data.length; i++) {
+        if (hasPrimaryKey(data[i])) {
+          continue;
+        }
+
+        for (const pk of pks) {
+          const prop = root.properties[pk];
+          let value =
+            returned?.[i][prop.fieldNames[0]] ??
+            (data.length === 1 && tableRes.affectedRows === 1 ? tableRes.insertId : undefined);
+
+          if (value != null && options.convertCustomTypes && prop.customType) {
+            value = prop.customType.convertToJSValue(value, this.platform);
+          }
+
+          if (value != null) {
+            data[i][pk] = value as never;
+          }
+        }
+
+        if (!hasPrimaryKey(data[i])) {
+          await resolvePrimaryKey(root, i);
+        }
+      }
+    }
+
+    // without a complete set of returned rows, the entity manager reloads the entities instead
+    return { ...res, rows: complete ? rows : [], row: complete ? rows[0] : undefined };
+  }
+
   override async nativeUpdateMany<T extends object>(
     entityName: EntityName<T>,
     where: FilterQuery<T>[],
@@ -1454,38 +1638,7 @@ export abstract class AbstractSqlDriver<
     const meta = this.metadata.get<T>(entityName);
 
     if (options.upsert) {
-      const uniqueFields =
-        options.onConflictFields ??
-        ((Utils.isPlainObject(where[0])
-          ? Object.keys(where[0]).flatMap(key => Utils.splitPrimaryKeys(key))
-          : meta.primaryKeys) as (keyof T)[]);
-      const qb = this.createQueryBuilder<T>(
-        entityName,
-        options.ctx,
-        'write',
-        options.convertCustomTypes,
-        options.loggerContext,
-      ).withSchema(this.getSchemaName(meta, options));
-      qb.setAbortOptions(pickAbortOptions(options));
-      const returning = getOnConflictReturningFields(meta, data[0], uniqueFields, options);
-      qb.insert(data as T[])
-        .onConflict(uniqueFields as any)
-        .returning(returning as any);
-
-      if (!options.onConflictAction || options.onConflictAction === 'merge') {
-        const fields = getOnConflictFields(meta, data[0], uniqueFields, options);
-        qb.merge(fields as any);
-      }
-
-      if (options.onConflictAction === 'ignore') {
-        qb.ignore();
-      }
-
-      if (options.onConflictWhere) {
-        qb.where(options.onConflictWhere as any);
-      }
-
-      return this.rethrow(qb.execute('run', false));
+      return meta.tptParent ? this.upsertTPT(meta, where, data, options) : this.upsertRows(meta, where, data, options);
     }
 
     const collections = options.processCollections ? data.map(d => this.extractManyToMany(meta, d)) : [];

--- a/packages/sql/src/AbstractSqlDriver.ts
+++ b/packages/sql/src/AbstractSqlDriver.ts
@@ -1389,7 +1389,7 @@ export abstract class AbstractSqlDriver<
     }
 
     if (options.upsert && meta.tptParent) {
-      res = await this.upsertTPT(meta, [where], [data], options);
+      res = await this.nativeUpdateMany(entityName, [where], [data], options);
     } else if (Utils.hasObjectKeys(data) || (meta.inheritanceType === 'tpt' && meta.ownsVersionProperty())) {
       // a TPT table declaring the version property is bumped even when only other tables of the hierarchy changed
       const qb = this.createQueryBuilder<T>(
@@ -1444,146 +1444,6 @@ export abstract class AbstractSqlDriver<
     return res;
   }
 
-  private async upsertRows<T extends object>(
-    meta: EntityMetadata<T>,
-    where: FilterQuery<T>[],
-    data: EntityDictionary<T>[],
-    options: NativeInsertUpdateManyOptions<T> & UpsertManyOptions<T>,
-  ): Promise<QueryResult<T>> {
-    const uniqueFields =
-      options.onConflictFields ??
-      ((Utils.isPlainObject(where[0])
-        ? Object.keys(where[0]).flatMap(key => Utils.splitPrimaryKeys(key))
-        : meta.primaryKeys) as (keyof T)[]);
-    const qb = this.createQueryBuilder<T>(
-      meta.class,
-      options.ctx,
-      'write',
-      options.convertCustomTypes,
-      options.loggerContext,
-    ).withSchema(this.getSchemaName(meta, options));
-    qb.setAbortOptions(pickAbortOptions(options));
-    let returning = getOnConflictReturningFields(meta, data[0], uniqueFields, options);
-
-    // a TPT table can only return its own columns
-    if (meta.inheritanceType === 'tpt' && Array.isArray(returning)) {
-      const tableProps = this.getTableProps(meta);
-      returning = returning.filter(
-        field => meta.primaryKeys.includes(field as EntityKey<T>) || tableProps.some(prop => prop.name === field),
-      );
-    }
-
-    qb.insert(data as T[])
-      .onConflict(uniqueFields as any)
-      .returning(returning as any);
-
-    if (!options.onConflictAction || options.onConflictAction === 'merge') {
-      const fields = getOnConflictFields(meta, data[0], uniqueFields, options);
-      qb.merge(fields as any);
-    }
-
-    if (options.onConflictAction === 'ignore') {
-      qb.ignore();
-    }
-
-    if (options.onConflictWhere) {
-      qb.where(options.onConflictWhere as any);
-    }
-
-    return this.rethrow(qb.execute('run', false));
-  }
-
-  /** A TPT row spans several tables, so the upsert runs per table from the root down, which provides the PK for the child tables. */
-  private async upsertTPT<T extends object>(
-    meta: EntityMetadata<T>,
-    where: FilterQuery<T>[],
-    data: EntityDictionary<T>[],
-    options: NativeInsertUpdateManyOptions<T> & UpsertManyOptions<T>,
-  ): Promise<QueryResult<T>> {
-    const pks = meta.primaryKeys;
-    const hasPrimaryKey = (row: Dictionary) => pks.every(pk => row[pk] != null);
-
-    // the root insert provides the PK of each new row, so rows without one are processed one by one
-    if (data.length > 1 && !data.every(hasPrimaryKey)) {
-      const results = await Utils.runSerial(data.keys(), i => this.upsertTPT(meta, [where[i]], [data[i]], options));
-      const affectedRows = results.reduce((sum, res) => sum + res.affectedRows, 0);
-      return { ...results[0], affectedRows, rows: results.every(res => res.row) ? results.map(res => res.row!) : [] };
-    }
-
-    const lookupPrimaryKey = async () => {
-      const found = await this.findOne(meta.class, where[0] as ObjectQuery<T>, {
-        fields: pks as any[],
-        ctx: options.ctx,
-        convertCustomTypes: true,
-        connectionType: 'write',
-        schema: options.schema,
-      });
-
-      if (found) {
-        pks.forEach(pk => (data[0][pk] = found[pk] as never));
-      }
-    };
-
-    if (!hasPrimaryKey(data[0])) {
-      await lookupPrimaryKey();
-    }
-
-    const tables: EntityMetadata<T>[] = [];
-
-    for (let current: EntityMetadata<T> | undefined = meta; current; current = current.tptParent) {
-      tables.unshift(current);
-    }
-
-    const owns = (table: EntityMetadata<T>, key: string) =>
-      pks.includes(key as EntityKey<T>) || table.ownProps!.some(prop => prop.name === key.split('.')[0]);
-    const uniqueFields = options.onConflictFields ?? (Utils.keys(where[0] as Dictionary) as (keyof T)[]);
-    const rows: Dictionary[] = data.map(() => ({}));
-    let complete = true;
-    let res!: QueryResult<T>;
-
-    for (const table of tables) {
-      const isRoot = table === tables[0];
-      // only the root table can use the conflict target of a new row, and only when it owns those columns
-      const rootConflict =
-        isRoot && !hasPrimaryKey(data[0]) && !isRaw(uniqueFields) && uniqueFields.every(f => owns(table, f as string));
-      const tableRes = await this.upsertRows(
-        table,
-        where,
-        data.map(
-          row => Object.fromEntries(Object.entries(row).filter(([key]) => owns(table, key))) as EntityDictionary<T>,
-        ),
-        {
-          ...options,
-          onConflictFields: rootConflict ? uniqueFields : pks,
-          onConflictMergeFields: options.onConflictMergeFields?.filter(f => owns(table, f as string)),
-          onConflictExcludeFields: options.onConflictExcludeFields?.filter(f => owns(table, f as string)),
-          onConflictWhere: isRoot ? options.onConflictWhere : undefined,
-        } as typeof options,
-      );
-      res ??= tableRes;
-
-      // the returned rows align with the input only when every row came back (`do nothing` skips existing ones)
-      if (tableRes.rows?.length === data.length) {
-        tableRes.rows.forEach((row, i) => Object.assign(rows[i], row));
-      } else {
-        complete = false;
-      }
-
-      if (isRoot && !hasPrimaryKey(data[0])) {
-        const insertId = tableRes.affectedRows === 1 ? tableRes.insertId : undefined;
-        pks.forEach(pk => (data[0][pk] ??= (rows[0][table.properties[pk].fieldNames[0]] ?? insertId) as never));
-
-        // the row was inserted concurrently between the lookup and the upsert
-        if (!hasPrimaryKey(data[0])) {
-          await lookupPrimaryKey();
-        }
-      }
-    }
-
-    // without a complete set of returned rows, the entity manager reloads the entities instead
-    return { ...res, rows: complete ? rows : [], row: complete ? rows[0] : undefined };
-  }
-
   override async nativeUpdateMany<T extends object>(
     entityName: EntityName<T>,
     where: FilterQuery<T>[],
@@ -1596,7 +1456,73 @@ export abstract class AbstractSqlDriver<
     const meta = this.metadata.get<T>(entityName);
 
     if (options.upsert) {
-      return meta.tptParent ? this.upsertTPT(meta, where, data, options) : this.upsertRows(meta, where, data, options);
+      if (meta.tptParent) {
+        // TPT parent tables go first, the PK they provide is the conflict target of this table
+        await this.nativeUpdateMany(meta.tptParent.class, where, data, options);
+
+        for (const [i, row] of data.entries()) {
+          if (meta.primaryKeys.some(pk => row[pk] == null)) {
+            const found = await this.findOne(meta.tptParent.class as EntityName<T>, where[i] as ObjectQuery<T>, {
+              fields: meta.primaryKeys as any[],
+              ctx: options.ctx,
+              connectionType: 'write',
+              schema: options.schema,
+            });
+            meta.primaryKeys.forEach(pk => (row[pk] = found?.[pk] as never));
+          }
+        }
+
+        options = { ...options, onConflictFields: meta.primaryKeys, onConflictWhere: undefined };
+      }
+
+      const uniqueFields =
+        options.onConflictFields ??
+        ((Utils.isPlainObject(where[0])
+          ? Object.keys(where[0]).flatMap(key => Utils.splitPrimaryKeys(key))
+          : meta.primaryKeys) as (keyof T)[]);
+      const qb = this.createQueryBuilder<T>(
+        entityName,
+        options.ctx,
+        'write',
+        options.convertCustomTypes,
+        options.loggerContext,
+      ).withSchema(this.getSchemaName(meta, options));
+      qb.setAbortOptions(pickAbortOptions(options));
+      let returning = getOnConflictReturningFields(meta, data[0], uniqueFields, options);
+
+      if (meta.inheritanceType === 'tpt') {
+        // each TPT table only carries its own columns, the entity is reloaded instead of mapping the returned rows
+        const own = (key: string) =>
+          meta.primaryKeys.includes(key as EntityKey<T>) ||
+          this.getTableProps(meta).some(prop => prop.name === key.split('.')[0]);
+        data = data.map(
+          row => Object.fromEntries(Object.entries(row).filter(([key]) => own(key))) as EntityDictionary<T>,
+        );
+        options.onConflictMergeFields = options.onConflictMergeFields?.filter(f => own(f as string));
+        options.onConflictExcludeFields = options.onConflictExcludeFields?.filter(f => own(f as string));
+        returning = [];
+      }
+
+      qb.insert(data as T[])
+        .onConflict(uniqueFields as any)
+        .returning(returning as any);
+
+      if (!options.onConflictAction || options.onConflictAction === 'merge') {
+        const fields = getOnConflictFields(meta, data[0], uniqueFields, options);
+        qb.merge(fields as any);
+      }
+
+      if (options.onConflictAction === 'ignore') {
+        qb.ignore();
+      }
+
+      if (options.onConflictWhere) {
+        qb.where(options.onConflictWhere as any);
+      }
+
+      const res = await this.rethrow(qb.execute('run', false));
+
+      return meta.inheritanceType === 'tpt' ? { ...res, row: undefined, rows: [] } : res;
     }
 
     const collections = options.processCollections ? data.map(d => this.extractManyToMany(meta, d)) : [];

--- a/packages/sql/src/AbstractSqlDriver.ts
+++ b/packages/sql/src/AbstractSqlDriver.ts
@@ -1493,27 +1493,25 @@ export abstract class AbstractSqlDriver<
     return this.rethrow(qb.execute('run', false));
   }
 
-  /**
-   * A TPT row spans several tables, so the upsert runs once per table starting from the root,
-   * and the primary key resolved by the root table is used as the conflict target of the child tables.
-   */
+  /** A TPT row spans several tables, so the upsert runs per table from the root down, which provides the PK for the child tables. */
   private async upsertTPT<T extends object>(
     meta: EntityMetadata<T>,
     where: FilterQuery<T>[],
     data: EntityDictionary<T>[],
     options: NativeInsertUpdateManyOptions<T> & UpsertManyOptions<T>,
   ): Promise<QueryResult<T>> {
-    const tables: EntityMetadata<T>[] = [];
-
-    for (let current: EntityMetadata<T> | undefined = meta; current; current = current.tptParent) {
-      tables.unshift(current);
-    }
-
-    const root = tables[0];
     const pks = meta.primaryKeys;
     const hasPrimaryKey = (row: Dictionary) => pks.every(pk => row[pk] != null);
-    const resolvePrimaryKey = async (target: EntityMetadata<T>, i: number) => {
-      const found = await this.findOne(target.class, where[i] as ObjectQuery<T>, {
+
+    // the root insert provides the PK of each new row, so rows without one are processed one by one
+    if (data.length > 1 && !data.every(hasPrimaryKey)) {
+      const results = await Utils.runSerial(data.keys(), i => this.upsertTPT(meta, [where[i]], [data[i]], options));
+      const affectedRows = results.reduce((sum, res) => sum + res.affectedRows, 0);
+      return { ...results[0], affectedRows, rows: results.every(res => res.row) ? results.map(res => res.row!) : [] };
+    }
+
+    const lookupPrimaryKey = async () => {
+      const found = await this.findOne(meta.class, where[0] as ObjectQuery<T>, {
         fields: pks as any[],
         ctx: options.ctx,
         convertCustomTypes: true,
@@ -1522,102 +1520,62 @@ export abstract class AbstractSqlDriver<
       });
 
       if (found) {
-        pks.forEach(pk => (data[i][pk] = found[pk] as never));
+        pks.forEach(pk => (data[0][pk] = found[pk] as never));
       }
     };
-    let uniqueFields =
-      options.onConflictFields ??
-      ((Utils.isPlainObject(where[0])
-        ? Object.keys(where[0]).flatMap(key => Utils.splitPrimaryKeys(key))
-        : pks) as (keyof T)[]);
 
-    // a conflict target on a child table cannot drive the root insert, so the PK is looked up first
-    if (isRaw(uniqueFields) || !uniqueFields.every(field => root.ownProps!.some(prop => prop.name === field))) {
-      for (let i = 0; i < data.length; i++) {
-        if (!hasPrimaryKey(data[i])) {
-          await resolvePrimaryKey(meta, i);
-        }
-      }
-
-      uniqueFields = pks;
+    if (!hasPrimaryKey(data[0])) {
+      await lookupPrimaryKey();
     }
 
-    // without `returning`, the PKs of a batched insert cannot be mapped back to the rows
-    if (!this.platform.usesReturningStatement() && data.length > 1 && !data.every(hasPrimaryKey)) {
-      const results: QueryResult<T>[] = [];
+    const tables: EntityMetadata<T>[] = [];
 
-      for (let i = 0; i < data.length; i++) {
-        results.push(await this.upsertTPT(meta, [where[i]], [data[i]], options));
-      }
-
-      const affectedRows = results.reduce((sum, res) => sum + res.affectedRows, 0);
-      const rows = results.every(res => res.row) ? results.map(res => res.row!) : [];
-      return { ...results[0], affectedRows, rows };
+    for (let current: EntityMetadata<T> | undefined = meta; current; current = current.tptParent) {
+      tables.unshift(current);
     }
 
+    const owns = (table: EntityMetadata<T>, key: string) =>
+      pks.includes(key as EntityKey<T>) || table.ownProps!.some(prop => prop.name === key.split('.')[0]);
+    const uniqueFields = options.onConflictFields ?? (Utils.keys(where[0] as Dictionary) as (keyof T)[]);
     const rows: Dictionary[] = data.map(() => ({}));
     let complete = true;
-    const pick = (fields: (keyof T)[] | undefined, table: EntityMetadata<T>) =>
-      fields?.filter(field => {
-        const name = (field as string).split('.')[0];
-        return pks.includes(name as EntityKey<T>) || table.ownProps!.some(prop => prop.name === name);
-      });
     let res!: QueryResult<T>;
 
     for (const table of tables) {
-      const isRoot = table === root;
-      const tableData = data.map(row => {
-        const tableRow: Dictionary = {};
+      const isRoot = table === tables[0];
+      // only the root table can use the conflict target of a new row, and only when it owns those columns
+      const rootConflict =
+        isRoot && !hasPrimaryKey(data[0]) && !isRaw(uniqueFields) && uniqueFields.every(f => owns(table, f as string));
+      const tableRes = await this.upsertRows(
+        table,
+        where,
+        data.map(
+          row => Object.fromEntries(Object.entries(row).filter(([key]) => owns(table, key))) as EntityDictionary<T>,
+        ),
+        {
+          ...options,
+          onConflictFields: rootConflict ? uniqueFields : pks,
+          onConflictMergeFields: options.onConflictMergeFields?.filter(f => owns(table, f as string)),
+          onConflictExcludeFields: options.onConflictExcludeFields?.filter(f => owns(table, f as string)),
+          onConflictWhere: isRoot ? options.onConflictWhere : undefined,
+        } as typeof options,
+      );
+      res ??= tableRes;
 
-        for (const key of Utils.keys(row)) {
-          if (pks.includes(key) || table.ownProps!.some(prop => prop.name === key)) {
-            tableRow[key] = row[key];
-          }
-        }
-
-        return tableRow as EntityDictionary<T>;
-      });
-      const tableOptions = {
-        ...options,
-        onConflictFields: isRoot ? uniqueFields : pks,
-        onConflictMergeFields: pick(options.onConflictMergeFields as (keyof T)[], table),
-        onConflictExcludeFields: pick(options.onConflictExcludeFields as (keyof T)[], table),
-        onConflictWhere: isRoot ? options.onConflictWhere : undefined,
-      } as NativeInsertUpdateManyOptions<T> & UpsertManyOptions<T>;
-      const tableRes = await this.upsertRows(table, where, tableData, tableOptions);
       // the returned rows align with the input only when every row came back (`do nothing` skips existing ones)
-      const returned = tableRes.rows?.length === data.length ? tableRes.rows : undefined;
-      returned?.forEach((row, i) => Object.assign(rows[i], row));
-      complete &&= !!returned;
-
-      if (!isRoot) {
-        continue;
+      if (tableRes.rows?.length === data.length) {
+        tableRes.rows.forEach((row, i) => Object.assign(rows[i], row));
+      } else {
+        complete = false;
       }
 
-      res = tableRes;
+      if (isRoot && !hasPrimaryKey(data[0])) {
+        const insertId = tableRes.affectedRows === 1 ? tableRes.insertId : undefined;
+        pks.forEach(pk => (data[0][pk] ??= (rows[0][table.properties[pk].fieldNames[0]] ?? insertId) as never));
 
-      for (let i = 0; i < data.length; i++) {
-        if (hasPrimaryKey(data[i])) {
-          continue;
-        }
-
-        for (const pk of pks) {
-          const prop = root.properties[pk];
-          let value =
-            returned?.[i][prop.fieldNames[0]] ??
-            (data.length === 1 && tableRes.affectedRows === 1 ? tableRes.insertId : undefined);
-
-          if (value != null && options.convertCustomTypes && prop.customType) {
-            value = prop.customType.convertToJSValue(value, this.platform);
-          }
-
-          if (value != null) {
-            data[i][pk] = value as never;
-          }
-        }
-
-        if (!hasPrimaryKey(data[i])) {
-          await resolvePrimaryKey(root, i);
+        // the row was inserted concurrently between the lookup and the upsert
+        if (!hasPrimaryKey(data[0])) {
+          await lookupPrimaryKey();
         }
       }
     }

--- a/packages/sql/src/query/QueryBuilder.ts
+++ b/packages/sql/src/query/QueryBuilder.ts
@@ -2365,6 +2365,10 @@ export class QueryBuilder<
           prop =>
             prop.returning || (prop.persist !== false && ((prop.primary && prop.autoincrement) || prop.defaultRaw)),
         )
+        // a TPT table can only return its own columns
+        .filter(
+          prop => meta.inheritanceType !== 'tpt' || prop.primary || meta.ownProps!.some(p => p.name === prop.name),
+        )
         .filter(prop => !data || !(prop.name in data));
 
       if (returningProps.length > 0) {

--- a/tests/features/table-per-type-inheritance/tpt-upsert.test.ts
+++ b/tests/features/table-per-type-inheritance/tpt-upsert.test.ts
@@ -1,0 +1,194 @@
+import { MikroORM, OptionalProps, Utils, type IDatabaseDriver } from '@mikro-orm/core';
+import { Entity, PrimaryKey, Property, ReflectMetadataProvider, Unique } from '@mikro-orm/decorators/legacy';
+import { mockLogger, PLATFORMS } from '../../bootstrap.js';
+
+@Entity({ inheritance: 'tpt' })
+abstract class Animal {
+  [OptionalProps]?: 'version';
+
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  @Unique()
+  name!: string;
+
+  @Property({ version: true })
+  version!: number;
+}
+
+@Entity()
+class Dog extends Animal {
+  @Property()
+  breed!: string;
+}
+
+@Entity()
+class Puppy extends Dog {
+  @Property()
+  @Unique()
+  tag!: string;
+
+  @Property({ nullable: true })
+  toy?: string;
+}
+
+const options = {
+  sqlite: { dbName: ':memory:' },
+  mysql: { dbName: 'mikro_orm_tpt_upsert', port: 3308 },
+  postgresql: { dbName: 'mikro_orm_tpt_upsert' },
+};
+
+describe.each(Utils.keys(options))('TPT upsert [%s]', type => {
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init<IDatabaseDriver>({
+      entities: [Animal, Dog, Puppy],
+      driver: PLATFORMS[type],
+      metadataProvider: ReflectMetadataProvider,
+      ...options[type],
+    });
+    await orm.schema.refresh();
+  });
+
+  beforeEach(async () => {
+    await orm.schema.clear();
+    orm.em.clear();
+  });
+
+  afterAll(() => orm.close(true));
+
+  test('em.upsert(Type, data) with PK inserts and then updates every table', async () => {
+    const dog = await orm.em.upsert(Dog, { id: 1, name: 'Rex', breed: 'poodle' });
+    expect(dog).toBeInstanceOf(Dog);
+    expect(dog.version).toBe(1);
+    orm.em.clear();
+
+    const updated = await orm.em.upsert(Dog, { id: 1, name: 'Rexy', breed: 'labrador' });
+    expect(updated.name).toBe('Rexy');
+    expect(updated.breed).toBe('labrador');
+    orm.em.clear();
+
+    const found = await orm.em.findOneOrFail(Dog, 1);
+    expect(found.name).toBe('Rexy');
+    expect(found.breed).toBe('labrador');
+    expect(await orm.em.count(Animal)).toBe(1);
+  });
+
+  test('em.upsert(Type, data) with a unique root column resolves the PK for the child table', async () => {
+    const dog = await orm.em.upsert(Dog, { name: 'Rex', breed: 'poodle' });
+    expect(dog.id).toBeDefined();
+    orm.em.clear();
+
+    const updated = await orm.em.upsert(Dog, { name: 'Rex', breed: 'labrador' });
+    expect(updated.id).toBe(dog.id);
+    expect(updated.breed).toBe('labrador');
+    orm.em.clear();
+
+    const all = await orm.em.find(Dog, {});
+    expect(all).toHaveLength(1);
+    expect(all[0].breed).toBe('labrador');
+  });
+
+  test('em.upsert(Type, data) with a unique column below the root', async () => {
+    const puppy = await orm.em.upsert(Puppy, { name: 'Rex', breed: 'poodle', tag: 'A1' });
+    orm.em.clear();
+
+    const updated = await orm.em.upsert(
+      Puppy,
+      { name: 'Rexy', breed: 'labrador', tag: 'A1', toy: 'ball' },
+      { onConflictFields: ['tag'] },
+    );
+    expect(updated.id).toBe(puppy.id);
+    orm.em.clear();
+
+    const found = await orm.em.findOneOrFail(Puppy, puppy.id);
+    expect(found).toMatchObject({ name: 'Rexy', breed: 'labrador', tag: 'A1', toy: 'ball' });
+    expect(await orm.em.count(Animal)).toBe(1);
+  });
+
+  test('em.upsert(entity)', async () => {
+    const dog = orm.em.create(Dog, { id: 1, name: 'Rex', breed: 'poodle' });
+    await orm.em.upsert(dog);
+    orm.em.clear();
+
+    const dog2 = orm.em.create(Dog, { id: 1, name: 'Rexy', breed: 'labrador' });
+    await orm.em.upsert(dog2);
+    orm.em.clear();
+
+    const found = await orm.em.findOneOrFail(Dog, 1);
+    expect(found.name).toBe('Rexy');
+    expect(found.breed).toBe('labrador');
+  });
+
+  test('em.upsertMany(Type, data) with PK', async () => {
+    await orm.em.upsertMany(Dog, [
+      { id: 1, name: 'Rex', breed: 'poodle' },
+      { id: 2, name: 'Fido', breed: 'poodle' },
+    ]);
+    orm.em.clear();
+
+    const dogs = await orm.em.upsertMany(Dog, [
+      { id: 1, name: 'Rex', breed: 'labrador' },
+      { id: 2, name: 'Fido', breed: 'labrador' },
+      { id: 3, name: 'Spot', breed: 'beagle' },
+    ]);
+    expect(dogs.map(d => d.breed)).toEqual(['labrador', 'labrador', 'beagle']);
+    orm.em.clear();
+
+    const found = await orm.em.find(Dog, {}, { orderBy: { id: 'asc' } });
+    expect(found.map(d => [d.name, d.breed])).toEqual([
+      ['Rex', 'labrador'],
+      ['Fido', 'labrador'],
+      ['Spot', 'beagle'],
+    ]);
+  });
+
+  test('em.upsertMany(Type, data) with a unique root column', async () => {
+    const created = await orm.em.upsertMany(Dog, [
+      { name: 'Rex', breed: 'poodle' },
+      { name: 'Fido', breed: 'poodle' },
+    ]);
+    expect(created[0].id).not.toBe(created[1].id);
+    orm.em.clear();
+
+    const dogs = await orm.em.upsertMany(Dog, [
+      { name: 'Rex', breed: 'labrador' },
+      { name: 'Spot', breed: 'beagle' },
+    ]);
+    expect(dogs[0].id).toBe(created[0].id);
+    expect(dogs[1].id).toBeGreaterThan(created[1].id);
+    orm.em.clear();
+
+    const found = await orm.em.find(Dog, {}, { orderBy: { id: 'asc' } });
+    expect(found.map(d => [d.name, d.breed])).toEqual([
+      ['Rex', 'labrador'],
+      ['Fido', 'poodle'],
+      ['Spot', 'beagle'],
+    ]);
+  });
+
+  test('em.upsert(Type, data) with onConflictAction ignore keeps the existing row in every table', async () => {
+    await orm.em.upsert(Dog, { id: 1, name: 'Rex', breed: 'poodle' });
+    orm.em.clear();
+
+    const dog = await orm.em.upsert(Dog, { id: 1, name: 'Rexy', breed: 'labrador' }, { onConflictAction: 'ignore' });
+    expect(dog.name).toBe('Rex');
+    expect(dog.breed).toBe('poodle');
+  });
+
+  test('three level hierarchy upserts each table once', async () => {
+    const mock = mockLogger(orm);
+    await orm.em.upsert(Puppy, { id: 1, name: 'Rex', breed: 'poodle', tag: 'A1' });
+    const inserts = mock.mock.calls.map(c => c[0]).filter(q => q.includes('insert into'));
+    expect(inserts).toHaveLength(3);
+    expect(inserts[0]).toMatch(/insert into .animal./);
+    expect(inserts[1]).toMatch(/insert into .dog./);
+    expect(inserts[2]).toMatch(/insert into .puppy./);
+    orm.em.clear();
+
+    const found = await orm.em.findOneOrFail(Puppy, 1);
+    expect(found).toMatchObject({ name: 'Rex', breed: 'poodle', tag: 'A1' });
+  });
+});

--- a/tests/features/table-per-type-inheritance/tpt-upsert.test.ts
+++ b/tests/features/table-per-type-inheritance/tpt-upsert.test.ts
@@ -91,23 +91,6 @@ describe.each(Utils.keys(options))('TPT upsert [%s]', type => {
     expect(all[0].breed).toBe('labrador');
   });
 
-  test('em.upsert(Type, data) with a unique column below the root', async () => {
-    const puppy = await orm.em.upsert(Puppy, { name: 'Rex', breed: 'poodle', tag: 'A1' });
-    orm.em.clear();
-
-    const updated = await orm.em.upsert(
-      Puppy,
-      { name: 'Rexy', breed: 'labrador', tag: 'A1', toy: 'ball' },
-      { onConflictFields: ['tag'] },
-    );
-    expect(updated.id).toBe(puppy.id);
-    orm.em.clear();
-
-    const found = await orm.em.findOneOrFail(Puppy, puppy.id);
-    expect(found).toMatchObject({ name: 'Rexy', breed: 'labrador', tag: 'A1', toy: 'ball' });
-    expect(await orm.em.count(Animal)).toBe(1);
-  });
-
   test('em.upsert(entity)', async () => {
     const dog = orm.em.create(Dog, { id: 1, name: 'Rex', breed: 'poodle' });
     await orm.em.upsert(dog);


### PR DESCRIPTION
Third item from #8226. `em.upsert()` and `em.upsertMany()` built a single insert against the leaf table of a TPT entity, with the columns of the whole hierarchy in it, so the query died on the first inherited column (`table dog has no column named name`).

The upsert branch of `nativeUpdateMany` now deals with TPT tables directly. A table with a parent upserts the parent table with the same data first (recursively, so the root goes first), looks up the primary key of any row that has none, and then upserts on the primary key. A TPT table inserts only its own columns, filters `onConflictMergeFields` and `onConflictExcludeFields` down to those columns, and returns no rows, so the entity manager reloads the entity through the reload path it already has instead of mapping returned rows. `onConflictWhere` applies to the root table only. For a row without a primary key, the conflict fields have to live on the root table, because the lookup runs against the parent table.

Child metadata does not inherit the `unique` flags and indexes of parent tables, so `getWhereCondition` walks the TPT chain when it derives the conflict target. `em.upsert(Dog, { name, breed })` with a unique `name` on the root table finds the existing row. The default `returning` list the QueryBuilder adds to inserts is scoped to the table's own columns as well, which also affects plain `qb.insert()` on TPT children.

Related to #8226
