### PR TITLE
ci: reset the working tree between publish retries

### DIFF
--- a/scripts/publish-with-retry.sh
+++ b/scripts/publish-with-retry.sh
@@ -8,6 +8,7 @@ set -uo pipefail
 
 attempts=${PUBLISH_ATTEMPTS:-3}
 delay=${PUBLISH_RETRY_DELAY:-30}
+root=$(git rev-parse --show-toplevel)
 
 for i in $(seq 1 "$attempts"); do
   if "$@"; then
@@ -15,6 +16,10 @@ for i in $(seq 1 "$attempts"); do
   fi
 
   if [ "$i" -lt "$attempts" ]; then
+    # lerna rewrites the package.json files while packing and only restores them when the
+    # publish completes, so a failed attempt leaves the tree dirty and the next one would
+    # bail out with EUNCOMMIT before it even starts
+    git -C "$root" checkout -- .
     echo "::warning::publish attempt $i/$attempts failed, retrying in ${delay}s"
     sleep "$delay"
   fi


### PR DESCRIPTION
The retry added in #8250 never had a chance to work. `lerna publish` rewrites the `package.json` files while packing and restores them only when the publish completes, so a failed attempt leaves the tree dirty. Attempts 2 and 3 then bail out with `EUNCOMMIT` listing all 20 packages, before they even talk to the registry.

Restoring the tracked files before each retry fixes that. `dist` is untracked, so the built contents are left alone.

Seen in [this run](https://github.com/mikro-orm/mikro-orm/actions/runs/33996458442/job/101387749687), where the sigstore 409 hit `@mikro-orm/core`, `@mikro-orm/decorators` and `@mikro-orm/knex-compat`. Those three are still missing from npm for `7.2.0-dev.21`.
