### PR TITLE
docs: updated schema-first-guide.md reference to the hash option to the latest version name

### DIFF
--- a/docs/docs/schema-first-guide.md
+++ b/docs/docs/schema-first-guide.md
@@ -780,9 +780,9 @@ npm install argon2
 The next step is to create the class that our DB value will be transformed to and from. Let's add it to the "users" module. We'll use the suffix "runtimeType" to make it clear this will be set as the runtime type at an entity. We'll also make the type automatically rehash the password on successful verification if needed.
 
 ```ts title="src/modules/user/password.runtimeType.ts
-import { hash, verify, needsRehash, Options } from 'argon2';
+import { hash, verify, needsRehash, type HashOptions } from 'argon2';
 
-const hashOptions: Options = {
+const hashOptions: HashOptions = {
   hashLength: 100
 };
 

--- a/docs/versioned_docs/version-6.6/schema-first-guide.md
+++ b/docs/versioned_docs/version-6.6/schema-first-guide.md
@@ -800,9 +800,9 @@ npm install argon2
 The next step is to create the class that our DB value will be transformed to and from. Let's add it to the "users" module. We'll use the suffix "runtimeType" to make it clear this will be set as the runtime type at an entity. We'll also make the type automatically rehash the password on successful verification if needed.
 
 ```ts title="src/modules/user/password.runtimeType.ts
-import { hash, verify, needsRehash, Options } from 'argon2';
+import { hash, verify, needsRehash, type HashOptions } from 'argon2';
 
-const hashOptions: Options = {
+const hashOptions: HashOptions = {
   hashLength: 100
 };
 

--- a/docs/versioned_docs/version-7.0/schema-first-guide.md
+++ b/docs/versioned_docs/version-7.0/schema-first-guide.md
@@ -780,9 +780,9 @@ npm install argon2
 The next step is to create the class that our DB value will be transformed to and from. Let's add it to the "users" module. We'll use the suffix "runtimeType" to make it clear this will be set as the runtime type at an entity. We'll also make the type automatically rehash the password on successful verification if needed.
 
 ```ts title="src/modules/user/password.runtimeType.ts
-import { hash, verify, needsRehash, Options } from 'argon2';
+import { hash, verify, needsRehash, type HashOptions } from 'argon2';
 
-const hashOptions: Options = {
+const hashOptions: HashOptions = {
   hashLength: 100
 };
 

--- a/docs/versioned_docs/version-7.1/schema-first-guide.md
+++ b/docs/versioned_docs/version-7.1/schema-first-guide.md
@@ -780,9 +780,9 @@ npm install argon2
 The next step is to create the class that our DB value will be transformed to and from. Let's add it to the "users" module. We'll use the suffix "runtimeType" to make it clear this will be set as the runtime type at an entity. We'll also make the type automatically rehash the password on successful verification if needed.
 
 ```ts title="src/modules/user/password.runtimeType.ts
-import { hash, verify, needsRehash, Options } from 'argon2';
+import { hash, verify, needsRehash, type HashOptions } from 'argon2';
 
-const hashOptions: Options = {
+const hashOptions: HashOptions = {
   hashLength: 100
 };
 


### PR DESCRIPTION
Because this is a change in argon2, not in MikroORM, and the guide never makes mention of a version,
all versions of the docs are updated to assume latest argon2.