### PR TITLE
fix(decorators): skip `@oxc-node/core` helper frames when resolving entity path

### DIFF
--- a/packages/decorators/src/utils.ts
+++ b/packages/decorators/src/utils.ts
@@ -184,10 +184,13 @@ export function lookupPathFromDecorator(name: string, stack?: string[]): string 
     line++;
   }
 
-  // Skip decorator runtime helpers (tslib, @oxc-project/runtime, etc.)
+  // Skip decorator runtime helpers (tslib, @oxc-project/runtime, @oxc-node/core, etc.)
   // The @oxc-project/runtime check covers both node_modules installs and Rolldown-bundled
   // virtual modules (e.g. \0@oxc-project+runtime@0.120.0/helpers/decorate.js).
-  while (line < stack.length && /node_modules\/tslib\/|@oxc-project[/+]runtime/.test(stack[line].replace(/\\/g, '/'))) {
+  while (
+    line < stack.length &&
+    /node_modules\/tslib\/|@oxc-project[/+]runtime|@oxc-node\/core\//.test(stack[line].replace(/\\/g, '/'))
+  ) {
     line++;
   }
 

--- a/tests/Utils.win.test.ts
+++ b/tests/Utils.win.test.ts
@@ -445,6 +445,17 @@ describe('Utils', () => {
     ];
     expect(lookupPathFromDecorator('Customer', stack5)).toBe('Customer');
 
+    // @oxc-node/core injects its own `__decorate` helper, which needs to be skipped like tslib
+    const stack6 = [
+      '    at lookupPathFromDecorator (/usr/local/var/www/my-project/node_modules/@mikro-orm/decorators/utils.js:170:23)',
+      '    at <anonymous> (/usr/local/var/www/my-project/node_modules/@mikro-orm/decorators/legacy/Entity.js:8:49)',
+      '    at __decorate (/usr/local/var/www/my-project/node_modules/@oxc-node/core/src/helpers/decorate.js:17:22)',
+      '    at <anonymous> (/usr/local/var/www/my-project/src/entities/Customer.ts:7:16)',
+      '    at ModuleJob.run (node:internal/modules/esm/module_job:569:25)',
+      '    at async node:internal/modules/esm/loader:650:26',
+    ];
+    expect(lookupPathFromDecorator('Customer', stack6)).toBe('/usr/local/var/www/my-project/src/entities/Customer.ts');
+
     // unknown type of stack trace fallback
     expect(
       lookupPathFromDecorator('Customer', [


### PR DESCRIPTION
`@oxc-node/core` injects its own `__decorate` helper from `node_modules/@oxc-node/core/src/helpers/decorate.js`. `lookupPathFromDecorator` treated that frame as the decorator call site and returned the helper's path as the entity source, so discovery with the reflection metadata provider failed with `Source file './node_modules/@oxc-node/core/src/helpers/decorate.ts' not found`.

The loop that skips helper frames now covers `@oxc-node/core` as well, next to tslib and `@oxc-project/runtime`. Found while running nestjs-realworld-example-app on TypeScript 7, where `@oxc-node/core` replaces the `@swc-node/register` loader.
