### PR TITLE
perf(core): skip structural variance measurement of `defineEntity` builder and entity types

### DIFF
--- a/packages/core/src/entity/defineEntity.ts
+++ b/packages/core/src/entity/defineEntity.ts
@@ -1614,6 +1614,9 @@ type InferColumnType<T extends string> = T extends
 // before the Base in the intersection — TypeScript picks earlier overloads first.
 type BaseEntityMethodKeys = 'toObject' | 'toPOJO' | 'serialize' | 'assign' | 'populate' | 'init' | 'toReference';
 
+// `in out` skips variance measurement, which would otherwise structurally compare every `IWrappedEntity` method whenever two inferred entity types meet
+interface BaseEntityMethods<in out Entity extends object> extends Pick<IWrappedEntity<Entity>, BaseEntityMethodKeys> {}
+
 /** Infers the entity type from a `defineEntity()` properties map, resolving builders, base classes, and primary keys. */
 export type InferEntityFromProperties<
   Properties extends Record<string, any>,
@@ -1627,23 +1630,20 @@ export type InferEntityFromProperties<
 > = (IsNever<Base> extends true
   ? {}
   : Base extends { toObject(...args: any[]): any }
-    ? Pick<
-        IWrappedEntity<
-          {
-            -readonly [K in keyof Properties]: InferBuilderValue<MaybeReturnType<Properties[K]>>;
-          } & {
-            [PrimaryKeyProp]?: InferCombinedPrimaryKey<Properties, PK, Base>;
-          } & (IsNever<Repository> extends true
-              ? {}
-              : { [EntityRepositoryType]?: Repository extends Constructor<infer R> ? R : Repository }) &
-            NarrowDiscriminator<
-              Omit<Base, typeof PrimaryKeyProp>,
-              BaseDiscriminatorColumn,
-              DiscriminatorValue,
-              Embeddable
-            >
-        >,
-        BaseEntityMethodKeys
+    ? BaseEntityMethods<
+        {
+          -readonly [K in keyof Properties]: InferBuilderValue<MaybeReturnType<Properties[K]>>;
+        } & {
+          [PrimaryKeyProp]?: InferCombinedPrimaryKey<Properties, PK, Base>;
+        } & (IsNever<Repository> extends true
+            ? {}
+            : { [EntityRepositoryType]?: Repository extends Constructor<infer R> ? R : Repository }) &
+          NarrowDiscriminator<
+            Omit<Base, typeof PrimaryKeyProp>,
+            BaseDiscriminatorColumn,
+            DiscriminatorValue,
+            Embeddable
+          >
       >
     : {}) & {
   -readonly [K in keyof Properties]: InferBuilderValue<MaybeReturnType<Properties[K]>>;

--- a/packages/core/src/entity/defineEntity.ts
+++ b/packages/core/src/entity/defineEntity.ts
@@ -91,7 +91,7 @@ type HasKind<Options, K extends string> = Options extends { kind: infer X extend
   : false;
 
 /** Lightweight chain result type for property builders - reduces type instantiation cost by avoiding full class resolution. */
-export interface PropertyChain<Value, Options> {
+export interface PropertyChain<in out Value, in out Options> {
   '~type'?: { value: Value };
   '~options': Options;
 
@@ -299,10 +299,11 @@ type _AssertPropertyChainNoExtras = AssertTrue<
 // instantiating the full builder class in production builds (~680 instantiations).
 
 /** @internal */
-export class UniversalPropertyOptionsBuilder<Value, Options, IncludeKeys extends BuilderKeys> implements Record<
-  Exclude<UniversalPropertyKeys, ExcludeKeys>,
-  any
-> {
+export class UniversalPropertyOptionsBuilder<
+  in out Value,
+  in out Options,
+  in out IncludeKeys extends BuilderKeys,
+> implements Record<Exclude<UniversalPropertyKeys, ExcludeKeys>, any> {
   '~options': Options;
 
   '~type'?: {
@@ -450,9 +451,7 @@ export class UniversalPropertyOptionsBuilder<Value, Options, IncludeKeys extends
     UniversalPropertyOptionsBuilder<Value, Omit<Options, 'autoincrement'> & { autoincrement: false }, IncludeKeys>,
     IncludeKeys
   >;
-  autoincrement(
-    autoincrement = true,
-  ): Pick<UniversalPropertyOptionsBuilder<Value, Omit<Options, 'autoincrement'>, IncludeKeys>, IncludeKeys> {
+  autoincrement(autoincrement = true): any {
     return this.assignOptions({ autoincrement });
   }
 
@@ -576,9 +575,7 @@ export class UniversalPropertyOptionsBuilder<Value, Options, IncludeKeys extends
     UniversalPropertyOptionsBuilder<Value, Omit<Options, 'persist'> & { persist: false }, IncludeKeys>,
     IncludeKeys
   >;
-  persist(
-    persist = true,
-  ): Pick<UniversalPropertyOptionsBuilder<Value, Omit<Options, 'persist'>, IncludeKeys>, IncludeKeys> {
+  persist(persist = true): any {
     return this.assignOptions({ persist });
   }
 

--- a/packages/core/src/entity/defineEntity.ts
+++ b/packages/core/src/entity/defineEntity.ts
@@ -451,7 +451,17 @@ export class UniversalPropertyOptionsBuilder<
     UniversalPropertyOptionsBuilder<Value, Omit<Options, 'autoincrement'> & { autoincrement: false }, IncludeKeys>,
     IncludeKeys
   >;
-  autoincrement(autoincrement = true): any {
+  autoincrement(
+    autoincrement = true,
+  ):
+    | Pick<
+        UniversalPropertyOptionsBuilder<Value, Omit<Options, 'autoincrement'> & { autoincrement: true }, IncludeKeys>,
+        IncludeKeys
+      >
+    | Pick<
+        UniversalPropertyOptionsBuilder<Value, Omit<Options, 'autoincrement'> & { autoincrement: false }, IncludeKeys>,
+        IncludeKeys
+      > {
     return this.assignOptions({ autoincrement });
   }
 
@@ -575,7 +585,17 @@ export class UniversalPropertyOptionsBuilder<
     UniversalPropertyOptionsBuilder<Value, Omit<Options, 'persist'> & { persist: false }, IncludeKeys>,
     IncludeKeys
   >;
-  persist(persist = true): any {
+  persist(
+    persist = true,
+  ):
+    | Pick<
+        UniversalPropertyOptionsBuilder<Value, Omit<Options, 'persist'> & { persist: true }, IncludeKeys>,
+        IncludeKeys
+      >
+    | Pick<
+        UniversalPropertyOptionsBuilder<Value, Omit<Options, 'persist'> & { persist: false }, IncludeKeys>,
+        IncludeKeys
+      > {
     return this.assignOptions({ persist });
   }
 

--- a/tests/bench/types/defineEntity-extends.ts
+++ b/tests/bench/types/defineEntity-extends.ts
@@ -19,7 +19,7 @@ bench('entity extends entity', () => {
       extra: p.string(),
     },
   });
-}).types([1549, 'instantiations']);
+}).types([1558, 'instantiations']);
 
 bench('entity extends entity with discriminator', () => {
   const base = defineEntity({
@@ -40,7 +40,7 @@ bench('entity extends entity with discriminator', () => {
       extra: p.string(),
     },
   });
-}).types([1617, 'instantiations']);
+}).types([1626, 'instantiations']);
 
 bench('embeddable extends embeddable', () => {
   const base = defineEntity({
@@ -60,7 +60,7 @@ bench('embeddable extends embeddable', () => {
       bar: p.string(),
     },
   });
-}).types([992, 'instantiations']);
+}).types([1001, 'instantiations']);
 
 bench('embeddable extends embeddable with discriminator', () => {
   const base = defineEntity({
@@ -83,7 +83,7 @@ bench('embeddable extends embeddable with discriminator', () => {
       bar: p.string(),
     },
   });
-}).types([1043, 'instantiations']);
+}).types([1052, 'instantiations']);
 
 bench('polymorphic embeddables', () => {
   const base = defineEntity({
@@ -198,7 +198,7 @@ bench('polymorphic embeddables', () => {
       data: () => p.embedded([documentDataAwEdCard, documentDataCoCheckMig, documentDataMvDiCard]).object(),
     },
   });
-}).types([3919, 'instantiations']);
+}).types([3928, 'instantiations']);
 
 bench('realistic entity (~20 props, relations, extends)', () => {
   const base = defineEntity({
@@ -270,7 +270,7 @@ bench('realistic entity (~20 props, relations, extends)', () => {
       tags: () => p.manyToMany(Tag),
     },
   });
-}).types([4367, 'instantiations']);
+}).types([4361, 'instantiations']);
 
 bench('realistic entity - InferEntity usage', () => {
   const base = defineEntity({
@@ -350,7 +350,7 @@ bench('realistic entity - InferEntity usage', () => {
 
   // Force evaluation of all entity types
   const _check: [IAuthor, IBook, ITag, IPublisher] = {} as any;
-}).types([4475, 'instantiations']);
+}).types([4469, 'instantiations']);
 
 bench('realistic entity - setClass pattern', () => {
   const BaseSchema = defineEntity({
@@ -436,4 +436,4 @@ bench('realistic entity - setClass pattern', () => {
   PublisherSchema.setClass(Publisher);
   AuthorSchema.setClass(Author);
   BookSchema.setClass(Book);
-}).types([4768, 'instantiations']);
+}).types([4762, 'instantiations']);

--- a/tests/bench/types/defineEntity-extends.ts
+++ b/tests/bench/types/defineEntity-extends.ts
@@ -270,7 +270,7 @@ bench('realistic entity (~20 props, relations, extends)', () => {
       tags: () => p.manyToMany(Tag),
     },
   });
-}).types([8553, 'instantiations']);
+}).types([4367, 'instantiations']);
 
 bench('realistic entity - InferEntity usage', () => {
   const base = defineEntity({
@@ -350,7 +350,7 @@ bench('realistic entity - InferEntity usage', () => {
 
   // Force evaluation of all entity types
   const _check: [IAuthor, IBook, ITag, IPublisher] = {} as any;
-}).types([8661, 'instantiations']);
+}).types([4475, 'instantiations']);
 
 bench('realistic entity - setClass pattern', () => {
   const BaseSchema = defineEntity({
@@ -436,4 +436,4 @@ bench('realistic entity - setClass pattern', () => {
   PublisherSchema.setClass(Publisher);
   AuthorSchema.setClass(Author);
   BookSchema.setClass(Book);
-}).types([8953, 'instantiations']);
+}).types([4768, 'instantiations']);

--- a/tests/bench/types/defineEntity.ts
+++ b/tests/bench/types/defineEntity.ts
@@ -19,7 +19,7 @@ bench('defineEntity with relations', () => {
       strictNullRef: () => p.oneToOne(Foo).strictNullable(),
     },
   });
-}).types([3602, 'instantiations']);
+}).types([3601, 'instantiations']);
 
 bench('defineEntity with ref and nullable', () => {
   const Foo = defineEntity({
@@ -36,7 +36,7 @@ bench('defineEntity with ref and nullable', () => {
       scalarRefNullable: p.string().ref().nullable(),
     },
   });
-}).types([3074, 'instantiations']);
+}).types([3073, 'instantiations']);
 
 bench('defineEntity only with ref and nullable', () => {
   const Foo = defineEntity({
@@ -46,7 +46,7 @@ bench('defineEntity only with ref and nullable', () => {
       toOneRefNullable: () => p.oneToOne(Foo).ref().nullable(),
     },
   });
-}).types([1905, 'instantiations']);
+}).types([1914, 'instantiations']);
 
 bench('defineEntity only with nullable and ref', () => {
   const Foo = defineEntity({
@@ -56,7 +56,7 @@ bench('defineEntity only with nullable and ref', () => {
       toOneRefNullable: () => p.oneToOne(Foo).nullable().ref(),
     },
   });
-}).types([1908, 'instantiations']);
+}).types([1917, 'instantiations']);
 
 bench('defineEntity with relations using class', () => {
   class Foo {
@@ -88,7 +88,7 @@ bench('defineEntity with relations using class', () => {
       scalarRefNullable: p.string().ref().nullable(),
     },
   });
-}).types([3631, 'instantiations']);
+}).types([3630, 'instantiations']);
 
 bench('defineEntity with ref and nullable using class', () => {
   class Foo {
@@ -120,7 +120,7 @@ bench('defineEntity with ref and nullable using class', () => {
       scalarRefNullable: p.string().ref().nullable(),
     },
   });
-}).types([3631, 'instantiations']);
+}).types([3630, 'instantiations']);
 
 bench('defineEntity only with ref and nullable using class', () => {
   class Foo {
@@ -138,7 +138,7 @@ bench('defineEntity only with ref and nullable using class', () => {
       toOneRefNullable: () => p.oneToOne(Foo).ref().nullable(),
     },
   });
-}).types([2475, 'instantiations']);
+}).types([2496, 'instantiations']);
 
 bench('defineEntity only with nullable and ref using class', () => {
   class Foo {
@@ -156,7 +156,7 @@ bench('defineEntity only with nullable and ref using class', () => {
       toOneRefNullable: () => p.oneToOne(Foo).nullable().ref(),
     },
   });
-}).types([2478, 'instantiations']);
+}).types([2499, 'instantiations']);
 
 bench('EntitySchema', () => {
   interface IFoo {
@@ -205,7 +205,7 @@ bench('EntitySchema', () => {
       },
     } as any,
   });
-}).types([365, 'instantiations']);
+}).types([374, 'instantiations']);
 
 bench('defineEntity with setClass pattern (circular relations)', () => {
   const AuthorSchema = defineEntity({
@@ -241,7 +241,7 @@ bench('defineEntity with setClass pattern (circular relations)', () => {
 
   AuthorSchema.setClass(Author);
   BookSchema.setClass(Book);
-}).types([1985, 'instantiations']);
+}).types([1983, 'instantiations']);
 
 bench('defineEntity with indexes', () => {
   const Bar = defineEntity({
@@ -255,7 +255,7 @@ bench('defineEntity with indexes', () => {
     },
     indexes: [{ name: 'idx_status_views', properties: ['status', 'views'] }],
   });
-}).types([1982, 'instantiations']);
+}).types([1991, 'instantiations']);
 
 // a generic builder call (`fieldName`, `index`, ...) ending an arrow-defined relation chain makes TS infer from the chain's return type and measure variance of the whole entity type
 bench('defineEntity relation chain ending with a generic builder call', () => {

--- a/tests/bench/types/defineEntity.ts
+++ b/tests/bench/types/defineEntity.ts
@@ -256,3 +256,22 @@ bench('defineEntity with indexes', () => {
     indexes: [{ name: 'idx_status_views', properties: ['status', 'views'] }],
   });
 }).types([1982, 'instantiations']);
+
+// GH #8240: a generic builder call (`fieldName`, `index`, ...) ending an arrow-defined relation chain makes TS infer
+// from the chain's return type, which blew up to ~155k instantiations via structural variance measurement
+bench('defineEntity relation chain ending with a generic builder call', () => {
+  const Bar = defineEntity({
+    name: 'Bar',
+    properties: {
+      id: p.integer().primary(),
+    },
+  });
+
+  const Foo = defineEntity({
+    name: 'Foo',
+    properties: {
+      id: p.integer().primary(),
+      bar: () => p.oneToOne(Bar).lazy().fieldName('bar_id'),
+    },
+  });
+}).types([20902, 'instantiations']);

--- a/tests/bench/types/defineEntity.ts
+++ b/tests/bench/types/defineEntity.ts
@@ -19,7 +19,7 @@ bench('defineEntity with relations', () => {
       strictNullRef: () => p.oneToOne(Foo).strictNullable(),
     },
   });
-}).types([7758, 'instantiations']);
+}).types([3602, 'instantiations']);
 
 bench('defineEntity with ref and nullable', () => {
   const Foo = defineEntity({
@@ -36,7 +36,7 @@ bench('defineEntity with ref and nullable', () => {
       scalarRefNullable: p.string().ref().nullable(),
     },
   });
-}).types([7242, 'instantiations']);
+}).types([3074, 'instantiations']);
 
 bench('defineEntity only with ref and nullable', () => {
   const Foo = defineEntity({
@@ -88,7 +88,7 @@ bench('defineEntity with relations using class', () => {
       scalarRefNullable: p.string().ref().nullable(),
     },
   });
-}).types([7787, 'instantiations']);
+}).types([3631, 'instantiations']);
 
 bench('defineEntity with ref and nullable using class', () => {
   class Foo {
@@ -120,7 +120,7 @@ bench('defineEntity with ref and nullable using class', () => {
       scalarRefNullable: p.string().ref().nullable(),
     },
   });
-}).types([7787, 'instantiations']);
+}).types([3631, 'instantiations']);
 
 bench('defineEntity only with ref and nullable using class', () => {
   class Foo {
@@ -241,7 +241,7 @@ bench('defineEntity with setClass pattern (circular relations)', () => {
 
   AuthorSchema.setClass(Author);
   BookSchema.setClass(Book);
-}).types([6187, 'instantiations']);
+}).types([1985, 'instantiations']);
 
 bench('defineEntity with indexes', () => {
   const Bar = defineEntity({
@@ -257,8 +257,7 @@ bench('defineEntity with indexes', () => {
   });
 }).types([1982, 'instantiations']);
 
-// GH #8240: a generic builder call (`fieldName`, `index`, ...) ending an arrow-defined relation chain makes TS infer
-// from the chain's return type, which blew up to ~155k instantiations via structural variance measurement
+// a generic builder call (`fieldName`, `index`, ...) ending an arrow-defined relation chain makes TS infer from the chain's return type and measure variance of the whole entity type
 bench('defineEntity relation chain ending with a generic builder call', () => {
   const Bar = defineEntity({
     name: 'Bar',
@@ -274,4 +273,4 @@ bench('defineEntity relation chain ending with a generic builder call', () => {
       bar: () => p.oneToOne(Bar).lazy().fieldName('bar_id'),
     },
   });
-}).types([20902, 'instantiations']);
+}).types([10994, 'instantiations']);


### PR DESCRIPTION
When a generic builder call (`fieldName`, `index`, `unique`, ...) ends an arrow-defined relation chain, e.g. `() => p.oneToOne(Bar).lazy().fieldName('bar_id')`, TS runs return-type inference against the chain's own inferred type. That forces variance measurement of `InferEntityFromProperties<...>`, `PropertyChain` and `UniversalPropertyOptionsBuilder`, and TS did all of it structurally: the `Base extends { toObject }` branch walked every `IWrappedEntity` method (`populate`, `init`, down into `EntityLoaderOptions`), and the two builder types have dozens of chained methods each. That is ~155k instantiations vs ~430 for the reverse call order, and the language server pays it again on every edit.

Two changes:

- the `IWrappedEntity` branch is wrapped in an interface declared `in out`, so TS skips measuring it (and the structural fallback)
- `PropertyChain` and `UniversalPropertyOptionsBuilder` are declared `in out` as well; the `autoincrement`/`persist` implementation signatures return the union of their overload returns, because under invariance the old `Omit<Options, ...>` return no longer relates to either overload

The issue case drops from ~155k to ~11k instantiations (the rest is the one-time measurement of the entity alias itself, about 1ms per type parameter), and every existing `defineEntity` bench roughly halves.

Closes #8240