### PR TITLE
fix(cli): surface the real error when a TypeScript loader fails to load

### DIFF
--- a/packages/cli/src/CLIHelper.ts
+++ b/packages/cli/src/CLIHelper.ts
@@ -353,6 +353,8 @@ export class CLIHelper {
       tsimp: { cjs: 'tsimp/import', cb: setEsmImportProvider },
     } as const;
 
+    const errors: Error[] = [];
+
     for (const loader of Utils.keys(loaders)) {
       if (explicitLoader !== 'auto' && loader !== explicitLoader) {
         continue;
@@ -361,13 +363,33 @@ export class CLIHelper {
       const { esm, cjs, cb } = loaders[loader] as { esm: string; cjs: string; cb?: (mod: any) => void };
       const isEsm = this.isESM();
       const module = isEsm && esm ? esm : cjs;
-      const mod = await Utils.tryImport({ module });
+      let mod: any;
+
+      try {
+        mod = await Utils.tryImport({ module });
+      } catch (e: any) {
+        const error = new Error(`Failed to load TypeScript loader \`${loader}\` (${module}): ${e.message}`, {
+          cause: e,
+        });
+
+        if (explicitLoader !== 'auto') {
+          throw error;
+        }
+
+        errors.push(error);
+        continue;
+      }
 
       if (mod) {
         cb?.(mod);
         process.env.MIKRO_ORM_CLI_TS_LOADER = loader;
         return true;
       }
+    }
+
+    // a loader that is installed but broken is a real problem, not a missing dependency
+    if (errors.length > 0) {
+      throw new Error(errors.map(e => e.message).join('\n'), { cause: errors[0] });
     }
 
     // eslint-disable-next-line no-console

--- a/packages/core/src/utils/Utils.ts
+++ b/packages/core/src/utils/Utils.ts
@@ -1119,7 +1119,12 @@ export class Utils {
     try {
       return await import(module);
     } catch (err: any) {
-      if (warning && err.code === 'ERR_MODULE_NOT_FOUND') {
+      // only a missing module is expected here, anything else is a real failure inside the module
+      if (!['ERR_MODULE_NOT_FOUND', 'MODULE_NOT_FOUND'].includes(err.code)) {
+        throw err;
+      }
+
+      if (warning) {
         // eslint-disable-next-line no-console
         console.warn(warning);
       }

--- a/tests/Utils.win.test.ts
+++ b/tests/Utils.win.test.ts
@@ -722,6 +722,10 @@ describe('Utils', () => {
     expect(warnSpy).toHaveBeenCalledWith('not found');
   });
 
+  test('tryImport rethrows errors other than missing module', async () => {
+    await expect(Utils.tryImport({ module: 'data:text/javascript,throw new Error("boom")' })).rejects.toThrow('boom');
+  });
+
   test('getPrimaryKeyCond', () => {
     // @ts-expect-error no PK so this correctly fails compilation
     expect(Utils.getPrimaryKeyCond({ a: null }, ['a'])).toBe(null);

--- a/tests/features/cli/CLIHelper.test.ts
+++ b/tests/features/cli/CLIHelper.test.ts
@@ -180,6 +180,59 @@ describe('CLIHelper', () => {
     pkg['mikro-orm'].preferTs = false;
   });
 
+  test('reports the real error when a TS loader is installed but fails to load', async () => {
+    pathExistsMock.mockReturnValue(true);
+    pkg['mikro-orm'].preferTs = true;
+    tryImportMock.mockImplementation(({ module: id }) => {
+      if (id === '@swc-node/register/esm-register') {
+        throw new TypeError(`Cannot read properties of undefined (reading 'Js')`);
+      }
+
+      return undefined;
+    });
+    await expect(configure()).rejects.toThrow(
+      "Failed to load TypeScript loader `swc` (@swc-node/register/esm-register): Cannot read properties of undefined (reading 'Js')",
+    );
+    pkg['mikro-orm'].preferTs = false;
+  });
+
+  test('falls back to the next TS loader in auto mode when one fails to load', async () => {
+    pathExistsMock.mockReturnValue(true);
+    pkg['mikro-orm'].preferTs = true;
+    const registerMock = vi.fn();
+    tryImportMock.mockImplementation(({ module: id }) => {
+      if (id === '@swc-node/register/esm-register') {
+        throw new TypeError(`Cannot read properties of undefined (reading 'Js')`);
+      }
+
+      if (id === 'tsx/esm/api') {
+        return { register: registerMock };
+      }
+
+      return undefined;
+    });
+    const cli = (await configure()) as any;
+    expect(cli.$0).toBe('mikro-orm');
+    expect(registerMock).toHaveBeenCalledTimes(1);
+    expect(process.env.MIKRO_ORM_CLI_TS_LOADER).toBe('tsx');
+    pkg['mikro-orm'].preferTs = false;
+  });
+
+  test('fails immediately when an explicitly configured TS loader fails to load', async () => {
+    pathExistsMock.mockReturnValue(true);
+    pkg['mikro-orm'].preferTs = true;
+    pkg['mikro-orm'].tsLoader = 'swc';
+    tryImportMock.mockImplementation(() => {
+      throw new TypeError(`Cannot read properties of undefined (reading 'Js')`);
+    });
+    await expect(configure()).rejects.toThrow(
+      "Failed to load TypeScript loader `swc` (@swc-node/register/esm-register): Cannot read properties of undefined (reading 'Js')",
+    );
+    expect(tryImportMock).toHaveBeenCalledTimes(1);
+    delete pkg['mikro-orm'].tsLoader;
+    pkg['mikro-orm'].preferTs = false;
+  });
+
   test('configures yargs instance [swc and ts-paths] without baseUrl', async () => {
     pathExistsMock.mockReturnValue(true);
     pkg['mikro-orm'].preferTs = true;


### PR DESCRIPTION
`Utils.tryImport` swallowed every import error, so a TS loader that is installed but broken looked the same as a missing one. `@swc-node/register` peers on TS < 7 and throws on import under TypeScript 7, so the CLI printed the generic "neither oxc, swc, tsx, jiti nor tsimp found" warning and then failed with "config file not found", which hid the actual cause.

`tryImport` now only ignores missing modules and rethrows anything else. In `registerTypeScriptSupport`, a broken loader in `auto` mode is skipped in favour of the remaining ones. If none of them works, the collected errors are thrown with the loader name and module path. An explicitly configured `tsLoader` fails immediately with the same message.
