### PR TITLE
fix(postgres): forward `pool.min` to the `pg` pool

### DIFF
--- a/packages/postgresql/src/PostgreSqlConnection.ts
+++ b/packages/postgresql/src/PostgreSqlConnection.ts
@@ -43,6 +43,7 @@ export class PostgreSqlConnection extends AbstractSqlConnection {
   mapOptions(overrides: PoolConfig): PoolConfig {
     const ret = { ...this.getConnectionOptions() } as PoolConfig;
     const pool = this.config.get('pool');
+    Utils.defaultValue(ret, 'min', pool?.min);
     Utils.defaultValue(ret, 'max', pool?.max);
     Utils.defaultValue(ret, 'idleTimeoutMillis', pool?.idleTimeoutMillis);
 

--- a/tests/features/entity-manager/EntityManager.postgre.test.ts
+++ b/tests/features/entity-manager/EntityManager.postgre.test.ts
@@ -128,6 +128,31 @@ describe('EntityManagerPostgre', () => {
     });
   });
 
+  test('pool options are mapped to the pg pool config', async () => {
+    const config = new Configuration(
+      {
+        driver: PostgreSqlDriver,
+        clientUrl: 'postgre://root@127.0.0.1:1234/db_name',
+        logger: vi.fn(),
+        pool: { min: 2, max: 5, idleTimeoutMillis: 30_000 },
+      } as any,
+      false,
+    );
+    const driver = new PostgreSqlDriver(config);
+    expect(driver.getConnection().mapOptions({})).toMatchObject({
+      min: 2,
+      max: 5,
+      idleTimeoutMillis: 30_000,
+    });
+
+    // explicit driverOptions win over the pool config
+    expect(driver.getConnection().mapOptions({ min: 4 })).toMatchObject({
+      min: 4,
+      max: 5,
+      idleTimeoutMillis: 30_000,
+    });
+  });
+
   test('driverOptions.onPoolCreated receives the pg.Pool', async () => {
     let receivedPool: Pool | undefined;
     const config = new Configuration(


### PR DESCRIPTION
`PostgreSqlConnection.mapOptions()` forwards `pool.max` and `pool.idleTimeoutMillis` to `pg`, but not `pool.min`, so the pool always ran with `min = 0` and closed every idle connection once pg-pool's idle timeout elapsed, no matter what `pool.min` was set to.

`pg-pool` supports `min`, so this maps it the same way `max` is already mapped. The other drivers map it to their own pool option already.

Closes #8234
