### PR TITLE
fix(sql): join TPT parent tables for relations targeting a sub-class

### DIFF
--- a/packages/sql/src/AbstractSqlDriver.ts
+++ b/packages/sql/src/AbstractSqlDriver.ts
@@ -2651,7 +2651,7 @@ export abstract class AbstractSqlDriver<
           // INNER JOINs get nested inside the polymorphic LEFT JOIN by processNestedJoins, which
           // keeps the resulting query valid for rows pointing to other polymorphic targets.
           if (targetMeta.inheritanceType === 'tpt' && targetMeta.tptParent) {
-            this.addTPTParentJoinsForRelation(qb, targetMeta as EntityMetadata<T>, tableAlias, targetPath);
+            qb.addTPTParentJoins(targetMeta, tableAlias, targetPath);
           }
 
           // For polymorphic targets that are TPT base classes, also LEFT JOIN
@@ -2711,11 +2711,6 @@ export abstract class AbstractSqlDriver<
       const schema =
         prop.targetMeta!.schema === '*' ? (options?.schema ?? this.config.get('schema')) : prop.targetMeta!.schema;
       qb.join(field as any, tableAlias, {}, joinType, path, schema);
-
-      // For relations to TPT child entities, INNER JOIN parent tables (GH #7469)
-      if (meta2.inheritanceType === 'tpt' && meta2.tptParent) {
-        this.addTPTParentJoinsForRelation(qb, meta2, tableAlias, path);
-      }
 
       // For relations to TPT base classes, add LEFT JOINs for all child tables (polymorphic loading)
       if (meta2.inheritanceType === 'tpt' && meta2.tptChildren?.length && !ref) {
@@ -2786,38 +2781,6 @@ export abstract class AbstractSqlDriver<
     }
 
     return fields;
-  }
-
-  /**
-   * Walks the TPT inheritance chain of `leafMeta` and INNER JOINs each parent table.
-   * Registers the parent aliases in `qb.state.tptAlias` so column resolution finds them
-   * when filter conditions reference parent-table columns.
-   * @internal
-   */
-  protected addTPTParentJoinsForRelation<T extends object>(
-    qb: AnyQueryBuilder<T>,
-    leafMeta: EntityMetadata,
-    leafAlias: string,
-    basePath: string,
-  ): void {
-    let childAlias = leafAlias;
-    let childMeta: EntityMetadata = leafMeta;
-
-    while (childMeta.tptParent) {
-      const parentMeta = childMeta.tptParent;
-      const parentAlias = qb.getNextAlias(parentMeta.className);
-      qb.createAlias(parentMeta.class, parentAlias);
-      qb.state.tptAlias[`${leafAlias}:${parentMeta.className}`] = parentAlias;
-      qb.addPropertyJoin(
-        childMeta.tptParentProp!,
-        childAlias,
-        parentAlias,
-        JoinType.innerJoin,
-        `${basePath}.[tpt]${childMeta.className}`,
-      );
-      childAlias = parentAlias;
-      childMeta = parentMeta;
-    }
   }
 
   /**

--- a/packages/sql/src/query/QueryBuilder.ts
+++ b/packages/sql/src/query/QueryBuilder.ts
@@ -1592,9 +1592,10 @@ export class QueryBuilder<
     }
 
     if (Utils.isPlainObject(cond)) {
-      return Object.entries(cond).some(
-        ([key, value]) => key.startsWith(`${alias}.`) || this.condReferencesAlias(value, alias),
-      );
+      return Object.entries(cond).some(([key, value]) => {
+        const [keyAlias, field] = this.helper.splitField(key as EntityKey<Entity>);
+        return this.helper.getTPTAliasForProperty(field, keyAlias) === alias || this.condReferencesAlias(value, alias);
+      });
     }
 
     return false;
@@ -3224,9 +3225,40 @@ export class QueryBuilder<
       this.#state.joins[aliasedName].path ??= path;
     }
 
+    if (prop.targetMeta!.inheritanceType === 'tpt' && prop.targetMeta!.tptParent) {
+      this.addTPTParentJoins(prop.targetMeta!, alias, path);
+    }
+
     this.nestReferencedJoins(this.#state.joins[aliasedName]);
 
     return { prop, key: aliasedName };
+  }
+
+  /**
+   * Walks the TPT inheritance chain of `leafMeta` and INNER JOINs each parent table.
+   * Registers the parent aliases in `state.tptAlias` so column resolution finds them
+   * when conditions reference parent-table columns.
+   * @internal
+   */
+  addTPTParentJoins(leafMeta: EntityMetadata, leafAlias: string, basePath: string): void {
+    let childAlias = leafAlias;
+    let childMeta: EntityMetadata = leafMeta;
+
+    while (childMeta.tptParent) {
+      const parentMeta = childMeta.tptParent;
+      const parentAlias = this.getNextAlias(parentMeta.className);
+      this.createAlias(parentMeta.class, parentAlias);
+      this.#state.tptAlias[`${leafAlias}:${parentMeta.className}`] = parentAlias;
+      this.addPropertyJoin(
+        childMeta.tptParentProp!,
+        childAlias,
+        parentAlias,
+        JoinType.innerJoin,
+        `${basePath}.[tpt]${childMeta.className}`,
+      );
+      childAlias = parentAlias;
+      childMeta = parentMeta;
+    }
   }
 
   protected prepareFields<T>(
@@ -3997,6 +4029,8 @@ export class QueryBuilder<
         } else {
           join.cond = { ...join.cond, [k]: cond[k] };
         }
+
+        this.nestReferencedJoins(join);
       }
     }
   }

--- a/tests/features/table-per-type-inheritance/tpt-relation-to-subtype.test.ts
+++ b/tests/features/table-per-type-inheritance/tpt-relation-to-subtype.test.ts
@@ -1,0 +1,143 @@
+import { MikroORM } from '@mikro-orm/sqlite';
+import { Entity, Filter, ManyToOne, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+import { mockLogger } from '../../bootstrap.js';
+
+@Filter({ name: 'softDelete', cond: { deletedAt: null }, default: true })
+@Entity({ inheritance: 'tpt' })
+class Animal {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @Property({ nullable: true })
+  deletedAt?: Date;
+}
+
+@Entity()
+class Dog extends Animal {
+  @Property()
+  breed!: string;
+}
+
+@Entity()
+class Puppy extends Dog {
+  @Property()
+  toy!: string;
+}
+
+@Entity()
+class Tag {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  label!: string;
+
+  @ManyToOne(() => Dog)
+  dog!: Dog;
+
+  @ManyToOne(() => Puppy, { nullable: true })
+  puppy?: Puppy;
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    entities: [Animal, Dog, Puppy, Tag],
+    dbName: ':memory:',
+    metadataProvider: ReflectMetadataProvider,
+  });
+  await orm.schema.refresh();
+
+  const dog = orm.em.create(Dog, { name: 'Rex', breed: 'labrador' });
+  const other = orm.em.create(Dog, { name: 'Ace', breed: 'beagle' });
+  const puppy = orm.em.create(Puppy, { name: 'Bit', breed: 'poodle', toy: 'ball' });
+  await orm.em.flush();
+  orm.em.create(Tag, { label: 'first', dog, puppy });
+  orm.em.create(Tag, { label: 'second', dog: other });
+  await orm.em.flush();
+  orm.em.clear();
+});
+
+afterAll(() => orm.close(true));
+
+describe('base-owned columns through a relation to a TPT subtype', () => {
+  test('where on a base-owned property joins the base table', async () => {
+    const res = await orm.em.fork().find(Tag, { dog: { name: 'Rex' } }, { filters: false });
+    expect(res.map(t => t.label)).toEqual(['first']);
+  });
+
+  test('orderBy on a base-owned property joins the base table', async () => {
+    const asc = await orm.em.fork().find(Tag, {}, { orderBy: { dog: { name: 'asc' } }, filters: false });
+    expect(asc.map(t => t.label)).toEqual(['second', 'first']);
+
+    const desc = await orm.em.fork().find(Tag, {}, { orderBy: { dog: { name: 'desc' } }, filters: false });
+    expect(desc.map(t => t.label)).toEqual(['first', 'second']);
+  });
+
+  test('count with a where on a base-owned property', async () => {
+    expect(await orm.em.fork().count(Tag, { dog: { name: 'Rex' } }, { filters: false })).toBe(1);
+  });
+
+  test('$in on a base-owned property', async () => {
+    const res = await orm.em.fork().find(Tag, { dog: { name: { $in: ['Rex', 'Ace'] } } }, { filters: false });
+    expect(res.map(t => t.label).sort()).toEqual(['first', 'second']);
+  });
+
+  test('multi-level TPT reaches both the grandparent and the mid-level table', async () => {
+    const em = orm.em.fork();
+    expect(await em.find(Tag, { puppy: { name: 'Bit' } }, { filters: false })).toHaveLength(1);
+    em.clear();
+    expect(await em.find(Tag, { puppy: { breed: 'poodle' } }, { filters: false })).toHaveLength(1);
+  });
+
+  test('where on a subtype-owned property still works', async () => {
+    const res = await orm.em.fork().find(Tag, { dog: { breed: 'labrador' } }, { filters: false });
+    expect(res.map(t => t.label)).toEqual(['first']);
+  });
+
+  test('joinAndSelect with a where on a base-owned property', async () => {
+    const res = await orm.em
+      .fork()
+      .createQueryBuilder(Tag, 't')
+      .joinAndSelect('t.dog', 'd')
+      .where({ 'd.name': 'Rex' })
+      .getResultList();
+    expect(res.map(t => [t.label, t.dog.name, t.dog.breed])).toEqual([['first', 'Rex', 'labrador']]);
+  });
+
+  test('reading the subtype directly by a base-owned property still works', async () => {
+    const res = await orm.em.fork().find(Dog, { name: 'Rex' }, { filters: false });
+    expect(res.map(d => d.breed)).toEqual(['labrador']);
+  });
+});
+
+describe('filter conditions on base-owned columns through a relation to a TPT subtype', () => {
+  test('a filter cond on a base-owned column does not forward-reference the base join', async () => {
+    const mock = mockLogger(orm);
+    const res = await orm.em.fork().find(Tag, {});
+    expect(res).toHaveLength(2);
+    expect(mock.mock.calls[0][0]).toMatch(
+      'from `tag` as `t0` ' +
+        'inner join (`dog` as `d1` inner join `animal` as `a2` on `d1`.`id` = `a2`.`id`) ' +
+        'on `t0`.`dog_id` = `d1`.`id` and `a2`.`deleted_at` is null',
+    );
+  });
+
+  test('the filter is actually applied to rows of the subtype', async () => {
+    const em = orm.em.fork();
+    const dog = await em.findOneOrFail(Dog, { name: 'Rex' });
+    dog.deletedAt = new Date();
+    await em.flush();
+    em.clear();
+
+    expect((await em.find(Tag, {})).map(t => t.label)).toEqual(['second']);
+
+    const back = await em.findOneOrFail(Dog, { name: 'Rex' }, { filters: false });
+    back.deletedAt = undefined;
+    await em.flush();
+  });
+});


### PR DESCRIPTION
When a relation targets a TPT sub-class, columns owned by a parent table could not be reached through the relation in `where`, `orderBy`, `count`, `$in`, `groupBy` or `qb.join()`. Only the joined-populate path added the parent joins. `joinReference()` now joins the parent chain itself, so every relation join gets it and the driver-side helper is no longer needed.

Filter conditions on an inherited column were attached to the sub-class join but referenced the parent alias joined after it, which postgres and mssql reject. `condReferencesAlias()` now resolves TPT inherited columns to their owning alias, and `mergeOnConditions()` nests the referenced joins like explicit join conditions already do.

Closes #8231
