### PR TITLE
docs: fix wrong default propagation claim for em.transactional in upgrade guide

### DIFF
--- a/docs/docs/upgrading-v6-to-v7.md
+++ b/docs/docs/upgrading-v6-to-v7.md
@@ -434,7 +434,7 @@ The mechanism for processing serialized primary keys in MongoDB driver has chang
 
 ## Default propagation in `@Transactional` is `REQUIRED`
 
-The default [propagation mode](./transactions.md#transaction-propagation) of the `@Transactional` decorator is now `REQUIRED`, which means that if there is an ongoing transaction, the decorated method will join it; otherwise, a new transaction will be started. The previous default was `REQUIRES_NEW`, which always started a new transaction. `REQUIRES_NEW` remains the default for the `em.transactional` method.
+The default [propagation mode](./transactions.md#transaction-propagation) of the `@Transactional` decorator is now `REQUIRED`, which means that if there is an ongoing transaction, the decorated method will join it; otherwise, a new transaction will be started. The previous default was `REQUIRES_NEW`, which always started a new transaction. `NESTED` remains the default for the `em.transactional` method, which creates a savepoint when a transaction is already active.
 
 ## `dataloader` dependency
 

--- a/docs/versioned_docs/version-7.0/upgrading-v6-to-v7.md
+++ b/docs/versioned_docs/version-7.0/upgrading-v6-to-v7.md
@@ -452,7 +452,7 @@ The mechanism for processing serialized primary keys in MongoDB driver has chang
 
 ## Default propagation in `@Transactional` is `REQUIRED`
 
-The default [propagation mode](./transactions.md#transaction-propagation) of the `@Transactional` decorator is now `REQUIRED`, which means that if there is an ongoing transaction, the decorated method will join it; otherwise, a new transaction will be started. The previous default was `REQUIRES_NEW`, which always started a new transaction. `REQUIRES_NEW` remains the default for the `em.transactional` method.
+The default [propagation mode](./transactions.md#transaction-propagation) of the `@Transactional` decorator is now `REQUIRED`, which means that if there is an ongoing transaction, the decorated method will join it; otherwise, a new transaction will be started. The previous default was `REQUIRES_NEW`, which always started a new transaction. `NESTED` remains the default for the `em.transactional` method, which creates a savepoint when a transaction is already active.
 
 ## `dataloader` dependency
 

--- a/docs/versioned_docs/version-7.1/upgrading-v6-to-v7.md
+++ b/docs/versioned_docs/version-7.1/upgrading-v6-to-v7.md
@@ -452,7 +452,7 @@ The mechanism for processing serialized primary keys in MongoDB driver has chang
 
 ## Default propagation in `@Transactional` is `REQUIRED`
 
-The default [propagation mode](./transactions.md#transaction-propagation) of the `@Transactional` decorator is now `REQUIRED`, which means that if there is an ongoing transaction, the decorated method will join it; otherwise, a new transaction will be started. The previous default was `REQUIRES_NEW`, which always started a new transaction. `REQUIRES_NEW` remains the default for the `em.transactional` method.
+The default [propagation mode](./transactions.md#transaction-propagation) of the `@Transactional` decorator is now `REQUIRED`, which means that if there is an ongoing transaction, the decorated method will join it; otherwise, a new transaction will be started. The previous default was `REQUIRES_NEW`, which always started a new transaction. `NESTED` remains the default for the `em.transactional` method, which creates a savepoint when a transaction is already active.
 
 ## `dataloader` dependency
 

--- a/docs/versioned_docs/version-7.2/upgrading-v6-to-v7.md
+++ b/docs/versioned_docs/version-7.2/upgrading-v6-to-v7.md
@@ -434,7 +434,7 @@ The mechanism for processing serialized primary keys in MongoDB driver has chang
 
 ## Default propagation in `@Transactional` is `REQUIRED`
 
-The default [propagation mode](./transactions.md#transaction-propagation) of the `@Transactional` decorator is now `REQUIRED`, which means that if there is an ongoing transaction, the decorated method will join it; otherwise, a new transaction will be started. The previous default was `REQUIRES_NEW`, which always started a new transaction. `REQUIRES_NEW` remains the default for the `em.transactional` method.
+The default [propagation mode](./transactions.md#transaction-propagation) of the `@Transactional` decorator is now `REQUIRED`, which means that if there is an ongoing transaction, the decorated method will join it; otherwise, a new transaction will be started. The previous default was `REQUIRES_NEW`, which always started a new transaction. `NESTED` remains the default for the `em.transactional` method, which creates a savepoint when a transaction is already active.
 
 ## `dataloader` dependency
 


### PR DESCRIPTION
Closes #8258

The upgrade guide's "Default propagation in `@Transactional` is `REQUIRED`" section says:

> `REQUIRES_NEW` remains the default for the `em.transactional` method.

That's wrong. The Transactions page says `NESTED` is the default for `em.transactional`, and the code backs that up:

- `em.transactional()` calls `TransactionManager.handle()`, which does `options.propagation ??= TransactionPropagation.NESTED` (`packages/core/src/utils/TransactionManager.ts:23`) — there's no other path.
- `EntityManager.transactional()`'s JSDoc already says a savepoint is created by default when nesting.
- `transaction-propagation.sqlite.test.ts` has a test asserting that nesting produces a `SAVEPOINT`.

Same wrong sentence appears in both `docs/docs/upgrading-v6-to-v7.md` and the `version-7.2` snapshot, so both are fixed here.

New wording, matching how the Transactions page already phrases it:

> `NESTED` remains the default for the `em.transactional` method, which creates a savepoint when a transaction is already active.