### PR TITLE
feat(cli): add Nub TypeScript loader option

### DIFF
--- a/docs/docs/quick-start.md
+++ b/docs/docs/quick-start.md
@@ -327,7 +327,7 @@ Another way to control these CLI-related settings is with the environment variab
 
 - `MIKRO_ORM_CLI_CONFIG`: the path to ORM config file
 - `MIKRO_ORM_CLI_PREFER_TS`: enforce use of the TS paths (e.g. `entitiesTs` or `pathTs`)
-- `MIKRO_ORM_CLI_TS_LOADER`: set preferred TS loader (one of `oxc`, `swc`, `tsx`, `nub`, `jiti`, `tsimp`); `nub` cannot be combined with `MIKRO_ORM_CLI_TS_CONFIG_PATH`
+- `MIKRO_ORM_CLI_TS_LOADER`: set preferred TS loader (one of `oxc`, `swc`, `tsx`, `nub`, `jiti`, `tsimp`); `nub` is the final automatic fallback when using the project `tsconfig.json` and cannot be combined with `MIKRO_ORM_CLI_TS_CONFIG_PATH`
 - `MIKRO_ORM_CLI_TS_CONFIG_PATH`: path to the tsconfig.json (for TS support)
 - `MIKRO_ORM_CLI_ALWAYS_ALLOW_TS`: enable `.ts` files to use without detected TS support
 - `MIKRO_ORM_CLI_VERBOSE`: enable verbose logging (e.g. print queries used in seeder or schema diffing)

--- a/docs/docs/quick-start.md
+++ b/docs/docs/quick-start.md
@@ -327,7 +327,7 @@ Another way to control these CLI-related settings is with the environment variab
 
 - `MIKRO_ORM_CLI_CONFIG`: the path to ORM config file
 - `MIKRO_ORM_CLI_PREFER_TS`: enforce use of the TS paths (e.g. `entitiesTs` or `pathTs`)
-- `MIKRO_ORM_CLI_TS_LOADER`: set preferred TS loader (one of `oxc`, `swc`, `tsx`, `jiti`, `tsimp`, `nub`); `nub` is the final automatic fallback when using the project `tsconfig.json` and cannot be combined with `MIKRO_ORM_CLI_TS_CONFIG_PATH`
+- `MIKRO_ORM_CLI_TS_LOADER`: set preferred TS loader (one of `oxc`, `swc`, `tsx`, `jiti`, `tsimp`, `nub`), see [TypeScript loaders in CLI](./typescript-loaders.md)
 - `MIKRO_ORM_CLI_TS_CONFIG_PATH`: path to the tsconfig.json (for TS support)
 - `MIKRO_ORM_CLI_ALWAYS_ALLOW_TS`: enable `.ts` files to use without detected TS support
 - `MIKRO_ORM_CLI_VERBOSE`: enable verbose logging (e.g. print queries used in seeder or schema diffing)

--- a/docs/docs/quick-start.md
+++ b/docs/docs/quick-start.md
@@ -327,7 +327,7 @@ Another way to control these CLI-related settings is with the environment variab
 
 - `MIKRO_ORM_CLI_CONFIG`: the path to ORM config file
 - `MIKRO_ORM_CLI_PREFER_TS`: enforce use of the TS paths (e.g. `entitiesTs` or `pathTs`)
-- `MIKRO_ORM_CLI_TS_LOADER`: set preferred TS loader (one of `oxc`, `swc`, `tsx`, `nub`, `jiti`, `tsimp`); Nub uses the project `tsconfig.json`
+- `MIKRO_ORM_CLI_TS_LOADER`: set preferred TS loader (one of `oxc`, `swc`, `tsx`, `nub`, `jiti`, `tsimp`); `nub` cannot be combined with `MIKRO_ORM_CLI_TS_CONFIG_PATH`
 - `MIKRO_ORM_CLI_TS_CONFIG_PATH`: path to the tsconfig.json (for TS support)
 - `MIKRO_ORM_CLI_ALWAYS_ALLOW_TS`: enable `.ts` files to use without detected TS support
 - `MIKRO_ORM_CLI_VERBOSE`: enable verbose logging (e.g. print queries used in seeder or schema diffing)

--- a/docs/docs/quick-start.md
+++ b/docs/docs/quick-start.md
@@ -327,7 +327,7 @@ Another way to control these CLI-related settings is with the environment variab
 
 - `MIKRO_ORM_CLI_CONFIG`: the path to ORM config file
 - `MIKRO_ORM_CLI_PREFER_TS`: enforce use of the TS paths (e.g. `entitiesTs` or `pathTs`)
-- `MIKRO_ORM_CLI_TS_LOADER`: set preferred TS loader (one of `oxc`, `swc`, `tsx`, `nub`, `jiti`, `tsimp`); `nub` is the final automatic fallback when using the project `tsconfig.json` and cannot be combined with `MIKRO_ORM_CLI_TS_CONFIG_PATH`
+- `MIKRO_ORM_CLI_TS_LOADER`: set preferred TS loader (one of `oxc`, `swc`, `tsx`, `jiti`, `tsimp`, `nub`); `nub` is the final automatic fallback when using the project `tsconfig.json` and cannot be combined with `MIKRO_ORM_CLI_TS_CONFIG_PATH`
 - `MIKRO_ORM_CLI_TS_CONFIG_PATH`: path to the tsconfig.json (for TS support)
 - `MIKRO_ORM_CLI_ALWAYS_ALLOW_TS`: enable `.ts` files to use without detected TS support
 - `MIKRO_ORM_CLI_VERBOSE`: enable verbose logging (e.g. print queries used in seeder or schema diffing)

--- a/docs/docs/quick-start.md
+++ b/docs/docs/quick-start.md
@@ -327,7 +327,7 @@ Another way to control these CLI-related settings is with the environment variab
 
 - `MIKRO_ORM_CLI_CONFIG`: the path to ORM config file
 - `MIKRO_ORM_CLI_PREFER_TS`: enforce use of the TS paths (e.g. `entitiesTs` or `pathTs`)
-- `MIKRO_ORM_CLI_TS_LOADER`: set preferred TS loader (one of `oxc`, `swc`, `tsx`, `jiti`, `tsimp`)
+- `MIKRO_ORM_CLI_TS_LOADER`: set preferred TS loader (one of `oxc`, `swc`, `tsx`, `nub`, `jiti`, `tsimp`); Nub uses the project `tsconfig.json`
 - `MIKRO_ORM_CLI_TS_CONFIG_PATH`: path to the tsconfig.json (for TS support)
 - `MIKRO_ORM_CLI_ALWAYS_ALLOW_TS`: enable `.ts` files to use without detected TS support
 - `MIKRO_ORM_CLI_VERBOSE`: enable verbose logging (e.g. print queries used in seeder or schema diffing)

--- a/docs/docs/typescript-loaders.md
+++ b/docs/docs/typescript-loaders.md
@@ -2,7 +2,7 @@
 title: TypeScript loaders in CLI
 ---
 
-The CLI needs to be able to `import()` your TypeScript files, both the ORM config and the entities it discovers from it. Node.js cannot do that on its own, so the CLI registers one of the supported TypeScript loaders before it loads your config.
+The CLI needs to be able to `import()` your TypeScript files, both the ORM config and the entities it discovers from it. Node.js can run TypeScript on its own nowadays, but only by stripping the types away, so files using enums or decorators still fail to parse. Entities defined with decorators are the common case, hence the CLI registers one of the supported TypeScript loaders before it loads your config. When it cannot find any, it falls back to the compiled JavaScript config and ignores the TypeScript one.
 
 ## Detection
 

--- a/docs/docs/typescript-loaders.md
+++ b/docs/docs/typescript-loaders.md
@@ -1,0 +1,64 @@
+---
+title: TypeScript loaders in CLI
+---
+
+The CLI needs to be able to `import()` your TypeScript files, both the ORM config and the entities it discovers from it. Node.js cannot do that on its own, so the CLI registers one of the supported TypeScript loaders before it loads your config.
+
+## Detection
+
+TypeScript support is detected automatically, based on things like the file extension of the config file, the presence of a TS loader in `process.execArgv`, or the test runner in use. You can enforce it via the `preferTs` setting in your `package.json`, or with the `MIKRO_ORM_CLI_PREFER_TS` environment variable:
+
+```json title="./package.json"
+"mikro-orm": {
+  "preferTs": true
+}
+```
+
+## Supported loaders
+
+- `oxc` via `@oxc-node/core`, supports metadata reflection
+- `swc` via `@swc-node/register`, supports metadata reflection
+- `tsx`
+- `jiti`
+- `tsimp`
+- `nub` via `@nubjs/loader`, supports metadata reflection (available from v7.2)
+
+Metadata reflection here means the loader honors `emitDecoratorMetadata`, which is required by the [`ReflectMetadataProvider`](./metadata-providers.md#reflectmetadataprovider) together with the legacy decorators. The other metadata providers do not depend on it.
+
+## Selecting a loader
+
+The default is `auto`, which goes through the loaders in the order above and picks the first one available in your dependencies. To pick one explicitly, use the `tsLoader` setting in your `package.json`:
+
+```json title="./package.json"
+"mikro-orm": {
+  "tsLoader": "jiti"
+}
+```
+
+Or override it via the `MIKRO_ORM_CLI_TS_LOADER` environment variable. With an explicit loader there is no fallback, if it is missing or fails to load, the CLI throws instead of trying the next one.
+
+## The tsconfig.json file
+
+Some loaders are pointed at your `tsconfig.json`, which defaults to `tsconfig.json` in the current working directory. Use the `tsConfigPath` setting or the `MIKRO_ORM_CLI_TS_CONFIG_PATH` environment variable to use a different one:
+
+```json title="./package.json"
+"mikro-orm": {
+  "tsConfigPath": "./tsconfig.cli.json"
+}
+```
+
+## Nub
+
+Nub resolves the `tsconfig.json` on its own, always the nearest one relative to each imported file, and it cannot be pointed at a custom path. Selecting it together with `tsConfigPath` therefore throws, and the automatic selection skips it whenever a custom tsconfig path is configured.
+
+It also only understands the legacy decorators, so `experimentalDecorators: true` is required, and it rejects files using the [ES decorators](./using-decorators.md). Pick another loader if your entities use those.
+
+```json title="./package.json"
+"mikro-orm": {
+  "tsLoader": "nub"
+}
+```
+
+## Compiling ahead of time
+
+The loaders above are only about running TypeScript directly. If you compile your project with `tsc`, Babel or SWC instead, see [Usage with transpilers](./usage-with-transpilers.md) for the decorator options those need.

--- a/docs/docs/upgrading-v6-to-v7.md
+++ b/docs/docs/upgrading-v6-to-v7.md
@@ -136,11 +136,11 @@ TypeScript support was previously provided by `ts-node`. In v7, the CLI supports
 - `oxc` via `@oxc-node/core`, supports metadata reflection
 - `swc` via `@swc-node/register`, supports metadata reflection
 - `tsx`
-- `nub` via `@nubjs/loader`, selected explicitly and using the project `tsconfig.json` (available from v7.2)
+- `nub` via `@nubjs/loader`, supports metadata reflection (available from v7.2)
 - `jiti`
 - `tsimp`
 
-The default is `auto`, which means it goes through all those options sequentially and picks the first one available in the project dependencies.
+The default is `auto`, which means it goes through all those options sequentially and picks the first one available in the project dependencies. `nub` is skipped there, it is always opt-in.
 
 To pick a loader explicitly, use the `tsLoader` setting in your `package.json`:
 
@@ -152,13 +152,15 @@ To pick a loader explicitly, use the `tsLoader` setting in your `package.json`:
 
 Or override it via `MIKRO_ORM_CLI_TS_LOADER` env var.
 
-To use Nub, install `@nubjs/loader` and select it explicitly. Nub reads the project `tsconfig.json`.
+To use Nub, install `@nubjs/loader` and select it explicitly:
 
 ```json
 "mikro-orm": {
   "tsLoader": "nub"
 }
 ```
+
+Nub reads the `tsconfig.json` it discovers on its own (the nearest one relative to each imported file), it cannot be pointed at a custom path, so combining it with the `tsConfigPath` option is not supported. Decorator metadata requires `experimentalDecorators: true`, the TC39 decorators are not supported yet.
 
 ```diff
 -npm install ts-node

--- a/docs/docs/upgrading-v6-to-v7.md
+++ b/docs/docs/upgrading-v6-to-v7.md
@@ -131,36 +131,7 @@ Also, the `checkDuplicateEntities` discovery option is removed, since it is no l
 
 ## TypeScript support in CLI
 
-TypeScript support was previously provided by `ts-node`. In v7, the CLI supports various TS loaders:
-
-- `oxc` via `@oxc-node/core`, supports metadata reflection
-- `swc` via `@swc-node/register`, supports metadata reflection
-- `tsx`
-- `jiti`
-- `tsimp`
-- `nub` via `@nubjs/loader`, supports metadata reflection and is available from v7.2 as the final automatic fallback when using the project `tsconfig.json`
-
-The default is `auto`, which means it goes through all those options sequentially and picks the first one available in the project dependencies. Nub runs last and only when the project `tsconfig.json` is used.
-
-To pick a loader explicitly, use the `tsLoader` setting in your `package.json`:
-
-```json
-"mikro-orm": {
-  "tsLoader": "jiti"
-}
-```
-
-Or override it via `MIKRO_ORM_CLI_TS_LOADER` env var.
-
-To select Nub explicitly, install `@nubjs/loader`.
-
-```json
-"mikro-orm": {
-  "tsLoader": "nub"
-}
-```
-
-Nub reads the `tsconfig.json` it discovers on its own (the nearest one relative to each imported file), it cannot be pointed at a custom path, so combining it with the `tsConfigPath` option is not supported. Decorator metadata requires `experimentalDecorators: true`, the TC39 decorators are not supported yet.
+TypeScript support was previously provided by `ts-node`. In v7, the CLI supports various TS loaders (`oxc`, `swc`, `tsx`, `jiti`, `tsimp` and, from v7.2, `nub`), picking the first one available in your dependencies. See [TypeScript loaders in CLI](./typescript-loaders.md) for the full list and how to select one explicitly.
 
 ```diff
 -npm install ts-node

--- a/docs/docs/upgrading-v6-to-v7.md
+++ b/docs/docs/upgrading-v6-to-v7.md
@@ -136,11 +136,11 @@ TypeScript support was previously provided by `ts-node`. In v7, the CLI supports
 - `oxc` via `@oxc-node/core`, supports metadata reflection
 - `swc` via `@swc-node/register`, supports metadata reflection
 - `tsx`
-- `nub` via `@nubjs/loader`, supports metadata reflection (available from v7.2)
 - `jiti`
 - `tsimp`
+- `nub` via `@nubjs/loader`, supports metadata reflection and is available from v7.2 as the final automatic fallback when using the project `tsconfig.json`
 
-The default is `auto`, which means it goes through all those options sequentially and picks the first one available in the project dependencies. `nub` is skipped there, it is always opt-in.
+The default is `auto`, which means it goes through all those options sequentially and picks the first one available in the project dependencies. Nub runs last and only when the project `tsconfig.json` is used.
 
 To pick a loader explicitly, use the `tsLoader` setting in your `package.json`:
 
@@ -152,7 +152,7 @@ To pick a loader explicitly, use the `tsLoader` setting in your `package.json`:
 
 Or override it via `MIKRO_ORM_CLI_TS_LOADER` env var.
 
-To use Nub, install `@nubjs/loader` and select it explicitly:
+To select Nub explicitly, install `@nubjs/loader`.
 
 ```json
 "mikro-orm": {

--- a/docs/docs/upgrading-v6-to-v7.md
+++ b/docs/docs/upgrading-v6-to-v7.md
@@ -136,6 +136,7 @@ TypeScript support was previously provided by `ts-node`. In v7, the CLI supports
 - `oxc` via `@oxc-node/core`, supports metadata reflection
 - `swc` via `@swc-node/register`, supports metadata reflection
 - `tsx`
+- `nub` via `@nubjs/loader`, selected explicitly and using the project `tsconfig.json`
 - `jiti`
 - `tsimp`
 
@@ -150,6 +151,14 @@ To pick a loader explicitly, use the `tsLoader` setting in your `package.json`:
 ```
 
 Or override it via `MIKRO_ORM_CLI_TS_LOADER` env var.
+
+To use Nub, install `@nubjs/loader` and select it explicitly. Nub reads the project `tsconfig.json`.
+
+```json
+"mikro-orm": {
+  "tsLoader": "nub"
+}
+```
 
 ```diff
 -npm install ts-node

--- a/docs/docs/upgrading-v6-to-v7.md
+++ b/docs/docs/upgrading-v6-to-v7.md
@@ -136,7 +136,7 @@ TypeScript support was previously provided by `ts-node`. In v7, the CLI supports
 - `oxc` via `@oxc-node/core`, supports metadata reflection
 - `swc` via `@swc-node/register`, supports metadata reflection
 - `tsx`
-- `nub` via `@nubjs/loader`, selected explicitly and using the project `tsconfig.json`
+- `nub` via `@nubjs/loader`, selected explicitly and using the project `tsconfig.json` (available from v7.2)
 - `jiti`
 - `tsimp`
 

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -134,6 +134,7 @@ module.exports = {
         'deployment',
         'define-entity',
         'using-decorators',
+        'typescript-loaders',
         'folder-based-discovery',
         'metadata-providers',
         'metadata-cache',

--- a/packages/cli/src/CLIHelper.ts
+++ b/packages/cli/src/CLIHelper.ts
@@ -340,7 +340,7 @@ export class CLIHelper {
    */
   static async registerTypeScriptSupport(
     configPath = 'tsconfig.json',
-    tsLoader?: 'oxc' | 'swc' | 'tsx' | 'nub' | 'jiti' | 'tsimp' | 'auto',
+    tsLoader?: 'oxc' | 'swc' | 'tsx' | 'jiti' | 'tsimp' | 'nub' | 'auto',
   ): Promise<boolean> {
     /* v8 ignore if */
     if (process.versions.bun) {
@@ -373,7 +373,7 @@ export class CLIHelper {
     const errors: Error[] = [];
 
     for (const loader of Utils.keys(loaders)) {
-      if (loader === 'nub' && explicitLoader === 'auto' && !usesDefaultTsConfig) {
+      if (loader === 'nub' && !usesDefaultTsConfig) {
         continue;
       }
 
@@ -440,7 +440,7 @@ export class CLIHelper {
 export interface Settings {
   verbose?: boolean;
   preferTs?: boolean;
-  tsLoader?: 'oxc' | 'swc' | 'tsx' | 'nub' | 'jiti' | 'tsimp' | 'auto';
+  tsLoader?: 'oxc' | 'swc' | 'tsx' | 'jiti' | 'tsimp' | 'nub' | 'auto';
   tsConfigPath?: string;
   configPaths?: string[];
 }

--- a/packages/cli/src/CLIHelper.ts
+++ b/packages/cli/src/CLIHelper.ts
@@ -336,6 +336,7 @@ export class CLIHelper {
   /**
    * Tries to register TS support in the following order: oxc, swc, tsx, jiti, tsimp, nub
    * Use `MIKRO_ORM_CLI_TS_LOADER` env var to set the loader explicitly.
+   * `nub` is skipped when a custom tsconfig path is used, and it supports only the legacy decorators.
    * This method is used only in CLI context.
    */
   static async registerTypeScriptSupport(
@@ -416,9 +417,10 @@ export class CLIHelper {
     const loadersMessage = usesDefaultTsConfig
       ? '`oxc`, `swc`, `tsx`, `jiti`, `tsimp` nor `nub`'
       : '`oxc`, `swc`, `tsx`, `jiti` nor `tsimp`';
+    const nubHint = usesDefaultTsConfig ? '' : ' The `nub` loader was skipped as a custom tsconfig path is configured.';
     // eslint-disable-next-line no-console
     console.warn(
-      `Neither ${loadersMessage} found in the project dependencies, support for working with TypeScript files might not work. To use \`oxc\`, install \`@oxc-node/core\`. To use \`swc\`, install both \`@swc-node/register\` and \`@swc/core\`.`,
+      `Neither ${loadersMessage} found in the project dependencies, support for working with TypeScript files might not work.${nubHint} To use \`oxc\`, install \`@oxc-node/core\`. To use \`swc\`, install both \`@swc-node/register\` and \`@swc/core\`.`,
     );
 
     return false;

--- a/packages/cli/src/CLIHelper.ts
+++ b/packages/cli/src/CLIHelper.ts
@@ -340,7 +340,7 @@ export class CLIHelper {
    */
   static async registerTypeScriptSupport(
     configPath = 'tsconfig.json',
-    tsLoader?: 'oxc' | 'swc' | 'tsx' | 'jiti' | 'tsimp' | 'auto',
+    tsLoader?: 'oxc' | 'swc' | 'tsx' | 'nub' | 'jiti' | 'tsimp' | 'auto',
   ): Promise<boolean> {
     /* v8 ignore if */
     if (process.versions.bun) {
@@ -355,10 +355,19 @@ export class CLIHelper {
     const setEsmImportProvider = () => {
       return ((globalThis as any).dynamicImportProvider = (id: string) => import(id).then(mod => mod?.default ?? mod));
     };
+    if (
+      explicitLoader === 'nub' &&
+      fs.normalizePath(fs.absolutePath(configPath)) !== fs.normalizePath(fs.absolutePath('tsconfig.json'))
+    ) {
+      throw new Error(
+        'The `nub` loader does not support a custom tsconfig path. Use the project tsconfig.json or select another loader.',
+      );
+    }
     const loaders = {
       oxc: { esm: '@oxc-node/core/register', cjs: '@oxc-node/core/register' },
       swc: { esm: '@swc-node/register/esm-register', cjs: '@swc-node/register' },
       tsx: { esm: 'tsx/esm/api', cjs: 'tsx/cjs/api', cb: (tsx: any) => tsx.register({ tsconfig: configPath }) },
+      nub: { esm: '@nubjs/loader', cjs: '@nubjs/loader' },
       jiti: { cjs: 'jiti/register', cb: setEsmImportProvider },
       tsimp: { cjs: 'tsimp/import', cb: setEsmImportProvider },
     } as const;
@@ -366,6 +375,10 @@ export class CLIHelper {
     const errors: Error[] = [];
 
     for (const loader of Utils.keys(loaders)) {
+      if (loader === 'nub' && explicitLoader === 'auto') {
+        continue;
+      }
+
       if (explicitLoader !== 'auto' && loader !== explicitLoader) {
         continue;
       }
@@ -426,7 +439,7 @@ export class CLIHelper {
 export interface Settings {
   verbose?: boolean;
   preferTs?: boolean;
-  tsLoader?: 'oxc' | 'swc' | 'tsx' | 'jiti' | 'tsimp' | 'auto';
+  tsLoader?: 'oxc' | 'swc' | 'tsx' | 'nub' | 'jiti' | 'tsimp' | 'auto';
   tsConfigPath?: string;
   configPaths?: string[];
 }

--- a/packages/cli/src/CLIHelper.ts
+++ b/packages/cli/src/CLIHelper.ts
@@ -335,7 +335,7 @@ export class CLIHelper {
 
   /**
    * Tries to register TS support in the following order: oxc, swc, tsx, jiti, tsimp
-   * Use `MIKRO_ORM_CLI_TS_LOADER` env var to set the loader explicitly.
+   * Use `MIKRO_ORM_CLI_TS_LOADER` env var to set the loader explicitly, `nub` is available only that way.
    * This method is used only in CLI context.
    */
   static async registerTypeScriptSupport(
@@ -355,10 +355,7 @@ export class CLIHelper {
     const setEsmImportProvider = () => {
       return ((globalThis as any).dynamicImportProvider = (id: string) => import(id).then(mod => mod?.default ?? mod));
     };
-    if (
-      explicitLoader === 'nub' &&
-      fs.normalizePath(fs.absolutePath(configPath)) !== fs.normalizePath(fs.absolutePath('tsconfig.json'))
-    ) {
+    if (explicitLoader === 'nub' && fs.absolutePath(configPath) !== fs.absolutePath('tsconfig.json')) {
       throw new Error(
         'The `nub` loader does not support a custom tsconfig path. Use the project tsconfig.json or select another loader.',
       );
@@ -375,6 +372,7 @@ export class CLIHelper {
     const errors: Error[] = [];
 
     for (const loader of Utils.keys(loaders)) {
+      // nub is opt-in only, it is never part of the automatic detection
       if (loader === 'nub' && explicitLoader === 'auto') {
         continue;
       }

--- a/packages/cli/src/CLIHelper.ts
+++ b/packages/cli/src/CLIHelper.ts
@@ -334,8 +334,8 @@ export class CLIHelper {
   }
 
   /**
-   * Tries to register TS support in the following order: oxc, swc, tsx, jiti, tsimp
-   * Use `MIKRO_ORM_CLI_TS_LOADER` env var to set the loader explicitly, `nub` is available only that way.
+   * Tries to register TS support in the following order: oxc, swc, tsx, jiti, tsimp, nub
+   * Use `MIKRO_ORM_CLI_TS_LOADER` env var to set the loader explicitly.
    * This method is used only in CLI context.
    */
   static async registerTypeScriptSupport(
@@ -352,10 +352,11 @@ export class CLIHelper {
     process.env.MIKRO_ORM_CLI_ALWAYS_ALLOW_TS ??= '1';
 
     const explicitLoader = tsLoader ?? process.env.MIKRO_ORM_CLI_TS_LOADER ?? 'auto';
+    const usesDefaultTsConfig = fs.absolutePath(configPath) === fs.absolutePath('tsconfig.json');
     const setEsmImportProvider = () => {
       return ((globalThis as any).dynamicImportProvider = (id: string) => import(id).then(mod => mod?.default ?? mod));
     };
-    if (explicitLoader === 'nub' && fs.absolutePath(configPath) !== fs.absolutePath('tsconfig.json')) {
+    if (explicitLoader === 'nub' && !usesDefaultTsConfig) {
       throw new Error(
         'The `nub` loader does not support a custom tsconfig path. Use the project tsconfig.json or select another loader.',
       );
@@ -364,16 +365,15 @@ export class CLIHelper {
       oxc: { esm: '@oxc-node/core/register', cjs: '@oxc-node/core/register' },
       swc: { esm: '@swc-node/register/esm-register', cjs: '@swc-node/register' },
       tsx: { esm: 'tsx/esm/api', cjs: 'tsx/cjs/api', cb: (tsx: any) => tsx.register({ tsconfig: configPath }) },
-      nub: { esm: '@nubjs/loader', cjs: '@nubjs/loader' },
       jiti: { cjs: 'jiti/register', cb: setEsmImportProvider },
       tsimp: { cjs: 'tsimp/import', cb: setEsmImportProvider },
+      nub: { esm: '@nubjs/loader', cjs: '@nubjs/loader' },
     } as const;
 
     const errors: Error[] = [];
 
     for (const loader of Utils.keys(loaders)) {
-      // nub is opt-in only, it is never part of the automatic detection
-      if (loader === 'nub' && explicitLoader === 'auto') {
+      if (loader === 'nub' && explicitLoader === 'auto' && !usesDefaultTsConfig) {
         continue;
       }
 
@@ -413,9 +413,12 @@ export class CLIHelper {
       throw new Error(errors.map(e => e.message).join('\n'), { cause: errors[0] });
     }
 
+    const loadersMessage = usesDefaultTsConfig
+      ? '`oxc`, `swc`, `tsx`, `jiti`, `tsimp` nor `nub`'
+      : '`oxc`, `swc`, `tsx`, `jiti` nor `tsimp`';
     // eslint-disable-next-line no-console
     console.warn(
-      'Neither `oxc`, `swc`, `tsx`, `jiti` nor `tsimp` found in the project dependencies, support for working with TypeScript files might not work. To use `oxc`, install `@oxc-node/core`. To use `swc`, install both `@swc-node/register` and `@swc/core`.',
+      `Neither ${loadersMessage} found in the project dependencies, support for working with TypeScript files might not work. To use \`oxc\`, install \`@oxc-node/core\`. To use \`swc\`, install both \`@swc-node/register\` and \`@swc/core\`.`,
     );
 
     return false;

--- a/packages/core/src/utils/Utils.ts
+++ b/packages/core/src/utils/Utils.ts
@@ -793,7 +793,8 @@ export class Utils {
           arg.includes('ts-node') || // check for ts-node loader
           arg.includes('@swc-node/register') || // check for swc-node/register loader
           arg.includes('node_modules/tsx/') || // check for tsx loader
-          arg.includes('@oxc-node/core') // check for oxc-node loader
+          arg.includes('@oxc-node/core') || // check for oxc-node loader
+          arg.includes('@nubjs/loader') // check for Nub loader
         );
       })
     );

--- a/tests/features/cli/CLIHelper.test.ts
+++ b/tests/features/cli/CLIHelper.test.ts
@@ -228,6 +228,9 @@ describe('CLIHelper', () => {
     expect(warnSpy).toHaveBeenCalledWith(
       expect.stringContaining('Neither `oxc`, `swc`, `tsx`, `jiti` nor `tsimp` found'),
     );
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('The `nub` loader was skipped as a custom tsconfig path is configured.'),
+    );
     delete pkg['mikro-orm'].tsConfigPath;
     pkg['mikro-orm'].preferTs = false;
   });
@@ -299,7 +302,7 @@ describe('CLIHelper', () => {
     const argv = process.argv;
     const execArgv = process.execArgv;
     process.argv = ['node', 'cli.js'];
-    // these all short-circuit the detection before the `execArgv` check
+    // clear the vars that would short-circuit the detection before the `execArgv` check
     vi.stubEnv('VITEST', '');
     vi.stubEnv('TS_JEST', '');
     vi.stubEnv('MIKRO_ORM_CLI_ALWAYS_ALLOW_TS', '');

--- a/tests/features/cli/CLIHelper.test.ts
+++ b/tests/features/cli/CLIHelper.test.ts
@@ -117,9 +117,9 @@ describe('CLIHelper', () => {
     ['oxc', '@oxc-node/core/register'],
     ['swc', '@swc-node/register/esm-register'],
     ['tsx', 'tsx/esm/api'],
-    ['nub', '@nubjs/loader'],
     ['jiti', 'jiti/register'],
     ['tsimp', 'tsimp/import'],
+    ['nub', '@nubjs/loader'],
   ] as const)('configures CLI instance with TS support [%s]', async (loader, module) => {
     pathExistsMock.mockImplementation(path => (path as string).endsWith('package.json'));
     pkg['mikro-orm'].preferTs = true;

--- a/tests/features/cli/CLIHelper.test.ts
+++ b/tests/features/cli/CLIHelper.test.ts
@@ -159,6 +159,7 @@ describe('CLIHelper', () => {
     expect(cli.$0).toBe('mikro-orm');
     expect(tryImportMock).toHaveBeenCalledTimes(2);
     expect(tryImportMock).toHaveBeenCalledWith({ module: '@swc-node/register/esm-register' });
+    delete pkg['mikro-orm'].tsConfigPath;
     pkg['mikro-orm'].preferTs = false;
   });
 
@@ -169,19 +170,20 @@ describe('CLIHelper', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(i => i);
     const cli = (await configure()) as any;
     expect(cli.$0).toBe('mikro-orm');
-    expect(tryImportMock).toHaveBeenCalledTimes(5);
+    expect(tryImportMock).toHaveBeenCalledTimes(6);
     expect(tryImportMock).toHaveBeenCalledWith({ module: '@oxc-node/core/register' });
     expect(tryImportMock).toHaveBeenCalledWith({ module: '@swc-node/register/esm-register' });
     expect(tryImportMock).toHaveBeenCalledWith({ module: 'tsx/esm/api' });
     expect(tryImportMock).toHaveBeenCalledWith({ module: 'jiti/register' });
     expect(tryImportMock).toHaveBeenCalledWith({ module: 'tsimp/import' });
+    expect(tryImportMock).toHaveBeenCalledWith({ module: '@nubjs/loader' });
     const warning =
-      'Neither `oxc`, `swc`, `tsx`, `jiti` nor `tsimp` found in the project dependencies, support for working with TypeScript files might not work. To use `oxc`, install `@oxc-node/core`. To use `swc`, install both `@swc-node/register` and `@swc/core`.';
+      'Neither `oxc`, `swc`, `tsx`, `jiti`, `tsimp` nor `nub` found in the project dependencies, support for working with TypeScript files might not work. To use `oxc`, install `@oxc-node/core`. To use `swc`, install both `@swc-node/register` and `@swc/core`.';
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining(warning));
     pkg['mikro-orm'].preferTs = false;
   });
 
-  test('does not select the Nub loader automatically', async () => {
+  test('selects the Nub loader as the final automatic fallback', async () => {
     pathExistsMock.mockReturnValue(true);
     pkg['mikro-orm'].preferTs = true;
     tryImportMock.mockImplementation(({ module: id }) => (id === '@nubjs/loader' ? {} : undefined));
@@ -189,8 +191,44 @@ describe('CLIHelper', () => {
 
     await configure();
 
+    expect(tryImportMock).toHaveBeenCalledTimes(6);
+    expect(tryImportMock).toHaveBeenLastCalledWith({ module: '@nubjs/loader' });
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(process.env.MIKRO_ORM_CLI_TS_LOADER).toBe('nub');
+    pkg['mikro-orm'].preferTs = false;
+  });
+
+  test('keeps existing loaders ahead of the Nub automatic fallback', async () => {
+    pathExistsMock.mockReturnValue(true);
+    pkg['mikro-orm'].preferTs = true;
+    tryImportMock.mockImplementation(({ module: id }) =>
+      id === '@oxc-node/core/register' || id === '@nubjs/loader' ? {} : undefined,
+    );
+
+    await configure();
+
+    expect(tryImportMock).toHaveBeenCalledTimes(1);
+    expect(tryImportMock).toHaveBeenCalledWith({ module: '@oxc-node/core/register' });
     expect(tryImportMock).not.toHaveBeenCalledWith({ module: '@nubjs/loader' });
-    expect(warnSpy).toHaveBeenCalled();
+    expect(process.env.MIKRO_ORM_CLI_TS_LOADER).toBe('oxc');
+    pkg['mikro-orm'].preferTs = false;
+  });
+
+  test('skips the Nub automatic fallback with a custom tsconfig path', async () => {
+    pathExistsMock.mockReturnValue(true);
+    pkg['mikro-orm'].preferTs = true;
+    pkg['mikro-orm'].tsConfigPath = './tsconfig.cli.json';
+    tryImportMock.mockImplementation(({ module: id }) => (id === '@nubjs/loader' ? {} : undefined));
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(i => i);
+
+    await configure();
+
+    expect(tryImportMock).toHaveBeenCalledTimes(5);
+    expect(tryImportMock).not.toHaveBeenCalledWith({ module: '@nubjs/loader' });
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Neither `oxc`, `swc`, `tsx`, `jiti` nor `tsimp` found'),
+    );
+    delete pkg['mikro-orm'].tsConfigPath;
     pkg['mikro-orm'].preferTs = false;
   });
 

--- a/tests/features/cli/CLIHelper.test.ts
+++ b/tests/features/cli/CLIHelper.test.ts
@@ -117,6 +117,7 @@ describe('CLIHelper', () => {
     ['oxc', '@oxc-node/core/register'],
     ['swc', '@swc-node/register/esm-register'],
     ['tsx', 'tsx/esm/api'],
+    ['nub', '@nubjs/loader'],
     ['jiti', 'jiti/register'],
     ['tsimp', 'tsimp/import'],
   ] as const)('configures CLI instance with TS support [%s]', async (loader, module) => {
@@ -180,6 +181,19 @@ describe('CLIHelper', () => {
     pkg['mikro-orm'].preferTs = false;
   });
 
+  test('does not select the Nub loader automatically', async () => {
+    pathExistsMock.mockReturnValue(true);
+    pkg['mikro-orm'].preferTs = true;
+    tryImportMock.mockImplementation(({ module: id }) => (id === '@nubjs/loader' ? {} : undefined));
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(i => i);
+
+    await configure();
+
+    expect(tryImportMock).not.toHaveBeenCalledWith({ module: '@nubjs/loader' });
+    expect(warnSpy).toHaveBeenCalled();
+    pkg['mikro-orm'].preferTs = false;
+  });
+
   test('reports the real error when a TS loader is installed but fails to load', async () => {
     pathExistsMock.mockReturnValue(true);
     pkg['mikro-orm'].preferTs = true;
@@ -231,6 +245,37 @@ describe('CLIHelper', () => {
     expect(tryImportMock).toHaveBeenCalledTimes(1);
     delete pkg['mikro-orm'].tsLoader;
     pkg['mikro-orm'].preferTs = false;
+  });
+
+  test.each(['./tsconfig.json', process.cwd() + '/tsconfig.json'])(
+    'accepts the default tsconfig path for the Nub loader [%s]',
+    async configPath => {
+      tryImportMock.mockReturnValueOnce({});
+
+      await expect(CLIHelper.registerTypeScriptSupport(configPath, 'nub')).resolves.toBe(true);
+      expect(tryImportMock).toHaveBeenCalledWith({ module: '@nubjs/loader' });
+    },
+  );
+
+  test('detects a preloaded Nub loader', () => {
+    const argv = process.argv;
+    const execArgv = process.execArgv;
+    process.argv = ['node', 'cli.js'];
+    process.execArgv = ['--import', '@nubjs/loader'];
+
+    try {
+      expect(Utils.detectTypeScriptSupport()).toBe(true);
+    } finally {
+      process.argv = argv;
+      process.execArgv = execArgv;
+    }
+  });
+
+  test('rejects the Nub loader when a different tsconfig path is configured', async () => {
+    await expect(CLIHelper.registerTypeScriptSupport('./tsconfig.cli.json', 'nub')).rejects.toThrow(
+      'The `nub` loader does not support a custom tsconfig path. Use the project tsconfig.json or select another loader.',
+    );
+    expect(tryImportMock).not.toHaveBeenCalled();
   });
 
   test('configures yargs instance [swc and ts-paths] without baseUrl', async () => {

--- a/tests/features/cli/CLIHelper.test.ts
+++ b/tests/features/cli/CLIHelper.test.ts
@@ -261,11 +261,19 @@ describe('CLIHelper', () => {
     const argv = process.argv;
     const execArgv = process.execArgv;
     process.argv = ['node', 'cli.js'];
-    process.execArgv = ['--import', '@nubjs/loader'];
+    // these all short-circuit the detection before the `execArgv` check
+    vi.stubEnv('VITEST', '');
+    vi.stubEnv('TS_JEST', '');
+    vi.stubEnv('MIKRO_ORM_CLI_ALWAYS_ALLOW_TS', '');
 
     try {
+      process.execArgv = ['--import', '@nubjs/loader'];
       expect(Utils.detectTypeScriptSupport()).toBe(true);
+
+      process.execArgv = ['--import', '@some/other-loader'];
+      expect(Utils.detectTypeScriptSupport()).toBe(false);
     } finally {
+      vi.unstubAllEnvs();
       process.argv = argv;
       process.execArgv = execArgv;
     }


### PR DESCRIPTION
Adds `@nubjs/loader` as a CLI TypeScript loader.

It runs last in the automatic selection, and only when the project `tsconfig.json` is used, since Nub discovers the tsconfig on its own and cannot be pointed at a custom path. Selecting it explicitly together with a custom tsconfig path throws.