### PR TITLE
feat(core): add `through` option for read-only to-one relations resolved via subquery

### DIFF
--- a/docs/docs/relationships.md
+++ b/docs/docs/relationships.md
@@ -625,7 +625,7 @@ const CustomerSchema = defineEntity({
     edges: () => p.oneToMany(Edge).mappedBy('start'),
     // the account linked via an edge in the `cleared` state
     account: () => p.manyToOne(Account).through(() => Edge).where({ state: 'cleared' }).ref().nullable(),
-    // the most recent edge of this customer
+    // the newest edge of this customer, picked out of the `edges` collection
     latestEdge: () => p.oneToOne(Edge).through(() => Edge).orderBy({ id: 'desc' }).ref().nullable(),
   },
 });
@@ -661,7 +661,7 @@ export const Customer = defineEntity({
     edges: () => p.oneToMany(Edge).mappedBy('start'),
     // the account linked via an edge in the `cleared` state
     account: () => p.manyToOne(Account).through(() => Edge).where({ state: 'cleared' }).ref().nullable(),
-    // the most recent edge of this customer
+    // the newest edge of this customer, picked out of the `edges` collection
     latestEdge: () => p.oneToOne(Edge).through(() => Edge).orderBy({ id: 'desc' }).ref().nullable(),
   },
 });
@@ -699,7 +699,7 @@ export class Customer {
   @ManyToOne(() => Account, { through: () => Edge, where: { state: 'cleared' }, ref: true, nullable: true })
   account?: Ref<Account>;
 
-  // the most recent edge of this customer
+  // the newest edge of this customer, picked out of the `edges` collection
   @OneToOne(() => Edge, { through: () => Edge, orderBy: { id: 'desc' }, ref: true, nullable: true })
   latestEdge?: Ref<Edge>;
 
@@ -741,7 +741,7 @@ export class Customer {
   @ManyToOne({ through: () => Edge, where: { state: 'cleared' }, ref: true, nullable: true })
   account?: Ref<Account>;
 
-  // the most recent edge of this customer
+  // the newest edge of this customer, picked out of the `edges` collection
   @OneToOne({ through: () => Edge, orderBy: { id: 'desc' }, ref: true, nullable: true })
   latestEdge?: Ref<Edge>;
 
@@ -768,7 +768,7 @@ export class Edge {
   </TabItem>
 </Tabs>
 
-When reading, such relation behaves like any other to-one relation: it can be populated with both loading strategies, used in `where` and `orderBy` conditions, combined with `ref` or `mapToPk`, and it takes part in `Loaded<>` type inference and serialization. Under the hood, the ORM selects the target primary key via a subquery on the `through` entity, so for the `account` property above the generated column looks like this:
+When reading, such relation behaves like any other to-one relation: it can be populated with both loading strategies, used in `where` and `orderBy` conditions, combined with `ref` or `mapToPk`, and it takes part in `Loaded<>` type inference and serialization. Under the hood, the ORM selects the target primary key via a subquery on the `through` entity. For the `account` property above, the subquery goes through the pivot entity: it filters `edge` rows by the FK back to the customer and by the `where` condition, and selects the FK to the account:
 
 ```sql
 select c.*, (
@@ -777,6 +777,19 @@ select c.*, (
   limit 1
 ) as account_id from customer as c
 ```
+
+The `latestEdge` property shows the other use: `through` is the target entity itself, so there is no pivot and the subquery selects the primary key of `edge` directly. It picks one row out of what the `edges` collection would hold, using `orderBy` to decide which one:
+
+```sql
+select c.*, (
+  select e.id from edge as e
+  where e.start_id = c.id
+  order by e.id desc
+  limit 1
+) as latest_edge_id from customer as c
+```
+
+This is the same as loading the `edges` collection and taking the newest item, without loading the whole collection. Combine it with `where` to pick e.g. the newest edge in a given state.
 
 The relation is read-only, no column or foreign key constraint is created for it and assignments to it are ignored during flush. To create or change the link, work with the `through` entity directly, e.g. via a `OneToMany` relation to it like the `edges` collection above. When several rows match, the first one is used, add a unique index on the `through` entity if you need to guarantee there is at most one.
 

--- a/docs/docs/relationships.md
+++ b/docs/docs/relationships.md
@@ -596,6 +596,201 @@ export class BookTag {
 
 Again, more information about how collections work can be found on [collections page](./collections.md).
 
+## To-one relations through another entity
+
+Sometimes the link to a single related entity is not stored as a foreign key on the owning table. Typical cases are a pivot entity carrying the link together with extra columns, or a to-many relation from which you want to expose just one item, e.g. the latest one. Both can be modeled as a read-only `ManyToOne` or `OneToOne` relation with the `through` option, which resolves the target via a correlated subquery instead of a foreign key column.
+
+The `through` entity needs a `ManyToOne` property pointing to the owning entity. When it differs from the target, it also needs a `ManyToOne` property pointing to the target entity, this is the pivot entity case. When `through` is the target entity itself, its primary key is selected directly, this is how you pick a single item out of a `OneToMany` relation. The `where` and `orderBy` options apply to the `through` entity and the first matching row is used.
+
+<Tabs
+  groupId="entity-def"
+  defaultValue="define-entity-class"
+  values={[
+    {label: 'defineEntity + class', value: 'define-entity-class'},
+    {label: 'defineEntity', value: 'define-entity'},
+    {label: 'reflect-metadata', value: 'reflect-metadata'},
+    {label: 'ts-morph', value: 'ts-morph'},
+]
+  }
+>
+  <TabItem value="define-entity-class">
+
+```ts
+import { defineEntity, p } from '@mikro-orm/core';
+
+const CustomerSchema = defineEntity({
+  name: 'Customer',
+  properties: {
+    id: p.integer().primary(),
+    edges: () => p.oneToMany(Edge).mappedBy('start'),
+    // the account linked via an edge in the `cleared` state
+    account: () => p.manyToOne(Account).through(() => Edge).where({ state: 'cleared' }).ref().nullable(),
+    // the most recent edge of this customer
+    latestEdge: () => p.oneToOne(Edge).through(() => Edge).orderBy({ id: 'desc' }).ref().nullable(),
+  },
+});
+
+export class Customer extends CustomerSchema.class {}
+CustomerSchema.setClass(Customer);
+
+const EdgeSchema = defineEntity({
+  name: 'Edge',
+  properties: {
+    id: p.integer().primary(),
+    start: () => p.manyToOne(Customer),
+    end: () => p.manyToOne(Account),
+    state: p.string(),
+  },
+});
+
+export class Edge extends EdgeSchema.class {}
+EdgeSchema.setClass(Edge);
+```
+
+  </TabItem>
+
+  <TabItem value="define-entity">
+
+```ts
+import { defineEntity, InferEntity, p } from '@mikro-orm/core';
+
+export const Customer = defineEntity({
+  name: 'Customer',
+  properties: {
+    id: p.integer().primary(),
+    edges: () => p.oneToMany(Edge).mappedBy('start'),
+    // the account linked via an edge in the `cleared` state
+    account: () => p.manyToOne(Account).through(() => Edge).where({ state: 'cleared' }).ref().nullable(),
+    // the most recent edge of this customer
+    latestEdge: () => p.oneToOne(Edge).through(() => Edge).orderBy({ id: 'desc' }).ref().nullable(),
+  },
+});
+
+export interface ICustomer extends InferEntity<typeof Customer> {}
+
+export const Edge = defineEntity({
+  name: 'Edge',
+  properties: {
+    id: p.integer().primary(),
+    start: () => p.manyToOne(Customer),
+    end: () => p.manyToOne(Account),
+    state: p.string(),
+  },
+});
+
+export interface IEdge extends InferEntity<typeof Edge> {}
+```
+
+  </TabItem>
+
+  <TabItem value="reflect-metadata">
+
+```ts
+@Entity()
+export class Customer {
+
+  @PrimaryKey()
+  id!: number;
+
+  @OneToMany(() => Edge, e => e.start)
+  edges = new Collection<Edge>(this);
+
+  // the account linked via an edge in the `cleared` state
+  @ManyToOne(() => Account, { through: () => Edge, where: { state: 'cleared' }, ref: true, nullable: true })
+  account?: Ref<Account>;
+
+  // the most recent edge of this customer
+  @OneToOne(() => Edge, { through: () => Edge, orderBy: { id: 'desc' }, ref: true, nullable: true })
+  latestEdge?: Ref<Edge>;
+
+}
+
+@Entity()
+export class Edge {
+
+  @PrimaryKey()
+  id!: number;
+
+  @ManyToOne(() => Customer)
+  start!: Customer;
+
+  @ManyToOne(() => Account)
+  end!: Account;
+
+  @Property()
+  state!: string;
+
+}
+```
+
+  </TabItem>
+
+  <TabItem value="ts-morph">
+
+```ts
+@Entity()
+export class Customer {
+
+  @PrimaryKey()
+  id!: number;
+
+  @OneToMany(() => Edge, e => e.start)
+  edges = new Collection<Edge>(this);
+
+  // the account linked via an edge in the `cleared` state
+  @ManyToOne({ through: () => Edge, where: { state: 'cleared' }, ref: true, nullable: true })
+  account?: Ref<Account>;
+
+  // the most recent edge of this customer
+  @OneToOne({ through: () => Edge, orderBy: { id: 'desc' }, ref: true, nullable: true })
+  latestEdge?: Ref<Edge>;
+
+}
+
+@Entity()
+export class Edge {
+
+  @PrimaryKey()
+  id!: number;
+
+  @ManyToOne()
+  start!: Customer;
+
+  @ManyToOne()
+  end!: Account;
+
+  @Property()
+  state!: string;
+
+}
+```
+
+  </TabItem>
+</Tabs>
+
+When reading, such relation behaves like any other to-one relation: it can be populated with both loading strategies, used in `where` and `orderBy` conditions, combined with `ref` or `mapToPk`, and it takes part in `Loaded<>` type inference and serialization. Under the hood, the ORM selects the target primary key via a subquery on the `through` entity, so for the `account` property above the generated column looks like this:
+
+```sql
+select c.*, (
+  select e.end_id from edge as e
+  where e.start_id = c.id and e.state = 'cleared'
+  limit 1
+) as account_id from customer as c
+```
+
+The relation is read-only, no column or foreign key constraint is created for it and assignments to it are ignored during flush. To create or change the link, work with the `through` entity directly, e.g. via a `OneToMany` relation to it like the `edges` collection above. When several rows match, the first one is used, add a unique index on the `through` entity if you need to guarantee there is at most one.
+
+The `where` and `orderBy` options can only reference own columns of the `through` entity. If you need conditions on related entities, use the `formula` option instead and write the subquery yourself, the `through` option is just a shortcut for it:
+
+```ts
+@ManyToOne(() => Account, {
+  formula: cols => `(select e.end_id from edge e join account a on a.id = e.end_id where e.start_id = ${cols.id} and e.state = 'cleared' and a.active = 1)`,
+  ref: true,
+  nullable: true,
+})
+account?: Ref<Account>;
+```
+
 ## Referencing Non-Primary Key Columns
 
 By default, ManyToOne and OneToOne relations reference the primary key of the target entity. You can use the `targetKey` option to reference a different unique column instead.

--- a/packages/core/src/entity/defineEntity.ts
+++ b/packages/core/src/entity/defineEntity.ts
@@ -213,6 +213,11 @@ export interface PropertyChain<in out Value, in out Options> {
     discriminatorMap: Dictionary<string>,
   ): HasKind<Options, 'm:1' | '1:1' | 'm:n'> extends true ? PropertyChain<Value, Options> : never;
 
+  /** Resolve this read-only to-one relation via a subquery on another entity (see {@doclink relationships#to-one-relations-through-another-entity | To-one relations through another entity}). */
+  through(
+    through: () => EntityName,
+  ): HasKind<Options, 'm:1' | '1:1'> extends true ? PropertyChain<Value, Options> : never;
+
   // M:N-only methods (not available on other relation kinds, embedded, or scalars)
   pivotTable(pivotTable: string): HasKind<Options, 'm:n'> extends true ? PropertyChain<Value, Options> : never;
   pivotEntity(
@@ -951,6 +956,11 @@ export class UniversalPropertyOptionsBuilder<
   /** Override default name for pivot table (see {@doclink naming-strategy | Naming Strategy}). */
   pivotTable(pivotTable: string): Pick<UniversalPropertyOptionsBuilder<Value, Options, IncludeKeys>, IncludeKeys> {
     return this.assignOptions({ pivotTable });
+  }
+
+  /** Resolve this read-only to-one relation via a subquery on another entity (see {@doclink relationships#to-one-relations-through-another-entity | To-one relations through another entity}). */
+  through(through: () => EntityName): Pick<UniversalPropertyOptionsBuilder<Value, Options, IncludeKeys>, IncludeKeys> {
+    return this.assignOptions({ through });
   }
 
   /** Set pivot entity for this relation (see {@doclink collections#custom-pivot-table-entity | Custom pivot table entity}). */

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -392,6 +392,36 @@ export class MetadataError<T extends AnyEntity = AnyEntity> extends ValidationEr
     );
   }
 
+  static throughRelationMissingProperty(
+    meta: EntityMetadata,
+    prop: EntityProperty,
+    through: EntityMetadata,
+    side: 'owner' | 'target',
+  ): MetadataError {
+    const target = side === 'owner' ? meta.className : prop.targetMeta!.className;
+    return this.fromMessage(
+      meta,
+      prop,
+      `uses 'through' entity ${through.className} which has no ManyToOne property pointing to ${target}`,
+    );
+  }
+
+  static throughRelationCompositeTarget(meta: EntityMetadata, prop: EntityProperty): MetadataError {
+    return this.fromMessage(
+      meta,
+      prop,
+      `uses 'through' option which is not supported for targets with composite primary key`,
+    );
+  }
+
+  static throughRelationInvalidKind(meta: EntityMetadata, prop: EntityProperty): MetadataError {
+    return this.fromMessage(
+      meta,
+      prop,
+      `uses 'through' option which is only supported for ManyToOne and OneToOne relations`,
+    );
+  }
+
   static fromMissingOption(meta: EntityMetadata, prop: EntityProperty, option: string): MetadataError {
     return this.fromMessage(meta, prop, `is missing '${option}' option`);
   }

--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -2656,6 +2656,7 @@ export class MetadataDiscovery {
     const pointsTo = (p: EntityProperty, m: EntityMetadata) => {
       const candidate = this.#metadata.find(p.target);
 
+      /* v8 ignore next 3 */
       if (!candidate) {
         return false;
       }

--- a/packages/core/src/metadata/MetadataDiscovery.ts
+++ b/packages/core/src/metadata/MetadataDiscovery.ts
@@ -17,7 +17,7 @@ import { MetadataProvider } from './MetadataProvider.js';
 import type { NamingStrategy } from '../naming-strategy/NamingStrategy.js';
 import { MetadataStorage } from './MetadataStorage.js';
 import { EntitySchema } from './EntitySchema.js';
-import { Cascade, ReferenceKind } from '../enums.js';
+import { Cascade, type QueryOrderMap, ReferenceKind } from '../enums.js';
 import { MetadataError } from '../errors.js';
 import type { Platform } from '../platforms/Platform.js';
 import { t, Type } from '../types/index.js';
@@ -219,10 +219,11 @@ export class MetadataDiscovery {
     filtered.forEach(meta => this.initCheckConstraints(meta));
     filtered.forEach(meta => this.initTriggers(meta));
 
-    forEachProp((_m, p) => {
+    forEachProp((m, p) => {
       this.initDefaultValue(p);
       this.inferTypeFromDefault(p);
       this.initRelation(p);
+      this.initThroughRelation(m, p);
       this.initColumnType(p);
     });
 
@@ -288,12 +289,14 @@ export class MetadataDiscovery {
     const missing: EntityClass[] = [];
     this.#discovered.forEach(meta =>
       Object.values(meta.properties).forEach(prop => {
-        if (prop.kind === ReferenceKind.MANY_TO_MANY && prop.pivotEntity) {
-          const pivotEntity = prop.pivotEntity as unknown as EntityClass | (() => EntityClass);
+        const indirect = (prop.kind === ReferenceKind.MANY_TO_MANY ? prop.pivotEntity : prop.through) as unknown as
+          | EntityClass
+          | (() => EntityClass)
+          | undefined;
+
+        if (indirect) {
           const target =
-            typeof pivotEntity === 'function' && !pivotEntity.prototype
-              ? (pivotEntity as () => EntityClass)()
-              : pivotEntity;
+            typeof indirect === 'function' && !indirect.prototype ? (indirect as () => EntityClass)() : indirect;
 
           if (!this.#discovered.find(m => m.className === Utils.className(target)) || !discoveredByIdentity(target)) {
             missing.push(target);
@@ -2627,6 +2630,71 @@ export class MetadataDiscovery {
         prop.formula = table => `${table}.${this.#platform.quoteIdentifier(prop.fieldNames[0])}`;
       }
     }
+  }
+
+  /** Resolves the `through` option of a virtual to-one relation into a read-only formula property. */
+  private initThroughRelation(meta: EntityMetadata, prop: EntityProperty): void {
+    // already resolved, or not a through relation at all
+    if (prop.through?.ownerProperty || !prop.through) {
+      return;
+    }
+
+    if (![ReferenceKind.MANY_TO_ONE, ReferenceKind.ONE_TO_ONE].includes(prop.kind)) {
+      throw MetadataError.throughRelationInvalidKind(meta, prop);
+    }
+
+    const targetMeta = prop.targetMeta!;
+
+    // the subquery selects a single column
+    if (targetMeta.compositePK) {
+      throw MetadataError.throughRelationCompositeTarget(meta, prop);
+    }
+
+    const through = prop.through as unknown as EntityClass | (() => EntityClass);
+    const throughMeta = this.#metadata.get(!through.prototype ? (through as () => EntityClass)() : through);
+    // a property is considered to point at an entity when it targets it or one of its parents
+    const pointsTo = (p: EntityProperty, m: EntityMetadata) => {
+      const candidate = this.#metadata.find(p.target);
+
+      if (!candidate) {
+        return false;
+      }
+
+      return candidate.class === m.class || m.class.prototype instanceof candidate.class;
+    };
+    const fks = Object.values(throughMeta.properties).filter(p => p.kind === ReferenceKind.MANY_TO_ONE);
+    const ownerProp = fks.find(p => pointsTo(p, meta));
+
+    if (!ownerProp) {
+      throw MetadataError.throughRelationMissingProperty(meta, prop, throughMeta, 'owner');
+    }
+
+    let targetProperty: string | undefined;
+    const selectsTarget =
+      throughMeta.class === targetMeta.class || throughMeta.class.prototype instanceof targetMeta.class;
+
+    if (!selectsTarget) {
+      const targetProp = fks.find(p => p !== ownerProp && pointsTo(p, targetMeta));
+
+      if (!targetProp) {
+        throw MetadataError.throughRelationMissingProperty(meta, prop, throughMeta, 'target');
+      }
+
+      targetProperty = targetProp.name;
+    }
+
+    prop.through = {
+      entity: throughMeta.class,
+      where: prop.where,
+      orderBy: prop.orderBy ? (Utils.asArray(prop.orderBy) as QueryOrderMap<any>[]) : undefined,
+      ownerProperty: ownerProp.name,
+      targetProperty,
+    };
+    // the condition and ordering apply to the `through` entity, not to the target, so they must not leak into the target joins
+    delete prop.where;
+    delete prop.orderBy;
+    prop.persist = false;
+    prop.formula = columns => this.#platform.getThroughRelationFormula(prop, columns);
   }
 
   private initColumnType(prop: EntityProperty): void {

--- a/packages/core/src/metadata/types.ts
+++ b/packages/core/src/metadata/types.ts
@@ -531,9 +531,19 @@ interface PolymorphicOptions {
   discriminatorMap?: Dictionary<string>;
 }
 
-export interface ManyToOneOptions<Owner, Target> extends ReferenceOptions<Owner, Target>, PolymorphicOptions {
+export interface ManyToOneOptions<Owner, Target, Through = Target>
+  extends ReferenceOptions<Owner, Target>, PolymorphicOptions {
   /** Point to the inverse side property name. */
   inversedBy?: (string & keyof Target) | ((e: Target) => any);
+
+  /** Resolve this read-only relation via a subquery on another entity: a pivot entity with FKs to both sides, or the target itself to pick a single item out of a to-many relation (see {@doclink relationships#to-one-relations-through-another-entity | To-one relations through another entity}). */
+  through?: () => EntityName<Through>;
+
+  /** Condition applied on the `through` entity. */
+  where?: FilterQuery<Through>;
+
+  /** Ordering applied on the `through` entity, the first matching row is used. */
+  orderBy?: QueryOrderMap<Through> | QueryOrderMap<Through>[];
 
   /** Wrap the entity in {@apilink Reference} wrapper. */
   ref?: boolean;
@@ -610,10 +620,19 @@ export interface OneToManyOptions<Owner, Target> extends ReferenceOptions<Owner,
   mappedBy: (string & keyof Target) | ((e: Target) => any);
 }
 
-export interface OneToOneOptions<Owner, Target>
-  extends Partial<Omit<OneToManyOptions<Owner, Target>, 'orderBy'>>, PolymorphicOptions {
+export interface OneToOneOptions<Owner, Target, Through = Target>
+  extends Partial<Omit<OneToManyOptions<Owner, Target>, 'orderBy' | 'where'>>, PolymorphicOptions {
   /** Set this side as owning. Owning side is where the foreign key is defined. This option is not required if you use `inversedBy` or `mappedBy` to distinguish owning and inverse side. */
   owner?: boolean;
+
+  /** Resolve this read-only relation via a subquery on another entity: a pivot entity with FKs to both sides, or the target itself to pick a single item out of a to-many relation (see {@doclink relationships#to-one-relations-through-another-entity | To-one relations through another entity}). */
+  through?: () => EntityName<Through>;
+
+  /** Condition for {@doclink collections#declarative-partial-loading | Declarative partial loading}, or the condition applied on the `through` entity. */
+  where?: FilterQuery<Through>;
+
+  /** Ordering applied on the `through` entity, the first matching row is used. */
+  orderBy?: QueryOrderMap<Through> | QueryOrderMap<Through>[];
 
   /** Point to the inverse side property name. */
   inversedBy?: (string & keyof Target) | ((e: Target) => any);

--- a/packages/core/src/platforms/Platform.ts
+++ b/packages/core/src/platforms/Platform.ts
@@ -815,6 +815,7 @@ export abstract class Platform {
    * Builds the correlated subquery used as the formula of a virtual to-one relation defined via `through`.
    * @internal
    */
+  /* v8 ignore next 3 */
   getThroughRelationFormula(prop: EntityProperty, columns: FormulaColumns<any>): string {
     throw new Error(`${this.constructor.name} does not support the 'through' option of ${prop.name}`);
   }

--- a/packages/core/src/platforms/Platform.ts
+++ b/packages/core/src/platforms/Platform.ts
@@ -15,6 +15,7 @@ import type {
   EntityValue,
   EntityKey,
   FilterKey,
+  FormulaColumns,
 } from '../typings.js';
 import { ExceptionConverter } from './ExceptionConverter.js';
 import { MetadataError } from '../errors.js';
@@ -808,6 +809,14 @@ export abstract class Platform {
     Object.defineProperty(copy, JsonProperty, { enumerable: false, value: true });
 
     return copy;
+  }
+
+  /**
+   * Builds the correlated subquery used as the formula of a virtual to-one relation defined via `through`.
+   * @internal
+   */
+  getThroughRelationFormula(prop: EntityProperty, columns: FormulaColumns<any>): string {
+    throw new Error(`${this.constructor.name} does not support the 'through' option of ${prop.name}`);
   }
 
   /** Initializes the platform with the ORM configuration. */

--- a/packages/core/src/typings.ts
+++ b/packages/core/src/typings.ts
@@ -1063,6 +1063,17 @@ export type SerializeDTO<
 
 type TargetKeys<T> = T extends EntityClass<infer P> ? keyof P : keyof T;
 type PropertyName<T> = IsUnknown<T> extends false ? TargetKeys<T> : string;
+/** Resolved `through` option of a virtual to-one relation, populated during discovery. */
+export interface ThroughRelation {
+  entity: EntityClass;
+  where?: FilterQuery<any>;
+  orderBy?: QueryOrderMap<any>[];
+  /** M:1 property on the `through` entity pointing back to the owner. */
+  ownerProperty: string;
+  /** M:1 property on the `through` entity pointing to the target, undefined when the target is selected directly. */
+  targetProperty?: string;
+}
+
 /** Table reference object passed to formula callbacks, including alias and schema information. */
 export type FormulaTable = {
   alias: string;
@@ -1528,6 +1539,7 @@ export interface EntityProperty<Owner = any, Target = any> {
   fixedOrderColumn?: string;
   pivotTable: string;
   pivotEntity: EntityClass<Target>;
+  through?: ThroughRelation;
   joinColumns: string[];
   ownColumns: string[];
   inverseJoinColumns: string[];

--- a/packages/decorators/src/es/ManyToOne.ts
+++ b/packages/decorators/src/es/ManyToOne.ts
@@ -11,9 +11,9 @@ import {
 import { prepareMetadataContext, processDecoratorParameters } from '../utils.js';
 
 /** Defines a many-to-one relationship (TC39 decorator). */
-export function ManyToOne<Target extends object, Owner extends object>(
-  entity: ManyToOneOptions<Owner, Target> | ((e?: Owner) => EntityName<Target> | EntityName[]) = {},
-  options: Partial<ManyToOneOptions<Owner, Target>> = {},
+export function ManyToOne<Target extends object, Owner extends object, Through extends object = Target>(
+  entity: ManyToOneOptions<Owner, Target, Through> | ((e?: Owner) => EntityName<Target> | EntityName[]) = {},
+  options: Partial<ManyToOneOptions<Owner, Target, Through>> = {},
 ): (
   _: unknown,
   context: ClassFieldDecoratorContext<Owner, Target | Primary<Target> | undefined | null | Ref<Target>>,
@@ -23,7 +23,7 @@ export function ManyToOne<Target extends object, Owner extends object>(
     context: ClassFieldDecoratorContext<Owner, Target | Primary<Target> | undefined | null | Ref<Target>>,
   ): void {
     const meta = prepareMetadataContext(context, ReferenceKind.MANY_TO_ONE);
-    options = processDecoratorParameters<ManyToOneOptions<Owner, Target>>({ entity, options });
+    options = processDecoratorParameters<ManyToOneOptions<Owner, Target, Through>>({ entity, options });
     const property = { name: context.name, kind: ReferenceKind.MANY_TO_ONE } as EntityProperty<Target>;
     meta.properties[context.name as EntityKey<Owner>] = Utils.mergeConfig(
       meta.properties[context.name as EntityKey<Owner>] ?? {},

--- a/packages/decorators/src/es/OneToOne.ts
+++ b/packages/decorators/src/es/OneToOne.ts
@@ -2,7 +2,6 @@ import {
   type EntityKey,
   type EntityName,
   type EntityProperty,
-  type OneToManyOptions,
   type OneToOneOptions,
   type Primary,
   type Ref,
@@ -11,10 +10,10 @@ import {
 import { prepareMetadataContext, processDecoratorParameters } from '../utils.js';
 
 /** Defines a one-to-one relationship (TC39 decorator). */
-export function OneToOne<Target extends object, Owner extends object>(
-  entity?: OneToOneOptions<Owner, Target> | string | ((e: Owner) => EntityName<Target> | EntityName[]),
-  mappedByOrOptions?: (string & keyof Target) | ((e: Target) => any) | Partial<OneToOneOptions<Owner, Target>>,
-  options: Partial<OneToOneOptions<Owner, Target>> = {},
+export function OneToOne<Target extends object, Owner extends object, Through extends object = Target>(
+  entity?: OneToOneOptions<Owner, Target, Through> | string | ((e: Owner) => EntityName<Target> | EntityName[]),
+  mappedByOrOptions?: (string & keyof Target) | ((e: Target) => any) | Partial<OneToOneOptions<Owner, Target, Through>>,
+  options: Partial<OneToOneOptions<Owner, Target, Through>> = {},
 ): (
   _: unknown,
   context: ClassFieldDecoratorContext<Owner, Target | Primary<Target> | Ref<Target> | null | undefined>,
@@ -26,7 +25,7 @@ export function OneToOne<Target extends object, Owner extends object>(
     context: ClassFieldDecoratorContext<Owner, Target | Primary<Target> | Ref<Target> | null | undefined>,
   ) {
     const meta = prepareMetadataContext(context, ReferenceKind.ONE_TO_ONE);
-    options = processDecoratorParameters<OneToManyOptions<Owner, Target>>({ entity, mappedBy, options });
+    options = processDecoratorParameters<OneToOneOptions<Owner, Target, Through>>({ entity, mappedBy, options });
     const property = { name: context.name, kind: ReferenceKind.ONE_TO_ONE } as EntityProperty<Owner>;
     meta.properties[context.name as EntityKey<Owner>] = Object.assign(
       meta.properties[context.name as EntityKey<Owner>] ?? {},

--- a/packages/decorators/src/legacy/ManyToOne.ts
+++ b/packages/decorators/src/legacy/ManyToOne.ts
@@ -8,20 +8,20 @@ import {
 import { processDecoratorParameters, validateSingleDecorator, getMetadataFromDecorator } from '../utils.js';
 
 /** Defines a many-to-one relationship (legacy TypeScript decorator). */
-export function ManyToOne<Target extends object, Owner extends object>(
+export function ManyToOne<Target extends object, Owner extends object, Through extends object = Target>(
   entity: (e?: any) => EntityName<Target> | EntityName[],
-  options?: Partial<ManyToOneOptions<Owner, Target>>,
+  options?: Partial<ManyToOneOptions<Owner, Target, Through>>,
 ): (target: Owner, propertyName: string) => void;
 export function ManyToOne<Target extends object, Owner extends object>(entity: string, options?: any): never;
-export function ManyToOne<Target extends object, Owner extends object>(
-  options?: ManyToOneOptions<Owner, Target>,
+export function ManyToOne<Target extends object, Owner extends object, Through extends object = Target>(
+  options?: ManyToOneOptions<Owner, Target, Through>,
 ): (target: Owner, propertyName: string) => void;
-export function ManyToOne<Target extends object, Owner extends object>(
-  entity: ManyToOneOptions<Owner, Target> | ((e?: any) => EntityName<Target> | EntityName[]) = {},
-  options: Partial<ManyToOneOptions<Owner, Target>> = {},
+export function ManyToOne<Target extends object, Owner extends object, Through extends object = Target>(
+  entity: ManyToOneOptions<Owner, Target, Through> | ((e?: any) => EntityName<Target> | EntityName[]) = {},
+  options: Partial<ManyToOneOptions<Owner, Target, Through>> = {},
 ) {
   return function (target: Owner, propertyName: keyof Owner) {
-    options = processDecoratorParameters<ManyToOneOptions<Owner, Target>>({ entity, options });
+    options = processDecoratorParameters<ManyToOneOptions<Owner, Target, Through>>({ entity, options });
     const meta = getMetadataFromDecorator(target.constructor as Owner);
     validateSingleDecorator(meta, propertyName as string, ReferenceKind.MANY_TO_ONE);
     const property = { name: propertyName, kind: ReferenceKind.MANY_TO_ONE } as EntityProperty;

--- a/packages/decorators/src/legacy/OneToOne.ts
+++ b/packages/decorators/src/legacy/OneToOne.ts
@@ -2,30 +2,29 @@ import {
   type EntityKey,
   type EntityName,
   type EntityProperty,
-  type OneToManyOptions,
   type OneToOneOptions,
   ReferenceKind,
 } from '@mikro-orm/core';
 import { processDecoratorParameters, validateSingleDecorator, getMetadataFromDecorator } from '../utils.js';
 
 /** Defines a one-to-one relationship (legacy TypeScript decorator). */
-export function OneToOne<Target, Owner>(
+export function OneToOne<Target, Owner, Through = Target>(
   entity: (e: Owner) => EntityName<Target> | EntityName[],
-  mappedByOrOptions?: (string & keyof Target) | ((e: Target) => any) | Partial<OneToOneOptions<Owner, Target>>,
-  options?: Partial<OneToOneOptions<Owner, Target>>,
+  mappedByOrOptions?: (string & keyof Target) | ((e: Target) => any) | Partial<OneToOneOptions<Owner, Target, Through>>,
+  options?: Partial<OneToOneOptions<Owner, Target, Through>>,
 ): (target: Owner, propertyName: string) => void;
-export function OneToOne<Target, Owner>(
-  entity?: OneToOneOptions<Owner, Target>,
+export function OneToOne<Target, Owner, Through = Target>(
+  entity?: OneToOneOptions<Owner, Target, Through>,
 ): (target: Owner, propertyName: string) => void;
-export function OneToOne<Target, Owner>(
-  entity?: OneToOneOptions<Owner, Target> | ((e: Owner) => EntityName<Target> | EntityName[]),
-  mappedByOrOptions?: (string & keyof Target) | ((e: Target) => any) | Partial<OneToOneOptions<Owner, Target>>,
-  options: Partial<OneToOneOptions<Owner, Target>> = {},
+export function OneToOne<Target, Owner, Through = Target>(
+  entity?: OneToOneOptions<Owner, Target, Through> | ((e: Owner) => EntityName<Target> | EntityName[]),
+  mappedByOrOptions?: (string & keyof Target) | ((e: Target) => any) | Partial<OneToOneOptions<Owner, Target, Through>>,
+  options: Partial<OneToOneOptions<Owner, Target, Through>> = {},
 ) {
   const mappedBy = typeof mappedByOrOptions === 'object' ? mappedByOrOptions.mappedBy : mappedByOrOptions;
   options = typeof mappedByOrOptions === 'object' ? { ...mappedByOrOptions, ...options } : options;
   return function (target: Owner, propertyName: string) {
-    options = processDecoratorParameters<OneToManyOptions<Owner, Target>>({ entity, mappedBy, options });
+    options = processDecoratorParameters<OneToOneOptions<Owner, Target, Through>>({ entity, mappedBy, options });
     const meta = getMetadataFromDecorator((target as any).constructor);
     validateSingleDecorator(meta, propertyName, ReferenceKind.ONE_TO_ONE);
     const property = { name: propertyName, kind: ReferenceKind.ONE_TO_ONE } as EntityProperty<Target>;

--- a/packages/sql/src/AbstractSqlPlatform.ts
+++ b/packages/sql/src/AbstractSqlPlatform.ts
@@ -2,7 +2,9 @@ import {
   type RawQueryFragment,
   type Constructor,
   type EntityManager,
+  type EntityProperty,
   type EntityRepository,
+  type FormulaColumns,
   type IDatabaseDriver,
   type IsolationLevel,
   isRaw,
@@ -11,7 +13,9 @@ import {
   Platform,
   raw,
   Utils,
+  ValidationError,
 } from '@mikro-orm/core';
+import type { AbstractSqlDriver } from './AbstractSqlDriver.js';
 import { SqlEntityRepository } from './SqlEntityRepository.js';
 import { SqlSchemaGenerator } from './schema/SqlSchemaGenerator.js';
 import { type SchemaHelper } from './schema/SchemaHelper.js';
@@ -62,6 +66,46 @@ export abstract class AbstractSqlPlatform extends Platform {
   /* v8 ignore next */
   createNativeQueryBuilder(): NativeQueryBuilder {
     return new NativeQueryBuilder(this);
+  }
+
+  /** @inheritDoc */
+  override getThroughRelationFormula(prop: EntityProperty, columns: FormulaColumns<any>): string {
+    const through = prop.through!;
+    const driver = this.config.getDriver() as AbstractSqlDriver;
+    const alias = `${prop.name}_through`;
+    const qb = driver.createQueryBuilder(through.entity, undefined, 'read', true, undefined, alias);
+    const throughMeta = driver.getMetadata().get(through.entity);
+    const ownerProp = throughMeta.properties[through.ownerProperty];
+    const ownerMeta = driver.getMetadata().get(ownerProp.target);
+
+    ownerProp.fieldNames.forEach((fieldName, idx) => {
+      const referencedColumn = ownerProp.referencedColumnNames[idx];
+      const referencedProp = ownerProp.referencedPKs
+        .map(name => ownerMeta.properties[name])
+        .find(p => p.fieldNames.includes(referencedColumn))!;
+      // the column mapping resolves the right alias even for TPT owners, only the column name may differ for composite FK properties
+      const ownerAlias = columns[referencedProp.name].slice(0, columns[referencedProp.name].lastIndexOf('.'));
+      qb.andWhere(raw('?? = ??', [`${alias}.${fieldName}`, `${ownerAlias}.${referencedColumn}`]));
+    });
+
+    if (through.where) {
+      qb.andWhere(through.where);
+    }
+
+    if (through.orderBy) {
+      qb.orderBy(through.orderBy);
+    }
+
+    qb.select(through.targetProperty ?? throughMeta.primaryKeys[0]).limit(1);
+    const sql = qb.getFormattedQuery();
+
+    if (Object.keys(qb.state.joins).length > 0) {
+      throw new ValidationError(
+        `The 'where' and 'orderBy' options of the through relation ${prop.name} can only reference own columns of ${throughMeta.className}`,
+      );
+    }
+
+    return `(${sql})`;
   }
 
   getBeginTransactionSQL(options?: { isolationLevel?: IsolationLevel; readOnly?: boolean }): string[] {

--- a/tests/features/through-relations/to-one-through.test.ts
+++ b/tests/features/through-relations/to-one-through.test.ts
@@ -1,0 +1,515 @@
+import {
+  Collection,
+  defineEntity,
+  EntitySchema,
+  LoadStrategy,
+  MetadataError,
+  MikroORM,
+  Utils,
+  ValidationError,
+  wrap,
+  type IDatabaseDriver,
+  type Loaded,
+  type Ref,
+  type Rel,
+} from '@mikro-orm/core';
+import {
+  Entity,
+  ManyToOne,
+  OneToMany,
+  OneToOne,
+  PrimaryKey,
+  Property,
+  ReflectMetadataProvider,
+} from '@mikro-orm/decorators/legacy';
+import { mockLogger, PLATFORMS } from '../../bootstrap.js';
+import { SqliteDriver } from '@mikro-orm/sqlite';
+import type { SqlEntityManager } from '@mikro-orm/sql';
+
+@Entity()
+class Account {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+}
+
+@Entity()
+class Customer {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @OneToMany(() => Edge, e => e.start)
+  edges = new Collection<Edge>(this);
+
+  @ManyToOne(() => Account, {
+    through: () => Edge,
+    where: { state: 'cleared' },
+    ref: true,
+    nullable: true,
+  })
+  account?: Ref<Account>;
+
+  @OneToOne(() => Edge, {
+    through: () => Edge,
+    orderBy: { id: 'desc' },
+    ref: true,
+    nullable: true,
+  })
+  latestEdge?: Ref<Edge>;
+
+  @ManyToOne(() => Account, {
+    through: () => Edge,
+    where: { state: 'pending' },
+    mapToPk: true,
+    nullable: true,
+  })
+  pendingAccountId?: number;
+}
+
+@Entity()
+class Edge {
+  @PrimaryKey()
+  id!: number;
+
+  @ManyToOne(() => Customer)
+  start!: Customer;
+
+  @ManyToOne(() => Account)
+  end!: Account;
+
+  @Property()
+  state!: string;
+}
+
+const options = {
+  sqlite: { dbName: ':memory:' },
+  mysql: { dbName: 'mikro_orm_through_to_one', port: 3308 },
+  postgresql: { dbName: 'mikro_orm_through_to_one' },
+  mssql: { dbName: 'mikro_orm_through_to_one', password: 'Root.Root' },
+};
+
+describe.each(Utils.keys(options))('to-one relations through another entity [%s]', type => {
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init<IDatabaseDriver>({
+      entities: [Customer, Account, Edge],
+      driver: PLATFORMS[type],
+      metadataProvider: ReflectMetadataProvider,
+      ...options[type],
+    });
+    await orm.schema.refresh();
+
+    const acc1 = orm.em.create(Account, { name: 'acc1' });
+    const acc2 = orm.em.create(Account, { name: 'acc2' });
+    const acc3 = orm.em.create(Account, { name: 'acc3' });
+    const c1 = orm.em.create(Customer, { name: 'c1' });
+    const c2 = orm.em.create(Customer, { name: 'c2' });
+    orm.em.create(Edge, { start: c1, end: acc1, state: 'pending' });
+    orm.em.create(Edge, { start: c1, end: acc2, state: 'cleared' });
+    orm.em.create(Edge, { start: c2, end: acc3, state: 'pending' });
+    await orm.em.flush();
+    orm.em.clear();
+  });
+
+  afterAll(() => orm.close(true));
+
+  afterEach(() => orm.em.clear());
+
+  test('no column is created for the virtual relations', async () => {
+    const diff = await orm.schema.getUpdateSchemaSQL({ wrap: false });
+    expect(diff).toBe('');
+    const meta = orm.getMetadata(Customer);
+    expect(meta.properties.account.persist).toBe(false);
+    expect(meta.properties.account.through).toMatchObject({ ownerProperty: 'start', targetProperty: 'end' });
+    expect(meta.properties.latestEdge.through).toMatchObject({ ownerProperty: 'start' });
+  });
+
+  test.each([LoadStrategy.SELECT_IN, LoadStrategy.JOINED])('populate (%s)', async strategy => {
+    const customers = await orm.em.find(
+      Customer,
+      {},
+      { populate: ['account', 'latestEdge', 'edges'], orderBy: { name: 'asc' }, strategy },
+    );
+    expect(customers).toHaveLength(2);
+    expect(customers[0].account!.$.name).toBe('acc2');
+    expect(customers[0].pendingAccountId).toBe(customers[0].edges.find(e => e.state === 'pending')!.end.id);
+    expect(customers[0].latestEdge!.$.state).toBe('cleared');
+    expect(customers[1].account).toBeNull();
+    expect(customers[1].pendingAccountId).toBe(customers[1].edges.find(e => e.state === 'pending')!.end.id);
+    expect(customers[1].latestEdge!.$.state).toBe('pending');
+
+    const c1: Loaded<Customer, 'account'> = customers[0];
+    expect(c1.account?.$.name).toBe('acc2');
+  });
+
+  test('generated subquery', async () => {
+    const sql = (orm.em as SqlEntityManager).createQueryBuilder(Customer, 'c').select('*').getFormattedQuery();
+
+    if (type === 'sqlite') {
+      expect(sql).toBe(
+        'select `c`.*, ' +
+          "(select `account_through`.`end_id` from `edge` as `account_through` where (`account_through`.`start_id` = `c`.`id`) and `account_through`.`state` = 'cleared' limit 1) as `account_id`, " +
+          '(select `latestEdge_through`.`id` from `edge` as `latestEdge_through` where (`latestEdge_through`.`start_id` = `c`.`id`) order by `latestEdge_through`.`id` desc limit 1) as `latest_edge_id`, ' +
+          "(select `pendingAccountId_through`.`end_id` from `edge` as `pendingAccountId_through` where (`pendingAccountId_through`.`start_id` = `c`.`id`) and `pendingAccountId_through`.`state` = 'pending' limit 1) as `pending_account_id_id` " +
+          'from `customer` as `c`',
+      );
+    } else {
+      expect(sql).toContain('account_through');
+    }
+  });
+
+  test('querying and ordering by the virtual relation', async () => {
+    const acc2 = await orm.em.findOneOrFail(Account, { name: 'acc2' });
+    const customers = await orm.em.find(Customer, { account: acc2 });
+    expect(customers.map(c => c.name)).toEqual(['c1']);
+    const without = await orm.em.find(Customer, { account: null });
+    expect(without.map(c => c.name)).toEqual(['c2']);
+
+    const ordered = await orm.em.find(Customer, {}, { orderBy: { latestEdge: 'desc' } });
+    expect(ordered.map(c => c.name)).toEqual(['c2', 'c1']);
+  });
+
+  test('serialization', async () => {
+    const c1 = await orm.em.findOneOrFail(Customer, { name: 'c1' }, { populate: ['account'] });
+    expect(wrap(c1).toObject()).toMatchObject({
+      name: 'c1',
+      account: { name: 'acc2' },
+      pendingAccountId: expect.any(Number),
+      latestEdge: expect.any(Number),
+    });
+  });
+
+  test('virtual relations are read-only', async () => {
+    const c2 = await orm.em.findOneOrFail(Customer, { name: 'c2' });
+    const acc1 = await orm.em.findOneOrFail(Account, { name: 'acc1' });
+    c2.account = wrap(acc1).toReference();
+    const mock = mockLogger(orm);
+    await orm.em.flush();
+    expect(mock).not.toHaveBeenCalled();
+  });
+});
+
+describe('to-one relations through another entity (schema variants)', () => {
+  test('defineEntity', async () => {
+    const Account2 = defineEntity({
+      name: 'Account2',
+      properties: p => ({ id: p.integer().primary(), name: p.string() }),
+    });
+    const Customer2 = defineEntity({
+      name: 'Customer2',
+      properties: p => ({
+        id: p.integer().primary(),
+        account: () =>
+          p
+            .manyToOne(Account2)
+            .through(() => Edge2)
+            .where({ state: 'cleared' })
+            .ref()
+            .nullable(),
+      }),
+    });
+    const Edge2 = defineEntity({
+      name: 'Edge2',
+      properties: p => ({
+        id: p.integer().primary(),
+        start: () => p.manyToOne(Customer2),
+        end: () => p.manyToOne(Account2),
+        state: p.string(),
+      }),
+    });
+    const orm = await MikroORM.init({
+      entities: [Customer2, Account2, Edge2],
+      driver: SqliteDriver,
+      dbName: ':memory:',
+    });
+    await orm.schema.create();
+    const acc = orm.em.create(Account2, { name: 'acc' });
+    const customer = orm.em.create(Customer2, {});
+    orm.em.create(Edge2, { start: customer, end: acc, state: 'cleared' });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const loaded = await orm.em.findOneOrFail(Customer2, customer.id, { populate: ['account'] });
+    expect(loaded.account!.$.name).toBe('acc');
+    await orm.close(true);
+  });
+
+  test('through entity referencing a non-primary key of the owner', async () => {
+    @Entity()
+    class Account4 {
+      @PrimaryKey()
+      id!: number;
+    }
+
+    @Entity()
+    class Customer4 {
+      @PrimaryKey()
+      id!: number;
+
+      @Property({ unique: true })
+      code!: string;
+
+      @ManyToOne(() => Account4, { through: () => Edge4, nullable: true })
+      account?: Rel<Account4>;
+    }
+
+    @Entity()
+    class Edge4 {
+      @PrimaryKey()
+      id!: number;
+
+      @ManyToOne(() => Customer4, { targetKey: 'code' })
+      start!: Customer4;
+
+      @ManyToOne(() => Account4)
+      end!: Account4;
+    }
+
+    const orm = await MikroORM.init({
+      entities: [Customer4, Account4, Edge4],
+      driver: SqliteDriver,
+      dbName: ':memory:',
+      metadataProvider: ReflectMetadataProvider,
+    });
+    await orm.schema.create();
+    const acc = orm.em.create(Account4, {});
+    const customer = orm.em.create(Customer4, { code: 'c' });
+    orm.em.create(Edge4, { start: customer, end: acc });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const sql = orm.em.createQueryBuilder(Customer4, 'c').select('*').getFormattedQuery();
+    expect(sql).toBe(
+      'select `c`.*, (select `account_through`.`end_id` from `edge4` as `account_through` where (`account_through`.`start_id` = `c`.`code`) limit 1) as `account_id` from `customer4` as `c`',
+    );
+    const loaded = await orm.em.findOneOrFail(Customer4, customer.id, { populate: ['account'] });
+    expect(loaded.account!.id).toBe(acc.id);
+    await orm.close(true);
+  });
+
+  test('EntitySchema', async () => {
+    const Account3: EntitySchema = new EntitySchema({
+      name: 'Account3',
+      properties: { id: { type: 'number', primary: true }, name: { type: 'string' } },
+    });
+    const Customer3: EntitySchema = new EntitySchema({
+      name: 'Customer3',
+      properties: {
+        id: { type: 'number', primary: true },
+        account: {
+          kind: 'm:1',
+          entity: () => Account3,
+          through: () => Edge3,
+          where: { state: 'cleared' },
+          nullable: true,
+        },
+      },
+    });
+    const Edge3: EntitySchema = new EntitySchema({
+      name: 'Edge3',
+      properties: {
+        id: { type: 'number', primary: true },
+        start: { kind: 'm:1', entity: () => Customer3 },
+        end: { kind: 'm:1', entity: () => Account3 },
+        state: { type: 'string' },
+      },
+    });
+    const orm = await MikroORM.init({
+      entities: [Customer3, Account3, Edge3],
+      driver: SqliteDriver,
+      dbName: ':memory:',
+    });
+    await orm.schema.create();
+    const acc = orm.em.create(Account3, { name: 'acc' });
+    const customer = orm.em.create(Customer3, {});
+    orm.em.create(Edge3, { start: customer, end: acc, state: 'cleared' });
+    await orm.em.flush();
+    orm.em.clear();
+
+    const loaded = await orm.em.findOneOrFail(Customer3, customer.id, { populate: ['account'] });
+    expect(loaded.account.name).toBe('acc');
+    await orm.close(true);
+  });
+});
+
+describe('to-one relations through another entity (validation)', () => {
+  test('through is only allowed on to-one relations', async () => {
+    @Entity()
+    class Author {
+      @PrimaryKey()
+      id!: number;
+
+      @OneToMany(() => Book, b => b.author, { ...({ through: () => Book } as object) })
+      books = new Collection<Rel<Book>>(this);
+    }
+
+    @Entity()
+    class Book {
+      @PrimaryKey()
+      id!: number;
+
+      @ManyToOne(() => Author)
+      author!: Rel<Author>;
+    }
+
+    await expect(
+      MikroORM.init({
+        entities: [Author, Book],
+        driver: SqliteDriver,
+        dbName: ':memory:',
+        metadataProvider: ReflectMetadataProvider,
+      }),
+    ).rejects.toThrow(
+      new MetadataError(
+        `Author.books uses 'through' option which is only supported for ManyToOne and OneToOne relations`,
+      ),
+    );
+  });
+
+  test('through is not allowed for targets with composite primary key', async () => {
+    @Entity()
+    class Author {
+      @PrimaryKey()
+      id!: number;
+
+      @ManyToOne(() => Book, { through: () => Book, nullable: true })
+      firstBook?: Rel<Book>;
+    }
+
+    @Entity()
+    class Book {
+      @PrimaryKey()
+      isbn!: string;
+
+      @PrimaryKey()
+      edition!: number;
+
+      @ManyToOne(() => Author)
+      author!: Rel<Author>;
+    }
+
+    await expect(
+      MikroORM.init({
+        entities: [Author, Book],
+        driver: SqliteDriver,
+        dbName: ':memory:',
+        metadataProvider: ReflectMetadataProvider,
+      }),
+    ).rejects.toThrow(
+      new MetadataError(
+        `Author.firstBook uses 'through' option which is not supported for targets with composite primary key`,
+      ),
+    );
+  });
+
+  test('through entity needs a FK to the owner', async () => {
+    @Entity()
+    class Author {
+      @PrimaryKey()
+      id!: number;
+
+      @ManyToOne(() => Book, { through: () => Book, nullable: true })
+      firstBook?: Rel<Book>;
+    }
+
+    @Entity()
+    class Book {
+      @PrimaryKey()
+      id!: number;
+    }
+
+    await expect(
+      MikroORM.init({
+        entities: [Author, Book],
+        driver: SqliteDriver,
+        dbName: ':memory:',
+        metadataProvider: ReflectMetadataProvider,
+      }),
+    ).rejects.toThrow(
+      new MetadataError(
+        `Author.firstBook uses 'through' entity Book which has no ManyToOne property pointing to Author`,
+      ),
+    );
+  });
+
+  test('through entity needs a FK to the target', async () => {
+    @Entity()
+    class Publisher {
+      @PrimaryKey()
+      id!: number;
+    }
+
+    @Entity()
+    class Author {
+      @PrimaryKey()
+      id!: number;
+
+      @ManyToOne(() => Publisher, { through: () => Book, nullable: true })
+      publisher?: Rel<Publisher>;
+    }
+
+    @Entity()
+    class Book {
+      @PrimaryKey()
+      id!: number;
+
+      @ManyToOne(() => Author)
+      author!: Rel<Author>;
+    }
+
+    await expect(
+      MikroORM.init({
+        entities: [Author, Book, Publisher],
+        driver: SqliteDriver,
+        dbName: ':memory:',
+        metadataProvider: ReflectMetadataProvider,
+      }),
+    ).rejects.toThrow(
+      new MetadataError(
+        `Author.publisher uses 'through' entity Book which has no ManyToOne property pointing to Publisher`,
+      ),
+    );
+  });
+
+  test('where and orderBy can only reference own columns of the through entity', async () => {
+    @Entity()
+    class Author {
+      @PrimaryKey()
+      id!: number;
+
+      @Property()
+      name!: string;
+
+      @ManyToOne(() => Book, { through: () => Book, where: { author: { name: 'foo' } }, nullable: true })
+      firstBook?: Rel<Book>;
+    }
+
+    @Entity()
+    class Book {
+      @PrimaryKey()
+      id!: number;
+
+      @ManyToOne(() => Author)
+      author!: Rel<Author>;
+    }
+
+    const orm = await MikroORM.init({
+      entities: [Author, Book],
+      driver: SqliteDriver,
+      dbName: ':memory:',
+      metadataProvider: ReflectMetadataProvider,
+    });
+    expect(() => orm.em.createQueryBuilder(Author).select('*').getFormattedQuery()).toThrow(
+      new ValidationError(
+        `The 'where' and 'orderBy' options of the through relation firstBook can only reference own columns of Book`,
+      ),
+    );
+    await orm.close(true);
+  });
+});


### PR DESCRIPTION
Adds a `through` option to `ManyToOne` and `OneToOne` relations. The relation is resolved via a correlated subquery on another entity instead of a FK column. This covers a pivot entity carrying the link with extra columns to filter on, and also picking a single item out of a to-many relation (e.g. the latest one) by pointing `through` at the target entity itself.

```ts
@ManyToOne(() => Account, { through: () => Edge, where: { state: 'cleared' }, ref: true, nullable: true })
account?: Ref<Account>;

@OneToOne(() => Edge, { through: () => Edge, orderBy: { id: 'desc' }, ref: true, nullable: true })
latestEdge?: Ref<Edge>;
```

`where` and `orderBy` apply to the `through` entity and the first matching row is used. Under the hood this is the existing non-persistent formula relation, so populate with both strategies, `Loaded<>` inference, serialization, `mapToPk` and conditions on the relation work without new code paths. The SQL platform generates the subquery with the query builder, so values go through custom types and platform quoting. The relation is read-only, writes go through the pivot entity.

Discovery checks that the `through` entity has M:1 properties to both sides and rejects composite PK targets. Conditions that would need a join inside the subquery are rejected at query time, because a join alias could shadow the outer owner alias. The new docs section also covers the manual `formula` approach for cases the option does not handle.

Closes #8238