### PR TITLE
chore(ci): enable corepack before setup-node and drop the double setup-node workaround

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,23 +21,15 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0 # needed for the last update time
-      - name: Use Node.js 22
+      # corepack must be enabled before setup-node so its yarn cache step can find yarn
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Use Node.js 24
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           token: ${{ secrets.GH_TOKEN }}
-          package-manager-cache: false
-
-      - name: Enable corepack
-        run: |
-          corepack enable
-          corepack prepare yarn@stable --activate
-
-      # Yarn dependencies cannot be cached until yarn is installed
-      # WORKAROUND: https://github.com/actions/setup-node/issues/531
-      - name: Extract cached dependencies
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
           cache: yarn
 
       - name: Install
@@ -47,11 +39,6 @@ jobs:
         run: |
           git config --global user.name "Martin Adámek"
           git config --global user.email "banan23@gmail.com"
-
-      - name: Install
-        run: |
-          corepack prepare yarn@stable --activate
-          yarn
 
       - name: Build docs
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,17 +66,12 @@ jobs:
           ref: ${{ inputs.ref }}
           token: ${{ secrets.GH_TOKEN }}
 
+      # corepack must be enabled before setup-node so its yarn cache step can find yarn
+      - run: corepack enable
+
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
-          package-manager-cache: false
-
-      - run: |
-          corepack enable
-          corepack prepare yarn@stable --activate
-
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
           cache: yarn
           registry-url: 'https://registry.npmjs.org'
           always-auth: false
@@ -133,17 +128,12 @@ jobs:
           ref: ${{ inputs.ref }}
           token: ${{ secrets.GH_TOKEN }}
 
+      # corepack must be enabled before setup-node so its yarn cache step can find yarn
+      - run: corepack enable
+
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
-          package-manager-cache: false
-
-      - run: |
-          corepack enable
-          corepack prepare yarn@stable --activate
-
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
           cache: yarn
           registry-url: 'https://registry.npmjs.org'
           always-auth: false
@@ -188,20 +178,14 @@ jobs:
           ref: ${{ inputs.ref }}
           token: ${{ secrets.GH_TOKEN }}
 
+      # corepack must be enabled before setup-node so its yarn cache step can find yarn
+      - name: Enable corepack
+        run: corepack enable
+
       - name: Use Node.js 24
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
-          package-manager-cache: false
-
-      - name: Enable corepack
-        run: |
-          corepack enable
-          corepack prepare yarn@stable --activate
-
-      - name: Activate cache for Node.js 24
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
           cache: yarn
           cache-dependency-path: docs/yarn.lock
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,22 +19,14 @@ jobs:
       - name: Checkout Source code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Use Node.js 22
+      # corepack must be enabled before setup-node so its yarn cache step can find yarn
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Use Node.js 24
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
-          package-manager-cache: false
-
-      - name: Enable corepack
-        run: |
-          corepack enable
-          corepack prepare yarn@stable --activate
-
-      # Yarn dependencies cannot be cached until yarn is installed
-      # WORKAROUND: https://github.com/actions/setup-node/issues/531
-      - name: Extract cached dependencies
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
           cache: yarn
 
       - name: Install
@@ -54,22 +46,14 @@ jobs:
       - name: Checkout Source code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Use Node.js 22
+      # corepack must be enabled before setup-node so its yarn cache step can find yarn
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Use Node.js 24
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
-          package-manager-cache: false
-
-      - name: Enable corepack
-        run: |
-          corepack enable
-          corepack prepare yarn@stable --activate
-
-      # Yarn dependencies cannot be cached until yarn is installed
-      # WORKAROUND: https://github.com/actions/setup-node/issues/531
-      - name: Extract cached dependencies
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
           cache: yarn
 
       - name: Install
@@ -100,22 +84,14 @@ jobs:
       - name: Checkout Source code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Use Node.js 22
+      # corepack must be enabled before setup-node so its yarn cache step can find yarn
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Use Node.js 24
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
-          package-manager-cache: false
-
-      - name: Enable corepack
-        run: |
-          corepack enable
-          corepack prepare yarn@stable --activate
-
-      # Yarn dependencies cannot be cached until yarn is installed
-      # WORKAROUND: https://github.com/actions/setup-node/issues/531
-      - name: Extract cached dependencies
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
           cache: yarn
 
       - name: Install
@@ -141,23 +117,16 @@ jobs:
       - name: Checkout Source code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: ${{ matrix.node-version }}
-          package-manager-cache: false
-
+      # corepack must be enabled before setup-node so its yarn cache step can find yarn
       - name: Enable corepack
         run: |
           npm install -g corepack@latest --force
           corepack enable
-          corepack prepare yarn@stable --activate
 
-      # Yarn dependencies cannot be cached until yarn is installed
-      # WORKAROUND: https://github.com/actions/setup-node/issues/531
-      - name: Extract cached dependencies
+      - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
+          node-version: ${{ matrix.node-version }}
           cache: yarn
 
       - name: Install & pull docker images
@@ -258,22 +227,14 @@ jobs:
       - name: Checkout Source code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      # corepack must be enabled before setup-node so its yarn cache step can find yarn
+      - name: Enable corepack
+        run: corepack enable
+
       - name: Use Node.js 24
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
-          package-manager-cache: false
-
-      - name: Enable corepack
-        run: |
-          corepack enable
-          corepack prepare yarn@stable --activate
-
-      # Yarn dependencies cannot be cached until yarn is installed
-      # WORKAROUND: https://github.com/actions/setup-node/issues/531
-      - name: Extract cached dependencies
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
           cache: yarn
 
       - name: Install
@@ -290,22 +251,14 @@ jobs:
       - name: Checkout Source code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      # corepack must be enabled before setup-node so its yarn cache step can find yarn
+      - name: Enable corepack
+        run: corepack enable
+
       - name: Use Node.js 24
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
-          package-manager-cache: false
-
-      - name: Enable corepack
-        run: |
-          corepack enable
-          corepack prepare yarn@stable --activate
-
-      # Yarn dependencies cannot be cached until yarn is installed
-      # WORKAROUND: https://github.com/actions/setup-node/issues/531
-      - name: Extract cached dependencies
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
           cache: yarn
 
       - name: Install
@@ -336,9 +289,10 @@ jobs:
         run: |
           npm install -g corepack@latest --force
           corepack enable
-          corepack prepare yarn@stable --activate
 
-      # Yarn dependencies cannot be cached until yarn is installed
+      # Yarn dependencies cannot be cached until yarn is installed, and unlike the linux jobs
+      # we cannot enable corepack before setup-node here: corepack's windows shim hardcodes
+      # the node.exe next to it, so yarn (and the tests) would run on the preinstalled node.
       # WORKAROUND: https://github.com/actions/setup-node/issues/531
       - name: Extract cached dependencies
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -359,22 +313,14 @@ jobs:
       - name: Checkout Source code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      # corepack must be enabled before setup-node so its yarn cache step can find yarn
+      - name: Enable corepack
+        run: corepack enable
+
       - name: Use Node.js 24
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
-          package-manager-cache: false
-
-      - name: Enable corepack
-        run: |
-          corepack enable
-          corepack prepare yarn@stable --activate
-
-      # Yarn dependencies cannot be cached until yarn is installed
-      # WORKAROUND: https://github.com/actions/setup-node/issues/531
-      - name: Extract cached dependencies
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
           cache: yarn
 
       - name: Install & build & pull docker images


### PR DESCRIPTION
setup-node v7 can cache yarn as long as the `yarn` shim exists when the action runs. Enabling corepack first lets one setup-node step install node and restore the cache (see https://github.com/actions/setup-node/issues/531#issuecomment-5399619713), so the second "Extract cached dependencies" step is gone from every linux job in the tests, docs and release workflows.

Also removed:

- `corepack prepare yarn@stable --activate`, which did nothing since `packageManager` pins yarn in both root and `docs/`
- a duplicated install step in the docs workflow

The windows job keeps the two-step workaround. corepack's windows shim hardcodes the `node.exe` next to it, so enabling corepack before setup-node would run yarn and the tests on the preinstalled node rather than the matrix version.
