### PR TITLE
fix(core): keep populated relations clean after a result cache hit

### DIFF
--- a/packages/core/src/entity/EntityFactory.ts
+++ b/packages/core/src/entity/EntityFactory.ts
@@ -539,35 +539,33 @@ export class EntityFactory {
     const recomputeSnapshot = this.#recomputeSnapshot;
     this.#recomputeSnapshot = !!options.recomputeSnapshot;
 
-    try {
-      if (options.initialized) {
-        this.#hydrator.hydrate(
-          entity,
-          meta,
-          data,
-          this,
-          'full',
-          options.newEntity,
-          options.convertCustomTypes,
-          options.schema,
-          this.#driver.getSchemaName(meta, options),
-          options.normalizeAccessors,
-        );
-      } else {
-        this.#hydrator.hydrateReference(
-          entity,
-          meta,
-          data,
-          this,
-          options.convertCustomTypes,
-          options.schema,
-          this.#driver.getSchemaName(meta, options),
-          options.normalizeAccessors,
-        );
-      }
-    } finally {
-      this.#recomputeSnapshot = recomputeSnapshot;
+    if (options.initialized) {
+      this.#hydrator.hydrate(
+        entity,
+        meta,
+        data,
+        this,
+        'full',
+        options.newEntity,
+        options.convertCustomTypes,
+        options.schema,
+        this.#driver.getSchemaName(meta, options),
+        options.normalizeAccessors,
+      );
+    } else {
+      this.#hydrator.hydrateReference(
+        entity,
+        meta,
+        data,
+        this,
+        options.convertCustomTypes,
+        options.schema,
+        this.#driver.getSchemaName(meta, options),
+        options.normalizeAccessors,
+      );
     }
+
+    this.#recomputeSnapshot = recomputeSnapshot;
 
     Utils.keys(data).forEach(key => {
       helper(entity)?.__loadedProperties.add(key);

--- a/packages/core/src/entity/EntityFactory.ts
+++ b/packages/core/src/entity/EntityFactory.ts
@@ -69,6 +69,7 @@ export class EntityFactory {
   readonly #eventManager: EventManager;
   readonly #comparator: EntityComparator;
   readonly #em: EntityManager;
+  #recomputeSnapshot = false;
 
   constructor(em: EntityManager) {
     this.#em = em;
@@ -89,6 +90,8 @@ export class EntityFactory {
   ): New<T, P> {
     data = Reference.unwrapReference(data as T);
     options.initialized ??= true;
+    // nested relations created by the hydrator need the same DB-form snapshot as the root (GH #8268)
+    options.recomputeSnapshot ??= this.#recomputeSnapshot;
 
     if (EntityHelper.isEntity(data)) {
       return data as New<T, P>;
@@ -533,30 +536,37 @@ export class EntityFactory {
     data: EntityData<T>,
     options: FactoryOptions,
   ): void {
-    if (options.initialized) {
-      this.#hydrator.hydrate(
-        entity,
-        meta,
-        data,
-        this,
-        'full',
-        options.newEntity,
-        options.convertCustomTypes,
-        options.schema,
-        this.#driver.getSchemaName(meta, options),
-        options.normalizeAccessors,
-      );
-    } else {
-      this.#hydrator.hydrateReference(
-        entity,
-        meta,
-        data,
-        this,
-        options.convertCustomTypes,
-        options.schema,
-        this.#driver.getSchemaName(meta, options),
-        options.normalizeAccessors,
-      );
+    const recomputeSnapshot = this.#recomputeSnapshot;
+    this.#recomputeSnapshot = !!options.recomputeSnapshot;
+
+    try {
+      if (options.initialized) {
+        this.#hydrator.hydrate(
+          entity,
+          meta,
+          data,
+          this,
+          'full',
+          options.newEntity,
+          options.convertCustomTypes,
+          options.schema,
+          this.#driver.getSchemaName(meta, options),
+          options.normalizeAccessors,
+        );
+      } else {
+        this.#hydrator.hydrateReference(
+          entity,
+          meta,
+          data,
+          this,
+          options.convertCustomTypes,
+          options.schema,
+          this.#driver.getSchemaName(meta, options),
+          options.normalizeAccessors,
+        );
+      }
+    } finally {
+      this.#recomputeSnapshot = recomputeSnapshot;
     }
 
     Utils.keys(data).forEach(key => {

--- a/tests/issues/GH8268.test.ts
+++ b/tests/issues/GH8268.test.ts
@@ -1,0 +1,54 @@
+import { MikroORM, Ref } from '@mikro-orm/sqlite';
+import { Entity, OneToOne, PrimaryKey, Property } from '@mikro-orm/decorators/legacy';
+
+@Entity()
+class Child {
+  @PrimaryKey({ type: 'number' })
+  id!: number;
+
+  @Property({ type: 'string' })
+  name!: string;
+
+  @Property({ type: 'json' })
+  payload!: Record<string, unknown>;
+}
+
+@Entity()
+class Parent {
+  @PrimaryKey({ type: 'number' })
+  id!: number;
+
+  @Property({ type: 'string' })
+  name!: string;
+
+  @OneToOne(() => Child, { ref: true })
+  child!: Ref<Child>;
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    entities: [Parent, Child],
+    dbName: ':memory:',
+  });
+  await orm.schema.create();
+});
+
+afterAll(() => orm.close(true));
+
+test('result cache hit does not mark populated relations dirty', async () => {
+  const em0 = orm.em.fork();
+  const child = em0.create(Child, { id: 1, name: 'child', payload: { a: 1, b: { c: 2 } } });
+  em0.create(Parent, { id: 1, name: 'parent', child });
+  await em0.flush();
+
+  const emA = orm.em.fork();
+  await emA.findOne(Parent, 1, { populate: ['child'], cache: 1000 });
+
+  const emB = orm.em.fork();
+  await emB.findOne(Parent, 1, { populate: ['child'], cache: 1000 });
+
+  emB.getUnitOfWork().computeChangeSets();
+  expect(emB.getUnitOfWork().getChangeSets()).toHaveLength(0);
+});


### PR DESCRIPTION
Since 6.6.6 a result cache hit recreates the root entity with `recomputeSnapshot: true`, but populated relations are built by the compiled hydrator through nested `factory.create()` calls that never got the flag. Their snapshot stayed in JS form (a JSON object) while the comparator compares against the DB form (a JSON string), so the next `flush()` wrote a spurious `UPDATE` of json columns with nothing modified.

The factory now propagates `recomputeSnapshot` to nested creates while the root entity is being hydrated, so the whole cached graph ends up with a DB-form snapshot.

Closes #8268
