### PR TITLE
chore(ci): retry npm publish on sigstore transparency log conflicts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,7 +116,7 @@ jobs:
           fi
 
       - name: Publish to npm
-        run: yarn publish:prod ${{ steps.dist-tag.outputs.tag }} --yes
+        run: ./scripts/publish-with-retry.sh yarn publish:prod ${{ steps.dist-tag.outputs.tag }} --yes
 
       - name: Publish to JSR
         run: yarn publish:jsr
@@ -165,7 +165,7 @@ jobs:
           git fetch --depth=1 origin +refs/tags/*:refs/tags/*
 
       - name: Publish to npm
-        run: yarn lerna publish from-package --contents dist --dist-tag ${{ inputs.dist-tag }} --force-publish --yes
+        run: ./scripts/publish-with-retry.sh yarn lerna publish from-package --contents dist --dist-tag ${{ inputs.dist-tag }} --force-publish --yes
 
       - name: Create git tag
         if: inputs.dist-tag == 'rc'

--- a/scripts/publish-with-retry.sh
+++ b/scripts/publish-with-retry.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Retries `lerna publish`, which flakes on sigstore provenance ("409 an equivalent entry
+# already exists in the transparency log") when Rekor times out and the request is retried
+# with the same signature. A fresh attempt signs with a new ephemeral key, so it goes
+# through; `from-package` only picks up packages missing from the registry, so retrying
+# never republishes anything.
+set -uo pipefail
+
+attempts=${PUBLISH_ATTEMPTS:-3}
+delay=${PUBLISH_RETRY_DELAY:-30}
+
+for i in $(seq 1 "$attempts"); do
+  if "$@"; then
+    exit 0
+  fi
+
+  if [ "$i" -lt "$attempts" ]; then
+    echo "::warning::publish attempt $i/$attempts failed, retrying in ${delay}s"
+    sleep "$delay"
+  fi
+done
+
+echo "::error::publish failed after $attempts attempts"
+exit 1


### PR DESCRIPTION
The canary release has been failing on most commits today with `TLOG_CREATE_ENTRY_ERROR ... (409) an equivalent entry already exists in the transparency log`.

When Rekor is slow, the sigstore fetch layer retries on 5xx/408 and resubmits the identical signed entry, which then conflicts with the one that did land. `TLogClient` has a `fetchOnConflict` branch for exactly this case, but `sigstore` hardcodes it to `false`, still the case in the latest 5.0.0, so no dependency bump helps.

Retrying the publish step works around it: each attempt signs with a new ephemeral key, so it produces a different tlog entry. Retrying is safe because `from-package` only publishes packages missing from the registry, and the 409 happens while building the attestation, before the registry upload.
