### PR TITLE
fix(sql): select inline embeddable columns once when populating via joins

### DIFF
--- a/packages/sql/src/AbstractSqlDriver.ts
+++ b/packages/sql/src/AbstractSqlDriver.ts
@@ -2606,6 +2606,8 @@ export abstract class AbstractSqlDriver<
     if (options.parentJoinPath) {
       // alias all fields in the primary table
       meta.props
+        // flattened children of inline embeddables are expanded via their parent, iterating them too would select the columns twice
+        .filter(prop => !prop.embedded)
         .filter(prop => this.shouldHaveColumn(meta, prop, populate, options.explicitFields, options.exclude))
         .forEach(prop =>
           fields.push(
@@ -2816,7 +2818,7 @@ export abstract class AbstractSqlDriver<
       // Add fields from this child (only ownProps, skip PKs)
       const schema = childMeta.schema === '*' ? '*' : this.getSchemaName(childMeta);
       childMeta
-        .ownProps!.filter(p => !p.primary && this.platform.shouldHaveColumn(p, []))
+        .ownProps!.filter(p => !p.primary && !p.embedded && this.platform.shouldHaveColumn(p, []))
         .forEach(prop =>
           fields.push(...(this.mapPropToFieldNames(qb, prop, childAlias, childMeta, schema) as InternalField<T>[])),
         );

--- a/tests/features/table-per-type-inheritance/embedded-json-in-tpt-child.test.ts
+++ b/tests/features/table-per-type-inheritance/embedded-json-in-tpt-child.test.ts
@@ -1,0 +1,70 @@
+import { MikroORM, ref, type Ref } from '@mikro-orm/sqlite';
+import {
+  Embeddable,
+  Embedded,
+  Entity,
+  ManyToOne,
+  PrimaryKey,
+  Property,
+  ReflectMetadataProvider,
+} from '@mikro-orm/decorators/legacy';
+import { mockLogger } from '../../helpers.js';
+
+@Embeddable()
+class Meta {
+  @Property()
+  a!: string;
+
+  @Property({ type: 'json' })
+  b!: any;
+}
+
+@Entity({ inheritance: 'tpt' })
+class Animal {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  name!: string;
+}
+
+@Entity()
+class Dog extends Animal {
+  @Embedded(() => Meta)
+  meta!: Meta;
+}
+
+@Entity()
+class Owner {
+  @PrimaryKey()
+  id!: number;
+
+  @ManyToOne(() => Animal, { ref: true })
+  pet!: Ref<Animal>;
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    entities: [Owner, Animal, Dog, Meta],
+    dbName: ':memory:',
+    metadataProvider: ReflectMetadataProvider,
+  });
+  await orm.schema.create();
+  const dog = orm.em.create(Dog, { id: 1, name: 'rex', meta: { a: 'x', b: { y: 1 } } });
+  orm.em.create(Owner, { id: 1, pet: ref(dog) });
+  await orm.em.flush();
+  orm.em.clear();
+});
+
+afterAll(() => orm.close(true));
+
+test('embedded columns of a TPT child are selected once when populating the base relation', async () => {
+  const mock = mockLogger(orm);
+  const owners = await orm.em.fork().find(Owner, {}, { populate: ['pet'] });
+  expect((owners[0].pet.$ as Dog).meta).toEqual({ a: 'x', b: { y: 1 } });
+  expect(mock.mock.calls[0][0]).toMatch(
+    "select `o0`.*, `d2`.`meta_a` as `d2__meta_a`, `d2`.`meta_b` as `d2__meta_b`, case when `d2`.`id` is not null then 'dog' else 'animal' end as `p1____tpt_type`, `p1`.`id` as `p1__id`, `p1`.`name` as `p1__name` from `owner` as `o0` inner join `animal` as `p1` on `o0`.`pet_id` = `p1`.`id` left join `dog` as `d2` on `p1`.`id` = `d2`.`id`",
+  );
+});

--- a/tests/issues/GH8271.test.ts
+++ b/tests/issues/GH8271.test.ts
@@ -1,0 +1,67 @@
+import { defineEntity, p } from '@mikro-orm/core';
+import { MikroORM } from '@mikro-orm/sqlite';
+import { mockLogger } from '../helpers.js';
+
+const Meta = defineEntity({
+  name: 'Meta',
+  embeddable: true,
+  properties: {
+    a: p.string(),
+    b: p.json(),
+  },
+});
+
+const Group = defineEntity({
+  name: 'Group',
+  properties: {
+    id: p.integer().primary(),
+    meta: p.embedded(Meta),
+    lazyMeta: p.embedded(Meta).lazy(),
+  },
+});
+
+const User = defineEntity({
+  name: 'User',
+  properties: {
+    id: p.integer().primary(),
+    name: p.string(),
+    group: p.manyToOne(Group).ref(),
+  },
+});
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    entities: [User, Group, Meta],
+    dbName: ':memory:',
+  });
+  await orm.schema.create();
+  orm.em.create(User, {
+    id: 1,
+    name: 'john',
+    group: { id: 1, meta: { a: 'x', b: { y: 1 } }, lazyMeta: { a: 'z', b: { y: 2 } } },
+  });
+  await orm.em.flush();
+  orm.em.clear();
+});
+
+afterAll(() => orm.close(true));
+
+test('GH #8271 embedded columns are selected once when populating via join, lazy embeddables are skipped', async () => {
+  const mock = mockLogger(orm);
+  const em = orm.em.fork();
+  const users = await em.find(User, { name: 'john' }, { populate: ['group'] });
+  expect(users[0].group.$.meta).toEqual({ a: 'x', b: { y: 1 } });
+  expect(users[0].group.$.lazyMeta).toBeUndefined();
+  expect(mock.mock.calls[0][0]).toMatch(
+    "select `u0`.*, `g1`.`id` as `g1__id`, `g1`.`meta_a` as `g1__meta_a`, `g1`.`meta_b` as `g1__meta_b` from `user` as `u0` inner join `group` as `g1` on `u0`.`group_id` = `g1`.`id` where `u0`.`name` = 'john'",
+  );
+
+  em.clear();
+  const users2 = await em.find(User, { name: 'john' }, { populate: ['group.lazyMeta'] });
+  expect(users2[0].group.$.lazyMeta).toEqual({ a: 'z', b: { y: 2 } });
+  expect(mock.mock.calls[1][0]).toMatch(
+    "select `u0`.*, `g1`.`id` as `g1__id`, `g1`.`meta_a` as `g1__meta_a`, `g1`.`meta_b` as `g1__meta_b`, `g1`.`lazy_meta_a` as `g1__lazy_meta_a`, `g1`.`lazy_meta_b` as `g1__lazy_meta_b` from `user` as `u0` inner join `group` as `g1` on `u0`.`group_id` = `g1`.`id` where `u0`.`name` = 'john'",
+  );
+});


### PR DESCRIPTION
When a relation is loaded via join, the select list for the joined table iterated both the inline embedded property and its flattened child properties, so each embeddable column was pushed twice. Plain columns collapsed because identical `?? as ??` fragments are deduplicated, but JSON and custom-type columns go through `convertToJSValueSQL` and produce a fresh fragment every time. That is the duplicate from the issue.

The joined-load loop now skips the flattened children, since the parent property already expands them. This also means lazy inline embeddables respect `populate` in joined loads instead of leaking through their children. The TPT descendant join path had the same iteration and is fixed the same way.

Closes #8271