### PR TITLE
fix(core): treat `@Formula` properties as nullable in cursor pagination

### DIFF
--- a/packages/core/src/drivers/DatabaseDriver.ts
+++ b/packages/core/src/drivers/DatabaseDriver.ts
@@ -351,8 +351,8 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
       nullable = false,
     ): OrderDefinition<T> => {
       const propMeta = properties[prop];
-      // a nullable relation or embeddable makes its joined columns null too
-      nullable ||= !!propMeta?.nullable;
+      // nullable relations and embeddables null out their joined columns, and a formula can yield null unannounced
+      nullable ||= !!propMeta?.nullable || !!propMeta?.formula;
 
       if (Utils.isPlainObject(direction)) {
         const childProps =
@@ -532,8 +532,8 @@ export abstract class DatabaseDriver<C extends Connection> implements IDatabaseD
       nullable = false,
     ): Dictionary => {
       const propMeta = properties[prop];
-      // a nullable relation or embeddable makes its joined columns null too
-      nullable ||= !!propMeta?.nullable;
+      // nullable relations and embeddables null out their joined columns, and a formula can yield null unannounced
+      nullable ||= !!propMeta?.nullable || !!propMeta?.formula;
 
       if (Utils.isPlainObject(direction)) {
         if (offset === undefined) {

--- a/tests/features/cursor-based-pagination/cursor-formula-nulls.test.ts
+++ b/tests/features/cursor-based-pagination/cursor-formula-nulls.test.ts
@@ -1,0 +1,122 @@
+import { MikroORM, Options, QueryOrderMap } from '@mikro-orm/core';
+import { Entity, Formula, PrimaryKey, Property, ReflectMetadataProvider } from '@mikro-orm/decorators/legacy';
+import { PLATFORMS } from '../../bootstrap.js';
+
+@Entity()
+class User {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+
+  @Property({ nullable: true, type: 'integer' })
+  age?: number | null;
+
+  // the expression yields null for small and missing ages, yet the metadata does not declare it nullable
+  @Formula(alias => `(case when ${alias}.age > 15 then ${alias}.age else null end)`, { type: 'integer' })
+  bigAge?: number | null;
+
+  @Formula(alias => `(case when ${alias}.age > 15 then ${alias}.age else null end)`, {
+    type: 'integer',
+    nullable: true,
+  })
+  bigAgeNullable?: number | null;
+}
+
+describe.each(['sqlite', 'mysql', 'postgresql', 'mssql'] as const)(
+  'cursor pagination over a formula column (%s)',
+  type => {
+    let orm: MikroORM;
+
+    beforeAll(async () => {
+      const options: Partial<Options> = {};
+
+      if (type === 'mysql') {
+        options.port = 3308;
+      }
+
+      if (type === 'mssql') {
+        options.password = 'Root.Root';
+      }
+
+      orm = await MikroORM.init({
+        metadataProvider: ReflectMetadataProvider,
+        entities: [User],
+        dbName: type === 'sqlite' ? ':memory:' : 'mikro_orm_test_cursor_formula_nulls',
+        driver: PLATFORMS[type],
+        ...options,
+      });
+      await orm.schema.refresh();
+
+      orm.em.create(User, { id: 1, name: 'User 1', age: 10 });
+      orm.em.create(User, { id: 2, name: 'User 2', age: 20 });
+      orm.em.create(User, { id: 3, name: 'User 3', age: null });
+      orm.em.create(User, { id: 4, name: 'User 4', age: 12 });
+      orm.em.create(User, { id: 5, name: 'User 5', age: 30 });
+
+      await orm.em.flush();
+      orm.em.clear();
+    });
+
+    afterAll(() => orm.close(true));
+
+    afterEach(() => orm.em.clear());
+
+    /** Walks the whole result set one row per page, so every page boundary is a cursor round trip. */
+    const walk = async (orderBy: QueryOrderMap<User>, backwards = false): Promise<number[]> => {
+      const ids: number[] = [];
+      let cursor: string | undefined;
+
+      // the data set has 5 rows, a higher bound only guards against a broken cursor looping
+      for (let i = 0; i < 10; i++) {
+        const page = await orm.em.findByCursor(User, {
+          ...(backwards ? { last: 1, before: cursor } : { first: 1, after: cursor }),
+          orderBy,
+        });
+
+        if (page.items.length === 0) {
+          break;
+        }
+
+        ids.push(...page.items.map(user => user.id));
+        cursor = backwards ? page.startCursor! : page.endCursor!;
+        orm.em.clear();
+
+        if (backwards ? !page.hasPrevPage : !page.hasNextPage) {
+          break;
+        }
+      }
+
+      return ids;
+    };
+
+    test('the formula property is not declared nullable', async () => {
+      expect(orm.getMetadata().get(User).properties.bigAge.nullable).toBeFalsy();
+      expect(orm.getMetadata().get(User).properties.bigAgeNullable.nullable).toBe(true);
+    });
+
+    // the cursor default is nulls last for asc and nulls first for desc
+    describe.each([
+      ['bigAge', 'asc', [2, 5, 1, 3, 4]],
+      ['bigAge', 'desc', [1, 3, 4, 5, 2]],
+      ['bigAgeNullable', 'asc', [2, 5, 1, 3, 4]],
+      ['bigAgeNullable', 'desc', [1, 3, 4, 5, 2]],
+    ] as const)('ordered by %s %s', (prop, dir, expected) => {
+      const orderBy = { [prop]: dir, id: 'asc' } as QueryOrderMap<User>;
+
+      test('a single page returns every row', async () => {
+        const { items } = await orm.em.findByCursor(User, { first: 100, orderBy });
+        expect(items.map(user => user.id)).toEqual(expected);
+      });
+
+      test('paginating forward crosses the null boundary', async () => {
+        expect(await walk(orderBy)).toEqual(expected);
+      });
+
+      test('paginating backward crosses the null boundary', async () => {
+        expect(await walk(orderBy, true)).toEqual([...expected].reverse());
+      });
+    });
+  },
+);


### PR DESCRIPTION
Cursor pagination on `next` decides whether a sort key can be null from `propMeta.nullable`. That flag controls two things: whether the rewritten `orderBy` spells out `nulls first/last`, and whether the cursor condition gets the `or x is null` branch that reaches past the current offset. `@Formula` never sets `nullable`, so a `findByCursor` ordered by a formula that yields NULL for some rows silently dropped the null block. On sqlite, mysql and mssql the forward walk stopped after it, because the database-default null placement disagrees with what the cursor assumes; on postgres one direction lost the rows past it. The same formula with `nullable: true` paginated correctly.

A formula is an arbitrary expression whose nullability we cannot know, so both derivations now treat formula-backed properties as nullable. Ordinary columns keep the SQL they emit today. Dropping the `nullable` gate altogether was considered and rejected: it would add an emulated null-placement prefix to every mysql/mssql cursor `order by` and an `or x is null` to every cursor `where`, including the common indexed non-null case.

Columns declared non-nullable in metadata but holding NULLs in the data are still not handled. That is a metadata mismatch the ORM has no way to detect.
