### PR TITLE
fix(core): handle `orderBy` directions carrying a nulls qualifier

### DIFF
--- a/packages/core/src/drivers/DatabaseDriver.ts
+++ b/packages/core/src/drivers/DatabaseDriver.ts
@@ -347,7 +347,8 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
         return { [prop]: value } as OrderDefinition<T>;
       }
 
-      const desc = (direction as unknown) === QueryOrderNumeric.DESC || direction.toString().toLowerCase() === 'desc';
+      const desc =
+        (direction as unknown) === QueryOrderNumeric.DESC || direction.toString().toLowerCase().startsWith('desc');
       const dir = Utils.xor(desc, isLast) ? 'desc' : 'asc';
       return { [prop]: dir } as OrderDefinition<T>;
     };
@@ -457,8 +458,8 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
         return { [prop]: value };
       }
 
-      const isDesc = (direction as unknown) === QueryOrderNumeric.DESC || direction.toString().toLowerCase() === 'desc';
       const dirStr = direction.toString().toLowerCase();
+      const isDesc = (direction as unknown) === QueryOrderNumeric.DESC || dirStr.startsWith('desc');
       let nullsFirst: boolean;
 
       if (dirStr.includes('nulls first')) {

--- a/packages/core/src/drivers/DatabaseDriver.ts
+++ b/packages/core/src/drivers/DatabaseDriver.ts
@@ -462,7 +462,10 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
           );
           return o;
         }, {});
-        return { [prop]: value };
+
+        // an unconstrained group must stay unconstrained, an empty object condition would instead
+        // match only rows where every child value is null (e.g. object embeddables)
+        return Utils.hasObjectKeys(value) ? { [prop]: value } : {};
       }
 
       const dirStr = direction.toString().toLowerCase();
@@ -489,14 +492,16 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
 
       // Handle null offset (intentional null cursor value)
       if (offset === null) {
+        // hasItemsAfterNull: forward + nullsFirst, or backward + nullsLast
+        const hasItemsAfterNull = Utils.xor(nullsFirst, inverse);
+
         if (eq) {
-          // Equal to null
-          return { [prop]: null };
+          // the `>=` half of the keyset condition: every row when the nulls come first in this
+          // direction, only the null ones when they come last
+          return hasItemsAfterNull ? {} : { [prop]: null };
         }
 
         // Strict comparison with null cursor value
-        // hasItemsAfterNull: forward + nullsFirst, or backward + nullsLast
-        const hasItemsAfterNull = Utils.xor(nullsFirst, inverse);
         if (hasItemsAfterNull) {
           return { [prop]: { $ne: null } };
         }

--- a/packages/core/src/drivers/DatabaseDriver.ts
+++ b/packages/core/src/drivers/DatabaseDriver.ts
@@ -347,9 +347,16 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
         return { [prop]: value } as OrderDefinition<T>;
       }
 
-      const desc =
-        (direction as unknown) === QueryOrderNumeric.DESC || direction.toString().toLowerCase().startsWith('desc');
-      const dir = Utils.xor(desc, isLast) ? 'desc' : 'asc';
+      const dirStr = direction.toString().toLowerCase();
+      const desc = (direction as unknown) === QueryOrderNumeric.DESC || dirStr.startsWith('desc');
+      let dir = Utils.xor(desc, isLast) ? 'desc' : 'asc';
+      const nullsFirst = dirStr.includes('nulls first');
+
+      // backward pagination reverses the whole ordering, so the nulls placement flips with the direction
+      if (nullsFirst || dirStr.includes('nulls last')) {
+        dir += Utils.xor(nullsFirst, isLast) ? ' nulls first' : ' nulls last';
+      }
+
       return { [prop]: dir } as OrderDefinition<T>;
     };
 

--- a/packages/mongodb/src/MongoConnection.ts
+++ b/packages/mongodb/src/MongoConnection.ts
@@ -34,8 +34,8 @@ import {
   inspect,
   type IsolationLevel,
   type LoggingOptions,
-  QueryOrder,
   type QueryOrderMap,
+  QueryOrderNumeric,
   type QueryResult,
   type Transaction,
   type TransactionEventBroadcaster,
@@ -182,6 +182,18 @@ export class MongoConnection extends Connection {
     throw new Error(`${this.constructor.name} does not support generic execute method`);
   }
 
+  /**
+   * Maps an order direction to mongo's `1`/`-1`, ignoring any `nulls first`/`nulls last` qualifier, which mongo cannot honor.
+   * @internal
+   */
+  static getSortDirection(direction: string | number): 1 | -1 {
+    if (typeof direction === 'number') {
+      return direction === QueryOrderNumeric.DESC ? -1 : 1;
+    }
+
+    return direction.toLowerCase().startsWith('desc') ? -1 : 1;
+  }
+
   async find<T extends object>(
     entityName: EntityName<T>,
     where: FilterQuery<T>,
@@ -251,7 +263,7 @@ export class MongoConnection extends Connection {
         Utils.keys(o).forEach(k => {
           const direction = o[k] as SortDirection;
           if (typeof direction === 'string') {
-            orderByTuples.push([k.toString(), direction.toUpperCase() === QueryOrder.ASC ? 1 : -1]);
+            orderByTuples.push([k.toString(), MongoConnection.getSortDirection(direction)]);
           } else {
             orderByTuples.push([k.toString(), direction]);
           }

--- a/packages/mongodb/src/MongoDriver.ts
+++ b/packages/mongodb/src/MongoDriver.ts
@@ -186,7 +186,8 @@ export class MongoDriver extends DatabaseDriver<MongoConnection> {
 
       for (const order of orderBy) {
         for (const [key, dir] of Object.entries(order)) {
-          sortSpec[key] = dir === 'ASC' || dir === 'asc' || dir === 1 ? 1 : -1;
+          sortSpec[key] =
+            typeof dir === 'string' || typeof dir === 'number' ? MongoConnection.getSortDirection(dir) : dir;
         }
       }
 

--- a/tests/features/cursor-based-pagination/cursor-nested-nullable.test.ts
+++ b/tests/features/cursor-based-pagination/cursor-nested-nullable.test.ts
@@ -1,6 +1,23 @@
 import { Cursor, MikroORM, ref, Ref, SimpleLogger } from '@mikro-orm/core';
-import { Entity, ManyToOne, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+import {
+  Embeddable,
+  Embedded,
+  Entity,
+  ManyToOne,
+  PrimaryKey,
+  Property,
+  ReflectMetadataProvider,
+} from '@mikro-orm/decorators/legacy';
 import { PLATFORMS } from '../../bootstrap.js';
+
+@Embeddable()
+class Meta {
+  @Property({ nullable: true, type: 'integer' })
+  score?: number | null;
+
+  @Property({ nullable: true, type: 'string' })
+  tag?: string | null;
+}
 
 @Entity()
 class Author {
@@ -24,6 +41,9 @@ class Book {
 
   @ManyToOne(() => Author, { ref: true, nullable: true })
   author?: Ref<Author> | null;
+
+  @Embedded(() => Meta, { object: true, nullable: true })
+  meta?: Meta | null;
 }
 
 describe('cursor pagination with nested null values', () => {
@@ -42,9 +62,9 @@ describe('cursor pagination with nested null values', () => {
     const author1 = orm.em.create(Author, { id: 1, name: 'Author 1', rating: 5 });
     const author2 = orm.em.create(Author, { id: 2, name: 'Author 2', rating: null });
 
-    orm.em.create(Book, { id: 1, title: 'Book 1', author: ref(author1) });
-    orm.em.create(Book, { id: 2, title: 'Book 2', author: ref(author2) });
-    orm.em.create(Book, { id: 3, title: 'Book 3', author: null });
+    orm.em.create(Book, { id: 1, title: 'Book 1', author: ref(author1), meta: { score: 5, tag: 'x' } });
+    orm.em.create(Book, { id: 2, title: 'Book 2', author: ref(author2), meta: { score: null, tag: 'y' } });
+    orm.em.create(Book, { id: 3, title: 'Book 3', author: null, meta: null });
 
     await orm.em.flush();
     orm.em.clear();
@@ -122,11 +142,27 @@ describe('cursor pagination with nested null values', () => {
       populate: ['author'],
     });
 
-    // Should get books with non-null author ratings
-    expect(result.items.length).toBeGreaterThanOrEqual(0);
+    // book 3 has no author at all, so it joins as a null rating and sorts next to book 2
+    expect(result.items.map(b => b.id)).toEqual([3, 1]);
+  });
+
+  test('paginate forward from an object embeddable with a null value', async () => {
+    orm.em.clear();
+    const orderBy = { meta: { score: 'asc nulls first' }, id: 'asc' } as const;
+    const book = await orm.em.findOneOrFail(Book, { id: 2 });
+    const cursor = await orm.em.findByCursor(Book, { first: 10, orderBy });
+    const afterCursor = cursor.from(book);
+    orm.em.clear();
+
+    const result = await orm.em.findByCursor(Book, { first: 10, after: afterCursor, orderBy });
+
+    // book 3 has no `meta` at all, so its score is null too and it sorts next to book 2
+    expect(result.items.map(b => b.id)).toEqual([3, 1]);
   });
 
   test('throws error for missing nested property when relation not populated', async () => {
+    orm.em.clear();
+
     // Get book WITHOUT populating author
     const book = await orm.em.findOneOrFail(Book, { id: 1 });
 

--- a/tests/features/cursor-based-pagination/cursor-nullable-columns.test.ts
+++ b/tests/features/cursor-based-pagination/cursor-nullable-columns.test.ts
@@ -462,6 +462,43 @@ describe('cursor pagination - null cursor condition branches', () => {
     expect(result.items.length).toBeGreaterThanOrEqual(0);
   });
 
+  test('the nulls qualifier reaches the emitted order by', async () => {
+    // sqlite sorts nulls first on `asc` by default, so `nulls last` is only honored if the qualifier survives
+    const cursor = await orm.em.findByCursor(User, {
+      first: 10,
+      orderBy: { age: 'asc nulls last', id: 'asc' },
+    });
+
+    expect(cursor.items.map(u => u.age)).toEqual([10, 20, 30, null]);
+  });
+
+  test('backward pagination inverts the nulls placement together with the direction', async () => {
+    const cursor = await orm.em.findByCursor(User, {
+      last: 2,
+      orderBy: { age: 'asc nulls last', id: 'asc' },
+    });
+
+    expect(cursor.items.map(u => u.age)).toEqual([30, null]);
+  });
+
+  test('the nulls first qualifier survives and inverts on backward pagination', async () => {
+    // sqlite sorts nulls last on `desc` by default, mirroring the `nulls last` cases above
+    const forward = await orm.em.findByCursor(User, {
+      first: 10,
+      orderBy: { age: 'desc nulls first', id: 'asc' },
+    });
+
+    expect(forward.items.map(u => u.age)).toEqual([null, 30, 20, 10]);
+    orm.em.clear();
+
+    const backward = await orm.em.findByCursor(User, {
+      last: 2,
+      orderBy: { age: 'desc nulls first', id: 'asc' },
+    });
+
+    expect(backward.items.map(u => u.age)).toEqual([20, 10]);
+  });
+
   test('descending direction with a nulls qualifier keeps sorting descending', async () => {
     const cursor1 = await orm.em.findByCursor(User, {
       first: 2,

--- a/tests/features/cursor-based-pagination/cursor-nullable-columns.test.ts
+++ b/tests/features/cursor-based-pagination/cursor-nullable-columns.test.ts
@@ -230,10 +230,7 @@ describe('cursor pagination - ordering by nullable column', () => {
       orderBy: { age: 'asc', id: 'asc' },
     });
 
-    expect(cursor.items).toHaveLength(4);
-    // Null values should be somewhere in the result set
-    const nullIndex = cursor.items.findIndex(u => u.age === null);
-    expect(nullIndex).toBeGreaterThanOrEqual(0);
+    expect(cursor.items.map(u => u.age)).toEqual([null, 10, 20, 30]);
   });
 
   test('can order by nullable column descending', async () => {
@@ -242,10 +239,7 @@ describe('cursor pagination - ordering by nullable column', () => {
       orderBy: { age: 'desc', id: 'asc' },
     });
 
-    expect(cursor.items).toHaveLength(4);
-    // Null values should be somewhere in the result set
-    const nullIndex = cursor.items.findIndex(u => u.age === null);
-    expect(nullIndex).toBeGreaterThanOrEqual(0);
+    expect(cursor.items.map(u => u.age)).toEqual([30, 20, 10, null]);
   });
 
   test('can paginate through results with null in cursor', async () => {
@@ -333,25 +327,13 @@ describe('cursor pagination - null cursor condition branches', () => {
 
   afterAll(() => orm.close(true));
 
-  test('parseDirection handles nulls first directive', async () => {
-    // This test ensures the 'nulls first' string parsing branch is covered
-    // The actual ordering may vary by database, but the code path is exercised
+  test('nulls first directive places the nulls first', async () => {
     const cursor = await orm.em.findByCursor(User, {
       first: 10,
       orderBy: { age: 'asc nulls first', id: 'asc' },
     });
 
-    expect(cursor.items).toHaveLength(4);
-  });
-
-  test('parseDirection handles nulls last directive', async () => {
-    // This test ensures the 'nulls last' string parsing branch is covered
-    const cursor = await orm.em.findByCursor(User, {
-      first: 10,
-      orderBy: { age: 'asc nulls last', id: 'asc' },
-    });
-
-    expect(cursor.items).toHaveLength(4);
+    expect(cursor.items.map(u => u.age)).toEqual([null, 10, 20, 30]);
   });
 
   test('cursor condition with null value and nulls first (forward)', async () => {
@@ -377,8 +359,8 @@ describe('cursor pagination - null cursor condition branches', () => {
       orderBy: { age: 'asc nulls first', id: 'asc' },
     });
 
-    // Result count depends on database NULLS ordering support
-    expect(result.items.length).toBeGreaterThanOrEqual(0);
+    // nulls sort first, so every non-null row comes after the null cursor
+    expect(result.items.map(u => u.age)).toEqual([10, 20, 30]);
   });
 
   test('cursor condition with null value and nulls last (forward)', async () => {
@@ -458,8 +440,8 @@ describe('cursor pagination - null cursor condition branches', () => {
       orderBy: { age: 'asc nulls last', id: 'asc' },
     });
 
-    // Result count depends on database NULLS ordering support
-    expect(result.items.length).toBeGreaterThanOrEqual(0);
+    // nulls sort last, so every non-null row comes before the null cursor
+    expect(result.items.map(u => u.age)).toEqual([10, 20, 30]);
   });
 
   test('the nulls qualifier reaches the emitted order by', async () => {

--- a/tests/features/cursor-based-pagination/cursor-nullable-columns.test.ts
+++ b/tests/features/cursor-based-pagination/cursor-nullable-columns.test.ts
@@ -461,4 +461,23 @@ describe('cursor pagination - null cursor condition branches', () => {
     // Result count depends on database NULLS ordering support
     expect(result.items.length).toBeGreaterThanOrEqual(0);
   });
+
+  test('descending direction with a nulls qualifier keeps sorting descending', async () => {
+    const cursor1 = await orm.em.findByCursor(User, {
+      first: 2,
+      orderBy: { age: 'desc nulls last', id: 'asc' },
+    });
+
+    expect(cursor1.items.map(u => u.age)).toEqual([30, 20]);
+    orm.em.clear();
+
+    const cursor2 = await orm.em.findByCursor(User, {
+      first: 2,
+      after: cursor1,
+      orderBy: { age: 'desc nulls last', id: 'asc' },
+    });
+
+    // same as a plain `desc`, the null row is not part of the descending window here
+    expect(cursor2.items.map(u => u.age)).toEqual([10]);
+  });
 });

--- a/tests/features/order-by-nulls-ordering.mongo.test.ts
+++ b/tests/features/order-by-nulls-ordering.mongo.test.ts
@@ -1,0 +1,106 @@
+import {
+  Entity,
+  ManyToOne,
+  OneToMany,
+  PrimaryKey,
+  Property,
+  ReflectMetadataProvider,
+  SerializedPrimaryKey,
+} from '@mikro-orm/decorators/legacy';
+import { QueryOrder } from '@mikro-orm/core';
+import { Collection, MikroORM, ObjectId } from '@mikro-orm/mongodb';
+
+@Entity()
+class Team {
+  @PrimaryKey({ type: 'ObjectId' })
+  _id!: ObjectId;
+
+  @SerializedPrimaryKey()
+  id!: string;
+
+  @Property()
+  name!: string;
+
+  @OneToMany(() => User, user => user.team)
+  users = new Collection<User>(this);
+}
+
+@Entity()
+class User {
+  @PrimaryKey({ type: 'ObjectId' })
+  _id!: ObjectId;
+
+  @SerializedPrimaryKey()
+  id!: string;
+
+  @Property()
+  name!: string;
+
+  @Property({ nullable: true })
+  age?: number;
+
+  @ManyToOne(() => Team)
+  team!: Team;
+}
+
+describe('orderBy with nulls ordering (mongo)', () => {
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      metadataProvider: ReflectMetadataProvider,
+      entities: [User, Team],
+      clientUrl: 'mongodb://localhost:27017/mikro-orm-test-order-by-nulls',
+    });
+    await orm.schema.clear();
+
+    const team = orm.em.create(Team, { name: 't1' });
+    orm.em.create(User, { name: 'a', age: 10, team });
+    orm.em.create(User, { name: 'b', age: 20, team });
+    orm.em.create(User, { name: 'c', age: 30, team });
+    await orm.em.flush();
+    orm.em.clear();
+  });
+
+  afterAll(async () => {
+    await orm.schema.drop();
+    await orm.close(true);
+  });
+
+  beforeEach(() => orm.em.clear());
+
+  test.each([
+    QueryOrder.ASC_NULLS_FIRST,
+    QueryOrder.ASC_NULLS_LAST,
+    QueryOrder.asc_nulls_first,
+    QueryOrder.asc_nulls_last,
+  ])('find() with %s sorts ascending', async direction => {
+    const users = await orm.em.find(User, {}, { orderBy: { age: direction } });
+    expect(users.map(u => u.age)).toEqual([10, 20, 30]);
+  });
+
+  test.each([
+    QueryOrder.DESC_NULLS_FIRST,
+    QueryOrder.DESC_NULLS_LAST,
+    QueryOrder.desc_nulls_first,
+    QueryOrder.desc_nulls_last,
+  ])('find() with %s sorts descending', async direction => {
+    const users = await orm.em.find(User, {}, { orderBy: { age: direction } });
+    expect(users.map(u => u.age)).toEqual([30, 20, 10]);
+  });
+
+  test('aggregate $sort path (populate with limit) respects the nulls qualifier direction', async () => {
+    const teams = await orm.em.find(
+      Team,
+      {},
+      {
+        populate: ['users'],
+        populateHints: {
+          users: { limit: 2, orderBy: { age: QueryOrder.ASC_NULLS_FIRST } },
+        },
+      },
+    );
+
+    expect(teams[0].users.getItems().map(u => u.age)).toEqual([10, 20]);
+  });
+});


### PR DESCRIPTION
Directions carrying a `nulls first` / `nulls last` qualifier were compared for equality against `asc`/`desc`, so they never matched and fell through to the descending branch. Both sites now read the direction off the prefix.

On mongo that meant `orderBy: { age: 'asc nulls first' }` returned rows in descending order, both in the `find()` path and in the aggregate `$sort` path used by `populateHints` with a limit. The `desc nulls *` variants happened to come out right, but only by falling through. Mongo always sorts null and missing values lowest and cannot honor an explicit placement, so the qualifier stays ignored there. I kept that silent rather than warning, since a warning on every such query would be noise for something mongo can never do. Both mongo call sites now share one parser.

The same equality check sits in cursor pagination in `DatabaseDriver`, where it is worse: `desc nulls last` sorted ascending *and* built a `$gt` condition instead of `$lt`, so pages came back fully inverted on every driver. The existing coverage only used `asc nulls *` variants, which were correct by accident.

Cursor pagination also dropped the qualifier entirely when building the order by, so it asked for the database default placement while the cursor condition kept reasoning about the placement the caller requested. The qualifier now survives, and backward pagination flips it along with the direction, which is what makes the reversed page line up with the forward ordering.

Tightening the assertions in those cursor tests turned up one more thing. Several of them only checked `length >= 0`, and behind that sat a broken keyset condition: the decomposition is `a >= x AND (a > x OR b > y)`, but for a null offset the `a >= x` half was emitted as `a IS NULL`. Where the nulls sort first in the scan direction that half should mean every row, so the narrower version filtered out precisely the rows the `OR` existed to admit and the page came back empty. Nested cursors silently lost rows the same way, and an unconstrained nested group now collapses instead of becoming an empty object condition, which for object embeddables matched only rows whose every child value was null.
